### PR TITLE
[JUJU-3386] Add check for explicit base in bundles when image-id constraint is set

### DIFF
--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -99,7 +99,7 @@ func (d *deployBundle) deploy(
 	}
 	d.printDryRunUnmarshalErrors(ctx, unmarshalErrors)
 
-	err = d.checkExplicitBase(bundleData)
+	err = d.checkExplicitSeries(bundleData)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -178,23 +178,18 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 	return nil
 }
 
-// checkExplicitBase returns an error if the image-id constraint is used and
-// there is no base (series) explicitly defined by the user.
-func (d *deployBundle) checkExplicitBase(bundleData *charm.BundleData) error {
+// checkExplicitSeries returns an error if the image-id constraint is used and
+// there is no series explicitly defined by the user.
+func (d *deployBundle) checkExplicitSeries(bundleData *charm.BundleData) error {
 	for _, applicationSpec := range bundleData.Applications {
-		charmURL, err := resolveCharmURL(applicationSpec.Charm, d.defaultCharmSchema)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		cons, err := constraints.Parse(applicationSpec.Constraints)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if (cons.HasImageID() || d.modelConstraints.HasImageID()) &&
 			applicationSpec.Series == "" &&
-			charmURL.Series == "" &&
 			bundleData.Series == "" {
-			return errors.Forbiddenf("base must be explicitly provided when image-id constraint is used")
+			return errors.Forbiddenf("series must be explicitly provided when image-id constraint is used")
 		}
 	}
 	return nil

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -16,7 +16,8 @@ type bundleSuite struct {
 var _ = gc.Suite(&bundleSuite{})
 
 func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
-	explicitSeriesError := "series must be explicitly provided when image-id constraint is used"
+	explicitSeriesErrorUbuntu := "series must be explicitly provided for \"ch:ubuntu\" when image-id constraint is used"
+	explicitSeriesError := "series must be explicitly provided for(.)*"
 
 	testCases := []struct {
 		title         string
@@ -24,30 +25,32 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 		bundleData    *charm.BundleData
 		expectedError string
 	}{
-		// NO IMAGE-ID
 		{
 			title: "two apps, no image-id, no series -> no error",
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
 			},
 			deployBundle: deployBundle{},
 		},
-		// NO SERIES
 		{
 			title: "two apps, one with image-id, no series -> error",
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -60,9 +63,11 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -79,9 +84,11 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -93,16 +100,68 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			},
 			expectedError: explicitSeriesError,
 		},
-		// SERIES IN APPS
+		{
+			title: "two apps, machine with image-id in (app).To, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"1": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle:  deployBundle{},
+			expectedError: explicitSeriesErrorUbuntu,
+		},
+		{
+			title: "two apps, machine with image-id not in (app).To, no series -> no error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"1"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"1": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
 		{
 			title: "two apps, one with image-id, series in same app -> no error",
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Series:      "focal",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -114,10 +173,12 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Series:      "focal",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -127,17 +188,19 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 					ImageID: strptr("ubuntu-bf2"),
 				},
 			},
-			expectedError: explicitSeriesError,
+			expectedError: explicitSeriesErrorUbuntu,
 		},
 		{
 			title: "two apps, model with image-id, series in two apps -> no error",
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Series:      "focal",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Series:      "focal",
 						Constraints: "mem=2G",
 					},
@@ -155,10 +218,12 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Series:      "focal",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -168,7 +233,7 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 					ImageID: strptr("ubuntu-bf2"),
 				},
 			},
-			expectedError: explicitSeriesError,
+			expectedError: explicitSeriesErrorUbuntu,
 		},
 		{
 			title: "two apps, model and one app with image-id, series in two apps -> no error",
@@ -176,10 +241,12 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			bundleData: &charm.BundleData{
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Series:      "focal",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Series:      "focal",
 						Constraints: "mem=2G",
 					},
@@ -191,16 +258,43 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 				},
 			},
 		},
-		// SERIES IN BUNDLE
+		{
+			title: "two apps, machine with image-id in (app).To, series in app -> no error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Series:      "jammy",
+						Constraints: "mem=2G",
+						To:          []string{"0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"1": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
 		{
 			title: "two apps, one with image-id, series in bundle -> no error",
 			bundleData: &charm.BundleData{
 				Series: "focal",
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "image-id=ubuntu-bf2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -213,9 +307,11 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 				Series: "focal",
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Constraints: "mem=2G",
 					},
 				},
@@ -232,9 +328,11 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 				Series: "focal",
 				Applications: map[string]*charm.ApplicationSpec{
 					"prometheus2": {
+						Charm:       "ch:prometheus2",
 						Constraints: "cpu-cores=2",
 					},
 					"ubuntu": {
+						Charm:       "ch:ubuntu",
 						Series:      "jammy",
 						Constraints: "mem=2G",
 					},
@@ -245,6 +343,32 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 					ImageID: strptr("ubuntu-bf2"),
 				},
 			},
+		},
+		{
+			title: "two apps, machine with image-id in (app).To, series in bundle -> no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"1": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
 		},
 	}
 	for i, test := range testCases {

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -1,0 +1,261 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer
+
+import (
+	"github.com/juju/charm/v10"
+	"github.com/juju/juju/core/constraints"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type bundleSuite struct {
+}
+
+var _ = gc.Suite(&bundleSuite{})
+
+func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
+	explicitSeriesError := "series must be explicitly provided when image-id constraint is used"
+
+	testCases := []struct {
+		title         string
+		deployBundle  deployBundle
+		bundleData    *charm.BundleData
+		expectedError string
+	}{
+		// NO IMAGE-ID
+		{
+			title: "two apps, no image-id, no series -> no error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
+		// NO SERIES
+		{
+			title: "two apps, one with image-id, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle:  deployBundle{},
+			expectedError: explicitSeriesError,
+		},
+		{
+			title: "two apps, model with image-id, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+			expectedError: explicitSeriesError,
+		},
+		{
+			title: "two apps, model and one app with image-id, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+			expectedError: explicitSeriesError,
+		},
+		// SERIES IN APPS
+		{
+			title: "two apps, one with image-id, series in same app -> no error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Series:      "focal",
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
+		{
+			title: "two apps, model with image-id, series in one app -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Series:      "focal",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+			expectedError: explicitSeriesError,
+		},
+		{
+			title: "two apps, model with image-id, series in two apps -> no error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Series:      "focal",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Series:      "focal",
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+		},
+		{
+			title: "two apps, model and one app with image-id, series in one app -> error",
+
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Series:      "focal",
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+			expectedError: explicitSeriesError,
+		},
+		{
+			title: "two apps, model and one app with image-id, series in two apps -> no error",
+
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Series:      "focal",
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Series:      "focal",
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+		},
+		// SERIES IN BUNDLE
+		{
+			title: "two apps, one with image-id, series in bundle -> no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
+		{
+			title: "two apps, model with image-id, series in bundle -> no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+		},
+		{
+			title: "two apps, model with image-id, series in bundle and app -> no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Series:      "jammy",
+						Constraints: "mem=2G",
+					},
+				},
+			},
+			deployBundle: deployBundle{
+				modelConstraints: constraints.Value{
+					ImageID: strptr("ubuntu-bf2"),
+				},
+			},
+		},
+	}
+	for i, test := range testCases {
+		c.Logf("test %d [%s]", i, test.title)
+
+		err := test.deployBundle.checkExplicitSeries(test.bundleData)
+
+		if test.expectedError != "" {
+			c.Check(err, gc.ErrorMatches, test.expectedError)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+		}
+	}
+}

--- a/tests/suites/deploy/bundles/overlay_bundle_image_id_no_base.yaml
+++ b/tests/suites/deploy/bundles/overlay_bundle_image_id_no_base.yaml
@@ -1,0 +1,11 @@
+applications:
+    ubuntu:
+        charm: ubuntu
+        scale: 1
+
+---
+
+applications:
+    ubuntu:
+        scale: 2
+        constraints: image-id=ubuntu-bf2  

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -59,6 +59,20 @@ run_deploy_bundle_overlay_with_image_id_on_base_bundle() {
 	destroy_model "test-bundles-deploy-overlay-image-id-on-base-bundle"
 }
 
+run_deploy_bundle_overlay_with_image_id_no_base() {
+	echo
+
+	file="${TEST_DIR}/test-bundles-deploy-overlay-image-id-no-base.log"
+
+	ensure "test-bundles-deploy-overlay-image-id-no-base" "${file}"
+
+	bundle=./tests/suites/deploy/bundles/overlay_bundle_image_id_no_base.yaml
+	got=$(juju deploy ${bundle} 2>&1 || true)
+	check_contains "${got}" 'base must be explicitly provided when image-id constraint is used'
+
+	destroy_model "test-bundles-deploy-overlay-image-id_no_base"
+}
+
 run_deploy_cmr_bundle() {
 	echo
 
@@ -330,6 +344,7 @@ test_deploy_bundles() {
 		run "run_deploy_bundle_overlay"
 		run "run_deploy_bundle_overlay_with_image_id"
 		run "run_deploy_bundle_overlay_with_image_id_on_base_bundle"
+		run "run_deploy_bundle_overlay_with_image_id_no_base"
 		run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
 		run "run_deploy_exported_charmhub_bundle_with_float_revisions"
 		run "run_deploy_trusted_bundle"


### PR DESCRIPTION
This check was already present for charm deploys, now we add it to the bundles deploy. We do this by iterating over the list of applications in the (merged with overlay) bundle, and if we found one using image-id constraint, then we look for the base (series) to be explicitly provided.

Bonus: I also removed an unused field in the `Firewaller` struct, which was making the linter fail.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

These steps are exactly the ones in the new `run_deploy_bundle_overlay_with_image_id_no_base` integration test.

Add the following bundles to bundles.yaml:
```yaml
applications:
    ubuntu:
        charm: ubuntu
        scale: 1

---

applications:
    ubuntu:
        scale: 2
        constraints: image-id=ubuntu-bf2  
```
then trying to deploy it must fail:
```sh
$ juju deploy ./bundles.yaml
ERROR base must be explicitly provided when image-id constraint is used
```

When adding the series to the bundle:
```yaml
applications:
    ubuntu:
        charm: ubuntu
        scale: 1

---

applications:
    ubuntu:
        series: focal
        scale: 2
        constraints: image-id=ubuntu-bf2  
```
the deploy works:
```sh
$ juju deploy ./bundles.yaml
Located charm "ubuntu" in charm-hub, channel stable
Executing changes:
- upload charm ubuntu from charm-hub for series focal with architecture=amd64
- deploy application ubuntu from charm-hub on focal
- add unit ubuntu/0 to new machine 16
- add unit ubuntu/1 to new machine 17
Deploy of bundle completed.
```

