### PR TITLE
[JUJU-3377] Backport catacomb-scoped context changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0
-	github.com/juju/worker/v3 v3.1.0
+	github.com/juju/worker/v3 v3.2.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/juju/viddy v0.0.0-beta5/go.mod h1:5Yvv+opdIEDt15Tt0++8YvccVykcGJeVXxq
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v3 v3.1.0 h1:rt1yXAGTXYosC4kOcjdlvi0SnISyDtOUj3cKfOtZTLE=
-github.com/juju/worker/v3 v3.1.0/go.mod h1:C7MMHkc7dqghNul0WYnBlFgKPXXSGpJBkgibxqfymII=
+github.com/juju/worker/v3 v3.2.0 h1:u2D0bc8r6AEuUR6B8he1nErJcZE04uKr6Gtj1KGargA=
+github.com/juju/worker/v3 v3.2.0/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -165,7 +165,6 @@ type Firewaller struct {
 	applicationids       map[names.ApplicationTag]*applicationData
 	exposedChange        chan *exposedChange
 	spaceInfos           network.SpaceInfos
-	modelFirewallRules   firewall.IngressRules
 	globalMode           bool
 	globalIngressRuleRef map[string]int // map of rule names to count of occurrences
 


### PR DESCRIPTION
This is a straight cherry-pick backwards of the commits in https://github.com/juju/juju/pull/15403.

The QA steps were effectively executed against this branch, it just landed after 3.2 was created from develop.