### PR TITLE
Ignore build number in unit tests that check build number.

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -229,6 +229,8 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	expectedVersion := jujuversion.Current
+	expectedVersion.Build = 666
 	// Maps are harder to check...
 	// http://ci.jujucharms.com/job/make-check-juju/4853/testReport/junit/github/com_juju_juju_apiserver_facades_controller_caasunitprovisioner/TestAll/
 	expectedResult := &params.KubernetesProvisioningInfo{
@@ -237,7 +239,7 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 			ServiceType:    "loadbalancer",
 		},
 		ImageRepo: params.DockerImageInfo{
-			RegistryPath: fmt.Sprintf("jujusolutions/jujud-operator:%s", jujuversion.Current.String()+".666"),
+			RegistryPath: fmt.Sprintf("jujusolutions/jujud-operator:%s", expectedVersion.String()),
 		},
 		Devices: []params.KubernetesDeviceParams{
 			{

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -610,6 +610,8 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		}...,
 	)
 
+	expectedVersion := jujuversion.Current
+	expectedVersion.Build = 666
 	probCmds := &core.ExecAction{
 		Command: []string{
 			"mongo",
@@ -756,7 +758,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "api-server",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "test-account/jujud-operator:" + jujuversion.Current.String() + ".666",
+			Image:           "test-account/jujud-operator:" + expectedVersion.String(),
 			Env: []core.EnvVar{{
 				Name:  osenv.JujuFeatureFlagEnvKey,
 				Value: "developer-mode",
@@ -882,7 +884,7 @@ EOF
 	statefulSetSpec.Spec.Template.Spec.InitContainers = []core.Container{{
 		Name:            "charm-init",
 		ImagePullPolicy: core.PullIfNotPresent,
-		Image:           "test-account/jujud-operator:" + jujuversion.Current.String() + ".666",
+		Image:           "test-account/jujud-operator:" + expectedVersion.String(),
 		WorkingDir:      "/var/lib/juju",
 		Command:         []string{"/opt/containeragent"},
 		Args:            []string{"init", "--containeragent-pebble-dir", "/containeragent/pebble", "--charm-modified-version", "0", "--data-dir", "/var/lib/juju", "--bin-dir", "/charm/bin", "--controller"},

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -212,6 +212,12 @@ started upgrade to 3.9.99
 func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c *gc.C) {
 	s.reset(c)
 
+	s.PatchValue(&jujuversion.Current, func() version.Number {
+		v := jujuversion.Current
+		v.Build = 0
+		return v
+	}())
+
 	s.PatchValue(&CheckCanImplicitUpload,
 		func(model.ModelType, bool, version.Number, version.Number) bool { return true },
 	)


### PR DESCRIPTION
Changes to the Makefile for cgo introduced build number into unit tests. This should be allowed, but some tests need to be made resilient to this.

## QA steps

Run unit tests with and without `-ldflags "-X github.com/juju/juju/version.build=12345"`

## Documentation changes

N/A

## Bug reference

N/A