### PR TITLE
[tests/resources] remove call to nonexistent func

### DIFF
--- a/tests/suites/resources/basic.sh
+++ b/tests/suites/resources/basic.sh
@@ -44,7 +44,7 @@ run_resource_attach() {
 
 	juju deploy juju-qa-test
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-	juju attach juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
+	juju attach-resource juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
 
 	juju config juju-qa-test foo-file=true
 	# wait for config-changed, the charm will update the status
@@ -70,7 +70,7 @@ run_resource_attach_large() {
 	# Use urandom to add alpha numeric characters with new lines added to the file
 	dd if=/dev/urandom bs=1048576 count=100 2>/dev/null | base64 >"${FILE}"
 	line=$(head -n 1 "${FILE}")
-	juju attach juju-qa-test foo-file="${FILE}"
+	juju attach-resource juju-qa-test foo-file="${FILE}"
 
 	juju config juju-qa-test foo-file=true
 	# wait for config-changed, the charm will update the status

--- a/tests/suites/resources/refresh.sh
+++ b/tests/suites/resources/refresh.sh
@@ -53,7 +53,7 @@ run_resource_refresh_no_new_charm_rev_supply_res_rev() {
 	# refresh the resource revision without changing the
 	# charm url
 	echo
-	name="resource-refresh-no-new-charm-rev"
+	name="resource-refresh-no-new-charm-rev-supply-res-rev"
 
 	file="${TEST_DIR}/test-${name}.log"
 

--- a/tests/suites/resources/task.sh
+++ b/tests/suites/resources/task.sh
@@ -15,7 +15,6 @@ test_resources() {
 
 	test_basic_resources
 	test_upgrade_resources
-	test_attach_resources
 
 	destroy_controller "test-resources"
 }


### PR DESCRIPTION
28640b504dcdb5660483aa1ec0f5ef3d5b1bf9a3 deleted the `test_attach_resources` test in the resources suite, but didn't remove the reference from `task.sh`. Test runs were failing with
```
18:39:48 suites/resources/task.sh: line 18: test_attach_resources: command not found
```

Also, change the `name` in `run_resource_refresh_no_new_charm_rev_supply_res_rev` to disambiguate from `run_resource_refresh_no_new_charm_rev`. This test is still failing, unfortunately.

## QA steps

```sh
cd tests
./main.sh -v resources
```