### PR TITLE
[branch test] deploy mongodb from 3.6/stable

### DIFF
--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -8,7 +8,7 @@ run_branch() {
 
 	juju branch | check 'Active branch is "master"'
 
-	juju deploy mongodb
+	juju deploy mongodb --channel 3.6/stable
 
 	wait_for "mongodb" "$(idle_condition "mongodb")"
 


### PR DESCRIPTION
The `branches` tests were failing because the `mongodb` charm doesn't have a `latest/stable` channel. Install it from `3.6/stable` as [recommended by Charmhub](https://charmhub.io/mongodb).

## QA steps

```
cd tests
./main.sh -v -s '"test_active_branch_output"' branches test_branch
```