### PR TITLE
[resources test] fix expected status messages

### DIFF
--- a/tests/suites/resources/refresh.sh
+++ b/tests/suites/resources/refresh.sh
@@ -64,14 +64,14 @@ run_resource_refresh_no_new_charm_rev_supply_res_rev() {
 	juju config juju-qa-test foo-file=true
 
 	# wait for update-status
-	wait_for "resource line one: testing four." "$(workload_status juju-qa-test 0).message"
+	wait_for "resource line one: testing two." "$(workload_status juju-qa-test 0).message"
 	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "2"'
 	juju config juju-qa-test foo-file=false
 
 	juju refresh juju-qa-test --resource foo-file=3
 
 	juju config juju-qa-test foo-file=true
-	wait_for "resource line one: testing three." "$(workload_status juju-qa-test 0).message"
+	wait_for "resource line one: testing one plus one." "$(workload_status juju-qa-test 0).message"
 	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "3"'
 
 	destroy_model "test-${name}"


### PR DESCRIPTION
The `resources` test `run_resource_refresh_no_new_charm_rev_supply_res_rev` was failing because the test was expecting the wrong status messages.

The messages should match the resources listed [here](https://charmhub.io/juju-qa-test#juju-qa-test--resource-versions-and-contents).

`juju-qa-test` from `latest/stable` deploys with resource revision 2:
```
$ juju charm-resources juju-qa-test --channel latest/stable
Resource  Revision
foo-file  2
```
which has the message `testing two.`

When the `foo-file` resource is updated to revision 3, it should have the message `testing one plus one.`

## QA steps

```sh
cd tests
./main.sh -v resources run_resource_refresh_no_new_charm_rev_supply_res_rev
```