### PR TITLE
[JUJU-3364] Fix manual aws

### DIFF
--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -1,3 +1,42 @@
+create_vpc() {
+	vpc_id=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
+	aws ec2 wait vpc-available --vpc-ids "${vpc_id}"
+
+	aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-support '{"Value":true}' >/dev/null
+	aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-hostnames '{"Value":true}' >/dev/null
+
+	echo $vpc_id
+}
+
+create_igw() {
+	igw_id=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text)
+	aws ec2 attach-internet-gateway --internet-gateway-id "${igw_id}" --vpc-id "${vpc_id}" >/dev/null
+
+	echo $igw_id
+}
+
+create_subnet() {
+	subnet_id=$(aws ec2 create-subnet --vpc-id "${vpc_id}" --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
+
+	routetable_id=$(aws ec2 create-route-table --vpc-id "${vpc_id}" --query 'RouteTable.RouteTableId' --output text)
+
+	aws ec2 associate-route-table --route-table-id "${routetable_id}" --subnet-id "${subnet_id}" >/dev/null
+	aws ec2 create-route --route-table-id "${routetable_id}" --destination-cidr-block 0.0.0.0/0 --gateway-id "${igw_id}" >/dev/null
+
+	echo $subnet_id
+}
+
+create_secgroup() {
+	sg_id=$(aws ec2 create-security-group --group-name "ci-manual-deploy" --description "run_deploy_manual_aws" --vpc-id "${vpc_id}" --query 'GroupId' --output text)
+	aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0 >/dev/null
+	aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 0-65535 --cidr 0.0.0.0/0 >/dev/null
+	aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 0-65535 --cidr 0.0.0.0/0 >/dev/null
+	aws ec2 authorize-security-group-egress --group-id "${sg_id}" --protocol tcp --port 0-65535 --cidr 0.0.0.0/0 >/dev/null
+	aws ec2 authorize-security-group-egress --group-id "${sg_id}" --protocol udp --port 0-65535 --cidr 0.0.0.0/0 >/dev/null
+
+	echo $sg_id
+}
+
 run_deploy_manual_aws() {
 	echo
 
@@ -31,50 +70,42 @@ run_deploy_manual_aws() {
 	fi
 	instance_image_id="${OUT}"
 
-	local vpc_id sg_id subnet_id
+	local vpc_id igw_id sg_id subnet_id
 
 	OUT=$(aws ec2 describe-vpcs | jq '.Vpcs[] | select(.Tags[]? | select((.Key=="Name") and (.Value=="manual-deploy")))' || true)
-	vpc_id=$(echo "${OUT}" | jq -r '.VpcId' || true)
-	if [[ -z ${vpc_id} ]]; then
-		# VPC doesn't exist, create one along with all the required setup.
-		vpc_id=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
-		aws ec2 wait vpc-available --vpc-ids "${vpc_id}"
-
-		aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-support '{"Value":true}'
-		aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-hostnames '{"Value":true}'
-
-		igw_id=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text)
-		aws ec2 attach-internet-gateway --internet-gateway-id "${igw_id}" --vpc-id "${vpc_id}"
-
-		subnet_id=$(aws ec2 create-subnet --vpc-id "${vpc_id}" --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
-
-		routetable_id=$(aws ec2 create-route-table --vpc-id "${vpc_id}" --query 'RouteTable.RouteTableId' --output text)
-
-		aws ec2 associate-route-table --route-table-id "${routetable_id}" --subnet-id "${subnet_id}"
-		aws ec2 create-route --route-table-id "${routetable_id}" --destination-cidr-block 0.0.0.0/0 --gateway-id "${igw_id}"
-
-		sg_id=$(aws ec2 create-security-group --group-name "ci-manual-deploy" --description "run_deploy_manual_aws" --vpc-id "${vpc_id}" --query 'GroupId' --output text)
-		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0
-		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 0-65535 --cidr 0.0.0.0/0
-		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 0-65535 --cidr 0.0.0.0/0
-		aws ec2 authorize-security-group-egress --group-id "${sg_id}" --protocol tcp --port 0-65535 --cidr 0.0.0.0/0
-		aws ec2 authorize-security-group-egress --group-id "${sg_id}" --protocol udp --port 0-65535 --cidr 0.0.0.0/0
+	if [[ -z ${OUT} ]]; then
+		vpc_id=$(create_vpc)
+		echo "===> Creating vpc $vpc_id"
 	else
-		OUT=$(aws ec2 describe-subnets | jq '.Subnets[] | select(.Tags[]? | select((.Key=="Name") and (.Value=="manual-deploy")))' || true)
-		if [[ -z ${OUT} ]]; then
-			echo "Subnet not found: unknown state."
-			echo "Delete VPC and start again."
-			exit 1
-		fi
-		subnet_id=$(echo "${OUT}" | jq -r '.SubnetId')
+		vpc_id=$(echo "${OUT}" | jq -r '.VpcId' || true)
+		echo "===> Re-using vpc $vpc_id"
+	fi
 
-		OUT=$(aws ec2 describe-security-groups | jq ".SecurityGroups[] | select(.VpcId==\"${vpc_id}\" and .GroupName==\"ci-manual-deploy\")" || true)
-		if [[ -z ${OUT} ]]; then
-			echo "Security group not found: unknown state."
-			echo "Delete VPC and start again."
-			exit 1
-		fi
+	OUT=$(aws ec2 describe-internet-gateways | jq ".InternetGateways[] | select(.Attachments[0].VpcId == \"${vpc_id}\")")
+	if [[ -z ${OUT} ]]; then
+		igw_id=$(create_igw)
+		echo "===> Creating igw $igw_id"
+	else
+		igw_id=$(echo "${OUT}" | jq -r '.InternetGatewayId')
+		echo "===> Re-using igw $igw_id"
+	fi
+
+	OUT=$(aws ec2 describe-subnets | jq '.Subnets[] | select(.Tags[]? | select((.Key=="Name") and (.Value=="manual-deploy")))' || true)
+	if [[ -z ${OUT} ]]; then
+		subnet_id=$(create_subnet)
+		echo "===> Creating subnet $subnet_id"
+	else
+		subnet_id=$(echo "${OUT}" | jq -r '.SubnetId')
+		echo "===> Re-using subnet $subnet_id"
+	fi
+
+	OUT=$(aws ec2 describe-security-groups | jq ".SecurityGroups[] | select(.VpcId==\"${vpc_id}\" and .GroupName==\"ci-manual-deploy\")" || true)
+	if [[ -z ${OUT} ]]; then
+		sg_id=$(create_secgroup)
+		echo "===> Creating secgroup $sg_id"
+	else
 		sg_id=$(echo "${OUT}" | jq -r '.GroupId')
+		echo "===> Re-using secgroup $sg_id"
 	fi
 
 	aws ec2 create-key-pair --key-name "${name}" --query 'KeyMaterial' --output text >"${TEST_DIR}/${name}.pem"


### PR DESCRIPTION
Previously we would branch on if a vpc has been created. If one already exists, validate it is correctly configured or fail. However, somehow the vpc ends up incorrectly configured. Specifically the subnet disappears

So instead perform each step in setting up the vpc idempotently

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Base cases

With a 'clean' aws state (i.e. no vpcs called 'manual-deploy')

Ensure the following succeeds
```
./main.sh -v -c aws -p aws -R eu-west-2 manual test_deploy_manual
```
This should contain output:
```
===> Creating vpc vpc-0987e5dd6fee2d87b
===> Creating igw igw-036ecbd393d8fae51
===> Creating subnet subnet-030d0e55ee07d3870
===> Creating secgroup sg-057e2e3611589c4f6
===> Creating machines in aws
```

Now that resources have been created, run the suite again
```
./main.sh -v -c aws -p aws -R eu-west-2 manual test_deploy_manual
```
This should contain output:
```
===> Re-using vpc vpc-0987e5dd6fee2d87b
===> Re-using igw igw-036ecbd393d8fae51
===> Re-using subnet subnet-030d0e55ee07d3870
===> Re-using secgroup sg-057e2e3611589c4f6
===> Creating machines in aws
```

### Special cases

Manually delete (detach first) the internet gateway attached to the vpc and re-run the test suite. It should succees and contain:
```
===> Re-using vpc vpc-0987e5dd6fee2d87b
===> Creating igw igw-036ecbd393d8fae51
===> Re-using subnet subnet-030d0e55ee07d3870
===> Re-using secgroup sg-057e2e3611589c4f6
===> Creating machines in aws
```

Manually delete the subnet in out vpc and re-run the test suite. It should succees and contain:
```
===> Re-using vpc vpc-0987e5dd6fee2d87b
===> Re-using igw igw-036ecbd393d8fae51
===> Creating subnet subnet-030d0e55ee07d3870
===> Re-using secgroup sg-057e2e3611589c4f6
===> Creating machines in aws
```

Manually delete the sec group called `ci-manual-deploy` and re-run the test suite. It should succees and contain:
```
===> Re-using vpc vpc-0987e5dd6fee2d87b
===> Re-using igw igw-036ecbd393d8fae51
===> Re-using subnet subnet-030d0e55ee07d3870
===> Creating secgroup sg-057e2e3611589c4f6
===> Creating machines in aws
```

