### PR TITLE
[JUJU-3426] Fix error message for deploying cs: charms on 3.1 controller with 3.0 client

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -530,7 +530,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 			// The following error raise is an assumption. If we have an alternative source at some point,
 			// then this error will have to change. The proper way to do this is to have a separate
 			// error type that's raised in AddCharmWithAuthorizationFromURL above for unsupported schema.
-			return errors.Annotatef(err, "schema not supported")
+			return errors.Annotatef(err, "schema %q not supported", origin.Source)
 		}
 		return errors.Annotatef(err, "storing charm %q", deployableURL.Name)
 	}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -526,7 +526,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
 		}
-		if origin.Source != commoncharm.OriginLocal || origin.Source != commoncharm.OriginCharmHub {
+		if origin.Source != commoncharm.OriginLocal && origin.Source != commoncharm.OriginCharmHub {
 			return errors.Annotatef(err, "schema not supported")
 		}
 		return errors.Annotatef(err, "storing charm %q", deployableURL.Name)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -527,6 +527,9 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 			return errors.Trace(termErr.UserErr())
 		}
 		if origin.Source != commoncharm.OriginLocal && origin.Source != commoncharm.OriginCharmHub {
+			// The following error raise is an assumption. If we have an alternative source at some point,
+			// then this error will have to change. The proper way to do this is to have a separate
+			// error type that's raised in AddCharmWithAuthorizationFromURL above for unsupported schema.
 			return errors.Annotatef(err, "schema not supported")
 		}
 		return errors.Annotatef(err, "storing charm %q", deployableURL.Name)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -526,6 +526,9 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
 		}
+		if origin.Source != commoncharm.OriginLocal || origin.Source != commoncharm.OriginCharmHub {
+			return errors.Annotatef(err, "schema not supported")
+		}
 		return errors.Annotatef(err, "storing charm %q", deployableURL.Name)
 	}
 	ctx.Infof(formatLocatedText(curl, csOrigin))


### PR DESCRIPTION
This is a simple change that's part of the work for removing charmstore charm support.

When deploying a CharmStore charm using 3.0 client against a 3.1 controller we're getting (a slightly confusing) error message that looked like the following:

```sh
$ j deploy cs:ubuntu
WARNING Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
        Migration of this model to a juju 3.1 controller will be prohibited.
ERROR storing charm "ubuntu": unknown schema for charm URL "cs:ubuntu-21"
```

The `storing charm "ubuntu"` part is the problem.

## QA steps

Bootstrap a `3.1` controller. And compile a juju client with this change (that'll be a `3.0` client), when deploying a `cs` charm, the interaction should look like the following:

```sh
$ j deploy cs:ubuntu
WARNING Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
        Migration of this model to a juju 3.1 controller will be prohibited.
ERROR schema "charm-store" not supported: unknown schema for charm URL "cs:ubuntu-21"
```


## Notes & Discussion

As I noted in the commit message, a better way might be to create an error type for this, but it might be a little overkill in this case because (hopefully) we won't have any other phase that we transition out from charmhub into a new kind of repo anytime soon.