### PR TITLE
Don't try and checkout musl cross make if it exists.

### DIFF
--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -37,7 +37,7 @@ musl_install_system() {
 
 musl_install_local() {
     ./configure --prefix=${MUSL_PATH} || { echo "Failed to configure musl"; exit 1; }
-    make install || { echo "Failed to install musl"; exit 1; }
+    make install GNU_SITE=https://mirrors.kernel.org/gnu || { exit 1; }
 
     mkdir -p ${MUSL_BIN_PATH} || { echo "Failed to create ${MUSL_BIN_PATH}"; exit 1; }
     ln -s ${MUSL_PATH}/bin/musl-gcc ${MUSL_BIN_PATH}/musl-gcc || { echo "Failed to link musl-gcc"; exit 1; }
@@ -74,6 +74,9 @@ musl_install_cross_arch() {
     cd ${MUSL_PATH}
     mkdir -p ${MUSL_PATH}/build
 
+    rm -f config.mak
+    touch config.mak
+
     case "${BUILD_ARCH}" in
         amd64)   echo "TARGET=x86_64-linux-musl" >> config.mak ;;
         arm64)   echo "TARGET=aarch64-linux-musl" >> config.mak ;;
@@ -90,7 +93,7 @@ musl_install_cross_arch() {
     echo "COMMON_CONFIG += CFLAGS=\"-g0 -Os\" CXXFLAGS=\"-g0 -Os\" LDFLAGS=\"-s\"" >> config.mak
 
     echo "Building musl-${BUILD_ARCH}"
-    make install || { exit 1; }
+    make install GNU_SITE=https://mirrors.kernel.org/gnu || { exit 1; }
 
     echo "Linking musl-${BUILD_ARCH} to musl-gcc"
     cd ${MUSL_PATH}/output/bin

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -64,9 +64,14 @@ musl_install() {
 
 musl_install_cross_arch() {
     mkdir -p ${MUSL_PATH} || { exit 1; }
-    git clone https://github.com/richfelker/musl-cross-make.git ${MUSL_PATH}
-    cd ${MUSL_PATH}
 
+    git -C "$MUSL_PATH" rev-parse
+    # If MUSL_PATH is not a git repo lets check it out at the location.
+    if [ $? -ne 0 ]; then
+      git clone https://github.com/richfelker/musl-cross-make.git ${MUSL_PATH}
+    fi
+
+    cd ${MUSL_PATH}
     mkdir -p ${MUSL_PATH}/build
 
     case "${BUILD_ARCH}" in


### PR DESCRIPTION
- When musl cross make is already checked out we need to stop it from trying to checkout the repository again.
- Every time we remake musl we should recreate the config so as not to repeat the config keys over and over
- Changes to a more reliable gnu source uri

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Make juju and force the musl install step to fail after git checkout.
2. Re run the build removing the failure and everything should work.

## Documentation changes

N/A

## Bug reference

N/A
