### PR TITLE
Ensure submakes can share jobs with parent make.

### DIFF
--- a/scripts/dqlite/Makefile
+++ b/scripts/dqlite/Makefile
@@ -14,30 +14,30 @@ MUSL_PATH=${PROJECT_DIR}/_deps/musl-${DQLITE_BUILD_ARCH}
 MUSL_BIN_PATH=${MUSL_PATH}/output/bin
 
 ${DQLITE_ARCHIVE_PATH}:
-	@./scripts/dqlite/scripts/dqlite/build-lxd.sh
+	+@./scripts/dqlite/scripts/dqlite/build-lxd.sh
 
 dqlite-build-lxd: ${DQLITE_ARCHIVE_PATH}
 
 dqlite-build:
-	@./scripts/dqlite/scripts/dqlite/build.sh
+	+@./scripts/dqlite/scripts/dqlite/build.sh
 
 dqlite-push: ${DQLITE_ARCHIVE_PATH}
-	@./scripts/dqlite/scripts/dqlite/push.sh
+	+@./scripts/dqlite/scripts/dqlite/push.sh
 
 dqlite-install:
-	@./scripts/dqlite/scripts/dqlite/install.sh
+	+@./scripts/dqlite/scripts/dqlite/install.sh
 
 dqlite-install-if-missing:
-	@./scripts/dqlite/scripts/dqlite/install-if-missing.sh
+	+@./scripts/dqlite/scripts/dqlite/install-if-missing.sh
 
 musl-install:
-	@./scripts/dqlite/scripts/musl/install.sh
+	+@./scripts/dqlite/scripts/musl/install.sh
 
 musl-install-if-missing:
-	@./scripts/dqlite/scripts/musl/install-if-missing.sh
+	+@./scripts/dqlite/scripts/musl/install-if-missing.sh
 
 repl-install:
-	@./scripts/dqlite/scripts/repl/install.sh
+	+@./scripts/dqlite/scripts/repl/install.sh
 
 repl:
-	@./scripts/dqlite/scripts/repl/repl.sh
+	+@./scripts/dqlite/scripts/repl/repl.sh


### PR DESCRIPTION
Submakes need environment passed from the parent make to use the jobserver to share job semaphore.

## QA steps

`make -j$(nproc) ...` should speed up full musl toolchain builds.

## Documentation changes

N/A

## Bug reference

[`make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.`](https://jenkins.juju.canonical.com/job/build-juju/9608/consoleText)