### PR TITLE
Fix improper check for musl-cross-make.

### DIFF
--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -65,9 +65,10 @@ musl_install() {
 musl_install_cross_arch() {
     mkdir -p ${MUSL_PATH} || { exit 1; }
 
-    git -C "$MUSL_PATH" rev-parse
     # If MUSL_PATH is not a git repo lets check it out at the location.
-    if [ $? -ne 0 ]; then
+    if git --git-dir "$MUSL_PATH/.git" rev-parse; then
+      echo "musl-cross-make already fetched"
+    else
       git clone https://github.com/richfelker/musl-cross-make.git ${MUSL_PATH}
     fi
 


### PR DESCRIPTION
Improper check for musl-cross-make being checked out was finding the juju .git directory instead.

## QA steps

- Ensure you delete the `_deps` directory first.
- MUSL_PRECOMPILED=0 MUSL_CROSS_COMPILE=1 MUSL_LOCAL_PLACEMENT=local make musl-install

## Documentation changes

N/A

## Bug reference

[17:24:36 make: *** [scripts/dqlite/Makefile:37: musl-install-if-missing] Error 128](https://jenkins.juju.canonical.com/job/build-juju/9632/consoleText)