### PR TITLE
[JUJU-3467] Fixed test-deploy-test-deploy-bundles-aws base/series issue

### DIFF
--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -209,7 +209,7 @@ func (d *deployBundle) checkExplicitSeries(bundleData *charm.BundleData) error {
 		if (appHasImageID || modelHasImageID || machineHasImageID) &&
 			applicationSpec.Series == "" &&
 			bundleData.Series == "" {
-			return errors.Forbiddenf("series must be explicitly provided for %q when image-id constraint is used", applicationSpec.Charm)
+			return errors.Forbiddenf("base must be explicitly provided for %q when image-id constraint is used", applicationSpec.Charm)
 		}
 	}
 	return nil

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -16,8 +16,8 @@ type bundleSuite struct {
 var _ = gc.Suite(&bundleSuite{})
 
 func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
-	explicitSeriesErrorUbuntu := "series must be explicitly provided for \"ch:ubuntu\" when image-id constraint is used"
-	explicitSeriesError := "series must be explicitly provided for(.)*"
+	explicitSeriesErrorUbuntu := "base must be explicitly provided for \"ch:ubuntu\" when image-id constraint is used"
+	explicitSeriesError := "base must be explicitly provided for(.)*"
 
 	testCases := []struct {
 		title         string

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -68,7 +68,7 @@ run_deploy_bundle_overlay_with_image_id_no_base() {
 
 	bundle=./tests/suites/deploy/bundles/overlay_bundle_image_id_no_base.yaml
 	got=$(juju deploy ${bundle} 2>&1 || true)
-	check_contains "${got}" 'base must be explicitly provided when image-id constraint is used'
+	check_contains "${got}" 'base must be explicitly provided for "ubuntu" when image-id constraint is used'
 
 	destroy_model "test-bundles-deploy-overlay-image-id_no_base"
 }


### PR DESCRIPTION
This PR addresses the run_deploy_bundle_overlay_with_image_id_no_base base/series issue, ensuring proper functionality in the deployment process. Additionally, it fixes the bundle suite unit test to improve overall test reliability and code stability.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

```sh
# CI
cd tests
./main.sh -v -p aws deploy run_deploy_bundle_overlay_with_image_id_no_base
# Unit
cd ../cmd/juju/application/deployer
go test -check.f bundleSuite
```

## Documentation changes

Nope

## Bug reference

Nope