### PR TITLE
Fix data race in openDatabase.

### DIFF
--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -380,6 +380,11 @@ func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
 
 func (w *dbWorker) openDatabase(namespace string) error {
 	err := w.dbRunner.StartWorker(namespace, func() (worker.Worker, error) {
+		w.mu.RLock()
+		defer w.mu.RUnlock()
+		if w.dbApp == nil {
+			return nil, errors.New("db worker shutting down")
+		}
 		return w.cfg.NewDBWorker(w.dbApp, namespace,
 			WithClock(w.cfg.Clock),
 			WithLogger(w.cfg.Logger),


### PR DESCRIPTION
Worker start function call could happen after shutdownDqlite is called, causing a data race on w.dbApp.
Additionally, w.dbApp could be nil, causing a panic in NewTrackedDBWorker.

## QA steps

`make run-go-tests TEST_ARGS=-race TEST_PACKAGES=./worker/dbaccessor`

## Documentation changes

N/A

## Bug reference

```
==================
WARNING: DATA RACE
Read at 0x00c0005050a8 by goroutine 166:
  github.com/juju/juju/worker/dbaccessor.(*dbWorker).openDatabase.func1()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/worker/dbaccessor/worker.go:383 

Previous write at 0x00c0005050a8 by goroutine 165:
  github.com/juju/juju/worker/dbaccessor.(*dbWorker).shutdownDqlite()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/worker/dbaccessor/worker.go:582 +0x377
```
[unit-tests-race-amd64/958](https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/958/consoleText)