### PR TITLE
Update ppc64le prebuilt sha + Use juju/musl-cross-make.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - '**.go'
       - 'go.mod'
       - '.github/workflows/build.yml'
+      - 'scripts/dqlite/**'
+      - 'Makefile'
+      - 'make_functions.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -7,6 +7,9 @@ on:
       - '**.go'
       - 'go.mod'
       - '.github/workflows/client-tests.yml'
+      - 'scripts/dqlite/**'
+      - 'Makefile'
+      - 'make_functions.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -7,6 +7,8 @@ on:
       - '**.go'
       - 'go.mod'
       - '.github/workflows/gen.yml'
+      - 'Makefile'
+      - 'make_functions.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -8,6 +8,9 @@ on:
       - 'go.mod'
       - 'snap/**'
       - '.github/workflows/migrate.yml'
+      - 'scripts/dqlite/**'
+      - 'Makefile'
+      - 'make_functions.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -8,6 +8,9 @@ on:
       - 'go.mod'
       - 'snap/**'
       - '.github/workflows/snap.yml'
+      - 'scripts/dqlite/**'
+      - 'Makefile'
+      - 'make_functions.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -11,6 +11,9 @@ on:
       - 'snap/**'
       - '.github/workflows/upgrade.yml'
       - '.github/setup-lxd/**'
+      - 'scripts/dqlite/**'
+      - 'Makefile'
+      - 'make_functions.sh'
     branches-ignore:
       - 'develop'
   workflow_dispatch:

--- a/scripts/dqlite/scripts/dqlite/dqlite-build.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-build.sh
@@ -118,7 +118,7 @@ build() {
     git clone https://github.com/sqlite/sqlite.git --depth 1 --branch ${TAG_SQLITE}
     cd sqlite
     ./configure --disable-shared CFLAGS="${CUSTOM_CFLAGS}"
-    make
+    make CFLAGS="${CUSTOM_CFLAGS}"
     cd ../
 
     # dqlite

--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -9,7 +9,7 @@ sha() {
 		amd64) echo "124a578c8bd63d9288093f4de4aaffa09c034d6641065cd079e446ac91b1b611" ;;
 		arm64) echo "0943427d17dce0dc9d7da7777dd1f6ed8d5cea4d6c9d872411075181b9299d7e" ;;
 		s390x) echo "690240895b765eb78a0a00ebc148361b947b64483e636a76d9d033780d5ef758" ;;
-		ppc64le) echo "4d774403e3a5f80657029f760168f313aeb13dba8dc5787c24a9e96e5d9b96ff" ;;
+		ppc64le) echo "bfc1f413e24eed715694684455b8dfe51e6c375176827acb841e80a5c51fae57" ;;
 		*) { echo "Unsupported arch ${BUILD_ARCH}."; exit 1; } ;;
 	esac
 }

--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -9,7 +9,7 @@ sha() {
 		amd64) echo "124a578c8bd63d9288093f4de4aaffa09c034d6641065cd079e446ac91b1b611" ;;
 		arm64) echo "0943427d17dce0dc9d7da7777dd1f6ed8d5cea4d6c9d872411075181b9299d7e" ;;
 		s390x) echo "690240895b765eb78a0a00ebc148361b947b64483e636a76d9d033780d5ef758" ;;
-		ppc64le) echo "bfc1f413e24eed715694684455b8dfe51e6c375176827acb841e80a5c51fae57" ;;
+		ppc64le) echo "b83faf851327645e9db4a2e0df28959c1b08cc1f3ef2cf5dbf67804abd061f5c" ;;
 		*) { echo "Unsupported arch ${BUILD_ARCH}."; exit 1; } ;;
 	esac
 }

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -69,7 +69,7 @@ musl_install_cross_arch() {
     if git --git-dir "$MUSL_PATH/.git" rev-parse; then
       echo "musl-cross-make already fetched"
     else
-      git clone https://github.com/richfelker/musl-cross-make.git ${MUSL_PATH}
+      git clone https://github.com/juju/musl-cross-make.git ${MUSL_PATH}
     fi
 
     cd ${MUSL_PATH}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -242,7 +242,7 @@ parts:
 
       CFLAGS="${CUSTOM_CFLAGS}" \
         ./configure --disable-shared
-      make
+      make CFLAGS="${CUSTOM_CFLAGS}"
 
       mkdir -p $SNAPCRAFT_PART_INSTALL/libsqlite3
       cp -r $SNAPCRAFT_PART_BUILD/*.* $SNAPCRAFT_PART_INSTALL/libsqlite3


### PR DESCRIPTION
- ~Update ppc64le [prebuilt sha](https://jenkins.juju.canonical.com/job/build-dqlite-ppc64el/6/consoleText) for `-mlong-double-64` cc flag.~ Fix sqlite3 building to pass CUSTOM_CFLAGS to make, due to configure not properly saving it in the generated Makefile. Patched in [new prebuilt sha](https://jenkins.juju.canonical.com/job/build-dqlite-ppc64el/9), should probably rebuild once this lands.
- Use juju/musl-cross-make for [less noisy tar operations](https://github.com/juju/musl-cross-make/pull/1).
- Force github action builds on tooling changes.

## QA steps

Green GHA.

## Documentation changes

N/A

## Bug reference

N/A