### PR TITLE
[JUJU-3481] fix bundle deploy test (w/o fixed revisions)

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -20,6 +20,9 @@ applications:
     to:
     - "1"
     constraints: arch=amd64
+    storage:
+      block: loop,100M
+      files: tmpfs,1,100M
 machines:
   "0": {}
   "1": {}

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -17,6 +17,9 @@ applications:
     to:
     - "1"
     constraints: arch=amd64
+    storage:
+      block: loop,100M
+      files: tmpfs,1,100M
 machines:
   "0": {}
   "1": {}


### PR DESCRIPTION
`test-deploy-test-deploy-bundles-aws` was failing for the same reason as #15437. A new revision of the `ubuntu` charm was released which includes filesystem storage. Our CI tests were not prepared for this - currently we try to tear down the model before the storage has been correctly provisioned, leaving things in a borked state. See [lp#2015422](https://bugs.launchpad.net/juju/+bug/2015422) for the underlying issue.

The fix is as in #15437:
- Specify the storage as `tmpfs` (this time inside the bundle).
- Add a `wait_for` to allow the `ubuntu` charm to fully deploy before attempting to destroy the model.

I had to use `yq 'sort_keys(..)'` on the input and output bundles so that the diff would give a fair comparison.

Finally, there was a separate issue tearing down `influxdb`: the PGP key used by the charm is invalid, and so it fails to install the required software. This also blocks model teardown. See [lp#2004303](https://bugs.launchpad.net/influxdb-charm/+bug/2004303).
```
2023-04-11 00:39:02 WARNING unit.influxdb/0.install logger.go:60 W: GPG error: https://repos.influxdata.com/ubuntu xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D8FF8E1F7DF8B07E
2023-04-11 00:39:02 WARNING unit.influxdb/0.install logger.go:60 E: The repository 'https://repos.influxdata.com/ubuntu xenial InRelease' is not signed.
2023-04-11 00:39:02 INFO unit.influxdb/0.juju-log server.go:316 Couldn't acquire DPKG lock. Will retry in 10 seconds
```
Use the workaround suggested in the bug report - set the charm config to use the correct PGP key.

## QA steps

Check the failing subtest is now fixed:
```sh
cd tests
./main.sh -v deploy run_deploy_exported_charmhub_bundle_with_float_revisions
```

and all the bundle tests now pass:
```sh
cd tests
./main.sh -v \
  -s '"test_cmr_bundles_export_overlay,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision,run_deploy_lxd_profile_bundle_openstack,run_deploy_lxd_profile_bundle"' \
  deploy test_deploy_bundles
```