### PR TITLE
[JUJU-3942] Replace ubuntu charm with tiny-bash in integration tests

### DIFF
--- a/tests/suites/deploy/bundles/overlay_bundle.yaml
+++ b/tests/suites/deploy/bundles/overlay_bundle.yaml
@@ -1,10 +1,10 @@
 applications:
-    ubuntu:
-        charm: ubuntu
+    tiny-bash:
+        charm: tiny-bash
         scale: 1
 
 ---
 
 applications:
-    ubuntu:
+    tiny-bash:
         scale: 2

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -12,10 +12,10 @@ applications:
     charm: telegraf
     channel: stable
     revision: 53
-  ubuntu:
-    charm: ubuntu
+  tinybash:
+    charm: tiny-bash
     channel: stable
-    revision: 20
+    revision: 2
     num_units: 1
     to:
     - "1"
@@ -25,6 +25,6 @@ machines:
   "1": {}
 relations:
 - - telegraf:juju-info
-  - ubuntu:juju-info
+  - tinybash:juju-info
 - - telegraf:influxdb-api
   - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -12,22 +12,19 @@ applications:
     charm: telegraf
     channel: stable
     revision: -1
-  ubuntu:
-    charm: ubuntu
+  tinybash:
+    charm: tiny-bash
     channel: stable
     revision: -1
     num_units: 1
     to:
     - "1"
     constraints: arch=amd64
-    storage:
-      block: loop,100M
-      files: tmpfs,1,100M
 machines:
   "0": {}
   "1": {}
 relations:
 - - telegraf:juju-info
-  - ubuntu:juju-info
+  - tinybash:juju-info
 - - telegraf:influxdb-api
   - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -10,21 +10,18 @@ applications:
   telegraf:
     charm: telegraf
     channel: stable
-  ubuntu:
-    charm: ubuntu
+  tinybash:
+    charm: tiny-bash
     channel: stable
     num_units: 1
     to:
     - "1"
     constraints: arch=amd64
-    storage:
-      block: loop,100M
-      files: tmpfs,1,100M
 machines:
   "0": {}
   "1": {}
 relations:
 - - telegraf:juju-info
-  - ubuntu:juju-info
+  - tinybash:juju-info
 - - telegraf:influxdb-api
   - influxdb:query

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -106,11 +106,11 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
-      .applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\"
+      .applications.tinybash.constraints = \"arch=${MODEL_ARCH}\"
     " "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 		yq -i "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
-      .applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\"
+      .applications.tinybash.constraints = \"arch=${MODEL_ARCH}\"
     " "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
 	fi
 
@@ -130,11 +130,11 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	if [[ -n ${MODEL_ARCH:-} ]]; then
 		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
 		telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
-		ubuntu_rev=$(juju info ubuntu --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
+		tinybash_rev=$(juju info tiny-bash --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
 	else
 		influxdb_rev=$(juju info influxdb --format json | jq -r '."channel-map"."latest/stable".revision')
 		telegraf_rev=$(juju info telegraf --format json | jq -r '."channel-map"."latest/stable".revision')
-		ubuntu_rev=$(juju info ubuntu --format json | jq -r '."channel-map"."latest/stable".revision')
+		tinybash_rev=$(juju info tiny-bash --format json | jq -r '."channel-map"."latest/stable".revision')
 	fi
 
 	echo "Make a copy of reference yaml and insert revisions in it"
@@ -142,13 +142,13 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	yq -i "
 		.applications.influxdb.revision = ${influxdb_rev} |
 		.applications.telegraf.revision = ${telegraf_rev} |
-		.applications.ubuntu.revision = ${ubuntu_rev}
+		.applications.tinybash.revision = ${tinybash_rev}
 	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
 	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
 			.applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
-			.applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\" |
+			.applications.tinybash_rev.constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
@@ -163,7 +163,6 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	yq -i 'sort_keys(..)' "${TEST_DIR}/exported_bundle.yaml"
 	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
-	wait_for "ubuntu" "$(idle_condition "ubuntu" 2)"
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }
 


### PR DESCRIPTION
This issue has already been addressed in https://github.com/juju/juju/pull/15453 but is still failing both on jenkins and locally.

The ubuntu charm has been updated and now includes a storage set, which breaks some of our CI tests. Using a charm which is only for testing purposes gives us more control and stability on our CI.

## QA steps

This test should succeed and finish without timeout.

```sh
cd tests
./main.sh -v deploy run_deploy_exported_charmhub_bundle_with_float_revisions
```

