### PR TITLE
Fixes panic with k8s metadata.

### DIFF
--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -172,15 +172,17 @@ func GetClusterMetadata(
 		}
 	}
 
-	if nominatedStorageClass != "" && selectedOperatorSC.Name != nominatedStorageClass {
-		return nil, &environs.NominatedStorageNotFound{
-			StorageName: nominatedStorageClass,
+	if nominatedStorageClass != "" {
+		if selectedOperatorSC == nil || selectedOperatorSC.Name != nominatedStorageClass {
+			return nil, &environs.NominatedStorageNotFound{
+				StorageName: nominatedStorageClass,
+			}
 		}
-	}
 
-	if nominatedStorageClass != "" && selectedWorkloadSC.Name != nominatedStorageClass {
-		return nil, &environs.NominatedStorageNotFound{
-			StorageName: nominatedStorageClass,
+		if selectedOperatorSC == nil || selectedWorkloadSC.Name != nominatedStorageClass {
+			return nil, &environs.NominatedStorageNotFound{
+				StorageName: nominatedStorageClass,
+			}
 		}
 	}
 

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -741,3 +741,24 @@ func (s *K8sMetadataSuite) TestNominatedStorageNotFound(c *gc.C) {
 	c.Assert(errors.As(err, &notFoundError), jc.IsTrue)
 	c.Assert(notFoundError.StorageName, gc.Equals, "my-nominated-storage")
 }
+
+// TestNominatedStorageNotFoundWithNilStorageClasses is a regression test to
+// make sure that when no storage classes are defined and a nominated storage
+// class has been specified a NominatedStorageNotFoundError is returned.
+func (s *K8sMetadataSuite) TestNominatedStorageNotFoundWithNilStorageClasses(c *gc.C) {
+	clientSet := fake.NewSimpleClientset(
+		newNode(map[string]string{}),
+	)
+
+	_, err := provider.GetClusterMetadata(
+		context.TODO(),
+		"my-nominated-storage",
+		clientSet.CoreV1().Nodes(),
+		clientSet.StorageV1().StorageClasses(),
+	)
+
+	var notFoundError *environs.NominatedStorageNotFound
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.As(err, &notFoundError), jc.IsTrue)
+	c.Assert(notFoundError.StorageName, gc.Equals, "my-nominated-storage")
+}


### PR DESCRIPTION
If a nominated storage class is defined for a kubernetes cluster but not storage classes existed in the cluster then a panic would result in the caas Kubernetes code.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the new k8s metadata tests to cover the regression.

## Documentation changes

N/A

## Bug reference

N/A
