### PR TITLE
Typo fixup in k8s metadata test.

### DIFF
--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -179,7 +179,7 @@ func GetClusterMetadata(
 			}
 		}
 
-		if selectedOperatorSC == nil || selectedWorkloadSC.Name != nominatedStorageClass {
+		if selectedWorkloadSC == nil || selectedWorkloadSC.Name != nominatedStorageClass {
 			return nil, &environs.NominatedStorageNotFound{
 				StorageName: nominatedStorageClass,
 			}


### PR DESCRIPTION
Quick fix for a typo in the metadata assertion tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Nil

## Documentation changes

N/A

## Bug reference
N/A
