### PR TITLE
Use `juju-qa-test` in bundle tests

### DIFF
--- a/tests/suites/deploy/bundles/overlay_bundle.yaml
+++ b/tests/suites/deploy/bundles/overlay_bundle.yaml
@@ -1,10 +1,10 @@
 applications:
-    tiny-bash:
-        charm: tiny-bash
+    juju-qa-test:
+        charm: juju-qa-test
         scale: 1
 
 ---
 
 applications:
-    tiny-bash:
+    juju-qa-test:
         scale: 2

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -12,10 +12,12 @@ applications:
     charm: telegraf
     channel: stable
     revision: 53
-  tinybash:
-    charm: tiny-bash
+  juju-qa-test:
+    charm: juju-qa-test
     channel: stable
-    revision: 2
+    revision: 4
+    resources:
+      foo-file: 2
     num_units: 1
     to:
     - "1"
@@ -25,6 +27,6 @@ machines:
   "1": {}
 relations:
 - - telegraf:juju-info
-  - tinybash:juju-info
+  - juju-qa-test:juju-info
 - - telegraf:influxdb-api
   - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -12,10 +12,12 @@ applications:
     charm: telegraf
     channel: stable
     revision: -1
-  tinybash:
-    charm: tiny-bash
-    channel: stable
+  juju-qa-test:
+    charm: juju-qa-test
+    channel: candidate
     revision: -1
+    resources:
+      foo-file: 2
     num_units: 1
     to:
     - "1"
@@ -25,6 +27,6 @@ machines:
   "1": {}
 relations:
 - - telegraf:juju-info
-  - tinybash:juju-info
+  - juju-qa-test:juju-info
 - - telegraf:influxdb-api
   - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -10,10 +10,12 @@ applications:
   telegraf:
     charm: telegraf
     channel: stable
-  tinybash:
-    charm: tiny-bash
-    channel: stable
+  juju-qa-test:
+    charm: juju-qa-test
+    channel: candidate
     num_units: 1
+    resources:
+      foo-file: 2
     to:
     - "1"
     constraints: arch=amd64
@@ -22,6 +24,6 @@ machines:
   "1": {}
 relations:
 - - telegraf:juju-info
-  - tinybash:juju-info
+  - juju-qa-test:juju-info
 - - telegraf:influxdb-api
   - influxdb:query


### PR DESCRIPTION
#15453 and #15460 tried to fix the deploy bundles tests, without success. Unfortunately, the `tiny-bash` charm doesn't support arm64, so we'll switch to the `juju-qa-test` charm which does.

## QA steps

Check the bundles tests now pass.

```sh
cd tests
./main.sh -v \
  -s '"test_cmr_bundles_export_overlay,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision,run_deploy_lxd_profile_bundle_openstack,run_deploy_lxd_profile_bundle"' \
  deploy test_deploy_bundles
```

## TODO

- [x] Test on amd64
- [x] Test on arm64