### PR TITLE
Faster Dqlite HA establishment

### DIFF
--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -38,7 +38,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 
 	mgrExp := s.nodeManager.EXPECT()
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
-	mgrExp.IsExistingNode().Return(false, nil).Times(2)
+	mgrExp.IsExistingNode().Return(false, nil).Times(4)
 	mgrExp.WithAddressOption("10.6.6.6").Return(nil)
 	mgrExp.WithClusterOption([]string{"10.6.6.7"}).Return(nil)
 	mgrExp.WithLogFuncOption().Return(nil)
@@ -46,17 +46,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := make(chan struct{})
-
-	appExp := s.dbApp.EXPECT()
-	appExp.Ready(gomock.Any()).Return(nil)
-	appExp.Client(gomock.Any()).Return(s.client, nil)
-	appExp.ID().DoAndReturn(func() uint64 {
-		close(sync)
-		return uint64(666)
-	})
-	appExp.Handover(gomock.Any()).Return(nil)
-	appExp.Close().Return(nil)
+	sync := s.expectNodeStartupAndShutdown()
 
 	// When we are starting up as a new node,
 	// we request details immediately.
@@ -66,8 +56,39 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
 
-	// Push a message onto the API details channel to simulate a move into HA.
-	// Note that this happens before the node can actually start.
+	// Without a bind address for ourselves we keep waiting.
+	select {
+	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0"},
+			"1": {ID: "1", InternalAddress: "10.6.6.7:1234"},
+		},
+	}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	// Without other cluster members we keep waiting.
+	select {
+	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
+		},
+	}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	// At this point, the Dqlite node is not started.
+	// The worker is waiting for legitimate server detail messages.
+	select {
+	case <-sync:
+		c.Fatal("Dqlite node should not be started yet.")
+	case <-time.After(testing.ShortWait):
+	}
+
+	// Push a message onto the API details channel,
+	// enabling node startup as a cluster member.
 	select {
 	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
@@ -112,17 +133,7 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := make(chan struct{})
-
-	appExp := s.dbApp.EXPECT()
-	appExp.Ready(gomock.Any()).Return(nil)
-	appExp.Client(gomock.Any()).Return(s.client, nil)
-	appExp.ID().DoAndReturn(func() uint64 {
-		close(sync)
-		return uint64(666)
-	})
-	appExp.Handover(gomock.Any()).Return(nil)
-	appExp.Close().Return(nil)
+	sync := s.expectNodeStartupAndShutdown()
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -161,17 +172,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := make(chan struct{})
-
-	appExp := s.dbApp.EXPECT()
-	appExp.Ready(gomock.Any()).Return(nil)
-	appExp.Client(gomock.Any()).Return(s.client, nil)
-	appExp.ID().DoAndReturn(func() uint64 {
-		close(sync)
-		return uint64(666)
-	})
-	appExp.Handover(gomock.Any()).Return(nil)
-	appExp.Close().Return(nil)
+	sync := s.expectNodeStartupAndShutdown()
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -245,17 +246,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := make(chan struct{})
-
-	appExp := s.dbApp.EXPECT()
-	appExp.Ready(gomock.Any()).Return(nil)
-	appExp.Client(gomock.Any()).Return(s.client, nil)
-	appExp.ID().DoAndReturn(func() uint64 {
-		close(sync)
-		return uint64(666)
-	})
-	appExp.Handover(gomock.Any()).Return(nil)
-	appExp.Close().Return(nil)
+	sync := s.expectNodeStartupAndShutdown()
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -293,6 +284,22 @@ func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 	s.nodeManager = NewMockNodeManager(ctrl)
 	return ctrl
+}
+
+func (s *workerSuite) expectNodeStartupAndShutdown() chan struct{} {
+	sync := make(chan struct{})
+
+	appExp := s.dbApp.EXPECT()
+	appExp.Ready(gomock.Any()).Return(nil)
+	appExp.Client(gomock.Any()).Return(s.client, nil)
+	appExp.ID().DoAndReturn(func() uint64 {
+		close(sync)
+		return uint64(666)
+	})
+	appExp.Handover(gomock.Any()).Return(nil)
+	appExp.Close().Return(nil)
+
+	return sync
 }
 
 func (s *workerSuite) newWorker(c *gc.C) worker.Worker {


### PR DESCRIPTION
The db-accessor worker listens via pub/sub for API server detail messages. These are use to:
- Determine a local-cloud address to rebind the original bootstrapped node to.
- Determine other node bind addresses to cluster with.

The first pass of this implementation returned an error when the details were received, but not representative of a cluster established by the peer-grouper, with suitable bind addresses.

Here we do not exit the worker with an error under these conditions, opting instead to simple log and keep waiting for messages with details that are complete enough to establish a cluster.

By keeping the worker live, we should be able to establish a quiesced HA cluster more quickly, as we're not churning the worker and its dependencies.

## QA steps

- Bootstrap to LXD and issue `juju enable-ha`.
- Run `lxc list` to find controller 0, and then connect to it via `lxc exec <container> bash`.
- `watch cat /var/lib/juju/dqlite/cluster.yaml`.
- We will eventually see 3 servers, all with role 0 (voter). It takes some time.

## Documentation changes

None.

## Bug reference

Should mitigate https://bugs.launchpad.net/juju/+bug/2015371.
