### PR TITLE
Add support for no-prompt to login/change-user-password.

### DIFF
--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -70,6 +70,8 @@ type changePasswordCommand struct {
 	User  string
 	Reset bool
 
+	noPrompt bool
+
 	// Internally initialised and used during run
 	controllerName string
 	userTag        names.UserTag
@@ -78,6 +80,7 @@ type changePasswordCommand struct {
 
 func (c *changePasswordCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Reset, "reset", false, "Reset user password")
+	f.BoolVar(&c.noPrompt, "no-prompt", false, "don't prompt for password and just read a line from stdin")
 }
 
 // Info implements Command.Info.
@@ -202,9 +205,23 @@ func (c *changePasswordCommand) resetUserPassword(ctx *cmd.Context) error {
 }
 
 func (c *changePasswordCommand) updateUserPassword(ctx *cmd.Context) error {
-	newPassword, err := readAndConfirmPassword(ctx)
-	if err != nil {
-		return errors.Trace(err)
+	var err error
+	var newPassword string
+	if c.noPrompt {
+		fmt.Fprintln(ctx.Stderr, "reading password from stdin...")
+		newPassword, err = readLine(ctx.Stdin)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		newPassword, err = readAndConfirmPassword(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	if newPassword == "" {
+		return errors.Errorf("password cannot be empty")
 	}
 
 	if err := c.api.SetPassword(c.userTag.Id(), newPassword); err != nil {

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -33,7 +33,7 @@ func (s *ChangePasswordCommandSuite) SetUpTest(c *gc.C) {
 	s.store = s.BaseSuite.store
 }
 
-func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, *juju.NewAPIConnectionParams, error) {
+func (s *ChangePasswordCommandSuite) run(c *gc.C, stdin string, args ...string) (*cmd.Context, *juju.NewAPIConnectionParams, error) {
 	var argsOut juju.NewAPIConnectionParams
 	newAPIConnection := func(args juju.NewAPIConnectionParams) (api.Connection, error) {
 		argsOut = args
@@ -43,7 +43,7 @@ func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context,
 		newAPIConnection, s.mockAPI, s.store,
 	)
 	ctx := cmdtesting.Context(c)
-	ctx.Stdin = strings.NewReader("sekrit\nsekrit\n")
+	ctx.Stdin = strings.NewReader(stdin)
 	err := cmdtesting.InitCommand(changePasswordCommand, args)
 	if err != nil {
 		return ctx, nil, err
@@ -91,7 +91,7 @@ func (s *ChangePasswordCommandSuite) assertAPICalls(c *gc.C, user, pass string) 
 }
 
 func (s *ChangePasswordCommandSuite) TestChangePassword(c *gc.C) {
-	context, args, err := s.run(c)
+	context, args, err := s.run(c, "sekrit\nsekrit\n")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAPICalls(c, "current-user", "sekrit")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
@@ -106,9 +106,24 @@ Your password has been changed.
 	})
 }
 
+func (s *ChangePasswordCommandSuite) TestChangePasswordNoPrompt(c *gc.C) {
+	context, args, err := s.run(c, "sneaky-password\n", "--no-prompt")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertAPICalls(c, "current-user", "sneaky-password")
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, `
+reading password from stdin...
+Your password has been changed.
+`[1:])
+	// The command should have logged in without a password to get a macaroon.
+	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+		User: "current-user",
+	})
+}
+
 func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New("failed to do something"))
-	_, _, err := s.run(c)
+	_, _, err := s.run(c, "sekrit\nsekrit\n")
 	c.Assert(err, gc.ErrorMatches, "failed to do something")
 	s.assertAPICalls(c, "current-user", "sekrit")
 }
@@ -116,24 +131,24 @@ func (s *ChangePasswordCommandSuite) TestChangePasswordFail(c *gc.C) {
 func (s *ChangePasswordCommandSuite) TestChangeOthersPassword(c *gc.C) {
 	// The checks for user existence and admin rights are tested
 	// at the apiserver level.
-	_, _, err := s.run(c, "other")
+	_, _, err := s.run(c, "sekrit\nsekrit\n", "other")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAPICalls(c, "other", "sekrit")
 }
 
 func (s *ChangePasswordCommandSuite) TestResetSelfPasswordFail(c *gc.C) {
-	context, _, err := s.run(c, "--reset")
+	context, _, err := s.run(c, "", "--reset")
 	s.assertResetSelfPasswordFail(c, context, err)
 }
 
 func (s *ChangePasswordCommandSuite) TestResetSelfPasswordSpecifyYourselfFail(c *gc.C) {
-	context, _, err := s.run(c, "--reset", "current-user")
+	context, _, err := s.run(c, "", "--reset", "current-user")
 	s.assertResetSelfPasswordFail(c, context, err)
 }
 
 func (s *ChangePasswordCommandSuite) TestResetPasswordFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New("failed to do something"))
-	context, _, err := s.run(c, "--reset", "other")
+	context, _, err := s.run(c, "", "--reset", "other")
 	c.Assert(err, gc.ErrorMatches, "failed to do something")
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
@@ -149,7 +164,7 @@ func (s *ChangePasswordCommandSuite) TestResetOthersPassword(c *gc.C) {
 	// The checks for user existence and admin rights are tested
 	// at the apiserver level.
 	s.mockAPI.key = []byte("no cats or dragons")
-	context, _, err := s.run(c, "other", "--reset")
+	context, _, err := s.run(c, "", "other", "--reset")
 	c.Assert(err, jc.ErrorIsNil)
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},
@@ -165,7 +180,7 @@ Ask the user to run:
 
 func (s *ChangePasswordCommandSuite) TestResetPasswordOldAPI(c *gc.C) {
 	s.mockAPI.version = 1
-	context, _, err := s.run(c, "--reset", "other")
+	context, _, err := s.run(c, "", "--reset", "other")
 	c.Assert(err, gc.ErrorMatches, "on this juju controller, reset password not supported")
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"BestAPIVersion", nil},

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -11,13 +11,24 @@ run_user_change_password() {
 	juju add-user test-change-password-user
 
 	echo "Change test-change-password-user password"
-	expect_that "juju change-user-password test-change-password-user" "
-expect \"new password: \" { send \"test-password\r\" }
-expect \"type new password again: \" { send \"test-password\r\"; puts \"Pass\" }
-" | check "Pass"
+	echo "test-password" | juju change-user-password test-change-password-user --no-prompt
+
+	echo "Change admin password"
+	echo "admin-password" | juju change-user-password admin --no-prompt
+
+	echo "Logout"
+	juju logout
+
+	echo "Login as test-change-password-user"
+	echo "test-password" | juju login --user test-change-password-user --no-prompt
+
+	echo "Logout"
+	juju logout
+
+	echo "Login as admin"
+	echo "admin-password" | juju login --user admin --no-prompt
 
 	destroy_model "user-change-password"
-
 }
 
 test_user_login_password() {


### PR DESCRIPTION
To make scripting easier for `login` and `change-user-password`, this introduces
a `--no-prompt` parameter to these commands. `login` also has a `--trust` for
trusting the controller's CA certificate when combined with `--no-prompt`.

With `--no-prompt` only the password can be read from stdin (newline expected), nothing else can be
read from stdin.

## QA steps

- `./main.sh -v -s '"test_user_manage"' user test_user_login_password`
- Also check you can still use the interactive flow.

## Documentation changes

Command documentation needs to be regenerated.

## Bug reference

N/A