### PR TITLE
Fix use of `juju info` in suites, channel-map is now channels.

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -130,13 +130,13 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
 	if [[ -n ${MODEL_ARCH:-} ]]; then
-		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
-		telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/stable".revision')
-		juju_qa_test_rev=$(juju info juju-qa-test --arch="${MODEL_ARCH}" --format json | jq -r '."channel-map"."latest/candidate".revision')
+		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
+		telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
+		juju_qa_test_rev=$(juju info juju-qa-test --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."candidate"[0].revision')
 	else
-		influxdb_rev=$(juju info influxdb --format json | jq -r '."channel-map"."latest/stable".revision')
-		telegraf_rev=$(juju info telegraf --format json | jq -r '."channel-map"."latest/stable".revision')
-		juju_qa_test_rev=$(juju info juju-qa-test --format json | jq -r '."channel-map"."latest/candidate".revision')
+		influxdb_rev=$(juju info influxdb --format json | jq -r '."channels"."latest"."stable"[0].revision')
+		telegraf_rev=$(juju info telegraf --format json | jq -r '."channels"."latest"."stable"[0].revision')
+		juju_qa_test_rev=$(juju info juju-qa-test --format json | jq -r '."channels"."latest"."candidate"[0].revision')
 	fi
 
 	echo "Make a copy of reference yaml and insert revisions in it"


### PR DESCRIPTION
`juju info` no longer has a `channel-map` field since 3.0, the bundle suite needs to adapt to this change.

## QA steps

Run test suite.

## Documentation changes

N/A

## Bug reference

[failed test run](https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/1753/consoleText)