### PR TITLE
[JUJU-3524] Update dqlite dep

### DIFF
--- a/database/dqlite/dqlite_linux.go
+++ b/database/dqlite/dqlite_linux.go
@@ -7,6 +7,11 @@ package dqlite
 
 import "github.com/canonical/go-dqlite"
 
+const (
+	// Enabled is true if dqlite is enabled.
+	Enabled = true
+)
+
 // NodeInfo holds information about a single server.
 type NodeInfo = dqlite.NodeInfo
 

--- a/database/dqlite/dqlite_other.go
+++ b/database/dqlite/dqlite_other.go
@@ -5,10 +5,12 @@
 
 package dqlite
 
+type NodeRole int
+
 type NodeInfo struct {
-	ID      uint64
-	Address string
-	Role    int
+	ID      uint64   `yaml:"ID"`
+	Address string   `yaml:"Address"`
+	Role    NodeRole `yaml:"Role"`
 }
 
 func ReconfigureMembership(string, []NodeInfo) error {

--- a/database/dqlite/dqlite_other.go
+++ b/database/dqlite/dqlite_other.go
@@ -5,6 +5,11 @@
 
 package dqlite
 
+const (
+	// Enabled is false if dqlite is disabled.
+	Enabled = false
+)
+
 type NodeRole int
 
 type NodeInfo struct {

--- a/database/node.go
+++ b/database/node.go
@@ -14,13 +14,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	// Note that this is a deliberate use of the same YAML dependency
-	// as go-dqlite. It preserves files as written by that library,
-	// whereas gopkg.in/yaml.v3 does not.
-	"github.com/ghodss/yaml"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/yaml.v3"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/database/app"

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -30,6 +30,14 @@ type nodeManagerSuite struct {
 
 var _ = gc.Suite(&nodeManagerSuite{})
 
+func (s *nodeManagerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	if !dqlite.Enabled {
+		c.Skip("This requires a dqlite server to be running")
+	}
+}
+
 func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *gc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
@@ -184,11 +185,10 @@ func (s *nodeManagerSuite) TestSetClusterServersSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// cluster.yaml should reflect the new server list.
-	c.Check(string(data), gc.Equals, `
-- Address: 10.6.6.6:17666
-  ID: 3297041220608546238
-  Role: 0
-`[1:])
+	var result []dqlite.NodeInfo
+	err = yaml.Unmarshal(data, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, servers)
 }
 
 func (s *nodeManagerSuite) TestSetNodeInfoSuccess(c *gc.C) {
@@ -226,11 +226,10 @@ Role: 0
 	c.Assert(err, jc.ErrorIsNil)
 
 	// info.yaml should reflect the new node info.
-	c.Check(string(data), gc.Equals, `
-Address: 10.6.6.6:17666
-ID: 3297041220608546238
-Role: 0
-`[1:])
+	var result dqlite.NodeInfo
+	err = yaml.Unmarshal(data, &result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, server)
 }
 
 func (s *nodeManagerSuite) TestWithAddressOptionSuccess(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.3
 	github.com/aws/smithy-go v1.13.5
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/go-dqlite v1.11.7
+	github.com/canonical/go-dqlite v1.11.9
 	github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
 	github.com/go-logr/logr v1.2.2
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -431,7 +431,6 @@ github.com/gdamore/tcell/v2 v2.5.1 h1:zc3LPdpK184lBW7syF2a5C6MV827KmErk9jGVnmsl/
 github.com/gdamore/tcell/v2 v2.5.1/go.mod h1:wSkrPaXoiIWZqW/g7Px4xc79di6FTcpB8tvaKJ6uGBo=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/canonical/go-dqlite v1.11.7 h1:eS+jif6HJ4HzKatQePvQggZI6xQukzg94zC9qLiGVgA=
-github.com/canonical/go-dqlite v1.11.7/go.mod h1:Dwp/03G1r4dtc+QSB9tV84RAAS7Mc6gy7tEvzCgcuQ8=
+github.com/canonical/go-dqlite v1.11.9 h1:aO7GG3QohddXsT+C7yEetdRHhhPUWNBKavz+/JabB90=
+github.com/canonical/go-dqlite v1.11.9/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7 h1:/L2OgTX7McauPmggZfYNWEu6D/QiPHcNDQ60grftM04=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7/go.mod h1:j3uyWpPkuWf8u0kB2v7n/XGVpYIg4luGetpSngCvzac=
 github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 h1:bey1JgA3D2EBabr2a7kWKj+JlEPxX1akv8rcRromotA=


### PR DESCRIPTION
The following updates the go-dqlite dependency independantly from another PR as there are some required changes because of this update.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Test pass in the following package: 

```sh
$ go test -v ./database -check.v
```

Additionally a quick smoke test:

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```
