### PR TITLE
[JUJU-3528] Fix db-accessor worker tests

### DIFF
--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -89,20 +89,12 @@ func (s *baseSuite) expectTimer(ticks int) <-chan struct{} {
 	return s.expectTick(ch, ticks)
 }
 
-func (s *baseSuite) expectTrackedDB(c *gc.C) chan struct{} {
-	done := make(chan struct{})
-
+// expectTrackedDBKill accommodates termination of the TrackedDB.
+// the expectations are soft, because the worker may not have called the
+// NewDBWorker function before it is killed.
+func (s *baseSuite) expectTrackedDBKill() {
 	s.trackedDB.EXPECT().Kill().AnyTimes()
-	s.trackedDB.EXPECT().Wait().DoAndReturn(func() error {
-		select {
-		case <-done:
-		case <-time.After(jujutesting.LongWait):
-			c.Fatal("timed out waiting for Wait to be called")
-		}
-		return nil
-	})
-
-	return done
+	s.trackedDB.EXPECT().Wait().Return(nil).AnyTimes()
 }
 
 type dbBaseSuite struct {

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -33,8 +33,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectClock()
-
-	done := s.expectTrackedDB(c)
+	s.expectTrackedDBKill()
 
 	mgrExp := s.nodeManager.EXPECT()
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
@@ -106,9 +105,6 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 		c.Fatal("timed out waiting for Dqlite node start")
 	}
 
-	// Close the wait on the tracked DB
-	close(done)
-
 	workertest.CleanKill(c, w)
 }
 
@@ -117,8 +113,7 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectClock()
-
-	done := s.expectTrackedDB(c)
+	s.expectTrackedDBKill()
 
 	mgrExp := s.nodeManager.EXPECT()
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
@@ -146,9 +141,6 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 		c.Fatal("timed out waiting for Dqlite node start")
 	}
 
-	// Close the wait on the tracked DB.
-	close(done)
-
 	workertest.CleanKill(c, w)
 }
 
@@ -157,8 +149,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 
 	s.expectAnyLogs()
 	s.expectClock()
-
-	done := s.expectTrackedDB(c)
+	s.expectTrackedDBKill()
 
 	dataDir := c.MkDir()
 	mgrExp := s.nodeManager.EXPECT()
@@ -212,9 +203,6 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 		c.Fatal("timed out waiting for cluster change to be processed")
 	}
 
-	// Close the wait on the tracked DB.
-	close(done)
-
 	workertest.CleanKill(c, w)
 }
 
@@ -223,8 +211,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectClock()
-
-	done := s.expectTrackedDB(c)
+	s.expectTrackedDBKill()
 
 	dataDir := c.MkDir()
 	mgrExp := s.nodeManager.EXPECT()
@@ -286,9 +273,6 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out waiting for cluster change to be processed")
 	}
-
-	// Close the wait on the tracked DB.
-	close(done)
 
 	err := workertest.CheckKilled(c, w)
 	c.Assert(errors.Is(err, dependency.ErrBounce), jc.IsTrue)


### PR DESCRIPTION
There is a tricky race possible in the `db-accessor` worker because in `openDatabase` the function that is passed to `StartWorker` is not invoked synchronously.

Under #15450 a change to lock+check the `dbApp` was made to appease the race checker, but there is still a race that can occur in tests where we `CleanKill` the worker, but get an error because the tracker worker start function returns one for a nil `dbApp`.

The solution here is to return `tomb.ErrDying`, which prevents us exiting with an error when we have killed the parent worker with `nil`.

Some other superfluous test composition is also tidied up.

## QA steps

Execute `make run-go-tests TEST_ARGS=-race TEST_PACKAGES=./worker/dbaccessor` in a loop.
