### PR TITLE
[JUJU-3488] Dynamically configure expected interfaces for spaces_ec2

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -9,19 +9,24 @@ run_juju_bind() {
 	juju reload-spaces
 	juju add-space isolated 172.31.254.0/24
 
+	# Create machine
 	# Note that due to the way that run_* funcs are executed, $1 holds the
 	# test name so the NIC ID is actually provided in $2
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	primary_iface=$(echo $ifaces | cut -d " " -f1)
+	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
+	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"
 
 	# Deploy test charm to dual-nic machine
 	juju deploy cs:~juju-qa/space-defender-3 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --series focal
 	unit_index=$(get_unit_index "space-defender")
 	wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens6"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "${primary_iface}"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "${hotplug_iface}"
 
 	assert_endpoint_binding_matches "space-defender" "" "alpha"
 	assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
@@ -32,8 +37,8 @@ run_juju_bind() {
 
 	# After the upgrade, defend-a should remain attached to ens5 but
 	# defend-b which has now been bound to alpha should also get ens5
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens5"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "${primary_iface}"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "${primary_iface}"
 
 	assert_endpoint_binding_matches "space-defender" "" "alpha"
 	assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -15,14 +15,18 @@ run_upgrade_charm_with_bind() {
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	primary_iface=$(echo $ifaces | cut -d " " -f1)
+	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
+	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"
 
 	# Deploy test charm to dual-nic machine
 	juju deploy cs:~juju-qa/space-defender-2 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --series focal
 	unit_index=$(get_unit_index "space-defender")
 	wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens6"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "${primary_iface}"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "${hotplug_iface}"
 
 	assert_endpoint_binding_matches "space-defender" "" "alpha"
 	assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
@@ -34,8 +38,8 @@ run_upgrade_charm_with_bind() {
 
 	# After the upgrade, defend-a should remain attached to ens5 but
 	# defend-b which has now been bound to alpha should also get ens5
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
-	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens5"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "${primary_iface}"
+	assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "${primary_iface}"
 
 	assert_endpoint_binding_matches "space-defender" "" "alpha"
 	assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -2,11 +2,8 @@
 #
 # Create a new machine, wait for it to boot and hotplug a pre-allocated
 # network interface which has been tagged: "nic-type: hotpluggable".
-#
-# Then, patch the netplan settings for the new interface, apply the new plan,
-# restart the machine agent and wait for juju to detect the new interface
-# before returning.
 add_multi_nic_machine() {
+	local hotplug_nic_id
 	hotplug_nic_id=$1
 
 	# Ensure machine is deployed to the same az as our nic
@@ -23,13 +20,26 @@ add_multi_nic_machine() {
 	aws ec2 attach-network-interface --device-index 1 \
 		--network-interface-id ${hotplug_nic_id} \
 		--instance-id $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${juju_machine_id}\"] | .[\"instance-id\"]")
+}
+
+# configure_multi_mic_netplan()
+#
+# Patch the netplan settings for the new interface, apply the new plan,
+# restart the machine agent and wait for juju to detect the new interface
+# before returning.
+configure_multi_nic_netplan() {
+	local juju_machine_id hotplug_iface
+	juju_machine_id=$1
+	hotplug_iface=$2
 
 	# Add an entry to netplan and apply it so the second interface comes online
 	echo "[+] updating netplan and restarting machine agent"
 	# shellcheck disable=SC2086,SC2016
 	juju ssh ${juju_machine_id} 'sudo sh -c "sed -i \"/version:/d\" /etc/netplan/50-cloud-init.yaml"'
 	# shellcheck disable=SC2086,SC2016
-	juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n    version: 2\n\" >> /etc/netplan/50-cloud-init.yaml"'
+	default_route=$(juju ssh ${juju_machine_id} 'ip route | grep default | cut -d " " -f3')
+	# shellcheck disable=SC2086,SC2016
+	juju ssh ${juju_machine_id} "sudo sh -c 'echo \"            gateway4: ${default_route}\n        ${hotplug_iface}:\n            dhcp4: true\n    version: 2\n\" >> /etc/netplan/50-cloud-init.yaml'"
 	# shellcheck disable=SC2086,SC2016
 	echo "[+] Reconfiguring netplan:"
 	juju ssh ${juju_machine_id} 'sudo cat /etc/netplan/50-cloud-init.yaml'


### PR DESCRIPTION
Most of the time they're constant, ens5 primary and ens6 hotplugged, but this is not always the case. This was causing occasional failures. Fix this by using ip to figure out which interfaces we should use instead of hard coding them

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -R eu-west-2 spaces_ec2 test_upgrade_charm_with_bind
./main.sh -v -c aws -R eu-west-2 spaces_ec2 test_juju_bind
```

Should both pass