### PR TITLE
Add juju- to aks test resource group name for easy cleanup.

### DIFF
--- a/tests/suites/deploy_aks/task.sh
+++ b/tests/suites/deploy_aks/task.sh
@@ -11,7 +11,7 @@ test_deploy_aks() {
 
 	# TODO(anvial): we need to add separate provider for such tests (for example, "aks") and move all this code to
 	# create/delete to code from here.
-	resource_group_name="test-aks-resource-group-$(rnd_str)"
+	resource_group_name="juju-test-aks-resource-group-$(rnd_str)"
 	az group create -l eastus -n "${resource_group_name}"
 	az aks create -g "${resource_group_name}" -n aks-cluster --generate-ssh-keys
 	juju add-k8s --aks --client --resource-group "${resource_group_name}" --storage test-aks-storage --cluster-name aks-cluster aks-k8s-cloud


### PR DESCRIPTION
Prefix the resource group in azure with `juju-` so that cleanup scripts can identify and delete left over resources cleanly.

## QA steps

- run test suite and check the name of the resource group created in azure.

## Documentation changes

N/A

## Bug reference

N/A