### PR TITLE
[JUJU-3549] More error info in interactive add-cloud

### DIFF
--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -177,17 +177,12 @@ func (p *environProvider) Ping(ctx context.ProviderCallContext, endpoint string)
 		return errors.Trace(err)
 	}
 
-	// Make sure we have an https url
-	if lxdEndpoint != endpoint {
-		return errors.Errorf("invalid URL %q: only HTTPS is supported", endpoint)
-	}
-
 	// Connect to the remote server anonymously so we can just verify it exists
 	// as we're not sure that the certificates are loaded in time for when the
 	// ping occurs i.e. interactive add-cloud
 	_, err = lxd.ConnectRemote(lxd.NewInsecureServerSpec(lxdEndpoint))
 	if err != nil {
-		return errors.Errorf("no lxd server running at %s", lxdEndpoint)
+		return errors.Annotatef(err, "no lxd server running at %s", lxdEndpoint)
 	}
 	return nil
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -5,9 +5,11 @@ package lxd_test
 
 import (
 	stdcontext "context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strings"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
@@ -513,7 +515,9 @@ func (s *providerSuite) TestPingFailWithNoEndpoint(c *gc.C) {
 	p, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
-	c.Assert(err, gc.ErrorMatches, "no lxd server running at "+server.URL)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		"no lxd server running at %[1]s: Failed to fetch %[1]s/1.0: 404 Not Found",
+		server.URL))
 }
 
 func (s *providerSuite) TestPingFailWithHTTP(c *gc.C) {
@@ -523,7 +527,10 @@ func (s *providerSuite) TestPingFailWithHTTP(c *gc.C) {
 	p, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
-	c.Assert(err, gc.ErrorMatches, "invalid URL \""+server.URL+"\": only HTTPS is supported")
+	httpsURL := "https://" + strings.TrimPrefix(server.URL, "http://")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		`no lxd server running at %[1]s: Get "%[1]s/1.0": http: server gave HTTP response to HTTPS client`,
+		httpsURL))
 }
 
 type ProviderFunctionalSuite struct {

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -79,15 +79,16 @@ func (p MaasEnvironProvider) CloudSchema() *jsonschema.Schema {
 
 // Ping tests the connection to the cloud, to verify the endpoint is valid.
 func (p MaasEnvironProvider) Ping(ctx context.ProviderCallContext, endpoint string) error {
+	var err error
 	base, version, includesVersion := gomaasapi.SplitVersionedURL(endpoint)
 	if includesVersion {
-		err := p.checkMaas(base, version)
+		err = p.checkMaas(base, version)
 		if err == nil {
 			return nil
 		}
 	} else {
 		// No version info in the endpoint - try both in preference order.
-		err := p.checkMaas(endpoint, apiVersion2)
+		err = p.checkMaas(endpoint, apiVersion2)
 		if err == nil {
 			return nil
 		}
@@ -96,7 +97,7 @@ func (p MaasEnvironProvider) Ping(ctx context.ProviderCallContext, endpoint stri
 			return nil
 		}
 	}
-	return errors.Errorf("No MAAS server running at %s", endpoint)
+	return errors.Annotatef(err, "No MAAS server running at %s", endpoint)
 }
 
 func (p MaasEnvironProvider) checkMaas(endpoint, ver string) error {

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -218,7 +218,7 @@ func (s *MaasPingSuite) TestPingNoEndpoint(c *gc.C) {
 			return nil, errors.New("nope")
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "No MAAS server running at "+endpoint)
+	c.Assert(err, gc.ErrorMatches, "No MAAS server running at "+endpoint+": nope")
 	c.Assert(serverURLs, gc.DeepEquals, []string{
 		"https://foo.com/MAAS/api/2.0/",
 		"https://foo.com/MAAS/api/1.0/",
@@ -267,7 +267,7 @@ func (s *MaasPingSuite) TestPingVersionURLBad(c *gc.C) {
 			return nil, errors.New("nope")
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "No MAAS server running at "+endpoint)
+	c.Assert(err, gc.ErrorMatches, "No MAAS server running at "+endpoint+": nope")
 	c.Assert(serverURLs, gc.DeepEquals, []string{
 		"https://foo.com/MAAS/api/10.1/",
 	})

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -262,7 +262,7 @@ func (p EnvironProvider) Ping(ctx context.ProviderCallContext, endpoint string) 
 	c := p.ClientFromEndpoint(endpoint)
 	if _, err := c.IdentityAuthOptions(); err != nil {
 		handleCredentialError(err, ctx)
-		return errors.Wrap(err, errors.Errorf("No Openstack server running at %s", endpoint))
+		return errors.Annotatef(err, "No Openstack server running at %s", endpoint)
 	}
 	return nil
 }

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -521,10 +521,7 @@ func (localTests) TestPingInvalidHost(c *gc.C) {
 			c.Errorf("ping %q: expected error, but got nil.", t)
 			continue
 		}
-		expected := "No Openstack server running at " + t
-		if err.Error() != expected {
-			c.Errorf("ping %q: expected %q got %v", t, expected, err)
-		}
+		c.Check(err, gc.ErrorMatches, "(?m)No Openstack server running at "+t+".*")
 	}
 }
 func (localTests) TestPingNoEndpoint(c *gc.C) {
@@ -533,7 +530,7 @@ func (localTests) TestPingNoEndpoint(c *gc.C) {
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
-	c.Assert(err, gc.ErrorMatches, "No Openstack server running at "+server.URL)
+	c.Assert(err, gc.ErrorMatches, "(?m)No Openstack server running at "+server.URL+".*")
 }
 
 func (localTests) TestPingInvalidResponse(c *gc.C) {
@@ -544,7 +541,7 @@ func (localTests) TestPingInvalidResponse(c *gc.C) {
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
-	c.Assert(err, gc.ErrorMatches, "No Openstack server running at "+server.URL)
+	c.Assert(err, gc.ErrorMatches, "(?m)No Openstack server running at "+server.URL+".*")
 }
 
 func (localTests) TestPingOKCACertificate(c *gc.C) {


### PR DESCRIPTION
The interactive add-cloud is painful because it will often reject the endpoint URL without giving any reason why. See https://bugs.launchpad.net/juju/+bug/1908630
```
Enter the API endpoint url for the cloud []: 172.31.47.119
Can't validate endpoint: No Openstack server running at 172.31.47.119

Enter the API endpoint url for the cloud []: http://172.31.47.119/
Can't validate endpoint: No Openstack server running at http://172.31.47.119/

Enter the API endpoint url for the cloud []: http://172.31.47.119/identity/v3
Can't validate endpoint: No Openstack server running at http://172.31.47.119/identity/v3

Enter the API endpoint url for the cloud []: 172.31.47.119/identity
Can't validate endpoint: No Openstack server running at 172.31.47.119/identity

Enter the API endpoint url for the cloud []: http://172.31.47.119/identity
Can't validate endpoint: No Openstack server running at http://172.31.47.119/identity
```

In the Openstack provider's `Ping` method, at least pass on the error information to the user, to make it a little less painful.
```
Enter the API endpoint url for the cloud []: 172.31.47.119
Can't validate endpoint: No Openstack server running at 172.31.47.119: auth options fetching failed
caused by: request available auth options: failed executing the request /
caused by: Get "/": unsupported protocol scheme ""

Enter the API endpoint url for the cloud []: http://172.31.47.119
Can't validate endpoint: No Openstack server running at http://172.31.47.119: auth options fetching failed
caused by: request available auth options: failed executing the request http://172.31.47.119/
caused by: Get "http://172.31.47.119/": dial tcp 172.31.47.119:80: connect: no route to host
```

Do the same with the MAAS and LXD providers.

Also, fix a silly check in the LXD provider's `Ping` method that was rejecting perfectly good URLs. We're already using `lxd.EnsureHostPort(endpoint)` to fill in the scheme/port if not provided, but we were checking the returned value equals the input (and returning an unhelpful error if not). Remove this check.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run `juju add-cloud` interactively, and provide a bogus URL.