### PR TITLE
[JUJU-3539] Fix intermittent failure in TrackedDB tests

### DIFF
--- a/database/testing/fullsuite.go
+++ b/database/testing/fullsuite.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/juju/testing"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/database/testing/simplesuite.go
+++ b/database/testing/simplesuite.go
@@ -62,7 +62,7 @@ func (s *ControllerSuite) TrackedDB() coredatabase.TrackedDB {
 	return s.trackedDB
 }
 
-// NewDB returns a new sql.DB reference.
+// NewCleanDB returns a new sql.DB reference.
 func (s *ControllerSuite) NewCleanDB(c *gc.C) *sql.DB {
 	dir := c.MkDir()
 


### PR DESCRIPTION
`TestWorkerAttemptsToVerifyDBButSucceedsWithDifferentDB` composes a synchronisation point in the DB verification function passed to the `TrackedDB` worker.

The database returned by that function is not atomically used to replace the worker's reference, so we may race with a call for the worker to execute a transaction.

Here we just loop for a very short duration, waiting for the desired test state. Comments accompanying the change detail why this is acceptable for verifying the specific case.

## QA steps

Run `make run-go-tests TEST_ARGS=-race TEST_PACKAGES=./worker/dbaccessor` in a loop.
