### PR TITLE
[JUJU-3456] Fix returned error when yaml is invalid on diff-bundle

### DIFF
--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -279,9 +279,9 @@ func missingRelationEndpoint(rel string) bool {
 func (c *diffBundleCommand) bundleDataSource(ctx *cmd.Context, apiRoot base.APICallCloser) (charm.BundleDataSource, error) {
 	ds, err := charm.LocalBundleDataSource(c.bundle)
 
-	// NotValid/NotFound means we should try interpreting it as a charm store
-	// bundle URL.
-	if err != nil && !errors.IsNotValid(err) && !errors.IsNotFound(err) {
+	// NotFound means that the provided local file is not found, and
+	// therefore we should try interpreting it as a charm store bundle URL.
+	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}
 	if ds != nil {

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -136,6 +136,12 @@ machines:
 `[1:])
 }
 
+func (s *diffSuite) TestLocalBundleInvalidYaml(c *gc.C) {
+	_, err := s.runDiffBundle(c, s.writeLocalBundle(c, invalidYaml))
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err, gc.ErrorMatches, `.*cannot unmarshal bundle contents.*`[1:])
+}
+
 func (s *diffSuite) TestIncludeAnnotations(c *gc.C) {
 	ctx, err := s.runDiffBundle(c, "--annotations", s.writeLocalBundle(c, testCharmStoreBundle))
 	c.Assert(err, jc.ErrorIsNil)
@@ -757,6 +763,13 @@ machines:
 	invalidBundle = `
 machines:
   0:
+`
+	invalidYaml = `
+applications:
+  prometheus:
+    options:
+      admin-user: lovecraft
+va
 `
 	overlay1 = `
 applications:


### PR DESCRIPTION
When dealing with invalid yaml in local bundle, the error was treated as if the file was not present, therefore continuing to treat the input as a charm bundle url. 

This patch fixes the returned error if it's a NotValid error.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Having an empty juju model and this test.yaml bundle:
```yaml
series: focal
applications:
  ubuntu:
    charm: ubuntu
    channel: stable
    revision: 21
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
va
machines:
  "0":
    constraints: arch=amd64
```
then you should get this error:
```sh
$ juju diff-bundle test.yaml
ERROR cannot unmarshal bundle contents: unmarshal document 0: yaml: line 12: could not find expected ':'
```
if you remove line 12 then:
```sh
$ juju diff-bundle test.yaml
applications:
  ubuntu:
    missing: model
machines:
  "0":
    missing: model
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/2015315
