### PR TITLE
[JUJU-3554] Retry debug log

### DIFF
--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -116,6 +116,9 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 				Backlog: 10,
 				Limit:   100,
 			},
+		}, {
+			args:     []string{"--retry-delay", "-1s"},
+			errMatch: `negative retry delay not valid`,
 		},
 	} {
 		c.Logf("test %v", i)


### PR DESCRIPTION
When the controller agent restarts the connection via the API server is cut. This becomes inconvenient when debugging, as you now have to change your current context to restart the debug-log. Instead the juju debug-log should do this automatically. Or at least allow you to force a retry.

The following PR just retries the API client request if there is a specific failure. Retrying is opt-in at the moment, if we find it really useful, we can have it opt-out. For backwards compatibility we always unwrap any error from the retry.Call function, so that we only ever show the underlying error and not the retry one.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Multiple terminals are required for this.

#### debug-log should reconnect:

Term 0:

```sh
$ juju debug-log -m controller --retry
```

Term 1:

```sh
$ juju controller-config query-tracing-enabled=true
```

The unit agent should restart, but the debug-log should still stay connected and catch up once everything is back up.

#### debug-log should disconnect correctly without retrying

Term 0:

```sh
$ juju debug-log -m controller --retry
```

Term 1:

```sh
$ juju controller-config query-tracing-enabled=false
```

 