### PR TITLE
[JUJU-3568] Add podspec deprecation warning to CLI

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -859,6 +859,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	if err != nil {
 		return errors.Trace(err)
 	}
+	checkPodspec(charmInfo.Charm(), h.ctx)
 
 	resMap := h.makeResourceMap(charmInfo.Meta.Resources, p.Resources, p.LocalResources)
 

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -70,6 +70,7 @@ func (d *deployCharm) deploy(
 	if err != nil {
 		return err
 	}
+	checkPodspec(charmInfo.Charm(), ctx)
 
 	// storage cannot be added to a container.
 	if len(d.storage) > 0 || len(d.attachStorage) > 0 {
@@ -275,6 +276,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 	ctx.Infof(formatLocatedText(d.userCharmURL, commoncharm.Origin{}))
+	checkPodspec(charmInfo.Charm(), ctx)
 
 	if err := d.validateResourcesNeededForLocalDeploy(charmInfo.Meta); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/charm/v10"
 	charmresource "github.com/juju/charm/v10/resource"
 	jujuclock "github.com/juju/clock"
+	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -775,4 +776,14 @@ func CharmOnlyFlags() []string {
 	}
 
 	return charmOnlyFlags
+}
+
+// checkPodspec checks if the given charm is a podspec charm, and if so, prints
+// a deprecation warning.
+func checkPodspec(cm charm.CharmMeta, ctx *cmd.Context) bool {
+	isPodspec := corecharm.IsKubernetes(cm) && charm.MetaFormat(cm) == charm.FormatV1
+	if isPodspec {
+		ctx.Warningf("deploying podspec charm %q: podspec charms are deprecated. Support for them will be removed soon.", cm.Meta().Name)
+	}
+	return isPodspec
 }

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/resources"
 	commoncharm "github.com/juju/juju/api/common/charm"
+	"github.com/juju/juju/api/common/charms"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
@@ -396,6 +397,39 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 
 	_, err := f.GetDeployer(DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *deployerSuite) TestCheckPodspec(c *gc.C) {
+	tests := []struct {
+		charm     charms.CharmInfo
+		isPodspec bool
+	}{{
+		// redis-k8s
+		charm: charms.CharmInfo{
+			Meta: &charm.Meta{
+				Name: "redis-k8s",
+				Series: []string{
+					"kubernetes",
+				},
+			},
+		},
+		isPodspec: true,
+	}, {
+		// prometheus-k8s
+		charm: charms.CharmInfo{
+			Meta: &charm.Meta{
+				Name: "prometheus-k8s",
+				Containers: map[string]charm.Container{
+					"prometheus": {},
+				},
+			},
+		},
+		isPodspec: false,
+	}}
+
+	for _, t := range tests {
+		c.Check(checkPodspec(t.charm.Charm(), &cmd.Context{}), gc.Equals, t.isPodspec)
+	}
 }
 
 func (s *deployerSuite) makeBundleDir(c *gc.C, content string) string {


### PR DESCRIPTION
#14162 added this on the server-side, but now we make it more visible, by printing a warning to stdout when you `juju deploy` a podspec charm.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a k8s controller.

### Deploy from Charmhub
```console
$ juju deploy redis-k8s
Located charm "redis-k8s" in charm-hub, revision 7
WARNING deploying podspec charm "redis-k8s": podspec charms are deprecated. Support for them will be removed soon.
Deploying "redis-k8s" from charm-hub charm "redis-k8s", revision 7 in channel stable on ubuntu@20.04/stable
```

### Deploy local charm
```console
$ juju download redis-k8s
$ juju deploy ./redis-k8s_r7.charm --resource redis-image=redis
Located local charm "redis-k8s", revision 0
WARNING deploying podspec charm "redis-k8s": podspec charms are deprecated. Support for them will be removed soon.
Deploying "redis-k8s" from local charm "redis-k8s", revision 0 on ubuntu@20.04/stable
```

### Deploy bundle containing podspec charm

Create a file `bundle.yaml` with the following contents:
```yaml
applications:
  redis:
    charm: redis-k8s
```
```console
$ juju deploy ./bundle.yaml
Located charm "redis-k8s" in charm-hub, channel stable
Executing changes:
- upload charm redis-k8s from charm-hub with architecture=amd64
- deploy application redis from charm-hub using redis-k8s
WARNING deploying podspec charm "redis-k8s": podspec charms are deprecated. Support for them will be removed soon.
  added resource redis-image
Deploy of bundle completed.
```