### PR TITLE
[JUJU-3569] Fix secrets vault ci test

### DIFF
--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -7,18 +7,19 @@ run_secrets_juju() {
 	juju --show-log deploy etcd
 	juju --show-log integrate etcd easyrsa
 
-	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
 	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
+	wait_for "easyrsa" "$(idle_condition "easyrsa" 0 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
 	wait_for "active" "$(workload_status "etcd" 0).current"
-	wait_for "easyrsa" '.applications["etcd"] | .relations.certificates[0]'
 
-	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0 | cut -d: -f2)
-	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app | cut -d: -f2)
+	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0)
+	secret_owned_by_easyrsa_0_id=$(echo $secret_owned_by_easyrsa_0 | awk '{n=split($0,a,"/"); print a[n]}')
+	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app)
+	secret_owned_by_easyrsa_id=$(echo $secret_owned_by_easyrsa | awk '{n=split($0,a,"/"); print a[n]}')
 
-	juju exec --unit easyrsa/0 -- secret-ids | grep "$secret_owned_by_easyrsa"
-	juju exec --unit easyrsa/0 -- secret-ids | grep "$secret_owned_by_easyrsa_0"
+	juju exec --unit easyrsa/0 -- secret-ids | grep $secret_owned_by_easyrsa_id
+	juju exec --unit easyrsa/0 -- secret-ids | grep $secret_owned_by_easyrsa_0_id
 
 	echo "Set a label for the unit owned secret $secret_owned_by_easyrsa_0."
 	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_0" --label=easyrsa_0
@@ -30,15 +31,15 @@ run_secrets_juju() {
 	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" | grep 'owned-by: easyrsa-app'
 
 	# secret-get by URI - metadata.
-	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
-	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0_id}.owner" | grep unit
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.owner" | grep application
 
 	# secret-get by label or consumer label - content.
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 | grep 'owned-by: easyrsa/0'
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app | grep 'owned-by: easyrsa-app'
 
 	# secret-get by label - metadata.
-	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
+	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0_id}.label" | grep easyrsa_0
 
 	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
 	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"

--- a/tests/suites/secrets_iaas/task.sh
+++ b/tests/suites/secrets_iaas/task.sh
@@ -11,13 +11,12 @@ test_secrets_iaas() {
 
 	file="${TEST_DIR}/test-secrets-iaas.log"
 
-	# TODO: remove feature flag when secret is fully ready.
-	export JUJU_DEV_FEATURE_FLAGS=developer-mode
-
 	bootstrap "test-secrets-iaas" "${file}"
 
-	test_secrets_vault
 	test_secrets_juju
+	test_secrets_vault
 
+	# Takes too long to tear down, so forcibly destroy it
+	export KILL_CONTROLLER=true
 	destroy_controller "test-secrets-iaas"
 }

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -3,24 +3,26 @@ run_secrets_vault() {
 
 	prepare_vault
 
-	juju add-model "model-secrets-vault" --config secret-store=vault --config secret-store-config="{\"endpoint\":\"$VAULT_ADDR\",\"token\": \"$VAULT_TOKEN\"}"
+	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
+	juju add-model "model-secrets-vault" --config secret-backend=myvault
 
 	juju --show-log deploy easyrsa
 	juju --show-log deploy etcd
 	juju --show-log integrate etcd easyrsa
 
-	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
 	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
+	wait_for "easyrsa" "$(idle_condition "easyrsa" 0 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
 	wait_for "active" "$(workload_status "etcd" 0).current"
-	wait_for "easyrsa" '.applications["etcd"] | .relations.certificates[0]'
 
-	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0 | cut -d: -f2)
-	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app | cut -d: -f2)
+	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0)
+	secret_owned_by_easyrsa_0_id=$(echo $secret_owned_by_easyrsa_0 | awk '{n=split($0,a,"/"); print a[n]}')
+	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app)
+	secret_owned_by_easyrsa_id=$(echo $secret_owned_by_easyrsa | awk '{n=split($0,a,"/"); print a[n]}')
 
-	juju exec --unit easyrsa/0 -- secret-ids | grep "$secret_owned_by_easyrsa"
-	juju exec --unit easyrsa/0 -- secret-ids | grep "$secret_owned_by_easyrsa_0"
+	juju exec --unit easyrsa/0 -- secret-ids | grep $secret_owned_by_easyrsa_id
+	juju exec --unit easyrsa/0 -- secret-ids | grep $secret_owned_by_easyrsa_0_id
 
 	echo "Set a label for the unit owned secret $secret_owned_by_easyrsa_0."
 	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_0" --label=easyrsa_0
@@ -32,15 +34,15 @@ run_secrets_vault() {
 	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" | grep 'owned-by: easyrsa-app'
 
 	# secret-get by URI - metadata.
-	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
-	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0_id}.owner" | grep unit
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.owner" | grep application
 
 	# secret-get by label or consumer label - content.
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 | grep 'owned-by: easyrsa/0'
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app | grep 'owned-by: easyrsa-app'
 
 	# secret-get by label - metadata.
-	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
+	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0_id}.label" | grep easyrsa_0
 
 	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
 	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"
@@ -90,9 +92,10 @@ prepare_vault() {
 	juju --show-log deploy mysql-router
 	juju --show-log integrate mysql-router:db-router mysql-innodb-cluster:db-router
 	juju --show-log integrate mysql-router:shared-db vault:shared-db
+	juju --show-log expose vault
 
-	wait_for "active" '.applications["mysql-innodb-cluster"] | ."application-status".current'
-	wait_for "active" '.applications["mysql-router"] | ."application-status".current'
+	wait_for "active" '.applications["mysql-innodb-cluster"] | ."application-status".current' 900
+	wait_for "active" '.applications["mysql-router"] | ."application-status".current' 900
 	wait_for "blocked" "$(workload_status vault 0).current"
 	vault_public_addr=$(juju status --format json | jq -r '.applications.vault.units."vault/0"."public-address"')
 	export VAULT_ADDR="http://${vault_public_addr}:8200"


### PR DESCRIPTION
The secrets vault ci test was using the old 3.0 commands to set up the backend. It needed updating to work with 3.1.

## QA steps

`./main.sh secrets_iaas`