### PR TITLE
[JUJU-3566] Fix panic when deploying bundle with placement directive to undefined machine

### DIFF
--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -186,11 +186,18 @@ func (d *deployBundle) checkExplicitSeries(bundleData *charm.BundleData) error {
 		// has the image-id constraint
 		machineHasImageID := false
 		for _, to := range applicationSpec.To {
-			// TODO(nvinuesa): here we only check for the image-id
-			// constraint when the placement directive is explicitly
-			// defined in the bundle. Find a way to check indirect
-			// placements like lxd:0 and ubuntu:0.
-			if machine, ok := bundleData.Machines[to]; ok {
+
+			// This error can be ignored since the bundle has
+			// already been validated at this point, and it's not
+			// this method's responsibility to validate it.
+			placement, _ := charm.ParsePlacement(to)
+			// Only check for explicit series when image-id
+			// constraint *if* the placement machine is defined
+			// in the bundle. In the case of 'new' it does pass
+			// bundle validation but it won't be defined since it's
+			// a new machine, so don't perform any check in that
+			// case.
+			if machine, ok := bundleData.Machines[placement.Machine]; ok {
 				machineCons, err := constraints.Parse(machine.Constraints)
 				if err != nil {
 					return errors.Trace(err)

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -186,13 +186,19 @@ func (d *deployBundle) checkExplicitSeries(bundleData *charm.BundleData) error {
 		// has the image-id constraint
 		machineHasImageID := false
 		for _, to := range applicationSpec.To {
-			machineCons, err := constraints.Parse(bundleData.Machines[to].Constraints)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if machineCons.HasImageID() {
-				machineHasImageID = true
-				break
+			// TODO(nvinuesa): here we only check for the image-id
+			// constraint when the placement directive is explicitly
+			// defined in the bundle. Find a way to check indirect
+			// placements like lxd:0 and ubuntu:0.
+			if machine, ok := bundleData.Machines[to]; ok {
+				machineCons, err := constraints.Parse(machine.Constraints)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if machineCons.HasImageID() {
+					machineHasImageID = true
+					break
+				}
 			}
 		}
 		// Then we check if the constraints declared on the app have

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -370,6 +370,30 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			},
 			deployBundle: deployBundle{},
 		},
+		{
+			title: "application targetting non existing machine in bundle -> no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+						To:          []string{"ubuntu:0"},
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"lxd:0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
 	}
 	for i, test := range testCases {
 		c.Logf("test %d [%s]", i, test.title)

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -371,7 +371,74 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			deployBundle: deployBundle{},
 		},
 		{
-			title: "application targetting non existing machine in bundle -> no error",
+			title: "application targeting new container, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"lxc:new"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
+		{
+			title: "application targeting new machine, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"new"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+				},
+			},
+			deployBundle: deployBundle{},
+		},
+		{
+			title: "application targeting container in bundle, no series -> error",
+			bundleData: &charm.BundleData{
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"lxd:0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": {
+						Constraints: "image-id=ubuntu-bf2",
+					},
+				},
+			},
+			deployBundle:  deployBundle{},
+			expectedError: explicitSeriesErrorUbuntu,
+		},
+		{
+			title: "application targeting container in bundle, series in bundle -> no error",
 			bundleData: &charm.BundleData{
 				Series: "focal",
 				Applications: map[string]*charm.ApplicationSpec{


### PR DESCRIPTION
If an application in a bundle is deployed to a specific machine, and this machine uses the image-id constraint, then we check that the base is explicitly defined in the application.

This patches the case where the bundle contains a placement directive to a machine not defined in the bundle, for example `lxd:0`.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The deploy of this bundle:

```yaml
applications:
  prometheus2:
    num_units: 3
    charm: ch:prometheus2
    to:
    - 'lxd:0'
machines:
  '0':
```
should not fail:
```sh
$ juju deploy ./test.yaml
Located charm "prometheus2" in charm-hub, channel stable
Executing changes:
- upload charm prometheus2 from charm-hub with architecture=amd64
- deploy application prometheus2 from charm-hub
  added resource core
  added resource prometheus
- add new machine 2 (bundle machine 0)
- add lxd container 2/lxd/0 on new machine 2
- add unit prometheus2/0 to 2/lxd/0
- add unit prometheus2/1 to new machine 3
- add unit prometheus2/2 to new machine 4
Deploy of bundle completed.
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/2016903
