### PR TITLE
Update application offer migration import to fix LP 2016333.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2518,6 +2518,17 @@ func incApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) 
 	return incRefOp, errors.Trace(err)
 }
 
+// newApplicationOffersRefOp returns a txn.Op that creates a new reference
+// count for an application offer, starting at the count supplied. Used in
+// model migration, where offers are created in bulk.
+func newApplicationOffersRefOp(mb modelBackend, appName string, startCount int) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(refcountsC)
+	defer closer()
+	offerRefCountKey := applicationOffersRefCountKey(appName)
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, offerRefCountKey, startCount)
+	return incRefOp, errors.Trace(err)
+}
+
 // countApplicationOffersRefOp returns the number of offers for an application,
 // along with a txn.Op that ensures that that does not change.
 func countApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, int, error) {

--- a/state/migration_import_input_mock_test.go
+++ b/state/migration_import_input_mock_test.go
@@ -259,19 +259,19 @@ func (mr *MockApplicationOfferStateDocumentFactoryMockRecorder) MakeApplicationO
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOfferDoc", reflect.TypeOf((*MockApplicationOfferStateDocumentFactory)(nil).MakeApplicationOfferDoc), arg0)
 }
 
-// MakeIncApplicationOffersRefOp mocks base method.
-func (m *MockApplicationOfferStateDocumentFactory) MakeIncApplicationOffersRefOp(arg0 string) (txn.Op, error) {
+// MakeApplicationOffersRefOp mocks base method.
+func (m *MockApplicationOfferStateDocumentFactory) MakeApplicationOffersRefOp(arg0 string, arg1 int) (txn.Op, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeIncApplicationOffersRefOp", arg0)
+	ret := m.ctrl.Call(m, "MakeApplicationOffersRefOp", arg0, arg1)
 	ret0, _ := ret[0].(txn.Op)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp.
-func (mr *MockApplicationOfferStateDocumentFactoryMockRecorder) MakeIncApplicationOffersRefOp(arg0 interface{}) *gomock.Call {
+// MakeApplicationOffersRefOp indicates an expected call of MakeApplicationOffersRefOp.
+func (mr *MockApplicationOfferStateDocumentFactoryMockRecorder) MakeApplicationOffersRefOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIncApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferStateDocumentFactory)(nil).MakeIncApplicationOffersRefOp), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferStateDocumentFactory)(nil).MakeApplicationOffersRefOp), arg0, arg1)
 }
 
 // MockApplicationOfferInput is a mock of ApplicationOfferInput interface.
@@ -326,19 +326,19 @@ func (mr *MockApplicationOfferInputMockRecorder) MakeApplicationOfferDoc(arg0 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOfferDoc", reflect.TypeOf((*MockApplicationOfferInput)(nil).MakeApplicationOfferDoc), arg0)
 }
 
-// MakeIncApplicationOffersRefOp mocks base method.
-func (m *MockApplicationOfferInput) MakeIncApplicationOffersRefOp(arg0 string) (txn.Op, error) {
+// MakeApplicationOffersRefOp mocks base method.
+func (m *MockApplicationOfferInput) MakeApplicationOffersRefOp(arg0 string, arg1 int) (txn.Op, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeIncApplicationOffersRefOp", arg0)
+	ret := m.ctrl.Call(m, "MakeApplicationOffersRefOp", arg0, arg1)
 	ret0, _ := ret[0].(txn.Op)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp.
-func (mr *MockApplicationOfferInputMockRecorder) MakeIncApplicationOffersRefOp(arg0 interface{}) *gomock.Call {
+// MakeApplicationOffersRefOp indicates an expected call of MakeApplicationOffersRefOp.
+func (mr *MockApplicationOfferInputMockRecorder) MakeApplicationOffersRefOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIncApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferInput)(nil).MakeIncApplicationOffersRefOp), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferInput)(nil).MakeApplicationOffersRefOp), arg0, arg1)
 }
 
 // Offers mocks base method.

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -67,8 +67,8 @@ func (s stateApplicationOfferDocumentFactoryShim) MakeApplicationOfferDoc(app de
 	}), nil
 }
 
-func (s stateApplicationOfferDocumentFactoryShim) MakeIncApplicationOffersRefOp(name string) (txn.Op, error) {
-	return incApplicationOffersRefOp(s.importer.st, name)
+func (s stateApplicationOfferDocumentFactoryShim) MakeApplicationOffersRefOp(name string, startCnt int) (txn.Op, error) {
+	return newApplicationOffersRefOp(s.importer.st, name, startCnt)
 }
 
 type applicationDescriptionShim struct {
@@ -87,7 +87,7 @@ type ApplicationDescription interface {
 // Note: we need public methods here because gomock doesn't mock private methods
 type ApplicationOfferStateDocumentFactory interface {
 	MakeApplicationOfferDoc(description.ApplicationOffer) (applicationOfferDoc, error)
-	MakeIncApplicationOffersRefOp(string) (txn.Op, error)
+	MakeApplicationOffersRefOp(string, int) (txn.Op, error)
 }
 
 // ApplicationOfferDescription defines an in-place usage for reading
@@ -118,20 +118,37 @@ func (i ImportApplicationOffer) Execute(src ApplicationOfferInput,
 	if len(offers) == 0 {
 		return nil
 	}
+	refCounts := make(map[string]int, len(offers))
 	ops := make([]txn.Op, 0)
 	for _, offer := range offers {
 		appDoc, err := src.MakeApplicationOfferDoc(offer)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		appOps, err := i.addApplicationOfferOps(src, addApplicationOfferOpsArgs{
-			applicationOfferDoc: appDoc,
-			acl:                 offer.ACL(),
-		})
+		appOps, err := i.addApplicationOfferOps(src,
+			addApplicationOfferOpsArgs{
+				applicationOfferDoc: appDoc,
+				acl:                 offer.ACL(),
+			})
 		if err != nil {
 			return errors.Trace(err)
 		}
 		ops = append(ops, appOps...)
+		appName := offer.ApplicationName()
+		if appCnt, ok := refCounts[appName]; ok {
+			refCounts[appName] = appCnt + 1
+		} else {
+			refCounts[appName] = 1
+		}
+	}
+	// range the offers again to create refcount docs, an application
+	// may have more than one offer.
+	for appName, cnt := range refCounts {
+		refCntOpps, err := src.MakeApplicationOffersRefOp(appName, cnt)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ops = append(ops, refCntOpps)
 	}
 	if err := runner.RunTransaction(ops); err != nil {
 		return errors.Trace(err)
@@ -147,25 +164,19 @@ type addApplicationOfferOpsArgs struct {
 func (i ImportApplicationOffer) addApplicationOfferOps(src ApplicationOfferInput,
 	args addApplicationOfferOpsArgs,
 ) ([]txn.Op, error) {
-	appName := args.applicationOfferDoc.ApplicationName
-	incRefOp, err := src.MakeIncApplicationOffersRefOp(appName)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	docID := src.DocID(appName)
 	ops := []txn.Op{
 		{
 			C:      applicationOffersC,
-			Id:     docID,
+			Id:     src.DocID(args.applicationOfferDoc.OfferName),
 			Assert: txn.DocMissing,
 			Insert: args.applicationOfferDoc,
 		},
-		incRefOp,
 	}
 	for userName, access := range args.acl {
 		user := names.NewUserTag(userName)
-		ops = append(ops, createPermissionOp(applicationOfferKey(
-			args.applicationOfferDoc.OfferUUID), userGlobalKey(userAccessID(user)), permission.Access(access)))
+		h := createPermissionOp(applicationOfferKey(
+			args.applicationOfferDoc.OfferUUID), userGlobalKey(userAccessID(user)), permission.Access(access))
+		ops = append(ops, h)
 	}
 	return ops, nil
 }

--- a/state/migration_import_tasks_test.go
+++ b/state/migration_import_tasks_test.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/description/v3"
 	"github.com/juju/errors"
@@ -26,6 +28,8 @@ func (s *MigrationImportTasksSuite) TestImportApplicationOffers(c *gc.C) {
 
 	offerUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
+	offerUUID2, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
 
 	runner := ImportApplicationOfferRunner{
 		OfferUUID: offerUUID.String(),
@@ -35,6 +39,7 @@ func (s *MigrationImportTasksSuite) TestImportApplicationOffers(c *gc.C) {
 
 	entity := s.applicationOffer(ctrl)
 	offerDoc := applicationOfferDoc{
+		DocID:                  fmt.Sprintf("%s:%s", offerUUID.String(), "offer-name-foo"),
 		OfferUUID:              offerUUID.String(),
 		OfferName:              "offer-name-foo",
 		ApplicationName:        "foo",
@@ -43,21 +48,30 @@ func (s *MigrationImportTasksSuite) TestImportApplicationOffers(c *gc.C) {
 			"db": "db",
 		},
 	}
+	secondOfferDoc := offerDoc
+	secondOfferDoc.DocID = fmt.Sprintf("%s:%s", offerUUID2.String(), "second-offer")
+	secondOfferDoc.OfferUUID = offerUUID2.String()
+	secondOfferDoc.OfferName = "second-offer"
 
-	runner.Add(runner.applicationOffers(entity))
+	entity.EXPECT().ApplicationName().Return(offerDoc.ApplicationName).Times(2)
+	runner.Add(runner.applicationOffers(entity, entity))
+	runner.Add(runner.docID(offerDoc.OfferName, offerDoc.DocID))
+	runner.Add(runner.docID(secondOfferDoc.OfferName, secondOfferDoc.DocID))
 	runner.Add(runner.applicationOfferDoc(offerDoc, entity))
-	runner.Add(runner.docID)
+	runner.Add(runner.applicationOfferDoc(secondOfferDoc, entity))
 
 	refOp := txn.Op{
 		Assert: txn.DocMissing,
 	}
-	runner.Add(runner.applicationOffersRefOp(refOp))
+	runner.Add(runner.applicationOffersRefOp(refOp, 2))
 
-	entity.EXPECT().ACL().Return(map[string]string{"fred": "consume"})
+	entity.EXPECT().ACL().Return(map[string]string{"fred": "consume"}).Times(2)
 	permissionOp := createPermissionOp(applicationOfferKey(
 		offerUUID.String()), userGlobalKey(userAccessID(names.NewUserTag("fred"))), permission.ConsumeAccess)
+	permissionOp2 := createPermissionOp(applicationOfferKey(
+		offerUUID2.String()), userGlobalKey(userAccessID(names.NewUserTag("fred"))), permission.ConsumeAccess)
 
-	runner.Add(runner.transaction(offerDoc, refOp, permissionOp))
+	runner.Add(runner.transaction([]applicationOfferDoc{offerDoc, secondOfferDoc}, []txn.Op{permissionOp, permissionOp2}, refOp))
 
 	err = runner.Run(ctrl)
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,6 +92,7 @@ func (s *MigrationImportTasksSuite) TestImportApplicationOffersTransactionFailur
 
 	entity := s.applicationOffer(ctrl)
 	offerDoc := applicationOfferDoc{
+		DocID:                  fmt.Sprintf("%s:%s", offerUUID.String(), "offer-name-foo"),
 		OfferUUID:              offerUUID.String(),
 		OfferName:              "offer-name-foo",
 		ApplicationName:        "foo",
@@ -88,14 +103,15 @@ func (s *MigrationImportTasksSuite) TestImportApplicationOffersTransactionFailur
 	}
 
 	entity.EXPECT().ACL().Return(map[string]string{})
+	entity.EXPECT().ApplicationName().Return(offerDoc.ApplicationName)
 	runner.Add(runner.applicationOffers(entity))
 	runner.Add(runner.applicationOfferDoc(offerDoc, entity))
-	runner.Add(runner.docID)
+	runner.Add(runner.docID(offerDoc.OfferName, offerDoc.DocID))
 
 	refOp := txn.Op{
 		Assert: txn.DocMissing,
 	}
-	runner.Add(runner.applicationOffersRefOp(refOp))
+	runner.Add(runner.applicationOffersRefOp(refOp, 1))
 	runner.Add(runner.transactionWithError(errors.New("fail")))
 
 	err = runner.Run(ctrl)
@@ -122,11 +138,8 @@ func (s *ImportApplicationOfferRunner) Run(ctrl *gomock.Controller) error {
 	return m.Execute(s.model, s.runner)
 }
 
-func (s *ImportApplicationOfferRunner) applicationOffers(entity description.ApplicationOffer) func(ctrl *gomock.Controller) {
+func (s *ImportApplicationOfferRunner) applicationOffers(entities ...description.ApplicationOffer) func(ctrl *gomock.Controller) {
 	return func(ctrl *gomock.Controller) {
-		entities := []description.ApplicationOffer{
-			entity,
-		}
 		s.model.EXPECT().Offers().Return(entities)
 	}
 }
@@ -137,30 +150,40 @@ func (s *ImportApplicationOfferRunner) applicationOfferDoc(offerDoc applicationO
 	}
 }
 
-func (s *ImportApplicationOfferRunner) applicationOffersRefOp(op txn.Op) func(ctrl *gomock.Controller) {
+func (s *ImportApplicationOfferRunner) applicationOffersRefOp(op txn.Op, cnt int) func(ctrl *gomock.Controller) {
 	return func(ctrl *gomock.Controller) {
-		s.model.EXPECT().MakeIncApplicationOffersRefOp("foo").Return(op, nil)
+		s.model.EXPECT().MakeApplicationOffersRefOp("foo", cnt).Return(op, nil)
 	}
-}
-
-func (s *ImportApplicationOfferRunner) docID(ctrl *gomock.Controller) {
-	s.model.EXPECT().DocID("foo").Return("ao#foo")
 }
 
 func (s *MigrationImportTasksSuite) applicationOffer(ctrl *gomock.Controller) *MockApplicationOffer {
 	return NewMockApplicationOffer(ctrl)
 }
 
-func (s *ImportApplicationOfferRunner) transaction(offerDoc applicationOfferDoc, ops ...txn.Op) func(ctrl *gomock.Controller) {
+func (s *ImportApplicationOfferRunner) docID(offerName, docID string) func(ctrl *gomock.Controller) {
 	return func(ctrl *gomock.Controller) {
-		s.runner.EXPECT().RunTransaction(append([]txn.Op{
-			{
-				C:      applicationOffersC,
-				Id:     "ao#foo",
-				Assert: txn.DocMissing,
-				Insert: offerDoc,
-			},
-		}, ops...)).Return(nil)
+		s.model.EXPECT().DocID(offerName).Return(docID)
+	}
+}
+
+func (s *ImportApplicationOfferRunner) transaction(offerDocs []applicationOfferDoc, permissionOps []txn.Op, ops ...txn.Op) func(ctrl *gomock.Controller) {
+	return func(ctrl *gomock.Controller) {
+		useOps := make([]txn.Op, 0)
+
+		for i, doc := range offerDocs {
+			useOps = append(useOps, []txn.Op{
+				{
+					C:      applicationOffersC,
+					Id:     doc.DocID,
+					Assert: txn.DocMissing,
+					Insert: doc,
+				},
+				permissionOps[i],
+			}...)
+		}
+		useOps = append(useOps, ops...)
+
+		s.runner.EXPECT().RunTransaction(useOps).Return(nil)
 	}
 }
 


### PR DESCRIPTION
There were 2 things preventing model migration when more than one cmr offers for an application. 

One was the docID asserting a doc wasn't there, did always match the docID of what was being inserted. A mismatch between offerName and appName.

The second was having 2 refcount docs with a count of 1 based on appName instead of 1 refcount doc with a count of 2 where there were 2 offers on the same application. At first glance, incApplicationOffersRefOp should have returned a doc with a count of 2, however all cmr offer data was run as a single txn rather than multiple, thus the doc couldn't be found to be changed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
$ juju bootstrap localhost dst
$ juju bootstrap localhost src
$ juju add-model moveme
$ juju deploy mongodb --channel candidate 
$ juju offer mongodb:database 
$ juju offer mongodb:database mongdo-database
$ juju migrate moveme dst
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/2016333