### PR TITLE
Better default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+.PHONY: help
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | sort | column -t -s ':' |  sed -e 's/^/ /'
+
 # Export this first, incase we want to change it in the included makefiles.
 export CGO_ENABLED=0
 
@@ -265,11 +270,6 @@ define run_cgo_install
 endef
 
 default: build
-
-.PHONY: help
-help:
-	@echo "Usage: \n"
-	@sed -n 's/^##//p' ${MAKEFILE_LIST} | sort | column -t -s ':' |  sed -e 's/^/ /'
 
 .PHONY: juju
 juju: PACKAGE = github.com/juju/juju/cmd/juju

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help
 help:
 	@echo "Usage: \n"
-	@sed -n 's/^##//p' ${MAKEFILE_LIST} | sort | column -t -s ':' |  sed -e 's/^/ /'
+	@sed -n 's/^## //p' ${MAKEFILE_LIST} | sort | column -t -s ':' |  sed -e 's/^/ /'
 
 # Export this first, incase we want to change it in the included makefiles.
 export CGO_ENABLED=0
@@ -309,17 +309,16 @@ pebble:
 
 .PHONY: phony_explicit
 phony_explicit:
-## phone_explicit is a dummy target that can be added to pattern targets to
-## them phony make.
+# phone_explicit: is a dummy target that can be added to pattern targets to phony make.
 
 ${BUILD_DIR}/%/bin/juju: PACKAGE = github.com/juju/juju/cmd/juju
 ${BUILD_DIR}/%/bin/juju: phony_explicit
-## build for juju
+# build for juju
 	$(run_go_build)
 
 ${BUILD_DIR}/%/bin/jujuc: PACKAGE = github.com/juju/juju/cmd/jujuc
 ${BUILD_DIR}/%/bin/jujuc: phony_explicit
-## build for jujuc
+# build for jujuc
 	$(run_go_build)
 
 ${BUILD_DIR}/%/bin/jujud: PACKAGE = github.com/juju/juju/cmd/jujud
@@ -354,8 +353,7 @@ simplestreams: juju juju-metadata ${SIMPLESTREAMS_TARGETS}
 
 .PHONY: build
 build: rebuild-schema go-build
-## build builds all the targets specified by BUILD_AGENT_TARGETS and
-## BUILD_CLIENT_TARGETS while also rebuilding a new schema.
+## build: builds all the targets including rebuilding a new schema.
 
 .PHONY: go-agent-build
 go-agent-build: $(BUILD_AGENT_TARGETS) $(BUILD_CGO_AGENT_TARGETS)
@@ -368,8 +366,7 @@ go-client-build: $(BUILD_CLIENT_TARGETS)
 
 .PHONY: go-build
 go-build: go-agent-build go-client-build
-## build builds all the targets specified by BUILD_AGENT_TARGETS and
-## BUILD_CLIENT_TARGETS.
+## build: builds all the targets withouth rebuilding a new schema.
 
 .PHONY: release-build
 release-build: go-agent-build
@@ -572,8 +569,7 @@ image-check-build-skip:
 
 .PHONY: docker-builder
 docker-builder:
-## docker-builder: Makes sure that there is a buildx context for building the
-## oci images
+## docker-builder: Makes sure that there is a buildx context for building the oci images
 	-@docker buildx create --name ${DOCKER_BUILDX_CONTEXT}
 
 .PHONY: image-check
@@ -607,7 +603,7 @@ push-release-operator-image: operator-image
 
 .PHONY: host-install
 host-install:
-## install juju for host os/architecture
+## host-install: installs juju for host os/architecture
 	+GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) make juju
 
 .PHONY: minikube-operator-update


### PR DESCRIPTION
This solves two problems at once.

 1. There is a vscode plugin that is stalling because the default make target we currently have set is to build the whole of dqlite in a sub lxd container. This is because we include a sub-make file, which has the dqlite build target as the first target. This in turn causes problems with vscode itself.
 2. From a UX perspective, we shouldn't be attempting to build anything from a default make target sense. As the project has grown there isn't anything that feels like it should be default.

Instead, the default make file target is help. Makefiles don't have the ability to explicitly set the default target, instead, it just picks the first one. So the change is to put help right at the top, which forces it to be the default one.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
make
```

