### PR TITLE
Unregister metrics on error

### DIFF
--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -119,10 +119,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			w, err := newWorker(cfg)
 			if err != nil {
+				// Unregister the metrics collector if we fail to start the
+				// worker, so that we can safely register the metrics again.
+				config.PrometheusRegisterer.Unregister(metricsCollector)
 				return nil, errors.Trace(err)
 			}
 			return common.NewCleanupWorker(w, func() {
-				// clean up the metrics for the worker, so the next time a
+				// Clean up the metrics for the worker, so the next time a
 				// worker is created we can safely register the metrics again.
 				config.PrometheusRegisterer.Unregister(metricsCollector)
 			}), nil


### PR DESCRIPTION
The following tweaks are an observation when testing another PR, where failure to start a worker would prevent the worker from coming up. This is because the metrics were already registered and we don't allow a double add. The solution is to unregister the metrics when we hit any error case.

An alternative solution is to always unregister before a register, but from memory, there is a sticky situation in edge cases. I don't remember the exact reason, it was over 4 years ago, just that, we shouldn't.

There are other locations that also register but do so inside the worker loop. This seems like an anti-pattern,  as we're now pushing down the Prometheus registration into the worker. The worker doesn't need to know about that and we're coupling a worker to the register. This violates the cross-cutting concerns of the worker.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

The workers should come up.

```sh
$ juju bootstrap lxd test --build-agent
$ juju controller-config query-tracing-enabled=true 
```

Also, the tests pass in the affected worker packages.