### PR TITLE
[JUJU-2874] Build jujud on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,8 @@ define run_cgo_install
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
+		GOOS=${GOOS} \
+		GOARCH=${GOARCH} \
 		go install \
 			-mod=$(JUJU_GOMOD_MODE) \
 			-tags=$(BUILD_TAGS) \

--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -4,6 +4,8 @@ set -e
 
 source "$(dirname $0)/../env.sh"
 
+check_dependencies sha256sum
+
 sha() {
 	case ${BUILD_ARCH} in
 		amd64) echo "124a578c8bd63d9288093f4de4aaffa09c034d6641065cd079e446ac91b1b611" ;;

--- a/scripts/dqlite/scripts/musl/install-if-missing.sh
+++ b/scripts/dqlite/scripts/musl/install-if-missing.sh
@@ -4,13 +4,18 @@ set -e
 
 source "$(dirname $0)/musl-install.sh"
 
-PATH=${PATH}:${MUSL_BIN_PATH} which musl-gcc >/dev/null || { echo "Installing required musl dependencies"; install; exit 0; }
+PATH=${MUSL_BIN_PATH}:${PATH} which musl-gcc >/dev/null || { echo "Installing required musl dependencies"; install; exit 0; }
 
 echo "musl-gcc already installed"
 
+if [ $(is_darwin) = true ] && [ ! -f "${MUSL_LOCAL_PATH}/output/bin/musl-gcc" ]; then
+    post_musl_install_cross_darwin
+    exit 0
+fi
+
 if [ ! -f "${MUSL_LOCAL_PATH}/output/bin/musl-gcc" ]; then
-    P=$(PATH=${PATH}:${MUSL_BIN_PATH} which musl-gcc)
-    echo "Symlinking ${P}"
+    P=$(PATH=${MUSL_BIN_PATH}:${PATH} which musl-gcc)
+    echo "Symlinking ${P} to ${BUILD_ARCH}"
     mkdir -p ${MUSL_LOCAL_PATH}/output/bin || { echo "Failed to create ${MUSL_LOCAL_PATH}/output/bin"; exit 1; }
     ln -s "${P}" ${MUSL_LOCAL_PATH}/output/bin/musl-gcc || { echo "Failed to link musl-gcc"; exit 1; }
 fi


### PR DESCRIPTION
The following installs musl on Darwin via homebrew, which in turn allows building jujud. Once musl is installed there is no change to the make file as that's correctly set up to handle this case.

As sha256sum isn't available by default on a mac, we need to check it's available otherwise the error is rather cryptic.

This supersedes https://github.com/juju/juju/pull/15183 which did too much to get it all working. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ GOOS=linux GOARCH=arm64 make jujud
$ GOOS=linux GOARCH=amd64 make jujud
```
