### PR TITLE
[JUJU-3555] DB Accessor worker report

### DIFF
--- a/database/client/dqlite_other.go
+++ b/database/client/dqlite_other.go
@@ -18,6 +18,11 @@ func (c *Client) Cluster(context.Context) ([]dqlite.NodeInfo, error) {
 	return nil, nil
 }
 
+// Leader returns information about the current leader, if any.
+func (c *Client) Leader(ctx context.Context) (*dqlite.NodeInfo, error) {
+	return nil, nil
+}
+
 type YamlNodeStore struct {
 }
 

--- a/database/dqlite/dqlite_other.go
+++ b/database/dqlite/dqlite_other.go
@@ -12,6 +12,10 @@ const (
 
 type NodeRole int
 
+func (NodeRole) String() string {
+	return ""
+}
+
 type NodeInfo struct {
 	ID      uint64   `yaml:"ID"`
 	Address string   `yaml:"Address"`

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -626,3 +626,18 @@ func (mr *MockClientMockRecorder) Cluster(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cluster", reflect.TypeOf((*MockClient)(nil).Cluster), arg0)
 }
+
+// Leader mocks base method.
+func (m *MockClient) Leader(arg0 context.Context) (*dqlite.NodeInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Leader", arg0)
+	ret0, _ := ret[0].(*dqlite.NodeInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Leader indicates an expected call of Leader.
+func (mr *MockClientMockRecorder) Leader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Leader", reflect.TypeOf((*MockClient)(nil).Leader), arg0)
+}

--- a/worker/dbaccessor/shim.go
+++ b/worker/dbaccessor/shim.go
@@ -17,6 +17,8 @@ import (
 type Client interface {
 	// Cluster returns the current state of the Dqlite cluster.
 	Cluster(context.Context) ([]dqlite.NodeInfo, error)
+	// Leader returns information about the current leader, if any.
+	Leader(ctx context.Context) (*dqlite.NodeInfo, error)
 }
 
 // DBApp describes methods of a Dqlite database application,

--- a/worker/dbaccessor/tracker.go
+++ b/worker/dbaccessor/tracker.go
@@ -313,12 +313,20 @@ func defaultPingDBFunc(ctx context.Context, db *sql.DB) error {
 type report struct {
 	sync.Mutex
 
-	pingDuration    time.Duration
-	pingAttempts    uint32
+	// pingDuration is the duration of the last ping.
+	pingDuration time.Duration
+	// pingAttempts is the number of attempts to ping the database for the
+	// last ping.
+	pingAttempts uint32
+	// maxPingDuration is the maximum duration of a ping for a given lifetime
+	// of the worker.
 	maxPingDuration time.Duration
-	dbReplacements  uint32
+	// dbReplacements is the number of times the database has been replaced
+	// due to a failed ping.
+	dbReplacements uint32
 }
 
+// Report provides information for the engine report.
 func (r *report) Report() map[string]any {
 	r.Lock()
 	defer r.Unlock()

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -62,8 +62,8 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 	c.Assert(report, MapHasKeys, []string{
 		"db-replacements",
 		"max-ping-duration",
-		"ping-attempts",
-		"ping-duration",
+		"last-ping-attempts",
+		"last-ping-duration",
 	})
 
 	workertest.CleanKill(c, w)

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -266,6 +266,13 @@ func (w *dbWorker) Wait() error {
 	return w.catacomb.Wait()
 }
 
+// Report provides information for the engine report.
+func (w *dbWorker) Report() map[string]any {
+	// We need to guard against attempting to report when setting up or dying,
+	// so we don't end up panic'ing with missing information.
+	return w.dbRunner.Report()
+}
+
 // GetDB returns a TrackedDB reference for the dqlite-backed
 // database that contains the data for the specified namespace.
 // TODO (stickupkid): Before handing out any DB for any namespace,

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -277,6 +277,7 @@ func (w *dbWorker) Report() map[string]any {
 
 	if w.dbApp == nil {
 		result["leader"] = ""
+		result["leader-id"] = uint64(0)
 		result["leader-role"] = ""
 		return result
 	}
@@ -287,14 +288,17 @@ func (w *dbWorker) Report() map[string]any {
 	var (
 		leader     string
 		leaderRole string
+		leaderID   uint64
 	)
 	if client, err := w.dbApp.Client(ctx); err == nil {
 		if nodeInfo, err := client.Leader(ctx); err == nil {
+			leaderID = nodeInfo.ID
 			leader = nodeInfo.Address
 			leaderRole = nodeInfo.Role.String()
 		}
 	}
 
+	result["leader-id"] = leaderID
 	result["leader"] = leader
 	result["leader-role"] = leaderRole
 

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -113,6 +113,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 	report := w.(interface{ Report() map[string]any }).Report()
 	c.Assert(report, MapHasKeys, []string{
 		"leader",
+		"leader-id",
 		"leader-role",
 	})
 


### PR DESCRIPTION
The following wires up the db accessor to the engine report. It does this, by just conforming to the Report interface.

For now, we're only exposing a few things about the internals of the worker. These include:

 1. Leader and leader-role information.
 1. How many db replacements have taken place. A high number indicates issues with the underlying db.
 2. The max ping duration and ping duration.
 3. How many attempts it took to ping in the retry, for the last ping. This should show any issues with the underlying db. Higher the attempts the more likely there are contention issues.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju ssh -m controller 0
$ juju_engine_report | grep -A 18 "db-accessor:"
  db-accessor:
    inputs:
    - agent
    - is-controller-flag
    report:
      leader: 127.0.0.1:17666
      leader-role: voter
      workers:
        controller:
          report:
            db-replacements: 0
            last-ping-attempts: 1
            last-ping-duration: 12.604µs
            max-ping-duration: 12.604µs
          started: "2023-04-21 14:22:01"
          state: started
    start-count: 1
    started: "2023-04-21 14:22:01"
    state: started
```
