### PR TITLE
Don't fail when when sshing netplan apply

### DIFF
--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -45,7 +45,7 @@ configure_multi_nic_netplan() {
 	echo "[+] Reconfiguring netplan:"
 	juju ssh ${juju_machine_id} 'sudo cat /etc/netplan/50-cloud-init.yaml'
 	# shellcheck disable=SC2086,SC2016
-	juju ssh ${juju_machine_id} 'sudo netplan apply'
+	juju ssh ${juju_machine_id} 'sudo netplan apply' || true
 	echo "[+] Applied"
 	# shellcheck disable=SC2086,SC2016
 	juju ssh ${juju_machine_id} 'sudo systemctl restart jujud-machine-*'


### PR DESCRIPTION
Sometimes when we netplan apply over ssh, the session is terminated which leads to a false positive test result

If the ssh command returns non-zzero error code, ignore it and continue. If it's a legitimate failure, we will fail later down the line anyway

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -R eu-west-2 spaces_ec2
```

