### PR TITLE
[JUJU-3447] Enable ModelFirewaller for OpenStack

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2359,7 +2359,7 @@ potentially valuable resources.
 	SSHAllowKey: {
 		Description: `SSH allowlist is a comma-separated list of CIDRs from
 which machines in this model will accept connections to the SSH service.
-Currently only the aws & openstack providers supports ssh-allow`,
+Currently only the aws & openstack providers support ssh-allow`,
 		Type:  environschema.Tstring,
 		Group: environschema.EnvironGroup,
 	},

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1549,7 +1549,7 @@ func (c *Config) validateMode() error {
 func (c *Config) SSHAllow() []string {
 	allowList, ok := c.defined[SSHAllowKey].(string)
 	if !ok {
-		return []string{"0.0.0.0/0"}
+		return []string{"0.0.0.0/0", "::/0"}
 	}
 	if allowList == "" {
 		return []string{}
@@ -2359,7 +2359,7 @@ potentially valuable resources.
 	SSHAllowKey: {
 		Description: `SSH allowlist is a comma-separated list of CIDRs from
 which machines in this model will accept connections to the SSH service.
-Currently only the aws provider supports ssh-allow`,
+Currently only the aws & openstack providers supports ssh-allow`,
 		Type:  environschema.Tstring,
 		Group: environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -662,6 +662,10 @@ var configTests = []configTest{
 		}),
 		err: `cidr "blah" not valid`,
 	}, {
+		about:       "Absent ssh-allow entry",
+		useDefaults: config.NoDefaults,
+		attrs:       minimalConfigAttrs,
+	}, {
 		about:       "Invalid saas-ingress-allow cidr",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -832,8 +836,7 @@ func (test configTest) check(c *gc.C) {
 		c.Assert(cfg.ContainerImageStream(), gc.Equals, "released")
 	}
 
-	resourceTags, cfgHasResourceTags := cfg.ResourceTags()
-	c.Assert(cfgHasResourceTags, jc.IsTrue)
+	resourceTags, _ := cfg.ResourceTags()
 	if tags, ok := test.attrs["resource-tags"]; ok {
 		switch tags := tags.(type) {
 		case []string:
@@ -864,6 +867,7 @@ func (test configTest) check(c *gc.C) {
 	if val, ok := test.attrs[config.ContainerInheritPropertiesKey].(string); ok && val != "" {
 		c.Assert(cfg.ContainerInheritProperties(), gc.Equals, val)
 	}
+	c.Assert(cfg.SSHAllow(), gc.DeepEquals, []string{"0.0.0.0/0", "::/0"})
 }
 
 func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {

--- a/environs/models/model.go
+++ b/environs/models/model.go
@@ -21,6 +21,5 @@ type ModelFirewaller interface {
 	// It is expected that there be only one ingress rule result for a given
 	// port range - the rule's SourceCIDRs will contain all applicable source
 	// address rules for that port range.
-	// If the model security group doesn't exist, return a NotFound error
 	ModelIngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
+	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
 	github.com/go-logr/logr v1.2.2
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkPro
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4 h1:IzjmVasvOk8hqDbP0uSOTFZRTSsP4WYmVl9VcQPS92o=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
+github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a h1:H/l82+fC6idmYg1kfpQlCq7gYctri7AGn9RemqwN6bw=
+github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -495,6 +495,7 @@ func newState(name string, ops chan<- Operation, newStatePolicy state.NewPolicyF
 		ops:            ops,
 		newStatePolicy: newStatePolicy,
 		insts:          make(map[instance.Id]*dummyInstance),
+		modelRules:     firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("22"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR)},
 		creator:        string(buf),
 	}
 	return s

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1708,37 +1708,9 @@ func (e *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instan
 // allInstancesByState returns all instances in the environment
 // with one of the specified instance states.
 func (e *environ) allInstancesByState(ctx context.ProviderCallContext, states ...string) ([]instances.Instance, error) {
-	// NOTE(axw) we use security group filtering here because instances
-	// start out untagged. If Juju were to abort after starting an instance,
-	// but before tagging it, it would be leaked. We only need to do this
-	// for AllRunningInstances, as it is the result of AllRunningInstances that is used
-	// in "harvesting" unknown instances by the provisioner.
-	//
-	// One possible alternative is to modify ec2.RunInstances to allow the
-	// caller to specify ClientToken, and then format it like
-	//     <controller-uuid>:<model-uuid>:<machine-id>
-	//     (with base64-encoding to keep the size under the 64-byte limit)
-	//
-	// It is possible to filter on "client-token", and specify wildcards;
-	// therefore we could use client-token filters everywhere in the ec2
-	// provider instead of tags or security groups. The only danger is if
-	// we need to make non-idempotent calls to RunInstances for the machine
-	// ID. I don't think this is needed, but I am not confident enough to
-	// change this fundamental right now.
-	//
-	// An EC2 API call is required to resolve the group name to an id, as
-	// VPC enabled accounts do not support name based filtering.
-	groupName := e.jujuGroupName()
-	group, err := e.groupByName(ctx, groupName)
-	if isNotFoundError(err) {
-		// If there's no group, then there cannot be any instances.
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Trace(maybeConvertCredentialError(err, ctx))
-	}
 	filters := []types.Filter{
 		makeFilter("instance-state-name", states...),
-		makeFilter("instance.group-id", aws.ToString(group.GroupId)),
+		makeModelFilter(e.uuid()),
 	}
 	return e.allInstances(ctx, filters)
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -30,6 +30,10 @@ func MachineGroupName(e environs.Environ, machineId string) string {
 	return e.(*environ).machineGroupName(machineId)
 }
 
+func GlobalGroupName(e environs.Environ) string {
+	return e.(*environ).globalGroupName()
+}
+
 func EnvironEC2Client(e environs.Environ) Client {
 	return e.(*environ).ec2Client
 }

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -65,14 +65,9 @@ func (fakeNamespace) Value(s string) string {
 	return "juju-" + s
 }
 
-func SetUpGlobalGroup(e environs.Environ, ctx context.ProviderCallContext, name string, apiPort int) (neutron.SecurityGroupV2, error) {
+func EnsureGroup(e environs.Environ, ctx context.ProviderCallContext, name string, isModelGroup bool) (neutron.SecurityGroupV2, error) {
 	switching := &neutronFirewaller{firewallerBase: firewallerBase{environ: e.(*Environ)}}
-	return switching.setUpGlobalGroup(name, apiPort)
-}
-
-func EnsureGroup(e environs.Environ, ctx context.ProviderCallContext, name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
-	switching := &neutronFirewaller{firewallerBase: firewallerBase{environ: e.(*Environ)}}
-	return switching.ensureGroup(name, rules)
+	return switching.ensureGroup(name, isModelGroup)
 }
 
 func MachineGroupRegexp(e environs.Environ, machineId string) string {
@@ -155,7 +150,7 @@ func GetModelGroupNames(e environs.Environ) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	modelPattern, err := regexp.Compile(neutronFw.jujuGroupRegexp())
+	modelPattern, err := regexp.Compile(neutronFw.jujuGroupPrefixRegexp())
 	if err != nil {
 		return nil, err
 	}

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1076,10 +1076,6 @@ func (fw *Firewaller) flushModel() error {
 
 	ctx := stdcontext.Background()
 	curr, err := fw.environModelFirewaller.ModelIngressRules(fw.cloudCallContextFunc(ctx))
-	if errors.IsNotFound(err) {
-		fw.logger.Warningf("Model firewall not found so cannot re-write firewall rule %q. Ignoring", want)
-		return nil
-	}
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
This work has already been done for aws. Add OpenStack to the list of
providers which support this
https://github.com/juju/juju/pull/15329

As with aws, model ssh ingress is now managed by `ssh-allow` model config item.
Also, api-port is now only opened on the controller model 

This was mostly trivial, and involved removing a lot of responsibilities
from the OpenStack provider

This has involved updating the go-goose dependency

Also as a flyby fix an bug in config. ssh-allow was defaulting to the
wrong value if the entry was absent. Write a test for this case as well

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Verify ssh-allow

Deploy a controller to opensatck, add a model and deploy a machine
```
$ juju bootstrap openstack stack
$ juju add-model m
$ juju add-machine
```

Then find the model-level security group name, put it in an envvar. For me:
```
$ export MODEL_GROUP=juju-83a82f66-bfd4-4bb0-812a-e3edfb67d64d-57d8be23-4f99-4de0-8946-bb9e89d21f78
```

And now verify ssh-allow default settings
```
$ juju model-config ssh-allow
0.0.0.0/0,::/0
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
0.0.0.0/0
::/0
```

Now configure ssh-allow
```
$ juju model-config ssh-allow="192.168.0.0/24"
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

Add a machine to verify this doesn't reset things
```
$ juju model-config ssh-allow="192.168.0.0/24"
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

Add a new model pre-configured to check the config comes into effect even if no machines are present when it's set. (You will need to reset `MODEL_GROUP`
```
$ juju add-model m2 --config ssh-allow="192.168.2.0/24"
$ juju add-machine
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

### Verify multiple machines can be added to the same model
```
$ juju add-model m
$ juju add-machine
(wait)
$ juju add-machine
(wait)
$ juju status
Model  Controller  Cloud/Region           Version      SLA          Timestamp
m      mstack      microstack/microstack  3.2-beta4.1  unsupported  14:13:42+01:00

Machine  State    Address         Inst id                               Base          AZ    Message
0        started  192.168.222.61  9b7c14e8-dd6f-4cb3-ad19-0ffa8e852f48  ubuntu@22.04  nova  ACTIVE
1        started  192.168.222.54  5a51c5d4-af57-4231-b3d9-afc28736467a  ubuntu@22.04  nova  ACTIVE
```

### Verify `juju expose` still exposes
```
$ juju deploy postgresql
(wait)
$ juju expose postgresql
$ openstack security group show $MACHINE_GROUP
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                                                                                                                              |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| created_at      | 2023-04-25T13:14:34Z                                                                                                                                                                                                                               |
| description     | juju group                                                                                                                                                                                                                                         |
| id              | 1069e8a6-a3b1-4aee-8471-d02f48d395e1                                                                                                                                                                                                               |
| location        | cloud='', project.domain_id=, project.domain_name='default', project.id='8910e2a31e8a4834a266bfd5dc99d80c', project.name='admin', region_name='', zone=                                                                                            |
| name            | juju-20810b78-b20d-4543-837e-9715be4fcda1-01de2e1c-76a3-40a0-864f-694e16e2164b-2                                                                                                                                                                   |
| project_id      | 8910e2a31e8a4834a266bfd5dc99d80c                                                                                                                                                                                                                   |
| revision_number | 3                                                                                                                                                                                                                                                  |
| rules           | created_at='2023-04-25T13:14:34Z', direction='egress', ethertype='IPv6', id='11996358-35f0-4316-90f4-9eef38a623fc', updated_at='2023-04-25T13:14:34Z'                                                                                              |
|                 | created_at='2023-04-25T13:14:34Z', direction='egress', ethertype='IPv4', id='22a74304-8426-42cf-b93b-2a8a8b85357e', updated_at='2023-04-25T13:14:34Z'                                                                                              |
|                 | created_at='2023-04-25T13:18:28Z', direction='ingress', ethertype='IPv4', id='a847c482-a5a7-4935-af77-dcd52267a652', port_range_max='5432', port_range_min='5432', protocol='tcp', remote_ip_prefix='0.0.0.0/0', updated_at='2023-04-25T13:18:28Z' |
|                 | created_at='2023-04-25T13:18:28Z', direction='ingress', ethertype='IPv6', id='ae88d48b-53ff-4cbb-94a4-9fafa9ae4e9a', port_range_max='5432', port_range_min='5432', protocol='tcp', remote_ip_prefix='::/0', updated_at='2023-04-25T13:18:28Z'      |
| stateful        | True                                                                                                                                                                                                                                               |
| tags            | []                                                                                                                                                                                                                                                 |
| updated_at      | 2023-04-25T13:18:28Z                                                                                                                                                                                                                               |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

### Verify api-port
```
$ juju bootstrap openstack openstack --config api-port=17777
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 17777) | .remote_ip_prefix'
0.0.0.0/0
```

### Verify autocert-dns-name
```
$ juju bootstrap openstack openstack --config autocert-dns-name=example.com
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 80) | .remote_ip_prefix'
0.0.0.0/0
```
