### PR TITLE
[JUJU-3458] Use existing charm in DeployFromRepository.

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -129,6 +129,9 @@ type Bindings interface {
 type Charm interface {
 	CharmMeta
 	Config() *charm.Config
+	Metrics() *charm.Metrics
+	Actions() *charm.Actions
+	Revision() int
 	URL() *charm.URL
 	String() string
 	IsUploaded() bool

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -54,6 +54,7 @@ type DeployFromRepositoryState interface {
 	AddPendingResource(string, resource.Resource) (string, error)
 	RemovePendingResources(applicationID string, pendingIDs map[string]string) error
 	AddCharmMetadata(info state.CharmInfo) (Charm, error)
+	Charm(*charm.URL) (Charm, error)
 	ControllerConfig() (controller.Config, error)
 	Machine(string) (Machine, error)
 	ModelConstraints() (constraints.Value, error)
@@ -146,7 +147,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(arg params.DeployFromRe
 			// Remove the pending resources that are added before the AddApplication is called
 			removeResourcesErr := api.state.RemovePendingResources(dt.applicationName, pendingIDs)
 			if removeResourcesErr != nil {
-				logger.Errorf("unable to remove pending resources for %q", dt.applicationName)
+				deployRepoLogger.Errorf("unable to remove pending resources for %q", dt.applicationName)
 			}
 		}
 		return params.DeployFromRepositoryInfo{}, nil, []error{errors.Trace(err)}
@@ -320,12 +321,11 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 	// charm or the essential metadata from a charm to be async downloaded.
 	charmURL, resolvedOrigin, resolvedCharm, err := v.getCharm(arg)
 	if err != nil {
-		errs = append(errs, err...)
+		errs = append(errs, err)
 		// return any errors here, there is no need to continue with
 		// validation if we cannot find the charm.
 		return deployTemplate{}, errs
 	}
-	deployRepoLogger.Tracef("from getCharm: %s", charmURL, pretty.Sprint(resolvedOrigin))
 
 	// Various checks of the resolved charm against the arg provided.
 	dt, rcErrs := v.resolvedCharmValidation(resolvedCharm, arg)
@@ -358,7 +358,9 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 	dt.pendingResourceUploads = pendingResourceUploads
 	dt.resolvedResources = resources
 
-	deployRepoLogger.Tracef("validateDeployFromRepositoryArgs returning: %s", pretty.Sprint(dt))
+	if deployRepoLogger.IsTraceEnabled() {
+		deployRepoLogger.Tracef("validateDeployFromRepositoryArgs returning: %s", pretty.Sprint(dt))
+	}
 	return dt, errs
 }
 
@@ -723,12 +725,10 @@ func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedO
 
 // getCharm returns the charm being deployed. Either it already has been
 // used once, and we get the data from state. Or we get the essential metadata.
-func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepositoryArg) (*charm.URL, corecharm.Origin, charm.Charm, []error) {
-	errs := make([]error, 0)
+func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepositoryArg) (*charm.URL, corecharm.Origin, charm.Charm, error) {
 	initialCurl, requestedOrigin, usedModelDefaultBase, err := v.createOrigin(arg)
 	if err != nil {
-		errs = append(errs, err)
-		return nil, corecharm.Origin{}, nil, errs
+		return nil, corecharm.Origin{}, nil, errors.Trace(err)
 	}
 	deployRepoLogger.Tracef("from createOrigin: %s, %s", initialCurl, pretty.Sprint(requestedOrigin))
 	// TODO:
@@ -739,17 +739,14 @@ func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepository
 
 	charmURL, resolvedOrigin, err := v.resolveCharm(initialCurl, requestedOrigin, arg.Force, usedModelDefaultBase, arg.Cons)
 	if err != nil {
-		errs = append(errs, err)
-		return nil, corecharm.Origin{}, nil, errs
+		return nil, corecharm.Origin{}, nil, errors.Trace(err)
 	}
-	deployRepoLogger.Tracef("from resolveCharm: %s, %s", charmURL, pretty.Sprint(resolvedOrigin))
 	// Are we deploying a charm? if not, fail fast here.
 	// TODO: add a ErrorNotACharm or the like for the juju client.
 
 	repo, err := v.getCharmRepository(corecharm.CharmHub)
 	if err != nil {
-		errs = append(errs, err)
-		return nil, corecharm.Origin{}, nil, errs
+		return nil, corecharm.Origin{}, nil, errors.Trace(err)
 	}
 
 	// Check if a charm doc already exists for this charm URL. If so, the
@@ -761,13 +758,16 @@ func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepository
 	// We need to use GetDownloadURL instead of ResolveWithPreferredChannel
 	// to ensure that the resolved origin has the ID/Hash fields correctly
 	// populated.
-	// TODO: Handle already deployed charm.
-	//deployedCharm, err := api.backend.Charm(charmURL)
-	//if err == nil {
-	//	_, resolvedOrigin, err = repo.GetDownloadURL(charmURL, resolvedOrigin)
-	//	if err != nil {
-	//	}
-	//}
+	deployedCharm, err := v.state.Charm(charmURL)
+	if err != nil && !errors.Is(err, errors.NotFound) {
+		return nil, corecharm.Origin{}, nil, errors.Trace(err)
+	} else if err == nil {
+		_, resolvedOrigin, err = repo.GetDownloadURL(charmURL, resolvedOrigin)
+		if err != nil {
+			return nil, corecharm.Origin{}, nil, errors.Trace(err)
+		}
+		return charmURL, resolvedOrigin, deployedCharm, nil
+	}
 
 	// Fetch the essential metadata that we require to deploy the charm
 	// without downloading the full archive. The remaining metadata will
@@ -777,8 +777,7 @@ func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepository
 		Origin:   resolvedOrigin,
 	})
 	if err != nil {
-		errs = append(errs, errors.Annotatef(err, "retrieving essential metadata for charm %q", charmURL))
-		return nil, corecharm.Origin{}, nil, errs
+		return nil, corecharm.Origin{}, nil, errors.Annotatef(err, "retrieving essential metadata for charm %q", charmURL)
 	}
 	metaRes := essentialMeta[0]
 	resolvedCharm := corecharm.NewCharmInfoAdapter(metaRes)

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -158,6 +158,21 @@ func (mr *MockDeployFromRepositoryStateMockRecorder) AllSpaceInfos() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaceInfos", reflect.TypeOf((*MockDeployFromRepositoryState)(nil).AllSpaceInfos))
 }
 
+// Charm mocks base method.
+func (m *MockDeployFromRepositoryState) Charm(arg0 *v10.URL) (Charm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Charm", arg0)
+	ret0, _ := ret[0].(Charm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Charm indicates an expected call of Charm.
+func (mr *MockDeployFromRepositoryStateMockRecorder) Charm(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockDeployFromRepositoryState)(nil).Charm), arg0)
+}
+
 // ControllerConfig mocks base method.
 func (m *MockDeployFromRepositoryState) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -1680,6 +1680,20 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
 }
 
+// Actions mocks base method.
+func (m *MockCharm) Actions() *charm.Actions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Actions")
+	ret0, _ := ret[0].(*charm.Actions)
+	return ret0
+}
+
+// Actions indicates an expected call of Actions.
+func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
+}
+
 // Config mocks base method.
 func (m *MockCharm) Config() *charm.Config {
 	m.ctrl.T.Helper()
@@ -1734,6 +1748,34 @@ func (m *MockCharm) Meta() *charm.Meta {
 func (mr *MockCharmMockRecorder) Meta() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharm)(nil).Meta))
+}
+
+// Metrics mocks base method.
+func (m *MockCharm) Metrics() *charm.Metrics {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Metrics")
+	ret0, _ := ret[0].(*charm.Metrics)
+	return ret0
+}
+
+// Metrics indicates an expected call of Metrics.
+func (mr *MockCharmMockRecorder) Metrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockCharm)(nil).Metrics))
+}
+
+// Revision mocks base method.
+func (m *MockCharm) Revision() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Revision")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Revision indicates an expected call of Revision.
+func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }
 
 // String mocks base method.

--- a/apiserver/facades/client/application/updateseries_mocks_test.go
+++ b/apiserver/facades/client/application/updateseries_mocks_test.go
@@ -557,6 +557,20 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
 }
 
+// Actions mocks base method.
+func (m *MockCharm) Actions() *v10.Actions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Actions")
+	ret0, _ := ret[0].(*v10.Actions)
+	return ret0
+}
+
+// Actions indicates an expected call of Actions.
+func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
+}
+
 // Config mocks base method.
 func (m *MockCharm) Config() *v10.Config {
 	m.ctrl.T.Helper()
@@ -611,6 +625,34 @@ func (m *MockCharm) Meta() *v10.Meta {
 func (mr *MockCharmMockRecorder) Meta() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharm)(nil).Meta))
+}
+
+// Metrics mocks base method.
+func (m *MockCharm) Metrics() *v10.Metrics {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Metrics")
+	ret0, _ := ret[0].(*v10.Metrics)
+	return ret0
+}
+
+// Metrics indicates an expected call of Metrics.
+func (mr *MockCharmMockRecorder) Metrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockCharm)(nil).Metrics))
+}
+
+// Revision mocks base method.
+func (m *MockCharm) Revision() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Revision")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Revision indicates an expected call of Revision.
+func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }
 
 // String mocks base method.


### PR DESCRIPTION
When a charm is deployed for more than one application. There is no need to get the essential metadata again, as the charm exists in state. Part of deploy from repository

## QA steps

```sh

$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju bootstrap localhost friday-test
$ juju model-config logging-config="<root>=INFO;juju.apiserver.charmdownloader.charmdownloader=DEBUG" -m controller
$ juju add-model five
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju deploy ubuntu
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju deploy ubuntu twenty-two

# check for charms being downloaded, should only have 1 download of the ubuntu charm.
$ juju debug-log -m controller --include-module juju.apiserver.charmdownloader.charmdownloader --replay | grep "downloaded charm"
machine-0: 19:20:34 DEBUG juju.apiserver.charmdownloader.charmdownloader charmhub downloaded charm "ch:amd64/focal/ubuntu-22" from actual origin {charm-hub charm DksXQKAQTZfsUmBAGanZAhpoS4dpmXel f4bf4df5967192802ed19c1dd0da0b339fb6a59dc661daf99bb0c3e0b1640f5a 0xc001164c38 stable amd64/ubuntu/20.04 }
```

