### PR TITLE
Return loopback config address

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -918,7 +918,7 @@ func ConvertToSpaceAddress(addr SpaceAddressCandidate, lookup SubnetLookup) (Spa
 
 	// If this is not a loopback device, attempt to
 	// set the space ID based on the subnet.
-	if addr.ConfigMethod() != ConfigLoopback && cidr != "" {
+	if cidr != "" {
 		allMatching, err := subnets.GetByCIDR(cidr)
 		if err != nil {
 			return SpaceAddress{}, errors.Trace(err)


### PR DESCRIPTION
Currently, jujud will discover a loopback address that is not 127.0.0.1 but when network-get will try to get such address for a space, the loopback address will be filtered. This change attempts to change this to return said address.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
$ juju spaces:

Name Space ID Subnets
alpha 0 <CIDRS...>
bgp x.x.x.x/32
                 y.y.y.y/32
                 u.u.u.u/32

unit/x in juju debug-env (magpie bound to bgp):

lo: x.x.x.x/32, 127.0.0.1
network-get --ingress-address magpie

x.x.x.x/32,
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2017307
