### PR TITLE
[JUJU-3505] AllWatcher additional attrs

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -21,6 +21,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	corewatcher "github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -179,6 +180,13 @@ func (aw allWatcherDeltaTranslater) TranslateModel(info multiwatcher.EntityInfo)
 		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
 		return nil
 	}
+
+	var version string
+	if cfg, err := config.New(config.NoDefaults, orig.Config); err == nil {
+		versionNumber, _ := cfg.AgentVersion()
+		version = versionNumber.String()
+	}
+
 	return &params.ModelUpdate{
 		ModelUUID:      orig.ModelUUID,
 		Name:           orig.Name,
@@ -193,6 +201,10 @@ func (aw allWatcherDeltaTranslater) TranslateModel(info multiwatcher.EntityInfo)
 			Level: orig.SLA.Level,
 			Owner: orig.SLA.Owner,
 		},
+		Type:        orig.Type.String(),
+		Cloud:       orig.Cloud,
+		CloudRegion: orig.CloudRegion,
+		Version:     version,
 	}
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -439,6 +439,8 @@ const (
 //	~/.local/share/juju/<name>-private-key.pem
 //
 // if $XDG_DATA_HOME is defined it will be used instead of ~/.local/share
+//
+// The attrs map can not be nil, otherwise a panic is raised.
 func New(withDefaults Defaulting, attrs map[string]interface{}) (*Config, error) {
 	initSchema.Do(func() {
 		allFields = fields()

--- a/rpc/params/multiwatcher.go
+++ b/rpc/params/multiwatcher.go
@@ -405,6 +405,10 @@ type ModelUpdate struct {
 	Status         StatusInfo             `json:"status"`
 	Constraints    constraints.Value      `json:"constraints"`
 	SLA            ModelSLAInfo           `json:"sla"`
+	Type           string                 `json:"type"`
+	Cloud          string                 `json:"cloud"`
+	CloudRegion    string                 `json:"cloud-region"`
+	Version        string                 `json:"version"`
 }
 
 // EntityId returns a unique identifier for a model.


### PR DESCRIPTION
In order to help with the dashboard UI and to remove redundant subsequent calls to the API server for the same data, we just expose more information from the AllWatcher.

The code turned out to be relatively simple, we just weren't exposing it. Although, I'm starting to believe the AllWatcher is an anti-pattern, by sending data with the changes, rather than just what's changed leading to a better query API. The downside with the AllWatcher is that the data being sent has to accommodate all the data and it very much feels like we're passing data via a back channel. The API itself would be better served with a better query API.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Apply the following diff:

```diff
diff --git a/cmd/juju/waitfor/model.go b/cmd/juju/waitfor/model.go
index b495e3ff63..9c52bc8516 100644
--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -7,6 +7,7 @@ import (
        "io"
        "time"

+       "github.com/davecgh/go-spew/spew"
        "github.com/juju/cmd/v3"
        "github.com/juju/errors"
        "github.com/juju/gnuflag"
@@ -142,7 +143,7 @@ func (c *modelCommand) primeCache() {
 func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
        return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
                for _, delta := range deltas {
-                       logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+                       logger.Criticalf("delta %T: %v", delta.Entity, spew.Sdump(delta.Entity))

                        switch entityInfo := delta.Entity.(type) {
                        case *params.ApplicationInfo:

```

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju wait-for model default
```

You should now see the new changes in the log from the model.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1939341
