### PR TITLE
[JUJU-3593] Allow loopback addresses to be converted to SpaceAddresses

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -916,8 +916,7 @@ func ConvertToSpaceAddress(addr SpaceAddressCandidate, lookup SubnetLookup) (Spa
 		),
 	}
 
-	// If this is not a loopback device, attempt to
-	// set the space ID based on the subnet.
+	// Attempt to set the space ID based on the subnet.
 	if cidr != "" {
 		allMatching, err := subnets.GetByCIDR(cidr)
 		if err != nil {

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -918,7 +918,7 @@ func ConvertToSpaceAddress(addr SpaceAddressCandidate, lookup SubnetLookup) (Spa
 
 	// If this is not a loopback device, attempt to
 	// set the space ID based on the subnet.
-	if addr.ConfigMethod() != ConfigLoopback && cidr != "" {
+	if cidr != "" {
 		allMatching, err := subnets.GetByCIDR(cidr)
 		if err != nil {
 			return SpaceAddress{}, errors.Trace(err)

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -1090,6 +1090,7 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 	subs := network.SubnetInfos{
 		{ID: "1", CIDR: "192.168.0.0/24", SpaceID: "666"},
 		{ID: "2", CIDR: "252.80.0.0/12", SpaceID: "999"},
+		{ID: "3", CIDR: "10.0.0.10/32", SpaceID: "333"},
 	}
 
 	candidates := []network.SpaceAddressCandidate{
@@ -1104,6 +1105,13 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 			configMethod: network.ConfigDHCP,
 			subnetCIDR:   "192.168.0.0/24",
 		},
+		// This simulates an address added to the loopback device,
+		// such as done by BGP.
+		spaceAddressCandidate{
+			value:        "10.0.0.10",
+			configMethod: network.ConfigLoopback,
+			subnetCIDR:   "10.0.0.10/32",
+		},
 	}
 
 	addrs := make(network.SpaceAddresses, len(candidates))
@@ -1115,6 +1123,16 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 
 	sort.Sort(addrs)
 	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.10",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+				ConfigType: network.ConfigLoopback,
+				CIDR:       "10.0.0.10/32",
+			},
+			SpaceID: "333",
+		},
 		{
 			MachineAddress: network.MachineAddress{
 				Value:      "192.168.0.66",


### PR DESCRIPTION
Under https://github.com/juju/juju/pull/14663 we made changes to manual machines so that addresses added for BGP routing to the loopback device were discovered by Juju.

It turns out that this fix was insufficient to deliver the desired functionality, because when we use `ConvertToSpaceAddress` to service `network-get` requests, we omit these addresses meaning they do not get assigned a space. This in turn means they are not associated with a binding/relation.

Here we just remove the filter so that loopback addresses are considered.

## QA steps

This fix has already been verified by field. Unit tests are included to cover the change.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2017307
