### PR TITLE
[JUJU-3598] Ensure cancellation during bootstrap

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -64,16 +64,16 @@ jobs:
         run: |
           juju bootstrap lxd test31
           juju switch controller
-          juju wait-for application controller
+          juju wait-for application controller || juju status -m controller
 
         # TODO: create backup and juju restore
 
       - name: Migrate default model to 3.1 controller
         run: |
           juju switch test30
-          
+
           # Ensure application is fully deployed
-          juju wait-for application ubuntu
+          juju wait-for application ubuntu || juju status
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
@@ -102,4 +102,4 @@ jobs:
           done
           
           juju switch default
-          juju wait-for application ubuntu
+          juju wait-for application ubuntu || juju status

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -403,17 +403,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating namespace for controller stack")
 	}
 
-	// Check context manually for cancellation between each step (not ideal,
-	// but it avoids wiring context absolutely everywhere).
-	isDone := func() bool {
-		select {
-		case <-c.ctx.Context().Done():
-			return true
-		default:
-			return false
-		}
-	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -427,7 +417,7 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.createControllerService(c.ctx.Context()); err != nil {
 		return errors.Annotate(err, "creating service for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -440,7 +430,7 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.createControllerSecretSharedSecret(); err != nil {
 		return errors.Annotate(err, "creating shared-secret secret for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -448,7 +438,7 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.createControllerSecretServerPem(); err != nil {
 		return errors.Annotate(err, "creating server.pem secret for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -456,7 +446,7 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.ensureControllerConfigmapBootstrapParams(); err != nil {
 		return errors.Annotate(err, "creating bootstrap-params configmap for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -464,14 +454,14 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.ensureControllerConfigmapAgentConf(); err != nil {
 		return errors.Annotate(err, "creating agent config configmap for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
 	if err = c.ensureControllerApplicationSecret(); err != nil {
 		return errors.Annotate(err, "creating secret for controller application")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -492,14 +482,14 @@ func (c *controllerStack) Deploy() (err error) {
 	if err != nil {
 		return errors.Annotate(err, "creating service account for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
 	if err = c.patchServiceAccountForImagePullSecret(saName); err != nil {
 		return errors.Annotate(err, "patching image pull secret for controller service account")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 
@@ -507,7 +497,7 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.createControllerStatefulset(); err != nil {
 		return errors.Annotate(err, "creating statefulset for controller")
 	}
-	if isDone() {
+	if environsbootstrap.IsContextDone(c.ctx.Context()) {
 		return environsbootstrap.Cancelled()
 	}
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -1151,12 +1151,12 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *gc.C) {
 	ctxDoneChan := make(chan struct{}, 1)
 
 	gomock.InOrder(
-		mockStdCtx.EXPECT().Done().Return(ctxDoneChan),
+		mockStdCtx.EXPECT().Err().Return(nil),
 		mockStdCtx.EXPECT().Done().DoAndReturn(func() <-chan struct{} {
 			ctxDoneChan <- struct{}{}
 			return ctxDoneChan
 		}),
-		mockStdCtx.EXPECT().Err().Return(context.DeadlineExceeded),
+		mockStdCtx.EXPECT().Err().Return(context.DeadlineExceeded).MinTimes(1),
 	)
 
 	errChan := make(chan error)

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -165,19 +165,23 @@ func WaitForAgentInitialisation(
 	return errors.Annotatef(err, "unable to contact api server after %d attempts", apiAttempts)
 }
 
+// unknownError is used to wrap errors that we don't know how to handle.
 type unknownError struct {
 	err error
 }
 
+// Is implements errors.Is, so that we can identify this error type.
 func (e *unknownError) Is(other error) bool {
 	_, ok := other.(*unknownError)
 	return ok
 }
 
+// Cause implements errors.Cause, so that we can unwrap this error type.
 func (e *unknownError) Cause() error {
 	return e.err
 }
 
+// Error implements error.Error.
 func (e *unknownError) Error() string {
 	return e.err.Error()
 }

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	stdcontext "context"
 	"fmt"
 	"io"
 	"strings"
@@ -75,8 +76,12 @@ func WaitForAgentInitialisation(
 	isCAASController bool,
 	controllerName string,
 ) (err error) {
+	if ctx.Context().Err() != nil {
+		return errors.Errorf("unable to contact api server: (%v)", ctx.Context().Err())
+	}
+
 	// Make a best effort to find the new controller address so we can print it.
-	addressInfo := ""
+	var addressInfo string
 	controller, err := c.ClientStore().ControllerByName(controllerName)
 	if err == nil && len(controller.APIEndpoints) > 0 {
 		addr, err := network.ParseMachineHostPort(controller.APIEndpoints[0])
@@ -86,17 +91,23 @@ func WaitForAgentInitialisation(
 	}
 
 	ctx.Infof("Contacting Juju controller%s to verify accessibility...", addressInfo)
-	apiAttempts := 0
-	stop := make(chan struct{}, 1)
-	defer close(stop)
+
+	var apiAttempts int
 	err = retry.Call(retry.CallArgs{
 		Clock:    clock.WallClock,
 		Attempts: bootstrapReadyPollCount,
 		Delay:    bootstrapReadyPollDelay,
-		Stop:     stop,
+		Stop:     ctx.Context().Done(),
+		NotifyFunc: func(lastErr error, attempts int) {
+			apiAttempts = attempts
+		},
+		IsFatalError: func(err error) bool {
+			return errors.Is(err, &unknownError{}) ||
+				retry.IsRetryStopped(err) ||
+				errors.Is(err, stdcontext.Canceled) ||
+				errors.Is(err, stdcontext.DeadlineExceeded)
+		},
 		Func: func() error {
-			apiAttempts++
-
 			retryErr := tryAPI(c)
 			if retryErr == nil {
 				msg := fmt.Sprintf("\nBootstrap complete, controller %q is now available", controllerName)
@@ -109,15 +120,6 @@ func WaitForAgentInitialisation(
 				return nil
 			}
 
-			// Check whether context is cancelled after each attempt (as context
-			// isn't fully threaded through yet).
-			select {
-			case <-ctx.Context().Done():
-				stop <- struct{}{}
-				return errors.Annotatef(err, "contacting controller (cancelled)")
-			default:
-			}
-
 			// As the API server is coming up, it goes through a number of steps.
 			// Initially the upgrade steps run, but the api server allows some
 			// calls to be processed during the upgrade, but not the list blocks.
@@ -127,9 +129,10 @@ func WaitForAgentInitialisation(
 			// lead to EOF or "connection is shut down" error messages. We skip
 			// these too, hoping that things come back up before the end of the
 			// retry poll count.
-			errorMessage := errors.Cause(retryErr).Error()
+			cause := errors.Cause(retryErr)
+			errorMessage := cause.Error()
 			switch {
-			case errors.Cause(retryErr) == io.EOF,
+			case cause == io.EOF,
 				strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
 				strings.HasSuffix(errorMessage, "connection refused"),
 				strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
@@ -143,16 +146,40 @@ func WaitForAgentInitialisation(
 			case params.ErrCode(retryErr) == params.CodeUpgradeInProgress:
 				ctx.Verbosef("Still waiting for API to become available: %v", retryErr)
 				return retryErr
+			default:
+				return &unknownError{
+					err: retryErr,
+				}
 			}
-			stop <- struct{}{}
-			return retryErr
 		},
 	})
-	if err != nil {
+
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, &unknownError{}):
+		err = errors.Cause(err)
+	default:
 		err = retry.LastError(err)
-		return errors.Annotatef(err, "unable to contact api server after %d attempts", apiAttempts)
 	}
-	return nil
+	return errors.Annotatef(err, "unable to contact api server after %d attempts", apiAttempts)
+}
+
+type unknownError struct {
+	err error
+}
+
+func (e *unknownError) Is(other error) bool {
+	_, ok := other.(*unknownError)
+	return ok
+}
+
+func (e *unknownError) Cause() error {
+	return e.err
+}
+
+func (e *unknownError) Error() string {
+	return e.err.Error()
 }
 
 // BootstrapEndpointAddresses returns the addresses of the bootstrapped instance.

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -141,7 +141,7 @@ func (s *controllerSuite) TestWaitForAgentCancelled(c *gc.C) {
 		cancel()
 		bootstrapCtx := modelcmd.BootstrapContext(stdCtx, ctx)
 		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
-		c.Check(err, gc.ErrorMatches, `unable to contact api server after \d+ attempts: contacting controller \(cancelled\): .*`)
+		c.Check(err, gc.ErrorMatches, `unable to contact api server: .*`)
 	})
 }
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@
 package bootstrap
 
 import (
+	stdcontext "context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -730,6 +731,11 @@ func Bootstrap(
 	if err := doBootstrap(ctx, environ, callCtx, args, bootstrapParams); err != nil {
 		return errors.Trace(err)
 	}
+	if IsContextDone(ctx.Context()) {
+		ctx.Infof("Bootstrap cancelled, you may need to manually remove the bootstrap instance")
+		return Cancelled()
+	}
+
 	ctx.Infof("Bootstrap agent now started")
 	return nil
 }
@@ -1144,4 +1150,9 @@ func setPrivateMetadataSources(fetcher imagemetadata.SimplestreamsFetcher, metad
 // Cancelled returns an error that satisfies IsCancelled.
 func Cancelled() error {
 	return errCancelled
+}
+
+// IsContextDone returns true if the context is done.
+func IsContextDone(ctx stdcontext.Context) bool {
+	return ctx.Err() != nil
 }


### PR DESCRIPTION
Bootstrapping continues even during cancelation. It's hard to replicate because it requires timing the case just right. Although I've personally run into this many times whilst editing the manifest files. So to replicate it requires configuring a broken manifest config and bootstrapping with that.

The code just reuses the same setup as CAAS and just ensures that the context has an error or not. This is a change from the original which checked the done channel. This makes the function call a lot simpler.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Apply the following diff:

```diff
diff --git a/cmd/jujud/agent/machine/manifolds.go b/cmd/jujud/agent/machine/manifolds.go
index 8f7d2f476b..f21d21e12a 100644
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -691,7 +691,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
                })),

                dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-                       AgentName:            agentName,
+                       //AgentName:            agentName,
                        Clock:                config.Clock,
                        Hub:                  config.CentralHub,
                        Logger:               loggo.GetLogger("juju.worker.dbaccessor"),
```

```sh
$ juju bootstrap lxd test --build-agent
Creating Juju controller "test2" on lxd/default
Building local Juju agent binary version 3.2-beta3 for amd64
To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-3606ef-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 240.60.0.26:22
Connected to 240.60.0.26
Running machine configuration script...
```

`ctrl^C` during the `Running machine configuration script...` phase. It should cancel correctly.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968122
