### PR TITLE
[JUJU-3612] External controller schema

### DIFF
--- a/database/schema/controller.go
+++ b/database/schema/controller.go
@@ -231,27 +231,22 @@ CREATE TABLE external_controller (
     uuid            TEXT PRIMARY KEY,
     alias           TEXT,
     ca_cert_uuid    TEXT NOT NULL
-
-    -- TODO (stickupkid): There should be a foreign key constraint on the uuid
-    -- column to a controller(uuid) column. That's not possible because the
-    -- controller table is not created yet.
 );
 
 CREATE TABLE external_controller_address (
-    uuid                        TEXT PRIMARY KEY,
-    address                     TEXT,
-    external_controller_uuid    TEXT NOT NULL,
-    CONSTRAINT          fk_external_controller_address_external_controller
-        FOREIGN KEY         (external_controller_uuid)
+    uuid               TEXT PRIMARY KEY,
+    address            TEXT,
+    controller_uuid    TEXT NOT NULL,
+    CONSTRAINT         fk_external_controller_address_external_controller_uuid
+        FOREIGN KEY         (controller_uuid)
         REFERENCES          external_controller(uuid)
 );
 
-CREATE TABLE external_controller_model (
-    uuid                        TEXT PRIMARY KEY,
-    model_uuid                  TEXT NOT NULL,
-    external_controller_uuid    TEXT NOT NULL,
-    CONSTRAINT          fk_external_controller_model_external_controller
-        FOREIGN KEY         (external_controller_uuid)
+CREATE TABLE external_model (
+    uuid                TEXT PRIMARY KEY,
+    controller_uuid     TEXT NOT NULL,
+    CONSTRAINT          fk_external_model_external_controller_uuid
+        FOREIGN KEY         (controller_uuid)
         REFERENCES          external_controller(uuid)
 );
     `[1:]

--- a/database/schema/controller.go
+++ b/database/schema/controller.go
@@ -9,6 +9,7 @@ func ControllerDDL() []string {
 		leaseSchema,
 		changeLogSchema,
 		cloudSchema,
+		externalControllerSchema,
 	}
 
 	var deltas []string
@@ -222,4 +223,36 @@ CREATE TABLE cloud (
     storage_endpoint    TEXT,
     skip_tls_verify     BOOLEAN NOT NULL
 );`[1:]
+}
+
+func externalControllerSchema() string {
+	return `
+CREATE TABLE external_controller (
+    uuid            TEXT PRIMARY KEY,
+    alias           TEXT,
+    ca_cert_uuid    TEXT NOT NULL
+
+    -- TODO (stickupkid): There should be a foreign key constraint on the uuid
+    -- column to a controller(uuid) column. That's not possible because the
+    -- controller table is not created yet.
+);
+
+CREATE TABLE external_controller_address (
+    uuid                        TEXT PRIMARY KEY,
+    address                     TEXT,
+    external_controller_uuid    TEXT NOT NULL,
+    CONSTRAINT          fk_external_controller_address_external_controller
+        FOREIGN KEY         (external_controller_uuid)
+        REFERENCES          external_controller(uuid)
+);
+
+CREATE TABLE external_controller_model (
+    uuid                        TEXT PRIMARY KEY,
+    model_uuid                  TEXT NOT NULL,
+    external_controller_uuid    TEXT NOT NULL,
+    CONSTRAINT          fk_external_controller_model_external_controller
+        FOREIGN KEY         (external_controller_uuid)
+        REFERENCES          external_controller(uuid)
+);
+    `[1:]
 }

--- a/database/schema/controller_test.go
+++ b/database/schema/controller_test.go
@@ -1,0 +1,124 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	_ "github.com/mattn/go-sqlite3"
+	gc "gopkg.in/check.v1"
+)
+
+type schemaSuite struct {
+	testing.IsolationSuite
+
+	db *sql.DB
+}
+
+var _ = gc.Suite(&schemaSuite{})
+
+// SetUpTest creates a new sql.DB reference and ensures that the
+// controller schema is applied successfully.
+func (s *schemaSuite) TestDDLApply(c *gc.C) {
+	// Do not be tempted in moving to :memory: mode for this test suite. It will
+	// fail in non-deterministic ways. Unfortunately :memory: mode is not
+	// completely goroutine safe.
+	s.db = s.NewCleanDB(c)
+
+	s.AddCleanup(func(*gc.C) {
+		err := s.db.Close()
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	tx, err := s.db.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+
+	for idx, stmt := range ControllerDDL() {
+		c.Logf("Executing schema DDL index: %v", idx)
+		_, err := tx.Exec(stmt)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	c.Logf("Committing schema DDL")
+	err = tx.Commit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that each table is present.
+	expected := set.NewStrings(
+		// Leases
+		"lease",
+		"lease_type",
+		"lease_pin",
+
+		// Change log
+		"change_log",
+		"change_log_edit_type",
+		"change_log_namespace",
+
+		// Cloud
+		"cloud",
+		"auth_type",
+		"cloud_auth_type",
+		"ca_cert",
+		"cloud_ca_cert",
+		"cloud_region",
+		"cloud_type",
+
+		// External controller
+		"external_controller",
+		"external_controller_address",
+		"external_controller_model",
+	)
+	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
+}
+
+// NewCleanDB returns a new sql.DB reference.
+func (s *schemaSuite) NewCleanDB(c *gc.C) *sql.DB {
+	dir := c.MkDir()
+
+	url := fmt.Sprintf("file:%s/db.sqlite3?_foreign_keys=1", dir)
+	c.Logf("Opening sqlite3 db with: %v", url)
+
+	db, err := sql.Open("sqlite3", url)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return db
+}
+
+var (
+	internalTableNames = set.NewStrings(
+		"sqlite_sequence",
+	)
+)
+
+func readTableNames(c *gc.C, db *sql.DB) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rows, err := tx.QueryContext(ctx, "SELECT tbl_name FROM sqlite_master")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		err = rows.Scan(&table)
+		c.Assert(err, jc.ErrorIsNil)
+		tables = append(tables, table)
+	}
+
+	err = tx.Commit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	return set.NewStrings(tables...).SortedValues()
+}

--- a/database/schema/controller_test.go
+++ b/database/schema/controller_test.go
@@ -74,7 +74,7 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 		// External controller
 		"external_controller",
 		"external_controller_address",
-		"external_controller_model",
+		"external_model",
 	)
 	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }

--- a/database/schema/package_test.go
+++ b/database/schema/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Add external controller schema. This models itself is based on the existing entities in state and from the prior work from @manadart. The only difference is that we're also modeling the external controller model.

I've made a note about not correctly modeling the foreign key constraint on the controller, as we don't actually have a controller or model table. That can be added at a later date.

Also, I've added a test to ensure that the tables are present if you add any new schema. This should ensure that the schema is at least parsable. It doesn't check for behavior or correctness of the schema.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Ensure that the tests run and that we can bootstrap.

```sh
$ juju bootstrap lxd test --build-agent
```
