### PR TITLE
[JUJU-3614] Prevent panic on empty bundle contents

### DIFF
--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -311,7 +311,12 @@ func verifyBaseBundle(base BundleDataSource) error {
 		return nil
 	}
 
-	return verifyBundle(base.Parts()[0].Data, base.BasePath(), verifyBaseConstraints)
+	parts := base.Parts()
+	if len(parts) == 0 {
+		return nil
+	}
+
+	return verifyBundle(parts[0].Data, base.BasePath(), verifyBaseConstraints)
 }
 
 func verifyBundle(data *charm.BundleData, bundleDir string, verifyConstraints func(string) error) error {

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -209,6 +209,16 @@ type composeAndVerifyRepSuite struct {
 
 var _ = gc.Suite(&composeAndVerifyRepSuite{})
 
+func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleEmpty(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectEmptyParts()
+	s.expectBasePath()
+
+	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	c.Assert(err, gc.ErrorMatches, ".*bundle is empty not valid")
+	c.Assert(obtained, gc.IsNil)
+}
+
 func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleUnsupportedConstraints(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	bundleData, err := charm.ReadBundleData(strings.NewReader(unsupportedConstraintBundle))
@@ -379,6 +389,11 @@ func (s *composeAndVerifyRepSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *composeAndVerifyRepSuite) expectParts(part *charm.BundleDataPart) {
 	retVal := []*charm.BundleDataPart{part}
+	s.bundleDataSource.EXPECT().Parts().Return(retVal).AnyTimes()
+}
+
+func (s *composeAndVerifyRepSuite) expectEmptyParts() {
+	retVal := []*charm.BundleDataPart{}
 	s.bundleDataSource.EXPECT().Parts().Return(retVal).AnyTimes()
 }
 

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -197,7 +197,7 @@ func (d *deployBundle) checkExplicitSeries(bundleData *charm.BundleData) error {
 			// bundle validation but it won't be defined since it's
 			// a new machine, so don't perform any check in that
 			// case.
-			if machine, ok := bundleData.Machines[placement.Machine]; ok {
+			if machine, ok := bundleData.Machines[placement.Machine]; ok && machine != nil {
 				machineCons, err := constraints.Parse(machine.Constraints)
 				if err != nil {
 					return errors.Trace(err)

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -461,6 +461,28 @@ func (s *bundleSuite) TestCheckExplicitBase(c *gc.C) {
 			},
 			deployBundle: deployBundle{},
 		},
+		{
+			title: "ensure nil machine spec produces no error",
+			bundleData: &charm.BundleData{
+				Series: "focal",
+				Applications: map[string]*charm.ApplicationSpec{
+					"prometheus2": {
+						Charm:       "ch:prometheus2",
+						Constraints: "cpu-cores=2",
+						To:          []string{"ubuntu:0"},
+					},
+					"ubuntu": {
+						Charm:       "ch:ubuntu",
+						Constraints: "mem=2G",
+						To:          []string{"lxd:0"},
+					},
+				},
+				Machines: map[string]*charm.MachineSpec{
+					"0": nil,
+				},
+			},
+			deployBundle: deployBundle{},
+		},
 	}
 	for i, test := range testCases {
 		c.Logf("test %d [%s]", i, test.title)


### PR DESCRIPTION
If the contents of a bundle is empty, then don't panic when attempting to read the contents.

The code expected that a validation check on the bundle contents was done before hand, but that's not always the case. This just guards against the scenario.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ touch bundle.yaml
$ juju deploy ./bundle.yaml
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2017681