### PR TITLE
Minor fixes to add-credential help text

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -41,35 +41,35 @@ formatted YAML-formatted file.
 
 Sample yaml file shows five credentials being stored against four clouds:
 
-  credentials:
-    aws:
-      <credential-name>:
-        auth-type: access-key
-        access-key: <key>
-        secret-key: <key>
-    azure:
-      <credential-name>:
-        auth-type: service-principal-secret
-        application-id: <uuid>
-        application-password: <password>
-        subscription-id: <uuid>
-    lxd:
-      <credential-a>:
-        auth-type: interactive
-        trust-password: <password>
-      <credential-b>:
-        auth-type: interactive
-        trust-password: <password>
-    google:
-      <credential-name>:
-        auth-type: oauth2
-        project-id: <project-id>
-        private-key: <private-key>
-        client-email: <email>
-        client-id: <client-id>
+    credentials:
+      aws:
+        <credential-name>:
+          auth-type: access-key
+          access-key: <key>
+          secret-key: <key>
+      azure:
+        <credential-name>:
+          auth-type: service-principal-secret
+          application-id: <uuid>
+          application-password: <password>
+          subscription-id: <uuid>
+      lxd:
+        <credential-a>:
+          auth-type: interactive
+          trust-password: <password>
+        <credential-b>:
+          auth-type: interactive
+          trust-password: <password>
+      google:
+        <credential-name>:
+          auth-type: oauth2
+          project-id: <project-id>
+          private-key: <private-key>
+          client-email: <email>
+          client-id: <client-id>
 
 The <credential-name> parameter of each credential is arbitrary, but must
-be unique within each <cloud-name>. This allows allow each cloud to store 
+be unique within each <cloud-name>. This allows each cloud to store 
 multiple credentials.
 
 The format for a credential is cloud-specific. Thus, it's best to use


### PR DESCRIPTION
Indent the code sample by 4 spaces, so in Markdown, it will display correctly as a code block.

Remove duplicate use of the word "allow".