### PR TITLE
[JUJU-3584] Enable updating/setting owner labels by using secret-get

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -332,7 +332,7 @@ func (s *SecretsManagerAPI) getSecretConsumerInfo(consumerTag names.Tag, uriStr 
 	if consumer.Label != "" {
 		return consumer, nil
 	}
-	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, "", false)
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, "", false, false)
 	if errors.Is(err, errors.NotFound) {
 		// The secret is owned by a different application.
 		return consumer, nil
@@ -430,14 +430,51 @@ func (s *SecretsManagerAPI) ensureConsumerMetadataForAppOwnedSecretsForPeerUnits
 	return md, nil
 }
 
-func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string, ensureConsumerMetaData bool) (md *coresecrets.SecretMetadata, err error) {
+func (s *SecretsManagerAPI) updateLabelForAppOwnedOrUnitOwnedSecret(uri *coresecrets.URI, label string, md *coresecrets.SecretMetadata) error {
+	if uri == nil || label == "" {
+		// We have done this check before, but it doesn't hurt to do it again.
+		return nil
+	}
+
+	ownerTag, err := names.ParseTag(md.OwnerTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	isLeaderUnit, err := commonsecrets.IsLeaderUnit(s.authTag, s.leadershipChecker)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if ownerTag == s.authTag || commonsecrets.IsSameApplication(ownerTag, s.authTag) && isLeaderUnit {
+		// The secret is owned by the caller or the caller is the leader unit of the application owning the secret.
+		token, err := commonsecrets.LeadershipToken(s.authTag, s.leadershipChecker)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// Update the label.
+		_, err = s.secretsState.UpdateSecret(uri, state.UpdateSecretParams{
+			LeaderToken: token,
+			Label:       &label,
+		})
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string, ensureConsumerMetaData, updateLabel bool) (md *coresecrets.SecretMetadata, err error) {
 	notFoundErr := errors.NotFoundf("secret %q", uri)
 	if label != "" {
 		notFoundErr = errors.NotFoundf("secret with label %q", label)
 	}
 	defer func() {
-		if md == nil || md.OwnerTag == s.authTag.String() || !ensureConsumerMetaData {
-			// Either errored out or found a secret owned by the caller.
+		if md == nil {
+			return
+		}
+		if updateLabel {
+			if err = s.updateLabelForAppOwnedOrUnitOwnedSecret(uri, label, md); err != nil {
+				return
+			}
+		}
+		if md.OwnerTag == s.authTag.String() || !ensureConsumerMetaData {
 			return
 		}
 		md, err = s.ensureConsumerMetadataForAppOwnedSecretsForPeerUnits(md)
@@ -497,8 +534,12 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 			return nil, errors.Trace(err)
 		}
 	}
+
+	// arg.Label could be the consumer label for consumers or the owner label for owners.
+	possibleUpdateLabel := arg.Label != "" && uri != nil
+
 	// Owner units should always have the URI because we resolved the label to URI on uniter side already.
-	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label, true)
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label, true, possibleUpdateLabel)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}
@@ -507,9 +548,6 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 		// 2. application owned secrets can be accessed by all the units of the application using owner label or URI.
 		return getSecretValue(md.URI, md.LatestRevision)
 	}
-
-	// arg.Label is the consumer label for consumers.
-	possibleUpdateLabel := arg.Label != "" && uri != nil
 
 	if uri == nil {
 		var err error

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -669,6 +669,99 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *gc.C
 	})
 }
 
+func (s *SecretsManagerSuite) TestGetSecretContentForUnitOwnedSecretUpdateLabel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+	s.expectSecretAccessQuery(1)
+	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{
+		{
+			URI:            uri,
+			LatestRevision: 668,
+			Label:          "foo",
+			OwnerTag:       s.authTag.String(),
+		},
+	}, nil)
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
+	s.token.EXPECT().Check().Return(nil).Times(2)
+	s.secretsState.EXPECT().UpdateSecret(uri, state.UpdateSecretParams{
+		LeaderToken: s.token,
+		Label:       ptr("foo"),
+	}).Return(nil, nil)
+
+	s.secretsState.EXPECT().GetSecretValue(uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Label: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretUpdateLabel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+	s.expectSecretAccessQuery(1)
+	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{
+		{
+			URI:            uri,
+			LatestRevision: 668,
+			Label:          "foo",
+			OwnerTag:       names.NewApplicationTag("mariadb").String(),
+		},
+	}, nil)
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
+	s.token.EXPECT().Check().Return(nil).Times(2)
+	s.secretsState.EXPECT().UpdateSecret(uri, state.UpdateSecretParams{
+		LeaderToken: s.token,
+		Label:       ptr("foo"),
+	}).Return(nil, nil)
+
+	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, s.authTag).
+		Return(nil, errors.NotFoundf("secret consumer"))
+	s.secretsConsumer.EXPECT().SaveSecretConsumer(
+		uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{}).Return(nil)
+
+	s.secretsState.EXPECT().GetSecretValue(uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Label: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
 func (s *SecretsManagerSuite) TestGetSecretContentForUnitAccessApplicationOwnedSecret(c *gc.C) {
 	defer s.setup(c).Finish()
 


### PR DESCRIPTION
This PR implements updating/setting owner labels by using secret-get for:
- owner units;
- leader unit for application owned secrets; 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju exec --unit snappass-test/0 'secret-add ownedby=snappass-test'
secret:ch52creffbas7aip1bjg

juju exec --unit snappass-test/0 'secret-add ownedby=snappass-test/0 --owner unit'
secret:ch52csmffbas7aip1bk0

juju exec --unit snappass-test/0 -- secret-get ch52creffbas7aip1bjg --label=snappass-test
ownedby: snappass-test

juju exec --unit snappass-test/0 -- secret-get --label=snappass-test
ownedby: snappass-test

juju exec --unit snappass-test/1 -- secret-get --label=snappass-test
ownedby: snappass-test

juju exec --unit snappass-test/0 -- secret-get ch52csmffbas7aip1bk0 --label=snappass-test/0
ownedby: snappass-test/0

juju exec --unit snappass-test/0 -- secret-get --label=snappass-test/0
ownedby: snappass-test/0

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2017042
