### PR TITLE
[JUJU-3600] Remove unsupported arches from providers

### DIFF
--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/gomaasapi/v2"
 
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/context"
 )
@@ -29,7 +30,14 @@ func (env *maasEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (c
 	if err != nil {
 		return nil, err
 	}
-	validator.RegisterVocabulary(constraints.Arch, supportedArches)
+
+	// Only consume supported juju architectures for this release. This will
+	// also remove any duplicate architectures.
+	lxdArches := set.NewStrings(supportedArches...)
+	supported := set.NewStrings(arch.AllSupportedArches...).Intersection(lxdArches)
+
+	validator.RegisterVocabulary(constraints.Arch, supported.SortedValues())
+
 	return validator, nil
 }
 

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -2597,6 +2597,21 @@ func (suite *maasEnvironSuite) TestConstraintsValidator(c *gc.C) {
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
 }
 
+func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc.C) {
+	controller := newFakeController()
+	controller.bootResources = []gomaasapi.BootResource{
+		&fakeBootResource{name: "jammy", architecture: "i386"},
+		&fakeBootResource{name: "jammy", architecture: "amd64"},
+	}
+	env := suite.makeEnviron(c, controller)
+	validator, err := env.ConstraintsValidator(suite.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+}
+
 func (suite *maasEnvironSuite) TestConstraintsValidatorInvalidCredential(c *gc.C) {
 	controller := &fakeController{
 		bootResources:      []gomaasapi.BootResource{&fakeBootResource{name: "jammy", architecture: "amd64"}},


### PR DESCRIPTION
To prevent showing architectures from a provider that can't be used by juju, we filter the ones we can never support. For example the removal for armhf, ppc and i386 which are all 32 bit word size.

In addition, we filter them using a set collection to duplicates are removed from the output. This leads to a much cleaner output to the user making it much cleaner.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


Using default amd64

```sh
$ juju bootstrap lxd test --build-agent
```

Attempt i386 which no longer is supported

```sh
juju bootstrap lxd test --build-agent --constraints=arch=i386
ERROR bad "arch" constraint: "i386" not recognized
```

Attempt s390x which is supported, but is not supported by LXD locally

```sh
juju bootstrap lxd test2 --build-agent --constraints=arch=s390x
Creating Juju controller "test2" on lxd/default
ERROR invalid constraint value: arch=s390x
valid values are: [amd64]
```

Attempt to set the arch via constraints on a model

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju set-model-constraints arch=arm64
ERROR invalid constraint value: arch=arm64
valid values are: [amd64]
```

Attempt to set unsupported arch

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju set-model-constraints arch=i386
ERROR bad "arch" constraint: "i386" not recognized
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/2013869
