### PR TITLE
Client Unit tests with race on pr

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -58,6 +58,6 @@ jobs:
     - name: "Test client"
       run: |
         # Jenkins can perform the full jujud testing.
-        go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic -timeout=15m
-        go test -v ./cmd/plugins/... -check.v
+        go test -race -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic -timeout=15m
+        go test -race -v ./cmd/plugins/... -check.v
       shell: bash


### PR DESCRIPTION
This PR starts running client only tests with the race flag. It's important that tests are run and detecting race conditions. Even more so that we are blocking merging on detected problems.

This is direct feedback from retrospective to get better test coverage of Juju.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~~[x] Code style: imports ordered, good names, simple structure, etc~~
- [x] Comments saying why design decisions were made
- ~~[] Go unit tests, with comments saying what you're testing~~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~~[x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

Let the github actions on this PR run to completion. The change is directly related to running of GH actions.

## Documentation changes

nil

## Bug reference

nil
