### PR TITLE
Apply LXD Project before validating profiles

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -97,7 +97,7 @@ type modelUpgradeSuite struct {
 	bootstrapEnviron *mocks.MockBootstrapEnviron
 	blockChecker     *mocks.MockBlockCheckerInterface
 	registryProvider *registrymocks.MockRegistry
-	cloudSpec        environscloudspec.CloudSpec
+	cloudSpec        lxd.CloudSpec
 }
 
 var _ = gc.Suite(&modelUpgradeSuite{})
@@ -113,7 +113,7 @@ func (s *modelUpgradeSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.callContext = context.NewEmptyCloudCallContext()
-	s.cloudSpec = environscloudspec.CloudSpec{Type: "lxd"}
+	s.cloudSpec = lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 }
 
 func (s *modelUpgradeSuite) getModelUpgraderAPI(c *gc.C) (*gomock.Controller, *modelupgrader.ModelUpgraderAPI) {
@@ -136,7 +136,7 @@ func (s *modelUpgradeSuite) getModelUpgraderAPI(c *gc.C) (*gomock.Controller, *m
 			return s.registryProvider, nil
 		},
 		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
-			return s.cloudSpec, nil
+			return s.cloudSpec.CloudSpec, nil
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -95,7 +95,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 			return serverFactory
 		},
 	)
-	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 
 	backend := newFakeBackend()
 	hasUpgradeSeriesLocks := true
@@ -114,7 +114,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	err := migration.SourcePrecheck(
 		backend, version.MustParse("3.0.0"), allAlivePresence(), allAlivePresence(),
 		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
-			return cloudSpec, nil
+			return cloudSpec.CloudSpec, nil
 		},
 	)
 	c.Assert(err.Error(), gc.Equals, `

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -406,9 +406,11 @@ func (p environProviderCredentials) finalizeRemoteCredential(
 	}
 
 	insecureCreds := cloud.NewCredential(cloud.CertificateAuthType, credAttrs)
-	server, err := p.serverFactory.InsecureRemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   endpoint,
-		Credential: &insecureCreds,
+	server, err := p.serverFactory.InsecureRemoteServer(CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   endpoint,
+			Credential: &insecureCreds,
+		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -460,9 +462,11 @@ func (p environProviderCredentials) finalizeRemoteCredential(
 	attributes[credAttrServerCert] = lxdServerCert
 
 	secureCreds := cloud.NewCredential(cloud.CertificateAuthType, attributes)
-	server, err = p.serverFactory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   endpoint,
-		Credential: &secureCreds,
+	server, err = p.serverFactory.RemoteServer(CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   endpoint,
+			Credential: &secureCreds,
+		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -686,18 +686,22 @@ func (s *credentialsSuite) TestFinalizeCredentialNonLocal(c *gc.C) {
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	secureCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 		"client-cert": coretesting.CACert,
 		"client-key":  coretesting.CAKey,
 		"server-cert": coretesting.ServerCert,
 	})
-	secureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &secureCred,
+	secureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &secureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
@@ -750,18 +754,22 @@ func (s *credentialsSuite) TestFinalizeCredentialNonLocalWithCertAlreadyExists(c
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	secureCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 		"client-cert": coretesting.CACert,
 		"client-key":  coretesting.CAKey,
 		"server-cert": coretesting.ServerCert,
 	})
-	secureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &secureCred,
+	secureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &secureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
@@ -803,9 +811,11 @@ func (s *credentialsSuite) TestFinalizeCredentialRemoteWithInsecureError(c *gc.C
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
@@ -829,9 +839,11 @@ func (s *credentialsSuite) TestFinalizeCredentialRemoteWithCreateCertificateErro
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
@@ -870,9 +882,11 @@ func (s *credentialsSuite) TestFinalizeCredentialRemoveWithGetServerError(c *gc.
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",
@@ -912,18 +926,22 @@ func (s *credentialsSuite) TestFinalizeCredentialRemoteWithNewRemoteServerError(
 		"client-key":     coretesting.CAKey,
 		"trust-password": "fred",
 	})
-	insecureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &insecureCred,
+	insecureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &insecureCred,
+		},
 	}
 	secureCred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
 		"client-cert": coretesting.CACert,
 		"client-key":  coretesting.CAKey,
 		"server-cert": coretesting.ServerCert,
 	})
-	secureSpec := environscloudspec.CloudSpec{
-		Endpoint:   "8.8.8.8",
-		Credential: &secureCred,
+	secureSpec := lxd.CloudSpec{
+		CloudSpec: environscloudspec.CloudSpec{
+			Endpoint:   "8.8.8.8",
+			Credential: &secureCred,
+		},
 	}
 	params := environs.FinalizeCredentialParams{
 		CloudEndpoint: "8.8.8.8",

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -163,13 +163,9 @@ func (env *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.Cl
 	defer env.lock.Unlock()
 
 	serverFactory := env.provider.serverFactory
-	server, err := serverFactory.RemoteServer(spec)
+	server, err := serverFactory.RemoteServer(CloudSpec{CloudSpec: spec, Project: env.ecfgUnlocked.project()})
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	if project := env.ecfgUnlocked.project(); project != "" {
-		server.UseProject(project)
 	}
 
 	env.serverUnlocked = server

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -411,8 +411,6 @@ func (s *environCloudProfileSuite) TestSetCloudSpecUsesConfiguredProject(c *gc.C
 	s.expectHasProfileFalse("juju-controller")
 	s.expectCreateProfile("juju-controller", nil)
 
-	s.svr.EXPECT().UseProject("my-project")
-
 	err := s.cloudSpecEnv.SetCloudSpec(stdcontext.TODO(), lxdCloudSpec())
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -421,8 +419,14 @@ func (s *environCloudProfileSuite) setup(c *gc.C, cfgEdit map[string]interface{}
 	ctrl := gomock.NewController(c)
 	s.svr = lxd.NewMockServer(ctrl)
 
+	project, _ := cfgEdit["project"].(string)
+	cloudSpec := lxd.CloudSpec{
+		CloudSpec: lxdCloudSpec(),
+		Project:   project,
+	}
+
 	svrFactory := lxd.NewMockServerFactory(ctrl)
-	svrFactory.EXPECT().RemoteServer(lxdCloudSpec()).Return(s.svr, nil)
+	svrFactory.EXPECT().RemoteServer(cloudSpec).Return(s.svr, nil)
 
 	env, ok := s.NewEnvironWithServerFactory(c, svrFactory, cfgEdit).(environs.CloudSpecSetter)
 	c.Assert(ok, jc.IsTrue)

--- a/provider/lxd/package_mock_test.go
+++ b/provider/lxd/package_mock_test.go
@@ -12,7 +12,6 @@ import (
 	network "github.com/juju/juju/core/network"
 	series "github.com/juju/juju/core/series"
 	environs "github.com/juju/juju/environs"
-	cloudspec "github.com/juju/juju/environs/cloudspec"
 	client "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
 )
@@ -824,7 +823,7 @@ func (m *MockServerFactory) EXPECT() *MockServerFactoryMockRecorder {
 }
 
 // InsecureRemoteServer mocks base method.
-func (m *MockServerFactory) InsecureRemoteServer(arg0 cloudspec.CloudSpec) (Server, error) {
+func (m *MockServerFactory) InsecureRemoteServer(arg0 CloudSpec) (Server, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsecureRemoteServer", arg0)
 	ret0, _ := ret[0].(Server)
@@ -869,7 +868,7 @@ func (mr *MockServerFactoryMockRecorder) LocalServerAddress() *gomock.Call {
 }
 
 // RemoteServer mocks base method.
-func (m *MockServerFactory) RemoteServer(arg0 cloudspec.CloudSpec) (Server, error) {
+func (m *MockServerFactory) RemoteServer(arg0 CloudSpec) (Server, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteServer", arg0)
 	ret0, _ := ret[0].(Server)

--- a/provider/lxd/server_integration_test.go
+++ b/provider/lxd/server_integration_test.go
@@ -314,9 +314,7 @@ func (s *serverIntegrationSuite) TestLocalServerWithStorageNotSupported(c *gc.C)
 		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
-	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint: "",
-	})
+	svr, err := factory.RemoteServer(lxd.CloudSpec{})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(err, gc.IsNil)
 }
@@ -350,9 +348,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithEmptyEndpointYieldsLocalSer
 		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
-	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint: "",
-	})
+	svr, err := factory.RemoteServer(lxd.CloudSpec{})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(err, gc.IsNil)
 }
@@ -378,10 +374,13 @@ func (s *serverIntegrationSuite) TestRemoteServer(c *gc.C) {
 		"client-key":  "client-key",
 		"server-cert": "server-cert",
 	})
-	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
+	svr, err := factory.RemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(svr, gc.Equals, server)
 	c.Assert(err, gc.IsNil)
@@ -403,10 +402,13 @@ func (s *serverIntegrationSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 		"client-key":  "client-key",
 		"server-cert": "server-cert",
 	})
-	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
+	svr, err := factory.RemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(svr, gc.Equals, server)
 	c.Assert(err, gc.IsNil)
@@ -423,10 +425,13 @@ func (s *serverIntegrationSuite) TestInsecureRemoteServerDoesNotCallGetServer(c 
 		"client-key":  "client-key",
 		"server-cert": "server-cert",
 	})
-	svr, err := factory.InsecureRemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
+	svr, err := factory.InsecureRemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(svr, gc.Equals, server)
 	c.Assert(err, gc.IsNil)
@@ -439,10 +444,13 @@ func (s *serverIntegrationSuite) TestRemoteServerMissingCertificates(c *gc.C) {
 	factory, _ := lxd.NewRemoteServerFactory(ctrl)
 
 	creds := cloud.NewCredential("any", map[string]string{})
-	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
+	svr, err := factory.RemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
 	c.Assert(svr, gc.IsNil)
 	c.Assert(errors.Cause(err).Error(), gc.Equals, "credentials not valid")
 }
@@ -463,10 +471,13 @@ func (s *serverIntegrationSuite) TestRemoteServerWithUnSupportedAPIVersion(c *gc
 		"client-key":  "client-key",
 		"server-cert": "server-cert",
 	})
-	_, err := factory.RemoteServer(environscloudspec.CloudSpec{
-		Endpoint:   "https://10.0.0.9:8443",
-		Credential: &creds,
-	})
+	_, err := factory.RemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
 	c.Assert(errors.Cause(err).Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }
 

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -128,7 +128,7 @@ func (s *migrateSuite) setupJuju3Target(c *gc.C) (*gomock.Controller, environscl
 	server := mocks.NewMockServer(ctrl)
 	serverFactory := mocks.NewMockServerFactory(ctrl)
 	// - check LXD version.
-	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
@@ -145,5 +145,5 @@ func (s *migrateSuite) setupJuju3Target(c *gc.C) (*gomock.Controller, environscl
 	s.st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
 
-	return ctrl, cloudSpec
+	return ctrl, cloudSpec.CloudSpec
 }

--- a/upgrades/upgradevalidation/mocks/lxd_mock.go
+++ b/upgrades/upgradevalidation/mocks/lxd_mock.go
@@ -12,7 +12,6 @@ import (
 	network "github.com/juju/juju/core/network"
 	series "github.com/juju/juju/core/series"
 	environs "github.com/juju/juju/environs"
-	cloudspec "github.com/juju/juju/environs/cloudspec"
 	lxd0 "github.com/juju/juju/provider/lxd"
 	lxd1 "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
@@ -42,7 +41,7 @@ func (m *MockServerFactory) EXPECT() *MockServerFactoryMockRecorder {
 }
 
 // InsecureRemoteServer mocks base method.
-func (m *MockServerFactory) InsecureRemoteServer(arg0 cloudspec.CloudSpec) (lxd0.Server, error) {
+func (m *MockServerFactory) InsecureRemoteServer(arg0 lxd0.CloudSpec) (lxd0.Server, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsecureRemoteServer", arg0)
 	ret0, _ := ret[0].(lxd0.Server)
@@ -87,7 +86,7 @@ func (mr *MockServerFactoryMockRecorder) LocalServerAddress() *gomock.Call {
 }
 
 // RemoteServer mocks base method.
-func (m *MockServerFactory) RemoteServer(arg0 cloudspec.CloudSpec) (lxd0.Server, error) {
+func (m *MockServerFactory) RemoteServer(arg0 lxd0.CloudSpec) (lxd0.Server, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteServer", arg0)
 	ret0, _ := ret[0].(lxd0.Server)

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -45,7 +45,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 			return serverFactory
 		},
 	)
-	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 
 	// 1. Check controller model.
 	// - check agent version;
@@ -95,13 +95,13 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	server.EXPECT().ServerVersion().Return("5.2")
 
 	targetVersion := version.MustParse("3.666.2")
-	validators := upgradevalidation.ValidatorsForControllerUpgrade(true, targetVersion, cloudSpec)
+	validators := upgradevalidation.ValidatorsForControllerUpgrade(true, targetVersion, cloudSpec.CloudSpec)
 	checker := upgradevalidation.NewModelUpgradeCheck(ctrlModelTag.Id(), statePool, ctrlState, ctrlModel, validators...)
 	blockers, err := checker.Validate()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blockers, gc.IsNil)
 
-	validators = upgradevalidation.ValidatorsForControllerUpgrade(false, targetVersion, cloudSpec)
+	validators = upgradevalidation.ValidatorsForControllerUpgrade(false, targetVersion, cloudSpec.CloudSpec)
 	checker = upgradevalidation.NewModelUpgradeCheck(model1ModelTag.Id(), statePool, state1, model1, validators...)
 	blockers, err = checker.Validate()
 	c.Assert(err, jc.ErrorIsNil)
@@ -124,7 +124,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 			return serverFactory
 		},
 	)
-	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 
 	// - check no upgrade series in process.
 	state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
@@ -136,7 +136,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	server.EXPECT().ServerVersion().Return("5.2")
 
 	targetVersion := version.MustParse("3.0.0")
-	validators := upgradevalidation.ValidatorsForModelUpgrade(false, targetVersion, cloudSpec)
+	validators := upgradevalidation.ValidatorsForModelUpgrade(false, targetVersion, cloudSpec.CloudSpec)
 	checker := upgradevalidation.NewModelUpgradeCheck(modelTag.Id(), statePool, state, model, validators...)
 	blockers, err := checker.Validate()
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -352,7 +352,7 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 			return jujuhttp.NewClient(
 				jujuhttp.WithLogger(logger.ChildWithLabels("http", corelogger.HTTP)),
 			).Client()
-		})).RemoteServer(cloudspec)
+		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec})
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -346,11 +346,11 @@ func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType 
 		},
 	)
 
-	cloudSpec := environscloudspec.CloudSpec{Type: cloudType}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: cloudType}}
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 }
@@ -392,11 +392,11 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 			return serverFactory
 		},
 	)
-	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)


### PR DESCRIPTION
Currently, Juju's handling of LXD projects occurs after validating the default profile [here](https://github.com/juju/juju/blob/e2c7b4c88e516976666e3d0c9479d0d3c704e643/provider/lxd/server.go#L341). 

This is problematic on two fronts. First is that the default profile in the selected project is not being validated. The second issue is for ongoing development of LXD Cloud, which will be unable to use the default project at all, causing an immediate error.

As such, this properly applies the project before making any API request. 

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
`juju add-model <model> <cloud> --config project=<my-lxd-project>`
