### PR TITLE
Use model tag filter to list all ec2 instances

### DIFF
--- a/provider/ec2/internal/testing/instances.go
+++ b/provider/ec2/internal/testing/instances.go
@@ -54,6 +54,7 @@ type Instance struct {
 
 // TerminateInstances implements ec2.Client.
 func (srv *Server) TerminateInstances(ctx context.Context, in *ec2.TerminateInstancesInput, opts ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
+	srv.instanceMutatingCalls.next()
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 
@@ -92,6 +93,8 @@ func (srv *Server) instance(id string) (*Instance, error) {
 
 // RunInstances implements ec2.Client.
 func (srv *Server) RunInstances(ctx context.Context, in *ec2.RunInstancesInput, opts ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error) {
+	srv.instanceMutatingCalls.next()
+
 	min := aws.ToInt32(in.MinCount)
 	max := aws.ToInt32(in.MaxCount)
 	if min < 0 || max < 1 {
@@ -197,6 +200,7 @@ func (srv *Server) AssociateIamInstanceProfile(
 	params *ec2.AssociateIamInstanceProfileInput,
 	opts ...func(*ec2.Options),
 ) (*ec2.AssociateIamInstanceProfileOutput, error) {
+	srv.instanceMutatingCalls.next()
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 

--- a/provider/ec2/internal/testing/security_groups.go
+++ b/provider/ec2/internal/testing/security_groups.go
@@ -16,6 +16,7 @@ import (
 
 // CreateSecurityGroup implements ec2.Client.
 func (srv *Server) CreateSecurityGroup(ctx context.Context, in *ec2.CreateSecurityGroupInput, opts ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error) {
+	srv.groupMutatingCalls.next()
 	name := aws.ToString(in.GroupName)
 	if name == "" {
 		return nil, apiError("InvalidParameterValue", "empty security group name")
@@ -48,8 +49,10 @@ func (srv *Server) CreateSecurityGroup(ctx context.Context, in *ec2.CreateSecuri
 
 // DeleteSecurityGroup implements ec2.Client.
 func (srv *Server) DeleteSecurityGroup(ctx context.Context, in *ec2.DeleteSecurityGroupInput, opts ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	srv.groupMutatingCalls.next()
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+
 	if in.GroupName != nil {
 		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
 	}
@@ -97,8 +100,10 @@ func (srv *Server) group(group types.GroupIdentifier) *securityGroup {
 
 // AuthorizeSecurityGroupIngress implements ec2.Client.
 func (srv *Server) AuthorizeSecurityGroupIngress(ctx context.Context, in *ec2.AuthorizeSecurityGroupIngressInput, opts ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	srv.groupMutatingCalls.next()
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+
 	if in.GroupName != nil {
 		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
 	}
@@ -127,8 +132,10 @@ func (srv *Server) AuthorizeSecurityGroupIngress(ctx context.Context, in *ec2.Au
 
 // RevokeSecurityGroupIngress implements ec2.Client.
 func (srv *Server) RevokeSecurityGroupIngress(ctx context.Context, in *ec2.RevokeSecurityGroupIngressInput, opts ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	srv.groupMutatingCalls.next()
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+
 	if in.GroupName != nil {
 		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
 	}

--- a/provider/ec2/internal/testing/tags.go
+++ b/provider/ec2/internal/testing/tags.go
@@ -14,6 +14,8 @@ import (
 
 // CreateTags implements ec2.Client.
 func (srv *Server) CreateTags(ctx context.Context, in *ec2.CreateTagsInput, opts ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
+	srv.tagsMutatingCalls.next()
+
 	if err, ok := srv.apiCallErrors["CreateTags"]; ok {
 		return nil, err
 	}

--- a/provider/ec2/internal/testing/volume_attachments.go
+++ b/provider/ec2/internal/testing/volume_attachments.go
@@ -14,6 +14,8 @@ import (
 
 // AttachVolume implements ec2.Client.
 func (srv *Server) AttachVolume(ctx context.Context, in *ec2.AttachVolumeInput, opts ...func(*ec2.Options)) (*ec2.AttachVolumeOutput, error) {
+	srv.volumeMutatingCalls.next()
+
 	if err, ok := srv.apiCallErrors["AttachVolume"]; ok {
 		return nil, err
 	}
@@ -77,6 +79,8 @@ func (srv *Server) AttachVolume(ctx context.Context, in *ec2.AttachVolumeInput, 
 
 // DetachVolume implements ec2.Client.
 func (srv *Server) DetachVolume(ctx context.Context, in *ec2.DetachVolumeInput, opts ...func(*ec2.Options)) (*ec2.DetachVolumeOutput, error) {
+	srv.volumeMutatingCalls.next()
+
 	if err, ok := srv.apiCallErrors["DetachVolume"]; ok {
 		return nil, err
 	}

--- a/provider/ec2/internal/testing/volumes.go
+++ b/provider/ec2/internal/testing/volumes.go
@@ -18,6 +18,8 @@ import (
 
 // CreateVolume implements ec2.Client.
 func (srv *Server) CreateVolume(ctx context.Context, in *ec2.CreateVolumeInput, opts ...func(*ec2.Options)) (*ec2.CreateVolumeOutput, error) {
+	srv.volumeMutatingCalls.next()
+
 	if err, ok := srv.apiCallErrors["CreateVolume"]; ok {
 		return nil, err
 	}
@@ -54,6 +56,8 @@ func (srv *Server) CreateVolume(ctx context.Context, in *ec2.CreateVolumeInput, 
 
 // DeleteVolume implements ec2.Client.
 func (srv *Server) DeleteVolume(ctx context.Context, in *ec2.DeleteVolumeInput, opts ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error) {
+	srv.volumeMutatingCalls.next()
+
 	if err, ok := srv.apiCallErrors["DeleteVolume"]; ok {
 		return nil, err
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1684,6 +1684,18 @@ func (t *localServerSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	c.Assert(infoLists[1], gc.IsNil, gc.Commentf("expected slot for unknown instance to be nil"))
 }
 
+func (t *localServerSuite) TestStartInstanceIsAtomic(c *gc.C) {
+	env := t.prepareEnviron(c)
+	_, _ = testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
+	callCounts := t.srv.ec2srv.GetMutatingCallCount()
+
+	// Allow only 1 mutating call to instances and 0 to tags
+	// We don't care about volumes or groups
+	c.Assert(callCounts.Instances, gc.Equals, 1)
+	c.Assert(callCounts.Tags, gc.Equals, 0)
+
+}
+
 func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	_, _ = t.addTestingNetworkInterfaceToInstance(c, instId)


### PR DESCRIPTION
Use model tag filter to list all ec2 instances

Previously, we opted for sec group attachments instead. This caused issues because the sec group sometimes doesn't exists, meaning we need to wait for time out.

Recently we changed how to tag ec2 instances so tags are created at the same time as the instance itself, meaning we no longer need this hack

This will speed up many ec2 provider actions

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

#### Verify tags are created at instance creation

Insert a panic after this line
https://github.com/juju/juju/blob/develop/provider/ec2/environ.go#LL1162C21-L1162C21

Then, build juju and bootstrap. Verify the created controller instance's tags are populated

#### Verify standard actions

Undo the change above and rebuild

```sh
juju boostrap aws/eu-west-2 
juju add-model m
juju deploy ubuntu
juju destroy-controller aws
```

Should run without issue