### PR TITLE
Adjust detection of foreign key constraint violation errors for dqlite

### DIFF
--- a/database/errors.go
+++ b/database/errors.go
@@ -4,8 +4,7 @@
 package database
 
 import (
-	"strings"
-
+	dqlite "github.com/canonical/go-dqlite/driver"
 	"github.com/juju/errors"
 	"github.com/mattn/go-sqlite3"
 )
@@ -22,11 +21,8 @@ func IsErrConstraintUnique(err error) bool {
 		return true
 	}
 
-	// TODO (manadart 2022-12-16): The logic above works in unit tests using an
-	// in-memory SQLite DB, but appears to fail when running with Dqlite.
-	// Extended error codes can be enabled via PRAGMA, but we need to
-	// investigate further.
-	if strings.Contains(strings.ToLower(err.Error()), "unique constraint failed") {
+	var dqliteErr dqlite.Error
+	if errors.As(err, &dqliteErr) && dqliteErr.Code == int(sqlite3.ErrConstraintUnique) {
 		return true
 	}
 


### PR DESCRIPTION
The error object returned by dqlite's database/sql functions doesn't derive from sqlite3.Error, but from go-dqlite/driver.Error. We can use that to examine the error code returned by the server.

cc @manadart 

Signed-off-by: Cole Miller <cole.miller@canonical.com>

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~