### PR TITLE
[JUJU-3672] Fix relation interface name not found in juju status --relations --format json

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -21,7 +21,7 @@ type formattedStatus struct {
 	Applications       map[string]applicationStatus       `json:"applications"`
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
 	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
-	Relations          []relationStatus                   `json:"-" yaml:"-"`
+	Relations          []relationStatus                   `json:"relations,omitempty" yaml:"relations,omitempty"`
 	Storage            *storage.CombinedStorage           `json:"storage,omitempty" yaml:"storage,omitempty"`
 	Controller         *controllerStatus                  `json:"controller,omitempty" yaml:"controller,omitempty"`
 	Branches           map[string]branchStatus            `json:"branches,omitempty" yaml:"branches,omitempty"`

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -21,7 +21,7 @@ type formattedStatus struct {
 	Applications       map[string]applicationStatus       `json:"applications"`
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
 	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
-	Relations          []relationStatus                   `json:"relations,omitempty" yaml:"relations,omitempty"`
+	Relations          []relationStatus                   `json:"-" yaml:"-"`
 	Storage            *storage.CombinedStorage           `json:"storage,omitempty" yaml:"storage,omitempty"`
 	Controller         *controllerStatus                  `json:"controller,omitempty" yaml:"controller,omitempty"`
 	Branches           map[string]branchStatus            `json:"branches,omitempty" yaml:"branches,omitempty"`
@@ -117,27 +117,33 @@ type lxdProfileContents struct {
 }
 
 type applicationStatus struct {
-	Err              error                 `json:"-" yaml:",omitempty"`
-	Charm            string                `json:"charm" yaml:"charm"`
-	Base             *formattedBase        `json:"base,omitempty" yaml:"base,omitempty"`
-	CharmOrigin      string                `json:"charm-origin" yaml:"charm-origin"`
-	CharmName        string                `json:"charm-name" yaml:"charm-name"`
-	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
-	CharmChannel     string                `json:"charm-channel,omitempty" yaml:"charm-channel,omitempty"`
-	CharmVersion     string                `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
-	CharmProfile     string                `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
-	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
-	Scale            int                   `json:"scale,omitempty" yaml:"scale,omitempty"`
-	ProviderId       string                `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
-	Address          string                `json:"address,omitempty" yaml:"address,omitempty"`
-	Exposed          bool                  `json:"exposed" yaml:"exposed"`
-	Life             string                `json:"life,omitempty" yaml:"life,omitempty"`
-	StatusInfo       statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
-	Relations        map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
-	SubordinateTo    []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
-	Units            map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
-	Version          string                `json:"version,omitempty" yaml:"version,omitempty"`
-	EndpointBindings map[string]string     `json:"endpoint-bindings,omitempty" yaml:"endpoint-bindings,omitempty"`
+	Err              error                                  `json:"-" yaml:",omitempty"`
+	Charm            string                                 `json:"charm" yaml:"charm"`
+	Base             *formattedBase                         `json:"base,omitempty" yaml:"base,omitempty"`
+	CharmOrigin      string                                 `json:"charm-origin" yaml:"charm-origin"`
+	CharmName        string                                 `json:"charm-name" yaml:"charm-name"`
+	CharmRev         int                                    `json:"charm-rev" yaml:"charm-rev"`
+	CharmChannel     string                                 `json:"charm-channel,omitempty" yaml:"charm-channel,omitempty"`
+	CharmVersion     string                                 `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
+	CharmProfile     string                                 `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
+	CanUpgradeTo     string                                 `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
+	Scale            int                                    `json:"scale,omitempty" yaml:"scale,omitempty"`
+	ProviderId       string                                 `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	Address          string                                 `json:"address,omitempty" yaml:"address,omitempty"`
+	Exposed          bool                                   `json:"exposed" yaml:"exposed"`
+	Life             string                                 `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo       statusInfoContents                     `json:"application-status,omitempty" yaml:"application-status"`
+	Relations        map[string][]applicationStatusRelation `json:"relations,omitempty" yaml:"relations,omitempty"`
+	SubordinateTo    []string                               `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
+	Units            map[string]unitStatus                  `json:"units,omitempty" yaml:"units,omitempty"`
+	Version          string                                 `json:"version,omitempty" yaml:"version,omitempty"`
+	EndpointBindings map[string]string                      `json:"endpoint-bindings,omitempty" yaml:"endpoint-bindings,omitempty"`
+}
+
+type applicationStatusRelation struct {
+	RelatedApplicationName string `json:"related-application,omitempty" yaml:"related-application,omitempty"`
+	Interface              string `json:"interface,omitempty" yaml:"interface,omitempty"`
+	Scope                  string `json:"scope,omitempty" yaml:"scope,omitempty"`
 }
 
 type formattedBase struct {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -265,7 +265,6 @@ func (c *statusCommand) close() {
 	if c.storageAPI != nil {
 		c.storageAPI.Close()
 	}
-	return
 }
 
 func (c *statusCommand) getStatus() (*params.FullStatus, error) {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -495,8 +495,20 @@ var (
 			"since":   "01 Apr 15 01:23+10:00",
 		},
 		"relations": M{
-			"logging-directory": L{"wordpress"},
-			"info":              L{"mysql"},
+			"logging-directory": L{
+				M{
+					"interface":           "logging",
+					"related-application": "wordpress",
+					"scope":               "container",
+				},
+			},
+			"info": L{
+				M{
+					"interface":           "juju-info",
+					"related-application": "mysql",
+					"scope":               "container",
+				},
+			},
 		},
 		"endpoint-bindings": M{
 			"":                  network.AlphaSpaceName,
@@ -1437,7 +1449,13 @@ var statusTests = []testCase{
 				"applications": M{
 					"wordpress": wordpressCharm(M{
 						"relations": M{
-							"db": L{"mysql"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
 						},
 						"application-status": M{
 							"current": "error",
@@ -1473,7 +1491,13 @@ var statusTests = []testCase{
 					}),
 					"mysql": mysqlCharm(M{
 						"relations": M{
-							"server": L{"wordpress"},
+							"server": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "wordpress",
+									"scope":               "global",
+								},
+							},
 						},
 						"application-status": M{
 							"current": "waiting",
@@ -1548,7 +1572,13 @@ var statusTests = []testCase{
 				"applications": M{
 					"wordpress": wordpressCharm(M{
 						"relations": M{
-							"db": L{"mysql"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
 						},
 						"application-status": M{
 							"current": "error",
@@ -1584,7 +1614,13 @@ var statusTests = []testCase{
 					}),
 					"mysql": mysqlCharm(M{
 						"relations": M{
-							"server": L{"wordpress"},
+							"server": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "wordpress",
+									"scope":               "global",
+								},
+							},
 						},
 						"application-status": M{
 							"current": "waiting",
@@ -1844,8 +1880,20 @@ var statusTests = []testCase{
 							"cache":           network.AlphaSpaceName,
 						},
 						"relations": M{
-							"db":    L{"mysql"},
-							"cache": L{"varnish"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
+							"cache": L{
+								M{
+									"interface":           "varnish",
+									"related-application": "varnish",
+									"scope":               "global",
+								},
+							},
 						},
 					}),
 					"mysql": mysqlCharm(M{
@@ -1875,7 +1923,18 @@ var statusTests = []testCase{
 							"metrics-client": network.AlphaSpaceName,
 						},
 						"relations": M{
-							"server": L{"private", "project"},
+							"server": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "private",
+									"scope":               "global",
+								},
+								M{
+									"interface":           "mysql",
+									"related-application": "project",
+									"scope":               "global",
+								},
+							},
 						},
 					}),
 					"varnish": M{
@@ -1910,7 +1969,13 @@ var statusTests = []testCase{
 							"webcache": network.AlphaSpaceName,
 						},
 						"relations": M{
-							"webcache": L{"project"},
+							"webcache": L{
+								M{
+									"interface":           "varnish",
+									"related-application": "project",
+									"scope":               "global",
+								},
+							},
 						},
 					},
 					"private": wordpressCharm(M{
@@ -1947,7 +2012,13 @@ var statusTests = []testCase{
 							"foo-bar":         network.AlphaSpaceName,
 						},
 						"relations": M{
-							"db": L{"mysql"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
 						},
 					}),
 				},
@@ -2064,7 +2135,13 @@ var statusTests = []testCase{
 							"ring":     network.AlphaSpaceName,
 						},
 						"relations": M{
-							"ring": L{"riak"},
+							"ring": L{
+								M{
+									"interface":           "riak",
+									"related-application": "riak",
+									"scope":               "global",
+								},
+							},
 						},
 					},
 				},
@@ -2188,8 +2265,20 @@ var statusTests = []testCase{
 							"logging-dir":     network.AlphaSpaceName,
 						},
 						"relations": M{
-							"db":          L{"mysql"},
-							"logging-dir": L{"logging"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
+							"logging-dir": L{
+								M{
+									"interface":           "logging",
+									"related-application": "logging",
+									"scope":               "container",
+								},
+							},
 						},
 					}),
 					"mysql": mysqlCharm(M{
@@ -2236,8 +2325,20 @@ var statusTests = []testCase{
 							"metrics-client": network.AlphaSpaceName,
 						},
 						"relations": M{
-							"server":    L{"wordpress"},
-							"juju-info": L{"logging"},
+							"server": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "wordpress",
+									"scope":               "global",
+								},
+							},
+							"juju-info": L{
+								M{
+									"interface":           "juju-info",
+									"related-application": "logging",
+									"scope":               "container",
+								},
+							},
 						},
 					}),
 					"logging": loggingCharm,
@@ -2317,8 +2418,20 @@ var statusTests = []testCase{
 							"logging-dir":     network.AlphaSpaceName,
 						},
 						"relations": M{
-							"db":          L{"mysql"},
-							"logging-dir": L{"logging"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
+							"logging-dir": L{
+								M{
+									"interface":           "logging",
+									"related-application": "logging",
+									"scope":               "container",
+								},
+							},
 						},
 					}),
 					"mysql": mysqlCharm(M{
@@ -2365,8 +2478,20 @@ var statusTests = []testCase{
 							"metrics-client": network.AlphaSpaceName,
 						},
 						"relations": M{
-							"server":    L{"wordpress"},
-							"juju-info": L{"logging"},
+							"server": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "wordpress",
+									"scope":               "global",
+								},
+							},
+							"juju-info": L{
+								M{
+									"interface":           "juju-info",
+									"related-application": "logging",
+									"scope":               "container",
+								},
+							},
 						},
 					}),
 					"logging": loggingCharm,
@@ -2445,8 +2570,20 @@ var statusTests = []testCase{
 							"url":             network.AlphaSpaceName,
 						},
 						"relations": M{
-							"db":          L{"mysql"},
-							"logging-dir": L{"logging"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "mysql",
+									"scope":               "global",
+								},
+							},
+							"logging-dir": L{
+								M{
+									"interface":           "logging",
+									"related-application": "logging",
+									"scope":               "container",
+								},
+							},
 						},
 					}),
 					"logging": loggingCharm,
@@ -3394,7 +3531,13 @@ var statusTests = []testCase{
 							"since":   "01 Apr 15 01:23+10:00",
 						},
 						"relations": M{
-							"db": L{"hosted-mysql"},
+							"db": L{
+								M{
+									"interface":           "mysql",
+									"related-application": "hosted-mysql",
+									"scope":               "global",
+								},
+							},
 						},
 						"units": M{
 							"wordpress/0": M{

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -75,9 +75,13 @@ func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
 	c.Assert(out, jc.Contains, `
     relations:
       info:
-      - wordpress
+      - related-application: wordpress
+        interface: juju-info
+        scope: container
       logging-directory:
-      - wordpress
+      - related-application: wordpress
+        interface: logging
+        scope: container
     subordinate-to:
     - wordpress
 `)
@@ -85,9 +89,13 @@ func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
 	c.Assert(out, jc.Contains, `
     relations:
       juju-info:
-      - logging
+      - related-application: logging
+        interface: juju-info
+        scope: container
       logging-dir:
-      - logging
+      - related-application: logging
+        interface: logging
+        scope: container
 `)
 }
 


### PR DESCRIPTION
This PR includes relations for json/yaml format on juju status command;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju status --relations
Model  Controller  Cloud/Region        Version  SLA          Timestamp
clite  k1          microk8s/localhost  3.1.3    unsupported  23:01:53+10:00

App           Version  Status   Scale  Charm             Channel  Rev  Address         Exposed  Message
alertmanager           waiting    0/1  alertmanager-k8s  stable    47  10.152.183.205  no       installing agent
catalogue              waiting    0/1  catalogue-k8s     stable    13                  no       installing agent
grafana                waiting    0/1  grafana-k8s       stable    64                  no       installing agent
loki                   waiting    0/1  loki-k8s          stable    60                  no       installing agent
prometheus             waiting    0/1  prometheus-k8s    stable   103                  no       installing agent
traefik                waiting    0/1  traefik-k8s       stable   110                  no       installing agent

Unit            Workload  Agent       Address  Ports  Message
alertmanager/0  waiting   allocating                  installing agent
catalogue/0     waiting   allocating                  installing agent
grafana/0       waiting   allocating                  installing agent
loki/0          waiting   allocating                  installing agent
prometheus/0    waiting   allocating                  installing agent
traefik/0       waiting   allocating                  installing agent

Relation provider                   Requirer                     Interface              Type     Message
alertmanager:alerting               loki:alertmanager            alertmanager_dispatch  regular  joining  
alertmanager:alerting               prometheus:alertmanager      alertmanager_dispatch  regular  joining  
alertmanager:grafana-dashboard      grafana:grafana-dashboard    grafana_dashboard      regular  joining  
alertmanager:grafana-source         grafana:grafana-source       grafana_datasource     regular  joining  
alertmanager:replicas               alertmanager:replicas        alertmanager_replica   peer     joining  
alertmanager:self-metrics-endpoint  prometheus:metrics-endpoint  prometheus_scrape      regular  joining  
catalogue:catalogue                 alertmanager:catalogue       catalogue              regular  joining  
catalogue:catalogue                 grafana:catalogue            catalogue              regular  joining  
catalogue:catalogue                 prometheus:catalogue         catalogue              regular  joining  
grafana:grafana                     grafana:grafana              grafana_peers          peer     joining  
grafana:metrics-endpoint            prometheus:metrics-endpoint  prometheus_scrape      regular  joining  
loki:grafana-dashboard              grafana:grafana-dashboard    grafana_dashboard      regular  joining  
loki:grafana-source                 grafana:grafana-source       grafana_datasource     regular  joining  
loki:metrics-endpoint               prometheus:metrics-endpoint  prometheus_scrape      regular  joining  
prometheus:grafana-dashboard        grafana:grafana-dashboard    grafana_dashboard      regular  joining  
prometheus:grafana-source           grafana:grafana-source       grafana_datasource     regular  joining  
prometheus:prometheus-peers         prometheus:prometheus-peers  prometheus_peers       peer     joining  
traefik:ingress                     alertmanager:ingress         ingress                regular  joining  
traefik:ingress                     catalogue:ingress            ingress                regular  joining  
traefik:ingress-per-unit            loki:ingress                 ingress_per_unit       regular  joining  
traefik:ingress-per-unit            prometheus:ingress           ingress_per_unit       regular  joining  
traefik:metrics-endpoint            prometheus:metrics-endpoint  prometheus_scrape      regular  joining  
traefik:traefik-route               grafana:ingress              traefik_route          regular  joining

juju status --relations --format json  | jq '.applications | to_entries[] | {app_name: .key, relations: .value.relations}'
{
  "app_name": "alertmanager",
  "relations": {
    "alerting": [
      {
        "related-application": "loki",
        "interface": "alertmanager_dispatch",
        "scope": "global"
      },
      {
        "related-application": "prometheus",
        "interface": "alertmanager_dispatch",
        "scope": "global"
      }
    ],
    "catalogue": [
      {
        "related-application": "catalogue",
        "interface": "catalogue",
        "scope": "global"
      }
    ],
    "grafana-dashboard": [
      {
        "related-application": "grafana",
        "interface": "grafana_dashboard",
        "scope": "global"
      }
    ],
    "grafana-source": [
      {
        "related-application": "grafana",
        "interface": "grafana_datasource",
        "scope": "global"
      }
    ],
    "ingress": [
      {
        "related-application": "traefik",
        "interface": "ingress",
        "scope": "global"
      }
    ],
    "replicas": [
      {
        "related-application": "alertmanager",
        "interface": "alertmanager_replica",
        "scope": "global"
      }
    ],
    "self-metrics-endpoint": [
      {
        "related-application": "prometheus",
        "interface": "prometheus_scrape",
        "scope": "global"
      }
    ]
  }
}
{
  "app_name": "catalogue",
  "relations": {
    "catalogue": [
      {
        "related-application": "alertmanager",
        "interface": "catalogue",
        "scope": "global"
      },
      {
        "related-application": "grafana",
        "interface": "catalogue",
        "scope": "global"
      },
      {
        "related-application": "prometheus",
        "interface": "catalogue",
        "scope": "global"
      }
    ],
    "ingress": [
      {
        "related-application": "traefik",
        "interface": "ingress",
        "scope": "global"
      }
    ]
  }
}
{
  "app_name": "grafana",
  "relations": {
    "catalogue": [
      {
        "related-application": "catalogue",
        "interface": "catalogue",
        "scope": "global"
      }
    ],
    "grafana": [
      {
        "related-application": "grafana",
        "interface": "grafana_peers",
        "scope": "global"
      }
    ],
    "grafana-dashboard": [
      {
        "related-application": "alertmanager",
        "interface": "grafana_dashboard",
        "scope": "global"
      },
      {
        "related-application": "loki",
        "interface": "grafana_dashboard",
        "scope": "global"
      },
      {
        "related-application": "prometheus",
        "interface": "grafana_dashboard",
        "scope": "global"
      }
    ],
    "grafana-source": [
      {
        "related-application": "alertmanager",
        "interface": "grafana_datasource",
        "scope": "global"
      },
      {
        "related-application": "loki",
        "interface": "grafana_datasource",
        "scope": "global"
      },
      {
        "related-application": "prometheus",
        "interface": "grafana_datasource",
        "scope": "global"
      }
    ],
    "ingress": [
      {
        "related-application": "traefik",
        "interface": "traefik_route",
        "scope": "global"
      }
    ],
    "metrics-endpoint": [
      {
        "related-application": "prometheus",
        "interface": "prometheus_scrape",
        "scope": "global"
      }
    ]
  }
}
{
  "app_name": "loki",
  "relations": {
    "alertmanager": [
      {
        "related-application": "alertmanager",
        "interface": "alertmanager_dispatch",
        "scope": "global"
      }
    ],
    "grafana-dashboard": [
      {
        "related-application": "grafana",
        "interface": "grafana_dashboard",
        "scope": "global"
      }
    ],
    "grafana-source": [
      {
        "related-application": "grafana",
        "interface": "grafana_datasource",
        "scope": "global"
      }
    ],
    "ingress": [
      {
        "related-application": "traefik",
        "interface": "ingress_per_unit",
        "scope": "global"
      }
    ],
    "metrics-endpoint": [
      {
        "related-application": "prometheus",
        "interface": "prometheus_scrape",
        "scope": "global"
      }
    ]
  }
}
{
  "app_name": "prometheus",
  "relations": {
    "alertmanager": [
      {
        "related-application": "alertmanager",
        "interface": "alertmanager_dispatch",
        "scope": "global"
      }
    ],
    "catalogue": [
      {
        "related-application": "catalogue",
        "interface": "catalogue",
        "scope": "global"
      }
    ],
    "grafana-dashboard": [
      {
        "related-application": "grafana",
        "interface": "grafana_dashboard",
        "scope": "global"
      }
    ],
    "grafana-source": [
      {
        "related-application": "grafana",
        "interface": "grafana_datasource",
        "scope": "global"
      }
    ],
    "ingress": [
      {
        "related-application": "traefik",
        "interface": "ingress_per_unit",
        "scope": "global"
      }
    ],
    "metrics-endpoint": [
      {
        "related-application": "alertmanager",
        "interface": "prometheus_scrape",
        "scope": "global"
      },
      {
        "related-application": "grafana",
        "interface": "prometheus_scrape",
        "scope": "global"
      },
      {
        "related-application": "loki",
        "interface": "prometheus_scrape",
        "scope": "global"
      },
      {
        "related-application": "traefik",
        "interface": "prometheus_scrape",
        "scope": "global"
      }
    ],
    "prometheus-peers": [
      {
        "related-application": "prometheus",
        "interface": "prometheus_peers",
        "scope": "global"
      }
    ]
  }
}
{
  "app_name": "traefik",
  "relations": {
    "ingress": [
      {
        "related-application": "alertmanager",
        "interface": "ingress",
        "scope": "global"
      },
      {
        "related-application": "catalogue",
        "interface": "ingress",
        "scope": "global"
      }
    ],
    "ingress-per-unit": [
      {
        "related-application": "loki",
        "interface": "ingress_per_unit",
        "scope": "global"
      },
      {
        "related-application": "prometheus",
        "interface": "ingress_per_unit",
        "scope": "global"
      }
    ],
    "metrics-endpoint": [
      {
        "related-application": "prometheus",
        "interface": "prometheus_scrape",
        "scope": "global"
      }
    ],
    "traefik-route": [
      {
        "related-application": "grafana",
        "interface": "traefik_route",
        "scope": "global"
      }
    ]
  }
}

```

## Documentation changes
No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2018274
