### PR TITLE
Fix add-model k8s annotations error

### DIFF
--- a/api/client/modelmanager/modelmanager.go
+++ b/api/client/modelmanager/modelmanager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -76,10 +75,6 @@ func (c *Client) CreateModel(
 	var modelInfo params.ModelInfo
 	err := c.facade.FacadeCall("CreateModel", createArgs, &modelInfo)
 	if err != nil {
-		// We don't want the message to contain the "(already exists)" suffix.
-		if rpcErr, ok := errors.Cause(err).(*rpc.RequestError); ok {
-			return result, errors.New(rpcErr.Message)
-		}
 		return result, errors.Trace(err)
 	}
 	return convertParamsModelInfo(modelInfo)

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api/base"
 	cloudapi "github.com/juju/juju/api/client/cloud"
 	"github.com/juju/juju/api/client/modelmanager"
+	caasconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
@@ -255,6 +256,10 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		}
 		if params.IsCodeUnauthorized(err) {
 			common.PermissionsMessage(ctx.Stderr, "add a model")
+		}
+		if params.IsCodeNotValid(err) && cloud.Type == caasconstants.CAASProviderType {
+			// Workaround for https://bugs.launchpad.net/juju/+bug/1994454
+			return errors.Errorf("cannot create model %[1]q: a namespace called %[1]q already exists on this k8s cluster. Please pick a different model name.", c.Name)
 		}
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
If we try to add-model for a namespace which already exists, and the annotations are not what Juju expects, then it returns a strange "not valid" error:
```
failed to open kubernetes client: annotations map[controller.juju.is/id:e911779d-c210-4207-8a37-586029693d85 model.juju.is/id:b36d5a71-fe97-48cb-87f7-479c98a741df] for namespace "borked" must include map[model.juju.is/id:f58485c2-4f08-4571-88c4-2e6b9ece955c]
```
Catch this error on the client side in the `add-model` command. Add a unit test for this.

Also, fix a bug in the ModelManager API client (method CreateModel) where the RPC error code was being discarded.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju bootstrap microk8s c
$ juju add-model m
$ juju add-model m
ERROR cannot create model "m": a namespace called "m" already exists on this k8s cluster. Please pick a different model name.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1994454