### PR TITLE
[JUJU-3489] export mode model-config as empty string if it is empty

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/payloads"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/series"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state/migrations"
 	"github.com/juju/juju/storage/poolmanager"
@@ -121,6 +122,11 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 	modelConfig, found := export.modelSettings[modelGlobalKey]
 	if !found && !cfg.SkipSettings {
 		return nil, errors.New("missing model config")
+	}
+	// Ensure mode is set so importing model doesn't
+	// default to a value not valid in 2.9
+	if _, ok := modelConfig.Settings[config.ModeKey]; !ok {
+		modelConfig.Settings[config.ModeKey] = ""
 	}
 	delete(export.modelSettings, modelGlobalKey)
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -198,6 +198,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	dbModelCfg, err := s.Model.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	modelAttrs := dbModelCfg.AllAttrs()
+	modelAttrs["mode"] = ""
 	modelCfg := model.Config()
 	// Config as read from state has resources tags coerced to a map.
 	modelCfg["resource-tags"] = map[string]string{}


### PR DESCRIPTION
This stop the target controller from setting this config item to 'requires-prompts' which is invalid for the 2.9 agents running on the model, causing them to bounce

This isn't perfect, since you can still set the model-config to this invalid value, but that is a larger problem. We should probably handle model-config/import and the like via the model itself, rather than the controller

This will require versions 3.x to bump their minimum migration source versions to 2.9.43

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ juju-2.9 bootstrap lxd lxd-2.9
$ juju-2.9 add-model m
$ juju-2.9 deploy ubuntu -n2
$ juju-3.2 bootstrap lxd lxd-3.2
$ juju-2.9 switch lxd-2.9
$ juju-2.9 migrate m lxd-3.2
$ juju-3.2 switch lxd-3.2/m
$ juju-3.2 add-unit ubuntu
```
(verify the extra unit is added successfully)

## Bug reference

https://bugs.launchpad.net/juju/+bug/2015398