### PR TITLE
[JUJU-3489] Increase minimum version to migrate from

### DIFF
--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -140,7 +140,7 @@ func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers s
 
 func (r *restrictNewerClientSuite) TestAgentMethod(c *gc.C) {
 	r.PatchValue(&jujuversion.Current, version.MustParse("3.0.0"))
-	r.assertAgentMethod(c, "2.9.36", true)
+	r.assertAgentMethod(c, "2.9.43", true)
 	r.assertAgentMethod(c, "2.9.31", false)
 }
 

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -120,7 +120,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, `
 cannot migrate to controller ("3.0.0") due to issues:
 "foo/model-1":
-- current model ("2.9.35") has to be upgraded to "2.9.36" at least
+- current model ("2.9.35") has to be upgraded to "2.9.43" at least
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)
@@ -524,9 +524,9 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
 	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.36 before being migrated to a controller with version 3.0.0`)
+		`model must be upgraded to at least version 2.9.43 before being migrated to a controller with version 3.0.0`)
 
-	s.modelInfo.AgentVersion = version.MustParse("2.9.36")
+	s.modelInfo.AgentVersion = version.MustParse("2.9.43")
 	err = s.runPrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -138,7 +138,7 @@ func (s *migrateSuite) setupJuju3Target(c *gc.C) (*gomock.Controller, environscl
 		},
 	)
 	// - check agent version;
-	s.model.EXPECT().AgentVersion().Return(version.MustParse("2.9.36"), nil)
+	s.model.EXPECT().AgentVersion().Return(version.MustParse("2.9.43"), nil)
 	// - check no upgrade series in process.
 	s.st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines;

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -14,7 +14,7 @@ var logger = loggo.GetLogger("juju.upgrades.validations")
 // MinAgentVersions defines the minimum agent version
 // allowed to make a call to a controller with the major version.
 var MinAgentVersions = map[int]version.Number{
-	3: version.MustParse("2.9.36"),
+	3: version.MustParse("2.9.43"),
 }
 
 // MinClientVersions defines the minimum user client version

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -95,17 +95,17 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 			from:    "2.8.0",
 			to:      "3.0.0",
 			allowed: false,
-			minVers: "2.9.36",
+			minVers: "2.9.43",
 		}, {
-			from:    "2.9.36",
+			from:    "2.9.43",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.36",
+			minVers: "2.9.43",
 		}, {
-			from:    "2.9.37",
+			from:    "2.9.44",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.36",
+			minVers: "2.9.43",
 		},
 		{
 			from:    "2.9.0",


### PR DESCRIPTION
This is because 3.2 requires this change:
https://github.com/juju/juju/pull/15556

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap lxd lxd-3.2

$ git checkout juju-2.9.42
$ make install
$ juju bootstrap lxd lxd-2.9.42
$ juju add-model m
$ juju migrate m lxd-3.2
(appropriate error message)
$ git checkout jack-w-shaw/JUJU-3489_fix_migration
$ make install
$ juju bootstrap lxd lxd-2.9.43
$ juju add-model m
$ juju migrate m lxd-3.2
Migration started with ID ...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2015398