### PR TITLE
[JUJU-3489] Support requires-prompts mode model-config

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -275,6 +275,8 @@ const (
 	// The lack of a mode means it will default into compatibility mode.
 	//
 	//  - strict mode ensures that we handle any fallbacks as errors.
+	//  - requires-prompts mode has no effect and is only supported for
+	//    forwards compatibility
 	ModeKey = "mode"
 
 	//
@@ -1404,8 +1406,9 @@ func (c *Config) validateCharmHubURL() error {
 }
 
 // Mode returns the mode type for the configuration.
-// Only two modes exist at the moment (strict or ""). Empty string
-// implies compatible mode.
+// Only three modes are supported at the moment (requires-prompts, strict or "").
+// Empty string implies compatible mode.
+// "requires-prompts" has no effect and is only supported for forwards compatibility.
 func (c *Config) Mode() ([]string, bool) {
 	modes, ok := c.defined[ModeKey]
 	if !ok {
@@ -1432,6 +1435,7 @@ func (c *Config) validateMode() error {
 	for _, mode := range modes {
 		switch strings.TrimSpace(mode) {
 		case "strict":
+		case "requires-prompts":
 		default:
 			return errors.NotValidf("mode %q", mode)
 		}

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -428,6 +428,12 @@ var configTests = []configTest{
 			"mode": "strict",
 		}),
 	}, {
+		about:       "Mode flag includes requires-prompts",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"mode": "strict,requires-prompts",
+		}),
+	}, {
 		about:       "Logging output flag specified",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{


### PR DESCRIPTION
This will enable forwards compatibility with future controllers, particularly useful for model migrations

This will require versions 3.2 to bump their minimum migration source versions to 2.9.43

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ juju-2.9 bootstrap lxd lxd-2.9
$ juju-2.9 add-model m
$ juju-2.9 deploy ubuntu -n2
$ juju-3.2 bootstrap lxd lxd-3.2
$ juju-2.9 switch lxd-2.9
$ juju-2.9 migrate m lxd-3.2
$ juju-3.2 switch lxd-3.2:admin/m
$ juju-3.2 add-unit ubuntu
```
(verify the extra unit is added successfully)

## Bug reference

https://bugs.launchpad.net/juju/+bug/2015398