### PR TITLE
[JUJU-3542] Revisit test suites to use charms with no storage, and wait until ready

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -18,9 +18,11 @@ run_deploy_specific_series() {
 
 	ensure "test-deploy-specific-series" "${file}"
 
-	juju deploy postgresql --base ubuntu@20.04
-	base_name=$(juju status --format=json | jq ".applications.postgresql.base.name")
-	base_channel=$(juju status --format=json | jq ".applications.postgresql.base.channel")
+	juju deploy jameinel-ubuntu-lite --base ubuntu@20.04
+	base_name=$(juju status --format=json | jq '.applications."ubuntu-lite".base.name')
+	base_channel=$(juju status --format=json | jq '.applications."ubuntu-lite".base.channel')
+
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	destroy_model "test-deploy-specific-series"
 

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,12 +6,12 @@ test_log_permissions() {
 	file="${TEST_DIR}/test_log_permissions.log"
 	ensure "correct-log" "${file}"
 
-	juju deploy postgresql --base ubuntu@20.04
+	juju deploy jameinel-ubuntu-lite --base ubuntu@20.04
 
 	wait_for "started" '.machines."0"."juju-status".current'
 
-	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/unit-postgresql-0.log)" adm
-	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/unit-postgresql-0.log)" 640
+	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/unit-ubuntu-lite-0.log)" adm
+	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/unit-ubuntu-lite-0.log)" 640
 
 	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/machine-0.log)" 640
 	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/machine-0.log)" adm


### PR DESCRIPTION
There is an ongoing issue when trying to destroy models that have not been completely initialized. This is impacting our gating tests because in certain situations these tests fall into an endless loop. 

This PR adds some workarounds to avoid destroying models in `pending` state and try to use charms that do not require storage.


## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing

## QA steps

Run the integration tests locally in a previously deployed controller

```sh
make build
_build/linux_amd64/bin/juju bootstrap lxd lxd32rc1
cd tests
./main.sh -l lxd32rc1 machine test_log_permissions
./main.sh -l lxd32rc1 deploy run_deploy_specific_series
```


## Bug reference

A bug has been reported here:

https://bugs.launchpad.net/juju/+bug/2019004