### PR TITLE
[ci/docs] sync CLI docs from 3.3 branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,10 @@ name: "Docs"
 on:
   push:
     branches:
-      - 'develop'
+      - '3.3'
   pull_request:
     branches:
-      - 'develop'
+      - '3.3'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`develop` no longer exists, and future changes will go into `3.3` (since `main` is for dqlite changes).