### PR TITLE
[JUJU-3648] Allow schema gen building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,9 +471,9 @@ rebuild-schema:
 	@echo "Generating facade schema..."
 # GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
 ifdef SCHEMA_PATH
-	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
+	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
 else
-	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
+	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
 endif
 
@@ -506,8 +506,16 @@ install-mongo-dependencies:
 	@$(WAIT_FOR_DPKG)
 	@sudo apt-get --yes install  $(strip $(DEPENDENCIES))
 
+.PHONY: install-sqlite3-dependencies
+install-sqlite3-dependencies:
+## install-sqlite3-dependencies: Install libsqlite3-dev
+	@echo Installing libsqlite3-dev
+	@$(WAIT_FOR_DPKG)
+	@sudo apt-get update
+	@sudo apt-get --yes install libsqlite3-dev
+
 .PHONY: install-dependencies
-install-dependencies: install-snap-dependencies install-mongo-dependencies
+install-dependencies: install-snap-dependencies install-mongo-dependencies install-sqlite3-dependencies
 ## install-dependencies: Install all the dependencies
 	@echo "Installing dependencies"
 


### PR DESCRIPTION
This patch is broken off from #15539. Now we're actually pushing the DB into the APIServer, which means that we need to make the schema gen aware of sqlite.

The solution is to just set CGO_ENABLE=1 and then install the libsqlite3-dev apt package where required. This shouldn't be required for local development or for production builds but is required for testing. This isn't ideal, as we now have three different setups for local, production and now testing. Once we move to snaps for the controller agent, we can then at least merge local and production. With testing fixed in the future when we change to a RESTful API.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
$ make rebuild-schema
```

