### PR TITLE
[JUJU-3447] Enable ModelFirewaller for OpenStack

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1549,7 +1549,7 @@ func (c *Config) validateMode() error {
 func (c *Config) SSHAllow() []string {
 	allowList, ok := c.defined[SSHAllowKey].(string)
 	if !ok {
-		return []string{"0.0.0.0/0"}
+		return []string{"0.0.0.0/0", "::/0"}
 	}
 	if allowList == "" {
 		return []string{}
@@ -2359,7 +2359,7 @@ potentially valuable resources.
 	SSHAllowKey: {
 		Description: `SSH allowlist is a comma-separated list of CIDRs from
 which machines in this model will accept connections to the SSH service.
-Currently only the aws provider supports ssh-allow`,
+Currently only the aws & openstack providers support ssh-allow`,
 		Type:  environschema.Tstring,
 		Group: environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -668,6 +668,10 @@ var configTests = []configTest{
 		}),
 		err: `cidr "blah" not valid`,
 	}, {
+		about:       "Absent ssh-allow entry",
+		useDefaults: config.UseDefaults,
+		attrs:       minimalConfigAttrs,
+	}, {
 		about:       "Invalid saas-ingress-allow cidr",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -870,6 +874,7 @@ func (test configTest) check(c *gc.C) {
 	if val, ok := test.attrs[config.ContainerInheritPropertiesKey].(string); ok && val != "" {
 		c.Assert(cfg.ContainerInheritProperties(), gc.Equals, val)
 	}
+	c.Assert(cfg.SSHAllow(), gc.DeepEquals, []string{"0.0.0.0/0", "::/0"})
 }
 
 func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
+	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
 	github.com/go-logr/logr v1.2.2
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkPro
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4 h1:IzjmVasvOk8hqDbP0uSOTFZRTSsP4WYmVl9VcQPS92o=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
+github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a h1:H/l82+fC6idmYg1kfpQlCq7gYctri7AGn9RemqwN6bw=
+github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -495,6 +495,7 @@ func newState(name string, ops chan<- Operation, newStatePolicy state.NewPolicyF
 		ops:            ops,
 		newStatePolicy: newStatePolicy,
 		insts:          make(map[instance.Id]*dummyInstance),
+		modelRules:     firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("22"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR)},
 		creator:        string(buf),
 	}
 	return s

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -65,14 +65,9 @@ func (fakeNamespace) Value(s string) string {
 	return "juju-" + s
 }
 
-func SetUpGlobalGroup(e environs.Environ, ctx context.ProviderCallContext, name string, apiPort int) (neutron.SecurityGroupV2, error) {
+func EnsureGroup(e environs.Environ, ctx context.ProviderCallContext, name string, isModelGroup bool) (neutron.SecurityGroupV2, error) {
 	switching := &neutronFirewaller{firewallerBase: firewallerBase{environ: e.(*Environ)}}
-	return switching.setUpGlobalGroup(name, apiPort)
-}
-
-func EnsureGroup(e environs.Environ, ctx context.ProviderCallContext, name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
-	switching := &neutronFirewaller{firewallerBase: firewallerBase{environ: e.(*Environ)}}
-	return switching.ensureGroup(name, rules)
+	return switching.ensureGroup(name, isModelGroup)
 }
 
 func MachineGroupRegexp(e environs.Environ, machineId string) string {
@@ -155,7 +150,7 @@ func GetModelGroupNames(e environs.Environ) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	modelPattern, err := regexp.Compile(neutronFw.jujuGroupRegexp())
+	modelPattern, err := regexp.Compile(neutronFw.jujuGroupPrefixRegexp())
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -553,7 +553,12 @@ func (c *neutronFirewaller) IngressRules(ctx context.ProviderCallContext) (firew
 
 // OpenModelPorts implements Firewaller interface
 func (c *neutronFirewaller) OpenModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
-	if err := c.openPortsInGroup(ctx, c.jujuGroupRegexp(), rules); err != nil {
+	err := c.openPortsInGroup(ctx, c.jujuGroupRegexp(), rules)
+	if errors.IsNotFound(err) && !c.environ.usingSecurityGroups {
+		logger.Warningf("attempted to open %v but network port security is disabled. Already open", rules)
+		return nil
+	}
+	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -13,7 +13,6 @@ import (
 	gooseerrors "github.com/go-goose/goose/v5/errors"
 	"github.com/go-goose/goose/v5/neutron"
 	"github.com/juju/clock"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
 
@@ -54,6 +53,20 @@ type Firewaller interface {
 	// address rules for that port range.
 	IngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error)
 
+	// OpenModelPorts opens the given port ranges on the model firewall
+	OpenModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error
+
+	// CloseModelPorts Closes the given port ranges on the model firewall
+	CloseModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error
+
+	// ModelIngressRules returns the set of ingress rules on the model firewall.
+	// The rules are returned as sorted by network.SortIngressRules().
+	// It is expected that there be only one ingress rule result for a given
+	// port range - the rule's SourceCIDRs will contain all applicable source
+	// address rules for that port range.
+	// If the model security group doesn't exist, return a NotFound error
+	ModelIngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error)
+
 	// DeleteAllModelGroups deletes all security groups for the
 	// model.
 	DeleteAllModelGroups(ctx context.ProviderCallContext) error
@@ -77,7 +90,7 @@ type Firewaller interface {
 
 	// SetUpGroups sets up initial security groups, if any, and returns
 	// their names.
-	SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string, apiPort int) ([]string, error)
+	SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string) ([]string, error)
 
 	// OpenInstancePorts opens the given port ranges for the specified  instance.
 	OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, rules firewall.IngressRules) error
@@ -236,18 +249,22 @@ func (c *firewallerBase) jujuControllerGroupPrefix(controllerUUID string) string
 	return fmt.Sprintf("juju-%v-", controllerUUID)
 }
 
-func (c *firewallerBase) jujuGroupRegexp() string {
+func (c *firewallerBase) jujuGroupPrefixRegexp() string {
 	cfg := c.environ.Config()
 	return fmt.Sprintf("juju-.*-%v", cfg.UUID())
 }
 
+func (c *firewallerBase) jujuGroupRegexp() string {
+	return fmt.Sprintf("%s$", c.jujuGroupPrefixRegexp())
+}
+
 func (c *firewallerBase) globalGroupRegexp() string {
-	return fmt.Sprintf("%s-global", c.jujuGroupRegexp())
+	return fmt.Sprintf("%s-global", c.jujuGroupPrefixRegexp())
 }
 
 func (c *firewallerBase) machineGroupRegexp(machineID string) string {
 	// we are only looking to match 1 machine
-	return fmt.Sprintf("%s-%s$", c.jujuGroupRegexp(), machineID)
+	return fmt.Sprintf("%s-%s$", c.jujuGroupPrefixRegexp(), machineID)
 }
 
 type neutronFirewaller struct {
@@ -265,17 +282,17 @@ type neutronFirewaller struct {
 // Note: ideally we'd have a better way to determine group membership so that 2
 // people that happen to share an openstack account and name their environment
 // "openstack" don't end up destroying each other's machines.
-func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string, apiPort int) ([]string, error) {
-	jujuGroup, err := c.setUpGlobalGroup(c.jujuGroupName(controllerUUID), apiPort)
+func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string) ([]string, error) {
+	jujuGroup, err := c.ensureGroup(c.jujuGroupName(controllerUUID), true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	var machineGroup neutron.SecurityGroupV2
 	switch c.environ.Config().FirewallMode() {
 	case config.FwInstance:
-		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineID), nil)
+		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineID), false)
 	case config.FwGlobal:
-		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
+		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), false)
 	}
 	if err != nil {
 		handleCredentialError(err, ctx)
@@ -288,84 +305,13 @@ func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, control
 	return groups, nil
 }
 
-func (c *neutronFirewaller) setUpGlobalGroup(groupName string, apiPort int) (neutron.SecurityGroupV2, error) {
-	return c.ensureGroup(groupName,
-		[]neutron.RuleInfoV2{
-			{
-				Direction:      "ingress",
-				IPProtocol:     "tcp",
-				PortRangeMax:   22,
-				PortRangeMin:   22,
-				RemoteIPPrefix: "::/0",
-				EthernetType:   "IPv6",
-			},
-			{
-				Direction:      "ingress",
-				IPProtocol:     "tcp",
-				PortRangeMax:   22,
-				PortRangeMin:   22,
-				RemoteIPPrefix: "0.0.0.0/0",
-			},
-			{
-				Direction:      "ingress",
-				IPProtocol:     "tcp",
-				PortRangeMax:   apiPort,
-				PortRangeMin:   apiPort,
-				RemoteIPPrefix: "::/0",
-				EthernetType:   "IPv6",
-			},
-			{
-				Direction:      "ingress",
-				IPProtocol:     "tcp",
-				PortRangeMax:   apiPort,
-				PortRangeMin:   apiPort,
-				RemoteIPPrefix: "0.0.0.0/0",
-			},
-			{
-				Direction:    "ingress",
-				IPProtocol:   "tcp",
-				PortRangeMin: 1,
-				PortRangeMax: 65535,
-				EthernetType: "IPv6",
-			},
-			{
-				Direction:    "ingress",
-				IPProtocol:   "tcp",
-				PortRangeMin: 1,
-				PortRangeMax: 65535,
-			},
-			{
-				Direction:    "ingress",
-				IPProtocol:   "udp",
-				PortRangeMin: 1,
-				PortRangeMax: 65535,
-				EthernetType: "IPv6",
-			},
-			{
-				Direction:    "ingress",
-				IPProtocol:   "udp",
-				PortRangeMin: 1,
-				PortRangeMax: 65535,
-			},
-			{
-				Direction:    "ingress",
-				IPProtocol:   "icmp",
-				EthernetType: "IPv6",
-			},
-			{
-				Direction:  "ingress",
-				IPProtocol: "icmp",
-			},
-		})
-}
-
 // zeroGroup holds the zero security group.
 var zeroGroup neutron.SecurityGroupV2
 
 // ensureGroup returns the security group with name and rules.
 // If a group with name does not exist, one will be created.
 // If it exists, its permissions are set to rules.
-func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
+func (c *neutronFirewaller) ensureGroup(name string, isModelGroup bool) (neutron.SecurityGroupV2, error) {
 	// Due to parallelization of the provisioner, it's possible that we try
 	// to create the model security group a second time before the first time
 	// is complete causing failures.
@@ -397,50 +343,13 @@ func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2)
 		return zeroGroup, err
 	}
 
-	have := newRuleInfoSetFromRules(group.Rules)
-	want := newRuleInfoSetFromRuleInfo(rules)
-
-	// Find rules we want to delete, that we have but don't want, and
-	// delete them.
-	// Define a removal set to ensure that we only ever delete a ruleID once.
-	remove := set.NewStrings()
-	for k := range have {
-		// Neutron creates 2 egress rules with any new Security Group.
-		// Keep them.
-		if _, ok := want[k]; !ok && k.Direction != "egress" {
-			remove.Add(have[k])
-		}
-	}
-	for _, ruleID := range remove.SortedValues() {
-		if err = neutronClient.DeleteSecurityGroupRuleV2(ruleID); err != nil {
-			if gooseerrors.IsNotFound(err) {
-				continue
-			}
-			return zeroGroup, err
-		}
+	if !isModelGroup {
+		return group, nil
 	}
 
-	// Find rules we want to add, that we want but don't have, and add
-	// them.
-	add := make(ruleInfoSet)
-	for k := range want {
-		if _, ok := have[k]; !ok {
-			add[k] = want[k]
-		}
+	if err := c.ensureInternalRules(neutronClient, group); err != nil {
+		return zeroGroup, errors.Annotate(err, "failed to enable internal model rules")
 	}
-	for rule := range add {
-		rule.ParentGroupId = group.Id
-		// Neutron translates empty RemoteIPPrefix into
-		// 0.0.0.0/0 or ::/0 instead of ParentGroupId
-		// when EthernetType is set
-		if rule.RemoteIPPrefix == "" {
-			rule.RemoteGroupId = group.Id
-		}
-		if _, err := neutronClient.CreateSecurityGroupRuleV2(rule); err != nil {
-			return zeroGroup, err
-		}
-	}
-
 	// Since we may have done a few add or delete rules, get a new
 	// copy of the security group to return containing the end
 	// list of rules.
@@ -454,54 +363,62 @@ func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2)
 	return groupsFound[0], nil
 }
 
-// ruleInfoSet represents a Security Group Rule created for a Security Group.
-// The string will be the Security Group Rule Id, if the rule has previously been
-// created.
-type ruleInfoSet map[neutron.RuleInfoV2]string
-
-// newRuleSetForGroup returns a set of all of the permissions in a given
-// slice of SecurityGroupRules.  It ignores the group id, the
-// remove group id, and tenant id.  Keep the rule id to delete the rule if
-// necessary.
-func newRuleInfoSetFromRules(rules []neutron.SecurityGroupRuleV2) ruleInfoSet {
-	m := make(ruleInfoSet)
-	for _, r := range rules {
-		k := neutron.RuleInfoV2{
-			Direction:      r.Direction,
-			EthernetType:   r.EthernetType,
-			RemoteIPPrefix: r.RemoteIPPrefix,
-		}
-		if r.IPProtocol != nil {
-			k.IPProtocol = *r.IPProtocol
-		}
-		if r.PortRangeMax != nil {
-			k.PortRangeMax = *r.PortRangeMax
-		}
-		if r.PortRangeMin != nil {
-			k.PortRangeMin = *r.PortRangeMin
-		}
-		m[k] = r.Id
+func (c *neutronFirewaller) ensureInternalRules(neutronClient *neutron.Client, group neutron.SecurityGroupV2) error {
+	rules := []neutron.RuleInfoV2{
+		{
+			Direction:     "ingress",
+			IPProtocol:    "tcp",
+			PortRangeMin:  1,
+			PortRangeMax:  65535,
+			EthernetType:  "IPv6",
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
+		{
+			Direction:     "ingress",
+			IPProtocol:    "tcp",
+			PortRangeMin:  1,
+			PortRangeMax:  65535,
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
+		{
+			Direction:     "ingress",
+			IPProtocol:    "udp",
+			PortRangeMin:  1,
+			PortRangeMax:  65535,
+			EthernetType:  "IPv6",
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
+		{
+			Direction:     "ingress",
+			IPProtocol:    "udp",
+			PortRangeMin:  1,
+			PortRangeMax:  65535,
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
+		{
+			Direction:     "ingress",
+			IPProtocol:    "icmp",
+			EthernetType:  "IPv6",
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
+		{
+			Direction:     "ingress",
+			IPProtocol:    "icmp",
+			ParentGroupId: group.Id,
+			RemoteGroupId: group.Id,
+		},
 	}
-	return m
-}
-
-// newRuleSetForGroup returns a set of all of the permissions in a given
-// slice of RuleInfo.  It ignores the rule id, the group id, the
-// remove group id, and tenant id.
-func newRuleInfoSetFromRuleInfo(rules []neutron.RuleInfoV2) ruleInfoSet {
-	m := make(ruleInfoSet)
-	for _, r := range rules {
-		k := neutron.RuleInfoV2{
-			Direction:      r.Direction,
-			IPProtocol:     r.IPProtocol,
-			PortRangeMin:   r.PortRangeMin,
-			PortRangeMax:   r.PortRangeMax,
-			EthernetType:   r.EthernetType,
-			RemoteIPPrefix: r.RemoteIPPrefix,
+	for _, rule := range rules {
+		if _, err := neutronClient.CreateSecurityGroupRuleV2(rule); err != nil && !gooseerrors.IsDuplicateValue(err) {
+			return err
 		}
-		m[k] = ""
 	}
-	return m
+	return nil
 }
 
 func (c *neutronFirewaller) deleteSecurityGroups(ctx context.ProviderCallContext, match func(name string) bool) error {
@@ -537,7 +454,7 @@ func (c *neutronFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallCo
 
 // DeleteAllModelGroups implements Firewaller interface.
 func (c *neutronFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
-	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuGroupRegexp())
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuGroupPrefixRegexp())
 }
 
 // UpdateGroupController implements Firewaller interface.
@@ -548,7 +465,7 @@ func (c *neutronFirewaller) UpdateGroupController(ctx context.ProviderCallContex
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	re, err := regexp.Compile(c.jujuGroupRegexp())
+	re, err := regexp.Compile(c.jujuGroupPrefixRegexp())
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
@@ -621,6 +538,36 @@ func (c *neutronFirewaller) IngressRules(ctx context.ProviderCallContext) (firew
 			c.environ.Config().FirewallMode())
 	}
 	rules, err := c.ingressRulesInGroup(ctx, c.globalGroupRegexp())
+	if err != nil {
+		handleCredentialError(err, ctx)
+		return rules, errors.Trace(err)
+	}
+	return rules, nil
+}
+
+// OpenModelPorts implements Firewaller interface
+func (c *neutronFirewaller) OpenModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
+	if err := c.openPortsInGroup(ctx, c.jujuGroupRegexp(), rules); err != nil {
+		handleCredentialError(err, ctx)
+		return errors.Trace(err)
+	}
+	logger.Infof("opened ports in model group: %v", rules)
+	return nil
+}
+
+// CloseModelPorts implements Firewaller interface
+func (c *neutronFirewaller) CloseModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
+	if err := c.closePortsInGroup(ctx, c.jujuGroupRegexp(), rules); err != nil {
+		handleCredentialError(err, ctx)
+		return errors.Trace(err)
+	}
+	logger.Infof("closed ports in global group: %v", rules)
+	return nil
+}
+
+// ModelIngressRules implements Firewaller interface
+func (c *neutronFirewaller) ModelIngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error) {
+	rules, err := c.ingressRulesInGroup(ctx, c.jujuGroupRegexp())
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return rules, errors.Trace(err)
@@ -809,9 +756,18 @@ func (c *neutronFirewaller) ingressRulesInGroup(ctx context.ProviderCallContext,
 		if p.Direction == "egress" {
 			continue
 		}
+		// Skip internal security group rules
+		if p.RemoteGroupID != "" {
+			continue
+		}
+
 		portRange := corenetwork.PortRange{
 			Protocol: *p.IPProtocol,
 		}
+		if portRange.Protocol == "ipv6-icmp" {
+			portRange.Protocol = "icmp"
+		}
+
 		// NOTE: Juju firewall rule validation expects that icmp rules have port
 		// values set to -1
 		if p.PortRangeMin != nil {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -331,6 +331,13 @@ type Environ struct {
 	keystoneToolsDataSourceMutex sync.Mutex
 	keystoneToolsDataSource      simplestreams.DataSource
 
+	// usingSecurityGroups tracks whether this model is using security groups
+	// for firewalling. This will be false if a network has port_security disabled,
+	// true otherwise.
+	// However, once a model security group is created, it is not removed if such a model
+	// is added, this option sticks to true
+	usingSecurityGroups bool
+
 	firewaller   Firewaller
 	networking   Networking
 	configurator ProviderConfigurator
@@ -1152,6 +1159,7 @@ func (e *Environ) startInstance(
 			}
 		}
 	}
+	e.usingSecurityGroups = e.usingSecurityGroups || createSecurityGroups
 
 	var novaGroupNames []nova.SecurityGroupName
 	if createSecurityGroups {


### PR DESCRIPTION
This work has already been done for aws. Add OpenStack to the list of
providers which support this
https://github.com/juju/juju/pull/15329

As with aws, model ssh ingress is now managed by `ssh-allow` model config item.
Also, api-port is now only opened on the controller model 

This was mostly trivial, and involved removing a lot of responsibilities
from the OpenStack provider

This has involved updating the go-goose dependency

Also as a flyby fix an bug in config. ssh-allow was defaulting to the
wrong value if the entry was absent. Write a test for this case as well

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Verify ssh-allow

Deploy a controller to opensatck, add a model and deploy a machine
```
$ juju bootstrap openstack stack
$ juju add-model m
$ juju add-machine
```

Then find the model-level security group name, put it in an envvar. For me:
```
$ export MODEL_GROUP=juju-83a82f66-bfd4-4bb0-812a-e3edfb67d64d-57d8be23-4f99-4de0-8946-bb9e89d21f78
```

And now verify ssh-allow default settings
```
$ juju model-config ssh-allow
0.0.0.0/0,::/0
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
0.0.0.0/0
::/0
```

Now configure ssh-allow
```
$ juju model-config ssh-allow="192.168.0.0/24"
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

Add a machine to verify this doesn't reset things
```
$ juju model-config ssh-allow="192.168.0.0/24"
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

Add a new model pre-configured to check the config comes into effect even if no machines are present when it's set. (You will need to reset `MODEL_GROUP`
```
$ juju add-model m2 --config ssh-allow="192.168.2.0/24"
$ juju add-machine
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
192.168.0.0/24
```

### Verify multiple machines can be added to the same model
```
$ juju add-model m
$ juju add-machine
(wait)
$ juju add-machine
(wait)
$ juju status
Model  Controller  Cloud/Region           Version      SLA          Timestamp
m      mstack      microstack/microstack  3.2-beta4.1  unsupported  14:13:42+01:00

Machine  State    Address         Inst id                               Base          AZ    Message
0        started  192.168.222.61  9b7c14e8-dd6f-4cb3-ad19-0ffa8e852f48  ubuntu@22.04  nova  ACTIVE
1        started  192.168.222.54  5a51c5d4-af57-4231-b3d9-afc28736467a  ubuntu@22.04  nova  ACTIVE
```

### Verify `juju expose` still exposes
```
$ juju deploy postgresql
(wait)
$ juju expose postgresql
$ openstack security group show $MACHINE_GROUP
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                                                                                                                              |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| created_at      | 2023-04-25T13:14:34Z                                                                                                                                                                                                                               |
| description     | juju group                                                                                                                                                                                                                                         |
| id              | 1069e8a6-a3b1-4aee-8471-d02f48d395e1                                                                                                                                                                                                               |
| location        | cloud='', project.domain_id=, project.domain_name='default', project.id='8910e2a31e8a4834a266bfd5dc99d80c', project.name='admin', region_name='', zone=                                                                                            |
| name            | juju-20810b78-b20d-4543-837e-9715be4fcda1-01de2e1c-76a3-40a0-864f-694e16e2164b-2                                                                                                                                                                   |
| project_id      | 8910e2a31e8a4834a266bfd5dc99d80c                                                                                                                                                                                                                   |
| revision_number | 3                                                                                                                                                                                                                                                  |
| rules           | created_at='2023-04-25T13:14:34Z', direction='egress', ethertype='IPv6', id='11996358-35f0-4316-90f4-9eef38a623fc', updated_at='2023-04-25T13:14:34Z'                                                                                              |
|                 | created_at='2023-04-25T13:14:34Z', direction='egress', ethertype='IPv4', id='22a74304-8426-42cf-b93b-2a8a8b85357e', updated_at='2023-04-25T13:14:34Z'                                                                                              |
|                 | created_at='2023-04-25T13:18:28Z', direction='ingress', ethertype='IPv4', id='a847c482-a5a7-4935-af77-dcd52267a652', port_range_max='5432', port_range_min='5432', protocol='tcp', remote_ip_prefix='0.0.0.0/0', updated_at='2023-04-25T13:18:28Z' |
|                 | created_at='2023-04-25T13:18:28Z', direction='ingress', ethertype='IPv6', id='ae88d48b-53ff-4cbb-94a4-9fafa9ae4e9a', port_range_max='5432', port_range_min='5432', protocol='tcp', remote_ip_prefix='::/0', updated_at='2023-04-25T13:18:28Z'      |
| stateful        | True                                                                                                                                                                                                                                               |
| tags            | []                                                                                                                                                                                                                                                 |
| updated_at      | 2023-04-25T13:18:28Z                                                                                                                                                                                                                               |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

### Verify api-port
```
$ juju bootstrap openstack openstack --config api-port=17777
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 17777) | .remote_ip_prefix'
0.0.0.0/0
```

### Verify autocert-dns-name
```
$ juju bootstrap openstack openstack --config autocert-dns-name=example.com
(wait)
$ openstack security group show $MODEL_GROUP -f json | jq -r '.rules[] | select(.port_range_min == 80) | .remote_ip_prefix'
0.0.0.0/0
```

### Test with networks with port_security disabled

Create some OpenStack networks
```
$ openstack network create net1
$ openstack network create net2 --disable-port-security
```

Bootstrap to a netowrk with port_security disabled
```
juju bootstrap openstack openstack --config network=net2
```

Deploy a machine to net1
```
add-model m --config network=net2
juju add-machine
```
Verify the model sec group is not created

Change the config option to net1 and deploy another machine
```
juju model-config network=net1
juju add-machine
```
This should create the model sec group, attach it to the instance, and configure ssh to be open to the world

Change network back and add another machine
```
juju model-config network=net2
juju add-machine
```
This machine shouldn't be attached to a sec group

Then, reconfigure the model's ssh-allow
```
juju model-config ssh-allow=192.168.0.0/24
```
Then verify the model's sec group is re-configured