### PR TITLE
[JUJU-3675] Replace ubuntu with ubuntu-lite on CI tests when possible

### DIFF
--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -37,8 +37,8 @@ run_simplestream_metadata() {
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
 
-	juju deploy ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	juju deploy jameinel-ubuntu-lite
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 }
 
 test_bootstrap_simplestream() {

--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -23,7 +23,7 @@ run_block_remove_object() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ubuntu --base ubuntu@20.04
+	juju deploy jameinel-ubuntu-lite --base ubuntu@20.04 ubuntu
 	juju deploy ntp
 	juju integrate ntp ubuntu
 
@@ -56,7 +56,7 @@ run_block_all() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ubuntu --base ubuntu@20.04
+	juju deploy jameinel-ubuntu-lite --base ubuntu@20.04 ubuntu
 	juju expose ubuntu
 
 	juju disable-command all

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -8,7 +8,7 @@ run_model_migration() {
 	juju switch "alt-model-migration"
 	juju add-model "model-migration"
 
-	juju deploy ubuntu
+	juju deploy jameinel-ubuntu-lite ubuntu
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -8,11 +8,11 @@ run_refresh_local() {
 
 	ensure "${model_name}" "${file}"
 
-	juju download ubuntu --no-progress - >"${charm_name}"
-	juju deploy "${charm_name}" ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	juju download jameinel-ubuntu-lite --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu-lite
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
+	OUT=$(juju refresh ubuntu-lite --path "${charm_name}" 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added local charm"; then
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
@@ -24,8 +24,8 @@ run_refresh_local() {
 	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
-	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	wait_for "ubuntu-lite" "$(charm_rev "ubuntu-lite" "${revision}")"
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	destroy_model "${model_name}"
 }
@@ -97,16 +97,16 @@ run_refresh_channel_no_new_revision() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	juju deploy jameinel-ubuntu-lite
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 	# get revision to ensure it doesn't change
-	cs_revision=$(juju status --format json | jq -S '.applications | .["ubuntu"] | .["charm-rev"]')
+	cs_revision=$(juju status --format json | jq -S '.applications | .["ubuntu-lite"] | .["charm-rev"]')
 
-	juju refresh ubuntu --channel edge
+	juju refresh ubuntu-lite --channel edge
 
-	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
-	wait_for "ubuntu" "$(charm_rev "ubuntu" "${cs_revision}")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	wait_for "ubuntu-lite" "$(charm_channel "ubuntu-lite" "edge")"
+	wait_for "ubuntu-lite" "$(charm_rev "ubuntu-lite" "${cs_revision}")"
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -82,8 +82,8 @@ exec_simplestream_metadata() {
 	echo "${name}" >>"${TEST_DIR}/jujus"
 
 	juju add-model test-upgrade-"${test_name}"
-	juju deploy ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	juju deploy jameinel-ubuntu-lite
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	local CURRENT UPDATED
 
@@ -124,10 +124,10 @@ exec_simplestream_metadata() {
 		fi
 	done
 
-	juju refresh ubuntu
+	juju refresh ubuntu-lite
 
 	sleep 10
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 }
 
 test_upgrade_simplestream() {


### PR DESCRIPTION
This is part of an effort to ensure that our CI tests are more robust and to avoid flaky tests. Ideally, all charms used in the integration tests would be under our control, so this commit replaces ubuntu with our ubuntu-lite when possible.

In some cases it's not possible because of ubuntu-lite not supporting multiple bases or revisions.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the following suites locally:
- bootstrap
- cli
- model 
- refresh
- upgrade

