### PR TITLE
[JUJU-3700] Fix schema as regards CA certificate cardinality

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -225,7 +225,7 @@ func externalControllerSchema() string {
 CREATE TABLE external_controller (
     uuid            TEXT PRIMARY KEY,
     alias           TEXT,
-    ca_cert_uuid    TEXT NOT NULL
+    ca_cert         TEXT NOT NULL
 );
 
 CREATE TABLE external_controller_address (

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -204,6 +204,9 @@ CREATE TABLE cloud_region (
         REFERENCES          cloud(uuid)
 );
 
+CREATE UNIQUE INDEX idx_cloud_region_cloud_uuid_name
+ON cloud_region (cloud_uuid, name);
+
 CREATE INDEX idx_cloud_region_cloud_uuid
 ON cloud_region (cloud_uuid);
 

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -164,6 +164,19 @@ INSERT INTO auth_type VALUES
     (10, 'certificate'),
     (11, 'oauth2withcert');
 
+CREATE TABLE cloud (
+    uuid                TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    cloud_type_id       INT NOT NULL,
+    endpoint            TEXT NOT NULL,
+    identity_endpoint   TEXT,
+    storage_endpoint    TEXT,
+    skip_tls_verify     BOOLEAN NOT NULL,
+    CONSTRAINT          fk_cloud_type
+        FOREIGN KEY       (cloud_type_id)
+        REFERENCES        cloud_type(id)
+);
+
 CREATE TABLE cloud_auth_type (
     uuid              TEXT PRIMARY KEY,
     cloud_uuid        TEXT NOT NULL,
@@ -191,38 +204,20 @@ CREATE TABLE cloud_region (
         REFERENCES          cloud(uuid)
 );
 
-CREATE UNIQUE INDEX idx_cloud_region_cloud_uuid
+CREATE INDEX idx_cloud_region_cloud_uuid
 ON cloud_region (cloud_uuid);
-
-CREATE TABLE ca_cert (
-    uuid        TEXT PRIMARY KEY,
-    ca_cert     TEXT
-);
 
 CREATE TABLE cloud_ca_cert (
     uuid              TEXT PRIMARY KEY,
     cloud_uuid        TEXT NOT NULL,
-    ca_cert_uuid      TEXT NOT NULL,
+    ca_cert           TEXT NOT NULL,
     CONSTRAINT        fk_cloud_ca_cert_cloud
         FOREIGN KEY       (cloud_uuid)
-        REFERENCES        cloud(uuid),
-    CONSTRAINT        fk_cloud_ca_cert_ca_cert
-                          FOREIGN KEY (ca_cert_uuid)
-                          REFERENCES ca_cert(uuid)
+        REFERENCES        cloud(uuid)
 );
 
-CREATE UNIQUE INDEX idx_cloud_ca_cert_cloud_uuid_ca_cert_uuid
-ON cloud_ca_cert (cloud_uuid, ca_cert_uuid);
-
-CREATE TABLE cloud (
-    uuid                TEXT PRIMARY KEY,
-    name                TEXT NOT NULL,
-    cloud_type_id       INT NOT NULL,
-    endpoint            TEXT NOT NULL,
-    identity_endpoint   TEXT,
-    storage_endpoint    TEXT,
-    skip_tls_verify     BOOLEAN NOT NULL
-);`[1:]
+CREATE UNIQUE INDEX idx_cloud_ca_cert_cloud_uuid_ca_cert
+ON cloud_ca_cert (cloud_uuid, ca_cert);`[1:]
 }
 
 func externalControllerSchema() string {

--- a/domain/schema/controller_test.go
+++ b/domain/schema/controller_test.go
@@ -66,7 +66,6 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 		"cloud",
 		"auth_type",
 		"cloud_auth_type",
-		"ca_cert",
 		"cloud_ca_cert",
 		"cloud_region",
 		"cloud_type",


### PR DESCRIPTION
This fixes a few issues with schema creation:
- For consistency, the `cloud` table creation is moved ahead of references to it.
- A foreign key for `cloud_type` is added to the same table.
- The `ca_cert` table is not required, nor is the join table between it and `cloud`. Join tables model many-to-many relationships, whereas this is one-to-many. `ca_cert` is removed and `cloud_ca_cert` has certificates as text directly.
- The `cloud_region` table had a unique index on `cloud_uuid`, which would imply clouds have only one region. This is not the case, so the index is now non-unique. A new index is added to ensure region names are unique for a cloud.
- `external_controller` now has a `ca_cert` field instead of an ID intended for linking to the removed `ca_cert` table.

## QA steps

Unit tests pass
