### PR TITLE
[JUJU-3676] Add image-id to ec2 provider (aws)

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -257,7 +257,6 @@ var unsupportedConstraints = []string{
 	// use virt-type in StartInstances
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
-	constraints.ImageID,
 }
 
 // ConstraintsValidator is defined on the Environs interface.
@@ -666,6 +665,11 @@ func (e *environ) StartInstance(
 	rootVolumeTags[tagName] = instanceName + "-root"
 	volumeTags := CreateTagSpecification(types.ResourceTypeVolume, rootVolumeTags)
 
+	imageID := aws.String(spec.Image.Id)
+	if args.Constraints.HasImageID() {
+		imageID = aws.String(*args.Constraints.ImageID)
+	}
+
 	var instResp *ec2.RunInstancesOutput
 	commonRunArgs := &ec2.RunInstancesInput{
 		MinCount:            aws.Int32(1),
@@ -674,7 +678,7 @@ func (e *environ) StartInstance(
 		InstanceType:        types.InstanceType(spec.InstanceType.Name),
 		SecurityGroupIds:    groupIDs,
 		BlockDeviceMappings: blockDeviceMappings,
-		ImageId:             aws.String(spec.Image.Id),
+		ImageId:             imageID,
 		MetadataOptions: &types.InstanceMetadataOptionsRequest{
 			HttpEndpoint: types.InstanceMetadataEndpointStateEnabled,
 			// By forcing HTTP tokens here we move all created instances over to

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -832,7 +832,7 @@ func (env *maasEnviron) tagInstance(inst *maasInstance, instanceConfig *instance
 }
 
 func (env *maasEnviron) distroSeries(args environs.StartInstanceParams) (string, error) {
-	if args.Constraints.ImageID != nil && *args.Constraints.ImageID != "" {
+	if args.Constraints.HasImageID() {
 		return *args.Constraints.ImageID, nil
 	}
 	return coreseries.GetSeriesFromBase(args.InstanceConfig.Base)


### PR DESCRIPTION
We add the image-id constraint to the aws provider. This is done by replacing the ec2 ImageId provided by the config with the user-provided value in the image-id constraint.

Note: No checks are done on the value of the constraint, this means that the user must provide a correct image-id value for aws, otherwise two errors can be returned:
- `InvalidAMIID.Malformed`: If the provided image-id is not correctly formatted (i.e. `ami-xxxxxxxx`)
- `InvalidAMIID.NotFound`: If the provided image-id does not exist in the aws region in use
(see https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html)

Bonus: fix small condition check on the maas provider to use the HasImageID method of constraints.

_Note: Integration test will come in another PR_

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Since the idea is to test a custom aws image (AMI), we first must create our image: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html

For testing purposes, this image is exactly the same as a jammy ubuntu, no customization.

The image is located in `us-east-1`, and it's ami is: `ami-059f434f013a892d7`. We can now use this as image-id when creating a machine:

```
juju bootstrap aws c
juju add-model m
juju add-machine --constraints="image-id=ami-059f434f013a892d7"
```
This should correctly create a juju machine, while:
```
juju add-machine --constraints="image-id=foo"
```
will fail with:
```
$ juju status
Model  Controller  Cloud/Region   Version      SLA          Timestamp
m      c           aws/us-east-1  3.3-beta1.1  unsupported  15:52:16+02:00

Machine  State    Address         Inst id              Base          AZ          Message
0        pending  44.202.210.212  i-0c39a5c90b6367cda  ubuntu@22.04  us-east-1b  running
1        pending                  pending              ubuntu@22.04              failed to start machine 1 (cannot run instances: operation error EC2: RunInstances, https response error StatusCode: ...
```
and the logs:
```
controller-0: 15:52:47 WARNING juju.worker.provisioner machine 1 failed to start in availability zone us-east-1f: cannot run instances: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 3501f61d-74c7-469d-9f7e-376fe79fc7c2, api error InvalidAMIID.Malformed: Invalid id: "foo" (expecting "ami-...")
```
