### PR TITLE
[JUJU-3712] Model table dbworker cache

### DIFF
--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -475,7 +475,6 @@ func (c *defaultsCommand) getAllDefaults(client defaultsCommandAPI, ctx *cmd.Con
 func (c *defaultsCommand) getFilteredDefaults(client defaultsCommandAPI) (envconfig.ModelDefaultAttributes, error) {
 	attrs, err := client.ModelDefaults(c.cloud)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -117,7 +117,6 @@ func (s *OSCallTest) parseDir(fset *token.FileSet, calls map[string]set.Strings,
 		return !strings.HasSuffix(fi.Name(), "_test.go")
 	}, 0)
 	if err != nil {
-		fmt.Println(err)
 		return
 	}
 

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/domain/schema"
 )
@@ -65,7 +66,7 @@ func BootstrapDqlite(ctx context.Context, opt bootstrapOptFactory, logger Logger
 		return errors.Annotatef(err, "waiting for Dqlite readiness")
 	}
 
-	db, err := dqlite.Open(ctx, "controller")
+	db, err := dqlite.Open(ctx, coredatabase.ControllerNS)
 	if err != nil {
 		return errors.Annotatef(err, "opening controller database")
 	}

--- a/worker/dbaccessor/cache.go
+++ b/worker/dbaccessor/cache.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+)
+
+const (
+	// defaultNamespaceExpiry holds the duration for how long a namespace
+	// should be cached for.
+	defaultNamespaceExpiry = time.Minute
+)
+
+// nsCache holds a cache of namespaces that have been validated to exist.
+type nsCache struct {
+	mutex      sync.RWMutex
+	namespaces map[string]time.Time
+	clock      clock.Clock
+	expiry     time.Duration
+}
+
+func newNSCache(expiry time.Duration, clock clock.Clock) *nsCache {
+	return &nsCache{
+		namespaces: make(map[string]time.Time),
+		clock:      clock,
+		expiry:     expiry,
+	}
+}
+
+// Set adds the given namespace to the cache.
+func (c *nsCache) Set(namespace string, known bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// If we know the namespace exists, either insert it or update the existing
+	// entry.
+	if known {
+		c.namespaces[namespace] = c.clock.Now().Add(c.expiry)
+		return
+	}
+
+	// Otherwise just delete it from the namespaces map, even if it doesn't
+	// exist.
+	delete(c.namespaces, namespace)
+}
+
+// Exists returns whether the given namespace exists in the cache.
+func (c *nsCache) Exists(namespace string) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	expiry, ok := c.namespaces[namespace]
+	if !ok {
+		return false
+	}
+	return c.clock.Now().Before(expiry)
+}
+
+func (c *nsCache) Remove(namespace string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	delete(c.namespaces, namespace)
+}
+
+// Flush removes all namespaces from the cache that have expired. This just
+// ensures that we keep a nice and clean cache.
+func (c *nsCache) Flush() {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	now := c.clock.Now()
+	for namespace, expiry := range c.namespaces {
+		if now.After(expiry) {
+			delete(c.namespaces, namespace)
+		}
+	}
+}

--- a/worker/dbaccessor/cache_test.go
+++ b/worker/dbaccessor/cache_test.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type cacheSuite struct {
+	testing.IsolationSuite
+
+	clock *MockClock
+}
+
+var _ = gc.Suite(&cacheSuite{})
+
+func (s *cacheSuite) TestSet(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+
+	tests := []struct {
+		set    string
+		known  bool
+		has    string
+		exists bool
+	}{
+		{set: "foo", known: true, has: "foo", exists: true},
+		{set: "foo", known: false, has: "foo", exists: false},
+		{set: "", known: false, has: "foo", exists: false},
+	}
+
+	for _, test := range tests {
+		cache := newNSCache(time.Second, s.clock)
+		if test.set != "" {
+			cache.Set(test.set, test.exists)
+		}
+
+		c.Assert(cache.Exists(test.has), gc.Equals, test.exists)
+	}
+}
+
+func (s *cacheSuite) TestExistsExpired(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	gomock.InOrder(
+		s.clock.EXPECT().Now().Return(time.Now()),
+		s.clock.EXPECT().Now().Return(time.Now()),
+		s.clock.EXPECT().Now().Return(time.Now().Add(time.Second*2)),
+	)
+
+	cache := newNSCache(time.Second, s.clock)
+	cache.Set("foo", true)
+	c.Assert(cache.Exists("foo"), jc.IsTrue)
+	c.Assert(cache.Exists("foo"), jc.IsFalse)
+}
+
+func (s *cacheSuite) TestFlush(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	gomock.InOrder(
+		s.clock.EXPECT().Now().Return(time.Now()),
+		s.clock.EXPECT().Now().Return(time.Now()),
+		s.clock.EXPECT().Now().Return(time.Now().Add(time.Second*2)),
+	)
+
+	cache := newNSCache(time.Second, s.clock)
+	cache.Set("foo", true)
+	c.Assert(cache.Exists("foo"), jc.IsTrue)
+
+	cache.Flush()
+	c.Assert(cache.Exists("foo"), jc.IsFalse)
+}
+
+func (s *cacheSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.clock = NewMockClock(ctrl)
+
+	return ctrl
+}

--- a/worker/dbaccessor/doc.go
+++ b/worker/dbaccessor/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// DBAccessor is a worker that provides access to the Juju database.
+// It is responsible for accessing the various databases. Each database is
+// wrapped via a TrackedDBWorker, which is responsible for managing the
+// lifecycle of the database connection. If a database connection is temporarily
+// lost, the TrackedDBWorker will attempt to reconnect to the database. If the
+// connection is permanently lost, the TrackedDBWorker will terminate the
+// DBAccessor worker and a new one will be started by the worker manager.
+//
+// The DBAccessor is officially the only worker that should be accessing the
+// database directly. All other workers, including the apiserver should be
+// accessing the database via the domain services.
+package dbaccessor

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -119,7 +119,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				NewDBWorker:      config.NewDBWorker,
 			}
 
-			w, err := newWorker(cfg)
+			w, err := NewWorker(cfg)
 			if err != nil {
 				// Unregister the metrics collector if we fail to start the
 				// worker, so that we can safely register the metrics again.

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -4,6 +4,8 @@
 package dbaccessor
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -49,7 +51,7 @@ type ManifoldConfig struct {
 	Logger               Logger
 	PrometheusRegisterer prometheus.Registerer
 	NewApp               func(string, ...app.Option) (DBApp, error)
-	NewDBWorker          func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
+	NewDBWorker          func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 	NewMetricsCollector  func() *Collector
 }
 

--- a/worker/dbaccessor/manifold_test.go
+++ b/worker/dbaccessor/manifold_test.go
@@ -4,6 +4,8 @@
 package dbaccessor
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -64,7 +66,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return nil, nil
 		},
 		NewMetricsCollector: func() *Collector {

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -4,13 +4,17 @@
 package dbaccessor
 
 import (
+	"context"
+	sql "database/sql"
 	"testing"
 	time "time"
 
 	"github.com/golang/mock/gomock"
 	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
+	coredatabase "github.com/juju/juju/core/database"
 	databasetesting "github.com/juju/juju/database/testing"
 )
 
@@ -63,9 +67,9 @@ func (s *baseSuite) expectClock() {
 	s.clock.EXPECT().Now().Return(time.Now()).AnyTimes()
 }
 
-func (s *baseSuite) setupTimer() chan time.Time {
+func (s *baseSuite) setupTimer(interval time.Duration) chan time.Time {
 	s.timer.EXPECT().Stop().MinTimes(1)
-	s.clock.EXPECT().NewTimer(PollInterval).Return(s.timer)
+	s.clock.EXPECT().NewTimer(interval).Return(s.timer)
 
 	ch := make(chan time.Time)
 	s.timer.EXPECT().Chan().Return(ch).AnyTimes()
@@ -85,7 +89,7 @@ func (s *baseSuite) expectTick(ch chan time.Time, ticks int) <-chan struct{} {
 }
 
 func (s *baseSuite) expectTimer(ticks int) <-chan struct{} {
-	ch := s.setupTimer()
+	ch := s.setupTimer(PollInterval)
 	return s.expectTick(ch, ticks)
 }
 
@@ -100,4 +104,42 @@ func (s *baseSuite) expectTrackedDBKill() {
 type dbBaseSuite struct {
 	databasetesting.ControllerSuite
 	baseSuite
+}
+
+type workerTrackedDB struct {
+	tomb tomb.Tomb
+	db   coredatabase.TrackedDB
+}
+
+func newWorkerTrackedDB(db coredatabase.TrackedDB) *workerTrackedDB {
+	w := &workerTrackedDB{
+		db: db,
+	}
+	w.tomb.Go(w.loop)
+	return w
+}
+
+func (w *workerTrackedDB) loop() error {
+	<-w.tomb.Dying()
+	return tomb.ErrDying
+}
+
+func (w *workerTrackedDB) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *workerTrackedDB) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *workerTrackedDB) Txn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return w.db.Txn(ctx, fn)
+}
+
+func (w *workerTrackedDB) TxnNoRetry(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return w.db.TxnNoRetry(ctx, fn)
+}
+
+func (w *workerTrackedDB) Err() error {
+	return w.db.Err()
 }

--- a/worker/dbaccessor/shim.go
+++ b/worker/dbaccessor/shim.go
@@ -72,5 +72,10 @@ func NewApp(dataDir string, options ...app.Option) (DBApp, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &dbApp{dqliteApp}, nil
+	return WrapApp(dqliteApp), nil
+}
+
+// WrapApp wraps a Dqlite App reference, so that we can shim out Client.
+func WrapApp(dqliteApp *app.App) DBApp {
+	return &dbApp{dqliteApp}
 }

--- a/worker/dbaccessor/tracker.go
+++ b/worker/dbaccessor/tracker.go
@@ -86,7 +86,7 @@ type trackedDBWorker struct {
 }
 
 // NewTrackedDBWorker creates a new TrackedDBWorker
-func NewTrackedDBWorker(dbApp DBApp, namespace string, opts ...TrackedDBWorkerOption) (TrackedDB, error) {
+func NewTrackedDBWorker(ctx context.Context, dbApp DBApp, namespace string, opts ...TrackedDBWorkerOption) (TrackedDB, error) {
 	w := &trackedDBWorker{
 		dbApp:      dbApp,
 		namespace:  namespace,
@@ -100,7 +100,7 @@ func NewTrackedDBWorker(dbApp DBApp, namespace string, opts ...TrackedDBWorkerOp
 	}
 
 	var err error
-	w.db, err = w.dbApp.Open(context.TODO(), w.namespace)
+	w.db, err = w.dbApp.Open(ctx, w.namespace)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/dbaccessor/tracker.go
+++ b/worker/dbaccessor/tracker.go
@@ -180,6 +180,19 @@ func (w *trackedDBWorker) Report() map[string]any {
 }
 
 func (w *trackedDBWorker) loop() error {
+	defer func() {
+		w.mutex.Lock()
+		defer w.mutex.Unlock()
+
+		if w.db == nil {
+			return
+		}
+		err := w.db.Close()
+		if err != nil {
+			w.logger.Debugf("Closed database connection: %v", err)
+		}
+	}()
+
 	timer := w.clock.NewTimer(PollInterval)
 	defer timer.Stop()
 

--- a/worker/dbaccessor/tracker.go
+++ b/worker/dbaccessor/tracker.go
@@ -116,7 +116,7 @@ func NewTrackedDBWorker(ctx context.Context, dbApp DBApp, namespace string, opts
 // This is the function that almost all downstream database consumers
 // should use.
 func (w *trackedDBWorker) Txn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	return database.Retry(ctx, func() error {
+	return database.Retry(w.tomb.Context(ctx), func() error {
 		return errors.Trace(w.TxnNoRetry(ctx, fn))
 	})
 }
@@ -141,7 +141,7 @@ func (w *trackedDBWorker) TxnNoRetry(ctx context.Context, fn func(context.Contex
 	db := w.db
 	w.mutex.RUnlock()
 
-	return errors.Trace(database.Txn(ctx, db, fn))
+	return errors.Trace(database.Txn(w.tomb.Context(ctx), db, fn))
 }
 
 // meterDBOpResults decrements the active DB operation count,

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -36,7 +36,7 @@ func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
-	w, err := NewTrackedDBWorker(s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
+	w, err := NewTrackedDBWorker(context.TODO(), s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer workertest.DirtyKill(c, w)
@@ -53,7 +53,7 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
-	w, err := NewTrackedDBWorker(s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
+	w, err := NewTrackedDBWorker(context.TODO(), s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer workertest.DirtyKill(c, w)
@@ -364,7 +364,8 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 
 func (s *trackedDBWorkerSuite) newTrackedDBWorker(pingFn func(context.Context, *sql.DB) error) (TrackedDB, error) {
 	collector := NewMetricsCollector()
-	return NewTrackedDBWorker(s.dbApp, "controller",
+	return NewTrackedDBWorker(context.TODO(),
+		s.dbApp, "controller",
 		WithClock(s.clock),
 		WithLogger(s.logger),
 		WithPingDBFunc(pingFn),

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -108,7 +108,7 @@ type WorkerConfig struct {
 	Hub         Hub
 	Logger      Logger
 	NewApp      func(string, ...app.Option) (DBApp, error)
-	NewDBWorker func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
+	NewDBWorker func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 
 	// ControllerID uniquely identifies the controller that this
 	// worker is running on. It is equivalent to the machine ID.
@@ -440,7 +440,11 @@ func (w *dbWorker) openDatabase(namespace string) error {
 			return nil, tomb.ErrDying
 		}
 
-		return w.cfg.NewDBWorker(w.dbApp, namespace,
+		ctx, cancel := w.scopedContext()
+		defer cancel()
+
+		return w.cfg.NewDBWorker(ctx,
+			w.dbApp, namespace,
 			WithClock(w.cfg.Clock),
 			WithLogger(w.cfg.Logger),
 			WithMetricsCollector(w.cfg.MetricsCollector),

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -163,7 +163,7 @@ type dbWorker struct {
 	apiServerChanges chan apiserver.Details
 }
 
-func newWorker(cfg WorkerConfig) (*dbWorker, error) {
+func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 	var err error
 	if err = cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -249,16 +249,15 @@ func (w *dbWorker) loop() (err error) {
 				req.done <- errors.Annotatef(err, "ensuring namespace %q", req.namespace)
 				continue
 			}
-
 			if err := w.openDatabase(req.namespace); err != nil {
 				req.done <- errors.Annotatef(err, "opening database for namespace %q", req.namespace)
 				continue
 			}
-
 			req.done <- nil
 
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
+
 		case apiDetails := <-w.apiServerChanges:
 			if err := w.processAPIServerChange(apiDetails); err != nil {
 				return errors.Trace(err)

--- a/worker/dbaccessor/worker_integration_test.go
+++ b/worker/dbaccessor/worker_integration_test.go
@@ -1,0 +1,145 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor_test
+
+import (
+	"context"
+	sql "database/sql"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/pubsub/v2"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/workertest"
+
+	"github.com/juju/juju/agent"
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/database"
+	"github.com/juju/juju/database/app"
+	dqlite "github.com/juju/juju/database/dqlite"
+	databasetesting "github.com/juju/juju/database/testing"
+	"github.com/juju/juju/domain/schema"
+	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/dbaccessor"
+)
+
+type integrationSuite struct {
+	dqliteAppIntegrationSuite
+
+	dbGettter coredatabase.DBGetter
+	worker    worker.Worker
+}
+
+var _ = gc.Suite(&integrationSuite{})
+
+func (s *integrationSuite) SetUpSuite(c *gc.C) {
+	s.DBSuite.SetUpSuite(c)
+
+	params := agent.AgentConfigParams{
+		Tag:               names.NewMachineTag("1"),
+		UpgradedToVersion: jujuversion.Current,
+		Jobs:              []model.MachineJob{model.JobHostUnits},
+		Password:          "sekrit",
+		CACert:            "ca cert",
+		APIAddresses:      []string{"localhost:1235"},
+		Nonce:             "a nonce",
+		Model:             testing.ModelTag,
+		Controller:        testing.ControllerTag,
+	}
+	params.Paths.DataDir = s.RootPath()
+	params.Paths.LogDir = c.MkDir()
+	agentConfig, err := agent.NewAgentConfig(params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	logger := loggo.GetLogger("worker.dbaccessor.test")
+	nodeManager := database.NewNodeManager(agentConfig, logger)
+
+	w, err := dbaccessor.NewWorker(dbaccessor.WorkerConfig{
+		NewApp: func(string, ...app.Option) (dbaccessor.DBApp, error) {
+			return dbaccessor.WrapApp(s.DBApp()), nil
+		},
+		NewDBWorker:      dbaccessor.NewTrackedDBWorker,
+		NodeManager:      nodeManager,
+		MetricsCollector: dbaccessor.NewMetricsCollector(),
+		Clock:            clock.WallClock,
+		Logger:           logger,
+		Hub:              pubsub.NewStructuredHub(nil),
+		ControllerID:     agentConfig.Tag().Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.dbGettter = w
+	s.worker = w
+
+	db, err := s.DBApp().Open(context.TODO(), coredatabase.ControllerNS)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = database.NewDBMigration(db, logger, schema.ControllerDDL()).Apply()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *integrationSuite) TearDownSuite(c *gc.C) {
+	if dqlite.Enabled {
+		workertest.CleanKill(c, s.worker)
+	}
+
+	s.dqliteAppIntegrationSuite.TearDownSuite(c)
+}
+
+func (s *integrationSuite) TestWorkerAccessingControllerDB(c *gc.C) {
+	db, err := s.dbGettter.GetDB(coredatabase.ControllerNS)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(db, gc.NotNil)
+}
+
+func (s *integrationSuite) TestWorkerAccessingUnknownDB(c *gc.C) {
+	_, err := s.dbGettter.GetDB("foo")
+	c.Assert(err, gc.ErrorMatches, `.*namespace "foo" not found`)
+}
+
+func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
+	db, err := s.dbGettter.GetDB(coredatabase.ControllerNS)
+	c.Assert(err, jc.ErrorIsNil)
+	err = db.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("bar")`)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	db, err = s.dbGettter.GetDB("bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(db, gc.NotNil)
+}
+
+// integrationSuite defines a base suite for running integration tests against
+// the dqlite database. It overrides the various methods to prevent the creation
+// of a new database for each test.
+type dqliteAppIntegrationSuite struct {
+	databasetesting.DBSuite
+}
+
+func (s *dqliteAppIntegrationSuite) TearDownSuite(c *gc.C) {
+	s.IsolationSuite.TearDownSuite(c)
+
+	// Note: we don't call s.DBSuite.TearDownSuite here because we don't want
+	// to double close the dqlite app.
+}
+
+func (s *dqliteAppIntegrationSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	if !dqlite.Enabled {
+		c.Skip("This requires a dqlite server to be running")
+	}
+}
+
+func (s *dqliteAppIntegrationSuite) TearDownTest(c *gc.C) {
+	s.IsolationSuite.TearDownTest(c)
+}

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -474,7 +474,7 @@ func (s *workerSuite) newWorkerWithDB(c *gc.C, db TrackedDB) worker.Worker {
 		MetricsCollector: &Collector{},
 	}
 
-	w, err := newWorker(cfg)
+	w, err := NewWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -4,6 +4,7 @@
 package dbaccessor
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -325,7 +326,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return s.trackedDB, nil
 		},
 		MetricsCollector: &Collector{},

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -5,16 +5,18 @@ package dbaccessor
 
 import (
 	"context"
-	"errors"
+	sql "database/sql"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/database/dqlite"
 	"github.com/juju/juju/pubsub/apiserver"
@@ -22,7 +24,7 @@ import (
 )
 
 type workerSuite struct {
-	baseSuite
+	dbBaseSuite
 
 	nodeManager *MockNodeManager
 }
@@ -294,6 +296,142 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 	c.Assert(errors.Is(err, dependency.ErrBounce), jc.IsTrue)
 }
 
+func (s *workerSuite) TestEnsureNamespaceForController(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w := &dbWorker{
+		dbApp: s.dbApp,
+	}
+
+	err := w.ensureNamespace(coredatabase.ControllerNS)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestEnsureNamespaceForModelNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+
+	dataDir := c.MkDir()
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(dataDir, nil).MinTimes(1)
+
+	// If this is an existing node, we do not
+	// invoke the address or cluster options.
+	mgrExp.IsExistingNode().Return(true, nil).Times(3)
+	mgrExp.IsBootstrappedNode(gomock.Any()).Return(true, nil).Times(3)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+
+	sync := s.expectNodeStartupAndShutdown()
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	trackedWorkerDB := newWorkerTrackedDB(s.TrackedDB())
+
+	w := s.newWorkerWithDB(c, trackedWorkerDB)
+	defer workertest.DirtyKill(c, w)
+
+	dbw := w.(*dbWorker)
+	s.ensureStartup(c, dbw, sync)
+
+	err := dbw.ensureNamespace("foo")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestEnsureNamespaceForModel(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+
+	dataDir := c.MkDir()
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(dataDir, nil).MinTimes(1)
+
+	// If this is an existing node, we do not
+	// invoke the address or cluster options.
+	mgrExp.IsExistingNode().Return(true, nil).Times(3)
+	mgrExp.IsBootstrappedNode(gomock.Any()).Return(true, nil).Times(3)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+
+	sync := s.expectNodeStartupAndShutdown()
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	trackedWorkerDB := newWorkerTrackedDB(s.TrackedDB())
+
+	w := s.newWorkerWithDB(c, trackedWorkerDB)
+	defer workertest.DirtyKill(c, w)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	err := s.TrackedDB().Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
+		result, err := tx.ExecContext(ctx, stmt, "foo")
+		c.Assert(err, jc.ErrorIsNil)
+
+		num, err := result.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(num, gc.Equals, int64(1))
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	dbw := w.(*dbWorker)
+	s.ensureStartup(c, dbw, sync)
+
+	err = dbw.ensureNamespace("foo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) ensureStartup(c *gc.C, w *dbWorker, sync <-chan struct{}) {
+	select {
+	case <-sync:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for Dqlite node start")
+	}
+
+	// At this point we have started successfully.
+	// Push a message onto the API details channel.
+	// A single server does not cause a binding change.
+	select {
+	case w.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
+		},
+	}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	// Multiple servers still do not cause a binding change
+	// if there is no internal address to bind to.
+	select {
+	case w.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0"},
+			"1": {ID: "1", InternalAddress: "10.6.6.7:1234"},
+			"2": {ID: "2", InternalAddress: "10.6.6.8:1234"},
+		},
+	}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+}
+
 func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 	s.nodeManager = NewMockNodeManager(ctrl)
@@ -317,6 +455,10 @@ func (s *workerSuite) expectNodeStartupAndShutdown() chan struct{} {
 }
 
 func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
+	return s.newWorkerWithDB(c, s.trackedDB)
+}
+
+func (s *workerSuite) newWorkerWithDB(c *gc.C, db TrackedDB) worker.Worker {
 	cfg := WorkerConfig{
 		NodeManager:  s.nodeManager,
 		Clock:        s.clock,
@@ -327,7 +469,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 			return s.dbApp, nil
 		},
 		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
-			return s.trackedDB, nil
+			return db, nil
 		},
 		MetricsCollector: &Collector{},
 	}


### PR DESCRIPTION
Requires https://github.com/juju/juju/pull/15579 to merge first. Will rebase once done.

----

Following on from https://github.com/juju/juju/pull/15579 this defines an in-memory namespace cache
for the dbaccessor worker to prevent excessive reads to the db. 
The idea is that upon startup for large controllers with 100s of
models, it's not ideal to spam the controller DB to see if access to
a given model is allowed. The ns cache just sits in front of the
access requests and holds the data for a short amount of time. Part
of the dbaccessor worker will periodically flush the cache and new
requests will then be allowed.

A potential improvement would be to listen to either a trigger event
or a pubsub subscription for when a given model is removed and that
can be purged from the cache. It's probably not wise to use the
eventqueue/changestream at this level as this is a level below that
infrastructure and could cause complications.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```
