### PR TITLE
[JUJU-3702] ComputeSeries: assume manifest, fall back to series.

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -971,7 +971,7 @@ func (s *UpgradeSeriesMachineManagerSuite) expectValidateMachine(ctrl *gomock.Co
 func (s *UpgradeSeriesMachineManagerSuite) expectValidateApplicationOnMachine(ctrl *gomock.Controller) *mocks.MockApplication {
 	app := mocks.NewMockApplication(ctrl)
 	ch := mocks.NewMockCharm(ctrl)
-	ch.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
+	ch.EXPECT().Manifest().Return(nil).AnyTimes()
 	ch.EXPECT().Meta().Return(&charm.Meta{Series: []string{"xenial"}}).AnyTimes()
 	app.EXPECT().Charm().Return(ch, true, nil)
 	app.EXPECT().CharmOrigin().Return(&state.CharmOrigin{})

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -766,20 +766,6 @@ func (s *BundleDeployRepositorySuite) expectCharmstoreK8sCharm(curl *charm.URL, 
 		Meta: &charm.Meta{
 			Series: []string{"kubernetes"},
 		},
-		Manifest: &charm.Manifest{
-			Bases: []charm.Base{
-				{
-					Name:          "ubuntu",
-					Channel:       charm.Channel{Track: "20.04", Risk: "stable", Branch: ""},
-					Architectures: []string{"amd64"},
-				},
-				{
-					Name:          "ubuntu",
-					Channel:       charm.Channel{Track: "22.04", Risk: "stable", Branch: ""},
-					Architectures: []string{"amd64"},
-				},
-			},
-		},
 	}
 	s.expectCharmInfo(fullCurl.String(), charmInfo)
 	s.expectDeploy()

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -403,7 +403,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	s.expectModelGet(c)
 
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
-	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
+	s.charm.EXPECT().Manifest().Return(nil).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Series: []string{"focal"}}).AnyTimes()
 
 	f := &factory{
@@ -423,7 +423,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 	s.expectModelGet(c)
 
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
-	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
+	s.charm.EXPECT().Manifest().Return(nil).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Name: "meshuggah", Series: []string{"focal"}}).AnyTimes()
 
 	f := &factory{

--- a/core/charm/computedseries_test.go
+++ b/core/charm/computedseries_test.go
@@ -18,22 +18,6 @@ type computedSeriesSuite struct {
 
 var _ = gc.Suite(&computedSeriesSuite{})
 
-func (s *computedSeriesSuite) TestComputedSeriesLegacy(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	cm := NewMockCharmMeta(ctrl)
-	cm.EXPECT().Meta().Return(&charm.Meta{
-		Name:        "a",
-		Summary:     "b",
-		Description: "c",
-		Series:      []string{"bionic"},
-	}).AnyTimes()
-	cm.EXPECT().Manifest().Return(nil).AnyTimes()
-	series, err := ComputedSeries(cm)
-	c.Assert(err, gc.IsNil)
-	c.Assert(series, jc.DeepEquals, []string{"bionic"})
-}
-
 func (s *computedSeriesSuite) TestComputedSeriesNilManifest(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -103,7 +87,7 @@ func (s *computedSeriesSuite) TestComputedSeriesKubernetes(c *gc.C) {
 	}).AnyTimes()
 	series, err := ComputedSeries(cm)
 	c.Assert(err, gc.IsNil)
-	c.Assert(series, jc.DeepEquals, []string{"bionic", "kubernetes"})
+	c.Assert(series, jc.DeepEquals, []string{"bionic"})
 }
 
 func (s *computedSeriesSuite) TestComputedSeriesError(c *gc.C) {


### PR DESCRIPTION
With the use of charmhub, series in a charm is ignored in favor of a charm's manifest. As all charmhub released charms have a manifest, they are essentially metadata v2 charm. This leads to different behavior with deploying the same charm blob as a local charm, especially when the series = kubernetes. Kubernetes is not a valid base from a manifest. Seen in LP 1986382.

This change ensures juju prefers a manifest in any charm deployed, only falling back to series from metadata if no manifest is available. Nor do we add kubernetes as a series to the returned list.

Note: prior deployment of local old style k8s charms will require refresh with --force-series, as they believe they are "kubernetes"

## QA steps

```sh
# Bootstrap microk8s
$ juju add-model five
$ juju deploy metallb-speaker
Located charm "metallb-speaker" in charm-hub, revision 36
Deploying "metallb-speaker" from charm-hub charm "metallb-speaker", revision 36 in channel stable on jammy
# wait for it to settle
$ juju download metallb-speaker
Fetching charm "metallb-speaker" using "stable" channel and base "amd64/ubuntu/20.04"
Install the "metallb-speaker" charm with:
    juju deploy ./metallb-speaker_be50e27.charm
$ juju refresh metallb-speaker --path ./metallb-speaker_be50e27.charm
Added local charm "metallb-speaker", revision 0, to the model

# deploy a local old style k8s charm, you'll see the charm series as "focal" rather than "kubernetes"
$ juju deploy ./metallb-speaker_be50e27.charm --resource metallb-speaker-image=rocks.canonical.com/cdk/metallb/speaker:v0.12 local
Located local charm "metallb-speaker", revision 0
Deploying "local" from local charm "metallb-speaker", revision 0 on focal

# bootstrap lxd
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 22
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 22 in channel stable on focal
# deploy a local charm with no manifest
$ juju deploy ./testcharms//charms/ubuntu-plus
Located local charm "ubuntu-plus", revision 0
Deploying "ubuntu-plus" from local charm "ubuntu-plus", revision 0 on focal
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1986382
