### PR TITLE
[JUJU-3704] use ubuntu instead of jameinel-ubuntu-lite

### DIFF
--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -8,11 +8,11 @@ run_refresh_local() {
 
 	ensure "${model_name}" "${file}"
 
-	juju download jameinel-ubuntu-lite --no-progress - >"${charm_name}"
-	juju deploy "${charm_name}" ubuntu-lite
-	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+	juju download ubuntu --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
-	OUT=$(juju refresh ubuntu-lite --path "${charm_name}" 2>&1 || true)
+	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added local charm"; then
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
@@ -24,8 +24,8 @@ run_refresh_local() {
 	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
-	wait_for "ubuntu-lite" "$(charm_rev "ubuntu-lite" "${revision}")"
-	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
The `jameinel-ubuntu-lite` charm has no revisions and some of the `run_refresh_*` tests fail. This PR replaces that charm for `ubuntu`. I run the refresh suite in a local environment and it worked.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

*Commands to run to verify that the change works.*

```sh
cd tests
./main.sh refresh
```
