### PR TITLE
[JUJU-1467][WIP] Use operator status in juju status application filtering

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -388,10 +388,16 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 				return noStatus, errors.Annotate(err, "could not filter applications")
 			}
 
+			var operatorStatus status.Status
+			cachedApp, err := context.cachedModel.Application(appName)
+			if err == nil {
+				operatorStatus = cachedApp.OperatorStatus().Status
+			}
 			// There are matched units for this application
-			// or the application matched the given criteria.
+			// or the application matched the given criteria,
+			// or the operator status is in error state
 			deleted := false
-			if !matchedApps.Contains(appName) && !matches {
+			if !matchedApps.Contains(appName) && !matches && operatorStatus != status.Error {
 				delete(context.allAppsUnitsCharmBindings.applications, appName)
 				deleted = true
 			}

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -70,6 +70,11 @@ func (a *Application) CharmURL() string {
 	return a.details.CharmURL
 }
 
+// OperatorStatus returns the operator status for this application.
+func (a *Application) OperatorStatus() status.StatusInfo {
+	return a.details.OperatorStatus
+}
+
 // Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
 	a.metrics.ApplicationConfigReads.Inc()


### PR DESCRIPTION
This is about a behavior I caught when working on [this LP bug](https://bugs.launchpad.net/juju/+bug/1981833) about the `juju status`. I realized that when ran with a status pattern, `juju status error` doesn't include an application that is seemingly in the error state (via `juju status` -- without the pattern).

Basically the scenario is that the application's units' workload_statuses are reported as `waiting`, and the agent_status is `idle`. So the application is not matched with `error`. The only reason we see `error` in the `juju status` output in the cli, is that the status is set right before the `FullStatus` returns when processing applications using the [cachedModel](https://github.com/juju/juju/blob/97174a6cfb23c7d7a7229b128102da597707804a/apiserver/facades/client/client/status.go#L1336). The problem is, that that setting is done after the filtering is over, so when running `juju status error`, the application is not even matched to get to that point.

This change includes the operator status in the filtering logic, so any application that has it's operator status in the error state is not excluded, so the logic that sets the status further down the line can do its magic.

## QA steps

The scenario above can be reproduced as follows (using the description in the [mentioned LP bug](https://bugs.launchpad.net/juju/+bug/1981833)):

```
 $ juju bootstrap microk8s removeme
```

Deploy the `admission-webhook` charm.

```
 $ juju deploy admission-webhook --channel 1.4/stable
```

It will go into the `error` state. Confirm this with `juju status`. It may take a couple seconds to get there.

Now run

```
 $ juju status error
```

Without this change, the output doesn't include the `admission-webhook` app. With this change you should be able to see it.

Note that this behavior is not observed in the machine models (e.g. lxd), because according to @wallyworld the charm is failing for a different reason than in the caas models, which results in the unit workload_status being reported as `error` (and not `waiting` like in the caas model), so the filtering works correctly there.

## Notes & Discussion

This is a WIP because I'm not entirely sure how to write tests for this, I could use some advice about that.