### PR TITLE
[JUJU-3714] Fix interfaces retrieval on spaces_ec2 test

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -15,7 +15,8 @@ run_juju_bind() {
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("enp") or startswith("ens"))')
+	echo "debug -- ifaces: $ifaces"
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -15,7 +15,8 @@ run_upgrade_charm_with_bind() {
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("enp") or startswith("ens"))')
+	echo "debug -- ifaces: $ifaces"
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"


### PR DESCRIPTION
Spaces ec2 tests fail intermittently.

We added the interfaces starting with 'enp' as well, before only interfaces starting with 'ens' were retrieved, which could lead to the tests get stuck while waiting for all interfaces to be UP after netplan upgrade.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh -v spaces_ec2 test_upgrade_charm_with_bind test_juju_bind                                          
```
