### PR TITLE
Replace `Readdir(-1)` with `os.ReadDir`

### DIFF
--- a/cmd/jujud/introspect/introspect.go
+++ b/cmd/jujud/introspect/introspect.go
@@ -179,13 +179,8 @@ func (c *IntrospectCommand) getAgentTag() (names.Tag, error) {
 		return names.ParseTag(c.agent)
 	}
 	agentsDir := filepath.Join(c.dataDir, "agents")
-	dir, err := os.Open(agentsDir)
-	if err != nil {
-		return nil, errors.Annotate(err, "opening agents dir")
-	}
-	defer dir.Close()
 
-	entries, err := dir.Readdir(-1)
+	entries, err := os.ReadDir(agentsDir)
 	if err != nil {
 		return nil, errors.Annotate(err, "reading agents dir")
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -179,13 +179,8 @@ func FindAgents(dataDir string) (string, []string, []string, error) {
 	)
 
 	agentDir := filepath.Join(dataDir, "agents")
-	dir, err := os.Open(agentDir)
-	if err != nil {
-		return "", nil, nil, errors.Annotate(err, "opening agents dir")
-	}
-	defer func() { _ = dir.Close() }()
 
-	entries, err := dir.Readdir(-1)
+	entries, err := os.ReadDir(agentDir)
 	if err != nil {
 		return "", nil, nil, errors.Annotate(err, "reading agents dir")
 	}

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -175,12 +175,7 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	defer close(flockCh)
 
 	// Look for the debug hooks temporary dir, inside $TMPDIR.
-	tmpdir, err := os.Open(s.tmpdir)
-	if err != nil {
-		c.Fatalf("Failed to open $TMPDIR: %s", err)
-	}
-	defer func() { _ = tmpdir.Close() }()
-	entries, err := tmpdir.Readdir(-1)
+	entries, err := os.ReadDir(s.tmpdir)
 	if err != nil {
 		c.Fatalf("Failed to read $TMPDIR: %s", err)
 	}


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. `os.ReadDir` is recommended over `Readdir()`, as stated in the official doc [^1]

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~~[ ] Comments saying why design decisions were made~~
- ~~[ ] Go unit tests, with comments saying what you're testing~~
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

This PR does not introduce any functional changes. The code should continue to build and the existing tests should also pass.

```sh
go build ./...
```
