### PR TITLE
[JUJU-3714] Wait for NICs to be up before restarting machine on spaces_ec2 tests

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -14,9 +14,9 @@ run_juju_bind() {
 	# test name so the NIC ID is actually provided in $2
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
+
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("enp") or startswith("ens"))')
-	echo "debug -- ifaces: $ifaces"
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -14,9 +14,9 @@ run_upgrade_charm_with_bind() {
 	# test name so the NIC ID is actually provided in $2
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
+
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("enp") or startswith("ens"))')
-	echo "debug -- ifaces: $ifaces"
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"


### PR DESCRIPTION
On spaces_ec2 tests, we first add a new nic for the current juju machine, then we get it's ID from `ip link` and then we patch the netplan config with this new NIC id and restart the machine. This causes the test to fail sometimes because we get the NIC id before it's UP and not shown in `ip link`. 

This patch adds a wait_for to make sure that the NIC is UP before retrieving it's ID.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```
./main.sh -v -c aws -R us-west-1 spaces_ec2 test_juju_bind  
./main.sh -v -c aws -R us-west-1 spaces_ec2 test_upgrade_charm_with_bind  
```
