### PR TITLE
tech debt: use type aliases instead of shims for deployer api

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -51,45 +51,15 @@ type CharmsAPI interface {
 	store.CharmsAPI
 }
 
-// The following structs exist purely because Go cannot create a
-// struct with a field named the same as a method name. The DeployAPI
-// needs to both embed a *<package>.Client and provide the
-// api.Connection Client method.
-//
-// Once we pair down DeployAPI, this will not longer be a problem.
-
-// TODO(juju3) - remove when methods are migrated away
-type apiClient struct {
-	*apiclient.Client
-}
-
-type charmsClient struct {
-	*apicharms.Client
-}
-
-type applicationClient struct {
-	*application.Client
-}
-
-type modelConfigClient struct {
-	*modelconfig.Client
-}
-
-type machineManagerClient struct {
-	*machinemanager.Client
-}
-
-type annotationsClient struct {
-	*annotations.Client
-}
-
-type offerClient struct {
-	*applicationoffers.Client
-}
-
-type spacesClient struct {
-	*spaces.API
-}
+type (
+	charmsClient         = apicharms.Client
+	applicationClient    = application.Client
+	modelConfigClient    = modelconfig.Client
+	annotationsClient    = annotations.Client
+	offerClient          = applicationoffers.Client
+	spacesClient         = spaces.API
+	machineManagerClient = machinemanager.Client
+)
 
 type deployAPIAdapter struct {
 	api.Connection
@@ -100,7 +70,7 @@ type deployAPIAdapter struct {
 	*offerClient
 	*spacesClient
 	*machineManagerClient
-	legacyClient *apiClient
+	legacyClient *apiclient.Client
 }
 
 func (a *deployAPIAdapter) ModelUUID() (string, bool) {
@@ -213,14 +183,14 @@ func newDeployCommand() *DeployCommand {
 		}
 		return &deployAPIAdapter{
 			Connection:           apiRoot,
-			legacyClient:         &apiClient{Client: apiclient.NewClient(apiRoot)},
-			charmsClient:         &charmsClient{Client: apicharms.NewClient(apiRoot)},
-			applicationClient:    &applicationClient{Client: application.NewClient(apiRoot)},
-			machineManagerClient: &machineManagerClient{Client: machinemanager.NewClient(apiRoot)},
-			modelConfigClient:    &modelConfigClient{Client: modelconfig.NewClient(apiRoot)},
-			annotationsClient:    &annotationsClient{Client: annotations.NewClient(apiRoot)},
-			offerClient:          &offerClient{Client: applicationoffers.NewClient(controllerAPIRoot)},
-			spacesClient:         &spacesClient{API: spaces.NewAPI(apiRoot)},
+			legacyClient:         apiclient.NewClient(apiRoot),
+			charmsClient:         apicharms.NewClient(apiRoot),
+			applicationClient:    application.NewClient(apiRoot),
+			machineManagerClient: machinemanager.NewClient(apiRoot),
+			modelConfigClient:    modelconfig.NewClient(apiRoot),
+			annotationsClient:    annotations.NewClient(apiRoot),
+			offerClient:          applicationoffers.NewClient(controllerAPIRoot),
+			spacesClient:         spaces.NewAPI(apiRoot),
 		}, nil
 	}
 	deployCmd.NewConsumeDetailsAPI = func(url *charm.OfferURL) (deployer.ConsumeDetails, error) {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2213,11 +2213,11 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 			}
 			return &deployAPIAdapter{
 				Connection:        apiRoot,
-				legacyClient:      &apiClient{Client: apiclient.NewClient(apiRoot)},
-				charmsClient:      &charmsClient{Client: apicharms.NewClient(apiRoot)},
-				applicationClient: &applicationClient{Client: application.NewClient(apiRoot)},
-				modelConfigClient: &modelConfigClient{Client: modelconfig.NewClient(apiRoot)},
-				annotationsClient: &annotationsClient{Client: annotations.NewClient(apiRoot)},
+				legacyClient:      apiclient.NewClient(apiRoot),
+				charmsClient:      apicharms.NewClient(apiRoot),
+				applicationClient: application.NewClient(apiRoot),
+				modelConfigClient: modelconfig.NewClient(apiRoot),
+				annotationsClient: annotations.NewClient(apiRoot),
 			}, nil
 		}
 		deployCmd.NewResolver = func(charmsAPI store.CharmsAPI, downloadClientFn store.DownloadBundleClientFunc) deployer.Resolver {

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -573,16 +573,16 @@ func newCharmAdder(
 	conn api.Connection,
 ) store.CharmAdder {
 	return &charmAdderShim{
-		api:               &apiClient{Client: apiclient.NewClient(conn)},
-		charmsClient:      &charmsClient{Client: apicharms.NewClient(conn)},
-		modelConfigClient: &modelConfigClient{Client: modelconfig.NewClient(conn)},
+		api:               apiclient.NewClient(conn),
+		charmsClient:      apicharms.NewClient(conn),
+		modelConfigClient: modelconfig.NewClient(conn),
 	}
 }
 
 type charmAdderShim struct {
 	*charmsClient
 	*modelConfigClient
-	api *apiClient
+	api *apiclient.Client
 }
 
 func (c *charmAdderShim) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool) (*charm.URL, error) {


### PR DESCRIPTION
This resolves an old, out of date todo and allows us to remove some ugly boiler plate

NOTE: The TODO comment is slightly misleading. Yes, we couldn't just embed the structs initially because they clash with a `Client` method on api.Connection, but also they clash with eachother. Type aliases are a much nicer way to embed multiple structs with the same name

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure juju compiles with `make go-install` and unit test run with `go test github.com/juju/juju/cmd/juju/application`

Deploy a test charm and bundle

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
```
```
juju bootstrack microk8s mk8s
juju add-model m 
juju deploy cos-lite --trust
```
