### PR TITLE
[JUJU-3742] Add il-central-1 AWS region

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -59,6 +59,8 @@ clouds:
         endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
+      il-central-1:
+        endpoint: https://ec2.il-central-1.amazonaws.com
   aws-china:
     type: ec2
     description: Amazon China

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -53,14 +53,14 @@ clouds:
         endpoint: https://ec2.ap-northeast-2.amazonaws.com
       ap-northeast-3:
         endpoint: https://ec2.ap-northeast-3.amazonaws.com
+      il-central-1:
+        endpoint: https://ec2.il-central-1.amazonaws.com
       me-south-1:
         endpoint: https://ec2.me-south-1.amazonaws.com
       me-central-1:
         endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
-      il-central-1:
-        endpoint: https://ec2.il-central-1.amazonaws.com
   aws-china:
     type: ec2
     description: Amazon China

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -60,14 +60,14 @@ clouds:
         endpoint: https://ec2.ap-northeast-2.amazonaws.com
       ap-northeast-3:
         endpoint: https://ec2.ap-northeast-3.amazonaws.com
+      il-central-1:
+        endpoint: https://ec2.il-central-1.amazonaws.com
       me-south-1:
         endpoint: https://ec2.me-south-1.amazonaws.com
       me-central-1:
         endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
-      il-central-1:
-        endpoint: https://ec2.il-central-1.amazonaws.com
   aws-china:
     type: ec2
     description: Amazon China

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -66,6 +66,8 @@ clouds:
         endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
+      il-central-1:
+        endpoint: https://ec2.il-central-1.amazonaws.com
   aws-china:
     type: ec2
     description: Amazon China

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2106,6 +2106,7 @@ ap-northeast-3
 me-south-1
 me-central-1
 sa-east-1
+il-central-1
 `[1:])
 }
 
@@ -2113,7 +2114,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1, eu-central-1, eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3, me-central-1, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1, eu-central-1, eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3, me-central-1, me-south-1, sa-east-1, il-central-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2103,10 +2103,10 @@ ap-southeast-4
 ap-northeast-1
 ap-northeast-2
 ap-northeast-3
+il-central-1
 me-south-1
 me-central-1
 sa-east-1
-il-central-1
 `[1:])
 }
 
@@ -2114,7 +2114,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1, eu-central-1, eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3, me-central-1, me-south-1, sa-east-1, il-central-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1, eu-central-1, eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3, il-central-1, me-central-1, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 


### PR DESCRIPTION
This PR includes the `il-central-1` AWS region into our supported regions list, expanding our service coverage and providing more options for our users.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
juju regions aws
# Output should contain  il-central-1
```

## Documentation changes
None

## Bug reference

https://bugs.launchpad.net/juju/+bug/2015970
