### PR TITLE
[JUJU-3678] - Fix secret hook commands for non existing URIs

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -296,6 +296,11 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 		arg.Label == nil && len(arg.Params) == 0 && len(arg.Content.Data) == 0 && arg.Content.ValueRef == nil {
 		return errors.New("at least one attribute to update must be specified")
 	}
+	if _, err := s.secretsState.GetSecret(uri); err != nil {
+		// Check if the uri exists or not.
+		return errors.Trace(err)
+	}
+
 	token, err := s.canManage(uri)
 	if err != nil {
 		return errors.Trace(err)
@@ -369,6 +374,11 @@ func (s *SecretsManagerAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.
 }
 
 func (s *SecretsManagerAPI) removeSecret(uri *coresecrets.URI, revisions ...int) ([]coresecrets.ValueRef, error) {
+	if _, err := s.secretsState.GetSecret(uri); err != nil {
+		// Check if the uri exists or not.
+		return nil, errors.Trace(err)
+	}
+
 	_, err := s.canManage(uri)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -752,6 +762,10 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 		return s.getRemoteSecretContent(uri, arg.Refresh, arg.Peek, arg.Label, possibleUpdateLabel)
 	}
 
+	if _, err := s.secretsState.GetSecret(uri); err != nil {
+		// Check if the uri exists or not.
+		return nil, nil, false, errors.Trace(err)
+	}
 	if !s.canRead(uri, s.authTag) {
 		return nil, nil, false, apiservererrors.ErrPerm
 	}


### PR DESCRIPTION
The `secret-get`, `secret-remove`, `secret-set` hook commands should return a `not found` error instead of a `permission denied` error if the provided URI does not exist.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju exec --unit snappass-test/0 -- secret-remove chi61kasrlkic828vsn0
removing secrets: secret "secret:chi61kasrlkic828vsn0" not found

juju exec --unit snappass-test/0 -- secret-set ch0a1dmffbas7an5pcpg --label=easyrsa_0
updating secrets: secret "secret:ch0a1dmffbas7an5pcpg" not found

juju exec --unit snappass-test/0 -- secret-get chi61kasrlkic828vsn0
ERROR secret "secret:chi61kasrlkic828vsn0" not found
ERROR the following task failed:
 - id "41" with return code 1

use 'juju show-task' to inspect the failure
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2019180
