### PR TITLE
[JUJU-3751] Added github migrate action from 2.9 to 3.1

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Enable Snap parallel-instances
+        run: |
+          sudo snap set system experimental.parallel-instances=true
+
       - name: Setup LXD
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -7,7 +7,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'snap/**'
-      - '.github/workflows/migrate29.yml'
+      - '.github/workflows/migrate.yml'
   workflow_dispatch:
 
 permissions:
@@ -65,6 +65,9 @@ jobs:
 
         # TODO: create backup and juju restore
 
+      - name: Again Install Juju 2.9
+        run: sudo snap install juju --classic --channel 2.9/stable
+
       - name: Migrate default model to 3.1 controller
         run: |
           juju switch test29
@@ -78,15 +81,20 @@ jobs:
           
           juju migrate test-migrate test31
 
+      - name: Again Upgrade client to 3.1
+        run: |
+          sudo snap remove juju --purge
+          make go-install &>/dev/null
+
       - name: Check the migration was successful
         run: |
           set -x
           juju switch test31
           
-          # Wait for 'default' model to come through
+          # Wait for 'test-migrate' model to come through
           attempt=0
           while true; do
-            RES=$(juju models | grep 'default' || true)
+            RES=$(juju models | grep 'test-migrate' || true)
             if [[ -n $RES ]]; then
               break
             fi
@@ -98,5 +106,5 @@ jobs:
             fi
           done
           
-          juju switch default
+          juju switch test-migrate
           juju wait-for application ubuntu

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -59,7 +59,6 @@ jobs:
 
       - name: Upgrade client to 3.1
         run: |
-          sudo snap remove juju --purge
           make go-install &>/dev/null
 
       - name: Bootstrap 3.1 controller

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -104,3 +104,6 @@ jobs:
           
           juju switch test-migrate
           juju wait-for application ubuntu
+          
+          juju deploy ubuntu yet-another-ubuntu
+          juju wait-for application yet-another-ubuntu

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -34,14 +34,13 @@ jobs:
 
       - name: Install Juju 2.9
         run: |
-          sudo snap set system experimental.parallel-instances=true
-          sudo snap install juju --classic --channel 2.9/stable
+          sudo snap install juju_29 --classic --channel 2.9/stable
 
       - name: Bootstrap a 2.9 controller and model
         run: |
-          juju bootstrap lxd test29
-          juju add-model test-migrate
-          juju deploy ubuntu
+          juju_29 bootstrap lxd test29
+          juju_29 add-model test-migrate
+          juju_29 deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -67,28 +66,18 @@ jobs:
 
         # TODO: create backup and juju restore
 
-      - name: Set up Snap env
-        run: |
-          echo "GOPATH=/snap" >> $GITHUB_ENV
-          echo "snap/bin" >> $GITHUB_PATH
-
       - name: Migrate default model to 3.1 controller
         run: |
-          juju switch test29
+          juju_29 switch test29
           
           # Ensure application is fully deployed
-          juju wait-for application ubuntu
+          juju_29 wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
           
           juju_29 migrate test-migrate test31
-
-      - name: Set up Go env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check the migration was successful
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Install Juju 2.9
         run: |
           sudo snap set system experimental.parallel-instances=true
-          sudo snap install juju_29 --classic --channel 2.9/stable
+          sudo snap install juju --classic --channel 2.9/stable
 
       - name: Bootstrap a 2.9 controller and model
         run: |
-          juju_29 bootstrap lxd test29
-          juju_29 add-model test-migrate
-          juju_29 deploy ubuntu
+          juju bootstrap lxd test29
+          juju add-model test-migrate
+          juju deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -67,18 +67,28 @@ jobs:
 
         # TODO: create backup and juju restore
 
+      - name: Set up Snap env
+        run: |
+          echo "GOPATH=/snap" >> $GITHUB_ENV
+          echo "snap/bin" >> $GITHUB_PATH
+
       - name: Migrate default model to 3.1 controller
         run: |
-          juju_29 switch test29
+          juju switch test29
           
           # Ensure application is fully deployed
-          juju_29 wait-for application ubuntu
+          juju wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
           
           juju_29 migrate test-migrate test31
+
+      - name: Set up Go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check the migration was successful
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   migrate:
-    name: 2.9 -> 3.X
+    name: 2.9-to-3.x
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   migrate:
-    name: 2.9 -> 3.1
+    name: 2.9 -> 3.X
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
@@ -33,13 +33,13 @@ jobs:
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
       - name: Install Juju 2.9
-        run: sudo snap install juju --classic --channel 2.9/stable
+        run: sudo snap install juju_29 --classic --channel 2.9/stable
 
       - name: Bootstrap a 2.9 controller and model
         run: |
-          juju bootstrap lxd test29
-          juju add-model test-migrate
-          juju deploy ubuntu
+          juju_29 bootstrap lxd test29
+          juju_29 add-model test-migrate
+          juju_29 deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -65,36 +65,18 @@ jobs:
 
         # TODO: create backup and juju restore
 
-      - name: Reset Go env
-        run: |
-          echo "GOPATH=" >> $GITHUB_ENV
-          echo "" >> $GITHUB_PATH
-
-      - name: Again Install Juju 2.9
-        run: sudo snap install juju --classic --channel 2.9/stable
-
       - name: Migrate default model to 3.1 controller
         run: |
-          juju switch test29
+          juju_29 switch test29
           
           # Ensure application is fully deployed
-          juju wait-for application ubuntu
+          juju_29 wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
           
-          juju migrate test-migrate test31
-
-      - name: Set up Go env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      - name: Again Upgrade client to 3.1
-        run: |
-          sudo snap remove juju --purge
-          make go-install &>/dev/null
+          juju_29 migrate test-migrate test31
 
       - name: Check the migration was successful
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -33,7 +33,9 @@ jobs:
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
       - name: Install Juju 2.9
-        run: sudo snap install juju_29 --classic --channel 2.9/stable
+        run: |
+          sudo snap set system experimental.parallel-instances=true
+          sudo snap install juju_29 --classic --channel 2.9/stable
 
       - name: Bootstrap a 2.9 controller and model
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -65,6 +65,11 @@ jobs:
 
         # TODO: create backup and juju restore
 
+      - name: Reset Go env
+        run: |
+          echo "GOPATH=" >> $GITHUB_ENV
+          echo "" >> $GITHUB_PATH
+
       - name: Again Install Juju 2.9
         run: sudo snap install juju --classic --channel 2.9/stable
 
@@ -80,6 +85,11 @@ jobs:
           sleep 10
           
           juju migrate test-migrate test31
+
+      - name: Set up Go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Again Upgrade client to 3.1
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -57,11 +57,11 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      - name: Upgrade client to 3.1
+      - name: Upgrade client to 3.x
         run: |
           make go-install &>/dev/null
 
-      - name: Bootstrap 3.1 controller
+      - name: Bootstrap 3.x controller
         run: |
           juju bootstrap lxd test31
           juju switch controller
@@ -69,7 +69,7 @@ jobs:
 
         # TODO: create backup and juju restore
 
-      - name: Migrate default model to 3.1 controller
+      - name: Migrate default model to 3.x controller
         run: |
           juju_29 switch test29
           

--- a/.github/workflows/migrate29.yml
+++ b/.github/workflows/migrate29.yml
@@ -33,7 +33,7 @@ jobs:
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
       - name: Install Juju 2.9
-        run: sudo snap install juju --channel 2.9/stable
+        run: sudo snap install juju --classic --channel 2.9/stable
 
       - name: Bootstrap a 2.9 controller and model
         run: |

--- a/.github/workflows/migrate29.yml
+++ b/.github/workflows/migrate29.yml
@@ -1,4 +1,4 @@
-name: "Migrate"
+name: "Migrate 2.9"
 on:
   push:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'snap/**'
-      - '.github/workflows/migrate.yml'
+      - '.github/workflows/migrate29.yml'
   workflow_dispatch:
 
 permissions:
@@ -32,12 +32,12 @@ jobs:
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
-      - name: Install Juju 3.0
-        run: sudo snap install juju --channel 3.0/stable
+      - name: Install Juju 2.9
+        run: sudo snap install juju --channel 2.9/stable
 
-      - name: Bootstrap a 3.0 controller and model
+      - name: Bootstrap a 2.9 controller and model
         run: |
-          juju bootstrap lxd test30
+          juju bootstrap lxd test29
           juju add-model default
           juju deploy ubuntu
           
@@ -67,7 +67,7 @@ jobs:
 
       - name: Migrate default model to 3.1 controller
         run: |
-          juju switch test30
+          juju switch test29
           
           # Ensure application is fully deployed
           juju wait-for application ubuntu

--- a/.github/workflows/migrate29.yml
+++ b/.github/workflows/migrate29.yml
@@ -1,4 +1,4 @@
-name: "Migrate 2.9"
+name: "Migrate"
 on:
   push:
   pull_request:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   migrate:
-    name: Migrate
+    name: 2.9 -> 3.1
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
@@ -38,7 +38,7 @@ jobs:
       - name: Bootstrap a 2.9 controller and model
         run: |
           juju bootstrap lxd test29
-          juju add-model default
+          juju add-model test-migrate
           juju deploy ubuntu
           
           # TODO: use juju-restore
@@ -76,7 +76,7 @@ jobs:
           # so that migration prechecks pass.
           sleep 10
           
-          juju migrate default test31
+          juju migrate test-migrate test31
 
       - name: Check the migration was successful
         run: |


### PR DESCRIPTION
A new github action that verifies the upgrade process from version 2.9 to 3.1 version using model migration should be added. This test is designed to ensure the smooth transition and compatibility of data across different versions.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps


```sh
#check github action result for this PR (Migrate / 2.9-to-3.x)
```

