### PR TITLE
[JUJU-3697] Add image-id constraint on AWS integration tests

### DIFF
--- a/tests/suites/constraints/aws_ami_creation.sh
+++ b/tests/suites/constraints/aws_ami_creation.sh
@@ -1,0 +1,74 @@
+launch_and_wait_ec2() {
+	local name instance_name instance_id_result
+
+	name=${1}
+	instance_name=${2}
+	instance_image_id=${3}
+	subnet_id=${4}
+	sg_id=${5}
+	instance_id_result=${6}
+
+	tags="ResourceType=instance,Tags=[{Key=Name,Value=${instance_name}}]"
+	instance_id=$(aws ec2 run-instances --image-id "${instance_image_id}" \
+		--count 1 \
+		--instance-type t2.medium \
+		--associate-public-ip-address \
+		--tag-specifications "${tags}" \
+		--key-name "${name}" \
+		--subnet-id "${subnet_id}" \
+		--security-group-ids "${sg_id}" \
+		--query 'Instances[0].InstanceId' \
+		--output text)
+
+	echo "${instance_id}" >>"${TEST_DIR}/ec2-instances"
+
+	aws ec2 wait instance-running --instance-ids "${instance_id}"
+
+	# shellcheck disable=SC2086
+	eval $instance_id_result="'${instance_id}'"
+}
+
+create_ami_and_wait_available() {
+	local instance_id_ami_builder ami_id_result
+
+	instance_id_ami_builder=${1}
+	ami_id_result=${2}
+
+	ami_id=$(aws ec2 create-image --instance-id "${instance_id_ami_builder}" --name "test_ami_constraints" --description "Test ami used for constraints tests" --output text)
+
+	aws ec2 wait image-available --image-ids "${ami_id}"
+	echo "${ami_id}" >>"${TEST_DIR}/ec2-amis"
+	echo "Created ami: ${ami_id}"
+
+	# shellcheck disable=SC2086
+	eval $ami_id_result="'${ami_id}'"
+}
+
+run_cleanup_constraints_aws() {
+	set +e
+
+	if [[ -f "${TEST_DIR}/ec2-instances" ]]; then
+		echo "====> Cleaning up EC2 instances"
+		while read -r ec2_instance; do
+			aws ec2 terminate-instances --instance-ids="${ec2_instance}" >>"${TEST_DIR}/aws_cleanup"
+		done <"${TEST_DIR}/ec2-instances"
+	fi
+
+	if [[ -f "${TEST_DIR}/ec2-key-pairs" ]]; then
+		echo "====> Cleaning up EC2 key-pairs"
+		while read -r ec2_keypair; do
+			aws ec2 delete-key-pair --key-name="${ec2_keypair}" >>"${TEST_DIR}/aws_cleanup"
+		done <"${TEST_DIR}/ec2-key-pairs"
+	fi
+
+	if [[ -f "${TEST_DIR}/ec2-amis" ]]; then
+		echo "====> Cleaning up EC2 AMIs"
+		while read -r ec2_ami; do
+			aws ec2 deregister-image --image-id="${ec2_ami}" >>"${TEST_DIR}/aws_cleanup"
+		done <"${TEST_DIR}/ec2-amis"
+	fi
+
+	set_verbosity
+
+	echo "====> Completed cleaning up aws"
+}

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -13,6 +13,9 @@ test_constraints_common() {
 		"lxd" | "lxd-remote" | "localhost")
 			run "run_constraints_lxd"
 			;;
+		"ec2")
+			run "run_constraints_aws"
+			;;
 		"microk8s")
 			echo "==> TEST SKIPPED: constraints - there are no test for k8s cloud"
 			;;

--- a/tests/suites/constraints/constraints_aws.sh
+++ b/tests/suites/constraints/constraints_aws.sh
@@ -1,0 +1,77 @@
+run_constraints_aws() {
+	name="constraints-aws"
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+	echo "==> Checking for dependencies"
+	check_dependencies aws
+
+	file="${TEST_DIR}/constraints-aws.txt"
+
+	ensure "${name}" "${file}"
+
+	add_clean_func "run_cleanup_constraints_aws"
+
+	# In order to test the image-id constraint in AWS, we need to create a
+	# ami, but for that we first need to launch an ec2 instance from which
+	# the ami will be created.
+	#
+	# Retrieve the image_id corresponding to ubuntu jammy
+	OUT=$(aws ec2 describe-images \
+		--owners 099720109477 \
+		--filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-?????-amd64-server-????????" 'Name=state,Values=available' \
+		--query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
+		--output text)
+	if [[ -z ${OUT} ]]; then
+		echo "No image available: unknown state."
+		exit 1
+	fi
+	image_id="${OUT}"
+
+	# Retrieve the subnet id
+	sub1=$(aws ec2 describe-subnets | jq -r '.Subnets[] | select(.DefaultForAz==true and .CidrBlock=="172.31.0.0/20") | .SubnetId')
+
+	# Ensure we have a security group allowing SSH and controller access.
+	OUT=$(aws ec2 describe-security-groups | jq '.SecurityGroups[] | select(.GroupName=="ci-spaces-manual-ssh")' || true)
+	if [[ -z ${OUT} ]]; then
+		sg_id=$(aws ec2 create-security-group --group-name "ci-spaces-manual-ssh" --description "SSH access for manual spaces test" --query 'GroupId' --output text)
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 17070 --cidr 0.0.0.0/0
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 17070 --cidr 0.0.0.0/0
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 0-65535 --source-group "${sg_id}"
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 0-65535 --source-group "${sg_id}"
+	else
+		sg_id=$(echo "${OUT}" | jq -r '.GroupId')
+	fi
+
+	# Create a key-pair so that we can provision machines via SSH.
+	aws ec2 create-key-pair --key-name "${name}" --query 'KeyMaterial' --output text >"${TEST_DIR}/${name}.pem"
+	chmod 400 "${TEST_DIR}/${name}.pem"
+	echo "${name}" >>"${TEST_DIR}/ec2-key-pairs"
+
+	# Launch an ec2 instance using the retrieved jammy image id
+	local instance_id_ami_builder
+	launch_and_wait_ec2 "${name}" "constraints_aws_ami_builder" "${image_id}" "${sub1}" "${sg_id}" instance_id_ami_builder
+	echo "Created instance for ami builder: ${instance_id_ami_builder}"
+
+	# Create the ami from the ec2 instace_id
+	local ami_id
+	create_ami_and_wait_available "${instance_id_ami_builder}" ami_id
+
+	echo "Deploy 2 machines with different constraints"
+	juju add-machine --constraints "cores=2"
+	juju add-machine --constraints "image-id=${ami_id}"
+
+	wait_for_machine_agent_status "0" "started"
+	wait_for_machine_agent_status "1" "started"
+
+	echo "Ensure machine 0 has 2 cores"
+	machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
+	check_contains "${machine0_hardware}" "cores=2"
+
+	echo "Ensure machine 1 uses the correct AMI ID from image-id constraint"
+	machine_instance_id=$(juju show-machine --format json | jq -r '.["machines"]["1"]["instance-id"]')
+	aws ec2 describe-instances --instance-ids ${machine_instance_id} --query 'Reservations[0].Instances[0].ImageId' --output text | check "${ami_id}"
+
+	destroy_model "${name}"
+}


### PR DESCRIPTION
This CI test will make sure that the correct AMI is selected when adding a machine using the image-id constraint.

We test this by first adding creating a ec2 instance (ubuntu jammy) that will be used as AMI builder. Then we create the ami using the instanceId. 
Once the AMI is available, we add a juju machine with the ami-id as image-id constraint, and at last we check that the deployed machine has indeed the correct ami-id, by describing the instance using the aws client.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
cd tests
./main.sh -v -c aws -R us-east-1 constraints
```
You can also check that the clean-up works correctly by making sure that the 3 ec2 instances (one for the ami builder and the other 2 as juju machines) as well as the ami are correctly terminated on aws.

