### PR TITLE
[JUJU-3764] Fix some CI test failures for 2.9

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,7 +6,7 @@ run_charmhub_download() {
 
 	ensure "test-${name}" "${file}"
 
-	output=$(juju download mysql --series xenial --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
+	output=$(juju download mysql --series jammy --channel 8.0/stable --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
 	check_contains "${output}" 'Fetching charm "mysql"'
 
 	juju deploy "${TEST_DIR}/mysql.charm" mysql

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -18,7 +18,7 @@ run_deploy_specific_series() {
 
 	ensure "test-deploy-specific-series" "${file}"
 
-	juju deploy postgresql --series focal
+	juju deploy postgresql --series jammy
 	series=$(juju status --format=json | jq ".applications.postgresql.series")
 
 	destroy_model "test-deploy-specific-series"

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -9,8 +9,7 @@ run_relation_data_exchange() {
 
 	echo "Deploy 2 wordpress instances and one mysql instance"
 	juju deploy wordpress -n 2 --force --series bionic
-	# mysql charm does not have stable channel, so we use edge channel
-	juju deploy mysql --channel=edge --force --series focal
+	juju deploy mysql --channel=8.0/stable --force --series jammy
 
 	echo "Establish relation"
 	juju relate wordpress mysql

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -8,9 +8,9 @@ run_relation_list_app() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 departer instances"
+	juju deploy mysql --channel=8.0/stable --force --series jammy
 	juju deploy wordpress --force --series bionic
-	# mysql charm does not have stable channel, so we use edge channel
-	juju deploy mysql --channel=edge --force --series focal
+
 	juju relate wordpress mysql
 	wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"
 	wait_for "mysql" "$(idle_condition "mysql" 0 0)"


### PR DESCRIPTION
This fixes the following CI issues:

[Test-charmhub-download](https://jenkins.juju.canonical.com/job/test-charmhub-test-charmhub-download-lxd/1097/console) : "mysql" has no releases in channel "stable"

[Test-deploy-charms](https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-charms-aws/1977/console) : timeout on deploying “postgresql” of specific revision

[Test-relation-data-exchange](https://jenkins.juju.canonical.com/job/test-relations-test-relation-data-exchange-lxd/539/console) : no “wordpress” release in “edge” channel

[Test-relation-list-app](https://jenkins.juju.canonical.com/job/test-relations-test-relation-list-app-aws/538/console) : same prob



## QA steps

```sh
./main.sh -l lxd29 charmhub run_charmhub_download
```
```sh
./main.sh -l lxd29 deploy run_deploy_specific_series
```
```sh
./main.sh -l lxd29 relations run_relation_data_exchange
```
```sh
./main.sh -l lxd29 relations run_relation_list_app
```


