### PR TITLE
[JUJU-3688] Remove Err() from TrackedDB

### DIFF
--- a/core/database/trackeddb.go
+++ b/core/database/trackeddb.go
@@ -22,9 +22,4 @@ type TrackedDB interface {
 	// within a transaction that depends on the input context.
 	// No retries are attempted.
 	TxnNoRetry(context.Context, func(context.Context, *sql.Tx) error) error
-
-	// Err returns an error if the underlying tracked DB is in an error
-	// condition. Depending on the error, determines of the tracked DB can be
-	// requested again, or should be given up and thrown away.
-	Err() error
 }

--- a/database/testing/trackeddb.go
+++ b/database/testing/trackeddb.go
@@ -29,10 +29,6 @@ func (t *trackedDB) TxnNoRetry(ctx context.Context, fn func(context.Context, *sq
 	return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 }
 
-func (t *trackedDB) Err() error {
-	return nil
-}
-
 // TrackedDBFactory returns a DBFactory that returns the given database.
 func TrackedDBFactory(db coredatabase.TrackedDB) func() (coredatabase.TrackedDB, error) {
 	return func() (coredatabase.TrackedDB, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -2203,7 +2203,3 @@ func (t *trackedDB) Txn(ctx stdcontext.Context, fn func(stdcontext.Context, *sql
 func (t *trackedDB) TxnNoRetry(ctx stdcontext.Context, fn func(stdcontext.Context, *sql.Tx) error) error {
 	return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 }
-
-func (t *trackedDB) Err() error {
-	return nil
-}

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -468,20 +468,6 @@ func (m *MockTrackedDB) EXPECT() *MockTrackedDBMockRecorder {
 	return m.recorder
 }
 
-// Err mocks base method.
-func (m *MockTrackedDB) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockTrackedDBMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockTrackedDB)(nil).Err))
-}
-
 // Kill mocks base method.
 func (m *MockTrackedDB) Kill() {
 	m.ctrl.T.Helper()

--- a/worker/dbaccessor/tracker.go
+++ b/worker/dbaccessor/tracker.go
@@ -155,15 +155,6 @@ func (w *trackedDBWorker) meterDBOpResult(begin time.Time, err error) {
 	w.metrics.DBDuration.WithLabelValues(w.namespace, result).Observe(w.clock.Now().Sub(begin).Seconds())
 }
 
-// Err will return any fatal errors that have occurred on the worker, trying
-// to acquire the database.
-func (w *trackedDBWorker) Err() error {
-	w.mutex.RLock()
-	defer w.mutex.RUnlock()
-
-	return w.err
-}
-
 // Kill implements worker.Worker
 func (w *trackedDBWorker) Kill() {
 	w.tomb.Kill(nil)

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -160,7 +160,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 	workertest.CleanKill(c, w)
 
 	c.Assert(count, gc.Equals, uint64(1))
-	c.Assert(w.Err(), jc.ErrorIsNil)
 }
 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) {
@@ -211,8 +210,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) 
 	c.Assert(tables, SliceContains, "lease")
 
 	workertest.CleanKill(c, w)
-
-	c.Assert(w.Err(), jc.ErrorIsNil)
 }
 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
@@ -250,7 +247,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 	workertest.CleanKill(c, w)
 
 	c.Assert(count, gc.Equals, uint64(2))
-	c.Assert(w.Err(), jc.ErrorIsNil)
 }
 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceedsWithDifferentDB(c *gc.C) {
@@ -324,7 +320,6 @@ loop:
 	}
 
 	workertest.CleanKill(c, w)
-	c.Assert(w.Err(), jc.ErrorIsNil)
 }
 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
@@ -352,7 +347,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 	}
 
 	c.Assert(w.Wait(), gc.ErrorMatches, "boom")
-	c.Assert(w.Err(), gc.ErrorMatches, "boom")
 
 	// Ensure that the DB is dead.
 	err = w.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {

--- a/worker/lease/manifold/database_mock_test.go
+++ b/worker/lease/manifold/database_mock_test.go
@@ -35,20 +35,6 @@ func (m *MockTrackedDB) EXPECT() *MockTrackedDBMockRecorder {
 	return m.recorder
 }
 
-// Err mocks base method.
-func (m *MockTrackedDB) Err() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Err")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Err indicates an expected call of Err.
-func (mr *MockTrackedDBMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockTrackedDB)(nil).Err))
-}
-
 // Txn mocks base method.
 func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
 	m.ctrl.T.Helper()

--- a/worker/leaseexpiry/worker.go
+++ b/worker/leaseexpiry/worker.go
@@ -125,10 +125,8 @@ func (w *expiryWorker) expireLeases(ctx context.Context) error {
 
 		return nil
 	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return errors.Trace(w.trackedDB.Err())
+
+	return errors.Trace(err)
 }
 
 // Kill is part of the worker.Worker interface.


### PR DESCRIPTION
The `Err` method on `TrackedDB` is not required, as the design we settled on has the DB tracker worker monitoring its error state internally. This is a deliberate design choice, freeing DB consumers from needing to worry about anything other than running transactions.

Here, the method is removed from interface and implementations. It's only use in the `leaseexpiry` worker goes too. 

## QA steps

Just bootstrap and check that we have a controller come up, elected leader.
