### PR TITLE
[JUJU-3710] Selectively call Handover on Dqlite node shutdown

### DIFF
--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -46,7 +46,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := s.expectNodeStartupAndShutdown()
+	sync := s.expectNodeStartupAndShutdown(true)
 
 	// When we are starting up as a new node,
 	// we request details immediately.
@@ -141,7 +141,7 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := s.expectNodeStartupAndShutdown()
+	sync := s.expectNodeStartupAndShutdown(true)
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -177,7 +177,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := s.expectNodeStartupAndShutdown()
+	sync := s.expectNodeStartupAndShutdown(true)
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -262,7 +262,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
-	sync := s.expectNodeStartupAndShutdown()
+	sync := s.expectNodeStartupAndShutdown(false)
 
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
@@ -299,7 +299,7 @@ func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *workerSuite) expectNodeStartupAndShutdown() chan struct{} {
+func (s *workerSuite) expectNodeStartupAndShutdown(handover bool) chan struct{} {
 	sync := make(chan struct{})
 
 	appExp := s.dbApp.EXPECT()
@@ -309,7 +309,11 @@ func (s *workerSuite) expectNodeStartupAndShutdown() chan struct{} {
 		close(sync)
 		return uint64(666)
 	})
-	appExp.Handover(gomock.Any()).Return(nil)
+
+	if handover {
+		appExp.Handover(gomock.Any()).Return(nil)
+	}
+
 	appExp.Close().Return(nil)
 
 	return sync


### PR DESCRIPTION
Dqlite recommends calling `Handover` before `Close`, but `Handover` is only really required when in HA, to ensure that leadership/voting rights are transferred ahead of a node going down.

We currently call `Handover` when we shut down the node for address rebinding prior to going into HA. We use use a context with a 30 second time-out to limit the time we will wait, but in this case we will always do the waiting for no reason - there are no other nodes to transfer responsibilities to.

This patch makes the `Handover` call optional when shutting down the local node, and we use this to avoid the call when rebinding the Dqlite address.

This should make HA establishment slightly faster.

## QA steps

Bootstrap, enable HA and ensure we arrive at a stable cluster.
