### PR TITLE
Fix intermittent failure in firewaller facade suite

### DIFF
--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -5,10 +5,12 @@ package firewaller_test
 
 import (
 	"sort"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -22,6 +24,7 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 )
 
 type firewallerSuite struct {
@@ -279,12 +282,14 @@ func (s *firewallerSuite) TestWatchSubnets(c *gc.C) {
 	// Set up a spaces with two subnets
 	sp, err := s.State.AddSpace("outer-space", network.Id("outer-1"), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
+
 	_, err = s.State.AddSubnet(network.SubnetInfo{
 		CIDR:      "192.168.0.0/24",
 		SpaceID:   sp.Id(),
 		SpaceName: sp.Name(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+
 	sub2, err := s.State.AddSubnet(network.SubnetInfo{
 		CIDR:      "192.168.42.0/24",
 		SpaceID:   sp.Id(),
@@ -293,6 +298,25 @@ func (s *firewallerSuite) TestWatchSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.resources.Count(), gc.Equals, 0)
+
+	// This accommodates a race that was exposed after the removal of the
+	// model cache and an accompanying test composition aid that had the
+	// serendipitous effect of a short wait.
+	// What can happen is that we can get 2 watch events if we watch an
+	// entity right after its creation. We get the initial event upon
+	// watching, but this can be *before* the change stream has sent the
+	// creation event, meaning we get another unexpected one subsequently.
+	// To work around this we drain the collection's events for a short time.
+	raw := s.State.WatchSubnets(nil)
+	defer workertest.DirtyKill(c, raw)
+drain:
+	for {
+		select {
+		case <-raw.Changes():
+		case <-time.After(testing.ShortWait):
+			break drain
+		}
+	}
 
 	watchSubnetTags := []names.SubnetTag{
 		names.NewSubnetTag(sub2.ID()),


### PR DESCRIPTION
Under https://github.com/juju/juju/pull/15614 the model cache was removed, along with a testing aid, `WaitForModelWatchersIdle`. The call to this method was resulting in a short wait in tests that worked around a race now materialising after its removal.

We are checking that watching subnets via the facade results in the lower level watcher's initial event being consumed. This is checked by ensuring that we get no events following the initial watch result.

It is possible for this test to fail if we watch an entity immediately after creation, and the watch call returns before the Mongo event stream emits the creation event.

Here we mimic what the prior wait was doing by draining events via a different watcher for a brief period before advancing the test scenario.

## QA steps

Run `TestWatchSubnets` from _apiserver/facades/controller/firewaller_ in a loop.
