### PR TITLE
[JUJU-3778] Fix remote app proxy offer uuid reference

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -919,7 +919,6 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 		equal, _ := jc.DeepEqual(got, &params.RemoteApplicationUpdate{
 			Name:      "remote-db2",
 			ModelUUID: s.State.ModelUUID(),
-			OfferUUID: "offer-uuid",
 			OfferURL:  "admin/prod.db2",
 			Life:      "alive",
 			Status: params.StatusInfo{

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -234,7 +234,6 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 
 	_, err = api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:            uniqueRemoteApplicationName,
-		OfferUUID:       relation.OfferUUID,
 		SourceModel:     sourceModelTag,
 		Token:           relation.ApplicationToken,
 		Endpoints:       []charm.Relation{remoteEndpoint.Relation},

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -91,6 +91,9 @@ func (h *modelRestHandler) processRemoteApplication(r *http.Request, w http.Resp
 
 	// Get the backend state for the source model so we can lookup the app in that model to get the charm details.
 	offerUUID := remoteApp.OfferUUID()
+	if offerUUID == "" {
+		return h.byteSender(w, ".svg", []byte(common.DefaultCharmIcon))
+	}
 	sourceModelUUID := remoteApp.SourceModel().Id()
 	sourceSt, err := h.ctxt.srv.shared.statePool.Get(sourceModelUUID)
 	if err != nil {

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -376,7 +376,6 @@ func (aw allWatcherDeltaTranslater) TranslateRemoteApplication(info multiwatcher
 	return &params.RemoteApplicationUpdate{
 		ModelUUID: orig.ModelUUID,
 		Name:      orig.Name,
-		OfferUUID: orig.OfferUUID,
 		OfferURL:  orig.OfferURL,
 		Life:      orig.Life,
 		Status:    aw.translateStatus(orig.Status),

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -312,7 +312,6 @@ func (i *CharmInfo) Clone() EntityInfo {
 type RemoteApplicationUpdate struct {
 	ModelUUID string
 	Name      string
-	OfferUUID string
 	OfferURL  string
 	Life      life.Value
 	Status    StatusInfo

--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -80,7 +80,7 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kinetic", "kubernetes",
+		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kinetic", "kubernetes", "lunar",
 		"opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
 		"win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019",
 		"win7", "win8", "win81", "xenial"})

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -37,10 +37,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -53,10 +53,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -69,10 +69,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -85,10 +85,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"lunar", "kinetic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 var getOSFromSeriesTests = []struct {

--- a/rpc/params/multiwatcher.go
+++ b/rpc/params/multiwatcher.go
@@ -223,7 +223,6 @@ func (i *CharmInfo) EntityId() EntityId {
 type RemoteApplicationUpdate struct {
 	ModelUUID string     `json:"model-uuid"`
 	Name      string     `json:"name"`
-	OfferUUID string     `json:"offer-uuid"`
 	OfferURL  string     `json:"offer-url"`
 	Life      life.Value `json:"life"`
 	Status    StatusInfo `json:"status"`

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -864,7 +864,6 @@ func (app *backingRemoteApplication) updated(ctx *allWatcherContext) error {
 	info := &multiwatcher.RemoteApplicationUpdate{
 		ModelUUID: ctx.modelUUID, // ModelUUID not part of the remoteApplicationDoc
 		Name:      app.Name,
-		OfferUUID: app.OfferUUID,
 		OfferURL:  app.URL,
 		Life:      life.Value(app.Life.String()),
 	}
@@ -893,41 +892,39 @@ func (app *backingRemoteApplication) updated(ctx *allWatcherContext) error {
 }
 
 func (app *backingRemoteApplication) updateOfferInfo(ctx *allWatcherContext) error {
-	// Remote Applications reference an offer using the offer UUID.
-	// Offers in the store use offer name as the id key, so we need
-	// to look through the store entities to find any matching offer.
-	var offerInfo *multiwatcher.ApplicationOfferInfo
 	entities := ctx.store.All()
 	for _, e := range entities {
-		var ok bool
-		if offerInfo, ok = e.(*multiwatcher.ApplicationOfferInfo); ok {
-			if offerInfo.OfferUUID != app.OfferUUID {
-				offerInfo = nil
-				continue
-			}
-			break
+		var (
+			offerInfo *multiwatcher.ApplicationOfferInfo
+			ok        bool
+		)
+		if offerInfo, ok = e.(*multiwatcher.ApplicationOfferInfo); !ok {
+			continue
 		}
+		if offerInfo.ModelUUID != ctx.modelUUID {
+			continue
+		}
+		// TODO: be smarter about reading status.
+		// We should only read offers relevant to the remote app that has been updated,
+		// but there would be more db reads to do the filtering than just reading the
+		// connection info for each offer, even if it might not have changed.
+		remoteConnection, err := ctx.state.RemoteConnectionStatus(offerInfo.OfferUUID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		offerInfo.TotalConnectedCount = remoteConnection.TotalConnectionCount()
+		offerInfo.ActiveConnectedCount = remoteConnection.ActiveConnectionCount()
+		ctx.store.Update(offerInfo)
 	}
-	// If we have an existing remote application,
-	// adjust any offer info also.
-	if offerInfo == nil {
-		return nil
-	}
-	// TODO: be smarter about reading status.
-	remoteConnection, err := ctx.state.RemoteConnectionStatus(offerInfo.OfferUUID)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	offerInfo.TotalConnectedCount = remoteConnection.TotalConnectionCount()
-	offerInfo.ActiveConnectedCount = remoteConnection.ActiveConnectionCount()
-	ctx.store.Update(offerInfo)
 	return nil
 }
 
 func (app *backingRemoteApplication) removed(ctx *allWatcherContext) (err error) {
 	allWatcherLogger.Tracef(`remote application "%s:%s" removed`, ctx.modelUUID, ctx.id)
 	// TODO: see if we need the check of consumer proxy like in the change
-	err = app.updateOfferInfo(ctx)
+	if app.IsConsumerProxy {
+		err = app.updateOfferInfo(ctx)
+	}
 	if err != nil {
 		// We log the error but don't prevent the remote app removal.
 		allWatcherLogger.Errorf("updating application offer info: %v", err)

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -155,6 +155,39 @@ func (s *applicationOffers) AllApplicationOffers() (offers []*crossmodel.Applica
 	return offers, nil
 }
 
+// maybeConsumerProxyForOffer returns the remote app consumer proxy related to
+// the offer on the specified relation if one exists.
+func (st *State) maybeConsumerProxyForOffer(offer *crossmodel.ApplicationOffer, rel *Relation) (*RemoteApplication, bool, error) {
+	// Is the relation for an offer connection
+	offConn, err := st.OfferConnectionForRelation(rel.String())
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, false, errors.Trace(err)
+	}
+	if err != nil || offConn.OfferUUID() != offer.OfferUUID {
+		return nil, false, nil
+	}
+
+	// Get the remote app proxy for the connection.
+	remoteApp, isCrossModel, err := rel.RemoteApplication()
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	// Sanity check - we expect a cross model relation at this stage.
+	if !isCrossModel {
+		return nil, false, nil
+	}
+
+	// We have a remote app proxy, is it related to the offer in question.
+	_, err = rel.Endpoint(offer.ApplicationName)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, false, errors.Trace(err)
+		}
+		return nil, false, nil
+	}
+	return remoteApp, true, nil
+}
+
 // RemoveOfferOperation returns a model operation that will allow relation to leave scope.
 func (s *applicationOffers) RemoveOfferOperation(offerName string, force bool) (*RemoveOfferOperation, error) {
 	offerStore := &applicationOffers{s.st}
@@ -166,11 +199,20 @@ func (s *applicationOffers) RemoveOfferOperation(offerName string, force bool) (
 	}
 	var associatedAppProxies []*DestroyRemoteApplicationOperation
 	if err == nil {
-		remoteApps, err := s.st.RemoteApplicationsByOffer(offer.OfferUUID)
+		// Look at relations to the offer and if it is a cross model relation,
+		// record the associated remote app proxy in the remove operation.
+		rels, err := s.st.AllRelations()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		for _, remoteApp := range remoteApps {
+		for _, rel := range rels {
+			remoteApp, isCrossModel, err := s.st.maybeConsumerProxyForOffer(offer, rel)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if !isCrossModel {
+				continue
+			}
 			logger.Debugf("destroy consumer proxy %v for offer %v", remoteApp.Name(), offerName)
 			associatedAppProxies = append(associatedAppProxies, remoteApp.DestroyOperation(force))
 		}
@@ -311,11 +353,11 @@ func (op *RemoveOfferOperation) countOfferRelations(offer *crossmodel.Applicatio
 	}
 	var count int
 	for _, rel := range rels {
-		remoteApp, isCrossModel, err := rel.RemoteApplication()
+		remoteApp, isCrossModel, err := op.offerStore.st.maybeConsumerProxyForOffer(offer, rel)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		if !isCrossModel || remoteApp.OfferUUID() != offer.OfferUUID {
+		if !isCrossModel || remoteApp == nil {
 			continue
 		}
 		count++
@@ -354,13 +396,9 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 		Assert: bson.D{{"relationcount", app.doc.RelationCount}},
 	}}
 	for _, rel := range rels {
-		remoteApp, isCrossModel, err := rel.RemoteApplication()
+		remoteApp, isCrossModel, err := op.offerStore.st.maybeConsumerProxyForOffer(offer, rel)
 		if err != nil {
 			return nil, errors.Trace(err)
-		}
-		if isCrossModel && remoteApp.OfferUUID() != offer.OfferUUID {
-			logger.Debugf("removing offer %q, skipping relation %q for another offer %v", offer.OfferName, rel, remoteApp.OfferUUID())
-			isCrossModel = false
 		}
 		if isCrossModel && !op.Force {
 			logger.Debugf("aborting removal of offer %q due to relation %q", offer.OfferName, rel)

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -316,10 +316,11 @@ func (s *CleanupSuite) TestCleanupModelOffers(c *gc.C) {
 		},
 	}
 	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "remote-wordpress",
-		SourceModel: s.Model.ModelTag(),
-		Token:       "t0",
-		Endpoints:   wordpressEps,
+		Name:            "remote-wordpress",
+		SourceModel:     s.Model.ModelTag(),
+		IsConsumerProxy: true,
+		Token:           "t0",
+		Endpoints:       wordpressEps,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -382,14 +383,12 @@ func (s *CleanupSuite) TestCleanupModelOffers(c *gc.C) {
 		c.Assert(unit.Life(), gc.Equals, state.Alive)
 	}
 
-	s.assertCleanupCount(c, 2)
-
+	s.assertCleanupCount(c, 3)
 	allOffers, err := offers.ListOffers()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allOffers, gc.HasLen, 0)
-	wordpress, err := s.State.RemoteApplication("remote-wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(wordpress.Life(), gc.Equals, state.Dying)
+	_, err = s.State.RemoteApplication("remote-wordpress")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *CleanupSuite) TestCleanupRelationSettings(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1749,13 +1749,15 @@ func (i *importer) firewallRules() error {
 func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *remoteApplicationDoc {
 	doc := &remoteApplicationDoc{
 		Name:            app.Name(),
-		OfferUUID:       app.OfferUUID(),
 		URL:             app.URL(),
 		SourceModelUUID: app.SourceModelTag().Id(),
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
 		Version:         app.ConsumeVersion(),
+	}
+	if !doc.IsConsumerProxy {
+		doc.OfferUUID = app.OfferUUID()
 	}
 	descEndpoints := app.Endpoints()
 	eps := make([]remoteEndpointDoc, len(descEndpoints))

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -932,25 +932,24 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		macJSON = string(b)
 	}
 	applicationID := st.docID(args.Name)
-	version := args.ConsumeVersion
-	if !args.IsConsumerProxy {
-		if version, err = sequenceWithMin(st, args.OfferUUID, 1); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
 	// Create the application addition operations.
 	appDoc := &remoteApplicationDoc{
 		DocID:                applicationID,
 		Name:                 args.Name,
-		OfferUUID:            args.OfferUUID,
 		SourceControllerUUID: args.ExternalControllerUUID,
 		SourceModelUUID:      args.SourceModel.Id(),
 		URL:                  args.URL,
 		Bindings:             args.Bindings,
 		Life:                 Alive,
 		IsConsumerProxy:      args.IsConsumerProxy,
-		Version:              version,
+		Version:              args.ConsumeVersion,
 		Macaroon:             macJSON,
+	}
+	if !args.IsConsumerProxy {
+		if appDoc.Version, err = sequenceWithMin(st, args.OfferUUID, 1); err != nil {
+			return nil, errors.Trace(err)
+		}
+		appDoc.OfferUUID = args.OfferUUID
 	}
 	eps := make([]remoteEndpointDoc, len(args.Endpoints))
 	for i, ep := range args.Endpoints {
@@ -1067,23 +1066,6 @@ func (st *State) RemoteApplication(name string) (_ *RemoteApplication, err error
 		return nil, errors.Annotatef(err, "cannot get saas application %q", name)
 	}
 	return newRemoteApplication(st, appDoc), nil
-}
-
-// RemoteApplicationsByOffer returns remote applications state by offer uuid.
-func (st *State) RemoteApplicationsByOffer(offerUUID string) (_ []*RemoteApplication, err error) {
-	apps, closer := st.db().GetCollection(remoteApplicationsC)
-	defer closer()
-
-	var appDocs []remoteApplicationDoc
-	err = apps.Find(bson.D{{"offer-uuid", offerUUID}}).All(&appDocs)
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get saas applications with offer-uuid %q", offerUUID)
-	}
-	result := make([]*RemoteApplication, len(appDocs))
-	for i, appDoc := range appDocs {
-		result[i] = newRemoteApplication(st, &appDoc)
-	}
-	return result, nil
 }
 
 // AllRemoteApplications returns all the remote applications used by the model.

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -1081,18 +1081,6 @@ func (s *remoteApplicationSuite) TestAllRemoteApplications(c *gc.C) {
 	c.Assert(names[1], gc.Equals, "mysql")
 }
 
-func (s *remoteApplicationSuite) TestAllRemoteApplicationsByOffer(c *gc.C) {
-	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "another", SourceModel: s.Model.ModelTag(), OfferUUID: "another-offer"})
-	c.Assert(err, jc.ErrorIsNil)
-	applications, err := s.State.RemoteApplicationsByOffer("another-offer")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(applications, gc.HasLen, 1)
-
-	c.Assert(applications[0].Name(), gc.Equals, "another")
-	c.Assert(applications[0].OfferUUID(), gc.Equals, "another-offer")
-}
-
 func (s *remoteApplicationSuite) TestAddApplicationModelDying(c *gc.C) {
 	// Check that applications cannot be added if the model is initially Dying.
 	model, err := s.State.Model()

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5630,9 +5630,13 @@ func (s *upgradesSuite) TestRemoveOrphanedCrossModelProxies(c *gc.C) {
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Name:      "server",
-			Role:      charm.RoleProvider,
+			Role:      charm.RoleRequirer,
 			Scope:     charm.ScopeGlobal,
 		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	eps, err := s.state.InferEndpoints("good", "test")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.state.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.state.AddRemoteApplication(AddRemoteApplicationParams{


### PR DESCRIPTION
The remote app consumer proxy in the offer model was recording a single offer-uuid attribute. This was being used to associate the app proxy with a single offer. However this is wrong - a remote app proxy can be related to more than one offer, as determined by the relations from the proxy to the offer side application.

This PR changes things so that the offer-uuid is only recorded on the consumer side remote app entity (it is needed there to create the macaroon). On the offering side, the relations are used to navigate the associate between the remote app proxy and the offer and offered application. This logic is used in the offer removal workflow and an upgrade step to detect orphaned remote app proxies.

## QA steps

create a cross model relation between juju-qa-dummy-source and juju-qa-dummy-sink

```
$ juju remove-offer dummy-source
ERROR cannot delete application offer "dummy-source": offer has 1 relation

$ juju remove-offer dummy-source --force
WARNING! This command will remove offers: admin/o.dummy-source
This includes all relations to those offers.

Continue [y/N]? y
```

juju status and juju offers will show that the offer and offer connections are now gone.

## Bug reference

https://bugs.launchpad.net/bugs/2012583
