### PR TITLE
[JUJU-3796] Backport spaces_ec2 fixes

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -14,8 +14,9 @@ run_juju_bind() {
 	# test name so the NIC ID is actually provided in $2
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
+
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -14,8 +14,9 @@ run_upgrade_charm_with_bind() {
 	# test name so the NIC ID is actually provided in $2
 	hotplug_nic_id=$2
 	add_multi_nic_machine "$hotplug_nic_id"
+
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("ens"))')
+	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
 	configure_multi_nic_netplan "$juju_machine_id" "$hotplug_iface"

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -44,7 +44,7 @@ configure_multi_nic_netplan() {
 	echo "[+] Reconfiguring netplan:"
 	juju ssh ${juju_machine_id} 'sudo cat /etc/netplan/50-cloud-init.yaml'
 	# shellcheck disable=SC2086,SC2016
-	juju ssh ${juju_machine_id} 'sudo netplan apply'
+	juju ssh ${juju_machine_id} 'sudo netplan apply' || true
 	echo "[+] Applied"
 	# shellcheck disable=SC2086,SC2016
 	juju ssh ${juju_machine_id} 'sudo systemctl restart jujud-machine-*'


### PR DESCRIPTION
Backports https://github.com/juju/juju/pull/15524 and https://github.com/juju/juju/pull/15595

Sometimes when we netplan apply over ssh, the session is terminated which leads to a false positive test result

If the ssh command returns non-zero error code, ignore it and continue. If it's a legitimate failure, we will fail later down the line anyway

Also

On spaces_ec2 tests, we first add a new nic for the current juju machine, then we get it's ID from ip link and then we patch the netplan config with this new NIC id and restart the machine. This causes the test to fail sometimes because we get the NIC id before it's UP and not shown in ip link.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -R eu-west-2 spaces_ec2
```

