### PR TITLE
[JUJU-3812] Fix controller credentials

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -290,7 +290,7 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
 	fi
 
-	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	echo "====> BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 
 # post_bootstrap contains actions required after bootstrap specific to providers

--- a/tests/suites/credential/controller_credentials.sh
+++ b/tests/suites/credential/controller_credentials.sh
@@ -3,16 +3,16 @@ run_controller_credentials() {
 
 	juju show-cloud --controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}" aws 2>/dev/null || juju add-cloud --controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}" aws --force
 	juju add-credential aws -f "./tests/suites/credential/credentials-data/fake-credentials.yaml" --controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	OUT=$(juju credentials --controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}" --format=json 2>/dev/null | jq '.[] ."my-ec2"')
+	OUT=$(juju credentials --controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}" --format=json 2>/dev/null | jq '.[] | .aws')
 
 	EXPECTED=$(
 		cat <<'EOF'
 {
   "cloud-credentials": {
-    "mine": {
+    "fake-credential-name": {
       "auth-type": "access-key",
       "details": {
-        "access-key": "my-key"
+        "access-key": "fake-access-key"
       }
     }
   }
@@ -25,16 +25,16 @@ EOF
 		exit 1
 	fi
 
-	OUT=$(juju credentials --controller ${BOOTSTRAPPED_JUJU_CTRL_NAME} --show-secrets --format=json 2>/dev/null | jq '.[] ."my-ec2"')
+	OUT=$(juju credentials --controller ${BOOTSTRAPPED_JUJU_CTRL_NAME} --show-secrets --format=json 2>/dev/null | jq '.[] | .aws')
 	EXPECTED=$(
 		cat <<'EOF'
 {
   "cloud-credentials": {
-    "mine": {
+    "fake-credential-name": {
       "auth-type": "access-key",
       "details": {
-        "access-key": "my-key",
-        "secret-key": "my-secret"
+        "access-key": "fake-access-key",
+        "secret-key": "fake-secret-key"
       }
     }
   }


### PR DESCRIPTION
The following fixes the controller credentials integration tests. This was as an easy fix as they were just using the wrong names for look-up.

As a driveby, I moved the ADDITIONAL_ARGS logging to the right location in the output.


## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

```sh
cd tests && ./main.sh credential
```
