### PR TITLE
[JUJU-3821] Fixed test-deploy-aks-charms

### DIFF
--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -7,27 +7,17 @@ run_deploy_aks_charms() {
 	juju add-model "test-deploy-aks-charms"
 
 	echo "Deploy some charms"
-	juju deploy postgresql-k8s --channel 14/stable
-	#	Current Mattermost charm will crash (container crash) if related to new postgres charm (from edge)
-	#
-	# That is because new psql does not have TLS built-in. Fix is simple, integrate psql with certificates charm.
-	# However, MM should not have container crash but go to the blocked state with clear error message to a user until TLS is available.
-	# Thx to https://bugs.launchpad.net/charm-k8s-mattermost/+bug/1997540
-	juju deploy mattermost-k8s
-	juju deploy tls-certificates-operator --channel=edge
-	juju config tls-certificates-operator generate-self-signed-certificates="true" ca-common-name="Test CA"
+	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-source
 
-	juju relate postgresql-k8s tls-certificates-operator
-	# For postgresql-k8s the "db" interface needs to be specified as the charm provides more than one
-	juju relate mattermost-k8s postgresql-k8s:db
+	juju relate dummy-sink dummy-source
 
-	wait_for "tls-certificates-operator" "$(idle_condition "tls-certificates-operator" 2)"
-	wait_for "postgresql-k8s" "$(idle_condition "postgresql-k8s" 1)"
-	wait_for "mattermost-k8s" "$(idle_condition "mattermost-k8s" 0)"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0)"
+	wait_for "dummy-source" "$(idle_condition "dummy-source" 1)"
 
-	echo "Verify application is reachable"
-	mattermost_ip="$(juju status --format json | jq -r '.applications["mattermost-k8s"].units["mattermost-k8s/0"].address')"
-	curl "${mattermost_ip}:8065/api/v4/system/ping" >/dev/null
+	echo "Verify application"
+	juju config dummy-source token=yeah-boi
+	wait_for "yeah-boi" "$(workload_status "dummy-sink" 0).message"
 
 	echo "Destroy model"
 	juju destroy-model "test-deploy-aks-charms" --destroy-storage -y

--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -7,17 +7,27 @@ run_deploy_aks_charms() {
 	juju add-model "test-deploy-aks-charms"
 
 	echo "Deploy some charms"
-	juju deploy postgresql-k8s
+	juju deploy postgresql-k8s --channel 14/stable
+	#	Current Mattermost charm will crash (container crash) if related to new postgres charm (from edge)
+	#
+	# That is because new psql does not have TLS built-in. Fix is simple, integrate psql with certificates charm.
+	# However, MM should not have container crash but go to the blocked state with clear error message to a user until TLS is available.
+	# Thx to https://bugs.launchpad.net/charm-k8s-mattermost/+bug/1997540
 	juju deploy mattermost-k8s
+	juju deploy tls-certificates-operator --channel=edge
+	juju config tls-certificates-operator generate-self-signed-certificates="true" ca-common-name="Test CA"
+
+	juju relate postgresql-k8s tls-certificates-operator
+	# For postgresql-k8s the "db" interface needs to be specified as the charm provides more than one
 	juju relate mattermost-k8s postgresql-k8s:db
 
+	wait_for "tls-certificates-operator" "$(idle_condition "tls-certificates-operator" 2)"
 	wait_for "postgresql-k8s" "$(idle_condition "postgresql-k8s" 1)"
 	wait_for "mattermost-k8s" "$(idle_condition "mattermost-k8s" 0)"
 
-	# TODO(anvial): we can return this check after fixing issue with flapping connection by curl in aks environment.
-	#	echo "Verify application is reachable"
-	#	mattermost_ip="$(juju status --format json | jq -r '.applications["mattermost-k8s"].units["mattermost-k8s/0"].address')"
-	#	juju run --unit mattermost-k8s/0 curl "${mattermost_ip}:8065"
+	echo "Verify application is reachable"
+	mattermost_ip="$(juju status --format json | jq -r '.applications["mattermost-k8s"].units["mattermost-k8s/0"].address')"
+	curl "${mattermost_ip}:8065/api/v4/system/ping" >/dev/null
 
 	echo "Destroy model"
 	juju destroy-model "test-deploy-aks-charms" --destroy-storage -y


### PR DESCRIPTION
This PR adds `tls-certificates-operator` to fix mattermot-k8s. 

That is because new psql does not have TLS built-in. Fix is simple, integrate psql with certificates charm. However, MM should not have container crash but go to the blocked state with clear error message to a user until TLS is available. 

Thx to https://bugs.launchpad.net/charm-k8s-mattermost/+bug/1997540

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v deploy_aks run_deploy_aks
```

## Documentation changes

nope

## Bug reference

nope
