### PR TITLE
[JUJU-3827] Fix user removal integration test

### DIFF
--- a/tests/suites/user/manage.sh
+++ b/tests/suites/user/manage.sh
@@ -119,6 +119,8 @@ run_user_remove() {
 
 	echo "Add testuser2"
 	juju show-user testuser2 2>/dev/null || juju add-user testuser2
+
+	users=$(juju users)
 	check_contains "${users}" testuser2
 
 	echo "Remove testuser2"


### PR DESCRIPTION
This fixes a simple assignment that was missing prior to checking a value in the user integration test suite.

Adding it corrects the test composition and it now passes.

## QA steps

`(cd tests && ./main.sh -v user)`
