### PR TITLE
[JUJU-3811] Fix test-agents-multijob

### DIFF
--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -7,8 +7,8 @@ run_charmstore_charmrevisionupdater() {
 
 	ensure "${model_name}" "${file}"
 
-	# Deploy an old revision of mysql
-	juju deploy cs:postgresql-230 --series focal
+	# Deploy an old revision of postgresql
+	juju deploy cs:postgresql-288 --series jammy
 
 	# Wait for revision update worker to update the available revision.
 	wait_for "cs:postgresql-" '.applications["postgresql"] | ."can-upgrade-to"'


### PR DESCRIPTION
The previous version of the postgresql charm was failing due to some missing resource in the charm. As displayed in the CI:

```
| Located charm "postgresql" in charm-store, revision 230
| ERROR cs:postgresql-230 resource "wal-e": bad metadata: resource missing filename
```

 I've just changed the revision for the `charmstore_charmrevisionupdater` test. 

## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

Run manual QA steps. The QA may take a while

```sh
cd tests
./main.sh -v -p lxd agents
```
