### PR TITLE
[JUJU-3819] Fix run_charmstore_charmrevisionupdater test

### DIFF
--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -8,10 +8,10 @@ run_charmstore_charmrevisionupdater() {
 	ensure "${model_name}" "${file}"
 
 	# Deploy an old revision of postgresql
-	juju deploy cs:postgresql-288 --series jammy
+	juju deploy cs:jameinel-ubuntu-lite-9
 
 	# Wait for revision update worker to update the available revision.
-	wait_for "cs:postgresql-" '.applications["postgresql"] | ."can-upgrade-to"'
+	wait_for "cs:jameinel-ubuntu-lite-" '.applications["ubuntu-lite"] | ."can-upgrade-to"'
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
Unfortunately #15638 didn't fix the agents tests, as 288 is (currently) the latest revision of `postgresql`.

Time to replace `postgresql` with a stable charm that is under our control (I chose `jameinel-ubuntu-lite`).

## QA steps

These tests must be run on a fresh controller to pass, as they change the charm revision update period.

```sh
cd tests
./main.sh -v agents
```