### PR TITLE
[JUJU-3834] Added controller config schema

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -11,6 +11,7 @@ func ControllerDDL() []string {
 		cloudSchema,
 		externalControllerSchema,
 		modelListSchema,
+		controllerConfigSchema,
 	}
 
 	var deltas []string
@@ -277,5 +278,32 @@ func modelListSchema() string {
 CREATE TABLE model_list (
     uuid    TEXT PRIMARY KEY
 );
+`[1:]
+}
+
+func controllerConfigSchema() string {
+	return `
+CREATE TABLE controller_config (
+    key     TEXT PRIMARY KEY
+    value   TEXT
+);
+CREATE TRIGGER trg_log_controller_config_insert
+AFTER INSERT ON controller_config FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    VALUES (1, 1, NEW.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_controller_config_update
+AFTER UPDATE ON controller_config FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    VALUES (2, 1, OLD.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_controller_config_delete
+AFTER DELETE ON controller_config FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    VALUES (4, 1, OLD.key, DATETIME('now'));
+END;
 `[1:]
 }

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -287,6 +287,7 @@ CREATE TABLE controller_config (
     key     TEXT PRIMARY KEY,
     value   TEXT
 );
+
 CREATE TRIGGER trg_log_controller_config_insert
 AFTER INSERT ON controller_config FOR EACH ROW
 BEGIN

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -290,19 +290,19 @@ CREATE TABLE controller_config (
 CREATE TRIGGER trg_log_controller_config_insert
 AFTER INSERT ON controller_config FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
     VALUES (1, 1, NEW.key, DATETIME('now'));
 END;
 CREATE TRIGGER trg_log_controller_config_update
 AFTER UPDATE ON controller_config FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
     VALUES (2, 1, OLD.key, DATETIME('now'));
 END;
 CREATE TRIGGER trg_log_controller_config_delete
 AFTER DELETE ON controller_config FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_identifier, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
     VALUES (4, 1, OLD.key, DATETIME('now'));
 END;
 `[1:]

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -284,7 +284,7 @@ CREATE TABLE model_list (
 func controllerConfigSchema() string {
 	return `
 CREATE TABLE controller_config (
-    key     TEXT PRIMARY KEY
+    key     TEXT PRIMARY KEY,
     value   TEXT
 );
 CREATE TRIGGER trg_log_controller_config_insert

--- a/domain/schema/controller_test.go
+++ b/domain/schema/controller_test.go
@@ -77,6 +77,9 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 
 		// Model list
 		"model_list",
+
+		// Controller config
+		"controller_config",
 	)
 	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This PR introduces the controller config database schema, including the necessary table, columns and triggers to support the storage and management of controller configurations. 


## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd domain/schema
go test -check.f schemaSuite
```

## Documentation changes

None

## Bug reference

None