### PR TITLE
[JUJU-3793] Add single entity base NotifyWatcher

### DIFF
--- a/core/watcher/eventqueue/key.go
+++ b/core/watcher/eventqueue/key.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package eventqueue
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/watcher"
+)
+
+// KeyWatcher watches for changes to single database table row.
+// Any time the identified row changes, a notification is emitted.
+type KeyWatcher struct {
+	*BaseWatcher
+
+	out       chan struct{}
+	tableName string
+	keyValue  string
+}
+
+// NewKeyWatcher returns a new watcher that receives changes from the input
+// base watcher's db/queue when a specific database table row changes.
+func NewKeyWatcher(base *BaseWatcher, tableName string, keyValue string) *KeyWatcher {
+	w := &KeyWatcher{
+		BaseWatcher: base,
+		out:         make(chan struct{}),
+		tableName:   tableName,
+		keyValue:    keyValue,
+	}
+
+	w.tomb.Go(w.loop)
+	return w
+}
+
+// Changes returns the channel on which notifications
+// are sent when the watched database row changes.
+func (w *KeyWatcher) Changes() watcher.NotifyChannel {
+	return w.out
+}
+
+func (w *KeyWatcher) loop() error {
+	opt := changestream.FilteredNamespace(w.tableName, changestream.All, func(e changestream.ChangeEvent) bool {
+		return e.ChangedUUID() == w.keyValue
+	})
+	subscription, err := w.eventQueue.Subscribe(opt)
+	if err != nil {
+		return errors.Annotatef(err, "subscribing to entity %q in namespace %q", w.keyValue, w.tableName)
+	}
+	defer subscription.Unsubscribe()
+
+	// By reassigning the in and out channels, we effectively ticktock between
+	// read mode and dispatch mode. This ensures we always dispatch
+	// notifications for changes we received before reading more, and every
+	// channel read/write is guarded by checks of the tomb and subscription
+	// liveness.
+	// We begin in dispatch mode in order to send the initial notification.
+	var in <-chan []changestream.ChangeEvent
+	out := w.out
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-subscription.Done():
+			return ErrSubscriptionClosed
+		case _, ok := <-in:
+			if !ok {
+				w.logger.Debugf("change channel closed for %q; terminating watcher for %q", w.tableName, w.keyValue)
+				return nil
+			}
+
+			// We have changes. Tick over to dispatch mode.
+			in = nil
+			out = w.out
+		case out <- struct{}{}:
+			// We have dispatched. Tick over to read mode.
+			in = subscription.Changes()
+			out = nil
+		}
+	}
+}
+
+// Kill (worker.Worker) kills the watcher via its tomb.
+func (w *KeyWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait (worker.Worker) waits for the watcher's tomb to die,
+// and returns the error with which it was killed.
+func (w *KeyWatcher) Wait() error {
+	return w.tomb.Wait()
+}

--- a/core/watcher/eventqueue/key_test.go
+++ b/core/watcher/eventqueue/key_test.go
@@ -1,0 +1,101 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package eventqueue
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/testing"
+)
+
+var _ watcher.NotifyWatcher = &KeyWatcher{}
+
+type keySuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&keySuite{})
+
+func (s *keysSuite) TestNotificationsSent(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+
+	// We go through the worker loop 4 times:
+	// - Dispatch initial notification.
+	// - Read deltas.
+	// - Dispatch notification.
+	// - Pick up tomb.Dying()
+	done := make(chan struct{})
+	subExp.Done().Return(done).Times(4)
+
+	// Tick-tock-tick-tock. 2 assignments of the in channel.
+	deltas := make(chan []changestream.ChangeEvent)
+	subExp.Changes().Return(deltas).Times(2)
+
+	subExp.Unsubscribe()
+
+	s.queue.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewKeyWatcher(s.newBaseWatcher(), "random_namespace", "key_value")
+	defer workertest.DirtyKill(c, w)
+
+	// Initial notification.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	// Simulate an incoming change from the stream.
+	select {
+	case deltas <- []changestream.ChangeEvent{changeEvent{
+		changeType: 0,
+		namespace:  "random_namespace",
+		uuid:       "some-key-value",
+	}}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out dispatching change event")
+	}
+
+	// Notification for change.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *keySuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+
+	done := make(chan struct{})
+	close(done)
+	subExp.Done().Return(done)
+
+	subExp.Unsubscribe()
+
+	s.queue.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewKeyWatcher(s.newBaseWatcher(), "random_namespace", "key_value")
+	defer workertest.DirtyKill(c, w)
+
+	err := workertest.CheckKilled(c, w)
+	c.Check(errors.Is(err, ErrSubscriptionClosed), jc.IsTrue)
+}

--- a/core/watcher/eventqueue/keys_test.go
+++ b/core/watcher/eventqueue/keys_test.go
@@ -162,21 +162,3 @@ func (s *keysSuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
 	err := workertest.CheckKilled(c, w)
 	c.Check(errors.Is(err, ErrSubscriptionClosed), jc.IsTrue)
 }
-
-type changeEvent struct {
-	changeType changestream.ChangeType
-	namespace  string
-	uuid       string
-}
-
-func (e changeEvent) Type() changestream.ChangeType {
-	return e.changeType
-}
-
-func (e changeEvent) Namespace() string {
-	return e.namespace
-}
-
-func (e changeEvent) ChangedUUID() string {
-	return e.uuid
-}

--- a/core/watcher/eventqueue/package_test.go
+++ b/core/watcher/eventqueue/package_test.go
@@ -65,3 +65,21 @@ func (m subscriptionOptionMatcher) Matches(arg interface{}) bool {
 func (m subscriptionOptionMatcher) String() string {
 	return fmt.Sprintf("%s %d", m.opt.Namespace(), m.opt.ChangeMask())
 }
+
+type changeEvent struct {
+	changeType changestream.ChangeType
+	namespace  string
+	uuid       string
+}
+
+func (e changeEvent) Type() changestream.ChangeType {
+	return e.changeType
+}
+
+func (e changeEvent) Namespace() string {
+	return e.namespace
+}
+
+func (e changeEvent) ChangedUUID() string {
+	return e.uuid
+}


### PR DESCRIPTION
This adds the base watcher that will be recruited to watch a single entity in a name-space (table).

It implements the `NotifyWatcher` indirection from _core/watcher_

## QA steps

Accompanying tests base. QA steps will follow with patches that build specific watchers on this base.
