### PR TITLE
[JUJU-3830] Use juju-qa-test rather than postgres

### DIFF
--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,12 +6,12 @@ test_log_permissions() {
 	file="${TEST_DIR}/test_log_permissions.log"
 	ensure "correct-log" "${file}"
 
-	juju deploy postgresql --series focal
+	juju deploy juju-qa-test source --series focal
 
 	wait_for "started" '.machines."0"."juju-status".current'
 
-	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/unit-postgresql-0.log)" adm
-	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/unit-postgresql-0.log)" 640
+	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/unit-source-0.log)" adm
+	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/unit-source-0.log)" 640
 
 	check_contains "$(juju ssh 0 -- stat -c '%a' /var/log/juju/machine-0.log)" 640
 	check_contains "$(juju ssh 0 -- stat -c '%G' /var/log/juju/machine-0.log)" adm


### PR DESCRIPTION
If we're using postgres charm it prevents us from tearing down because of storage issues. This test doesn't need to use postgres, we should just use a simpler charm for now.


## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

```sh
$ cd tests && ./main.sh machine
```
