### PR TITLE
[JUJU-3838] Fix missing assingment on user remove integration test

### DIFF
--- a/tests/suites/user/manage.sh
+++ b/tests/suites/user/manage.sh
@@ -119,6 +119,7 @@ run_user_remove() {
 
 	echo "Add testuser2"
 	juju show-user testuser2 2>/dev/null || juju add-user testuser2
+	users=$(juju users)
 	check_contains "${users}" testuser2
 
 	echo "Remove testuser2"


### PR DESCRIPTION
The run_user_remove() test was checking for the content of the users variable but the variable was not being set. This patch fixes the test.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v user test_user_manage  
```
