### PR TITLE
Replace deprecated yq -j flag with -o=j

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -134,9 +134,9 @@ bootstrap() {
 
 		add_model "${model}" "${cloud}" "${bootstrapped_name}" "${output}"
 		name="${bootstrapped_name}"
-		BOOTSTRAPPED_CLOUD=$(juju show-model controller | yq -j | jq -r '.[] | .cloud')
+		BOOTSTRAPPED_CLOUD=$(juju show-model controller | yq -o=j | jq -r '.[] | .cloud')
 		export BOOTSTRAPPED_CLOUD
-		BOOTSTRAPPED_CLOUD_REGION=$(juju show-model controller | yq -j | jq -r '.[] | (.cloud + "/" + .region)')
+		BOOTSTRAPPED_CLOUD_REGION=$(juju show-model controller | yq -o=j | jq -r '.[] | (.cloud + "/" + .region)')
 		export BOOTSTRAPPED_CLOUD_REGION
 	else
 		local cloud_region

--- a/tests/suites/cli/display_clouds.sh
+++ b/tests/suites/cli/display_clouds.sh
@@ -82,7 +82,7 @@ EOF
 	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju clouds --client --format=json 2>/dev/null | jq -S 'with_entries(select(
 	                                                  .value.defined != "built-in")) | with_entries((select(.value.defined == "local")
 	                                                  | del(.value.defined) |  del(.value.description)))')
-	EXPECTED=$(echo "${CLOUDS}" | yq -j | jq -S '.[] | del(.clouds) | .[] |= ({endpoint} as $endpoint | .[] |= walk(
+	EXPECTED=$(echo "${CLOUDS}" | yq -o=j | jq -S '.[] | del(.clouds) | .[] |= ({endpoint} as $endpoint | .[] |= walk(
                                                   (objects | select(contains($endpoint))) |= del(.endpoint)
                                                 ))')
 	if [ "${CLOUD_LIST}" != "${EXPECTED}" ]; then
@@ -90,7 +90,7 @@ EOF
 		exit 1
 	fi
 
-	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format yaml --client 2>/dev/null | yq -j | jq -S 'with_entries((select(.value!= null)))')
+	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format yaml --client 2>/dev/null | yq -o=j | jq -S 'with_entries((select(.value!= null)))')
 	EXPECTED=$(
 		cat <<'EOF' | jq -S
 	{

--- a/tests/suites/metrics/metrics.sh
+++ b/tests/suites/metrics/metrics.sh
@@ -13,7 +13,7 @@ run_smoke_test() {
 
 	attempt=0
 	while true; do
-		OUT=$(juju metrics metered/0 --format yaml | yq -j | jq -r '.[]')
+		OUT=$(juju metrics metered/0 --format yaml | yq -o=j | jq -r '.[]')
 		if [[ -n ${OUT} ]]; then
 			break
 		fi


### PR DESCRIPTION
Should stop this warning from appearing in CI:
Flag --tojson has been deprecated, please use -o=json instead

*`-j` is an alias for `--tojson`, and `-o=j` is an alias for `-o=json`.*