### PR TITLE
[bash tests] print controller teardown logs

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -401,9 +401,9 @@ destroy_controller() {
 
 	echo "====> Destroying juju ($(green "${name}"))"
 	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
-		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % 2>&1 | OUTPUT "${output}"
 	else
-		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % >"${output}" 2>&1
+		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % 2>&1 | OUTPUT "${output}"
 	fi
 
 	set +e


### PR DESCRIPTION
When run in verbose mode (`-v` flag), the Bash testing harness will now print controller teardown logs to stdout. Do this using the built-in `OUTPUT` utility function.

We are having intermittent teardown failures in many tests. This should help us diagnose the issue(s).

## QA steps

Run a test suite but skip all tests, so we can just check bootstrap and teardown.

In verbose mode, controller teardown logs are emitted:
```console
$ ./main.sh -v -s test_charmrevisionupdater agents
...
====> Destroying juju (ctrl-0ltmoxoh)

    | Destroying controller
    | Waiting for hosted model resources to be reclaimed
    | Waiting for 1 model
    | All hosted models reclaimed, cleaning up controller machines

====> Destroyed juju (ctrl-0ltmoxoh)
...
```

In non-verbose mode, they are hidden, as before.
```console
$ ./main.sh -s test_charmrevisionupdater agents
...
====> Destroying juju (ctrl-ih74p7fe)
====> Destroyed juju (ctrl-ih74p7fe)
...
```