### PR TITLE
[JUJU-3783] Modify KeysWatcher to accept change type 

### DIFF
--- a/core/changestream/subscription.go
+++ b/core/changestream/subscription.go
@@ -3,6 +3,10 @@
 
 package changestream
 
+import (
+	"fmt"
+)
+
 // Subscription describes the ability to receive events
 // from the event queue and unsubscribe from the queue.
 type Subscription interface {
@@ -43,6 +47,9 @@ func (o SubscriptionOption) Filter() func(ChangeEvent) bool {
 // Namespace returns a SubscriptionOption that will subscribe to the given
 // namespace.
 func Namespace(namespace string, changeMask ChangeType) SubscriptionOption {
+	if changeMask == 0 {
+		panic(fmt.Errorf("unexpected changeMask value: 0"))
+	}
 	return SubscriptionOption{
 		namespace:  namespace,
 		changeMask: changeMask,

--- a/core/watcher/eventsource/keys_test.go
+++ b/core/watcher/eventsource/keys_test.go
@@ -62,7 +62,7 @@ func (s *keysSuite) TestInitialStateSent(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	w := NewKeysWatcher(s.newBaseWatcher(), "random_namespace", "key_name")
+	w := NewKeysWatcher(s.newBaseWatcher(), changestream.All, "random_namespace", "key_name")
 	defer workertest.DirtyKill(c, w)
 
 	select {
@@ -104,7 +104,7 @@ func (s *keysSuite) TestDeltasSent(c *gc.C) {
 		)},
 	).Return(s.sub, nil)
 
-	w := NewUUIDsWatcher(s.newBaseWatcher(), "external_controller")
+	w := NewUUIDsWatcher(s.newBaseWatcher(), changestream.All, "external_controller")
 	defer workertest.DirtyKill(c, w)
 
 	// No initial data.
@@ -156,9 +156,17 @@ func (s *keysSuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
 		)},
 	).Return(s.sub, nil)
 
-	w := NewUUIDsWatcher(s.newBaseWatcher(), "external_controller")
+	w := NewUUIDsWatcher(s.newBaseWatcher(), changestream.All, "external_controller")
 	defer workertest.DirtyKill(c, w)
 
 	err := workertest.CheckKilled(c, w)
 	c.Check(errors.Is(err, ErrSubscriptionClosed), jc.IsTrue)
+}
+
+func (s *keysSuite) TestInvalidChangeMask(c *gc.C) {
+	w := NewUUIDsWatcher(s.newBaseWatcher(), 0, "external_controller")
+	defer workertest.DirtyKill(c, w)
+
+	err := workertest.CheckKilled(c, w)
+	c.Assert(err, gc.ErrorMatches, "changeMask value: 0 not valid")
 }


### PR DESCRIPTION
This patch updates the `KeysWatcher` such that it takes the `changestream.ChangeType` as argument instead of having `changestream.All` hard-coded.
We needed this because the ExternalControllers domain needs to watch creations and updates.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~
