### PR TITLE
[JUJU-3847] Add sqlair package

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -708,7 +708,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// The lease expiry worker constantly deletes
 		// leases with an expiry time in the past.
-		leaseExpiryName: ifController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
+		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			ClockName:      clockName,
 			DBAccessorName: dbAccessorName,
 			Logger:         loggo.GetLogger("juju.worker.leaseexpiry"),

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -285,7 +285,6 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"certificate-watcher",
 		"audit-config-updater",
 		"is-primary-controller-flag",
-		"lease-expiry",
 		"lease-manager",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
@@ -299,6 +298,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 	// Explicitly guarded by ifPrimaryController.
 	primaryControllerWorkers := set.NewStrings(
 		"external-controller-updater",
+		"lease-expiry",
 		"secret-backend-rotate",
 	)
 
@@ -665,9 +665,12 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"lease-expiry": {
 		"agent",
+		"api-caller",
+		"api-config-watcher",
 		"clock",
 		"db-accessor",
 		"is-controller-flag",
+		"is-primary-controller-flag",
 		"query-logger",
 		"state-config-watcher",
 	},
@@ -1165,9 +1168,12 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"lease-expiry": {
 		"agent",
+		"api-caller",
+		"api-config-watcher",
 		"clock",
 		"db-accessor",
 		"is-controller-flag",
+		"is-primary-controller-flag",
 		"query-logger",
 		"state-config-watcher",
 	},

--- a/core/database/trackeddb.go
+++ b/core/database/trackeddb.go
@@ -6,15 +6,25 @@ package database
 import (
 	"context"
 	"database/sql"
+
+	"github.com/canonical/sqlair"
 )
 
 // TrackedDB defines an interface for keeping track of sql.DB. This is useful
 // knowing if the underlying DB can be reused after an error has occurred.
 type TrackedDB interface {
-	// Txn executes the input function against the tracked database,
+	// Txn executes the input function against the tracked database, using
+	// the sqlair package. The sqlair package provides a mapping library for
+	// SQL queries and statements.
+	// Retry semantics are applied automatically based on transient failures.
+	// This is the function that almost all downstream database consumers
+	// should use.
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+
+	// StdTxn executes the input function against the tracked database,
 	// within a transaction that depends on the input context.
 	// Retry semantics are applied automatically based on transient failures.
 	// This is the function that almost all downstream database consumers
 	// should use.
-	Txn(context.Context, func(context.Context, *sql.Tx) error) error
+	StdTxn(context.Context, func(context.Context, *sql.Tx) error) error
 }

--- a/core/database/trackeddb.go
+++ b/core/database/trackeddb.go
@@ -17,9 +17,4 @@ type TrackedDB interface {
 	// This is the function that almost all downstream database consumers
 	// should use.
 	Txn(context.Context, func(context.Context, *sql.Tx) error) error
-
-	// TxnNoRetry executes the input function against the tracked database,
-	// within a transaction that depends on the input context.
-	// No retries are attempted.
-	TxnNoRetry(context.Context, func(context.Context, *sql.Tx) error) error
 }

--- a/core/watcher/eventqueue/interface.go
+++ b/core/watcher/eventqueue/interface.go
@@ -4,18 +4,12 @@
 package eventqueue
 
 import (
-	"context"
-	"database/sql"
-
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 )
 
 // TrackedDB describes the ability to run database transactions.
-type TrackedDB interface {
-	// Txn runs the input function in a new transaction, guarded with
-	// the input context, and using a default retry strategy.
-	Txn(context.Context, func(context.Context, *sql.Tx) error) error
-}
+type TrackedDB = database.TrackedDB
 
 // EventQueue describes the ability to subscribe
 // to a subset of events from a change stream.

--- a/core/watcher/eventqueue/keys.go
+++ b/core/watcher/eventqueue/keys.go
@@ -111,7 +111,7 @@ func (w *KeysWatcher) getInitialState() ([]string, error) {
 	defer cancel()
 
 	var keys []string
-	err := w.db.Txn(w.tomb.Context(parentCtx), func(ctx context.Context, tx *sql.Tx) error {
+	err := w.db.StdTxn(w.tomb.Context(parentCtx), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, w.selectAll)
 		if err != nil {
 			if err == sql.ErrNoRows {

--- a/core/watcher/eventqueue/keys_test.go
+++ b/core/watcher/eventqueue/keys_test.go
@@ -52,7 +52,7 @@ func (s *keysSuite) TestInitialStateSent(c *gc.C) {
 
 	// The EventQueue is mocked, but we use a real Sqlite DB from which the
 	// initial state is read. Insert some data to verify.
-	err := s.TrackedDB().TxnNoRetry(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TrackedDB().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, "CREATE TABLE random_namespace (key_name TEXT PRIMARY KEY)"); err != nil {
 			return err
 		}

--- a/database/testing/fullsuite.go
+++ b/database/testing/fullsuite.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -76,7 +77,7 @@ func (s *DBSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.trackedDB = &trackedDB{
-		db: s.db,
+		db: sqlair.NewDB(s.db),
 	}
 }
 

--- a/database/testing/simplesuite.go
+++ b/database/testing/simplesuite.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	_ "github.com/mattn/go-sqlite3"
@@ -36,7 +37,7 @@ func (s *ControllerSuite) SetUpTest(c *gc.C) {
 	s.db = s.NewCleanDB(c)
 
 	s.trackedDB = &trackedDB{
-		db: s.db,
+		db: sqlair.NewDB(s.db),
 	}
 
 	s.ApplyControllerDDL(c, s.db)

--- a/database/testing/trackeddb.go
+++ b/database/testing/trackeddb.go
@@ -22,11 +22,8 @@ type trackedDB struct {
 
 func (t *trackedDB) Txn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	return defaultTransactionRunner.Retry(ctx, func() error {
-		return errors.Trace(t.TxnNoRetry(ctx, fn))
+		return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 	})
-}
-func (t *trackedDB) TxnNoRetry(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 }
 
 // TrackedDBFactory returns a DBFactory that returns the given database.

--- a/database/txn.go
+++ b/database/txn.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/juju/database/txn"
 )
 
@@ -14,15 +15,28 @@ var (
 	defaultTransactionRunner = txn.NewTransactionRunner()
 )
 
-// Txn defines a generic txn function for applying transactions on a given
+// Txn executes the input function against the tracked database, using
+// the sqlair package. The sqlair package provides a mapping library for
+// SQL queries and statements.
+// Retry semantics are applied automatically based on transient failures.
+// This is the function that almost all downstream database consumers
+// should use.
+//
+// This should not be used directly, instead the TrackedDB should be used to
+// handle transactions.
+func Txn(ctx context.Context, db *sqlair.DB, fn func(context.Context, *sqlair.TX) error) error {
+	return defaultTransactionRunner.Txn(ctx, db, fn)
+}
+
+// StdTxn defines a generic txn function for applying transactions on a given
 // database. It expects that no individual transaction function should take
 // longer than the default timeout.
 // There are no retry semantics for running the function.
 //
 // This should not be used directly, instead the TrackedDB should be used to
 // handle transactions.
-func Txn(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) error) error {
-	return defaultTransactionRunner.Txn(ctx, db, fn)
+func StdTxn(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) error) error {
+	return defaultTransactionRunner.StdTxn(ctx, db, fn)
 }
 
 // Retry defines a generic retry function for applying transactions on a given

--- a/database/txn/transaction_test.go
+++ b/database/txn/transaction_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&transactionRunnerSuite{})
 func (s *transactionRunnerSuite) TestTxn(c *gc.C) {
 	runner := txn.NewTransactionRunner()
 
-	err := runner.Txn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, "SELECT 1")
 		if err != nil {
 			return errors.Trace(err)
@@ -42,7 +42,7 @@ func (s *transactionRunnerSuite) TestTxnWithCancelledContext(c *gc.C) {
 
 	runner := txn.NewTransactionRunner()
 
-	err := runner.Txn(ctx, s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(ctx, s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		c.Fatal("should not be called")
 		return nil
 	})
@@ -54,7 +54,7 @@ func (s *transactionRunnerSuite) TestTxnInserts(c *gc.C) {
 
 	s.createTable(c)
 
-	err := runner.Txn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "INSERT INTO foo (id, name) VALUES (1, 'test')")
 		if err != nil {
 			return errors.Trace(err)
@@ -82,7 +82,7 @@ func (s *transactionRunnerSuite) TestTxnRollback(c *gc.C) {
 
 	s.createTable(c)
 
-	err := runner.Txn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "INSERT INTO foo (id, name) VALUES (1, 'test')")
 		if err != nil {
 			return errors.Trace(err)

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -41,7 +41,7 @@ func (st *State) UpdateExternalController(ctx context.Context, ci crossmodel.Con
 		return errors.Trace(err)
 	}
 
-	err = db.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		q := `
 INSERT INTO external_controller (uuid, alias, ca_cert)
 VALUES (?, ?, ?)

--- a/domain/modelmanager/state/state.go
+++ b/domain/modelmanager/state/state.go
@@ -35,7 +35,7 @@ func (s *State) Create(ctx context.Context, uuid service.UUID) error {
 		return errors.Trace(err)
 	}
 
-	return db.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
 		result, err := tx.ExecContext(ctx, stmt, uuid)
 		if err != nil {
@@ -59,7 +59,7 @@ func (s *State) Delete(ctx context.Context, uuid service.UUID) error {
 		return errors.Trace(err)
 	}
 
-	return db.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := "DELETE FROM model_list WHERE uuid = ?;"
 		result, err := tx.ExecContext(ctx, stmt, uuid)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,10 @@ require (
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
 	github.com/canonical/go-dqlite v1.11.9
 	github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7
+	github.com/canonical/sqlair v0.0.0-20230523095841-1ae7dd3a8542
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
@@ -164,7 +166,6 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/creack/pty v1.1.15 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dnaeon/go-vcr v1.2.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/canonical/go-dqlite v1.11.9 h1:aO7GG3QohddXsT+C7yEetdRHhhPUWNBKavz+/J
 github.com/canonical/go-dqlite v1.11.9/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7 h1:/L2OgTX7McauPmggZfYNWEu6D/QiPHcNDQ60grftM04=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7/go.mod h1:j3uyWpPkuWf8u0kB2v7n/XGVpYIg4luGetpSngCvzac=
+github.com/canonical/sqlair v0.0.0-20230523095841-1ae7dd3a8542 h1:gxMcSuVtoQp86Uhh1g3mT3BHMJ8XS/6vEd6ZGm+B8IE=
+github.com/canonical/sqlair v0.0.0-20230523095841-1ae7dd3a8542/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 h1:bey1JgA3D2EBabr2a7kWKj+JlEPxX1akv8rcRromotA=
 github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43/go.mod h1:A0/Jvt7qKuCDss37TYRNXSscVyS+tLWM5kBYipQOpWQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -2151,9 +2151,6 @@ type trackedDB struct {
 
 func (t *trackedDB) Txn(ctx stdcontext.Context, fn func(stdcontext.Context, *sql.Tx) error) error {
 	return defaultTransactionRunner.Retry(ctx, func() error {
-		return errors.Trace(t.TxnNoRetry(ctx, fn))
+		return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 	})
-}
-func (t *trackedDB) TxnNoRetry(ctx stdcontext.Context, fn func(stdcontext.Context, *sql.Tx) error) error {
-	return errors.Trace(defaultTransactionRunner.Txn(ctx, t.db, fn))
 }

--- a/worker/changestream/stream/stream.go
+++ b/worker/changestream/stream/stream.go
@@ -277,7 +277,7 @@ func (s *Stream) readChanges() ([]changeEvent, error) {
 	defer cancel()
 
 	var changes []changeEvent
-	err := s.db.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, query, s.lastID)
 		if err != nil {
 			return errors.Annotate(err, "querying for changes")

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -9,6 +9,7 @@ import (
 	sql "database/sql"
 	reflect "reflect"
 
+	sqlair "github.com/canonical/sqlair"
 	gomock "github.com/golang/mock/gomock"
 	app "github.com/juju/juju/database/app"
 	dqlite "github.com/juju/juju/database/dqlite"
@@ -480,8 +481,22 @@ func (mr *MockTrackedDBMockRecorder) Kill() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockTrackedDB)(nil).Kill))
 }
 
+// StdTxn mocks base method.
+func (m *MockTrackedDB) StdTxn(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StdTxn", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StdTxn indicates an expected call of StdTxn.
+func (mr *MockTrackedDBMockRecorder) StdTxn(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StdTxn", reflect.TypeOf((*MockTrackedDB)(nil).StdTxn), arg0, arg1)
+}
+
 // Txn mocks base method.
-func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
+func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sqlair.TX) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Txn", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -492,20 +507,6 @@ func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sq
 func (mr *MockTrackedDBMockRecorder) Txn(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Txn", reflect.TypeOf((*MockTrackedDB)(nil).Txn), arg0, arg1)
-}
-
-// TxnNoRetry mocks base method.
-func (m *MockTrackedDB) TxnNoRetry(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TxnNoRetry", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// TxnNoRetry indicates an expected call of TxnNoRetry.
-func (mr *MockTrackedDBMockRecorder) TxnNoRetry(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxnNoRetry", reflect.TypeOf((*MockTrackedDB)(nil).TxnNoRetry), arg0, arg1)
 }
 
 // Wait mocks base method.

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	time "time"
 
+	"github.com/canonical/sqlair"
 	"github.com/golang/mock/gomock"
 	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
@@ -132,10 +133,10 @@ func (w *workerTrackedDB) Wait() error {
 	return w.tomb.Wait()
 }
 
-func (w *workerTrackedDB) Txn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+func (w *workerTrackedDB) Txn(ctx context.Context, fn func(context.Context, *sqlair.TX) error) error {
 	return w.db.Txn(ctx, fn)
 }
 
-func (w *workerTrackedDB) TxnNoRetry(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	return w.db.TxnNoRetry(ctx, fn)
+func (w *workerTrackedDB) StdTxn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return w.db.StdTxn(ctx, fn)
 }

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -83,7 +83,7 @@ func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 
 	defer workertest.DirtyKill(c, w)
 
-	err = w.TxnNoRetry(context.Background(), func(_ context.Context, tx *sql.Tx) error {
+	err = w.StdTxn(context.Background(), func(_ context.Context, tx *sql.Tx) error {
 		if tx == nil {
 			return errors.New("nil transaction")
 		}
@@ -109,7 +109,7 @@ func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 	defer workertest.DirtyKill(c, w)
 
 	done := make(chan struct{})
-	err = w.Txn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err = w.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		defer close(done)
 
 		c.Assert(tx, gc.NotNil)
@@ -349,7 +349,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 	c.Assert(w.Wait(), gc.ErrorMatches, "boom")
 
 	// Ensure that the DB is dead.
-	err = w.Txn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err = w.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		c.Fatal("failed if called")
 		return nil
 	})
@@ -381,7 +381,7 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 	}()
 
 	// Ensure that the DB is dead.
-	err = w.Txn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err = w.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		close(sync)
 
 		select {
@@ -421,7 +421,7 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxnNoRetry(c *gc.C) {
 	}()
 
 	// Ensure that the DB is dead.
-	err = w.TxnNoRetry(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err = w.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		close(sync)
 
 		select {
@@ -451,7 +451,7 @@ func readTableNames(c *gc.C, w coredatabase.TrackedDB) []string {
 	// Attempt to use the new db, note there shouldn't be any leases in this
 	// db.
 	var tables []string
-	err := w.Txn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err := w.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.Query("SELECT tbl_name FROM sqlite_schema")
 		c.Assert(err, jc.ErrorIsNil)
 		defer rows.Close()

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -824,7 +824,7 @@ func (w *dbWorker) ensureNamespace(namespace string) error {
 
 func isNamespaceKnownToController(ctx context.Context, db coredatabase.TrackedDB, namespace string) (bool, error) {
 	var known bool
-	err := db.Txn(ctx, func(ctx context.Context, db *sql.Tx) error {
+	err := db.StdTxn(ctx, func(ctx context.Context, db *sql.Tx) error {
 		row := db.QueryRowContext(ctx, "SELECT uuid FROM model_list WHERE uuid=?", namespace)
 
 		var uuid string

--- a/worker/dbaccessor/worker_integration_test.go
+++ b/worker/dbaccessor/worker_integration_test.go
@@ -108,7 +108,7 @@ func (s *integrationSuite) TestWorkerAccessingUnknownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
 	db, err := s.dbManager.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = db.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = db.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("bar")`)
 		return err
 	})
@@ -133,7 +133,7 @@ func (s *integrationSuite) TestWorkerDeletingUnknownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 	ctrlDB, err := s.dbManager.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctrlDB.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("baz")`)
 		return err
 	})
@@ -145,7 +145,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 
 	// We need to unsure that we remove the namespace from the model list.
 	// Otherwise, the db will be recreated on the next call to GetDB.
-	err = ctrlDB.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM model_list WHERE uuid = "baz"`)
 		return errors.Cause(err)
 	})
@@ -164,7 +164,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerDeletingKnownDBWithoutGetFirst(c *gc.C) {
 	ctrlDB, err := s.dbManager.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctrlDB.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("fred")`)
 		return err
 	})
@@ -172,7 +172,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDBWithoutGetFirst(c *gc.C) {
 
 	// We need to unsure that we remove the namespace from the model list.
 	// Otherwise, the db will be recreated on the next call to GetDB.
-	err = ctrlDB.Txn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM model_list WHERE uuid = "fred"`)
 		return err
 	})

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -375,7 +375,7 @@ func (s *workerSuite) TestEnsureNamespaceForModel(c *gc.C) {
 	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
 	defer cancel()
 
-	err := s.TrackedDB().Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TrackedDB().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
 		result, err := tx.ExecContext(ctx, stmt, "foo")
 		c.Assert(err, jc.ErrorIsNil)
@@ -429,7 +429,7 @@ func (s *workerSuite) TestEnsureNamespaceForModelWithCache(c *gc.C) {
 	defer cancel()
 
 	var attempt int
-	err := s.TrackedDB().Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TrackedDB().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		attempt++
 
 		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
@@ -490,7 +490,7 @@ func (s *workerSuite) TestCloseDatabaseForController(c *gc.C) {
 	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
 	defer cancel()
 
-	err := s.TrackedDB().Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TrackedDB().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
 		result, err := tx.ExecContext(ctx, stmt, "foo")
 		c.Assert(err, jc.ErrorIsNil)
@@ -543,7 +543,7 @@ func (s *workerSuite) TestCloseDatabaseForModel(c *gc.C) {
 	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
 	defer cancel()
 
-	err := s.TrackedDB().Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TrackedDB().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := "INSERT INTO model_list (uuid) VALUES (?);"
 		result, err := tx.ExecContext(ctx, stmt, "foo")
 		c.Assert(err, jc.ErrorIsNil)

--- a/worker/lease/manifold/database_mock_test.go
+++ b/worker/lease/manifold/database_mock_test.go
@@ -9,6 +9,7 @@ import (
 	sql "database/sql"
 	reflect "reflect"
 
+	sqlair "github.com/canonical/sqlair"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -35,8 +36,22 @@ func (m *MockTrackedDB) EXPECT() *MockTrackedDBMockRecorder {
 	return m.recorder
 }
 
+// StdTxn mocks base method.
+func (m *MockTrackedDB) StdTxn(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StdTxn", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StdTxn indicates an expected call of StdTxn.
+func (mr *MockTrackedDBMockRecorder) StdTxn(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StdTxn", reflect.TypeOf((*MockTrackedDB)(nil).StdTxn), arg0, arg1)
+}
+
 // Txn mocks base method.
-func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
+func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sqlair.TX) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Txn", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -47,18 +62,4 @@ func (m *MockTrackedDB) Txn(arg0 context.Context, arg1 func(context.Context, *sq
 func (mr *MockTrackedDBMockRecorder) Txn(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Txn", reflect.TypeOf((*MockTrackedDB)(nil).Txn), arg0, arg1)
-}
-
-// TxnNoRetry mocks base method.
-func (m *MockTrackedDB) TxnNoRetry(arg0 context.Context, arg1 func(context.Context, *sql.Tx) error) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TxnNoRetry", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// TxnNoRetry indicates an expected call of TxnNoRetry.
-func (mr *MockTrackedDBMockRecorder) TxnNoRetry(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxnNoRetry", reflect.TypeOf((*MockTrackedDB)(nil).TxnNoRetry), arg0, arg1)
 }

--- a/worker/lease/store.go
+++ b/worker/lease/store.go
@@ -76,7 +76,7 @@ AND    l.name = ?`
 	}
 
 	var result map[lease.Key]lease.Info
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, q, args...)
 		if err != nil {
 			return errors.Trace(err)
@@ -104,7 +104,7 @@ WHERE  type = ?;`[1:]
 
 	uuid := utils.MustNewUUID().String()
 
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		d := fmt.Sprintf("+%d seconds", int64(math.Ceil(req.Duration.Seconds())))
 
 		_, err := tx.ExecContext(ctx, q, uuid, key.ModelUUID, key.Lease, req.Holder, d, key.Namespace)
@@ -136,7 +136,7 @@ WHERE  uuid = (
     AND    l.holder = ?
 )`[1:]
 
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		d := fmt.Sprintf("+%d seconds", int64(math.Ceil(req.Duration.Seconds())))
 		result, err := tx.ExecContext(ctx, q, d, key.Namespace, key.ModelUUID, key.Lease, req.Holder)
 
@@ -169,7 +169,7 @@ WHERE  uuid = (
     AND    l.holder = ?
 );`[1:]
 
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 
 		result, err := tx.ExecContext(ctx, q, key.Namespace, key.ModelUUID, key.Lease, holder)
 		if err == nil {
@@ -194,7 +194,7 @@ WHERE  t.type = ?
 AND    l.model_uuid = ?;`[1:]
 
 	var result map[lease.Key]lease.Info
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, q, namespace, modelUUID)
 		if err != nil {
 			return errors.Trace(err)
@@ -218,7 +218,7 @@ WHERE  t.type = ?
 AND    l.model_uuid = ?
 AND    l.name = ?;`[1:]
 
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, q, utils.MustNewUUID().String(), entity, key.Namespace, key.ModelUUID, key.Lease)
 		return errors.Trace(err)
 	})
@@ -246,7 +246,7 @@ WHERE  uuid = (
     AND    l.name = ?
     AND    p.entity_id = ?   
 );`[1:]
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, q, key.Namespace, key.ModelUUID, key.Lease, entity)
 		return errors.Trace(err)
 	})
@@ -264,7 +264,7 @@ FROM     lease l
 ORDER BY l.uuid;`[1:]
 
 	var result map[lease.Key][]string
-	err := s.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := s.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, q)
 		if err != nil {
 			return errors.Trace(err)

--- a/worker/leaseexpiry/worker.go
+++ b/worker/leaseexpiry/worker.go
@@ -99,7 +99,7 @@ func (w *expiryWorker) loop() error {
 }
 
 func (w *expiryWorker) expireLeases(ctx context.Context) error {
-	err := w.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := w.trackedDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, w.dml)
 		if err != nil {
 			// TODO (manadart 2022-12-15): This incarnation of the worker runs on

--- a/worker/leaseexpiry/worker.go
+++ b/worker/leaseexpiry/worker.go
@@ -99,7 +99,7 @@ func (w *expiryWorker) loop() error {
 }
 
 func (w *expiryWorker) expireLeases(ctx context.Context) error {
-	err := w.trackedDB.TxnNoRetry(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := w.trackedDB.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, w.dml)
 		if err != nil {
 			// TODO (manadart 2022-12-15): This incarnation of the worker runs on


### PR DESCRIPTION
The following adds sqlair package to the juju project. In doing so it
pushes the sqlair DB into the dbaccessor. This is the lowest level that
we interact with a raw DB. In this way, we never create sqlair wrappers
at the txn level. Instead, we always have a sqlair DB and we simply unwrap
it when required. This allows it to be a lot more cheaper in usage.

For now, we have Txn and StdTxn. Both run the same retry strategies, with
the same internals. The only difference is that Txn will use the new
shiny sqlair package and the StdTxn will use the stdlib one.

We will require another follow-up PR to move our domain logic over to
the Txn method instead of the StdTxn one. This will then allow us to
drop the custom mapping code we've been writing.

The code has to jump through some loop-holes around closing the db, as
that isn't directly exposed on the sqlair DB, but otherwise, it's a
nice easy drop-in replacement.



## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
```
