### PR TITLE
Ignore failure on `aws ec2 delete-network-interface`

### DIFF
--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -32,7 +32,7 @@ test_spaces_ec2() {
 	# We don't really care if this fails; stale NICs will be auto-purged the
 	# next time we run the test-suite
 	# shellcheck disable=SC2086
-	aws ec2 delete-network-interface --network-interface-id "$hotplug_nic_id" 2>/dev/null
+	aws ec2 delete-network-interface --network-interface-id "$hotplug_nic_id" 2>/dev/null || true
 }
 
 ensure_subnet() {


### PR DESCRIPTION
Ignores failures on `aws ec2 delete-network-interface`, especially since the comment explicitly states we don't care too much about the cleanup here.

## QA steps

Run suite

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-spaces_ec2-test-machines-in-spaces-aws/774/console