### PR TITLE
Fix data race in GetOSFromSeries

### DIFF
--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -105,14 +105,15 @@ func GetOSFromSeries(series string) (coreos.OSType, error) {
 	if series == "" {
 		return coreos.Unknown, errors.NotValidf("series %q", series)
 	}
+
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+
 	seriesName := SeriesName(series)
 	osType, err := getOSFromSeries(seriesName)
 	if err == nil {
 		return osType, nil
 	}
-
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
 
 	updateSeriesVersionsOnce()
 	return getOSFromSeries(seriesName)
@@ -433,15 +434,15 @@ func UpdateSeriesVersions() error {
 	return nil
 }
 
-var updatedseriesVersions bool
+var updatedSeriesVersions bool
 
 func updateSeriesVersionsOnce() {
-	if !updatedseriesVersions {
+	if !updatedSeriesVersions {
 		if err := updateSeriesVersions(); err != nil {
 			logger.Warningf("failed to update distro info: %v", err)
 		}
 		updateVersionSeries()
-		updatedseriesVersions = true
+		updatedSeriesVersions = true
 	}
 }
 


### PR DESCRIPTION
GetOSFromSeries was making reads (calling getOSFromSeries) outside the scope of a mutex lock.

## QA steps

Run tests with -race

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/1150/consoleText