### PR TITLE
Fix relation departing test waiting.

### DIFF
--- a/testcharms/charms/departer/metadata.yaml
+++ b/testcharms/charms/departer/metadata.yaml
@@ -5,7 +5,4 @@ peers:
   self:
     interface: dummy
 series:
-  - xenial
-  - bionic
-  - focal
   - jammy


### PR DESCRIPTION
Fixes 5s sleep being inadequate. Instead polls debug-log up to 10 times with 10s delay.

## QA steps

Apply this patch
```
diff --git a/testcharms/charms/departer/hooks/self-relation-departed b/testcharms/charms/departer/hooks/self-relation-departed
index 241c4f724d..b04dd07dc8 100644
--- a/testcharms/charms/departer/hooks/self-relation-departed
+++ b/testcharms/charms/departer/hooks/self-relation-departed
@@ -1,6 +1,8 @@
 #!/bin/sh
 echo $0

+sleep 30
+
 remote_unit=$(echo $JUJU_REMOTE_UNIT)
 departing_unit=$(echo $JUJU_DEPARTING_UNIT)
```

Run the test
```
./main.sh -v -s '"test_relation_data_exchange,test_relation_list_app"' relations test_relation_departing_unit`
```

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-relations-test-relation-departing-unit-lxd/591/consoleText