### PR TITLE
[JUJU-3850] Limit Txn concurrency

### DIFF
--- a/database/txn/errors.go
+++ b/database/txn/errors.go
@@ -28,19 +28,21 @@ func IsErrRetryable(err error) bool {
 
 	// Unwrap errors one at a time.
 	for ; err != nil; err = errors.Unwrap(err) {
-		if strings.Contains(err.Error(), "database is locked") {
+		errStr := err.Error()
+
+		if strings.Contains(errStr, "database is locked") {
 			return true
 		}
 
-		if strings.Contains(err.Error(), "cannot start a transaction within a transaction") {
+		if strings.Contains(errStr, "cannot start a transaction within a transaction") {
 			return true
 		}
 
-		if strings.Contains(err.Error(), "bad connection") {
+		if strings.Contains(errStr, "bad connection") {
 			return true
 		}
 
-		if strings.Contains(err.Error(), "checkpoint in progress") {
+		if strings.Contains(errStr, "checkpoint in progress") {
 			return true
 		}
 	}

--- a/database/txn/transaction.go
+++ b/database/txn/transaction.go
@@ -74,7 +74,7 @@ func WithNumParallelTxns(v int) Option {
 			return
 		}
 
-		o.semaphore = semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0)))
+		o.semaphore = semaphore.NewWeighted(int64(v))
 	}
 }
 

--- a/database/txn/transaction.go
+++ b/database/txn/transaction.go
@@ -62,19 +62,17 @@ func WithRetryStrategy(retryStrategy RetryStrategy) Option {
 	}
 }
 
-// WithNumParallelTxns defines the number of parallel transactions that can
-// be executed at any given time. This is useful for limiting the number of
-// transactions that can be executed at any given time.
+// WithSemaphore defines a semaphore for limiting the number of transactions
+// that can be executed at any given time.
 //
-// If the value is less than 1, then no semaphore will be used.
-func WithNumParallelTxns(v int) Option {
+// If nill is used, then no semaphore is used.
+func WithSemaphore(sem Semaphore) Option {
 	return func(o *option) {
-		if v < 1 {
+		if sem == nil {
 			o.semaphore = noopSemaphore{}
 			return
 		}
-
-		o.semaphore = semaphore.NewWeighted(int64(v))
+		o.semaphore = sem
 	}
 }
 

--- a/database/txn/transaction_test.go
+++ b/database/txn/transaction_test.go
@@ -13,6 +13,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/mattn/go-sqlite3"
+	"golang.org/x/sync/semaphore"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/database/testing"
@@ -53,7 +54,7 @@ func (s *transactionRunnerSuite) TestTxnWithCancelledContext(c *gc.C) {
 }
 
 func (s *transactionRunnerSuite) TestTxnParallelCancelledContext(c *gc.C) {
-	runner := txn.NewTransactionRunner(txn.WithNumParallelTxns(1))
+	runner := txn.NewTransactionRunner(txn.WithSemaphore(semaphore.NewWeighted(1)))
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/database/txn/transaction_test.go
+++ b/database/txn/transaction_test.go
@@ -6,12 +6,15 @@ package txn_test
 import (
 	"context"
 	"database/sql"
+	"sync"
+	"time"
 
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/mattn/go-sqlite3"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/database/testing"
 	"github.com/juju/juju/database/txn"
 )
@@ -47,6 +50,71 @@ func (s *transactionRunnerSuite) TestTxnWithCancelledContext(c *gc.C) {
 		return nil
 	})
 	c.Assert(err, gc.ErrorMatches, "context canceled")
+}
+
+func (s *transactionRunnerSuite) TestTxnParallelCancelledContext(c *gc.C) {
+	runner := txn.NewTransactionRunner(txn.WithNumParallelTxns(1))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// The following two goroutines will attempt to start a transaction
+	// concurrently. The first one will start, and the second one will be
+	// blocked until the first one has completed. We can then ensure that
+	// the second one is cancelled, because the context is cancelled.
+	sync := make(chan struct{})
+	step := make(chan struct{})
+	go func() {
+		defer wg.Done()
+
+		err := runner.StdTxn(context.Background(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+			close(sync)
+
+			select {
+			case <-time.After(jujutesting.ShortWait):
+			case <-step:
+			}
+			return nil
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Wait until the first transaction has started, before attempting a
+		// second one.
+		select {
+		case <-sync:
+		case <-time.After(jujutesting.ShortWait):
+			c.Fatal("should not be called")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Force the cancel to happen after the transaction has started.
+		cancel()
+		err := runner.StdTxn(ctx, s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+			c.Fatal("should not be called")
+			return nil
+		})
+		c.Assert(err, gc.ErrorMatches, "context canceled")
+
+		close(step)
+	}()
+
+	// The following ensures that we don't block whilst waiting for the tests
+	// to complete.
+	wait := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wait)
+	}()
+	select {
+	case <-wait:
+	case <-time.After(jujutesting.LongWait):
+		c.Fatal("failed waiting to complete")
+	}
 }
 
 func (s *transactionRunnerSuite) TestTxnInserts(c *gc.C) {


### PR DESCRIPTION
The following implements feedback from the benchmarking results that @tlm has been investigating whilst scaling juju. In order to prevent juju from thrashing the cpu with so many retries, we instead use a semaphore to limit how many transactions can happen at one particular time. This forces the backing off of transactions at the source. If dqlite is struggling, there is no need to make it worse. Instead, just force them to reign it back by blocking.

The changes here should not impact any small workload, so should be fine to land. One improvement that might be worth considering in the future, is to give certain namespaces different transaction runners, for example, giving the controller namespace a larger chunk of available slots. This will be easy to do, as we just push the txn runner into the dbaccessor directly. That can be a future PR though.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```
