### PR TITLE
[JUJU-3879] Allow 3.1 and newer clients to migrate models off a 2.9 controller

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1264,8 +1264,8 @@ func (s *state) APICall(facade string, vers int, id, method string, args, respon
 		}
 		logger.Debugf("%v.%v API call not supported", facade, method)
 		return errors.NewNotSupported(nil, fmt.Sprintf(
-			"juju client with major version %d used with a controller having major version %d not supported\nupdate your juju client to match the version running on the controller",
-			jujuversion.Current.Major, serverMajorVersion))
+			"juju client with version %d.%d used with a controller having major version %d not supported\nre-install your juju client to match the version running on the controller",
+			jujuversion.Current.Major, jujuversion.Current.Minor, serverMajorVersion))
 	}
 	panic("unreachable")
 }

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1200,8 +1200,8 @@ func (s *apiclientSuite) TestLoginIncompatibleClient(c *gc.C) {
 	err := conn.APICall("facade", 1, "id", "method", nil, nil)
 	c.Check(clock.waits, gc.HasLen, 0)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
-		"juju client with major version %d used with a controller having major version %d not supported\\n.*",
-		jujuversion.Current.Major, 99,
+		"juju client with version %d.%d used with a controller having major version %d not supported\\n.*",
+		jujuversion.Current.Major, jujuversion.Current.Minor, 99,
 	))
 }
 

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -48,7 +48,7 @@ func (r *restrictNewerClientSuite) TestOldClientAllowedMethods(c *gc.C) {
 
 func (r *restrictNewerClientSuite) TestRecentNewerClientAllowedMethods(c *gc.C) {
 	r.assertNewerClientAllowedMethods(c, 0, true)
-	r.assertNewerClientAllowedMethods(c, 1, false)
+	r.assertNewerClientAllowedMethods(c, 1, true)
 }
 
 func (r *restrictNewerClientSuite) assertNewerClientAllowedMethods(c *gc.C, minor int, allowed bool) {
@@ -108,7 +108,7 @@ func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
 
 func (r *restrictNewerClientSuite) TestWhitelistedClient(c *gc.C) {
 	r.assertWhitelistedClient(c, "2.9.35", false)
-	r.assertWhitelistedClient(c, "2.9.36", true)
+	r.assertWhitelistedClient(c, "2.9.42", true)
 }
 
 func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers string, allowed bool) {

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -22,7 +22,7 @@ var MinAgentVersions = map[int]version.Number{
 // or the minimum controller version needed to accept a call from a
 // client with the major version.
 var MinClientVersions = map[int]version.Number{
-	3: version.MustParse("2.9.36"),
+	3: version.MustParse("2.9.42"),
 }
 
 // MinMajorMigrateVersions defines the minimum version the model


### PR DESCRIPTION
We now allow a juju 3.1 CLI to run things like status and migrations against a 2.9 controller.
Also tweak the error message to use more accurate language when trying to use an incompatible client.

## QA steps

bootstrap a 2.9 controller and add a model
install the 3.1 snap
use the 3.1 snap cli to run status
check the 3.1 client cannot deploy etc
bootstrap a 3.1 controller
use the 3.1 snap cli to migrate a model to a 3.1 controller
