### PR TITLE
[JUJU-3866] UpdateOffer: validate endpoints before running DB transaction

### DIFF
--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -526,10 +526,6 @@ func removeApplicationOffersOps(st *State, application string) ([]txn.Op, error)
 var errDuplicateApplicationOffer = errors.Errorf("application offer already exists")
 
 func (s *applicationOffers) validateOfferArgs(offer crossmodel.AddApplicationOfferArgs) (err error) {
-	// Sanity checks.
-	if !names.IsValidApplication(offer.ApplicationName) {
-		return errors.NotValidf("application name %q", offer.ApplicationName)
-	}
 	// Same rules for valid offer names apply as for applications.
 	if !names.IsValidApplication(offer.OfferName) {
 		return errors.NotValidf("offer name %q", offer.OfferName)
@@ -541,6 +537,16 @@ func (s *applicationOffers) validateOfferArgs(offer crossmodel.AddApplicationOff
 		if !names.IsValidUser(readUser) {
 			return errors.NotValidf("offer reader %q", readUser)
 		}
+	}
+
+	// Check application and endpoints exist in state.
+	app, err := s.st.Application(offer.ApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = getApplicationEndpoints(app, offer.Endpoints)
+	if err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }


### PR DESCRIPTION
When updating an existing offer using an invalid endpoint, Juju was returning the expected error
```
ERROR cannot update application offer "prometheus": getting relation endpoint for relation "http" and application "prometheus": application "prometheus" has no "http" relation
```
However, it was still internally updating the offer in the database. This left the database in an inconsistent state, where the `applicationOffers` table contained an offer which referenced a nonexistent endpoint. This pretty much breaks the model to the point where you can't even run `juju status`. See [LP#1954830](https://bugs.launchpad.net/juju/+bug/1954830).

We already had a function `validateOfferArgs` to validate the offer, but this didn't include checking that the application and endpoints exist in state. That responsibility was left to the `makeApplicationOffer` method, but for `UpdateOffer`, this is run *after* the DB transaction - so it was no good.

This PR fixes the `validateOfferArgs` method, so it now also checks that the requested application and endpoints exist in state. We had an explicit `names.IsValidApplication` check which is no longer needed, as this is already done inside `state.Application`.

I've also improved our test coverage here, adding tests to check that `AddOffer` and `UpdateOffer` fail if the application or endpoints don't exist. This includes a regression test for the bug.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
# rebuild juju, update microk8s operator image, etc
juju bootstrap (lxd|microk8s) c
juju deploy juju-qa-dummy-source d
juju offer d:sink # valid endpoint
juju offer d:sink1 # invalid endpoint
juju status # should work as normal
```

Then, do a db dump:
```
JUJU_DEV_FEATURE_FLAGS='developer-mode' juju dump-db > db-dump.yaml
```
and check that the offer in the `applicationOffers` table still refers to the original valid endpoint `sink`.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1954830