### PR TITLE
[JUJU-3881] Any 3.x client can initiate migration from 2.9

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Install Juju 2.9
         run: |
-          sudo snap install juju_29 --classic --channel 2.9/stable
+          sudo snap install juju_29 --classic --channel 2.9/edge
 
       - name: Bootstrap a 2.9 controller and model
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -23,14 +23,11 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
+        channel: ["2.9/stable"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Enable Snap parallel-instances
-        run: |
-          sudo snap set system experimental.parallel-instances=true
 
       - name: Setup LXD
         if: matrix.cloud == 'lxd'
@@ -38,13 +35,14 @@ jobs:
 
       - name: Install Juju 2.9
         run: |
-          sudo snap install juju_29 --classic --channel 2.9/stable
+          sudo snap install juju --classic --channel ${{ matrix.channel }}
 
       - name: Bootstrap a 2.9 controller and model
         run: |
-          juju_29 bootstrap lxd test29
-          juju_29 add-model test-migrate
-          juju_29 deploy ubuntu
+          /snap/bin/juju version
+          /snap/bin/juju bootstrap lxd test29
+          /snap/bin/juju add-model test-migrate
+          /snap/bin/juju deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -63,6 +61,7 @@ jobs:
 
       - name: Bootstrap 3.x controller
         run: |
+          juju version
           juju bootstrap lxd test3x
           juju switch controller
           juju wait-for application controller
@@ -71,16 +70,17 @@ jobs:
 
       - name: Migrate default model to 3.x controller
         run: |
-          juju_29 switch test29
+          /snap/bin/juju switch test29
           
           # Ensure application is fully deployed
-          juju_29 wait-for application ubuntu
+          /snap/bin/juju wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
           
-          juju_29 migrate test-migrate test3x
+          /snap/bin/juju version
+          /snap/bin/juju migrate test-migrate test3x
 
       - name: Check the migration was successful
         run: |
@@ -107,6 +107,8 @@ jobs:
           
           juju deploy ubuntu yet-another-ubuntu
           juju wait-for application yet-another-ubuntu
+
+
   migrate_via_3x:
     name: 2.9-to-3.x via 3.x client
     runs-on: ubuntu-latest
@@ -116,14 +118,11 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
+        channel: ["2.9/stable"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Enable Snap parallel-instances
-        run: |
-          sudo snap set system experimental.parallel-instances=true
 
       - name: Setup LXD
         if: matrix.cloud == 'lxd'
@@ -131,13 +130,14 @@ jobs:
 
       - name: Install Juju 2.9
         run: |
-          sudo snap install juju_29 --classic --channel 2.9/edge
+          sudo snap install juju --classic --channel ${{ matrix.channel }}
 
       - name: Bootstrap a 2.9 controller and model
         run: |
-          juju_29 bootstrap lxd test29
-          juju_29 add-model test-migrate
-          juju_29 deploy ubuntu
+          /snap/bin/juju version
+          /snap/bin/juju bootstrap lxd test29
+          /snap/bin/juju add-model test-migrate
+          /snap/bin/juju deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -156,6 +156,7 @@ jobs:
 
       - name: Bootstrap 3.x controller
         run: |
+          juju version
           juju bootstrap lxd test3x
           juju switch controller
           juju wait-for application controller
@@ -167,12 +168,15 @@ jobs:
           juju switch test29
           
           # Ensure application is fully deployed
-          juju wait-for application ubuntu
+          # We have to use the old client to speak to the new controller, as
+          # this is blocked otherwise.
+          /snap/bin/juju wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
-          
+
+          juju version
           juju migrate test-migrate test3x
 
       - name: Check the migration was successful

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  migrate:
-    name: 2.9-to-3.x
+  migrate_via_29:
+    name: 2.9-to-3.x via 2.9 client
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
@@ -63,7 +63,7 @@ jobs:
 
       - name: Bootstrap 3.x controller
         run: |
-          juju bootstrap lxd test31
+          juju bootstrap lxd test3x
           juju switch controller
           juju wait-for application controller
 
@@ -80,12 +80,105 @@ jobs:
           # so that migration prechecks pass.
           sleep 10
           
-          juju_29 migrate test-migrate test31
+          juju_29 migrate test-migrate test3x
 
       - name: Check the migration was successful
         run: |
           set -x
-          juju switch test31
+          juju switch test3x
+          
+          # Wait for 'test-migrate' model to come through
+          attempt=0
+          while true; do
+            RES=$(juju models | grep 'test-migrate' || true)
+            if [[ -n $RES ]]; then
+              break
+            fi
+            sleep 5
+            attempt=$((attempt+1))
+            if [ "$attempt" -eq 10 ]; then
+              echo "Migration timed out"
+              exit 1
+            fi
+          done
+          
+          juju switch test-migrate
+          juju wait-for application ubuntu
+          
+          juju deploy ubuntu yet-another-ubuntu
+          juju wait-for application yet-another-ubuntu
+  migrate_via_3x:
+    name: 2.9-to-3.x via 3.x client
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: add microk8s tests
+        cloud: ["lxd"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Enable Snap parallel-instances
+        run: |
+          sudo snap set system experimental.parallel-instances=true
+
+      - name: Setup LXD
+        if: matrix.cloud == 'lxd'
+        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+
+      - name: Install Juju 2.9
+        run: |
+          sudo snap install juju_29 --classic --channel 2.9/stable
+
+      - name: Bootstrap a 2.9 controller and model
+        run: |
+          juju_29 bootstrap lxd test29
+          juju_29 add-model test-migrate
+          juju_29 deploy ubuntu
+          
+          # TODO: use juju-restore
+          # TODO: add users/permissions/models and test that those migrate over
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      - name: Set up Go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Upgrade client to 3.x
+        run: |
+          make go-install &>/dev/null
+
+      - name: Bootstrap 3.x controller
+        run: |
+          juju bootstrap lxd test3x
+          juju switch controller
+          juju wait-for application controller
+
+        # TODO: create backup and juju restore
+
+      - name: Migrate default model to 3.x controller
+        run: |
+          juju switch test29
+          
+          # Ensure application is fully deployed
+          juju wait-for application ubuntu
+          
+          # Wait a few secs for the machine status to update
+          # so that migration prechecks pass.
+          sleep 10
+          
+          juju migrate test-migrate test3x
+
+      - name: Check the migration was successful
+        run: |
+          set -x
+          juju switch test3x
           
           # Wait for 'test-migrate' model to come through
           attempt=0


### PR DESCRIPTION
This PR adds a new job to Migration github action, which checks the migration from 2.9 to 3.x via 3.x client.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
#just check github actions 
```
