### PR TITLE
 [JUJU-3882] Fixed test-deploy-test-deploy-bundle-aws in 3.1

### DIFF
--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -1,11 +1,11 @@
 series: jammy
 saas:
-  easyrsa:
-    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.easyrsa
+  dummy-source:
+    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.dummy-source
 applications:
-  etcd:
-    charm: etcd
+  dummy-sink:
+    charm: juju-qa-dummy-sink
     num_units: 1
 relations:
-  - - etcd:certificates
-    - easyrsa:client
+  - - dummy-sink:source
+    - dummy-source:sink

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -84,7 +84,7 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
@@ -116,7 +116,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
-	if [[ -n ${MODEL_ARCH-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
       .applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\"
@@ -140,7 +140,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	juju deploy "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
-	if [[ -n ${MODEL_ARCH-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
 		telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
 		juju_qa_test_rev=$(juju info juju-qa-test --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."candidate"[0].revision')
@@ -158,7 +158,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 		.applications.juju-qa-test.revision = ${juju_qa_test_rev}
 	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
-	if [[ -n ${MODEL_ARCH-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
 			.applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
 			.applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\" |
@@ -327,7 +327,7 @@ test_deploy_bundles() {
 		run "run_deploy_charmhub_bundle"
 		run "run_deploy_multi_app_single_charm_bundle"
 
-		case "${BOOTSTRAP_PROVIDER-}" in
+		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_profile_bundle_openstack"
 			run "run_deploy_lxd_profile_bundle"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -38,25 +38,33 @@ run_deploy_cmr_bundle() {
 
 	ensure "test-cmr-bundles-deploy" "${file}"
 
-	juju deploy easyrsa
-	wait_for "easyrsa" ".applications | keys[0]"
-	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
+	juju deploy juju-qa-dummy-source
+	juju offer dummy-source:sink
 
-	juju offer easyrsa:client
+	wait_for "dummy-source" "$(idle_condition "dummy-source")"
+
 	juju add-model other
-
 	juju switch other
 
 	bundle=./tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
 	sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" >"${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 	juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
-	wait_for "active" '.applications["etcd"] | ."application-status".current'
-	wait_for "etcd" "$(idle_condition "etcd")"
-	wait_for "active" "$(workload_status "etcd" 0).current"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+	juju switch "test-cmr-bundles-deploy"
+  juju config dummy-source token=yeah-boi
+  juju switch "other"
+  wait_for "active" '."application-endpoints"["dummy-source"]."application-status".current'
 
 	# TODO: no need to remove-relation before destroying model once we fixed(lp:1952221).
-	juju remove-relation etcd easyrsa
+	juju remove-relation dummy-sink dummy-source
+	# wait for relation removed.
+  wait_for null '.applications["dummy-sink"] | .relations.source[0]'
+  # The offer must be removed before model/controller destruction will work.
+  # See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
+  juju switch "test-cmr-bundles-deploy"
+  juju remove-offer "admin/test-cmr-bundles-deploy.dummy-source" -y
 
 	destroy_model "other"
 	destroy_model "test-cmr-bundles-deploy"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -53,18 +53,18 @@ run_deploy_cmr_bundle() {
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
 	juju switch "test-cmr-bundles-deploy"
-  juju config dummy-source token=yeah-boi
-  juju switch "other"
-  wait_for "active" '."application-endpoints"["dummy-source"]."application-status".current'
+	juju config dummy-source token=yeah-boi
+	juju switch "other"
+	wait_for "active" '."application-endpoints"["dummy-source"]."application-status".current'
 
 	# TODO: no need to remove-relation before destroying model once we fixed(lp:1952221).
 	juju remove-relation dummy-sink dummy-source
 	# wait for relation removed.
-  wait_for null '.applications["dummy-sink"] | .relations.source[0]'
-  # The offer must be removed before model/controller destruction will work.
-  # See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
-  juju switch "test-cmr-bundles-deploy"
-  juju remove-offer "admin/test-cmr-bundles-deploy.dummy-source" -y
+	wait_for null '.applications["dummy-sink"] | .relations.source[0]'
+	# The offer must be removed before model/controller destruction will work.
+	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
+	juju switch "test-cmr-bundles-deploy"
+	juju remove-offer "admin/test-cmr-bundles-deploy.dummy-source" -y
 
 	destroy_model "other"
 	destroy_model "test-cmr-bundles-deploy"
@@ -84,7 +84,7 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH-} ]]; then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
@@ -116,7 +116,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH-} ]]; then
 		yq -i "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
       .applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\"
@@ -140,7 +140,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	juju deploy "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH-} ]]; then
 		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
 		telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
 		juju_qa_test_rev=$(juju info juju-qa-test --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."candidate"[0].revision')
@@ -158,7 +158,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 		.applications.juju-qa-test.revision = ${juju_qa_test_rev}
 	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH-} ]]; then
 		yq -i "
 			.applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
 			.applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\" |
@@ -327,7 +327,7 @@ test_deploy_bundles() {
 		run "run_deploy_charmhub_bundle"
 		run "run_deploy_multi_app_single_charm_bundle"
 
-		case "${BOOTSTRAP_PROVIDER:-}" in
+		case "${BOOTSTRAP_PROVIDER-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_profile_bundle_openstack"
 			run "run_deploy_lxd_profile_bundle"


### PR DESCRIPTION
This PR updates the test environment by replacing the usage of third-party charms with juju-team managed charms. 

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p ec2 deploy run_deploy_cmr_bundle
```
