### PR TITLE
Fix persistent storage test by not prefering trusty...

### DIFF
--- a/testcharms/charms/dummy-storage/metadata.yaml
+++ b/testcharms/charms/dummy-storage/metadata.yaml
@@ -7,13 +7,9 @@ description: This dummy-storage charm is used for testing persistent storage.
 categories:
   - misc
 series:
-  - trusty
-  - xenial
-  - artful
-  - bionic
-  - eoan
-  - focal
   - jammy
+  - focal
+  - bionic
 
 storage:
   single-fs:


### PR DESCRIPTION
Trusty doesn't seem to work anymore on AWS with 2.9, so this moves to preferring jammy for persistent storage tests.

## QA steps

`BOOTSTRAP_CLOUD=aws BOOTSTRAP_PROVIDER=ec2 ./main.sh -v -s '"test_charm_storage"' storage test_persistent_storage`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-storage-test-persistent-storage-aws/760/consoleText