### PR TITLE
[JUJU-3782] Replace external controller retrieval in facades with new domain

### DIFF
--- a/apiserver/facades/controller/externalcontrollerupdater/domain_mock_test.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/domain_mock_test.go
@@ -35,6 +35,21 @@ func (m *MockEcService) EXPECT() *MockEcServiceMockRecorder {
 	return m.recorder
 }
 
+// Controller mocks base method.
+func (m *MockEcService) Controller(arg0 context.Context, arg1 string) (*crossmodel.ControllerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Controller", arg0, arg1)
+	ret0, _ := ret[0].(*crossmodel.ControllerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Controller indicates an expected call of Controller.
+func (mr *MockEcServiceMockRecorder) Controller(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockEcService)(nil).Controller), arg0, arg1)
+}
+
 // UpdateExternalController mocks base method.
 func (m *MockEcService) UpdateExternalController(arg0 context.Context, arg1 crossmodel.ControllerInfo, arg2 ...string) error {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
@@ -17,6 +17,7 @@ import (
 )
 
 type EcService interface {
+	Controller(ctx context.Context, controllerUUID string) (*crossmodel.ControllerInfo, error)
 	UpdateExternalController(ctx context.Context, ec crossmodel.ControllerInfo, modelUUIDs ...string) error
 }
 
@@ -76,17 +77,16 @@ func (s *ExternalControllerUpdaterAPI) ExternalControllerInfo(args params.Entiti
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		controller, err := s.externalControllers.Controller(controllerTag.Id())
+		controllerInfo, err := s.ecService.Controller(context.TODO(), controllerTag.Id())
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		info := controller.ControllerInfo()
 		result.Results[i].Result = &params.ExternalControllerInfo{
 			ControllerTag: controllerTag.String(),
-			Alias:         info.Alias,
-			Addrs:         info.Addrs,
-			CACert:        info.CACert,
+			Alias:         controllerInfo.Alias,
+			Addrs:         controllerInfo.Addrs,
+			CACert:        controllerInfo.CACert,
 		}
 	}
 	return result, nil

--- a/domain/externalcontroller/service/package_mock_test.go
+++ b/domain/externalcontroller/service/package_mock_test.go
@@ -35,6 +35,21 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// Controller mocks base method.
+func (m *MockState) Controller(arg0 context.Context, arg1 string) (*crossmodel.ControllerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Controller", arg0, arg1)
+	ret0, _ := ret[0].(*crossmodel.ControllerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Controller indicates an expected call of Controller.
+func (mr *MockStateMockRecorder) Controller(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockState)(nil).Controller), arg0, arg1)
+}
+
 // UpdateExternalController mocks base method.
 func (m *MockState) UpdateExternalController(arg0 context.Context, arg1 crossmodel.ControllerInfo, arg2 []string) error {
 	m.ctrl.T.Helper()

--- a/domain/externalcontroller/service/service.go
+++ b/domain/externalcontroller/service/service.go
@@ -36,8 +36,8 @@ func (s *Service) Controller(
 	ctx context.Context,
 	controllerUUID string,
 ) (*crossmodel.ControllerInfo, error) {
-
-	return nil, nil
+	controllerInfo, err := s.st.Controller(ctx, controllerUUID)
+	return controllerInfo, errors.Annotate(err, "retrieving external controller")
 }
 
 // UpdateExternalController persists the input controller

--- a/domain/externalcontroller/service/service.go
+++ b/domain/externalcontroller/service/service.go
@@ -13,6 +13,9 @@ import (
 
 // State describes retrieval and persistence methods for storage.
 type State interface {
+	// Controller returns the controller record.
+	Controller(ctx context.Context, controllerUUID string) (*crossmodel.ControllerInfo, error)
+
 	// UpdateExternalController persists the input controller
 	// record and associates it with the input model UUIDs.
 	UpdateExternalController(ctx context.Context, ec crossmodel.ControllerInfo, modelUUIDs []string) error
@@ -26,6 +29,15 @@ type Service struct {
 // NewService returns a new service reference wrapping the input state.
 func NewService(st State) *Service {
 	return &Service{st}
+}
+
+// Controller returns the controller record.
+func (s *Service) Controller(
+	ctx context.Context,
+	controllerUUID string,
+) (*crossmodel.ControllerInfo, error) {
+
+	return nil, nil
 }
 
 // UpdateExternalController persists the input controller

--- a/domain/externalcontroller/service/service_test.go
+++ b/domain/externalcontroller/service/service_test.go
@@ -60,6 +60,34 @@ func (s *serviceSuite) TestUpdateExternalControllerError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "updating external controller state: boom")
 }
 
+func (s *serviceSuite) TestRetrieveExternalControllerSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	m1 := utils.MustNewUUID().String()
+	ec := crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(m1),
+		Alias:         "that-other-controller",
+		Addrs:         []string{"10.10.10.10"},
+		CACert:        "random-cert-string",
+	}
+
+	s.state.EXPECT().Controller(gomock.Any(), m1).Return(&ec, nil)
+
+	res, err := NewService(s.state).Controller(context.Background(), m1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.Equals, &ec)
+}
+
+func (s *serviceSuite) TestRetrieveExternalControllerError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	ctrlUUID := "ctrl1"
+	s.state.EXPECT().Controller(gomock.Any(), ctrlUUID).Return(nil, errors.New("boom"))
+
+	_, err := NewService(s.state).Controller(context.Background(), ctrlUUID)
+	c.Assert(err, gc.ErrorMatches, "retrieving external controller: boom")
+}
+
 func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/externalcontroller/state/state_test.go
+++ b/domain/externalcontroller/state/state_test.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"context"
 	ctx "context"
 
 	"github.com/juju/collections/set"
@@ -40,13 +39,13 @@ func (s *stateSuite) TestRetrieveExternalController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Retrieve the created external controller.
-	controllerInfo, err := st.Controller(context.Background(), "ctrl1")
+	controllerInfo, err := st.Controller(ctx.Background(), "ctrl1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(controllerInfo.ControllerTag.Id(), gc.Equals, "ctrl1")
 	c.Assert(controllerInfo.Alias, gc.Equals, "my-controller")
 	c.Assert(controllerInfo.CACert, gc.Equals, "test-cert")
-	c.Assert(controllerInfo.Addrs, gc.DeepEquals, []string{"192.168.1.1", "10.0.0.1"})
+	c.Assert(controllerInfo.Addrs, jc.SameContents, []string{"192.168.1.1", "10.0.0.1"})
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerWithoutAddresses(c *gc.C) {
@@ -59,7 +58,7 @@ func (s *stateSuite) TestRetrieveExternalControllerWithoutAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Retrieve the created external controller.
-	controllerInfo, err := st.Controller(context.Background(), "ctrl1")
+	controllerInfo, err := st.Controller(ctx.Background(), "ctrl1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(controllerInfo.ControllerTag.Id(), gc.Equals, "ctrl1")
@@ -78,7 +77,7 @@ func (s *stateSuite) TestRetrieveExternalControllerWithoutAlias(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Retrieve the created external controller.
-	controllerInfo, err := st.Controller(context.Background(), "ctrl1")
+	controllerInfo, err := st.Controller(ctx.Background(), "ctrl1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(controllerInfo.ControllerTag.Id(), gc.Equals, "ctrl1")
@@ -91,8 +90,8 @@ func (s *stateSuite) TestRetrieveExternalControllerWithoutAlias(c *gc.C) {
 func (s *stateSuite) TestRetrieveExternalControllerNotFound(c *gc.C) {
 	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
 
-	// Retrieve a not-existant controller.
-	_, err := st.Controller(context.Background(), "ctrl1")
+	// Retrieve a not-existent controller.
+	_, err := st.Controller(ctx.Background(), "ctrl1")
 	c.Assert(err.Error(), jc.Contains, "external controller with UUID ctrl1")
 }
 


### PR DESCRIPTION
This patch adds the `Controller()` method on the new `domain/externalcontroller` state and service. 

Also, the facades have been updated to include the new method, and the tests and mocks have been updated as well.

This is the second PR on the external controller domain, the next (and last) one will replace the `Watch()` method and will also remove the old mongodb `/state` and verify that nothing else breaks.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/externalcontroller/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/externalcontrollerupdater/... -gocheck.v 
```
