### PR TITLE
Fix false positive IsFatalError case

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -104,8 +104,7 @@ func WaitForAgentInitialisation(
 		IsFatalError: func(err error) bool {
 			return errors.Is(err, &unknownError{}) ||
 				retry.IsRetryStopped(err) ||
-				errors.Is(err, stdcontext.Canceled) ||
-				errors.Is(err, stdcontext.DeadlineExceeded)
+				errors.Is(err, stdcontext.Canceled)
 		},
 		Func: func() error {
 			retryErr := tryAPI(c)


### PR DESCRIPTION
It turns out i/o timeout errors, which are retryable errors, are stdconttext.DeadlineExceeded errors. This was causing them to be caught as fatal errors incorrectly, leading to bootstraps often failing

Fix this by not longer counting stdcontext.DeadlineExceeded errors as fatal errors.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Verify we can bootstrap an aws controller
```sh
juju bootstrap aws/eu-west-2 aws
```
Repeat this multiple times to ensure it's consistent 
