### PR TITLE
[JUJU-3893] Use correct application name in client for upload pending resources for server side deploy

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -364,6 +364,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		if c.applicationName != "" {
 			appName = c.applicationName
 		}
+
 		configYAML, err := utils.CombinedConfig(ctx, c.model.Filesystem(), c.configOptions, appName)
 		if err != nil {
 			return errors.Trace(err)
@@ -371,7 +372,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 
 		info, localPendingResources, errs := deployAPI.DeployFromRepository(application.DeployFromRepositoryArg{
 			CharmName:        c.userRequestedURL.Name,
-			ApplicationName:  c.applicationName,
+			ApplicationName:  appName,
 			AttachStorage:    c.attachStorage,
 			Base:             base,
 			Channel:          channel,
@@ -389,9 +390,9 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 			Trust:            c.trust,
 		})
 
-		uploadErr := c.uploadExistingPendingResources(c.applicationName, localPendingResources, deployAPI, c.model.Filesystem())
+		uploadErr := c.uploadExistingPendingResources(appName, localPendingResources, deployAPI, c.model.Filesystem())
 		if uploadErr != nil {
-			ctx.Errorf("Unable to upload resources for %v, consider using --attach-resource. \n %v", c.applicationName, uploadErr)
+			ctx.Errorf("Unable to upload resources for %v, consider using --attach-resource. \n %v", appName, uploadErr)
 		}
 
 		ctx.Infof("%s", pretty.Sprint(info))


### PR DESCRIPTION
This is part of the server-side deploy work. It fixes a bug we've missed in the client about uploading a pending local resource. Without this change the app deploys, but the local resources couldn't be uploaded because the application name used is incorrect. This fixes it to use the correct app name so the local resource uploads work just fine.

It appears that we missed this one in the QAs for the local resource PRs before because we always tested it with an alias to make it easy for the QAers (e.g. `j deploy juju-qa-test removeme ...`).

## QA steps

The integration tests for Juju are currently using the old deploy code. This is uncovered by the current resource tests when I run the integration tests with the `JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy ` variable. So I don't think any additional tests are necessary.

```sh
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju bootstrap localhost wednesday
$ juju add-model test
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju deploy juju-qa-test --resource foo-file=./tests/suites/resources/foo-file.txt
```

Without this change you'd see:

```sh
ERROR Unable to upload resources for , consider using --attach-resource.
 invalid application ""
application.DeployInfo{
    Architecture: "amd64",
    Base:         series.Base{
        OS:      "ubuntu",
        Channel: series.Channel{Track:"20.04", Risk:"stable"},
    },
    Channel:          "stable",
    EffectiveChannel: (*string)(nil),
    Name:             "juju-qa-test",
    Revision:         19,
}
```

And with this change you should not only not see that error, but also be able to see that the resources are there:

```sh
$ juju resources juju-qa-test
Resource  Supplied by  Revision
foo-file  admin        2023-06-01T21:28
```
