### PR TITLE
[JUJU-3906] Fix cmr secrets watcher to lookup offer uuid

### DIFF
--- a/api/controller/crossmodelrelations/crossmodelrelations.go
+++ b/api/controller/crossmodelrelations/crossmodelrelations.go
@@ -465,7 +465,7 @@ func (c *Client) WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatch
 
 // WatchConsumedSecretsChanges returns a watcher which notifies of new secret revisions consumed by the
 // app with the specified token.
-func (c *Client) WatchConsumedSecretsChanges(applicationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
+func (c *Client) WatchConsumedSecretsChanges(applicationToken, relationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
 	var macs macaroon.Slice
 	if mac != nil {
 		macs = macaroon.Slice{mac}
@@ -473,12 +473,13 @@ func (c *Client) WatchConsumedSecretsChanges(applicationToken string, mac *macar
 
 	args := params.WatchRemoteSecretChangesArgs{Args: []params.WatchRemoteSecretChangesArg{{
 		ApplicationToken: applicationToken,
+		RelationToken:    relationToken,
 		Macaroons:        macs,
 		BakeryVersion:    bakery.LatestVersion,
 	}}}
 
 	// Use any previously cached discharge macaroons.
-	if ms, ok := c.getCachedMacaroon("watch consumed secret changes", applicationToken); ok {
+	if ms, ok := c.getCachedMacaroon("watch consumed secret changes", relationToken); ok {
 		args.Args[0].Macaroons = ms
 		args.Args[0].BakeryVersion = bakery.LatestVersion
 	}
@@ -510,7 +511,7 @@ func (c *Client) WatchConsumedSecretsChanges(applicationToken string, mac *macar
 			return nil, result.Error
 		}
 		args.Args[0].Macaroons = mac
-		c.cache.Upsert(applicationToken, mac)
+		c.cache.Upsert(relationToken, mac)
 
 		if err := apiCall(); err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -245,9 +245,9 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	attr, err := s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+	attr, err := s.authContext.Authenticator().CheckOfferMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -272,9 +272,9 @@ func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
 		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+	_, err = s.authContext.Authenticator().CheckOfferMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
 		"prod.another",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -295,9 +295,9 @@ func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
 		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+	_, err = s.authContext.Authenticator().CheckOfferMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -316,9 +316,9 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 	mac, err := authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+	_, err = authContext.Authenticator().CheckOfferMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -342,9 +342,10 @@ func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
 		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+	err = s.authContext.Authenticator().CheckRelationMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
+		"mysql-uuid",
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -364,9 +365,10 @@ func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
 		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+	err = s.authContext.Authenticator().CheckRelationMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
+		"mysql-uuid",
 		names.NewRelationTag("app:db offer:db"),
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -388,9 +390,10 @@ func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
 		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+	err = s.authContext.Authenticator().CheckRelationMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
+		"mysql-uuid",
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -408,9 +411,10 @@ func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
 		coretesting.ModelTag.Id(), "mysql-uuid", "mary", relationTag, bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+	err = authContext.Authenticator().CheckRelationMacaroons(
 		context.TODO(),
+		coretesting.ModelTag.Id(),
+		"mysql-uuid",
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -852,23 +852,26 @@ func (s *crossmodelRelationsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
-			checkers.DeclaredCaveat("offer-uuid", "db2-uuid"),
+			checkers.DeclaredCaveat("offer-uuid", "token-rel-db2-uuid"),
 			checkers.DeclaredCaveat("username", "mary"),
-		}, bakery.Op{"db2-uuid", "consume"})
+		}, bakery.Op{"token-rel-db2-uuid", "consume"})
 
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.WatchRemoteSecretChangesArgs{
 		Args: []params.WatchRemoteSecretChangesArg{
 			{
 				ApplicationToken: "token-db2",
+				RelationToken:    "token-rel-db2",
 				Macaroons:        macaroon.Slice{mac.M()},
 			},
 			{
 				ApplicationToken: "token-mysql",
+				RelationToken:    "token-rel-mysql",
 				Macaroons:        macaroon.Slice{mac.M()},
 			},
 			{
 				ApplicationToken: "token-postgresql",
+				RelationToken:    "token-rel-postgresql",
 				Macaroons:        macaroon.Slice{mac.M()},
 			},
 		},
@@ -881,13 +884,13 @@ func (s *crossmodelRelationsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 		URI:      "secret:9m4e2mr0ui3e8a215n4g",
 		Revision: 666,
 	}})
-	c.Assert(results.Results[1].Error.ErrorCode(), gc.Equals, params.CodeNotFound)
+	c.Assert(results.Results[1].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(results.Results[2].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(s.watchedSecretConsumers, jc.DeepEquals, []string{"db2"})
 	s.st.CheckCalls(c, []testing.StubCall{
-		{"GetSecretConsumerInfo", []interface{}{"token-db2"}},
+		{"GetSecretConsumerInfo", []interface{}{"token-db2", "token-rel-db2"}},
 		{"GetSecret", []interface{}{&coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}},
-		{"GetSecretConsumerInfo", []interface{}{"token-mysql"}},
-		{"GetSecretConsumerInfo", []interface{}{"token-postgresql"}},
+		{"GetSecretConsumerInfo", []interface{}{"token-mysql", "token-rel-mysql"}},
+		{"GetSecretConsumerInfo", []interface{}{"token-postgresql", "token-rel-postgresql"}},
 	})
 }

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -287,17 +287,17 @@ func (st *mockState) Application(id string) (commoncrossmodel.Application, error
 	return a, nil
 }
 
-func (st *mockState) GetSecretConsumerInfo(token string) (names.Tag, string, error) {
-	st.MethodCall(st, "GetSecretConsumerInfo", token)
+func (st *mockState) GetSecretConsumerInfo(appToken, relToken string) (names.Tag, string, error) {
+	st.MethodCall(st, "GetSecretConsumerInfo", appToken, relToken)
 	if err := st.NextErr(); err != nil {
 		return nil, "", err
 	}
 	for e, t := range st.remoteEntities {
-		if t == token {
-			return e, e.Id() + "-uuid", nil
+		if t == appToken {
+			return e, relToken + "-uuid", nil
 		}
 	}
-	return nil, "", errors.NotFoundf("token %v", token)
+	return nil, "", errors.NotFoundf("token %v", appToken)
 }
 
 func (st *mockState) GetSecret(uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -137,8 +137,8 @@ func (s *CrossModelSecretsAPI) checkRelationMacaroons(consumerTag names.Tag, mac
 
 	// A cross model secret can only be accessed if the corresponding cross model relation
 	// it is scoped to is accessible by the supplied macaroon.
-	auth := s.authCtxt.Authenticator(s.modelUUID, offerUUID)
-	return auth.CheckRelationMacaroons(s.ctx, names.NewRelationTag(relKey), mac, version)
+	auth := s.authCtxt.Authenticator()
+	return auth.CheckRelationMacaroons(s.ctx, s.modelUUID, offerUUID, names.NewRelationTag(relKey), mac, version)
 }
 
 // GetSecretContentInfo returns the secret values for the specified secrets.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -20432,11 +20432,15 @@
                             "items": {
                                 "$ref": "#/definitions/Macaroon"
                             }
+                        },
+                        "relation-token": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "application-token"
+                        "application-token",
+                        "relation-token"
                     ]
                 },
                 "WatchRemoteSecretChangesArgs": {

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -461,6 +461,9 @@ type WatchRemoteSecretChangesArg struct {
 	// ApplicationToken is the application token on the remote model.
 	ApplicationToken string `json:"application-token"`
 
+	// RelationToken is the relation token on the remote model.
+	RelationToken string `json:"relation-token"`
+
 	// Macaroons are used for authentication.
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
 

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -19,6 +19,7 @@ import (
 type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
+	Criticalf(string, ...interface{})
 	Infof(string, ...interface{})
 	Warningf(string, ...interface{})
 	Errorf(string, ...interface{})

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -376,10 +376,10 @@ func (m *mockRemoteRelationsFacade) RelationUnitSettings(relationUnits []params.
 	return result, nil
 }
 
-func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(appToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(appToken, relToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.stub.MethodCall(m, "WatchConsumedSecretsChanges", appToken, mac)
+	m.stub.MethodCall(m, "WatchConsumedSecretsChanges", appToken, relToken, mac)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -662,7 +662,7 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 	}
 
 	if w.secretChangesWatcher == nil {
-		w.secretChangesWatcher, err = w.remoteModelFacade.WatchConsumedSecretsChanges(applicationToken, w.offerMacaroon)
+		w.secretChangesWatcher, err = w.remoteModelFacade.WatchConsumedSecretsChanges(applicationToken, relationToken, w.offerMacaroon)
 		if err != nil && !errors.IsNotFound(err) {
 			w.checkOfferPermissionDenied(err, "", "")
 			if !isNotFound(err) {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -69,7 +69,7 @@ type RemoteModelRelationsFacade interface {
 
 	// WatchConsumedSecretsChanges starts a watcher for any changes to secrets
 	// consumed by the specified application.
-	WatchConsumedSecretsChanges(applicationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error)
+	WatchConsumedSecretsChanges(applicationToken, relationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -560,7 +560,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 		{"WatchRelationSuspendedStatus", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 		{"WatchLocalRelationChanges", []interface{}{"db2:db django:db"}},
 		{"WatchRelationChanges", []interface{}{"token-db2:db django:db", "token-offer-db2-uuid", macaroon.Slice{apiMac}}},
-		{"WatchConsumedSecretsChanges", []interface{}{"token-django", mac}},
+		{"WatchConsumedSecretsChanges", []interface{}{"token-django", "token-db2:db django:db", mac}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 
@@ -1049,7 +1049,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 		{"WatchRelationSuspendedStatus", []interface{}{"token-db2:db django:db", macaroon.Slice{apiMac}}},
 		{"WatchLocalRelationChanges", []interface{}{"db2:db django:db"}},
 		{"WatchRelationChanges", []interface{}{"token-db2:db django:db", "token-offer-db2-uuid", macaroon.Slice{apiMac}}},
-		{"WatchConsumedSecretsChanges", []interface{}{"token-django", mac}},
+		{"WatchConsumedSecretsChanges", []interface{}{"token-django", "token-db2:db django:db", mac}},
 	}
 
 	// If a relation is dying and there's been an error, when processing resumes


### PR DESCRIPTION
The consumer secrets watcher used in the remote relations worker for cmr is broken due to fixes made to the offer side remote application proxy. The offer uuid is not stored on the proxy any more as the offer uuid must be determined from the relation. To that end, the relation tag is now passed when setting up the watcher. A small cleanup of the auth context is also done, requiring that source model and offer uuids be passed into the auth calls.

To allow for backwards compatibility with older controllers in a multi-controller cmr scenario, we extract the offer uuid from the macaroon.

## QA steps

create a model for an offer

juju deploy juju-qa-dummy-source
juju offer dummy-source:sink
juju config dummy-source token=foo

create a model for the consumer 

juju deploy juju-qa-dummy-sink
juju relate dummy-sink controller.dummy-source

check that the apps are idle and active

create a secret in the offering model

juju exec --unit dummy-source/0 -- secret-add foo=bar
juju exec --unit dummy-source/0 -- secret-grant -r 0 secret://dcbb8270-42ff-4d15-8e42-843a6a8e49d8/chsn02ip43ljshc2j7j0

check that it can be read

juju exec --unit dummy-sink/0 -- secret-get secret://dcbb8270-42ff-4d15-8e42-843a6a8e49d8/chsn02ip43ljshc2j7j0

update the secret

juju exec --unit dummy-source/0 -- secret-set secret://dcbb8270-42ff-4d15-8e42-843a6a8e49d8/chsn02ip43ljshc2j7j0 foo=bar2

check the consuming charm has run the secret-changed hook and can ee the new value

 juju show-status-log dummy-sink/0
 juju exec --unit dummy-sink/0 -- secret-get secret://dcbb8270-42ff-4d15-8e42-843a6a8e49d8/chsn02ip43ljshc2j7j0 --peek


Also deploy a 3.1.2 controller and add consuming app and relate to offer.

## Bug reference

https://bugs.launchpad.net/bugs/2021969
