### PR TITLE
[JUJU-1682] Fix setting charmURL for subordinate units

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1585,6 +1585,8 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 		result.Machine, _ = unit.AssignedMachineId()
 	}
 	unitCharm := unit.CharmURL()
+	// Set the Charm field for the unit; if we have both the principle application's Charm and
+	// the unit's Charm (not nil), and either they're not the same, or this is a subordinate unit
 	if applicationCharm != "" && unitCharm != nil && (*unitCharm != applicationCharm || isSubordinate) {
 		result.Charm = *unitCharm
 	}

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1523,7 +1523,7 @@ func (context *statusContext) processUnits(units map[string]*state.Unit, applica
 	expectWorkload bool) map[string]params.UnitStatus {
 	unitsMap := make(map[string]params.UnitStatus)
 	for _, unit := range units {
-		unitsMap[unit.Name()] = context.processUnit(unit, applicationCharm, expectWorkload)
+		unitsMap[unit.Name()] = context.processUnit(unit, applicationCharm, expectWorkload, false)
 	}
 	return unitsMap
 }
@@ -1554,7 +1554,7 @@ func (context *statusContext) unitPublicAddress(unit *state.Unit) string {
 }
 
 func (context *statusContext) processUnit(unit *state.Unit, applicationCharm string,
-	expectWorkload bool) params.UnitStatus {
+	expectWorkload bool, isSubordinate bool) params.UnitStatus {
 	var result params.UnitStatus
 	if context.model.Type() == state.ModelTypeIAAS {
 		result.PublicAddress = context.unitPublicAddress(unit)
@@ -1585,7 +1585,7 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 		result.Machine, _ = unit.AssignedMachineId()
 	}
 	unitCharm := unit.CharmURL()
-	if applicationCharm != "" && unitCharm != nil && *unitCharm != applicationCharm {
+	if applicationCharm != "" && unitCharm != nil && (*unitCharm != applicationCharm || isSubordinate) {
 		result.Charm = *unitCharm
 	}
 	workloadVersion, err := context.status.UnitWorkloadVersion(unit.Name())
@@ -1614,7 +1614,7 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 				} else {
 					logger.Debugf("error fetching subordinate application charm for %q", subUnit.ApplicationName())
 				}
-				result.Subordinates[name] = context.processUnit(subUnit, subUnitAppCharm, true)
+				result.Subordinates[name] = context.processUnit(subUnit, subUnitAppCharm, true, true)
 			}
 		}
 	}

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -526,7 +526,7 @@ func (s *statusUnitTestSuite) TestSubordinateUpgradingFrom(c *gc.C) {
 	c.Assert(status, gc.NotNil)
 	unitStatus, ok := status.Applications["principal"].Units["principal/0"].Subordinates["subord/0"]
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(unitStatus.Charm, gc.Equals, "")
+	c.Assert(unitStatus.Charm, gc.Equals, "cs:quantal/logging-1")
 
 	err = subordApp.SetCharm(state.SetCharmConfig{
 		Charm: subordCharmNew,


### PR DESCRIPTION
This fixes a bug in setting the charmURL for a subordinate unit. It's observed in pylibjuju, where a FullStatus returns the application units such that the subordinate units don't have the `charm` field set. 



So it looks like a while ago https://github.com/juju/juju/pull/14345 fixed the logic for processing subordinate units by passing the unit's URL to the `processUnit` instead of the principle application URL to correctly set the "upgrading-from" value. As a consequence of this, however, because of the logic that was already there at the time, in the recursive call the unit's charm is the same as the charm we're passing (as the 2nd parameter to processUnit), which results in the charmURL not being set for the subordinate units (so therefore we don't see the charm value in the FullStatus in pylibjuju).

This fixes it by adding a boolean flag to the processUnit function to add to the existing logic a bypass for setting the charmURL in case we're coming from the subordinate processing path. As a result the charm field is correctly set for subordinate units in the FullStatus.

## QA steps

There are multiple ways to QA this. A test is fixed from #14345 where the charm field should be set, so that could be run individually:

```sh
 $ cd juju/apiserver/facades/client/client/ && go test -gocheck.v -gocheck.f TestSubordinateUpgradingFrom
```

And/or
```sh
 $ juju deploy ubuntu && juju deploy nrpe && juju relate ubuntu nrpe
```
Then run pylibjuju to get the status, and you should be able to see the charm url in the subordinates of a principle app:

```python
 $ cd python-libjuju && git fetch 2.9 && switch 2.9 && python -m  asyncio

asyncio REPL 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model; m = model.Model(); await m.connect(); st = await m.get_status()
>>> st.applications['ubuntu']['units']['ubuntu/0']['subordinates']['nrpe/0'].charm
'ch:amd64/jammy/nrpe-104'
```

And/or after relating the `ubuntu` and `nrpe`, run `juju status --format yaml` and you should see the charm url at the `upgrading-from` field of `nrpe` within the subordinates of `ubuntu`:

```yaml
....
    units:
      ubuntu/0:
        workload-status:
          current: active
          since: 05 Jun 2023 14:36:33-06:00
        juju-status:
          current: idle
          since: 05 Jun 2023 14:36:39-06:00
          version: 2.9.44.8
        leader: true
        machine: "0"
        public-address: 10.137.32.127
        subordinates:
          nrpe/0:
            workload-status:
              current: active
              message: Ready
              since: 05 Jun 2023 14:41:23-06:00
            juju-status:
              current: idle
              since: 05 Jun 2023 14:38:02-06:00
              version: 2.9.44.8
            leader: true
            upgrading-from: ch:amd64/jammy/nrpe-104 <-----------------------------------------------------
            open-ports:
            - icmp
            - 5666/tcp
            public-address: 10.137.32.127
......
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1987332
