### PR TITLE
Force podspec charms to scale 0 before upgrading to sidecar.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1222,52 +1222,41 @@ func isX509Error(err error) bool {
 	}
 }
 
-var apiCallRetryStrategy = retry.LimitTime(10*time.Second,
-	retry.Exponential{
-		Initial:  100 * time.Millisecond,
-		Factor:   2,
-		MaxDelay: 1500 * time.Millisecond,
-	},
-)
-
 // APICall places a call to the remote machine.
 //
 // This fills out the rpc.Request on the given facade, version for a given
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (s *state) APICall(facade string, vers int, id, method string, args, response interface{}) error {
-	for a := retry.Start(apiCallRetryStrategy, s.clock); a.Next(); {
-		err := s.client.Call(rpc.Request{
-			Type:    facade,
-			Version: vers,
-			Id:      id,
-			Action:  method,
-		}, args, response)
-		if err == nil {
-			return nil
-		}
-		code := params.ErrCode(err)
-		if code != params.CodeIncompatibleClient {
-			return errors.Trace(err)
-		}
-		// Default to major version 2 for older servers.
-		serverMajorVersion := 2
-		err = errors.Cause(err)
-		apiErr, ok := err.(*rpc.RequestError)
-		if ok {
-			if serverVersion, ok := apiErr.Info["server-version"]; ok {
-				serverVers, err := version.Parse(fmt.Sprintf("%v", serverVersion))
-				if err == nil {
-					serverMajorVersion = serverVers.Major
-				}
+	err := s.client.Call(rpc.Request{
+		Type:    facade,
+		Version: vers,
+		Id:      id,
+		Action:  method,
+	}, args, response)
+	if err == nil {
+		return nil
+	}
+	code := params.ErrCode(err)
+	if code != params.CodeIncompatibleClient {
+		return errors.Trace(err)
+	}
+	// Default to major version 2 for older servers.
+	serverMajorVersion := 2
+	err = errors.Cause(err)
+	apiErr, ok := err.(*rpc.RequestError)
+	if ok {
+		if serverVersion, ok := apiErr.Info["server-version"]; ok {
+			serverVers, err := version.Parse(fmt.Sprintf("%v", serverVersion))
+			if err == nil {
+				serverMajorVersion = serverVers.Major
 			}
 		}
-		logger.Debugf("%v.%v API call not supported", facade, method)
-		return errors.NewNotSupported(nil, fmt.Sprintf(
-			"juju client with version %d.%d used with a controller having major version %d not supported\nre-install your juju client to match the version running on the controller",
-			jujuversion.Current.Major, jujuversion.Current.Minor, serverMajorVersion))
 	}
-	panic("unreachable")
+	logger.Debugf("%v.%v API call not supported", facade, method)
+	return errors.NewNotSupported(nil, fmt.Sprintf(
+		"juju client with version %d.%d used with a controller having major version %d not supported\nre-install your juju client to match the version running on the controller",
+		jujuversion.Current.Major, jujuversion.Current.Minor, serverMajorVersion))
 }
 
 func (s *state) Close() error {

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -47,35 +47,33 @@ func OperationBlockedError(msg string) error {
 	}
 }
 
-var singletonErrorCodes = map[error]string{
-	stateerrors.ErrCannotEnterScopeYet: params.CodeCannotEnterScopeYet,
-	stateerrors.ErrCannotEnterScope:    params.CodeCannotEnterScope,
-	stateerrors.ErrUnitHasSubordinates: params.CodeUnitHasSubordinates,
-	stateerrors.ErrDead:                params.CodeDead,
-	txn.ErrExcessiveContention:         params.CodeExcessiveContention,
-	leadership.ErrClaimDenied:          params.CodeLeadershipClaimDenied,
-	lease.ErrClaimDenied:               params.CodeLeaseClaimDenied,
-	ErrBadId:                           params.CodeNotFound,
-	ErrBadCreds:                        params.CodeUnauthorized,
-	ErrNoCreds:                         params.CodeNoCreds,
-	ErrLoginExpired:                    params.CodeLoginExpired,
-	ErrPerm:                            params.CodeUnauthorized,
-	ErrNotLoggedIn:                     params.CodeUnauthorized,
-	ErrUnknownWatcher:                  params.CodeNotFound,
-	ErrStoppedWatcher:                  params.CodeStopped,
-	ErrTryAgain:                        params.CodeTryAgain,
-	ErrActionNotAvailable:              params.CodeActionNotAvailable,
+var singletonErrorCodes = map[errors.ConstError]string{
+	stateerrors.ErrCannotEnterScopeYet:           params.CodeCannotEnterScopeYet,
+	stateerrors.ErrCannotEnterScope:              params.CodeCannotEnterScope,
+	stateerrors.ErrUnitHasSubordinates:           params.CodeUnitHasSubordinates,
+	stateerrors.ErrDead:                          params.CodeDead,
+	stateerrors.ErrApplicationShouldNotHaveUnits: params.CodeAppShouldNotHaveUnits,
+	txn.ErrExcessiveContention:                   params.CodeExcessiveContention,
+	leadership.ErrClaimDenied:                    params.CodeLeadershipClaimDenied,
+	lease.ErrClaimDenied:                         params.CodeLeaseClaimDenied,
+	ErrBadId:                                     params.CodeNotFound,
+	ErrBadCreds:                                  params.CodeUnauthorized,
+	ErrNoCreds:                                   params.CodeNoCreds,
+	ErrLoginExpired:                              params.CodeLoginExpired,
+	ErrPerm:                                      params.CodeUnauthorized,
+	ErrNotLoggedIn:                               params.CodeUnauthorized,
+	ErrUnknownWatcher:                            params.CodeNotFound,
+	ErrStoppedWatcher:                            params.CodeStopped,
+	ErrTryAgain:                                  params.CodeTryAgain,
+	ErrActionNotAvailable:                        params.CodeActionNotAvailable,
 }
 
 func singletonCode(err error) (string, bool) {
-	// All error types may not be hashable; deal with
-	// that by catching the panic if we try to look up
-	// a non-hashable type.
-	defer func() {
-		_ = recover()
-	}()
-	code, ok := singletonErrorCodes[err]
-	return code, ok
+	if e, is := errors.AsType[errors.ConstError](err); is {
+		code, ok := singletonErrorCodes[e]
+		return code, ok
+	}
+	return "", false
 }
 
 func singletonError(err error) (bool, error) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1340,8 +1340,8 @@ func (api *APIBase) applicationSetCharm(
 
 	// If upgrading from a pod-spec (v1) charm to sidecar (v2), override the
 	// application's series to what it would be for a fresh sidecar deploy.
-	oldSeries := params.Application.Series()
-	if oldSeries == series.Kubernetes.String() && charm.MetaFormat(newCharm) >= charm.FormatV2 && corecharm.IsKubernetes(newCharm) {
+	if charm.MetaFormat(oldCharm) == charm.FormatV1 && corecharm.IsKubernetes(oldCharm) &&
+		charm.MetaFormat(newCharm) >= charm.FormatV2 && corecharm.IsKubernetes(newCharm) {
 		// Disallow upgrading from a v1 DaemonSet or Deployment type charm
 		// (only StatefulSet is supported in v2 right now).
 		deployment := oldCharm.Meta().Deployment
@@ -1367,8 +1367,9 @@ func (api *APIBase) applicationSetCharm(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		logger.Debugf("upgrading pod-spec to sidecar charm, setting series to %q", newSeries)
+		logger.Infof("upgrading pod-spec to sidecar charm, setting series to %q", newSeries)
 		cfg.Series = newSeries
+		cfg.RequireNoUnits = true
 	}
 
 	return params.Application.SetCharm(cfg)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -550,13 +550,28 @@ func (s *ApplicationSuite) TestSetCharmUpgradeFormat(c *gc.C) {
 	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
-	app := s.expectDefaultApplication(ctrl)
+	oldCharm := s.expectCharm(ctrl,
+		&charm.Meta{
+			Name:   "charm-postgresql",
+			Series: []string{"kubernetes"},
+		},
+		&charm.Manifest{},
+		&charm.Config{
+			Options: map[string]charm.Option{
+				"stringOption": {Type: "string"},
+				"intOption":    {Type: "int", Default: int(123)},
+			},
+		},
+	)
+
+	app := s.expectApplicationWithCharm(ctrl, oldCharm, "postgresql")
 	cfg := state.SetCharmConfig{
 		CharmOrigin: &state.CharmOrigin{
 			Source:   "charm-hub",
 			Platform: &state.Platform{OS: "ubuntu", Series: "bionic"},
 		},
-		Series: "focal",
+		Series:         "focal",
+		RequireNoUnits: true,
 	}
 	app.EXPECT().SetCharm(setCharmConfigMatcher{c: c, expected: cfg}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -258,6 +258,16 @@ application; overriding profiles on the container may cause unexpected
 behavior. 
 `
 
+const upgradedApplicationHasUnitsMessage = `
+Upgrading from an older PodSpec style charm to a newer Sidecar charm requires that
+the application be scaled down to 0 units.
+
+Before refreshing the application again, you must scale it to 0 units and wait for
+all those units to disappear before continuing.
+
+	juju scale-application %s 0
+`
+
 func (c *refreshCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "refresh",
@@ -515,7 +525,11 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		EndpointBindings:   c.Bindings,
 	}
 
-	if err := block.ProcessBlockedError(charmRefreshClient.SetCharm(generation, charmCfg), block.BlockChange); err != nil {
+	err = charmRefreshClient.SetCharm(generation, charmCfg)
+	err = block.ProcessBlockedError(err, block.BlockChange)
+	if params.IsCodeAppShouldNotHaveUnits(err) {
+		return errors.Errorf(upgradedApplicationHasUnitsMessage[1:], c.ApplicationName)
+	} else if err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/juju/schema v1.0.1
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.0.2
-	github.com/juju/txn/v2 v2.0.0
+	github.com/juju/txn/v2 v2.1.1
 	github.com/juju/utils/v3 v3.0.0
 	github.com/juju/version/v2 v2.0.0
 	github.com/juju/webbrowser v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL
 github.com/juju/testing v1.0.0/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
 github.com/juju/testing v1.0.2 h1:OR90RqCd9CJONxXamZAjLknpZdtqDyxqW8IwCbgw3i4=
 github.com/juju/testing v1.0.2/go.mod h1:h3Vd2rzB57KrdsBEy6R7bmSKPzP76BnNavt7i8PerwQ=
-github.com/juju/txn/v2 v2.0.0 h1:MbHrIrQ17dfJzQj+cfE5ZLJoPxpusJ3ztwIZ0v25+XQ=
-github.com/juju/txn/v2 v2.0.0/go.mod h1:Sh0uxANJLqw/GccwAhz4qIn+eWFVbAlQSBynFR4luY8=
+github.com/juju/txn/v2 v2.1.1 h1:IqRgd7ZCTkXBzhQo3ZaMqAL2qwWhUZifr0JYdDwvVPI=
+github.com/juju/txn/v2 v2.1.1/go.mod h1:Xs4JCc7hsNqdscPKDMcp/PWiJa7efmhNXwepi5CjnMo=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
 github.com/juju/usso v1.0.1/go.mod h1:3cvBcGVmWXyHhrBHBQtpNBzca/JRg4S5XH88Hj/NsYA=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -212,6 +212,7 @@ const (
 	CodeLeaseError                = "lease error"
 	CodeNotYetAvailable           = "not yet available; try again later"
 	CodeNotValid                  = "not valid"
+	CodeAppShouldNotHaveUnits     = "application should not have units"
 )
 
 // ErrCode returns the error code associated with
@@ -414,4 +415,8 @@ func IsCodeDeadlineExceeded(err error) bool {
 
 func IsLeaseError(err error) bool {
 	return ErrCode(err) == CodeLeaseError
+}
+
+func IsCodeAppShouldNotHaveUnits(err error) bool {
+	return ErrCode(err) == CodeAppShouldNotHaveUnits
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -311,6 +311,28 @@ func (s *ApplicationSuite) TestCAASSetCharm(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
+func (s *ApplicationSuite) TestCAASSetCharmRequireNoUnits(c *gc.C) {
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "caas-model",
+		Type: state.ModelTypeCAAS,
+	})
+	defer st.Close()
+	f := factory.NewFactory(st, s.StatePool)
+	ch := f.MakeCharm(c, &factory.CharmParams{Name: "mysql", Series: "kubernetes"})
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: ch, DesiredScale: 1})
+
+	// Add a compatible charm and force it.
+	sch := state.AddCustomCharm(c, st, "mysql", "metadata.yaml", metaBaseCAAS, "kubernetes", 2)
+
+	cfg := state.SetCharmConfig{
+		Charm:          sch,
+		ForceUnits:     true,
+		RequireNoUnits: true,
+	}
+	err := app.SetCharm(cfg)
+	c.Assert(err, gc.ErrorMatches, `.*application should not have units`)
+}
+
 func (s *ApplicationSuite) TestCAASSetCharmNewDeploymentFails(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",

--- a/state/errors/application.go
+++ b/state/errors/application.go
@@ -11,4 +11,8 @@ const (
 	// ProvisioningStateInconsistent is returned by SetProvisioningState when the provisioning state
 	// is inconsistent with the application scale.
 	ProvisioningStateInconsistent = errors.ConstError("provisioning state is inconsistent")
+
+	// ErrApplicationShouldNotHaveUnits is returned by SetCharm when the application has units when
+	// it is expected to not have units. Used for upgrading from podspec to sidecar charms.
+	ErrApplicationShouldNotHaveUnits = errors.ConstError("application should not have units")
 )

--- a/worker/caasapplicationprovisioner/ops.go
+++ b/worker/caasapplicationprovisioner/ops.go
@@ -340,7 +340,7 @@ func upgradePodSpec(appName string,
 			break
 		}
 
-		logger.Infof("app %q has just been upgraded from a podspec charm to sidecar, now deleting workload and operator pods %q", appName)
+		logger.Infof("app %q has just been upgraded from a podspec charm to sidecar, now deleting workload and operator pods", appName)
 		err = broker.DeleteService(appName)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return errors.Annotatef(err, "deleting workload pod for application %q", appName)


### PR DESCRIPTION
Upgrading from pospec charms to sidecar charms can be problematic when the unit numbers don't match the ordinal pod numbers. This one time change forces the users to scale the application to 0 before performing this particular charm upgrade. This has the side benefit of surfacing previous behaviour where the application would be unavailable during the charm upgrade from podspec to sidecar. This is now obvious because the admin must first scale the application down.

## QA steps

```
$ juju bootstrap microk8s
$ juju add-model a
$ juju deploy oidc-gatekeeper --revision 176 --channel ckf-1.7/stable
$ # wait for oidc-gatekeeper to settle down
$ juju remove-application oidc-gatekeeper
$ # wait for oidc-gatekeeper to disappear
$ juju deploy oidc-gatekeeper --revision 176 --channel ckf-1.7/stable
$ # wait for oidc-gatekeeper to settle down
$ juju refresh oidc-gatekeeper --channel latest/edge
Added charm-hub charm "oidc-gatekeeper", revision 213 in channel latest/edge, to the model
ERROR Upgrading from an older PodSpec style charm to a newer Sidecar charm requires that
the application be scaled down to 0 units.

Before refreshing the application again, you must scale it to 0 units and wait for
all those units to disappear before continuing.

    juju scale-application oidc-gatekeeper 0
$ juju scale-application oidc-gatekeeper 0
$ # wait for oidc-gatekeeper units to disappear
$ juju refresh oidc-gatekeeper --channel latest/edge
$ juju scale-application oidc-gatekeeper 1
$ # app should be upgraded
```

## Documentation changes

Document upgrade from podspec to sidecar charm that they need to be scaled to 0 first.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2023117