### PR TITLE
[JUJU-3919] Extended controller schema DDL for model migrations

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -24,7 +24,6 @@ func ControllerDDL(nodeID uint64) []database.Delta {
 		controllerNodeEntry(nodeID),
 		controllerNodeTriggers,
 		modelMigrationSchema,
-		controllerNodeSchema,
 	}
 
 	var deltas []database.Delta
@@ -389,8 +388,8 @@ BEGIN
 END;`)
 }
 
-func modelMigrationSchema() string {
-	return `
+func modelMigrationSchema() database.Delta {
+	return database.MakeDelta(`
 CREATE TABLE model_migration (
     uuid                    TEXT PRIMARY KEY,
     attempt                 INT,
@@ -481,6 +480,5 @@ AFTER DELETE ON model_migration_minion_sync FOR EACH ROW
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
     VALUES (4, 5, OLD.key, DATETIME('now'));
-END;
-`[1:]
+END;`)
 }

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -23,6 +23,11 @@ func ControllerDDL(nodeID uint64) []database.Delta {
 		controllerNodeTable,
 		controllerNodeEntry(nodeID),
 		controllerNodeTriggers,
+		modelMigrationSchema,
+		modelMigrationStatusSchema,
+		modelMigrationUserSchema,
+		modelMigrationMinionSyncSchema,
+		controllerNodeSchema,
 	}
 
 	var deltas []database.Delta
@@ -383,4 +388,159 @@ BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at)
     VALUES (4, 2, OLD.controller_id, DATETIME('now'));
 END;`)
+}
+
+func modelMigrationSchema() string {
+	return `
+CREATE TABLE model_migration (
+	uuid					TEXT PRIMARY KEY,
+	model_uuid				TEXT NOT NULL,
+	attempt					INT,
+	initiated_by_user_uuid	TEXT NOT NULL,
+	target_controller_uuid	TEXT NOT NULL,
+	target_cacert			TEXT,
+	target_entity			TEXT,
+	target_password			TEXT,
+	target_macaroons		TEXT,
+	active					BOOLEAN,
+	start_time				TIMESTAMP,
+	success_time			TIMESTAMP,
+	end_time				TIMESTAMP,
+	phase					TEXT,
+	phase_changed_time		TIMESTAMP,
+	status_message			TEXT
+	-- target_controller_alias
+	-- target_addresses
+	
+	-- TODO(anvial): Add foreign key constraints after corresponding tables are added.
+	-- 	CONSTRAINT				fk_migration_model
+	-- 		FOREIGN KEY			(model_uuid)
+	-- 		REFERENCES			model(uuid),
+	-- 	CONSTRAINT				fk_migration_initiated_by_user
+	-- 		FOREIGN KEY			(initiated_by_user_uuid)
+	-- 		REFERENCES			user(uuid),
+	-- 	CONSTRAINT				fk_migration_target_controller
+	-- 		FOREIGN KEY			(target_controller_uuid)
+	-- 		REFERENCES			controller(uuid)
+);
+
+CREATE TRIGGER trg_log_model_migration_insert
+AFTER INSERT ON model_migration FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (1, 1, NEW.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_update
+AFTER UPDATE ON model_migration FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (2, 1, OLD.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_delete
+AFTER DELETE ON model_migration FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (4, 1, OLD.key, DATETIME('now'));
+END;
+`[1:]
+}
+
+func modelMigrationStatusSchema() string {
+	return `
+CREATE TABLE model_migration_status (
+	uuid				TEXT PRIMARY KEY,
+	start_time			TIMESTAMP,
+	success_time		TIMESTAMP,
+	end_time			TIMESTAMP,
+	phase				TEXT,
+	phase_changed_time	TIMESTAMP,
+	status				TEXT
+);
+
+CREATE TRIGGER trg_log_model_migration_status_insert
+AFTER INSERT ON model_migration_status FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (1, 1, NEW.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_status_update
+AFTER UPDATE ON model_migration_status FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (2, 1, OLD.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_status_delete
+AFTER DELETE ON model_migration_status FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (4, 1, OLD.key, DATETIME('now'));
+END;
+`[1:]
+}
+
+func modelMigrationUserSchema() string {
+	return `
+CREATE TABLE model_migration_user (
+	user_uuid		TEXT PRIMARY KEY,
+	permission		TEXT
+    -- TODO(anvial): Add foreign key constraints after permissions tables are added.     
+	-- CONSTRAINT		fk_model_migration_user_permission
+	-- 		FOREIGN KEY	(permission_access)
+	-- 		REFERENCES	permission(access)                              
+);
+
+CREATE TRIGGER trg_log_model_migration_user_insert
+AFTER INSERT ON model_migration_user FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (1, 1, NEW.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_user_update
+AFTER UPDATE ON model_migration_user FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (2, 1, OLD.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_user_delete
+AFTER DELETE ON model_migration_user FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (4, 1, OLD.key, DATETIME('now'));
+END;
+`[1:]
+}
+
+func modelMigrationMinionSyncSchema() string {
+	return `
+CREATE TABLE model_migration_minion_sync (
+	uuid			TEXT PRIMARY KEY,
+	migration_uuid	TEXT NOT NULL,
+	phase			TEXT,
+	entity_key		TEXT,
+	time			TIMESTAMP,
+	success			BOOLEAN,
+	CONSTRAINT		fk_model_migration_minion_sync_model_migration
+		FOREIGN KEY	(migration_uuid)
+		REFERENCES	model_migration(uuid)
+);
+
+CREATE TRIGGER trg_log_model_migration_minion_sync_insert
+AFTER INSERT ON model_migration_minion_sync FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (1, 1, NEW.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_minion_sync_update
+AFTER UPDATE ON model_migration_minion_sync FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (2, 1, OLD.key, DATETIME('now'));
+END;
+CREATE TRIGGER trg_log_model_migration_minion_sync_delete
+AFTER DELETE ON model_migration_minion_sync FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    VALUES (4, 1, OLD.key, DATETIME('now'));
+END;
+`[1:]
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -82,6 +82,12 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 
 		// Controller nodes
 		"controller_node",
+
+		// Model migration
+		"model_migration",
+		"model_migration_status",
+		"model_migration_user",
+		"model_migration_minion_sync",
 	)
 	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This PR enhances the controller database schema by adding four new tables required for model migration:
- "model_migration"
- "model_migration_status"
- "model_migration_user"
- "model_migration_minion_sync"

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd domain/schema
go test -check.f schemaSuite
```