### PR TITLE
[JUJU-2938] Add DDL for controller_node table

### DIFF
--- a/domain/schema/controller_test.go
+++ b/domain/schema/controller_test.go
@@ -80,6 +80,9 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 
 		// Controller config
 		"controller_config",
+
+		// Controller nodes
+		"controller_node",
 	)
 	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This adds a new table and associated triggers for storing information about controller machines, specifically their Dqlite cluster information. 

This will be used to determine whether such machines have been realised as working controllers.

## QA steps

Unit tests in _domain/schema_ pass.
