### PR TITLE
[JUJU-2938] Database migrations use a Delta type instead of just a string

### DIFF
--- a/core/database/delta.go
+++ b/core/database/delta.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+// Delta represents a change to be run against the database in the
+// form of a DDL/DML statement and corresponding bind arguments.
+type Delta struct {
+	stmt string
+	args []any
+}
+
+// MakeDelta is a convenience function to return a Delta value.
+func MakeDelta(stmt string, args ...any) Delta {
+	return Delta{stmt: stmt, args: args}
+}
+
+// Stmt returns the DDL/DML statement.
+func (d Delta) Stmt() string {
+	return d.stmt
+}
+
+// Args returns the bind variables that should
+// accompany the Delta's statement.
+func (d Delta) Args() []any {
+	return d.args
+}

--- a/database/migration.go
+++ b/database/migration.go
@@ -8,19 +8,21 @@ import (
 	"database/sql"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/database"
 )
 
 // DBMigration is used to apply a series of deltas to a database.
 type DBMigration struct {
 	db     *sql.DB
 	logger Logger
-	deltas [][]string
+	deltas []database.Delta
 }
 
 // NewDBMigration returns a reference to a new migration that
 // is used to apply the input deltas to the input database.
 // The deltas are applied in the order supplied.
-func NewDBMigration(db *sql.DB, logger Logger, deltas ...[]string) *DBMigration {
+func NewDBMigration(db *sql.DB, logger Logger, deltas []database.Delta) *DBMigration {
 	return &DBMigration{
 		db:     db,
 		logger: logger,
@@ -31,12 +33,10 @@ func NewDBMigration(db *sql.DB, logger Logger, deltas ...[]string) *DBMigration 
 // Apply executes all deltas against the database inside a transaction.
 func (m *DBMigration) Apply(ctx context.Context) error {
 	return StdTxn(ctx, m.db, func(ctx context.Context, tx *sql.Tx) error {
-		for _, delta := range m.deltas {
-			for _, stmt := range delta {
-				_, err := tx.ExecContext(ctx, stmt)
-				if err != nil {
-					return errors.Trace(err)
-				}
+		for _, d := range m.deltas {
+			_, err := tx.ExecContext(ctx, d.Stmt(), d.Args()...)
+			if err != nil {
+				return errors.Trace(err)
 			}
 		}
 		return nil

--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/testing"
 )
 
@@ -19,13 +20,13 @@ type migrationSuite struct {
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
-	delta := []string{
-		"CREATE TABLE band(name TEXT PRIMARY KEY);",
-		"INSERT INTO band VALUES ('Blood Incantation');",
+	deltas := []database.Delta{
+		database.MakeDelta("CREATE TABLE band(name TEXT PRIMARY KEY);"),
+		database.MakeDelta("INSERT INTO band VALUES (?);", "Blood Incantation"),
 	}
 
 	db := s.DB()
-	m := NewDBMigration(db, stubLogger{}, delta)
+	m := NewDBMigration(db, stubLogger{}, deltas)
 	c.Assert(m.Apply(context.Background()), jc.ErrorIsNil)
 
 	rows, err := db.Query("SELECT * from band;")

--- a/database/testing/simplesuite.go
+++ b/database/testing/simplesuite.go
@@ -40,7 +40,7 @@ func (s *ControllerSuite) SetUpTest(c *gc.C) {
 		db: sqlair.NewDB(s.db),
 	}
 
-	s.ApplyControllerDDL(c, s.db)
+	s.ApplyControllerDDL(c)
 }
 
 func (s *ControllerSuite) TearDownTest(c *gc.C) {
@@ -78,13 +78,13 @@ func (s *ControllerSuite) NewCleanDB(c *gc.C) *sql.DB {
 
 // ApplyControllerDDL applies the controller schema to the provided sql.DB.
 // This is useful for tests that need to apply the schema to a new DB.
-func (s *ControllerSuite) ApplyControllerDDL(c *gc.C, db *sql.DB) {
+func (s *ControllerSuite) ApplyControllerDDL(c *gc.C) {
 	tx, err := s.db.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	for idx, stmt := range schema.ControllerDDL() {
+	for idx, delta := range schema.ControllerDDL() {
 		c.Logf("Executing schema DDL index: %v", idx)
-		_, err := tx.Exec(stmt)
+		_, err := tx.Exec(delta.Stmt(), delta.Args()...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/domain/schema/controller_test.go
+++ b/domain/schema/controller_test.go
@@ -40,9 +40,9 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 	tx, err := s.db.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	for idx, stmt := range ControllerDDL() {
+	for idx, delta := range ControllerDDL() {
 		c.Logf("Executing schema DDL index: %v", idx)
-		_, err := tx.Exec(stmt)
+		_, err := tx.Exec(delta.Stmt(), delta.Args()...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -2127,7 +2127,7 @@ func (e *environ) newCleanDB() (changestream.WatchableDB, error) {
 	}
 
 	for _, stmt := range domainschema.ControllerDDL() {
-		_, err := tx.Exec(stmt)
+		_, err := tx.Exec(stmt.Stmt(), stmt.Args()...)
 		if err != nil {
 			_ = tx.Rollback()
 			return nil, err


### PR DESCRIPTION
Using strings as deltas run by `database.DBMigration` prevents use of bind variables with the deltas.

Since we want to avoid the security faux pas of getting variables into statements with `fmt.Sprintf`, we introduce a new `Delta` type to _core/database_ that contains statement and bind variables.

The controller schema is now a slice of these instead of strings, and they are what is run by database migrations.

The new type lives in _core/database_ in order to avoid import cycles between _database_ and _domain/schema_.

## QA steps

Bootstrap to LXD successfully.
