### PR TITLE
[JUJU-3965] Attempt faster Dqlite shutdown

### DIFF
--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -55,12 +55,15 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *baseSuite) expectAnyLogs() {
-	s.logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Warningf(gomock.Any(), gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
+func (s *baseSuite) expectAnyLogs(c *gc.C) {
+	log := func(msg string, args ...any) { c.Logf(msg, args...) }
+
+	s.logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Do(log).AnyTimes()
+	s.logger.EXPECT().Warningf(gomock.Any(), gomock.Any()).Do(log).AnyTimes()
+	s.logger.EXPECT().Infof(gomock.Any(), gomock.Any()).Do(log).AnyTimes()
+	s.logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).Do(log).AnyTimes()
+	s.logger.EXPECT().Logf(gomock.Any(), gomock.Any()).Do(log).AnyTimes()
+
 	s.logger.EXPECT().IsTraceEnabled().AnyTimes()
 }
 

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -30,7 +30,7 @@ var _ = gc.Suite(&trackedDBWorkerSuite{})
 func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -47,7 +47,7 @@ func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -72,7 +72,7 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -97,7 +97,7 @@ func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -129,7 +129,7 @@ func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -165,7 +165,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -215,7 +215,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(2)
 
@@ -252,7 +252,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceedsWithDifferentDB(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -325,7 +325,7 @@ loop:
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -359,7 +359,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -399,7 +399,7 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerCancelsTxnNoRetry(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs()
+	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -216,12 +216,21 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 }
 
 func (w *dbWorker) loop() (err error) {
-	// The context here should not be tied to the catacomb, as the context will
-	// be cancelled when the worker is stopped, and we want to wait for the
-	// Dqlite app to shut down gracefully.
-	// There is a timeout in shutdownDqlite to ensure that we don't wait
+	// The context here should not be tied to the catacomb, as such a context
+	// would be cancelled when the worker is stopped, and we want to give a
+	// chance for the Dqlite app to shut down gracefully.
+	// There is a timeout in shutdownDqlite to ensure that we don't block
 	// forever.
-	defer w.shutdownDqlite(context.Background(), true)
+	// We allow a very short time to check whether we should attempt to hand
+	// over to another node.
+	// If we can't determine that we *shouldn't* within the time window,
+	// we go ahead and make the attempt.
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		bs, _ := w.cfg.NodeManager.IsBootstrappedNode(ctx)
+		w.shutdownDqlite(context.Background(), !bs)
+		cancel()
+	}()
 
 	extant, err := w.cfg.NodeManager.IsExistingNode()
 	if err != nil {


### PR DESCRIPTION
This introduces a time-boxed check whether the current node is the bootstrapped one, before shutting down Dqlite upon exiting the `db-accessor` worker loop.

What this allows us to do (if the check returns true within one second) is eschew the handover attempt, which should mean we exit up to 30 seconds faster in tests, and whenever else this worker restarts in a non-HA deployment.

## QA steps

To check for regression, bootstrap then `enable-ha`.
