### PR TITLE
[JUJU-3968] Fix token generation for offered apps which also consume

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -62,6 +62,9 @@ type Backend interface {
 	// specified cross-model relation key.
 	OfferNameForRelation(string) (string, error)
 
+	// AppNameForOffer returns the application for an offer.
+	AppNameForOffer(offerName string) (string, error)
+
 	// GetRemoteEntity returns the tag of the entity associated with the given token.
 	GetRemoteEntity(string) (names.Tag, error)
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -165,6 +165,15 @@ func (st stateShim) OfferNameForRelation(key string) (string, error) {
 	return offer.OfferName, nil
 }
 
+func (st stateShim) AppNameForOffer(offerName string) (string, error) {
+	offers := state.NewApplicationOffers(st.State)
+	offer, err := offers.ApplicationOffer(offerName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return offer.ApplicationName, nil
+}
+
 func (st stateShim) GetRemoteEntity(token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
 	return r.GetRemoteEntity(token)

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -120,7 +120,37 @@ func (api *CrossModelRelationsAPI) PublishRelationChanges(
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if err := commoncrossmodel.PublishRelationChange(api.st, relationTag, change); err != nil {
+		// Look up the application on the remote side of this relation
+		// ie from the model which published this change.
+		appOrOfferTag, err := api.st.GetRemoteEntity(change.ApplicationToken)
+		if err != nil && !errors.IsNotFound(err) {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		// The tag is either an application tag (legacy), or an offer tag.
+		var applicationTag names.Tag
+		if err == nil {
+			switch k := appOrOfferTag.Kind(); k {
+			case names.ApplicationTagKind:
+				applicationTag = appOrOfferTag
+			case names.ApplicationOfferTagKind:
+				// For an offer tag, load the offer and get the offered app from that.
+				appName, err := api.st.AppNameForOffer(appOrOfferTag.Id())
+				if err != nil && !errors.IsNotFound(err) {
+					results.Results[i].Error = apiservererrors.ServerError(err)
+					continue
+				}
+				if err == nil {
+					applicationTag = names.NewApplicationTag(appName)
+				}
+			default:
+				// Should never happen.
+				results.Results[i].Error = apiservererrors.ServerError(errors.NotValidf("offer app tag kind %q", k))
+				continue
+			}
+		}
+
+		if err := commoncrossmodel.PublishRelationChange(api.st, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
@@ -286,7 +316,7 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 	// This allows > 1 offers off the one application to be made.
 	// NB we need to export the application last so that everything else is in place when the worker is
 	// woken up by the watcher.
-	token, err := api.st.ExportLocalEntity(names.NewApplicationTag(appOffer.OfferName))
+	token, err := api.st.ExportLocalEntity(names.NewApplicationOfferTag(appOffer.OfferName))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, errors.Annotatef(err, "exporting local application offer %q", appOffer.OfferName)
 	}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -98,9 +98,15 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	s.api = api
 }
 
-func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeValue life.Value, suspendedReason string, forceCleanup bool) {
+func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeValue life.Value, suspendedReason string, forceCleanup, legacy bool) {
 	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
-	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
+	if legacy {
+		s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
+	} else {
+		s.st.remoteEntities[names.NewApplicationOfferTag("db2-offer")] = "token-db2"
+		s.st.offers["db2-offer"] = &crossmodel.ApplicationOffer{
+			OfferName: "db2-offer", ApplicationName: "db2"}
+	}
 	rel := newMockRelation(1)
 	ru1 := newMockRelationUnit()
 	ru2 := newMockRelationUnit()
@@ -148,9 +154,12 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeVa
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []testing.StubCall{
 		{"GetRemoteEntity", []interface{}{"token-db2:db django:db"}},
-		{"KeyRelation", []interface{}{"db2:db django:db"}},
 		{"GetRemoteEntity", []interface{}{"token-db2"}},
 	}
+	if !legacy {
+		expected = append(expected, testing.StubCall{"AppNameForOffer", []interface{}{"db2-offer"}})
+	}
+	expected = append(expected, testing.StubCall{"KeyRelation", []interface{}{"db2:db django:db"}})
 	if lifeValue == life.Alive {
 		c.Assert(rel.status, gc.Equals, status.Suspending)
 		if suspendedReason == "" {
@@ -202,19 +211,23 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeVa
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChanges(c *gc.C) {
-	s.assertPublishRelationsChanges(c, life.Alive, "", false)
+	s.assertPublishRelationsChanges(c, life.Alive, "", false, false)
+}
+
+func (s *crossmodelRelationsSuite) TestPublishRelationsChangesLegacy(c *gc.C) {
+	s.assertPublishRelationsChanges(c, life.Alive, "", false, true)
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChangesWithSuspendedReason(c *gc.C) {
-	s.assertPublishRelationsChanges(c, life.Alive, "reason", false)
+	s.assertPublishRelationsChanges(c, life.Alive, "reason", false, false)
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChangesDyingWhileSuspended(c *gc.C) {
-	s.assertPublishRelationsChanges(c, life.Dying, "", false)
+	s.assertPublishRelationsChanges(c, life.Dying, "", false, false)
 }
 
 func (s *crossmodelRelationsSuite) TestPublishRelationsChangesDyingForceCleanup(c *gc.C) {
-	s.assertPublishRelationsChanges(c, life.Dying, "", true)
+	s.assertPublishRelationsChanges(c, life.Dying, "", true, false)
 }
 
 func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
@@ -285,7 +298,7 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 	expectedRel.Stub = testing.Stub{} // don't care about api calls
 	c.Check(expectedRel, jc.DeepEquals, &mockRelation{id: 0, key: "offeredapp:local remote-apptoken:remote"})
 	c.Check(s.st.remoteEntities, gc.HasLen, 2)
-	c.Check(s.st.remoteEntities[names.NewApplicationTag("offered")], gc.Equals, "token-offered")
+	c.Check(s.st.remoteEntities[names.NewApplicationOfferTag("offered")], gc.Equals, "token-offered")
 	c.Check(s.st.remoteEntities[names.NewRelationTag("offeredapp:local remote-apptoken:remote")], gc.Equals, "rel-token")
 	c.Assert(s.st.offerConnections, gc.HasLen, 1)
 	offerConnection := s.st.offerConnections[0]
@@ -373,10 +386,9 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 	results, err := s.api.PublishIngressNetworkChanges(params.IngressNetworksChanges{
 		Changes: []params.IngressNetworksChangeEvent{
 			{
-				ApplicationToken: "token-db2",
-				RelationToken:    "token-db2:db django:db",
-				Networks:         []string{"1.2.3.4/32"},
-				Macaroons:        macaroon.Slice{mac.M()},
+				RelationToken: "token-db2:db django:db",
+				Networks:      []string{"1.2.3.4/32"},
+				Macaroons:     macaroon.Slice{mac.M()},
 			},
 		},
 	})
@@ -416,10 +428,9 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChangesRejected(c *g
 	results, err := s.api.PublishIngressNetworkChanges(params.IngressNetworksChanges{
 		Changes: []params.IngressNetworksChangeEvent{
 			{
-				ApplicationToken: "token-db2",
-				RelationToken:    "token-db2:db django:db",
-				Networks:         []string{"1.2.3.4/32"},
-				Macaroons:        macaroon.Slice{mac.M()},
+				RelationToken: "token-db2:db django:db",
+				Networks:      []string{"1.2.3.4/32"},
+				Macaroons:     macaroon.Slice{mac.M()},
 			},
 		},
 	})
@@ -687,8 +698,8 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettings(c *
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []testing.StubCall{
 		{"GetRemoteEntity", []interface{}{"token-db2:db django:db"}},
-		{"KeyRelation", []interface{}{"db2:db django:db"}},
 		{"GetRemoteEntity", []interface{}{"token-db2"}},
+		{"KeyRelation", []interface{}{"db2:db django:db"}},
 	}
 	s.st.CheckCalls(c, expected)
 	ru1.CheckCalls(c, []testing.StubCall{

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -177,6 +177,18 @@ func (st *mockState) OfferNameForRelation(key string) (string, error) {
 	return st.offerNames[key], nil
 }
 
+func (st *mockState) AppNameForOffer(offerName string) (string, error) {
+	st.MethodCall(st, "AppNameForOffer", offerName)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	offer, ok := st.offers[offerName]
+	if !ok {
+		return "", errors.NotFoundf("offer %q", offerName)
+	}
+	return offer.ApplicationName, nil
+}
+
 func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {
 	st.MethodCall(st, "ImportRemoteEntity", entity, token)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
+++ b/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
@@ -90,6 +90,21 @@ func (mr *MockRemoteRelationsStateMockRecorder) AllModelUUIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelUUIDs", reflect.TypeOf((*MockRemoteRelationsState)(nil).AllModelUUIDs))
 }
 
+// AppNameForOffer mocks base method.
+func (m *MockRemoteRelationsState) AppNameForOffer(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppNameForOffer", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppNameForOffer indicates an expected call of AppNameForOffer.
+func (mr *MockRemoteRelationsStateMockRecorder) AppNameForOffer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNameForOffer", reflect.TypeOf((*MockRemoteRelationsState)(nil).AppNameForOffer), arg0)
+}
+
 // Application mocks base method.
 func (m *MockRemoteRelationsState) Application(arg0 string) (crossmodel.Application, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -445,7 +445,12 @@ func (api *API) ConsumeRemoteRelationChanges(changes params.RemoteRelationsChang
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if err := commoncrossmodel.PublishRelationChange(api.st, relationTag, change); err != nil {
+		applicationTag, err := api.st.GetRemoteEntity(change.ApplicationToken)
+		if err != nil && !errors.IsNotFound(err) {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if err := commoncrossmodel.PublishRelationChange(api.st, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -22167,9 +22167,6 @@
                 "IngressNetworksChangeEvent": {
                     "type": "object",
                     "properties": {
-                        "application-token": {
-                            "type": "string"
-                        },
                         "bakery-version": {
                             "type": "integer"
                         },
@@ -22195,7 +22192,6 @@
                     "additionalProperties": false,
                     "required": [
                         "relation-token",
-                        "application-token",
                         "ingress-required"
                     ]
                 },

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/core/relation"
 )
 
-// ApplicationOfferAdminDetails represents the details about an
+// ApplicationOfferDetails represents the details about an
 // application offer. Depending on the access permission of the
 // user making the API call, and whether the call is "find" or "list",
 // not all fields will be populated.

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -25,7 +25,7 @@ type ExternalControllerInfoResult struct {
 	Error  *Error                  `json:"error"`
 }
 
-// SetControllersInfoParams contains the parameters for setting the
+// SetExternalControllersInfoParams contains the parameters for setting the
 // info for a set of external controllers.
 type SetExternalControllersInfoParams struct {
 	Controllers []SetExternalControllerInfoParams `json:"controllers"`
@@ -486,9 +486,6 @@ type IngressNetworksChangeEvent struct {
 	// RelationToken is the token of the relation.
 	RelationToken string `json:"relation-token"`
 
-	// ApplicationToken is the token of the application.
-	ApplicationToken string `json:"application-token"`
-
 	// Networks are the CIDRs for which ingress is required.
 	Networks []string `json:"networks,omitempty"`
 
@@ -558,7 +555,7 @@ type RegisterRemoteRelationResult struct {
 	Error  *Error                 `json:"error,omitempty"`
 }
 
-// RemoteRemoteRelationResults has a set of remote relation results.
+// RegisterRemoteRelationResults has a set of remote relation results.
 type RegisterRemoteRelationResults struct {
 	Results []RegisterRemoteRelationResult `json:"results,omitempty"`
 }
@@ -654,7 +651,7 @@ type RemoteEntities struct {
 	Tokens []string `json:"tokens"`
 }
 
-// RelationUnit holds a remote relation token and a unit tag.
+// RemoteRelationUnit holds a remote relation token and a unit tag.
 type RemoteRelationUnit struct {
 	RelationToken string         `json:"relation-token"`
 	Unit          string         `json:"unit"`
@@ -667,7 +664,7 @@ type RemoteRelationUnits struct {
 	RelationUnits []RemoteRelationUnit `json:"relation-units"`
 }
 
-// ModifyModelAccessRequest holds the parameters for making grant and revoke offer calls.
+// ModifyOfferAccessRequest holds the parameters for making grant and revoke offer calls.
 type ModifyOfferAccessRequest struct {
 	Changes []ModifyOfferAccess `json:"changes"`
 }

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -843,15 +843,9 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	// Set up the consuming model - create the remote app.
 	offeringModelTag := names.NewModelTag(utils.MustNewUUID().String())
-	appToken := utils.MustNewUUID().String()
-	app, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "mysql", SourceModel: offeringModelTag,
-		Endpoints: []charm.Relation{{Name: "database", Interface: "mysql", Role: "provider", Scope: "global"}},
-	})
-	c.Assert(err, jc.ErrorIsNil)
 	// Create the external controller info.
 	ec := state.NewExternalControllers(s.State)
-	_, err = ec.Save(crossmodel.ControllerInfo{
+	_, err := ec.Save(crossmodel.ControllerInfo{
 		ControllerTag: coretesting.ControllerTag,
 		Addrs:         []string{"1.2.3.4:1234"},
 		CACert:        coretesting.CACert}, offeringModelTag.Id())
@@ -868,8 +862,7 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(
 		c.Check(request, gc.Equals, "PublishIngressNetworkChanges")
 		expected := params.IngressNetworksChanges{
 			Changes: []params.IngressNetworksChangeEvent{{
-				RelationToken:    relToken,
-				ApplicationToken: appToken,
+				RelationToken: relToken,
 			}},
 		}
 
@@ -920,6 +913,11 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(
 	// Create the firewaller facade on the consuming model.
 	fw := s.newFirewallerWithClock(c, clock)
 
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "mysql", SourceModel: offeringModelTag,
+		Endpoints: []charm.Relation{{Name: "database", Interface: "mysql", Role: "provider", Scope: "global"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	eps, err := s.State.InferEndpoints("wordpress", "mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
@@ -930,8 +928,6 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(
 	relToken, err = re.ExportLocalEntity(rel.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = re.SaveMacaroon(rel.Tag(), mac)
-	c.Assert(err, jc.ErrorIsNil)
-	err = re.ImportRemoteEntity(app.Tag(), appToken)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should not have published any ingress events yet - no unit has entered scope.


### PR DESCRIPTION
Fixes a cross model relations corner case:

Model 1
app A
offer app A

Model 2
app B
app C
offer app C

Model 1
relate A->C

Model 2
relate B->A

The unit relation hooks for C do not fire.
The root cause is that only one cmr token for app A is created and used for both the offer relation and consumer relation. So model 2 gets a duplicate remote entity token and the resolution of token to entity tag fails for the C->A relation.

The fix is to create the token for offering relations keyed on application offer tag, not application tag. This allows the same app to be in both an offering and consuming relation to a given model since different tokens are created for the different roles of the app.

There was also an unused app token parameter in the ingress address change watcher which was removed. This is lucky as it avoids the need to look up offers in the firewaller worker.

## QA steps

I used modified dummy-source and dummy-sink charms with extra endpoints to set up a cross model scenario as per the description. After the relations were created, show-status-log on each of the various units showed relation created and joined hooks being run. Previously, the relation joined hooks for one of the units would have been missing.


## Bug reference

https://bugs.launchpad.net/juju/+bug/2022855
