### PR TITLE
[JUJU-3969] Precheck migration checks

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -39,16 +39,14 @@ jobs:
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
 
-      - name: Install Juju 2.9
-        run: |
-          # TODO(anvial): change to stable channel once juju 2.9.43 is released
-          sudo snap install juju_29 --classic --channel 2.9/edge
+      - name: Install Juju 3.1
+        run: sudo snap install juju --channel 3.1/stable
 
-      - name: Bootstrap a 2.9 controller and model
+      - name: Bootstrap a 3.1 controller and model
         run: |
-          juju_29 bootstrap lxd test29
-          juju_29 add-model test-migrate
-          juju_29 deploy ubuntu
+          juju bootstrap lxd test31
+          juju add-model test-migrate
+          juju deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
@@ -61,22 +59,22 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      - name: Upgrade client to 3.x
+      - name: Upgrade client to 4.0
         run: |
           make go-install &>/dev/null
 
-      - name: Bootstrap 3.x controller
+      - name: Bootstrap 4.0 controller
         run: |
-          juju bootstrap lxd test31
+          juju bootstrap lxd test40
           juju switch controller
           juju wait-for application controller || juju status -m controller
 
         # TODO: create backup and juju restore
 
-      - name: Migrate default model to 3.x controller
+      - name: Migrate default model to 4.0 controller
         run: |
-          juju_29 switch test29
-          
+          juju switch test31
+
           # Ensure application is fully deployed
           juju_29 wait-for application ubuntu
           
@@ -84,12 +82,12 @@ jobs:
           # so that migration prechecks pass.
           sleep 10
           
-          juju_29 migrate test-migrate test31
+          juju migrate test-migrate test40
 
       - name: Check the migration was successful
         run: |
           set -x
-          juju switch test31
+          juju switch test40
           
           # Wait for 'test-migrate' model to come through
           attempt=0

--- a/upgrades/upgradevalidation/interfaces.go
+++ b/upgrades/upgradevalidation/interfaces.go
@@ -19,7 +19,6 @@ type StatePool interface {
 
 // State represents a point of use interface for modelling a current model.
 type State interface {
-	AllCharmURLs() ([]*string, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)
 	MongoCurrentStatus() (*replicaset.Status, error)

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -22,7 +22,6 @@ func ValidatorsForModelMigrationSource(
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
-			checkForCharmStoreCharms,
 		)
 	}
 	return validators

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -17,15 +17,13 @@ func ValidatorsForModelMigrationSource(
 		getCheckTargetVersionForModel(targetVersion, MigrateToAllowed),
 		getCheckUpgradeSeriesLockForModel(false),
 	}
-	if targetVersion.Major == 3 {
+	if targetVersion.Major == 4 {
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
+			checkForCharmStoreCharms,
 		)
-		if targetVersion.Minor >= 1 {
-			validators = append(validators, checkForCharmStoreCharms)
-		}
 	}
 	return validators
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -66,49 +66,16 @@ type migrateSuite struct {
 	model     *mocks.MockModel
 }
 
-func (s *migrateSuite) TestValidatorsForModelMigrationSourceJuju3(c *gc.C) {
-	ctrl, cloudSpec := s.setupJuju3Target(c)
+func (s *migrateSuite) TestValidatorsForModelMigrationTargetJuju4(c *gc.C) {
+	ctrl, cloudSpec := s.setupJuju3Source(c)
 	defer ctrl.Finish()
 
+	s.st.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("no charms"))
+
 	modelTag := coretesting.ModelTag
-	targetVersion := version.MustParse("3.0.0")
+	targetVersion := version.MustParse("4.0.0")
 	validators := upgradevalidation.ValidatorsForModelMigrationSource(targetVersion, cloudSpec)
 
-	checker := upgradevalidation.NewModelUpgradeCheck(modelTag.Id(), s.statePool, s.st, s.model, validators...)
-	blockers, err := checker.Validate()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blockers, gc.IsNil)
-}
-
-func (s *migrateSuite) TestValidatorsForModelMigrationSourceJuju31(c *gc.C) {
-	ctrl, cloudSpec := s.setupJuju3Target(c)
-	defer ctrl.Finish()
-
-	// - check no charm store charms
-	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
-
-	modelTag := coretesting.ModelTag
-	targetVersion := version.MustParse("3.1.0")
-	validators := upgradevalidation.ValidatorsForModelMigrationSource(targetVersion, cloudSpec)
-
-	checker := upgradevalidation.NewModelUpgradeCheck(modelTag.Id(), s.statePool, s.st, s.model, validators...)
-	blockers, err := checker.Validate()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blockers, gc.IsNil)
-}
-
-func (s *migrateSuite) TestValidatorsForModelMigrationSourceJuju2(c *gc.C) {
-	defer s.initializeMocks(c).Finish()
-
-	modelTag := coretesting.ModelTag
-
-	// - check agent version;
-	s.model.EXPECT().AgentVersion().Return(version.MustParse("2.9.32"), nil)
-	// - check no upgrade series in process.
-	s.st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
-
-	targetVersion := version.MustParse("2.9.99")
-	validators := upgradevalidation.ValidatorsForModelMigrationSource(targetVersion, environscloudspec.CloudSpec{Type: "foo"})
 	checker := upgradevalidation.NewModelUpgradeCheck(modelTag.Id(), s.statePool, s.st, s.model, validators...)
 	blockers, err := checker.Validate()
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,7 +90,11 @@ func (s *migrateSuite) initializeMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *migrateSuite) setupJuju3Target(c *gc.C) (*gomock.Controller, environscloudspec.CloudSpec) {
+func (s *migrateSuite) setupJuju3Source(c *gc.C) (*gomock.Controller, environscloudspec.CloudSpec) {
+	return s.setupJujuSource(c, version.MustParse("3.2.0"))
+}
+
+func (s *migrateSuite) setupJujuSource(c *gc.C, version version.Number) (*gomock.Controller, environscloudspec.CloudSpec) {
 	ctrl := s.initializeMocks(c)
 	server := mocks.NewMockServer(ctrl)
 	serverFactory := mocks.NewMockServerFactory(ctrl)
@@ -138,7 +109,7 @@ func (s *migrateSuite) setupJuju3Target(c *gc.C) (*gomock.Controller, environscl
 		},
 	)
 	// - check agent version;
-	s.model.EXPECT().AgentVersion().Return(version.MustParse("2.9.43"), nil)
+	s.model.EXPECT().AgentVersion().Return(version, nil)
 	// - check no upgrade series in process.
 	s.st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines;

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -5,7 +5,6 @@ package upgradevalidation_test
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -69,8 +68,6 @@ type migrateSuite struct {
 func (s *migrateSuite) TestValidatorsForModelMigrationTargetJuju4(c *gc.C) {
 	ctrl, cloudSpec := s.setupJuju3Source(c)
 	defer ctrl.Finish()
-
-	s.st.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("no charms"))
 
 	modelTag := coretesting.ModelTag
 	targetVersion := version.MustParse("4.0.0")

--- a/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/upgrades/upgradevalidation/mocks/state_mock.go
@@ -75,21 +75,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllCharmURLs mocks base method.
-func (m *MockState) AllCharmURLs() ([]*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllCharmURLs")
-	ret0, _ := ret[0].([]*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllCharmURLs indicates an expected call of AllCharmURLs.
-func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
-}
-
 // HasUpgradeSeriesLocks mocks base method.
 func (m *MockState) HasUpgradeSeriesLocks() (bool, error) {
 	m.ctrl.T.Helper()

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -25,5 +25,4 @@ var (
 	CheckMongoStatusForControllerUpgrade        = checkMongoStatusForControllerUpgrade
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
-	CheckForCharmStoreCharms                    = checkForCharmStoreCharms
 )

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -18,16 +18,14 @@ func ValidatorsForControllerUpgrade(
 			getCheckTargetVersionForControllerModel(targetVersion),
 			checkMongoStatusForControllerUpgrade,
 		}
-		if targetVersion.Major == 3 {
+		if targetVersion.Major == 4 {
 			validators = append(validators,
 				checkMongoVersionForControllerModel,
 				checkNoWinMachinesForModel,
 				checkForDeprecatedUbuntuSeriesForModel,
 				getCheckForLXDVersion(cloudspec),
+				checkForCharmStoreCharms,
 			)
-			if targetVersion.Minor >= 1 {
-				validators = append(validators, checkForCharmStoreCharms)
-			}
 		}
 		return validators
 	}
@@ -35,17 +33,14 @@ func ValidatorsForControllerUpgrade(
 		getCheckTargetVersionForModel(targetVersion, UpgradeControllerAllowed),
 		checkModelMigrationModeForControllerUpgrade,
 	}
-	if targetVersion.Major >= 3 {
+	if targetVersion.Major >= 4 {
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
+			checkForCharmStoreCharms,
 		)
 	}
-	if targetVersion.Major >= 3 && targetVersion.Minor >= 1 {
-		validators = append(validators, checkForCharmStoreCharms)
-	}
-
 	return validators
 }
 
@@ -56,15 +51,13 @@ func ValidatorsForModelUpgrade(
 	validators := []Validator{
 		getCheckUpgradeSeriesLockForModel(force),
 	}
-	if targetVersion.Major == 3 {
+	if targetVersion.Major == 4 {
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
+			checkForCharmStoreCharms,
 		)
-		if targetVersion.Minor >= 1 {
-			validators = append(validators, checkForCharmStoreCharms)
-		}
 	}
 	return validators
 }

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -24,7 +24,6 @@ func ValidatorsForControllerUpgrade(
 				checkNoWinMachinesForModel,
 				checkForDeprecatedUbuntuSeriesForModel,
 				getCheckForLXDVersion(cloudspec),
-				checkForCharmStoreCharms,
 			)
 		}
 		return validators
@@ -38,7 +37,6 @@ func ValidatorsForControllerUpgrade(
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
-			checkForCharmStoreCharms,
 		)
 	}
 	return validators
@@ -56,7 +54,6 @@ func ValidatorsForModelUpgrade(
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
-			checkForCharmStoreCharms,
 		)
 	}
 	return validators

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -5,7 +5,6 @@ package upgradevalidation_test
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v3"
 	jc "github.com/juju/testing/checkers"
@@ -75,8 +74,6 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	ctrlState.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -88,8 +85,6 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check if the model has win machines;
 	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	state1.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -126,7 +121,6 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju4(c *gc.C) {
 	)
 	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 
-	state.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("no charms"))
 	// - check no upgrade series in process.
 	state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines.

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -25,7 +25,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	defer ctrl.Finish()
 
 	s.PatchValue(&upgradevalidation.MinAgentVersions, map[int]version.Number{
-		3: version.MustParse("2.9.1"),
+		4: version.MustParse("3.1.1"),
 	})
 
 	ctrlModelTag := names.NewModelTag("deadpork-0bad-400d-8000-4b1d0d06f00d")
@@ -49,7 +49,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 
 	// 1. Check controller model.
 	// - check agent version;
-	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("3.666.1"), nil)
+	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("4.666.1"), nil)
 	// - check mongo status;
 	ctrlState.EXPECT().MongoCurrentStatus().Return(&replicaset.Status{
 		Members: []replicaset.MemberStatus{
@@ -82,7 +82,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	server.EXPECT().ServerVersion().Return("5.2")
 	// 2. Check hosted models.
 	// - check agent version;
-	model1.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
+	model1.EXPECT().AgentVersion().Return(version.MustParse("3.1.1"), nil)
 	//  - check if model migration is ongoing;
 	model1.EXPECT().MigrationMode().Return(state.MigrationModeNone)
 	// - check if the model has win machines;
@@ -94,7 +94,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
-	targetVersion := version.MustParse("3.666.2")
+	targetVersion := version.MustParse("4.666.2")
 	validators := upgradevalidation.ValidatorsForControllerUpgrade(true, targetVersion, cloudSpec.CloudSpec)
 	checker := upgradevalidation.NewModelUpgradeCheck(ctrlModelTag.Id(), statePool, ctrlState, ctrlModel, validators...)
 	blockers, err := checker.Validate()
@@ -108,7 +108,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	c.Assert(blockers, gc.IsNil)
 }
 
-func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
+func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju4(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -126,6 +126,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	)
 	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 
+	state.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("no charms"))
 	// - check no upgrade series in process.
 	state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines.
@@ -135,7 +136,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
-	targetVersion := version.MustParse("3.0.0")
+	targetVersion := version.MustParse("4.0.0")
 	validators := upgradevalidation.ValidatorsForModelUpgrade(false, targetVersion, cloudSpec.CloudSpec)
 	checker := upgradevalidation.NewModelUpgradeCheck(modelTag.Id(), statePool, state, model, validators...)
 	blockers, err := checker.Validate()

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v10"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/replicaset/v3"
@@ -212,39 +210,6 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	if len(result) > 0 {
 		return NewBlocker("the model hosts deprecated ubuntu machine(s): %s",
 			stringifyMachineCounts(result),
-		), nil
-	}
-	return nil, nil
-}
-
-func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
-	curls, err := st.AllCharmURLs()
-	if errors.Is(err, errors.NotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	result := set.NewStrings()
-	for _, curlStr := range curls {
-		if curlStr == nil {
-			return nil, errors.New("malformed charm in database with no URL")
-		}
-		curl, err := charm.ParseURL(*curlStr)
-		if err != nil {
-			logger.Errorf("error from ParseURL: %s", err)
-			return nil, errors.New(fmt.Sprintf("malformed charm url in database: %q", *curlStr))
-		}
-		// TODO 6-dec-2022
-		// Update check once charm's ValidateSchema rejects charm store charms.
-		if !charm.CharmHub.Matches(curl.Schema) && !charm.Local.Matches(curl.Schema) {
-			c := curl.WithSeries("").WithArchitecture("")
-			result.Add(c.String())
-		}
-	}
-	if !result.IsEmpty() {
-		return NewBlocker("the model hosts deprecated charm store charms(s): %s",
-			strings.Join(result.SortedValues(), ", "),
 		), nil
 	}
 	return nil, nil

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -401,26 +401,3 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsNotFound(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
-
-	blocker, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker, gc.IsNil)
-}
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsError(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.BadRequestf("charm urls"))
-
-	_, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
-}

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -14,7 +14,7 @@ var logger = loggo.GetLogger("juju.upgrades.validations")
 // MinAgentVersions defines the minimum agent version
 // allowed to make a call to a controller with the major version.
 var MinAgentVersions = map[int]version.Number{
-	3: version.MustParse("2.9.43"),
+	4: version.MustParse("3.1.0"),
 }
 
 // MinClientVersions defines the minimum user client version
@@ -22,7 +22,7 @@ var MinAgentVersions = map[int]version.Number{
 // or the minimum controller version needed to accept a call from a
 // client with the major version.
 var MinClientVersions = map[int]version.Number{
-	3: version.MustParse("2.9.42"),
+	4: version.MustParse("3.1.0"),
 }
 
 // MinMajorMigrateVersions defines the minimum version the model
@@ -60,6 +60,13 @@ func versionCheck(
 	if !ok {
 		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
 	}
+
+	// We don't want to allow upgrades from a version that is lower than the
+	// minimum major version (for example, 2.9.0 to 4.0.0).
+	if from.Major < minVer.Major {
+		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
+	}
+
 	// Allow upgrades from rc etc.
 	from.Tag = ""
 	return from.Compare(minVer) >= 0, minVer, nil

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -24,42 +24,65 @@ type versionCheckTC struct {
 	allowed bool
 	minVers string
 	err     string
-	patch   bool
 }
 
 func (s *versionSuite) TestUpgradeControllerAllowed(c *gc.C) {
 	for i, t := range []versionCheckTC{
 		{
 			from:    "2.8.0",
-			to:      "3.0.0",
+			to:      "4.0.0",
 			allowed: false,
-			minVers: "2.9.36",
-			patch:   true,
-		}, {
-			from:    "2.9.65",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.36",
-			patch:   true,
-		}, {
-			from:    "2.9.37",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.36",
-			patch:   true,
+			minVers: "0.0.0",
+			err:     `upgrading controller to "4.0.0" is not supported from "2.8.0"`,
 		}, {
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
-			patch:   true,
-			err:     `upgrading controller to \"4.0.0\" is not supported from \"2.9.0\"`,
+			err:     `upgrading controller to "4.0.0" is not supported from "2.9.0"`,
 		}, {
-			from:    "3.0.0",
-			to:      "2.0.0",
+			from:    "2.9.65",
+			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
-			patch:   true,
+			err:     `upgrading controller to "4.0.0" is not supported from "2.9.65"`,
+		}, {
+			from:    "2.9.37",
+			to:      "3.0.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `upgrading controller to "3.0.0" is not supported from "2.9.37"`,
+		}, {
+			from:    "3.0.0",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.0.1",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.1.0",
+			to:      "4.0.0",
+			allowed: true,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.3.0",
+			to:      "4.0.0",
+			allowed: true,
+			minVers: "3.1.0",
+		}, {
+			from:    "4.0.0",
+			to:      "3.1.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `downgrade is not allowed`,
+		}, {
+			from:    "5.0.0",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "0.0.0",
 			err:     `downgrade is not allowed`,
 		},
 	} {
@@ -69,12 +92,6 @@ func (s *versionSuite) TestUpgradeControllerAllowed(c *gc.C) {
 
 func (s *versionSuite) assertUpgradeControllerAllowed(c *gc.C, i int, t versionCheckTC) {
 	c.Logf("testing %d", i)
-	if t.patch {
-		restore := jujutesting.PatchValue(&upgradevalidation.MinAgentVersions, map[int]version.Number{
-			3: version.MustParse("2.9.36"),
-		})
-		defer restore()
-	}
 
 	from := version.MustParse(t.from)
 	to := version.MustParse(t.to)
@@ -93,30 +110,57 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 	for i, t := range []versionCheckTC{
 		{
 			from:    "2.8.0",
-			to:      "3.0.0",
+			to:      "4.0.0",
 			allowed: false,
-			minVers: "2.9.43",
+			minVers: "0.0.0",
+			err:     `migrate to "4.0.0" is not supported from "2.8.0"`,
 		}, {
-			from:    "2.9.43",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.43",
-		}, {
-			from:    "2.9.44",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.43",
-		},
-		{
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
-			err:     `migrate to \"4.0.0\" is not supported from \"2.9.0\"`,
-		},
-		{
+			err:     `migrate to "4.0.0" is not supported from "2.9.0"`,
+		}, {
+			from:    "2.9.65",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `migrate to "4.0.0" is not supported from "2.9.65"`,
+		}, {
+			from:    "2.9.37",
+			to:      "3.0.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `migrate to "3.0.0" is not supported from "2.9.37"`,
+		}, {
 			from:    "3.0.0",
-			to:      "2.0.0",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.0.1",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.1.0",
+			to:      "4.0.0",
+			allowed: true,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.3.0",
+			to:      "4.0.0",
+			allowed: true,
+			minVers: "3.1.0",
+		}, {
+			from:    "4.0.0",
+			to:      "3.1.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `downgrade is not allowed`,
+		}, {
+			from:    "5.0.0",
+			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
 			err:     `downgrade is not allowed`,
@@ -128,6 +172,7 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 
 func (s *versionSuite) assertMigrateToAllowed(c *gc.C, i int, t versionCheckTC) {
 	c.Logf("testing %d", i)
+
 	from := version.MustParse(t.from)
 	to := version.MustParse(t.to)
 	minVers := version.MustParse(t.minVers)


### PR DESCRIPTION
The following updates the precheck migrations from 3.1.0 to 4.0. We
don't allow 2.9 and 3.0 explicitly.

I added additional code coverage for the 2.9 and 3.0 jumps.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

### Attempting to migrate a 2.9 model should fail.

```sh
$ sudo snap install juju --channel 2.9/stable
$ juju bootstrap lxd test29
$ juju add-model default
$ juju deploy ubuntu
$ sudo snap remove juju --purge
$ make go-install
$ juju bootstrap lxd test40
$ juju switch controller
$ juju wait-for application controller
$ juju switch test29
$ juju wait-for application ubuntu
$ sleep 10
$ juju migrate default test40
ERROR source prechecks failed: migrate to "4.0-beta1.1" is not supported from "2.9.42"
```

### Attempting to migrate a 3.1 model should succeed

```sh
$ sudo snap install juju --channel 3.1/stable
$ juju bootstrap lxd test31
$ juju add-model default
$ juju deploy ubuntu
$ sudo snap remove juju --purge
$ make go-install
$ juju bootstrap lxd test40
$ juju switch controller
$ juju wait-for application controller
$ juju switch test31
$ juju wait-for application ubuntu
$ sleep 10
$ juju migrate default test40
$ juju switch test40
$ sleep 10
$ juju switch default
$ juju wait-for application ubuntu 
```

