### PR TITLE
Fix model default tests + Allow empty default-series with default-base.

### DIFF
--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -231,16 +231,13 @@ func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {
 		cfgSeries, defaultSeriesOK := updateAttrs[config.DefaultSeriesKey]
 		_, defaultBaseOK := updateAttrs[config.DefaultBaseKey]
 
-		// If there is no default series, there is nothing to do.
-		if !defaultSeriesOK {
-			return nil
-		} else if defaultSeriesOK && defaultBaseOK {
-			// If the default-series is set and the default-base is set, error
-			// out, as you can't change both.
-			return errors.New("cannot set both default-series and default-base")
-		}
-
-		if defaultSeriesOK {
+		if defaultSeriesOK && defaultBaseOK {
+			if cfgSeries != "" {
+				// If the default-series is set (and non-empty) and the default-base is set, error
+				// out, as you can't change both.
+				return errors.New("cannot set both default-series and default-base")
+			}
+		} else if defaultSeriesOK {
 			// If the default-series is set, but empty, then we need to patch the
 			// base.
 			if cfgSeries == "" {
@@ -251,12 +248,12 @@ func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {
 				if err != nil {
 					return errors.Trace(err)
 				}
-
 				updateAttrs[config.DefaultBaseKey] = base.String()
 			}
-			// Always remove the default-series.
-			delete(updateAttrs, config.DefaultSeriesKey)
 		}
+
+		// Always remove the default-series.
+		delete(updateAttrs, config.DefaultSeriesKey)
 		return nil
 	}
 }

--- a/tests/suites/cli/model_defaults.sh
+++ b/tests/suites/cli/model_defaults.sh
@@ -3,7 +3,7 @@ run_model_defaults_isomorphic() {
 
 	FILE=$(mktemp)
 
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --format=yaml | juju model-defaults "${BOOTSTRAPPED_CLOUD}" --ignore-read-only-fields --file -
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=yaml | juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --ignore-read-only-fields --file -
 }
 
 run_model_defaults_cloudinit_userdata() {
@@ -17,29 +17,29 @@ cloudinit-userdata: |
     - shellcheck
 EOF
 
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --file "${FILE}"
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" cloudinit-userdata --format=yaml | grep -q 'default: ""'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" cloudinit-userdata --format=yaml | grep -q "shellcheck"
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --file "${FILE}"
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" cloudinit-userdata --format=yaml | grep -q 'default: ""'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" cloudinit-userdata --format=yaml | grep -q "shellcheck"
 }
 
 run_model_defaults_boolean() {
 	echo
 
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=json | jq '."automatically-retry-hooks"."default"' | grep '^true$'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks=false
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=json | jq '."automatically-retry-hooks"."controller"' | grep '^false$'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" | grep -E 'automatically-retry-hooks +true +false'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=yaml | grep 'default: true'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=yaml | grep 'controller: false'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=json | jq '."automatically-retry-hooks"."default"' | grep '^true$'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks=false
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=json | jq '."automatically-retry-hooks"."controller"' | grep '^false$'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" | grep -E 'automatically-retry-hooks +true +false'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=yaml | grep 'default: true'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" automatically-retry-hooks --format=yaml | grep 'controller: false'
 }
 
 run_model_defaults_region_aws() {
 	echo
 
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --format=json test-mode | jq '."test-mode"."default"'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --format=yaml aws/ca-central-1 test-mode=true
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --format=json aws/ca-central-1 test-mode | jq '."test-mode".regions[0].value' | grep '^true$'
-	juju model-defaults "${BOOTSTRAPPED_CLOUD}" --format=json test-mode | jq '."test-mode".regions[]|select(.name=="ca-central-1").value' | grep '^true$'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=json test-mode | jq '."test-mode"."default"'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=yaml aws/ca-central-1 test-mode=true
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=json aws/ca-central-1 test-mode | jq '."test-mode".regions[0].value' | grep '^true$'
+	juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=json test-mode | jq '."test-mode".regions[]|select(.name=="ca-central-1").value' | grep '^true$'
 }
 
 test_model_defaults() {
@@ -53,6 +53,10 @@ test_model_defaults() {
 
 		cd .. || exit
 
+		# save model-defaults
+		SAVED_DEFAULTS_FILE=$(mktemp)
+		juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --format=yaml >"${SAVED_DEFAULTS_FILE}"
+
 		run "run_model_defaults_isomorphic"
 		run "run_model_defaults_cloudinit_userdata"
 		run "run_model_defaults_boolean"
@@ -65,5 +69,8 @@ test_model_defaults() {
 			echo "==> TEST SKIPPED: run_model_defaults_region_aws runs on AWS only"
 			;;
 		esac
+
+		# restore model-defaults
+		juju model-defaults --cloud "${BOOTSTRAPPED_CLOUD}" --ignore-read-only-fields --file "${SAVED_DEFAULTS_FILE}"
 	)
 }


### PR DESCRIPTION
Fixes model default tests to not pass the model name incorrectly.
Fixes exporting model-config then reimporting model-config as it will always have both default-series and default-base, but default-series being empty while passing default-base should be allowed and ignored.

## QA steps

- `./main.sh -v -s '"test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_unregister"' cli test_model_defaults`
- `juju bootstrap microk8s; juju model-config --format=yaml | juju model-config --ignore-read-only-fields --file -`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-cli-test-model-defaults-lxd/1205/consoleText