### PR TITLE
[JUJU-2938] Record initial controller node in Dqlite

### DIFF
--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -75,7 +75,7 @@ func BootstrapDqlite(ctx context.Context, opt bootstrapOptFactory, logger Logger
 		}
 	}()
 
-	if err := NewDBMigration(db, logger, schema.ControllerDDL()).Apply(ctx); err != nil {
+	if err := NewDBMigration(db, logger, schema.ControllerDDL(dqlite.ID())).Apply(ctx); err != nil {
 		return errors.Annotate(err, "creating controller database schema")
 	}
 

--- a/database/testing/simplesuite.go
+++ b/database/testing/simplesuite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 )
 
-// ControllerSuite is used to provide an in-memory sql.DB reference to tests.
+// ControllerSuite is used to provide a sql.DB reference to tests.
 // It is pre-populated with the controller schema.
 type ControllerSuite struct {
 	testing.IsolationSuite
@@ -82,7 +82,7 @@ func (s *ControllerSuite) ApplyControllerDDL(c *gc.C) {
 	tx, err := s.db.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	for idx, delta := range schema.ControllerDDL() {
+	for idx, delta := range schema.ControllerDDL(0x2dc171858c3155be) {
 		c.Logf("Executing schema DDL index: %v", idx)
 		_, err := tx.Exec(delta.Stmt(), delta.Args()...)
 		c.Assert(err, jc.ErrorIsNil)

--- a/domain/schema/controller_test.go
+++ b/domain/schema/controller_test.go
@@ -40,7 +40,7 @@ func (s *schemaSuite) TestDDLApply(c *gc.C) {
 	tx, err := s.db.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	for idx, delta := range ControllerDDL() {
+	for idx, delta := range ControllerDDL(0x2dc171858c3155be) {
 		c.Logf("Executing schema DDL index: %v", idx)
 		_, err := tx.Exec(delta.Stmt(), delta.Args()...)
 		c.Assert(err, jc.ErrorIsNil)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -2127,7 +2127,7 @@ func (e *environ) newCleanDB() (changestream.WatchableDB, error) {
 		return nil, err
 	}
 
-	for _, stmt := range domainschema.ControllerDDL() {
+	for _, stmt := range domainschema.ControllerDDL(0x2dc171858c3155be) {
 		_, err := tx.Exec(stmt.Stmt(), stmt.Args()...)
 		if err != nil {
 			_ = tx.Rollback()

--- a/worker/dbaccessor/worker_integration_test.go
+++ b/worker/dbaccessor/worker_integration_test.go
@@ -83,7 +83,7 @@ func (s *integrationSuite) SetUpSuite(c *gc.C) {
 	db, err := s.DBApp().Open(context.TODO(), coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = database.NewDBMigration(db, logger, schema.ControllerDDL()).Apply(context.TODO())
+	err = database.NewDBMigration(db, logger, schema.ControllerDDL(s.DBApp().ID())).Apply(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
This ensures that upon bootstrap, we write the initial controller node entry into the controller database.

In following patches we will maintain entries based on issuance of the `enable-ha` command, and update them in the `db-accessor` worker when nodes are commissioned or bindings change.

## QA steps

- Bootstrap, `make repl-install`, `make repl`.
```
$ dqlite -s $(sudo cat /var/lib/juju/dqlite/info.yaml | grep "Address: " | cut -d" " -f2) controller
dqlite> select * from controller_node;
0|3297041220608546238|127.0.0.1
```
