### PR TITLE
[JUJU-3935] Remove fullDocumentBeforeChange field on mongodb changestream

### DIFF
--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -359,8 +359,7 @@ func (w *TxnWatcher) init() error {
 	db := w.session.DB(w.jujuDBName)
 
 	cs := bson.M{
-		"fullDocument":             "updateLookup",
-		"fullDocumentBeforeChange": "off",
+		"fullDocument": "updateLookup",
 	}
 	if len(w.resumeToken.Data) > 0 {
 		cs["resumeAfter"] = w.resumeToken


### PR DESCRIPTION
Having the fullDocumentBeforeChange value set to 'off' in the mongodb watcher results in this silent error:
```
BSON field '$changeStream.fullDocumentBeforeChange' is an unknown field
```
because this field is added on mongodb 6.0.
This error is particularly annoying since it prevents us from using `workertest.CleanKill` on some worker tests.

Since we are setting it to 'off' which is also the default value on mongodb >= 6.0, it's safe to simply remove it.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~
