### PR TITLE
Db slice transform including type cast

### DIFF
--- a/database/statement.go
+++ b/database/statement.go
@@ -12,6 +12,24 @@ import (
 // SliceToPlaceholder returns a string that can be used in a SQL/DML
 // statement as a parameter list for a [NOT] IN clause.
 // For example, passing []int{1, 2, 3} would return "?,?,?".
-func SliceToPlaceholder[T any](in []T) string {
-	return strings.Join(transform.Slice(in, func(item T) string { return "?" }), ",")
+// It also returns a suitable transformed slice of the input values to type any.
+func SliceToPlaceholder[T any](in []T) (string, []any) {
+	vals := make([]any, 0, len(in))
+	return strings.Join(transform.Slice(in, func(item T) string {
+		vals = append(vals, item)
+		return "?"
+	}), ","), vals
+}
+
+// SliceToPlaceholderTransform returns a string that can be used in SQL/DML
+// statement as a parameter list for a [NOT] IN clause.
+// For example, passing []int{1, 2, 3} would return "?,?,?".
+// Also takes a transform function to alter the type and meaning of the in slice
+// into a new slice that can be used with the parameters.
+func SliceToPlaceholderTransform[T any](in []T, trans func(T) any) (string, []any) {
+	vals := make([]any, 0, len(in))
+	return strings.Join(transform.Slice(in, func(item T) string {
+		vals = append(vals, trans(item))
+		return "?"
+	}), ","), vals
 }

--- a/database/statement_test.go
+++ b/database/statement_test.go
@@ -16,6 +16,7 @@ var _ = gc.Suite(&statementSuite{})
 
 func (s *statementSuite) TestSliceToPlaceholder(c *gc.C) {
 	args := []string{"won", "too", "free", "for"}
-	binds := SliceToPlaceholder(args)
+	binds, vals := SliceToPlaceholder(args)
 	c.Check(binds, gc.Equals, "?,?,?,?")
+	c.Check(vals, gc.DeepEquals, []any{"won", "too", "free", "for"})
 }


### PR DESCRIPTION
- Slice to placeholder is doing the heavy lifting of making sql placeholder strings based on a slice passed to it. However everytime we use this function we also need to do another transform on the slice to cast the type to a slice of any. With this chance the function now does both operations in a single iteration of the slice.

- Have also updated the upsert statements we are using to use sqlite's exclude so we don't have to repeat exec args.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run associated unit tests.

## Documentation changes

nil

## Bug reference
nil
