### PR TITLE
[JUJU-3982] Convert api watcher tests to unit tests

### DIFF
--- a/api/agent/storageprovisioner/provisioner.go
+++ b/api/agent/storageprovisioner/provisioner.go
@@ -15,20 +15,20 @@ import (
 
 const storageProvisionerFacade = "StorageProvisioner"
 
-// State provides access to a storageprovisioner's view of the state.
-type State struct {
+// Client provides access to a storageprovisioner facade client.
+type Client struct {
 	facade base.FacadeCaller
 }
 
-// NewState creates a new client-side StorageProvisioner facade.
-func NewState(caller base.APICaller) (*State, error) {
+// NewClient creates a new client-side StorageProvisioner facade.
+func NewClient(caller base.APICaller) (*Client, error) {
 	facadeCaller := base.NewFacadeCaller(caller, storageProvisionerFacade)
-	return &State{facadeCaller}, nil
+	return &Client{facadeCaller}, nil
 }
 
 // WatchApplications returns a StringsWatcher that notifies of
 // changes to the lifecycles of CAAS applications in the current model.
-func (st *State) WatchApplications() (watcher.StringsWatcher, error) {
+func (st *Client) WatchApplications() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
 	if err := st.facade.FacadeCall("WatchApplications", nil, &result); err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (st *State) WatchApplications() (watcher.StringsWatcher, error) {
 }
 
 // WatchBlockDevices watches for changes to the specified machine's block devices.
-func (st *State) WatchBlockDevices(m names.MachineTag) (watcher.NotifyWatcher, error) {
+func (st *Client) WatchBlockDevices(m names.MachineTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.String()}},
@@ -62,7 +62,7 @@ func (st *State) WatchBlockDevices(m names.MachineTag) (watcher.NotifyWatcher, e
 }
 
 // WatchMachine watches for changes to the specified machine.
-func (st *State) WatchMachine(m names.MachineTag) (watcher.NotifyWatcher, error) {
+func (st *Client) WatchMachine(m names.MachineTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.String()}},
@@ -84,17 +84,17 @@ func (st *State) WatchMachine(m names.MachineTag) (watcher.NotifyWatcher, error)
 
 // WatchVolumes watches for lifecycle changes to volumes scoped to the
 // entity with the specified tag.
-func (st *State) WatchVolumes(scope names.Tag) (watcher.StringsWatcher, error) {
+func (st *Client) WatchVolumes(scope names.Tag) (watcher.StringsWatcher, error) {
 	return st.watchStorageEntities("WatchVolumes", scope)
 }
 
 // WatchFilesystems watches for lifecycle changes to volumes scoped to the
 // entity with the specified tag.
-func (st *State) WatchFilesystems(scope names.Tag) (watcher.StringsWatcher, error) {
+func (st *Client) WatchFilesystems(scope names.Tag) (watcher.StringsWatcher, error) {
 	return st.watchStorageEntities("WatchFilesystems", scope)
 }
 
-func (st *State) watchStorageEntities(method string, scope names.Tag) (watcher.StringsWatcher, error) {
+func (st *Client) watchStorageEntities(method string, scope names.Tag) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: scope.String()}},
@@ -116,23 +116,23 @@ func (st *State) watchStorageEntities(method string, scope names.Tag) (watcher.S
 
 // WatchVolumeAttachments watches for changes to volume attachments
 // scoped to the entity with the specified tag.
-func (st *State) WatchVolumeAttachments(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
+func (st *Client) WatchVolumeAttachments(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
 	return st.watchAttachments("WatchVolumeAttachments", scope, apiwatcher.NewVolumeAttachmentsWatcher)
 }
 
 // WatchVolumeAttachmentPlans watches for changes to volume attachments
-// scoped to the entity with the tag passed to NewState.
-func (st *State) WatchVolumeAttachmentPlans(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
+// scoped to the entity with the tag passed to NewClient.
+func (st *Client) WatchVolumeAttachmentPlans(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
 	return st.watchAttachments("WatchVolumeAttachmentPlans", scope, apiwatcher.NewVolumeAttachmentPlansWatcher)
 }
 
 // WatchFilesystemAttachments watches for changes to filesystem attachments
 // scoped to the entity with the specified tag.
-func (st *State) WatchFilesystemAttachments(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
+func (st *Client) WatchFilesystemAttachments(scope names.Tag) (watcher.MachineStorageIdsWatcher, error) {
 	return st.watchAttachments("WatchFilesystemAttachments", scope, apiwatcher.NewFilesystemAttachmentsWatcher)
 }
 
-func (st *State) watchAttachments(
+func (st *Client) watchAttachments(
 	method string,
 	scope names.Tag,
 	newWatcher func(base.APICaller, params.MachineStorageIdsWatchResult) watcher.MachineStorageIdsWatcher,
@@ -157,7 +157,7 @@ func (st *State) watchAttachments(
 }
 
 // Volumes returns details of volumes with the specified tags.
-func (st *State) Volumes(tags []names.VolumeTag) ([]params.VolumeResult, error) {
+func (st *Client) Volumes(tags []names.VolumeTag) ([]params.VolumeResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -176,7 +176,7 @@ func (st *State) Volumes(tags []names.VolumeTag) ([]params.VolumeResult, error) 
 }
 
 // Filesystems returns details of filesystems with the specified tags.
-func (st *State) Filesystems(tags []names.FilesystemTag) ([]params.FilesystemResult, error) {
+func (st *Client) Filesystems(tags []names.FilesystemTag) ([]params.FilesystemResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -194,7 +194,7 @@ func (st *State) Filesystems(tags []names.FilesystemTag) ([]params.FilesystemRes
 	return results.Results, nil
 }
 
-func (st *State) VolumeAttachmentPlans(ids []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
+func (st *Client) VolumeAttachmentPlans(ids []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.VolumeAttachmentPlanResults
 	err := st.facade.FacadeCall("VolumeAttachmentPlans", args, &results)
@@ -207,7 +207,7 @@ func (st *State) VolumeAttachmentPlans(ids []params.MachineStorageId) ([]params.
 	return results.Results, nil
 }
 
-func (st *State) RemoveVolumeAttachmentPlan(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+func (st *Client) RemoveVolumeAttachmentPlan(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 	var results params.ErrorResults
 	args := params.MachineStorageIds{
 		Ids: ids,
@@ -219,7 +219,7 @@ func (st *State) RemoveVolumeAttachmentPlan(ids []params.MachineStorageId) ([]pa
 }
 
 // VolumeAttachments returns details of volume attachments with the specified IDs.
-func (st *State) VolumeAttachments(ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
+func (st *Client) VolumeAttachments(ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.VolumeAttachmentResults
 	err := st.facade.FacadeCall("VolumeAttachments", args, &results)
@@ -234,7 +234,7 @@ func (st *State) VolumeAttachments(ids []params.MachineStorageId) ([]params.Volu
 
 // VolumeBlockDevices returns details of block devices corresponding to the volume
 // attachments with the specified IDs.
-func (st *State) VolumeBlockDevices(ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
+func (st *Client) VolumeBlockDevices(ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.BlockDeviceResults
 	err := st.facade.FacadeCall("VolumeBlockDevices", args, &results)
@@ -248,7 +248,7 @@ func (st *State) VolumeBlockDevices(ids []params.MachineStorageId) ([]params.Blo
 }
 
 // FilesystemAttachments returns details of filesystem attachments with the specified IDs.
-func (st *State) FilesystemAttachments(ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
+func (st *Client) FilesystemAttachments(ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.FilesystemAttachmentResults
 	err := st.facade.FacadeCall("FilesystemAttachments", args, &results)
@@ -263,7 +263,7 @@ func (st *State) FilesystemAttachments(ids []params.MachineStorageId) ([]params.
 
 // VolumeParams returns the parameters for creating the volumes
 // with the specified tags.
-func (st *State) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+func (st *Client) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -283,7 +283,7 @@ func (st *State) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResu
 
 // RemoveVolumeParams returns the parameters for destroying or releasing
 // the volumes with the specified tags.
-func (st *State) RemoveVolumeParams(tags []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
+func (st *Client) RemoveVolumeParams(tags []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -303,7 +303,7 @@ func (st *State) RemoveVolumeParams(tags []names.VolumeTag) ([]params.RemoveVolu
 
 // FilesystemParams returns the parameters for creating the filesystems
 // with the specified tags.
-func (st *State) FilesystemParams(tags []names.FilesystemTag) ([]params.FilesystemParamsResult, error) {
+func (st *Client) FilesystemParams(tags []names.FilesystemTag) ([]params.FilesystemParamsResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -323,7 +323,7 @@ func (st *State) FilesystemParams(tags []names.FilesystemTag) ([]params.Filesyst
 
 // RemoveFilesystemParams returns the parameters for destroying or releasing
 // the filesystems with the specified tags.
-func (st *State) RemoveFilesystemParams(tags []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
+func (st *Client) RemoveFilesystemParams(tags []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
 	}
@@ -343,7 +343,7 @@ func (st *State) RemoveFilesystemParams(tags []names.FilesystemTag) ([]params.Re
 
 // VolumeAttachmentParams returns the parameters for creating the volume
 // attachments with the specified tags.
-func (st *State) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
+func (st *Client) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.VolumeAttachmentParamsResults
 	err := st.facade.FacadeCall("VolumeAttachmentParams", args, &results)
@@ -358,7 +358,7 @@ func (st *State) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params
 
 // FilesystemAttachmentParams returns the parameters for creating the
 // filesystem attachments with the specified tags.
-func (st *State) FilesystemAttachmentParams(ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error) {
+func (st *Client) FilesystemAttachmentParams(ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error) {
 	args := params.MachineStorageIds{ids}
 	var results params.FilesystemAttachmentParamsResults
 	err := st.facade.FacadeCall("FilesystemAttachmentParams", args, &results)
@@ -372,7 +372,7 @@ func (st *State) FilesystemAttachmentParams(ids []params.MachineStorageId) ([]pa
 }
 
 // SetVolumeInfo records the details of newly provisioned volumes.
-func (st *State) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
+func (st *Client) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
 	args := params.Volumes{Volumes: volumes}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("SetVolumeInfo", args, &results)
@@ -386,7 +386,7 @@ func (st *State) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, e
 }
 
 // SetFilesystemInfo records the details of newly provisioned filesystems.
-func (st *State) SetFilesystemInfo(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
+func (st *Client) SetFilesystemInfo(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
 	args := params.Filesystems{Filesystems: filesystems}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("SetFilesystemInfo", args, &results)
@@ -399,7 +399,7 @@ func (st *State) SetFilesystemInfo(filesystems []params.Filesystem) ([]params.Er
 	return results.Results, nil
 }
 
-func (st *State) CreateVolumeAttachmentPlans(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+func (st *Client) CreateVolumeAttachmentPlans(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	args := params.VolumeAttachmentPlans{VolumeAttachmentPlans: volumeAttachmentPlans}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("CreateVolumeAttachmentPlans", args, &results)
@@ -412,7 +412,7 @@ func (st *State) CreateVolumeAttachmentPlans(volumeAttachmentPlans []params.Volu
 	return results.Results, nil
 }
 
-func (st *State) SetVolumeAttachmentPlanBlockInfo(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+func (st *Client) SetVolumeAttachmentPlanBlockInfo(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	args := params.VolumeAttachmentPlans{VolumeAttachmentPlans: volumeAttachmentPlans}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("SetVolumeAttachmentPlanBlockInfo", args, &results)
@@ -426,7 +426,7 @@ func (st *State) SetVolumeAttachmentPlanBlockInfo(volumeAttachmentPlans []params
 }
 
 // SetVolumeAttachmentInfo records the details of newly provisioned volume attachments.
-func (st *State) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+func (st *Client) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
 	args := params.VolumeAttachments{VolumeAttachments: volumeAttachments}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("SetVolumeAttachmentInfo", args, &results)
@@ -440,7 +440,7 @@ func (st *State) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttach
 }
 
 // SetFilesystemAttachmentInfo records the details of newly provisioned filesystem attachments.
-func (st *State) SetFilesystemAttachmentInfo(filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
+func (st *Client) SetFilesystemAttachmentInfo(filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
 	args := params.FilesystemAttachments{FilesystemAttachments: filesystemAttachments}
 	var results params.ErrorResults
 	err := st.facade.FacadeCall("SetFilesystemAttachmentInfo", args, &results)
@@ -454,7 +454,7 @@ func (st *State) SetFilesystemAttachmentInfo(filesystemAttachments []params.File
 }
 
 // Life requests the life cycle of the entities with the specified tags.
-func (st *State) Life(tags []names.Tag) ([]params.LifeResult, error) {
+func (st *Client) Life(tags []names.Tag) ([]params.LifeResult, error) {
 	var results params.LifeResults
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
@@ -472,7 +472,7 @@ func (st *State) Life(tags []names.Tag) ([]params.LifeResult, error) {
 }
 
 // AttachmentLife requests the life cycle of the attachments with the specified IDs.
-func (st *State) AttachmentLife(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+func (st *Client) AttachmentLife(ids []params.MachineStorageId) ([]params.LifeResult, error) {
 	var results params.LifeResults
 	args := params.MachineStorageIds{ids}
 	if err := st.facade.FacadeCall("AttachmentLife", args, &results); err != nil {
@@ -486,7 +486,7 @@ func (st *State) AttachmentLife(ids []params.MachineStorageId) ([]params.LifeRes
 
 // EnsureDead progresses the entities with the specified tags to the Dead
 // life cycle state, if they are Alive or Dying.
-func (st *State) EnsureDead(tags []names.Tag) ([]params.ErrorResult, error) {
+func (st *Client) EnsureDead(tags []names.Tag) ([]params.ErrorResult, error) {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
@@ -504,7 +504,7 @@ func (st *State) EnsureDead(tags []names.Tag) ([]params.ErrorResult, error) {
 }
 
 // Remove removes the entities with the specified tags from state.
-func (st *State) Remove(tags []names.Tag) ([]params.ErrorResult, error) {
+func (st *Client) Remove(tags []names.Tag) ([]params.ErrorResult, error) {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
@@ -522,7 +522,7 @@ func (st *State) Remove(tags []names.Tag) ([]params.ErrorResult, error) {
 }
 
 // RemoveAttachments removes the attachments with the specified IDs from state.
-func (st *State) RemoveAttachments(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+func (st *Client) RemoveAttachments(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 	var results params.ErrorResults
 	args := params.MachineStorageIds{ids}
 	if err := st.facade.FacadeCall("RemoveAttachment", args, &results); err != nil {
@@ -536,7 +536,7 @@ func (st *State) RemoveAttachments(ids []params.MachineStorageId) ([]params.Erro
 
 // InstanceIds returns the provider specific instance ID for each machine,
 // or an CodeNotProvisioned error if not set.
-func (st *State) InstanceIds(tags []names.MachineTag) ([]params.StringResult, error) {
+func (st *Client) InstanceIds(tags []names.MachineTag) ([]params.StringResult, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
@@ -555,7 +555,7 @@ func (st *State) InstanceIds(tags []names.MachineTag) ([]params.StringResult, er
 }
 
 // SetStatus sets the status of storage entities.
-func (st *State) SetStatus(args []params.EntityStatusArgs) error {
+func (st *Client) SetStatus(args []params.EntityStatusArgs) error {
 	var result params.ErrorResults
 	err := st.facade.FacadeCall("SetStatus", params.SetStatus{args}, &result)
 	if err != nil {

--- a/api/agent/storageprovisioner/provisioner_test.go
+++ b/api/agent/storageprovisioner/provisioner_test.go
@@ -37,7 +37,7 @@ func (s *provisionerSuite) TestWatchApplications(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	watcher, err := st.WatchApplications()
 	c.Assert(watcher, gc.IsNil)
@@ -64,7 +64,7 @@ func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchVolumes(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -91,7 +91,7 @@ func (s *provisionerSuite) TestWatchFilesystems(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchFilesystems(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -118,7 +118,7 @@ func (s *provisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchVolumeAttachments(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -145,7 +145,7 @@ func (s *provisionerSuite) TestWatchVolumeAttachmentPlans(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchVolumeAttachmentPlans(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -172,7 +172,7 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchFilesystemAttachments(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -197,7 +197,7 @@ func (s *provisionerSuite) TestWatchBlockDevices(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchBlockDevices(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
@@ -228,7 +228,7 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -269,7 +269,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystems, err := st.Filesystems([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -315,7 +315,7 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.VolumeAttachments([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
@@ -365,7 +365,7 @@ func (s *provisionerSuite) TestVolumeAttachmentPlans(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.VolumeAttachmentPlans([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
@@ -401,7 +401,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.VolumeBlockDevices([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
@@ -440,7 +440,7 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystems, err := st.FilesystemAttachments([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
@@ -472,7 +472,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeParams, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -504,7 +504,7 @@ func (s *provisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeParams, err := st.RemoveVolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -539,7 +539,7 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystemParams, err := st.FilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -571,7 +571,7 @@ func (s *provisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystemParams, err := st.RemoveFilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
@@ -613,7 +613,7 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeParams, err := st.VolumeAttachmentParams([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
@@ -653,7 +653,7 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystemParams, err := st.FilesystemAttachmentParams([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
@@ -689,7 +689,7 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes := []params.Volume{{
 		VolumeTag: "volume-100",
@@ -761,7 +761,7 @@ func (s *provisionerSuite) TestCreateVolumeAttachmentPlan(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.CreateVolumeAttachmentPlans(attachmentPlan)
 	c.Check(err, jc.ErrorIsNil)
@@ -827,7 +827,7 @@ func (s *provisionerSuite) TestSetVolumeAttachmentPlanBlockInfo(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.SetVolumeAttachmentPlanBlockInfo(attachmentPlan)
 	c.Check(err, jc.ErrorIsNil)
@@ -856,7 +856,7 @@ func (s *provisionerSuite) TestRemoveVolumeAttachmentPlan(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.RemoveVolumeAttachmentPlan([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
@@ -891,7 +891,7 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystems := []params.Filesystem{{
 		FilesystemTag: "filesystem-100",
@@ -931,7 +931,7 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.SetVolumeAttachmentInfo(volumeAttachments)
 	c.Check(err, jc.ErrorIsNil)
@@ -964,7 +964,7 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.SetFilesystemAttachmentInfo(filesystemAttachments)
 	c.Check(err, jc.ErrorIsNil)
@@ -974,7 +974,7 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 }
 
 func (s *provisionerSuite) testOpWithTags(
-	c *gc.C, opName string, apiCall func(*storageprovisioner.State, []names.Tag) ([]params.ErrorResult, error),
+	c *gc.C, opName string, apiCall func(*storageprovisioner.Client, []names.Tag) ([]params.ErrorResult, error),
 ) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -991,7 +991,7 @@ func (s *provisionerSuite) testOpWithTags(
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes := []names.Tag{names.NewVolumeTag("100")}
 	errorResults, err := apiCall(st, volumes)
@@ -1001,13 +1001,13 @@ func (s *provisionerSuite) testOpWithTags(
 }
 
 func (s *provisionerSuite) TestRemove(c *gc.C) {
-	s.testOpWithTags(c, "Remove", func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+	s.testOpWithTags(c, "Remove", func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
 		return st.Remove(tags)
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
-	s.testOpWithTags(c, "EnsureDead", func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+	s.testOpWithTags(c, "EnsureDead", func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
 		return st.EnsureDead(tags)
 	})
 }
@@ -1028,7 +1028,7 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 		return nil
 	})
 
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes := []names.Tag{names.NewVolumeTag("100")}
 	lifeResults, err := st.Life(volumes)
@@ -1037,95 +1037,95 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 	c.Assert(lifeResults, jc.DeepEquals, []params.LifeResult{{Life: life.Alive}})
 }
 
-func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisioner.State) error) {
+func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisioner.Client) error) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("blargh")
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	err = apiCall(st)
 	c.Check(err, gc.ErrorMatches, "blargh")
 }
 
 func (s *provisionerSuite) TestWatchVolumesClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.WatchVolumes(names.NewMachineTag("123"))
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestVolumesClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.Volumes(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestVolumeParamsClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.VolumeParams(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveVolumeParamsClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.RemoveVolumeParams(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestFilesystemParamsClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.FilesystemParams(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveFilesystemParamsClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.RemoveFilesystemParams(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.Remove(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveAttachmentsClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.RemoveAttachments(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestSetVolumeInfoClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.SetVolumeInfo(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDeadClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.EnsureDead(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestLifeClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.Life(nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestAttachmentLifeClientError(c *gc.C) {
-	s.testClientError(c, func(st *storageprovisioner.State) error {
+	s.testClientError(c, func(st *storageprovisioner.Client) error {
 		_, err := st.AttachmentLife(nil)
 		return err
 	})
@@ -1140,7 +1140,7 @@ func (s *provisionerSuite) TestWatchVolumesServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = st.WatchVolumes(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "MSG")
@@ -1155,7 +1155,7 @@ func (s *provisionerSuite) TestVolumesServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1172,7 +1172,7 @@ func (s *provisionerSuite) TestVolumeParamsServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1189,7 +1189,7 @@ func (s *provisionerSuite) TestRemoveVolumeParamsServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.RemoveVolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1206,7 +1206,7 @@ func (s *provisionerSuite) TestFilesystemParamsServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.FilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1223,7 +1223,7 @@ func (s *provisionerSuite) TestRemoveFilesystemParamsServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.RemoveFilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1240,7 +1240,7 @@ func (s *provisionerSuite) TestSetVolumeInfoServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.SetVolumeInfo([]params.Volume{{
 		VolumeTag: names.NewVolumeTag("100").String(),
@@ -1250,7 +1250,7 @@ func (s *provisionerSuite) TestSetVolumeInfoServerError(c *gc.C) {
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
 }
 
-func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisioner.State, []names.Tag) ([]params.ErrorResult, error)) {
+func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisioner.Client, []names.Tag) ([]params.ErrorResult, error)) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
 			Results: []params.ErrorResult{{
@@ -1259,7 +1259,7 @@ func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisi
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	tags := []names.Tag{
 		names.NewVolumeTag("100"),
@@ -1271,13 +1271,13 @@ func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisi
 }
 
 func (s *provisionerSuite) TestRemoveServerError(c *gc.C) {
-	s.testServerError(c, func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+	s.testServerError(c, func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
 		return st.Remove(tags)
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDeadServerError(c *gc.C) {
-	s.testServerError(c, func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+	s.testServerError(c, func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
 		return st.EnsureDead(tags)
 	})
 }
@@ -1291,7 +1291,7 @@ func (s *provisionerSuite) TestLifeServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st, err := storageprovisioner.NewState(apiCaller)
+	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	tags := []names.Tag{
 		names.NewVolumeTag("100"),

--- a/api/watcher/package_test.go
+++ b/api/watcher/package_test.go
@@ -6,9 +6,9 @@ package watcher_test
 import (
 	stdtesting "testing"
 
-	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func TestAll(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -4,315 +4,316 @@
 package watcher_test
 
 import (
-	"context"
 	"time"
 
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
-	"github.com/juju/charm/v10"
+	"github.com/golang/mock/gomock"
 	"github.com/juju/names/v4"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/agent/deployer"
+	"github.com/juju/juju/api/agent/machiner"
 	"github.com/juju/juju/api/agent/migrationminion"
 	"github.com/juju/juju/api/agent/secretsmanager"
+	"github.com/juju/juju/api/agent/storageprovisioner"
+	apimocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/controller/crossmodelrelations"
-	"github.com/juju/juju/api/watcher"
-	"github.com/juju/juju/core/crossmodel"
+	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/migration"
-	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 type watcherSuite struct {
-	testing.JujuConnSuite
-
-	stateAPI api.Connection
-
-	// These are raw State objects. Use them for setup and assertions, but
-	// should never be touched by the API calls themselves
-	rawMachine *state.Machine
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&watcherSuite{})
 
-func (s *watcherSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.stateAPI, s.rawMachine = s.OpenAPIAsNewMachine(c, state.JobManageModel, state.JobHostUnits)
-}
+func setupWatcher[T any](c *gc.C, caller *apimocks.MockAPICaller, facadeName string) (string, chan T) {
+	caller.EXPECT().BestFacadeVersion(facadeName).Return(666).AnyTimes()
+	// Initial event.
+	eventCh := make(chan T)
 
-func (s *watcherSuite) TestWatchInitialEventConsumed(c *gc.C) {
-	// Machiner.Watch should send the initial event as part of the Watch
-	// call (for NotifyWatchers there is no state to be transmitted). So a
-	// call to Next() should not have anything to return.
-	var results params.NotifyWatchResults
-	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	err := s.stateAPI.APICall("Machiner", s.stateAPI.BestFacadeVersion("Machiner"), "", "Watch", args, &results)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	stopped := make(chan bool)
+	caller.EXPECT().APICall(facadeName, 666, "id-666", "Stop", nil, gomock.Any()).DoAndReturn(func(_ string, _ int, _ string, _ string, _ any, _ any) {
+		select {
+		case stopped <- true:
+		default:
+		}
+	}).Return(nil).AnyTimes()
 
-	// We expect the Call() to "Next" to block, so run it in a goroutine.
-	done := make(chan error)
-	go func() {
-		ignored := struct{}{}
-		done <- s.stateAPI.APICall("NotifyWatcher", s.stateAPI.BestFacadeVersion("NotifyWatcher"), result.NotifyWatcherId, "Next", nil, &ignored)
-	}()
-
-	select {
-	case err := <-done:
-		c.Errorf("Call(Next) did not block immediately after Watch(): err %v", err)
-	case <-time.After(coretesting.ShortWait):
-	}
+	caller.EXPECT().APICall(facadeName, 666, "id-666", "Next", nil, gomock.Any()).DoAndReturn(func(_ string, _ int, _ string, _ string, _ any, r *any) error {
+		select {
+		case ev, ok := <-eventCh:
+			if !ok {
+				c.FailNow()
+			}
+			*(*r).(*any) = ev
+			return nil
+		case <-stopped:
+		}
+		return &params.Error{Code: params.CodeStopped}
+	}).AnyTimes()
+	return "id-666", eventCh
 }
 
 func (s *watcherSuite) TestWatchMachine(c *gc.C) {
-	var results params.NotifyWatchResults
-	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	err := s.stateAPI.APICall("Machiner", s.stateAPI.BestFacadeVersion("Machiner"), "", "Watch", args, &results)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	w := watcher.NewNotifyWatcher(s.stateAPI, result)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("Machiner").Return(666)
+
+	watcherID, _ := setupWatcher[any](c, caller, "NotifyWatcher")
+
+	args := params.Entities{Entities: []params.Entity{{Tag: "machine-666"}}}
+	lifeResults := params.LifeResults{
+		Results: []params.LifeResult{{Life: life.Alive}},
+	}
+	caller.EXPECT().APICall("Machiner", 666, "", "Life", args, gomock.Any()).SetArg(5, lifeResults).Return(nil)
+	initialResults := params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{{
+			NotifyWatcherId: watcherID,
+		}},
+	}
+	caller.EXPECT().APICall("Machiner", 666, "", "Watch", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := machiner.NewClient(caller)
+	m, err := client.Machine(names.NewMachineTag("666"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	w, err := m.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
 	wc := watchertest.NewNotifyWatcherC(c, w)
 	defer wc.AssertStops()
+
 	wc.AssertOneChange()
 }
 
 func (s *watcherSuite) TestNotifyWatcherStopsWithPendingSend(c *gc.C) {
-	var results params.NotifyWatchResults
-	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	err := s.stateAPI.APICall("Machiner", s.stateAPI.BestFacadeVersion("Machiner"), "", "Watch", args, &results)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	// params.NotifyWatcher conforms to the watcher.NotifyWatcher interface
-	w := watcher.NewNotifyWatcher(s.stateAPI, result)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("Machiner").Return(666)
+
+	watcherID, _ := setupWatcher[any](c, caller, "NotifyWatcher")
+
+	args := params.Entities{Entities: []params.Entity{{Tag: "machine-666"}}}
+	lifeResults := params.LifeResults{
+		Results: []params.LifeResult{{Life: life.Alive}},
+	}
+	caller.EXPECT().APICall("Machiner", 666, "", "Life", args, gomock.Any()).SetArg(5, lifeResults).Return(nil)
+	initialResults := params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{{
+			NotifyWatcherId: watcherID,
+		}},
+	}
+	caller.EXPECT().APICall("Machiner", 666, "", "Watch", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := machiner.NewClient(caller)
+	m, err := client.Machine(names.NewMachineTag("666"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	w, err := m.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
 	wc := watchertest.NewNotifyWatcherC(c, w)
-	wc.AssertStops()
+	defer wc.AssertStops()
 }
 
-func (s *watcherSuite) TestWatchUnitsKeepsEvents(c *gc.C) {
-	// Create two applications, relate them, and add one unit to each - a
-	// principal and a subordinate.
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
-	eps, err := s.State.InferEndpoints("mysql", "logging")
-	c.Assert(err, jc.ErrorIsNil)
-	rel, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-	principal, err := mysql.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	err = principal.AssignToMachine(s.rawMachine)
-	c.Assert(err, jc.ErrorIsNil)
-	relUnit, err := rel.Unit(principal)
-	c.Assert(err, jc.ErrorIsNil)
-	err = relUnit.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	subordinate, err := s.State.Unit("logging/0")
+func (s *watcherSuite) TestWatchUnits(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("Deployer").Return(666)
+
+	watcherID, eventCh := setupWatcher[*params.StringsWatchResult](c, caller, "StringsWatcher")
+
+	args := params.Entities{Entities: []params.Entity{{Tag: "machine-666"}}}
+	initialResults := params.StringsWatchResults{
+		Results: []params.StringsWatchResult{{
+			StringsWatcherId: watcherID,
+			Changes:          []string{"unit-1", "unit-3"},
+		}},
+	}
+	caller.EXPECT().APICall("Deployer", 666, "", "WatchUnits", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := deployer.NewClient(caller)
+	m, err := client.Machine(names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	var results params.StringsWatchResults
-	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	err = s.stateAPI.APICall("Deployer", s.stateAPI.BestFacadeVersion("Deployer"), "", "WatchUnits", args, &results)
+	w, err := m.WatchUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	defer workertest.CleanKill(c, w)
 
-	// Start a StringsWatcher and check the initial event.
-	w := watcher.NewStringsWatcher(s.stateAPI, result)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
 
-	wc.AssertChange("mysql/0", "logging/0")
-	wc.AssertNoChange()
+	go func() {
+		eventCh <- &params.StringsWatchResult{
+			StringsWatcherId: watcherID,
+			Changes:          []string{"unit-1", "unit-2"},
+		}
+	}()
 
-	// Now, without reading any changes advance the lifecycle of both
-	// units.
-	err = subordinate.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	err = subordinate.Remove()
-	c.Assert(err, jc.ErrorIsNil)
-	err = principal.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Expect both changes are passed back.
-	wc.AssertChange("mysql/0", "logging/0")
-	wc.AssertNoChange()
+	// Initial event.
+	wc.AssertChange("unit-1", "unit-3")
+	wc.AssertChange("unit-1", "unit-2")
 }
 
 func (s *watcherSuite) TestStringsWatcherStopsWithPendingSend(c *gc.C) {
-	// Call the Deployer facade's WatchUnits for machine-0.
-	var results params.StringsWatchResults
-	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	err := s.stateAPI.APICall("Deployer", s.stateAPI.BestFacadeVersion("Deployer"), "", "WatchUnits", args, &results)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	// Start a StringsWatcher and check the initial event.
-	w := watcher.NewStringsWatcher(s.stateAPI, result)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("Deployer").Return(666)
+
+	watcherID, _ := setupWatcher[*params.StringsWatchResult](c, caller, "StringsWatcher")
+
+	args := params.Entities{Entities: []params.Entity{{Tag: "machine-666"}}}
+	initialResults := params.StringsWatchResults{
+		Results: []params.StringsWatchResult{{
+			StringsWatcherId: watcherID,
+			Changes:          []string{"unit-1", "unit-3"},
+		}},
+	}
+	caller.EXPECT().APICall("Deployer", 666, "", "WatchUnits", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := deployer.NewClient(caller)
+	m, err := client.Machine(names.NewMachineTag("666"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	w, err := m.WatchUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
-
-	// Create an application, deploy a unit of it on the machine.
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	principal, err := mysql.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	err = principal.AssignToMachine(s.rawMachine)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
-// TODO(fwereade): 2015-11-18 lp:1517391
 func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
-	s.Factory.MakeMachine(c, &factory.MachineParams{
-		Volumes: []state.HostVolumeParams{{
-			Volume: state.VolumeParams{
-				Pool: "modelscoped",
-				Size: 1024,
-			},
-		}},
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	var results params.MachineStorageIdsWatchResults
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("StorageProvisioner").Return(666)
+
+	watcherID, eventCh := setupWatcher[*params.MachineStorageIdsWatchResult](c, caller, "VolumeAttachmentsWatcher")
+
 	args := params.Entities{Entities: []params.Entity{{
-		Tag: s.Model.ModelTag().String(),
+		Tag: "machine-666",
 	}}}
-	err := s.stateAPI.APICall(
-		"StorageProvisioner",
-		s.stateAPI.BestFacadeVersion("StorageProvisioner"),
-		"", "WatchVolumeAttachments", args, &results)
+	initialResults := params.MachineStorageIdsWatchResults{
+		Results: []params.MachineStorageIdsWatchResult{{
+			MachineStorageIdsWatcherId: watcherID,
+			Changes: []params.MachineStorageId{{
+				MachineTag:    "machine-666",
+				AttachmentTag: "volume-0",
+			}},
+		}},
+	}
+	caller.EXPECT().APICall("StorageProvisioner", 666, "", "WatchVolumeAttachments", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client, err := storageprovisioner.NewClient(caller)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, gc.IsNil)
+	w, err := client.WatchVolumeAttachments(names.NewMachineTag("666"))
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
 
-	w := watcher.NewVolumeAttachmentsWatcher(s.stateAPI, result)
-	defer func() {
-
-		// Check we can stop the watcher...
-		w.Kill()
-		wait := make(chan error)
-		go func() {
-			wait <- w.Wait()
-		}()
+	assertNoChange := func() {
 		select {
-		case err := <-wait:
-			c.Assert(err, jc.ErrorIsNil)
+		case _, ok := <-w.Changes():
+			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+
+	assertChange := func(machine, attachment string) {
+		select {
+		case changes, ok := <-w.Changes():
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(changes, jc.SameContents, []corewatcher.MachineStorageId{{
+				MachineTag:    machine,
+				AttachmentTag: attachment,
+			}})
 		case <-time.After(coretesting.LongWait):
-			c.Fatalf("watcher never stopped")
+			c.Fatalf("timed out waiting for change")
 		}
+		assertNoChange()
+	}
 
-		// ...and that its channel hasn't been closed.
-		select {
-		case change, ok := <-w.Changes():
-			c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
-		default:
+	// Initial event.
+	assertChange("machine-666", "volume-0")
+
+	go func() {
+		eventCh <- &params.MachineStorageIdsWatchResult{
+			MachineStorageIdsWatcherId: watcherID,
+			Changes: []params.MachineStorageId{{
+				MachineTag:    "machine-666",
+				AttachmentTag: "volume-1",
+			}},
 		}
-
 	}()
-
-	// Check initial event;
-	select {
-	case changes, ok := <-w.Changes():
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(changes, jc.SameContents, []corewatcher.MachineStorageId{{
-			MachineTag:    "machine-1",
-			AttachmentTag: "volume-0",
-		}})
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for change")
-	}
-
-	// check no subsequent event.
-	select {
-	case <-w.Changes():
-		c.Fatalf("received unexpected change")
-	case <-time.After(coretesting.ShortWait):
-	}
+	assertChange("machine-666", "volume-1")
 }
 
-func (s *watcherSuite) assertSetupRelationStatusWatch(
-	c *gc.C, rel *state.Relation,
-) (func(life life.Value, suspended bool, reason string), func()) {
-	// Export the relation so it can be found with a token.
-	re := s.State.RemoteEntities()
-	token, err := re.ExportLocalEntity(rel.Tag())
-	c.Assert(err, jc.ErrorIsNil)
+type apicloser struct {
+	*apimocks.MockAPICaller
+}
 
-	// Create the offer connection details.
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
-	offers := state.NewApplicationOffers(s.State)
-	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
-		OfferName:       "hosted-mysql",
-		ApplicationName: "mysql",
-		Owner:           "admin",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		OfferUUID:       offer.OfferUUID,
-		Username:        "fred",
-		RelationKey:     rel.String(),
-		RelationId:      rel.Id(),
-		SourceModelUUID: s.State.ModelUUID(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
+func (*apicloser) Close() error {
+	return nil
+}
 
-	// Add the consume permission for the offer so the macaroon
-	// discharge can occur.
-	err = s.State.CreateOfferAccess(
-		names.NewApplicationOfferTag("hosted-mysql"),
-		names.NewUserTag("fred"), permission.ConsumeAccess)
-	c.Assert(err, jc.ErrorIsNil)
+func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	// Create a macaroon for authorisation.
-	store, err := s.State.NewBakeryStorage()
-	c.Assert(err, jc.ErrorIsNil)
-	b := bakery.New(bakery.BakeryParams{
-		RootKeyStore: store,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := b.Oven.NewMacaroon(
-		context.Background(),
-		bakery.LatestVersion,
-		[]checkers.Caveat{
-			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
-			checkers.DeclaredCaveat("relation-key", rel.String()),
-			checkers.DeclaredCaveat("username", "fred"),
-		}, bakery.NoOp)
-	c.Assert(err, jc.ErrorIsNil)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666)
 
-	// Start watching for a relation change.
-	client := crossmodelrelations.NewClient(s.stateAPI)
-	w, err := client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
-		Token:     token,
-		Macaroons: macaroon.Slice{mac.M()},
-	})
+	watcherID, eventCh := setupWatcher[*params.RelationLifeSuspendedStatusWatchResult](c, caller, "RelationStatusWatcher")
+
+	mac, err := apitesting.NewMacaroon("apimac")
 	c.Assert(err, jc.ErrorIsNil)
-	stop := func() {
-		workertest.CleanKill(c, w)
+	arg := params.RemoteEntityArg{
+		Token:     "token",
+		Macaroons: macaroon.Slice{mac},
 	}
+	args := params.RemoteEntityArgs{
+		Args: []params.RemoteEntityArg{arg},
+	}
+	initialResults := params.RelationStatusWatchResults{
+		Results: []params.RelationLifeSuspendedStatusWatchResult{{
+			RelationStatusWatcherId: watcherID,
+			Changes: []params.RelationLifeSuspendedStatusChange{{
+				Key:  "relation-wordpress:database mysql:server",
+				Life: "alive",
+			}},
+		}},
+	}
+	caller.EXPECT().APICall("CrossModelRelations", 666, "", "WatchRelationsSuspendedStatus", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := crossmodelrelations.NewClient(&apicloser{caller})
+	w, err := client.WatchRelationSuspendedStatus(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
 	assertNoChange := func() {
 		select {
 		case _, ok := <-w.Changes():
@@ -326,6 +327,7 @@ func (s *watcherSuite) assertSetupRelationStatusWatch(
 		case changes, ok := <-w.Changes():
 			c.Check(ok, jc.IsTrue)
 			c.Check(changes, gc.HasLen, 1)
+			c.Check(changes[0].Key, gc.Equals, "relation-wordpress:database mysql:server")
 			c.Check(changes[0].Life, gc.Equals, life)
 			c.Check(changes[0].Suspended, gc.Equals, suspended)
 			c.Check(changes[0].SuspendedReason, gc.Equals, reason)
@@ -337,207 +339,61 @@ func (s *watcherSuite) assertSetupRelationStatusWatch(
 
 	// Initial event.
 	assertChange(life.Alive, false, "")
-	return assertChange, stop
-}
 
-func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
-	// Create a pair of services and a relation between them.
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	eps, err := s.State.InferEndpoints("wordpress", "mysql")
-	c.Assert(err, jc.ErrorIsNil)
-	rel, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-
-	u, err := mysql.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	m := s.Factory.MakeMachine(c, &factory.MachineParams{})
-	err = u.AssignToMachine(m)
-	c.Assert(err, jc.ErrorIsNil)
-	relUnit, err := rel.Unit(u)
-	c.Assert(err, jc.ErrorIsNil)
-	err = relUnit.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
-	defer stop()
-
-	err = rel.SetSuspended(true, "another reason")
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(life.Alive, true, "another reason")
-
-	err = rel.SetSuspended(false, "")
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(life.Alive, false, "")
-
-	err = rel.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	err = rel.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(life.Dying, false, "")
-}
-
-func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
-	// Create a pair of services and a relation between them.
-	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	eps, err := s.State.InferEndpoints("wordpress", "mysql")
-	c.Assert(err, jc.ErrorIsNil)
-	rel, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange, stop := s.assertSetupRelationStatusWatch(c, rel)
-	defer stop()
-
-	err = rel.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(life.Dead, false, "")
-}
-
-func (s *watcherSuite) setupOfferStatusWatch(
-	c *gc.C,
-) (func(status status.Status, message string), func(), func()) {
-	// Create the offer connection details.
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
-	offers := state.NewApplicationOffers(s.State)
-	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
-		OfferName:       "hosted-mysql",
-		ApplicationName: "mysql",
-		Owner:           "admin",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Add the consume permission for the offer so the macaroon
-	// discharge can occur.
-	err = s.State.CreateOfferAccess(
-		names.NewApplicationOfferTag("hosted-mysql"),
-		names.NewUserTag("fred"), permission.ConsumeAccess)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Create a macaroon for authorisation.
-	store, err := s.State.NewBakeryStorage()
-	c.Assert(err, jc.ErrorIsNil)
-	b := bakery.New(bakery.BakeryParams{
-		RootKeyStore: store,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := b.Oven.NewMacaroon(
-		context.Background(),
-		bakery.LatestVersion,
-		[]checkers.Caveat{
-			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
-			checkers.DeclaredCaveat("offer-uuid", offer.OfferUUID),
-			checkers.DeclaredCaveat("username", "fred"),
-		}, bakery.NoOp)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Start watching for a relation change.
-	client := crossmodelrelations.NewClient(s.stateAPI)
-	w, err := client.WatchOfferStatus(params.OfferArg{
-		OfferUUID: offer.OfferUUID,
-		Macaroons: macaroon.Slice{mac.M()},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	stop := func() {
-		workertest.CleanKill(c, w)
-	}
-
-	assertNoChange := func() {
-		select {
-		case _, ok := <-w.Changes():
-			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
-		case <-time.After(coretesting.ShortWait):
+	go func() {
+		eventCh <- &params.RelationLifeSuspendedStatusWatchResult{
+			RelationStatusWatcherId: watcherID,
+			Changes: []params.RelationLifeSuspendedStatusChange{{
+				Key:             "relation-wordpress:database mysql:server",
+				Life:            "dying",
+				Suspended:       true,
+				SuspendedReason: "suspended",
+			}},
 		}
-	}
-
-	assertChange := func(status status.Status, message string) {
-		select {
-		case changes, ok := <-w.Changes():
-			c.Check(ok, jc.IsTrue)
-			if status == "" {
-				c.Assert(changes, gc.HasLen, 0)
-				break
-			}
-			c.Assert(changes, gc.HasLen, 1)
-			c.Check(changes[0].Name, gc.Equals, "hosted-mysql")
-			c.Check(changes[0].Status.Status, gc.Equals, status)
-			c.Check(changes[0].Status.Message, gc.Equals, message)
-		case <-time.After(coretesting.LongWait):
-			c.Fatalf("watcher didn't emit an event")
-		}
-	}
-
-	// Initial event.
-	assertChange(status.Unknown, "")
-	return assertChange, assertNoChange, stop
+	}()
+	assertChange(life.Dying, true, "suspended")
 }
 
 func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
-	// Create a pair of services and a relation between them.
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	assertChange, assertNoChange, stop := s.setupOfferStatusWatch(c)
-	defer stop()
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666)
 
-	err := mysql.SetStatus(status.StatusInfo{Status: status.Unknown, Message: "another message"})
+	watcherID, eventCh := setupWatcher[*params.OfferStatusWatchResult](c, caller, "OfferStatusWatcher")
+
+	mac, err := apitesting.NewMacaroon("apimac")
 	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange(status.Unknown, "another message")
-
-	// Removing offer and application both trigger events.
-	offers := state.NewApplicationOffers(s.State)
-	err = offers.Remove("hosted-mysql", false)
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange("terminated", "offer has been removed")
-	err = mysql.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange("terminated", "offer has been removed")
-	assertNoChange()
-}
-
-func ptr[T any](v T) *T {
-	return &v
-}
-
-func (s *watcherSuite) setupSecretRotationWatcher(
-	c *gc.C,
-) (*secrets.URI, func(corewatcher.SecretTriggerChange), func(), func()) {
-	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "mysql"})
-	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
-		Application: app,
-	})
-	store := state.NewSecrets(s.State)
-	uri := secrets.NewURI()
-	nexRotateTime := time.Now().Add(time.Hour)
-	_, err := store.CreateSecret(uri, state.CreateSecretParams{
-		Owner: unit.Tag(),
-		UpdateSecretParams: state.UpdateSecretParams{
-			LeaderToken:    &fakeToken{},
-			RotatePolicy:   ptr(secrets.RotateDaily),
-			NextRotateTime: ptr(nexRotateTime),
-			Data:           map[string]string{"foo": "bar"},
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	apiInfo := s.APIInfo(c)
-	apiInfo.Tag = unit.Tag()
-	apiInfo.Password = password
-	apiInfo.ModelTag = s.Model.ModelTag()
-
-	apiConn, err := api.Open(apiInfo, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	client := secretsmanager.NewClient(apiConn)
-	w, err := client.WatchSecretsRotationChanges(unit.Tag())
-	if !c.Check(err, jc.ErrorIsNil) {
-		_ = apiConn.Close()
-		c.FailNow()
+	arg := params.OfferArg{
+		OfferUUID:     "offer-uuid",
+		Macaroons:     macaroon.Slice{mac},
+		BakeryVersion: 3,
 	}
-	stop := func() {
-		workertest.CleanKill(c, w)
-		_ = apiConn.Close()
+	args := params.OfferArgs{
+		Args: []params.OfferArg{arg},
 	}
+	now := time.Now()
+	initialResults := params.OfferStatusWatchResults{
+		Results: []params.OfferStatusWatchResult{{
+			OfferStatusWatcherId: watcherID,
+			Changes: []params.OfferStatusChange{{
+				OfferName: "my offer",
+				Status: params.EntityStatus{
+					Status: "maintenance",
+					Info:   "working",
+					Data:   map[string]interface{}{"foo": "bar"},
+					Since:  &now,
+				},
+			}},
+		}},
+	}
+	caller.EXPECT().APICall("CrossModelRelations", 666, "", "WatchOfferStatus", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	client := crossmodelrelations.NewClient(&apicloser{caller})
+	w, err := client.WatchOfferStatus(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
 
 	assertNoChange := func() {
 		select {
@@ -547,351 +403,214 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 		}
 	}
 
-	assertChange := func(change corewatcher.SecretTriggerChange) {
+	assertChange := func(s status.Status, info string) {
 		select {
 		case changes, ok := <-w.Changes():
 			c.Check(ok, jc.IsTrue)
-			c.Assert(changes, gc.HasLen, 1)
-			c.Assert(changes[0], jc.DeepEquals, change)
+			c.Check(changes, gc.HasLen, 1)
+			c.Check(changes[0].Name, gc.Equals, "my offer")
+			c.Check(changes[0].Status, jc.DeepEquals, status.StatusInfo{
+				Status:  s,
+				Message: info,
+				Data:    map[string]interface{}{"foo": "bar"},
+				Since:   &now,
+			})
 		case <-time.After(coretesting.LongWait):
 			c.Fatalf("watcher didn't emit an event")
 		}
+		assertNoChange()
 	}
 
 	// Initial event.
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: nexRotateTime.Round(time.Second).UTC(),
-	})
-	return uri, assertChange, assertNoChange, stop
+	assertChange(status.Maintenance, "working")
+
+	go func() {
+		eventCh <- &params.OfferStatusWatchResult{
+			OfferStatusWatcherId: watcherID,
+			Changes: []params.OfferStatusChange{{
+				OfferName: "my offer",
+				Status: params.EntityStatus{
+					Status: "active",
+					Info:   "finished",
+					Data:   map[string]interface{}{"foo": "bar"},
+					Since:  &now,
+				},
+			}},
+		}
+	}()
+	assertChange(status.Active, "finished")
 }
 
-type fakeToken struct{}
+func (s *watcherSuite) assertSecretsTriggerWatcher(c *gc.C, caller *apimocks.MockAPICaller, apiName string, watchFunc func(ownerTags ...names.Tag) (corewatcher.SecretTriggerWatcher, error)) {
+	watcherID, eventCh := setupWatcher[*params.SecretTriggerWatchResult](c, caller, "SecretsTriggerWatcher")
 
-func (t *fakeToken) Check() error {
-	return nil
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: "application-mysql"}},
+	}
+	next := time.Now()
+	later := next.Add(time.Hour)
+	initialResults := params.SecretTriggerWatchResult{
+		WatcherId: watcherID,
+		Changes: []params.SecretTriggerChange{{
+			URI:             "secret:9m4e2mr0ui3e8a215n4g",
+			Revision:        666,
+			NextTriggerTime: next,
+		}},
+	}
+	caller.EXPECT().APICall("SecretsManager", 666, "", apiName, args, gomock.Any()).SetArg(5, initialResults).Return(nil)
+
+	w, err := watchFunc(names.NewApplicationTag("mysql"))
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	assertNoChange := func() {
+		select {
+		case _, ok := <-w.Changes():
+			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+
+	assertChange := func(when time.Time) {
+		select {
+		case changes, ok := <-w.Changes():
+			c.Check(ok, jc.IsTrue)
+			c.Check(changes, gc.HasLen, 1)
+			c.Check(changes[0].URI, jc.DeepEquals, &secrets.URI{ID: "9m4e2mr0ui3e8a215n4g"})
+			c.Check(changes[0].Revision, gc.Equals, 666)
+			c.Check(changes[0].NextTriggerTime, jc.DeepEquals, when)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("watcher didn't emit an event")
+		}
+		assertNoChange()
+	}
+
+	// Initial event.
+	assertChange(next)
+
+	go func() {
+		eventCh <- &params.SecretTriggerWatchResult{
+			WatcherId: "id-666",
+			Changes: []params.SecretTriggerChange{{
+				URI:             "secret:9m4e2mr0ui3e8a215n4g",
+				Revision:        666,
+				NextTriggerTime: later,
+			}},
+		}
+	}()
+	assertChange(later)
 }
 
 func (s *watcherSuite) TestSecretsRotationWatcher(c *gc.C) {
-	uri, assertChange, assertNoChange, stop := s.setupSecretRotationWatcher(c)
-	defer stop()
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	store := state.NewSecrets(s.State)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("SecretsManager").Return(666).AnyTimes()
 
-	nexRotateTime := time.Now().Add(24 * time.Hour).Round(time.Second)
-	_, err := store.UpdateSecret(uri, state.UpdateSecretParams{
-		LeaderToken:    &fakeToken{},
-		NextRotateTime: ptr(nexRotateTime),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: nexRotateTime,
-	})
-	assertNoChange()
-
-	_, err = store.UpdateSecret(uri, state.UpdateSecretParams{
-		LeaderToken:  &fakeToken{},
-		RotatePolicy: ptr(secrets.RotateNever),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: time.Time{},
-	})
-	assertNoChange()
+	client := secretsmanager.NewClient(caller)
+	s.assertSecretsTriggerWatcher(c, caller, "WatchSecretsRotationChanges", client.WatchSecretsRotationChanges)
 }
 
-func (s *watcherSuite) setupSecretExpiryWatcher(
-	c *gc.C,
-) (*secrets.URI, func(corewatcher.SecretTriggerChange), func(), func()) {
-	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "mysql"})
-	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
-		Application: app,
-	})
-	store := state.NewSecrets(s.State)
-	uri := secrets.NewURI()
-	nexRotateTime := time.Now().Add(time.Hour)
-	_, err := store.CreateSecret(uri, state.CreateSecretParams{
-		Owner: unit.Tag(),
-		UpdateSecretParams: state.UpdateSecretParams{
-			LeaderToken:    &fakeToken{},
-			RotatePolicy:   ptr(secrets.RotateDaily),
-			NextRotateTime: ptr(nexRotateTime),
-			Data:           map[string]string{"foo": "bar"},
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
+func (s *watcherSuite) TestSecretsRevisionsExpiryWatcher(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	apiInfo := s.APIInfo(c)
-	apiInfo.Tag = unit.Tag()
-	apiInfo.Password = password
-	apiInfo.ModelTag = s.Model.ModelTag()
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("SecretsManager").Return(666).AnyTimes()
 
-	apiConn, err := api.Open(apiInfo, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	client := secretsmanager.NewClient(apiConn)
-	w, err := client.WatchSecretsRotationChanges(unit.Tag())
-	if !c.Check(err, jc.ErrorIsNil) {
-		_ = apiConn.Close()
-		c.FailNow()
-	}
-	stop := func() {
-		workertest.CleanKill(c, w)
-		_ = apiConn.Close()
-	}
-
-	assertNoChange := func() {
-		select {
-		case _, ok := <-w.Changes():
-			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
-		case <-time.After(coretesting.ShortWait):
-		}
-	}
-
-	assertChange := func(change corewatcher.SecretTriggerChange) {
-		select {
-		case changes, ok := <-w.Changes():
-			c.Check(ok, jc.IsTrue)
-			c.Assert(changes, gc.HasLen, 1)
-			c.Assert(changes[0], jc.DeepEquals, change)
-		case <-time.After(coretesting.LongWait):
-			c.Fatalf("watcher didn't emit an event")
-		}
-	}
-
-	// Initial event.
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: nexRotateTime.Round(time.Second).UTC(),
-	})
-	return uri, assertChange, assertNoChange, stop
-}
-
-func (s *watcherSuite) TestSecretsExpiryWatcher(c *gc.C) {
-	uri, assertChange, assertNoChange, stop := s.setupSecretExpiryWatcher(c)
-	defer stop()
-
-	store := state.NewSecrets(s.State)
-
-	nexRotateTime := time.Now().Add(24 * time.Hour).Round(time.Second)
-	_, err := store.UpdateSecret(uri, state.UpdateSecretParams{
-		LeaderToken:    &fakeToken{},
-		NextRotateTime: ptr(nexRotateTime),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: nexRotateTime,
-	})
-	assertNoChange()
-
-	_, err = store.UpdateSecret(uri, state.UpdateSecretParams{
-		LeaderToken:  &fakeToken{},
-		RotatePolicy: ptr(secrets.RotateNever),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	assertChange(corewatcher.SecretTriggerChange{
-		URI:             uri,
-		NextTriggerTime: time.Time{},
-	})
-	assertNoChange()
-}
-
-func (s *watcherSuite) setupSecretsRevisionWatcher(
-	c *gc.C,
-) (*secrets.URI, func(uri *secrets.URI, rev int), func(), func()) {
-	// Set up the offer.
-	app := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
-		Application: app,
-	})
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
-	offers := state.NewApplicationOffers(s.State)
-	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
-		OfferName:       "hosted-mysql",
-		ApplicationName: "mysql",
-		Owner:           "admin",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Add the consume permission for the offer so the macaroon
-	// discharge can occur.
-	err = s.State.CreateOfferAccess(
-		names.NewApplicationOfferTag("hosted-mysql"),
-		names.NewUserTag("fred"), permission.ConsumeAccess)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Create a macaroon for authorisation.
-	bStore, err := s.State.NewBakeryStorage()
-	c.Assert(err, jc.ErrorIsNil)
-	b := bakery.New(bakery.BakeryParams{
-		RootKeyStore: bStore,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := b.Oven.NewMacaroon(
-		context.Background(),
-		bakery.LatestVersion,
-		[]checkers.Caveat{
-			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
-			checkers.DeclaredCaveat("offer-uuid", offer.OfferUUID),
-			checkers.DeclaredCaveat("username", "fred"),
-		}, bakery.Op{
-			Entity: "offer-uuid",
-			Action: "consume",
-		})
-	c.Assert(err, jc.ErrorIsNil)
-
-	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name: "foo", OfferUUID: offer.OfferUUID, URL: "me/model.foo", SourceModel: s.Model.ModelTag()})
-	c.Assert(err, jc.ErrorIsNil)
-	remoteRel, err := s.State.AddRelation(
-		state.Endpoint{"mysql", charm.Relation{Name: "server", Interface: "mysql", Role: charm.RoleProvider, Scope: charm.ScopeGlobal}},
-		state.Endpoint{"foo", charm.Relation{Name: "db", Interface: "mysql", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal}},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
-		SourceModelUUID: utils.MustNewUUID().String(),
-		OfferUUID:       offer.OfferUUID,
-		Username:        "fred",
-		RelationId:      remoteRel.Id(),
-		RelationKey:     remoteRel.Tag().Id(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Export the remote entities so they can be found with a token.
-	re := s.State.RemoteEntities()
-	appToken, err := re.ExportLocalEntity(remoteApp.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	relToken, err := re.ExportLocalEntity(remoteRel.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Create a secret to watch.
-	store := state.NewSecrets(s.State)
-	uri := secrets.NewURI()
-	_, err = store.CreateSecret(uri, state.CreateSecretParams{
-		Owner: unit.Tag(),
-		UpdateSecretParams: state.UpdateSecretParams{
-			LeaderToken:  &fakeToken{},
-			RotatePolicy: ptr(secrets.RotateDaily),
-			Data:         map[string]string{"foo": "bar"},
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	apiInfo := s.APIInfo(c)
-	apiInfo.Tag = unit.Tag()
-	apiInfo.Password = password
-	apiInfo.ModelTag = s.Model.ModelTag()
-
-	apiConn, err := api.Open(apiInfo, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	client := crossmodelrelations.NewClient(apiConn)
-	w, err := client.WatchConsumedSecretsChanges(appToken, relToken, mac.M())
-	if !c.Check(err, jc.ErrorIsNil) {
-		_ = apiConn.Close()
-		c.FailNow()
-	}
-	stop := func() {
-		workertest.CleanKill(c, w)
-		_ = apiConn.Close()
-	}
-
-	assertNoChange := func() {
-		select {
-		case _, ok := <-w.Changes():
-			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
-		case <-time.After(coretesting.ShortWait):
-		}
-	}
-
-	assertChange := func(uri *secrets.URI, rev int) {
-		select {
-		case changes, ok := <-w.Changes():
-			c.Check(ok, jc.IsTrue)
-			if uri == nil {
-				c.Assert(changes, gc.HasLen, 0)
-				break
-			}
-			c.Assert(changes, gc.HasLen, 1)
-			c.Assert(changes[0].URI.String(), gc.Equals, uri.String())
-			c.Assert(changes[0].Revision, gc.Equals, rev)
-		case <-time.After(coretesting.LongWait):
-			c.Fatalf("watcher didn't emit an event")
-		}
-	}
-	return uri, assertChange, assertNoChange, stop
+	client := secretsmanager.NewClient(caller)
+	s.assertSecretsTriggerWatcher(c, caller, "WatchSecretRevisionsExpiryChanges", client.WatchSecretRevisionsExpiryChanges)
 }
 
 func (s *watcherSuite) TestCrossModelSecretsRevisionWatcher(c *gc.C) {
-	uri, assertChange, assertNoChange, stop := s.setupSecretsRevisionWatcher(c)
-	defer stop()
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	store := state.NewSecrets(s.State)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666).AnyTimes()
+	watcherID, eventCh := setupWatcher[*params.SecretRevisionWatchResult](c, caller, "SecretsRevisionWatcher")
 
-	// Initial event - no changes since we're at rev 1 still.
-	assertChange(nil, 0)
-
-	err := s.State.SaveSecretRemoteConsumer(uri, names.NewUnitTag("foo/0"), &secrets.SecretConsumerMetadata{
-		CurrentRevision: 1,
-		LatestRevision:  1,
-	})
+	mac, err := apitesting.NewMacaroon("apimac")
 	c.Assert(err, jc.ErrorIsNil)
-	assertNoChange()
+	args := params.WatchRemoteSecretChangesArgs{Args: []params.WatchRemoteSecretChangesArg{{
+		ApplicationToken: "app-token",
+		RelationToken:    "rel-token",
+		Macaroons:        macaroon.Slice{mac},
+		BakeryVersion:    3,
+	}}}
+	initialResults := params.SecretRevisionWatchResults{
+		Results: []params.SecretRevisionWatchResult{{
+			WatcherId: watcherID,
+			Changes: []params.SecretRevisionChange{{
+				URI:      "secret:9m4e2mr0ui3e8a215n4g",
+				Revision: 666,
+			}},
+		}},
+	}
+	caller.EXPECT().APICall("CrossModelRelations", 666, "", "WatchConsumedSecretsChanges", args, gomock.Any()).SetArg(5, initialResults).Return(nil)
 
-	_, err = store.UpdateSecret(uri, state.UpdateSecretParams{
-		LeaderToken: &fakeToken{},
-		Data:        secrets.SecretData{"foo": "bar2"},
-	})
+	client := crossmodelrelations.NewClient(&apicloser{caller})
+	w, err := client.WatchConsumedSecretsChanges("app-token", "rel-token", mac)
 	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
 
-	assertChange(uri, 2)
-	assertNoChange()
+	assertNoChange := func() {
+		select {
+		case _, ok := <-w.Changes():
+			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+
+	assertChange := func(rev int) {
+		select {
+		case changes, ok := <-w.Changes():
+			c.Check(ok, jc.IsTrue)
+			c.Check(changes, gc.HasLen, 1)
+			c.Check(changes[0].URI, jc.DeepEquals, &secrets.URI{ID: "9m4e2mr0ui3e8a215n4g"})
+			c.Check(changes[0].Revision, gc.Equals, rev)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("watcher didn't emit an event")
+		}
+		assertNoChange()
+	}
+
+	// Initial event.
+	assertChange(666)
+
+	go func() {
+		eventCh <- &params.SecretRevisionWatchResult{
+			WatcherId: watcherID,
+			Changes: []params.SecretRevisionChange{{
+				URI:      "secret:9m4e2mr0ui3e8a215n4g",
+				Revision: 667,
+			}},
+		}
+	}()
+	assertChange(667)
 }
 
 type migrationSuite struct {
-	testing.JujuConnSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
-	const nonce = "noncey"
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	// Create a model to migrate.
-	hostedState := s.Factory.MakeModel(c, &factory.ModelParams{})
-	defer hostedState.Close()
-	hostedFactory := factory.NewFactory(hostedState, s.StatePool)
+	caller := apimocks.NewMockAPICaller(ctrl)
+	caller.EXPECT().BestFacadeVersion("MigrationMinion").Return(666).AnyTimes()
+	watcherID, eventCh := setupWatcher[*params.MigrationStatus](c, caller, "MigrationStatusWatcher")
 
-	// Create a machine in the hosted model to connect as.
-	m, password := hostedFactory.MakeMachineReturningPassword(c, &factory.MachineParams{
-		Nonce: nonce,
-	})
+	initialResult := params.NotifyWatchResult{
+		NotifyWatcherId: watcherID,
+	}
+	caller.EXPECT().APICall("MigrationMinion", 666, "", "Watch", nil, gomock.Any()).SetArg(5, initialResult).Return(nil)
 
-	// Connect as the machine to watch for migration status.
-	apiInfo := s.APIInfo(c)
-	apiInfo.Tag = m.Tag()
-	apiInfo.Password = password
-
-	hostedModel, err := hostedState.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	apiInfo.ModelTag = hostedModel.ModelTag()
-	apiInfo.Nonce = nonce
-
-	apiConn, err := api.Open(apiInfo, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	defer apiConn.Close()
-
-	// Start watching for a migration.
-	client := migrationminion.NewClient(apiConn)
+	client := migrationminion.NewClient(caller)
 	w, err := client.Watch()
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
@@ -918,32 +637,12 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 		assertNoChange()
 	}
 
-	// Initial event with no migration in progress.
-	assertChange("", migration.NONE)
+	go func() {
+		eventCh <- &params.MigrationStatus{
+			MigrationId: "mig-id",
+			Phase:       migration.QUIESCE.String(),
+		}
+	}()
 
-	// Now create a migration, should trigger watcher.
-	spec := state.MigrationSpec{
-		InitiatedBy: names.NewUserTag("someone"),
-		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
-			Addrs:         []string{"1.2.3.4:5"},
-			CACert:        "cert",
-			AuthTag:       names.NewUserTag("dog"),
-			Password:      "sekret",
-		},
-	}
-	mig, err := hostedState.CreateMigration(spec)
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(mig.Id(), migration.QUIESCE)
-
-	// Now abort the migration, this should be reported too.
-	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
-	assertChange(mig.Id(), migration.ABORT)
-	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
-	assertChange(mig.Id(), migration.ABORTDONE)
-
-	// Start a new migration, this should also trigger.
-	mig2, err := hostedState.CreateMigration(spec)
-	c.Assert(err, jc.ErrorIsNil)
-	assertChange(mig2.Id(), migration.QUIESCE)
+	assertChange("mig-id", migration.QUIESCE)
 }

--- a/core/watcher/watchertest/notify.go
+++ b/core/watcher/watchertest/notify.go
@@ -8,7 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	tomb "gopkg.in/tomb.v2"
+	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/testing"

--- a/worker/storageprovisioner/manifold_machine.go
+++ b/worker/storageprovisioner/manifold_machine.go
@@ -37,7 +37,7 @@ func (config MachineManifoldConfig) newWorker(a agent.Agent, apiCaller base.APIC
 		return nil, errors.NotValidf("missing Logger")
 	}
 	cfg := a.CurrentConfig()
-	api, err := storageprovisioner.NewState(apiCaller)
+	api, err := storageprovisioner.NewClient(apiCaller)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/storageprovisioner/manifold_model.go
+++ b/worker/storageprovisioner/manifold_model.go
@@ -44,7 +44,7 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			api, err := storageprovisioner.NewState(apiCaller)
+			api, err := storageprovisioner.NewClient(apiCaller)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
Convert the tests in `api/watcher` to unit tests by removing JujuConnSuite and using gomock instead.

As a drive by, rename storage provisioner "State" to "Client.

## QA steps

run unit tests
