### PR TITLE
[JUJU-3931] Add ed25519 and ecdsa keys to default authorized-keys

### DIFF
--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -85,7 +85,7 @@ func FinalizeAuthorizedKeys(ctx *cmd.Context, attrs map[string]interface{}) erro
 func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
 	files := ssh.PublicKeyFiles()
 	if path == "" {
-		files = append(files, "id_dsa.pub", "id_rsa.pub", "identity.pub")
+		files = append(files, "id_ed25519.pub", "id_ecdsa.pub", "id_rsa.pub", "id_dsa.pub", "identity.pub")
 	} else {
 		files = append(files, path)
 	}

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -61,11 +61,12 @@ func writeFile(c *gc.C, filename string, contents string) {
 func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
+	writeFile(c, filepath.Join(s.dotssh, "id_ed25519.pub"), "id_ed25519")
 	writeFile(c, filepath.Join(s.dotssh, "identity.pub"), "identity")
 	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
 	keys, err := common.ReadAuthorizedKeys(ctx, "")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(keys, gc.Equals, "id_rsa\nidentity\n")
+	c.Assert(keys, gc.Equals, "id_ed25519\nid_rsa\nidentity\n")
 	keys, err = common.ReadAuthorizedKeys(ctx, "test.pub") // relative to ~/.ssh
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(keys, gc.Equals, "test\n")
@@ -111,7 +112,7 @@ func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysPath(c *gc.C) {
 }
 
 func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysDefault(c *gc.C) {
-	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "meep")
+	writeFile(c, filepath.Join(s.dotssh, "id_ed25519.pub"), "meep")
 	attrs := map[string]interface{}{}
 	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Add ed25519 and ecdsa keys to default authorized-keys. 

These keys are initially loaded into the authorized-keys model config item when a model is created. But this was initially written before ecdsa and ed25519 keys were mainstream

The order here in authkeys.go is the order of precedence Juju will use when multiple keypairs with different algorithms exist. Roughly ordered from what are _generally_ considered to be most to least secure 

A future PR targeting 4.0 will remove id_dsa since this is no longer considered secure and is disabled by default in OpenSSH

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure you're using only an ecdsa or ed25519 key in `~/.ssh`. For instance:
```sh
$ ls ~/.ssh
allowed_signers  backup.sshebang  id_ed25519      known_hosts      ldap_known_hosts         macbook_id_rsa        sshebang.conf
authorized_keys      id_ed25519.pub  known_hosts.old  ldap_known_hosts.mombin    sshebang        staging-juju-rsa
```

Create a controller and a model. Verify the ed25519 key is loaded
```sh
$ juju bootstrap aws/eu-west-2 aws
$ juju add-model m
$ juju list-ssh-keys
Keys used in model: admin/m
07:d2:1b:5c:86:8d:dd:bb:d5:10:59:e6:85:a9:0f:cd (jack@jack-MS-7B85)
$ $ ssh-keygen -l -E md5 -f ~/.ssh/id_ed25519.pub 
256 MD5:07:d2:1b:5c:86:8d:dd:bb:d5:10:59:e6:85:a9:0f:cd jack@jack-MS-7B85 (ED25519)
```

Verify you can ssh into a newly created machine:
```sh
$ juju add-machine
(wait)
$ juju ssh 0
```
should successfully ssh into the machine

## Documentation

We should document somewhere that Juju will load these keys by default somewhere, including the order of precedence.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2012208