### PR TITLE
[JUJU-3946] Remove feature flag: server-side-charm-deploy

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              4,
 	"AllWatcher":                   3,
 	"Annotations":                  2,
-	"Application":                  18,
+	"Application":                  19,
 	"ApplicationOffers":            4,
 	"ApplicationScaler":            1,
 	"Backups":                      3,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/charm/v11"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/schema"
@@ -48,7 +47,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	environsconfig "github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -2980,10 +2978,6 @@ func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
 // local resource is provided, details required for uploading the validated
 // resource will be returned.
 func (api *APIBase) DeployFromRepository(args params.DeployFromRepositoryArgs) (params.DeployFromRepositoryResults, error) {
-	if !featureflag.Enabled(feature.ServerSideCharmDeploy) {
-		return params.DeployFromRepositoryResults{}, errors.NotImplementedf("this facade method is under develop")
-	}
-
 	if err := api.checkCanWrite(); err != nil {
 		return params.DeployFromRepositoryResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -60,9 +60,14 @@ var ClassifyDetachedStorage = storagecommon.ClassifyDetachedStorage
 
 var logger = loggo.GetLogger("juju.apiserver.application")
 
+// APIv19 provides the Application API facade for version 19.
+type APIv19 struct {
+	*APIBase
+}
+
 // APIv18 provides the Application API facade for version 18.
 type APIv18 struct {
-	*APIBase
+	*APIv19
 }
 
 // APIv17 provides the Application API facade for version 17.
@@ -2970,6 +2975,13 @@ func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
 		result.Error = apiservererrors.ServerError(errors.NotFoundf("leader for %s", entity.Tag))
 	}
 	return result, nil
+}
+
+// DeployFromRepository for facade v18. The method was still not fully complete until v19.
+// The NotImplemented error was for development purposes while use was behind a feature
+// flag in the juju client.
+func (api *APIv18) DeployFromRepository(args params.DeployFromRepositoryArgs) (params.DeployFromRepositoryResults, error) {
+	return params.DeployFromRepositoryResults{}, errors.NotImplementedf("this facade method is under development")
 }
 
 // DeployFromRepository is a one-stop deployment method for repository

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -961,7 +961,9 @@ func (s *applicationSuite) apiv16() *application.APIv16 {
 	return &application.APIv16{
 		APIv17: &application.APIv17{
 			APIv18: &application.APIv18{
-				APIBase: s.applicationAPI,
+				APIv19: &application.APIv19{
+					APIBase: s.applicationAPI,
+				},
 			},
 		},
 	}

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -25,11 +25,21 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Application", 18, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV18(ctx) // Added new DeployFromRepository
 	}, reflect.TypeOf((*APIv18)(nil)))
+	registry.MustRegister("Application", 19, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV19(ctx) // Added new DeployFromRepository
+	}, reflect.TypeOf((*APIv19)(nil)))
+}
 
+func newFacadeV19(ctx facade.Context) (*APIv19, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv19{api}, nil
 }
 
 func newFacadeV18(ctx facade.Context) (*APIv18, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := newFacadeV19(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1990,8 +1990,8 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv18 provides the Application API facade for version 18.",
-        "Version": 18,
+        "Description": "APIv19 provides the Application API facade for version 19.",
+        "Version": 19,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -342,7 +342,7 @@ func (c *repositoryCharm) String() string {
 // PrepareAndDeploy finishes preparing to deploy a repository charm,
 // then deploys it.
 func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver) error {
-	if deployAPI.BestFacadeVersion("Application") < 18 {
+	if deployAPI.BestFacadeVersion("Application") < 19 {
 		return c.compatibilityPrepareAndDeploy(ctx, deployAPI, resolver)
 	}
 	var base *series.Base
@@ -420,7 +420,7 @@ func formatDeployedText(dryRun bool, charmName string, info application.DeployIn
 }
 
 // compatibilityPrepareAndDeploy deploys repository charms to controllers
-// which do not have application facade 18 or greater.
+// which do not have application facade 19 or greater.
 func (c *repositoryCharm) compatibilityPrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver) error {
 	userRequestedURL := c.userRequestedURL
 	location := "charmhub"

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/api/client/application"
@@ -28,7 +27,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/series"
 	coreseries "github.com/juju/juju/core/series"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 )
 
@@ -344,8 +342,7 @@ func (c *repositoryCharm) String() string {
 // PrepareAndDeploy finishes preparing to deploy a repository charm,
 // then deploys it.
 func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver) error {
-	if (!featureflag.Enabled(feature.ServerSideCharmDeploy) && deployAPI.BestFacadeVersion("Application") >= 18) ||
-		deployAPI.BestFacadeVersion("Application") < 18 {
+	if deployAPI.BestFacadeVersion("Application") < 18 {
 		return c.compatibilityPrepareAndDeploy(ctx, deployAPI, resolver)
 	}
 	var base *series.Base

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -391,6 +391,14 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		Trust:            c.trust,
 	})
 
+	for _, err := range errs {
+		ctx.Errorf(err.Error())
+	}
+	if len(errs) != 0 {
+		return errors.Errorf("failed to deploy charm %q", charmName)
+	}
+
+	// No localPendingResources should exist if a dry-run.
 	uploadErr := c.uploadExistingPendingResources(info.Name, localPendingResources, deployAPI,
 		c.model.Filesystem())
 	if uploadErr != nil {
@@ -398,15 +406,8 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 			info.Name, uploadErr)
 	}
 
-	if len(errs) == 0 {
-		ctx.Infof(formatDeployedText(c.dryRun, charmName, info))
-		return nil
-	}
-
-	for _, err := range errs {
-		ctx.Errorf(err.Error())
-	}
-	return errors.Errorf("failed to deploy charm %q", charmName)
+	ctx.Infof(formatDeployedText(c.dryRun, charmName, info))
+	return nil
 }
 
 func formatDeployedText(dryRun bool, charmName string, info application.DeployInfo) string {

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -162,7 +162,7 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(18).AnyTimes()
+	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(19).AnyTimes()
 	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
 	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
 	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)
@@ -214,7 +214,7 @@ func (s *charmSuite) TestDeployFromRepositoryErrorNoUploadResources(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(18).AnyTimes()
+	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(19).AnyTimes()
 	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
 	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
 	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 type charmSuite struct {
-	osEnvSuite   coretesting.JujuOSEnvSuite
 	deployerAPI  *mocks.MockDeployerAPI
 	modelCommand *mocks.MockModelCommand
 	configFlag   *mocks.MockDeployConfigFlag
@@ -56,11 +55,6 @@ func (s *charmSuite) SetUpTest(c *gc.C) {
 			Name: s.url.Name,
 		},
 	}
-	s.osEnvSuite.SetUpTest(c)
-}
-
-func (s *charmSuite) TearDownTest(c *gc.C) {
-	s.osEnvSuite.TearDownTest(c)
 }
 
 func (s *charmSuite) TestSimpleCharmDeploy(c *gc.C) {
@@ -74,7 +68,7 @@ func (s *charmSuite) TestSimpleCharmDeploy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *charmSuite) TestRepositoryCharmDeployDryRun(c *gc.C) {
+func (s *charmSuite) TestRepositoryCharmDeployDryRunCompatibility(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(17).AnyTimes()
@@ -167,10 +161,7 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.osEnvSuite.SetFeatureFlags("server-side-charm-deploy")
-
 	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(18).AnyTimes()
-	s.resolver = mocks.NewMockResolver(ctrl)
 	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
 	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
 	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)
@@ -217,7 +208,7 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 
 	s.deployerAPI.EXPECT().DeployFromRepository(gomock.Any()).Return(dInfo, nil, nil)
 
-	err := repoCharm.PrepareAndDeploy(ctx, s.deployerAPI, s.resolver)
+	err := repoCharm.PrepareAndDeploy(ctx, s.deployerAPI, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(output.String(), gc.Equals,
 		"Deployed \"differentThanCharmName\" from charm-hub charm \"testme\", "+

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -168,9 +169,6 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 
 	dCharm := s.newDeployCharm()
 	dCharm.applicationName = "differentThanCharmName"
-	dCharm.validateCharmSeriesWithName = func(series, name string, imageStream string) error {
-		return nil
-	}
 
 	repoCharm := &repositoryCharm{
 		deployCharm:      *dCharm,
@@ -178,19 +176,16 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 		clock:            clock.WallClock,
 	}
 
-	stdOut := mocks.NewMockWriter(ctrl)
 	stdErr := mocks.NewMockWriter(ctrl)
 	output := bytes.NewBuffer([]byte{})
 	logOutput := func(p []byte) {
 		c.Logf("%q", p)
 		output.Write(p)
 	}
-	stdOut.EXPECT().Write(gomock.Any()).Return(0, nil).AnyTimes().Do(logOutput)
 	stdErr.EXPECT().Write(gomock.Any()).Return(0, nil).AnyTimes().Do(logOutput)
 
 	ctx := &cmd.Context{
 		Stderr: stdErr,
-		Stdout: stdOut,
 	}
 
 	dInfo := application.DeployInfo{
@@ -213,6 +208,41 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 	c.Check(output.String(), gc.Equals,
 		"Deployed \"differentThanCharmName\" from charm-hub charm \"testme\", "+
 			"revision 1 in channel latest/stable on ubuntu@20.04\n")
+}
+
+func (s *charmSuite) TestDeployFromRepositoryErrorNoUploadResources(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(18).AnyTimes()
+	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
+	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
+	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)
+
+	dCharm := s.newDeployCharm()
+
+	repoCharm := &repositoryCharm{
+		deployCharm:      *dCharm,
+		userRequestedURL: s.url,
+		clock:            clock.WallClock,
+	}
+
+	writer := mocks.NewMockWriter(ctrl)
+	writer.EXPECT().Write(gomock.Any()).Return(0, nil).AnyTimes()
+	ctx := &cmd.Context{
+		Stderr: writer,
+		Stdout: writer,
+	}
+
+	repoCharm.uploadExistingPendingResources = func(appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
+		c.Fatalf("Do not upload pending resources if errors")
+		return nil
+	}
+	expectedErrors := []error{errors.NotFoundf("test errors")}
+	s.deployerAPI.EXPECT().DeployFromRepository(gomock.Any()).Return(application.DeployInfo{}, nil, expectedErrors)
+
+	err := repoCharm.PrepareAndDeploy(ctx, s.deployerAPI, nil)
+	c.Assert(err, gc.ErrorMatches, "failed to deploy charm \"testme\"")
 }
 
 func (s *charmSuite) newDeployCharm() *deployCharm {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -33,7 +33,3 @@ const Generations = "generations"
 
 // RawK8sSpec indicates that it's allowed to set k8s spec using raw yaml format.
 const RawK8sSpec = "raw-k8s-spec"
-
-// ServerSideCharmDeploy indicates that server side deploy of repository charms
-// will be done.
-const ServerSideCharmDeploy = "server-side-charm-deploy"


### PR DESCRIPTION
Final step with server side repository charm deploy is to remove the feature flag. 

A side effect of this is that local resources to be uploaded for repository charm will no longer be verified before the charm is deployed. There are 2 types of resources, to correctly validate local resources we need charm metadata which is no longer available as the charm is deployed in 1 apiserver call rather than 2+ as before. If the local resource does not validate it's possible to use `juju attach-resource` later.

A drive by to ensure that the juju client is explicit about checking errors from DeployFromRepository before an pending local resources are uploaded. Best via unit test.

## QA steps

1. Test all permutations of juju client and agents, 3.2 and this code to ensure compatibility is maintained.
2. Any repository charm should deploy as before.  

See an error with `juju deploy juju-controller`
