### PR TITLE
[JUJU-4002] Allow migration from >=2.9.42 to 3.1.x

### DIFF
--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -60,14 +60,10 @@ func checkClientVersion(userLogin bool, callerVersion version.Number) func(facad
 			return nil
 		}
 
-		// Older clients can only connect to the next 0 version minor release,
-		// and then only if the client version is recent enough.
+		// Older clients are only allowed to connect to a server if it is
+		// within the min client versions map.
 		olderClient := callerVersion.Major < serverVersion.Major
 		if olderClient {
-			if serverVersion.Minor > 0 {
-				return incompatibleClientError
-			}
-			// Check whitelisted client versions.
 			if minClientVersion, ok := upgradevalidation.MinClientVersions[serverVersion.Major]; ok && callerVersion.Compare(minClientVersion) >= 0 {
 				return nil
 			}
@@ -79,14 +75,15 @@ func checkClientVersion(userLogin bool, callerVersion version.Number) func(facad
 			return nil
 		}
 
-		// Very new clients are rejected outright if not otherwise whitelisted above.
+		// Very new clients are rejected outright if not otherwise whitelisted
+		// above.
 		veryNewCaller := callerVersion.Major > serverVersion.Major && callerVersion.Minor != 0
 		if veryNewCaller {
 			return incompatibleClientError
 		}
 
-		// Newer clients with a 0 minor version can only connect to a server if it
-		// is recent enough.
+		// Newer clients with a 0 minor version can only connect to a server if
+		// it is recent enough.
 		if minServerVersion, ok := upgradevalidation.MinClientVersions[callerVersion.Major]; ok && serverVersion.Compare(minServerVersion) >= 0 {
 			return nil
 		}


### PR DESCRIPTION
The following just allows clients to connect the 3.1.x apiserver. Previously the code stated that if the minor version of the server version was greater than 0, it couldn't allow a connection. Which in term would return incompatible client error.

There is no point to this check. If the client is older, we should allow it to query the min client versions. We should force the client to jump to 3.0.x before 3.x.x. Removing the if statement and adding a test fixes this.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ git checkout upstream 2.9
$ make juju jujud
$ juju bootstrap lxd test29 --build-agent
$ juju add-model other
$ git checkout upstream 3.1
$ make juju jujud
$ juju bootstrap lxd test31 --build-agent
$ juju switch test29
$ juju migrate other test31
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2023756