### PR TITLE
[JUJU-3931] Remove insecure DSA keys

### DIFF
--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -84,7 +84,7 @@ func FinalizeAuthorizedKeys(ctx *cmd.Context, attrs map[string]interface{}) erro
 func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
 	files := ssh.PublicKeyFiles()
 	if path == "" {
-		files = append(files, "id_ed25519.pub", "id_ecdsa.pub", "id_rsa.pub", "id_dsa.pub", "identity.pub")
+		files = append(files, "id_ed25519.pub", "id_ecdsa.pub", "id_rsa.pub", "identity.pub")
 	} else {
 		files = append(files, path)
 	}

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -60,6 +60,7 @@ func writeFile(c *gc.C, filename string, contents string) {
 func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
+	writeFile(c, filepath.Join(s.dotssh, "id_dsa.pub"), "id_dsa") // Check dsa is NOT loaded
 	writeFile(c, filepath.Join(s.dotssh, "id_ed25519.pub"), "id_ed25519")
 	writeFile(c, filepath.Join(s.dotssh, "identity.pub"), "identity")
 	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")


### PR DESCRIPTION
We no longer by default load DSA keys into Juju's SSH keys

DSA keys are considered insecure and are disabled by default in OpenSSH
http://www.openssh.com/legacy.html

Remove these from the default ssh key loading so they are not accidentally loaded

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ ls ~/.ssh/id_dsa.pub
id_dsa.pub
$ juju add-model m
$ juju list-ssh-keys
No keys to display.
```

## Bug Reference

https://bugs.launchpad.net/juju/+bug/2012208