### PR TITLE
[JUJU-4001] Add ControllerForModel method on external controller domain

### DIFF
--- a/domain/externalcontroller/service/package_mock_test.go
+++ b/domain/externalcontroller/service/package_mock_test.go
@@ -50,6 +50,21 @@ func (mr *MockStateMockRecorder) Controller(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockState)(nil).Controller), arg0, arg1)
 }
 
+// ControllerForModel mocks base method.
+func (m *MockState) ControllerForModel(arg0 context.Context, arg1 string) (*crossmodel.ControllerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerForModel", arg0, arg1)
+	ret0, _ := ret[0].(*crossmodel.ControllerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerForModel indicates an expected call of ControllerForModel.
+func (mr *MockStateMockRecorder) ControllerForModel(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerForModel", reflect.TypeOf((*MockState)(nil).ControllerForModel), arg0, arg1)
+}
+
 // UpdateExternalController mocks base method.
 func (m *MockState) UpdateExternalController(arg0 context.Context, arg1 crossmodel.ControllerInfo, arg2 []string) error {
 	m.ctrl.T.Helper()

--- a/domain/externalcontroller/service/service.go
+++ b/domain/externalcontroller/service/service.go
@@ -16,6 +16,10 @@ type State interface {
 	// Controller returns the controller record.
 	Controller(ctx context.Context, controllerUUID string) (*crossmodel.ControllerInfo, error)
 
+	// ControllerForModel returns the controller record that's associated
+	// with the modelUUID.
+	ControllerForModel(ctx context.Context, modelUUID string) (*crossmodel.ControllerInfo, error)
+
 	// UpdateExternalController persists the input controller
 	// record and associates it with the input model UUIDs.
 	UpdateExternalController(ctx context.Context, ec crossmodel.ControllerInfo, modelUUIDs []string) error
@@ -38,6 +42,16 @@ func (s *Service) Controller(
 ) (*crossmodel.ControllerInfo, error) {
 	controllerInfo, err := s.st.Controller(ctx, controllerUUID)
 	return controllerInfo, errors.Annotate(err, "retrieving external controller")
+}
+
+// ControllerForModel returns the controller record that's associated
+// with the modelUUID.
+func (s *Service) ControllerForModel(
+	ctx context.Context,
+	modelUUID string,
+) (*crossmodel.ControllerInfo, error) {
+	controllerInfo, err := s.st.ControllerForModel(ctx, modelUUID)
+	return controllerInfo, errors.Annotate(err, "retrieving external controller for model")
 }
 
 // UpdateExternalController persists the input controller

--- a/domain/externalcontroller/service/service_test.go
+++ b/domain/externalcontroller/service/service_test.go
@@ -63,17 +63,17 @@ func (s *serviceSuite) TestUpdateExternalControllerError(c *gc.C) {
 func (s *serviceSuite) TestRetrieveExternalControllerSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	m1 := utils.MustNewUUID().String()
+	ctrlUUID := utils.MustNewUUID().String()
 	ec := crossmodel.ControllerInfo{
-		ControllerTag: names.NewControllerTag(m1),
+		ControllerTag: names.NewControllerTag(ctrlUUID),
 		Alias:         "that-other-controller",
 		Addrs:         []string{"10.10.10.10"},
 		CACert:        "random-cert-string",
 	}
 
-	s.state.EXPECT().Controller(gomock.Any(), m1).Return(&ec, nil)
+	s.state.EXPECT().Controller(gomock.Any(), ctrlUUID).Return(&ec, nil)
 
-	res, err := NewService(s.state).Controller(context.Background(), m1)
+	res, err := NewService(s.state).Controller(context.Background(), ctrlUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.Equals, &ec)
 }
@@ -85,6 +85,34 @@ func (s *serviceSuite) TestRetrieveExternalControllerError(c *gc.C) {
 	s.state.EXPECT().Controller(gomock.Any(), ctrlUUID).Return(nil, errors.New("boom"))
 
 	_, err := NewService(s.state).Controller(context.Background(), ctrlUUID)
+	c.Assert(err, gc.ErrorMatches, "retrieving external controller: boom")
+}
+
+func (s *serviceSuite) TestRetrieveExternalControllerForModelSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := utils.MustNewUUID().String()
+	ec := crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(modelUUID),
+		Alias:         "that-other-controller",
+		Addrs:         []string{"10.10.10.10"},
+		CACert:        "random-cert-string",
+	}
+
+	s.state.EXPECT().ControllerForModel(gomock.Any(), modelUUID).Return(&ec, nil)
+
+	res, err := NewService(s.state).ControllerForModel(context.Background(), modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.Equals, &ec)
+}
+
+func (s *serviceSuite) TestRetrieveExternalControllerForModelError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := "model1"
+	s.state.EXPECT().Controller(gomock.Any(), modelUUID).Return(nil, errors.New("boom"))
+
+	_, err := NewService(s.state).Controller(context.Background(), modelUUID)
 	c.Assert(err, gc.ErrorMatches, "retrieving external controller: boom")
 }
 


### PR DESCRIPTION
The legacy state ControllerForModel method has been reimplemented on the new dqlite domain. 

The main difference in behavior is that we don't need to assert that no more than 1 rows are retrieved from the external_model table, there simply cannot be more than one otherwise it would fail at insert because external_model has it's uuid as PRIMARY KEY and therefore unique.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/externalcontroller/state/... -gocheck.v
go test github.com/juju/juju/domain/externalcontroller/service/... -gocheck.v
```
