### PR TITLE
[JUJU-4002] Merge 3.1 into 3.2

### DIFF
--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -60,14 +60,10 @@ func checkClientVersion(userLogin bool, callerVersion version.Number) func(facad
 			return nil
 		}
 
-		// Older clients can only connect to the next 0 version minor release,
-		// and then only if the client version is recent enough.
+		// Older clients are only allowed to connect to a server if it is
+		// within the min client versions map.
 		olderClient := callerVersion.Major < serverVersion.Major
 		if olderClient {
-			if serverVersion.Minor > 0 {
-				return incompatibleClientError
-			}
-			// Check whitelisted client versions.
 			if minClientVersion, ok := upgradevalidation.MinClientVersions[serverVersion.Major]; ok && callerVersion.Compare(minClientVersion) >= 0 {
 				return nil
 			}
@@ -79,14 +75,15 @@ func checkClientVersion(userLogin bool, callerVersion version.Number) func(facad
 			return nil
 		}
 
-		// Very new clients are rejected outright if not otherwise whitelisted above.
+		// Very new clients are rejected outright if not otherwise whitelisted
+		// above.
 		veryNewCaller := callerVersion.Major > serverVersion.Major && callerVersion.Minor != 0
 		if veryNewCaller {
 			return incompatibleClientError
 		}
 
-		// Newer clients with a 0 minor version can only connect to a server if it
-		// is recent enough.
+		// Newer clients with a 0 minor version can only connect to a server if
+		// it is recent enough.
 		if minServerVersion, ok := upgradevalidation.MinClientVersions[callerVersion.Major]; ok && serverVersion.Compare(minServerVersion) >= 0 {
 			return nil
 		}

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -120,13 +120,16 @@ func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
 }
 
 func (r *restrictNewerClientSuite) TestWhitelistedClient(c *gc.C) {
-	r.assertWhitelistedClient(c, "2.9.41", false)
-	r.assertWhitelistedClient(c, "2.9.42", true)
+	// Ensure we're allowed to migrate from 2.9.x min release to 3.1.0.
+	r.assertWhitelistedClient(c, "2.9.41", "3.2.0", false)
+	r.assertWhitelistedClient(c, "2.9.42", "3.2.0", true)
+	r.assertWhitelistedClient(c, "2.9.42", "3.2.5", true)
+	r.assertWhitelistedClient(c, "2.9.42", "3.3.0", true)
 }
 
-func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers string, allowed bool) {
+func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, callerVers, serverVers string, allowed bool) {
 	r.PatchValue(&jujuversion.Current, version.MustParse(serverVers))
-	r.callerVersion = version.MustParse("3.0.0")
+	r.callerVersion = version.MustParse(callerVers)
 	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.callerVersion)
 	caller, err := root.FindMethod("ModelConfig", 3, "ModelSet")
 	if allowed {
@@ -139,12 +142,15 @@ func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers s
 }
 
 func (r *restrictNewerClientSuite) TestAgentMethod(c *gc.C) {
-	r.PatchValue(&jujuversion.Current, version.MustParse("3.0.0"))
-	r.assertAgentMethod(c, "2.9.43", true)
-	r.assertAgentMethod(c, "2.9.31", false)
+	// Ensure we're allowed to migrate from 2.9.x min release to 3.1.0.
+	r.assertAgentMethod(c, "2.9.42", "3.2.0", false)
+	r.assertAgentMethod(c, "2.9.43", "3.2.0", true)
+	r.assertAgentMethod(c, "2.9.43", "3.2.5", true)
+	r.assertAgentMethod(c, "2.9.43", "3.3.0", true)
 }
 
-func (r *restrictNewerClientSuite) assertAgentMethod(c *gc.C, agentVers string, allowed bool) {
+func (r *restrictNewerClientSuite) assertAgentMethod(c *gc.C, agentVers, serverVers string, allowed bool) {
+	r.PatchValue(&jujuversion.Current, version.MustParse(serverVers))
 	r.callerVersion = version.MustParse(agentVers)
 	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(false, r.callerVersion)
 	caller, err := root.FindMethod("Uniter", 18, "CurrentModel")


### PR DESCRIPTION
Merge 3.1 into 3.2.

Conflicts in restrict new client test which was resolved by updating the agent version to `2.9.43`.

cf2ece0f74 (upstream/3.1, 3.1) Merge pull request #15746 from SimonRichardson/fix-migration-failure


## QA steps

```sh
$ git checkout upstream 2.9
$ make juju jujud
$ juju bootstrap lxd test29 --build-agent
$ juju add-model other
$ git checkout upstream 3.2
$ make juju jujud
$ juju bootstrap lxd test32 --build-agent
$ juju switch test29
$ juju migrate other test32
```