### PR TITLE
[JUJU-3930] Apply DB migration to model databases

### DIFF
--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -26,7 +26,7 @@ func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 	}
 
 	db := s.DB()
-	m := NewDBMigration(db, stubLogger{}, deltas)
+	m := NewDBMigration(&txnRunner{db}, stubLogger{}, deltas)
 	c.Assert(m.Apply(context.Background()), jc.ErrorIsNil)
 
 	rows, err := db.Query("SELECT * from band;")

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -10,6 +10,7 @@ func ControllerDDL(nodeID uint64) []database.Delta {
 	schemas := []func() database.Delta{
 		leaseSchema,
 		changeLogSchema,
+		changeLogControllerNamespaces,
 		cloudSchema,
 		externalControllerSchema,
 		modelListSchema,
@@ -108,11 +109,6 @@ CREATE TABLE change_log_namespace (
 CREATE UNIQUE INDEX idx_change_log_namespace_namespace
 ON change_log_namespace (namespace);
 
-INSERT INTO change_log_namespace VALUES
-    (1, 'external_controller'),
-    (2, 'controller_node'),
-    (3, 'controller_config');
-
 CREATE TABLE change_log (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     edit_type_id        INT NOT NULL,
@@ -138,6 +134,14 @@ CREATE TABLE change_log_witness (
     upper_bound         INT NOT NULL DEFAULT(-1),
     updated_at          DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
 );`)
+}
+
+func changeLogControllerNamespaces() database.Delta {
+	return database.MakeDelta(`
+INSERT INTO change_log_namespace VALUES
+    (1, 'external_controller'),
+    (2, 'controller_node'),
+    (3, 'controller_config');`)
 }
 
 func cloudSchema() database.Delta {

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -1,0 +1,20 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import "github.com/juju/juju/core/database"
+
+// ModelDDL is used to create model databases.
+func ModelDDL() []database.Delta {
+	schemas := []func() database.Delta{
+		changeLogSchema,
+	}
+
+	var deltas []database.Delta
+	for _, fn := range schemas {
+		deltas = append(deltas, fn())
+	}
+
+	return deltas
+}


### PR DESCRIPTION
This ensures that model databases have the model schema DDL applied to them before they are made available downstream.

The following changes facilitate this:
- DDL for model databases is added to _domain/schema_.
- Database migrations now accept a transaction runner instead of a raw DB.
- The `dbaccessor` worker applies the DDL via DB migration to non-controller databases if required.

## QA steps

There are no consumers of model databases at present. Bootstrap to test for regression in DB migration logic; unit tests cover the rest.
