### PR TITLE
[JUJU-4012] Remove string resource type

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -313,6 +313,9 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		charmhubHTTPClient:  cfg.CharmhubHTTPClient,
 		dbGetter:            cfg.DBGetter,
 		dbDeleter:           cfg.DBDeleter,
+		machineTag:          cfg.Tag,
+		dataDir:             cfg.DataDir,
+		logDir:              cfg.LogDir,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/common/resource.go
+++ b/apiserver/common/resource.go
@@ -131,23 +131,6 @@ func (rs *Resources) Count() int {
 	return len(rs.resources)
 }
 
-// FIXME(nvinuesa): This `StringResource` should be removed and they should not
-// be registered.
-// StringResource is just a regular 'string' that matches the Resource
-// interface.
-type StringResource string
-
-func (StringResource) Kill() {
-}
-
-func (StringResource) Wait() error {
-	return nil
-}
-
-func (s StringResource) String() string {
-	return string(s)
-}
-
 // FIXME(nvinuesa): This `ValueResource` should be removed and they should not
 // be registered.
 // ValueResource is a Resource with a no-op Stop method, containing an

--- a/apiserver/common/resource_test.go
+++ b/apiserver/common/resource_test.go
@@ -154,12 +154,3 @@ func (resourceSuite) TestStopAll(c *gc.C) {
 
 	c.Assert(rs.Count(), gc.Equals, 0)
 }
-
-func (resourceSuite) TestStringResource(c *gc.C) {
-	rs := common.NewResources()
-	r1 := common.StringResource("foobar")
-	id := rs.Register(r1)
-	c.Check(rs.Get(id), gc.Equals, r1)
-	asStr := rs.Get(id).(common.StringResource).String()
-	c.Check(asStr, gc.Equals, "foobar")
-}

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/state"
+	"github.com/juju/names/v4"
 )
 
 // Context implements facade.Context in the simplest possible way.
@@ -35,6 +36,10 @@ type Context struct {
 	CharmhubHTTPClient_ facade.HTTPClient
 	ControllerDB_       changestream.WatchableDB
 	DBDeleter_          database.DBDeleter
+
+	MachineTag_ names.Tag
+	DataDir_    string
+	LogDir_     string
 
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
@@ -147,4 +152,19 @@ func (context Context) ControllerDB() (changestream.WatchableDB, error) {
 
 func (context Context) DBDeleter() database.DBDeleter {
 	return context.DBDeleter_
+}
+
+// MachineTag returns the current machine tag.
+func (context Context) MachineTag() names.Tag {
+	return context.MachineTag_
+}
+
+// DataDir returns the data directory.
+func (context Context) DataDir() string {
+	return context.DataDir_
+}
+
+// LogDir returns the log directory.
+func (context Context) LogDir() string {
+	return context.LogDir_
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -137,6 +137,15 @@ type Context interface {
 
 	// HTTPClient returns an HTTP client to use for the given purpose.
 	HTTPClient(purpose HTTPClientPurpose) HTTPClient
+
+	// MachineTag returns the current machine tag.
+	MachineTag() names.Tag
+
+	// DataDir returns the data directory.
+	DataDir() string
+
+	// LogDir returns the log directory.
+	LogDir() string
 }
 
 // ControllerDBGetter defines an interface for getting the controller DB.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -65,8 +65,6 @@ func (s *applicationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *applicationSuite) makeAPI(c *gc.C) *application.APIBase {
-	resources := common.NewResources()
-	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	model, err := s.State.Model()

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
@@ -35,9 +34,6 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 		return &stubApplicationOffers{}
 	}
 
-	resources := common.NewResources()
-	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
 	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery, nil, nil)
@@ -45,7 +41,8 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, getFakeControllerInfo,
-		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
+		c.MkDir(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -43,16 +43,15 @@ func createOffersAPI(
 	backend Backend,
 	statePool StatePool,
 	authorizer facade.Authorizer,
-	resources facade.Resources,
 	authContext *commoncrossmodel.AuthContext,
+	dataDir string,
 ) (*OffersAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
 
-	dataDir := resources.Get("dataDir").(common.StringResource)
 	api := &OffersAPI{
-		dataDir:     dataDir.String(),
+		dataDir:     dataDir,
 		authContext: authContext,
 		BaseAPI: BaseAPI{
 			ctx:                  context.Background(),

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -15,7 +15,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
@@ -48,9 +47,6 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 		return s.applicationOffers
 	}
 
-	resources := common.NewResources()
-	_ = resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-
 	getEnviron := func(modelUUID string) (environs.Environ, error) {
 		return s.env, nil
 	}
@@ -61,7 +57,8 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
-		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
+		c.MkDir(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
@@ -1142,9 +1139,6 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 		return &mockApplicationOffers{st: st.(*mockState)}
 	}
 
-	resources := common.NewResources()
-	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
-
 	getEnviron := func(modelUUID string) (environs.Environ, error) {
 		return s.env, nil
 	}
@@ -1154,7 +1148,8 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
-		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
+		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
+		c.MkDir(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -10,7 +10,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/testing"
@@ -31,7 +30,6 @@ const (
 type baseSuite struct {
 	jtesting.IsolationSuite
 
-	resources  *common.Resources
 	authorizer *testing.FakeAuthorizer
 
 	mockState         *mockState
@@ -44,7 +42,6 @@ type baseSuite struct {
 
 func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.resources = common.NewResources()
 	s.authorizer = &testing.FakeAuthorizer{
 		Tag:      names.NewUserTag("read"),
 		AdminTag: names.NewUserTag("admin"),

--- a/apiserver/facades/client/applicationoffers/register.go
+++ b/apiserver/facades/client/applicationoffers/register.go
@@ -55,7 +55,7 @@ func newOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		GetStateAccess(st),
 		GetStatePool(ctx.StatePool()),
 		ctx.Auth(),
-		ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
+		ctx.DataDir(),
 	)
 }

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	backupsAPI "github.com/juju/juju/apiserver/facades/client/backups"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -22,7 +21,6 @@ import (
 
 type backupsSuite struct {
 	testing.JujuConnSuite
-	resources  *common.Resources
 	authorizer *apiservertesting.FakeAuthorizer
 	api        *backupsAPI.API
 	meta       *backups.Metadata
@@ -35,9 +33,6 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	s.machineTag = names.NewMachineTag("0")
-	s.resources = common.NewResources()
-	s.resources.RegisterNamed("dataDir", common.StringResource(s.DataDir()))
-	s.resources.RegisterNamed("machineID", common.StringResource(s.machineTag.Id()))
 
 	ssInfo, err := s.State.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
@@ -61,7 +56,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 		controllerNodesF: func() ([]state.ControllerNode, error) { return nil, nil },
 		machineF:         func(id string) (backupsAPI.Machine, error) { return &testMachine{}, nil },
 	}
-	s.api, err = backupsAPI.NewAPI(shim, s.resources, s.authorizer)
+	s.api, err = backupsAPI.NewAPI(shim, s.authorizer, s.machineTag, s.DataDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	s.meta = backupstesting.NewMetadataStarted()
 }
@@ -86,13 +81,13 @@ func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *
 }
 
 func (s *backupsSuite) TestNewAPIOkay(c *gc.C) {
-	_, err := backupsAPI.NewAPI(&stateShim{State: s.State, Model: s.Model}, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPI(&stateShim{State: s.State, Model: s.Model}, s.authorizer, s.machineTag, s.DataDir(), "")
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 	s.authorizer.Tag = names.NewApplicationTag("eggs")
-	_, err := backupsAPI.NewAPI(&stateShim{State: s.State, Model: s.Model}, s.resources, s.authorizer)
+	_, err := backupsAPI.NewAPI(&stateShim{State: s.State, Model: s.Model}, s.authorizer, s.machineTag, s.DataDir(), "")
 	c.Check(errors.Cause(err), gc.Equals, apiservererrors.ErrPerm)
 }
 
@@ -101,7 +96,7 @@ func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
 	defer otherState.Close()
 	otherModel, err := otherState.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = backupsAPI.NewAPI(&stateShim{State: otherState, Model: otherModel}, s.resources, s.authorizer)
+	_, err = backupsAPI.NewAPI(&stateShim{State: otherState, Model: otherModel}, s.authorizer, s.machineTag, s.DataDir(), "")
 	c.Check(err, gc.ErrorMatches, "backups are only supported from the controller model\nUse juju switch to select the controller model")
 }
 
@@ -112,6 +107,6 @@ func (s *backupsSuite) TestBackupsCAASFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	isController := true
-	_, err = backupsAPI.NewAPI(&stateShim{State: otherState, Model: otherModel, isController: &isController}, s.resources, s.authorizer)
+	_, err = backupsAPI.NewAPI(&stateShim{State: otherState, Model: otherModel, isController: &isController}, s.authorizer, s.machineTag, s.DataDir(), "")
 	c.Assert(err, gc.ErrorMatches, "backups on kubernetes controllers not supported")
 }

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -24,5 +24,11 @@ func newFacade(ctx facade.Context) (*API, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewAPI(&stateShim{st, model}, ctx.Resources(), ctx.Auth())
+	return NewAPI(
+		&stateShim{State: st, Model: model},
+		ctx.Auth(),
+		ctx.MachineTag(),
+		ctx.DataDir(),
+		ctx.LogDir(),
+	)
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -14,8 +14,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facade/facadetest"
 	apiservermocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/client/charms"
 	"github.com/juju/juju/apiserver/facades/client/charms/interfaces"
@@ -24,14 +24,9 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/arch"
-	"github.com/juju/juju/core/changestream"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
-	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/leadership"
-	"github.com/juju/juju/core/lease"
-	"github.com/juju/juju/core/multiwatcher"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -47,35 +42,6 @@ type charmsSuite struct {
 
 var _ = gc.Suite(&charmsSuite{})
 
-// charmsSuiteContext implements the facade.Context interface.
-type charmsSuiteContext struct {
-	auth facade.Authorizer
-	st   *state.State
-}
-
-func (ctx *charmsSuiteContext) Abort() <-chan struct{}                    { return nil }
-func (ctx *charmsSuiteContext) Auth() facade.Authorizer                   { return ctx.auth }
-func (ctx *charmsSuiteContext) Cancel() <-chan struct{}                   { return nil }
-func (ctx *charmsSuiteContext) Dispose()                                  {}
-func (ctx *charmsSuiteContext) Resources() facade.Resources               { return common.NewResources() }
-func (ctx *charmsSuiteContext) State() *state.State                       { return ctx.st }
-func (ctx *charmsSuiteContext) StatePool() *state.StatePool               { return nil }
-func (ctx *charmsSuiteContext) ID() string                                { return "" }
-func (ctx *charmsSuiteContext) RequestRecorder() facade.RequestRecorder   { return nil }
-func (ctx *charmsSuiteContext) Presence() facade.Presence                 { return nil }
-func (ctx *charmsSuiteContext) Hub() facade.Hub                           { return nil }
-func (ctx *charmsSuiteContext) MultiwatcherFactory() multiwatcher.Factory { return nil }
-
-func (ctx *charmsSuiteContext) LeadershipClaimer(string) (leadership.Claimer, error)  { return nil, nil }
-func (ctx *charmsSuiteContext) LeadershipRevoker(string) (leadership.Revoker, error)  { return nil, nil }
-func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error)        { return nil, nil }
-func (ctx *charmsSuiteContext) LeadershipPinner(string) (leadership.Pinner, error)    { return nil, nil }
-func (ctx *charmsSuiteContext) LeadershipReader(string) (leadership.Reader, error)    { return nil, nil }
-func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)               { return nil, nil }
-func (ctx *charmsSuiteContext) HTTPClient(facade.HTTPClientPurpose) facade.HTTPClient { return nil }
-func (ctx *charmsSuiteContext) ControllerDB() (changestream.WatchableDB, error)       { return nil, nil }
-func (ctx *charmsSuiteContext) DBDeleter() coredatabase.DBDeleter                     { return nil }
-
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
@@ -85,9 +51,9 @@ func (s *charmsSuite) SetUpTest(c *gc.C) {
 	}
 
 	var err error
-	s.api, err = charms.NewFacade(&charmsSuiteContext{
-		auth: s.auth,
-		st:   s.ControllerModel(c).State(),
+	s.api, err = charms.NewFacade(facadetest.Context{
+		Auth_:  s.auth,
+		State_: s.ControllerModel(c).State(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -40,7 +40,6 @@ type NodeService interface {
 type HighAvailabilityAPI struct {
 	st          *state.State
 	nodeService NodeService
-	resources   facade.Resources
 	authorizer  facade.Authorizer
 }
 

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/highavailability"
@@ -31,7 +30,6 @@ import (
 type clientSuite struct {
 	testing.JujuConnSuite
 
-	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 	haServer   *highavailability.HighAvailabilityAPI
 
@@ -47,19 +45,14 @@ var (
 
 func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.resources = common.NewResources()
-	err := s.resources.RegisterNamed("machineID", common.StringResource("0"))
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:        s.AdminUserTag(c),
 		Controller: true,
 	}
-
+	var err error
 	s.haServer, err = highavailability.NewHighAvailabilityAPI(facadetest.Context{
 		State_:        s.State,
-		Resources_:    s.resources,
 		Auth_:         s.authorizer,
 		ControllerDB_: stubWatchableDB{},
 	})
@@ -503,9 +496,8 @@ func (s *clientSuite) TestEnableHAHostedModelErrors(c *gc.C) {
 	defer st2.Close()
 
 	haServer, err := highavailability.NewHighAvailabilityAPI(facadetest.Context{
-		State_:     st2,
-		Resources_: s.resources,
-		Auth_:      s.authorizer,
+		State_: st2,
+		Auth_:  s.authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -562,9 +554,8 @@ func (s *clientSuite) TestHighAvailabilityCAASFails(c *gc.C) {
 	defer st.Close()
 
 	_, err := highavailability.NewHighAvailabilityAPI(facadetest.Context{
-		State_:     st,
-		Resources_: s.resources,
-		Auth_:      s.authorizer,
+		State_: st,
+		Auth_:  s.authorizer,
 	})
 	c.Assert(err, gc.ErrorMatches, "high availability on kubernetes controllers not supported")
 }

--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -43,7 +43,6 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 	return &HighAvailabilityAPI{
 		st:          st,
 		nodeService: service.NewService(state.NewState(domain.NewDBFactory(ctx.ControllerDB))),
-		resources:   ctx.Resources(),
 		authorizer:  authorizer,
 	}, nil
 }

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -277,6 +277,20 @@ func (mr *MockContextMockRecorder) DBDeleter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBDeleter", reflect.TypeOf((*MockContext)(nil).DBDeleter))
 }
 
+// DataDir mocks base method.
+func (m *MockContext) DataDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DataDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// DataDir indicates an expected call of DataDir.
+func (mr *MockContextMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockContext)(nil).DataDir))
+}
+
 // Dispose mocks base method.
 func (m *MockContext) Dispose() {
 	m.ctrl.T.Helper()
@@ -404,6 +418,34 @@ func (m *MockContext) LeadershipRevoker(arg0 string) (leadership.Revoker, error)
 func (mr *MockContextMockRecorder) LeadershipRevoker(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeadershipRevoker", reflect.TypeOf((*MockContext)(nil).LeadershipRevoker), arg0)
+}
+
+// LogDir mocks base method.
+func (m *MockContext) LogDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LogDir indicates an expected call of LogDir.
+func (mr *MockContextMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockContext)(nil).LogDir))
+}
+
+// MachineTag mocks base method.
+func (m *MockContext) MachineTag() names.Tag {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MachineTag")
+	ret0, _ := ret[0].(names.Tag)
+	return ret0
+}
+
+// MachineTag indicates an expected call of MachineTag.
+func (mr *MockContextMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockContext)(nil).MachineTag))
 }
 
 // MultiwatcherFactory mocks base method.

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -105,16 +105,6 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		serverHost:   serverHost,
 	}
 
-	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := r.resources.RegisterNamed("dataDir", common.StringResource(srv.dataDir)); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	// Facades involved with managing application offers need the auth context
 	// to mint and validate macaroons.
 	localOfferAccessEndpoint := url.URL{
@@ -579,6 +569,21 @@ func (ctx *facadeContext) ControllerDB() (changestream.WatchableDB, error) {
 // DBDeleter returns a database deleter.
 func (ctx *facadeContext) DBDeleter() coredatabase.DBDeleter {
 	return ctx.r.shared.dbDeleter
+}
+
+// MachineTag returns the current machine tag.
+func (ctx *facadeContext) MachineTag() names.Tag {
+	return ctx.r.shared.machineTag
+}
+
+// DataDir returns the data directory.
+func (ctx *facadeContext) DataDir() string {
+	return ctx.r.shared.dataDir
+}
+
+// LogDir returns the log directory.
+func (ctx *facadeContext) LogDir() string {
+	return ctx.r.shared.logDir
 }
 
 // adminRoot dispatches API calls to those available to an anonymous connection

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/facade"
 	jujucontroller "github.com/juju/juju/controller"
@@ -53,6 +54,10 @@ type sharedServerContext struct {
 	controllerConfig jujucontroller.Config
 	features         set.Strings
 
+	machineTag names.Tag
+	dataDir    string
+	logDir     string
+
 	unsubscribe func()
 }
 
@@ -67,6 +72,9 @@ type sharedServerConfig struct {
 	charmhubHTTPClient  facade.HTTPClient
 	dbGetter            changestream.WatchableDBGetter
 	dbDeleter           database.DBDeleter
+	machineTag          names.Tag
+	dataDir             string
+	logDir              string
 }
 
 func (c *sharedServerConfig) validate() error {
@@ -94,6 +102,15 @@ func (c *sharedServerConfig) validate() error {
 	if c.dbDeleter == nil {
 		return errors.NotValidf("nil dbDeleter")
 	}
+	if c.machineTag == nil {
+		return errors.NotValidf("empty machineTag")
+	}
+	if c.dataDir == "" {
+		return errors.NotValidf("empty dataDir")
+	}
+	if c.logDir == "" {
+		return errors.NotValidf("empty logDir")
+	}
 	return nil
 }
 
@@ -112,6 +129,9 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		charmhubHTTPClient:  config.charmhubHTTPClient,
 		dbGetter:            config.dbGetter,
 		dbDeleter:           config.dbDeleter,
+		machineTag:          config.machineTag,
+		dataDir:             config.dataDir,
+		logDir:              config.logDir,
 	}
 	ctx.features = config.controllerConfig.Features()
 	// We are able to get the current controller config before subscribing to changes

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -105,12 +105,6 @@ func (c *sharedServerConfig) validate() error {
 	if c.machineTag == nil {
 		return errors.NotValidf("empty machineTag")
 	}
-	if c.dataDir == "" {
-		return errors.NotValidf("empty dataDir")
-	}
-	if c.logDir == "" {
-		return errors.NotValidf("empty logDir")
-	}
 	return nil
 }
 

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
 	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -64,6 +65,9 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 		logger:              loggo.GetLogger("test"),
 		dbGetter:            StubDBGetter{},
 		dbDeleter:           StubDBDeleter{},
+		machineTag:          names.NewMachineTag("0"),
+		dataDir:             c.MkDir(),
+		logDir:              c.MkDir(),
 	}
 }
 


### PR DESCRIPTION
The following removes the string resource type from the apiserver common package. The string resource was used to thread through a string into different parts of the code base without explicitly adding it to a context. I don't mind this if we went all in and created better design patterns around it. In the end, the amount of work required to just get a string out of a resource container (think IOC container) and verify it was just a little bit much.

Instead, we're going to focus apiserver resources as watcher-only types. The work here is just laying the path for that.

Just hoisting the already accessible values onto the context, for now, will allow any facade to get access to them.

The API facade/handle code is a freaking MESS of spaghetti code which we should resolve at some point. Factory/visitor pattern would do wonders here, by just adding information and routes when required. That's for another PR.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju deploy juju-qa-dummy-source d
$ juju offer d:sink
$ juju status
```
