### PR TITLE
[JUJU-3930] Apply DB migration to model databases

### DIFF
--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -26,7 +26,7 @@ func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 	}
 
 	db := s.DB()
-	m := NewDBMigration(db, stubLogger{}, deltas)
+	m := NewDBMigration(&txnRunner{db}, stubLogger{}, deltas)
 	c.Assert(m.Apply(context.Background()), jc.ErrorIsNil)
 
 	rows, err := db.Query("SELECT * from band;")

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -10,6 +10,7 @@ func ControllerDDL(nodeID uint64) []database.Delta {
 	schemas := []func() database.Delta{
 		leaseSchema,
 		changeLogSchema,
+		changeLogControllerNamespaces,
 		cloudSchema,
 		externalControllerSchema,
 		modelListSchema,
@@ -108,11 +109,6 @@ CREATE TABLE change_log_namespace (
 CREATE UNIQUE INDEX idx_change_log_namespace_namespace
 ON change_log_namespace (namespace);
 
-INSERT INTO change_log_namespace VALUES
-    (1, 'external_controller'),
-    (2, 'controller_node'),
-    (3, 'controller_config');
-
 CREATE TABLE change_log (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     edit_type_id        INT NOT NULL,
@@ -138,6 +134,14 @@ CREATE TABLE change_log_witness (
     upper_bound         INT NOT NULL DEFAULT(-1),
     updated_at          DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
 );`)
+}
+
+func changeLogControllerNamespaces() database.Delta {
+	return database.MakeDelta(`
+INSERT INTO change_log_namespace VALUES
+    (1, 'external_controller'),
+    (2, 'controller_node'),
+    (3, 'controller_config');`)
 }
 
 func cloudSchema() database.Delta {

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -1,0 +1,20 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import "github.com/juju/juju/core/database"
+
+// ModelDDL is used to create model databases.
+func ModelDDL() []database.Delta {
+	schemas := []func() database.Delta{
+		changeLogSchema,
+	}
+
+	var deltas []database.Delta
+	for _, fn := range schemas {
+		deltas = append(deltas, fn())
+	}
+
+	return deltas
+}

--- a/worker/dbaccessor/worker_integration_test.go
+++ b/worker/dbaccessor/worker_integration_test.go
@@ -5,8 +5,9 @@ package dbaccessor_test
 
 import (
 	"context"
-	sql "database/sql"
+	"database/sql"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -22,7 +23,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/database"
 	"github.com/juju/juju/database/app"
-	dqlite "github.com/juju/juju/database/dqlite"
+	"github.com/juju/juju/database/dqlite"
 	databasetesting "github.com/juju/juju/database/testing"
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/testing"
@@ -80,10 +81,11 @@ func (s *integrationSuite) SetUpSuite(c *gc.C) {
 	s.dbDeleter = w
 	s.worker = w
 
-	db, err := s.DBApp().Open(context.TODO(), coredatabase.ControllerNS)
+	db, err := s.DBApp().Open(context.Background(), coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = database.NewDBMigration(db, logger, schema.ControllerDDL(s.DBApp().ID())).Apply(context.TODO())
+	err = database.NewDBMigration(
+		&txnRunner{db}, logger, schema.ControllerDDL(s.DBApp().ID())).Apply(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -110,7 +112,7 @@ func (s *integrationSuite) TestWorkerAccessingUnknownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
 	db, err := s.dbGetter.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = db.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = db.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("bar")`)
 		return err
 	})
@@ -119,6 +121,18 @@ func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
 	db, err = s.dbGetter.GetDB("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(db, gc.NotNil)
+
+	// Check that the model schema DDL was applied.
+	type EditType struct {
+		EditType string `db:"edit_type"`
+	}
+	var results []EditType
+	q := sqlair.MustPrepare("SELECT &EditType.* FROM change_log_edit_type", EditType{})
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, q).GetAll(&results)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(results, gc.HasLen, 3)
 }
 
 func (s *integrationSuite) TestWorkerDeletingControllerDB(c *gc.C) {
@@ -135,7 +149,7 @@ func (s *integrationSuite) TestWorkerDeletingUnknownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 	ctrlDB, err := s.dbGetter.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("baz")`)
 		return err
 	})
@@ -147,7 +161,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 
 	// We need to unsure that we remove the namespace from the model list.
 	// Otherwise, the db will be recreated on the next call to GetDB.
-	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM model_list WHERE uuid = "baz"`)
 		return errors.Cause(err)
 	})
@@ -166,7 +180,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerDeletingKnownDBWithoutGetFirst(c *gc.C) {
 	ctrlDB, err := s.dbGetter.GetDB(coredatabase.ControllerNS)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO model_list (uuid) VALUES ("fred")`)
 		return err
 	})
@@ -174,7 +188,7 @@ func (s *integrationSuite) TestWorkerDeletingKnownDBWithoutGetFirst(c *gc.C) {
 
 	// We need to unsure that we remove the namespace from the model list.
 	// Otherwise, the db will be recreated on the next call to GetDB.
-	err = ctrlDB.StdTxn(context.TODO(), func(ctx context.Context, tx *sql.Tx) error {
+	err = ctrlDB.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM model_list WHERE uuid = "fred"`)
 		return err
 	})
@@ -211,4 +225,12 @@ func (s *dqliteAppIntegrationSuite) SetUpTest(c *gc.C) {
 
 func (s *dqliteAppIntegrationSuite) TearDownTest(c *gc.C) {
 	s.IsolationSuite.TearDownTest(c)
+}
+
+type txnRunner struct {
+	db *sql.DB
+}
+
+func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
+	return errors.Trace(database.StdTxn(ctx, r.db, f))
 }


### PR DESCRIPTION
This ensures that model databases have the model schema DDL applied to them before they are made available downstream.

The following changes facilitate this:
- DDL for model databases is added to _domain/schema_.
- Database migrations now accept a transaction runner instead of a raw DB.
- The `TrackedDB` worker applies the DDL via DB migration to non-controller databases upon start-up if required.

## QA steps

There are no consumers of model databases at present. Bootstrap to test for regression in DB migration logic; unit tests cover the rest.