### PR TITLE
[JUJU-4011] Inject logger instead of having a singleton on facades

### DIFF
--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/state"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 )
 
@@ -36,6 +37,7 @@ type Context struct {
 	CharmhubHTTPClient_ facade.HTTPClient
 	ControllerDB_       changestream.WatchableDB
 	DBDeleter_          database.DBDeleter
+	Logger_             loggo.Logger
 
 	MachineTag_ names.Tag
 	DataDir_    string
@@ -167,4 +169,8 @@ func (context Context) DataDir() string {
 // LogDir returns the log directory.
 func (context Context) LogDir() string {
 	return context.LogDir_
+}
+
+func (context Context) Logger() loggo.Logger {
+	return context.Logger_
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
 
@@ -68,6 +69,7 @@ type Context interface {
 	LeadershipContext
 	ControllerDBGetter
 	DBManager
+	Logger
 
 	// Cancel channel represents an indication from the API server that
 	// all interruptable calls should stop. The channel is only ever
@@ -158,6 +160,12 @@ type ControllerDBGetter interface {
 type DBManager interface {
 	// DBDeleter returns an a deleter for databases based on namespace.
 	DBDeleter() coredatabase.DBDeleter
+}
+
+// Logger defines an interface for getting the apiserver logger instance.
+type Logger interface {
+	// Logger returns the apiserver logger instance.
+	Logger() loggo.Logger
 }
 
 // RequestRecorder is implemented by types that can record information about

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -24,8 +24,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.caasapplication")
-
 type Facade struct {
 	auth      facade.Authorizer
 	resources facade.Resources
@@ -34,6 +32,7 @@ type Facade struct {
 	model     Model
 	clock     clock.Clock
 	broker    Broker
+	logger    loggo.Logger
 }
 
 // NewFacade returns a new CAASOperator facade.
@@ -44,6 +43,7 @@ func NewFacade(
 	st State,
 	broker Broker,
 	clock clock.Clock,
+	logger loggo.Logger,
 ) (*Facade, error) {
 	if !authorizer.AuthApplicationAgent() && !authorizer.AuthUnitAgent() {
 		return nil, apiservererrors.ErrPerm
@@ -60,6 +60,7 @@ func NewFacade(
 		model:     model,
 		clock:     clock,
 		broker:    broker,
+		logger:    logger,
 	}, nil
 }
 
@@ -81,7 +82,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 		return errResp(errors.NotValidf("pod-uuid"))
 	}
 
-	logger.Debugf("introducing pod %q (%q)", args.PodName, args.PodUUID)
+	f.logger.Debugf("introducing pod %q (%q)", args.PodName, args.PodUUID)
 
 	application, err := f.state.Application(tag.Name)
 	if err != nil {

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -50,7 +51,7 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	s.st = newMockState()
 	s.broker = &mockBroker{}
 
-	facade, err := caasapplication.NewFacade(s.resources, s.authorizer, s.st, s.st, s.broker, s.clock)
+	facade, err := caasapplication.NewFacade(s.resources, s.authorizer, s.st, s.st, s.broker, s.clock, loggo.GetLogger("juju.apiserver.caasaplication"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade
 }

--- a/apiserver/facades/agent/caasapplication/register.go
+++ b/apiserver/facades/agent/caasapplication/register.go
@@ -40,5 +40,6 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 		systemState,
 		&stateShim{st},
 		broker,
-		ctx.StatePool().Clock())
+		ctx.StatePool().Clock(),
+		ctx.Logger().Child("caasapplication"))
 }

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -5,6 +5,7 @@ package credentialvalidator_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -31,7 +32,7 @@ func (s *BackendSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.state = newMockState()
 
-	s.backend = credentialvalidator.NewBackend(s.state)
+	s.backend = credentialvalidator.NewBackend(s.state, loggo.GetLogger("juju.api.credentialvalidator"))
 }
 
 func (s *BackendSuite) TestModelUsesCredential(c *gc.C) {

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -4,7 +4,6 @@
 package credentialvalidator
 
 import (
-	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common/credentialcommon"
@@ -13,8 +12,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
 )
-
-var logger = loggo.GetLogger("juju.api.credentialvalidator")
 
 // CredentialValidatorV2 defines the methods on version 2 facade for the
 // credentialvalidator API endpoint.

--- a/apiserver/facades/agent/credentialvalidator/register.go
+++ b/apiserver/facades/agent/credentialvalidator/register.go
@@ -18,5 +18,5 @@ func Register(registry facade.FacadeRegistry) {
 
 // newCredentialValidatorAPI creates a new CredentialValidator API endpoint on server-side.
 func newCredentialValidatorAPI(ctx facade.Context) (*CredentialValidatorAPI, error) {
-	return internalNewCredentialValidatorAPI(NewBackend(NewStateShim(ctx.State())), ctx.Resources(), ctx.Auth())
+	return internalNewCredentialValidatorAPI(NewBackend(NewStateShim(ctx.State()), ctx.Logger().Child("credentialvalidator")), ctx.Resources(), ctx.Auth())
 }

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	coretesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
@@ -850,7 +851,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, nil)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine, loggo.GetLogger("juju.apiserver.instancemutater")).Return(s.watcher, nil)
 	s.watcher.EXPECT().Changes().Return(ch)
 	s.resources.EXPECT().Register(s.watcher).Return("1")
 }
@@ -861,14 +862,14 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, nil)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine, loggo.GetLogger("juju.apiserver.instancemutater")).Return(s.watcher, nil)
 	s.watcher.EXPECT().Changes().Return(ch)
 }
 
 func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLXDProfileVerificationNeededError() {
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, errors.New("watcher error"))
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine, loggo.GetLogger("juju.apiserver.instancemutater")).Return(s.watcher, errors.New("watcher error"))
 }
 
 func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLXDProfileVerificationNeededWithManualMachine() {
@@ -877,7 +878,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(true, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Times(0)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine, loggo.GetLogger("juju.apiserver.instancemutater")).Times(0)
 }
 
 type InstanceMutaterAPIWatchContainersSuite struct {

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/charm/v11"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3/catacomb"
 
@@ -29,6 +30,8 @@ type machineLXDProfileWatcher struct {
 	backend InstanceMutaterState
 
 	catacomb catacomb.Catacomb
+
+	logger loggo.Logger
 }
 
 // Kill is part of the worker.Worker interface.
@@ -95,6 +98,7 @@ type appInfo struct {
 type MachineLXDProfileWatcherConfig struct {
 	machine Machine
 	backend InstanceMutaterState
+	logger  loggo.Logger
 }
 
 func newMachineLXDProfileWatcher(config MachineLXDProfileWatcherConfig) (*machineLXDProfileWatcher, error) {
@@ -108,6 +112,7 @@ func newMachineLXDProfileWatcher(config MachineLXDProfileWatcherConfig) (*machin
 		applications: make(map[string]appInfo),
 		machine:      config.machine,
 		backend:      config.backend,
+		logger:       config.logger,
 	}
 
 	if err := catacomb.Invoke(catacomb.Plan{
@@ -126,7 +131,7 @@ func newMachineLXDProfileWatcher(config MachineLXDProfileWatcherConfig) (*machin
 	}
 	close(w.initialized)
 
-	logger.Debugf("started MachineLXDProfileWatcher for machine-%s with %#v", w.machine.Id(), w.applications)
+	config.logger.Debugf("started MachineLXDProfileWatcher for machine-%s with %#v", w.machine.Id(), w.applications)
 	return w, nil
 }
 
@@ -153,21 +158,21 @@ func (w *machineLXDProfileWatcher) loop() error {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		case apps := <-appWatcher.Changes():
-			logger.Tracef("application charm changes: %v", apps)
+			w.logger.Tracef("application charm changes: %v", apps)
 			for _, appName := range apps {
 				if err := w.applicationCharmURLChange(appName); err != nil {
 					return errors.Annotatef(err, "processing change for application %q", appName)
 				}
 			}
 		case charms := <-charmWatcher.Changes():
-			logger.Tracef("charm changes: %v", charms)
+			w.logger.Tracef("charm changes: %v", charms)
 			for _, chURL := range charms {
 				if err := w.charmChange(chURL); err != nil {
 					return errors.Annotatef(err, "processing change for charm %q", chURL)
 				}
 			}
 		case units := <-unitWatcher.Changes():
-			logger.Debugf("unit changes on %v: %v", w.machine.Id(), units)
+			w.logger.Debugf("unit changes on %v: %v", w.machine.Id(), units)
 			for _, unitName := range units {
 				u, err := w.backend.Unit(unitName)
 				unitLife := state.Dead
@@ -188,7 +193,7 @@ func (w *machineLXDProfileWatcher) loop() error {
 			}
 		case <-instanceWatcher.Changes():
 			id := w.machine.Id()
-			logger.Tracef("instance changes machine-%s", id)
+			w.logger.Tracef("instance changes machine-%s", id)
 			if err := w.provisionedChange(); err != nil {
 				return errors.Annotatef(err, "processing change for machine-%s", id)
 			}
@@ -203,19 +208,19 @@ func (w *machineLXDProfileWatcher) unitMachineID(u Unit) (string, error) {
 		return machineID, errors.Trace(err)
 	}
 	if !isSubordinate {
-		logger.Warningf("unit %s has no machine id, start watching when machine id assigned.", u.Name())
+		w.logger.Warningf("unit %s has no machine id, start watching when machine id assigned.", u.Name())
 		return machineID, errors.Trace(err)
 	}
 	principal, err := w.backend.Unit(principalName)
 	if errors.IsNotFound(err) {
-		logger.Warningf("unit %s is subordinate, principal %s not found", u.Name(), principalName)
+		w.logger.Warningf("unit %s is subordinate, principal %s not found", u.Name(), principalName)
 		return "", errors.NotFoundf("principal unit %q", principalName)
 	} else if err != nil {
 		return "", errors.Trace(err)
 	}
 	machineID, err = principal.AssignedMachineId()
 	if errors.IsNotAssigned(err) {
-		logger.Warningf("principal unit %s has no machine id, start watching when machine id assigned.", principalName)
+		w.logger.Warningf("principal unit %s has no machine id, start watching when machine id assigned.", principalName)
 	}
 	return machineID, errors.Trace(err)
 }
@@ -243,7 +248,7 @@ func (w *machineLXDProfileWatcher) init() error {
 			// to what is watched when the machineId is assigned.
 			// Otherwise return an error.
 			if _, err := unit.AssignedMachineId(); errors.IsNotAssigned(err) {
-				logger.Warningf("unit %s has no application, nor machine id, start watching when machine id assigned.", unitName)
+				w.logger.Warningf("unit %s has no application, nor machine id, start watching when machine id assigned.", unitName)
 				continue
 			} else if err != nil {
 				return errors.Trace(err)
@@ -294,7 +299,7 @@ func (w *machineLXDProfileWatcher) applicationCharmURLChange(appName string) err
 
 	app, err := w.backend.Application(appName)
 	if errors.IsNotFound(err) {
-		logger.Debugf("not watching removed %s on machine-%s", appName, w.machine.Id())
+		w.logger.Debugf("not watching removed %s on machine-%s", appName, w.machine.Id())
 		return nil
 	} else if err != nil {
 		return errors.Trace(err)
@@ -313,7 +318,7 @@ func (w *machineLXDProfileWatcher) applicationCharmURLChange(appName string) err
 		}
 		ch, err := w.backend.Charm(chURL)
 		if errors.IsNotFound(err) {
-			logger.Debugf("not watching %s with removed charm %s on machine-%s", appName, *cURL, w.machine.Id())
+			w.logger.Debugf("not watching %s with removed charm %s on machine-%s", appName, *cURL, w.machine.Id())
 			return nil
 		} else if err != nil {
 			return errors.Annotatef(err, "error getting charm %s to evaluate for lxd profile notification", *cURL)
@@ -324,19 +329,19 @@ func (w *machineLXDProfileWatcher) applicationCharmURLChange(appName string) err
 		// 2. the new profile is not empty.
 		lxdProfile := ch.LXDProfile()
 		if (!info.charmProfile.Empty() && lxdProfile.Empty()) || !lxdProfile.Empty() {
-			logger.Debugf("notifying due to change of charm lxd profile for app %s, machine-%s", appName, w.machine.Id())
+			w.logger.Debugf("notifying due to change of charm lxd profile for app %s, machine-%s", appName, w.machine.Id())
 			notify = true
 		} else {
-			logger.Debugf("no notification of charm lxd profile needed for %s, machine-%s", appName, w.machine.Id())
+			w.logger.Debugf("no notification of charm lxd profile needed for %s, machine-%s", appName, w.machine.Id())
 		}
 
 		info.charmProfile = lxdProfile
 		info.charmURL = *cURL
 		w.applications[appName] = info
 	} else {
-		logger.Tracef("not watching %s on machine-%s", appName, w.machine.Id())
+		w.logger.Tracef("not watching %s on machine-%s", appName, w.machine.Id())
 	}
-	logger.Tracef("end of application charm url change %#v", w.applications)
+	w.logger.Tracef("end of application charm url change %#v", w.applications)
 	return nil
 }
 
@@ -375,7 +380,7 @@ func (w *machineLXDProfileWatcher) charmChange(chURL string) error {
 		}
 		ch, err := w.backend.Charm(curl)
 		if errors.IsNotFound(err) {
-			logger.Debugf("charm %s removed for %s on machine-%s", chURL, appName, w.machine.Id())
+			w.logger.Debugf("charm %s removed for %s on machine-%s", chURL, appName, w.machine.Id())
 			continue
 		} else if err != nil {
 			return errors.Trace(err)
@@ -385,17 +390,17 @@ func (w *machineLXDProfileWatcher) charmChange(chURL string) error {
 		// 1. the prior charm had a profile and the new one does not.
 		// 2. the new profile is not empty.
 		if (!info.charmProfile.Empty() && lxdProfile.Empty()) || !lxdProfile.Empty() {
-			logger.Debugf("notifying due to change of charm lxd profile for charm %s, machine-%s", chURL, w.machine.Id())
+			w.logger.Debugf("notifying due to change of charm lxd profile for charm %s, machine-%s", chURL, w.machine.Id())
 			notify = true
 		} else {
-			logger.Debugf("no notification of charm lxd profile needed for %s, machine-%s", appName, w.machine.Id())
+			w.logger.Debugf("no notification of charm lxd profile needed for %s, machine-%s", appName, w.machine.Id())
 		}
 
 		info.charmProfile = lxdProfile
 		info.charmURL = chURL
 		w.applications[appName] = info
 	}
-	logger.Tracef("end of charm metadata change")
+	w.logger.Tracef("end of charm metadata change")
 	return nil
 }
 
@@ -413,7 +418,7 @@ func (w *machineLXDProfileWatcher) addUnit(unit Unit) error {
 	var notify bool
 	defer func(notify *bool) {
 		if *notify {
-			logger.Debugf("notifying due to add unit requires lxd profile change machine-%s", w.machine.Id())
+			w.logger.Debugf("notifying due to add unit requires lxd profile change machine-%s", w.machine.Id())
 			w.notify()
 		}
 	}(&notify)
@@ -426,16 +431,16 @@ func (w *machineLXDProfileWatcher) addUnit(unit Unit) error {
 		return errors.Annotatef(err, "finding assigned machine for unit %q", unitName)
 	}
 	if unitMachineId != w.machine.Id() {
-		logger.Debugf("ignoring unit change on machine-%s as it is not machine-%s", unitMachineId, w.machine.Id())
+		w.logger.Debugf("ignoring unit change on machine-%s as it is not machine-%s", unitMachineId, w.machine.Id())
 		return nil
 	}
-	logger.Debugf("start watching %q on machine-%s", unitName, w.machine.Id())
+	w.logger.Debugf("start watching %q on machine-%s", unitName, w.machine.Id())
 	notify, err = w.add(unit)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	logger.Tracef("end of unit change %#v", w.applications)
+	w.logger.Tracef("end of unit change %#v", w.applications)
 	return nil
 }
 
@@ -450,7 +455,7 @@ func (w *machineLXDProfileWatcher) add(unit Unit) (bool, error) {
 			// this happens for new units to existing machines.
 			app, err := unit.Application()
 			if errors.IsNotFound(err) {
-				logger.Debugf("failed to process new unit %s for %s on machine-%s; application removed", unitName, appName, w.machine.Id())
+				w.logger.Debugf("failed to process new unit %s for %s on machine-%s; application removed", unitName, appName, w.machine.Id())
 				return false, nil
 			} else if err != nil {
 				return false, errors.Annotatef(err, "failed to get application %s for machine-%s", appName, w.machine.Id())
@@ -464,7 +469,7 @@ func (w *machineLXDProfileWatcher) add(unit Unit) (bool, error) {
 		}
 		ch, err := w.backend.Charm(curl)
 		if errors.IsNotFound(err) {
-			logger.Debugf("charm %s removed for %s on machine-%s", *curlStr, unitName, w.machine.Id())
+			w.logger.Debugf("charm %s removed for %s on machine-%s", *curlStr, unitName, w.machine.Id())
 			return false, nil
 		} else if err != nil {
 			return false, errors.Annotatef(err, "failed to get charm %q for %s on machine-%s", *curlStr, appName, w.machine.Id())
@@ -508,7 +513,7 @@ func (w *machineLXDProfileWatcher) removeUnit(unitName string) error {
 	var notify bool
 	defer func(notify *bool) {
 		if *notify {
-			logger.Debugf("notifying due to remove unit requires lxd profile change machine-%s", w.machine.Id())
+			w.logger.Debugf("notifying due to remove unit requires lxd profile change machine-%s", w.machine.Id())
 			w.notify()
 		}
 	}(&notify)
@@ -523,7 +528,7 @@ func (w *machineLXDProfileWatcher) removeUnit(unitName string) error {
 		// actual fact you can bump into this more often than not in legitimate
 		// circumstances. So instead of being an error, this should just be a
 		// debug log.
-		logger.Debugf("unit removed before being added, application name not found")
+		w.logger.Debugf("unit removed before being added, application name not found")
 		return nil
 	}
 	if !app.units.Contains(unitName) {
@@ -565,15 +570,15 @@ func (w *machineLXDProfileWatcher) provisionedChange() error {
 	}
 	_, err = m.InstanceId()
 	if errors.IsNotProvisioned(err) {
-		logger.Debugf("machine-%s not provisioned yet", w.machine.Id())
+		w.logger.Debugf("machine-%s not provisioned yet", w.machine.Id())
 		return nil
 	} else if err != nil {
-		logger.Criticalf("%q.provisionedChange error getting instanceID: %s", w.machine.Id(), err)
+		w.logger.Criticalf("%q.provisionedChange error getting instanceID: %s", w.machine.Id(), err)
 		return err
 	}
 	w.provisioned = true
 
-	logger.Debugf("notifying due to machine-%s now provisioned", w.machine.Id())
+	w.logger.Debugf("notifying due to machine-%s now provisioned", w.machine.Id())
 	w.notify()
 	return nil
 }

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -15,6 +15,7 @@ import (
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
+	loggo "github.com/juju/loggo"
 	names "github.com/juju/names/v4"
 )
 
@@ -42,18 +43,18 @@ func (m *MockInstanceMutatorWatcher) EXPECT() *MockInstanceMutatorWatcherMockRec
 }
 
 // WatchLXDProfileVerificationForMachine mocks base method.
-func (m *MockInstanceMutatorWatcher) WatchLXDProfileVerificationForMachine(arg0 instancemutater.Machine) (state.NotifyWatcher, error) {
+func (m *MockInstanceMutatorWatcher) WatchLXDProfileVerificationForMachine(arg0 instancemutater.Machine, arg1 loggo.Logger) (state.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationForMachine", arg0)
+	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationForMachine", arg0, arg1)
 	ret0, _ := ret[0].(state.NotifyWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLXDProfileVerificationForMachine indicates an expected call of WatchLXDProfileVerificationForMachine.
-func (mr *MockInstanceMutatorWatcherMockRecorder) WatchLXDProfileVerificationForMachine(arg0 interface{}) *gomock.Call {
+func (mr *MockInstanceMutatorWatcherMockRecorder) WatchLXDProfileVerificationForMachine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationForMachine", reflect.TypeOf((*MockInstanceMutatorWatcher)(nil).WatchLXDProfileVerificationForMachine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationForMachine", reflect.TypeOf((*MockInstanceMutatorWatcher)(nil).WatchLXDProfileVerificationForMachine), arg0, arg1)
 }
 
 // MockInstanceMutaterState is a mock of InstanceMutaterState interface.

--- a/apiserver/facades/agent/instancemutater/package_test.go
+++ b/apiserver/facades/agent/instancemutater/package_test.go
@@ -6,6 +6,7 @@ package instancemutater
 import (
 	"testing"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -44,6 +45,7 @@ func NewTestAPI(
 		resources:   resources,
 		authorizer:  authorizer,
 		getAuthFunc: getAuthFunc,
+		logger:      loggo.GetLogger("juju.apiserver.instancemutater"),
 	}, nil
 }
 
@@ -52,6 +54,7 @@ func NewTestLxdProfileWatcher(c *gc.C, machine Machine, backend InstanceMutaterS
 	w, err := newMachineLXDProfileWatcher(MachineLXDProfileWatcherConfig{
 		backend: backend,
 		machine: machine,
+		logger:  loggo.GetLogger("juju.apiserver.instancemutater"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return w

--- a/apiserver/facades/agent/instancemutater/register.go
+++ b/apiserver/facades/agent/instancemutater/register.go
@@ -21,5 +21,5 @@ func newFacadeV3(ctx facade.Context) (*InstanceMutaterAPI, error) {
 	st := &instanceMutaterStateShim{State: ctx.State()}
 
 	watcher := &instanceMutatorWatcher{st: st}
-	return NewInstanceMutaterAPI(st, watcher, ctx.Resources(), ctx.Auth())
+	return NewInstanceMutaterAPI(st, watcher, ctx.Resources(), ctx.Auth(), ctx.Logger().Child("instancemutater"))
 }

--- a/apiserver/facades/agent/meterstatus/meterstatus.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus.go
@@ -17,8 +17,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.meterstatus")
-
 // MeterStatus defines the methods exported by the meter status API facade.
 type MeterStatus interface {
 	GetMeterStatus(args params.Entities) (params.MeterStatusResults, error)
@@ -56,6 +54,7 @@ func NewMeterStatusAPI(
 	st MeterStatusState,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
+	logger loggo.Logger,
 ) (*MeterStatusAPI, error) {
 	if !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
 		return nil, apiservererrors.ErrPerm

--- a/apiserver/facades/agent/meterstatus/meterstatus_test.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus_test.go
@@ -5,6 +5,7 @@ package meterstatus_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -49,7 +50,7 @@ func (s *meterStatusSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	status, err := meterstatus.NewMeterStatusAPI(s.State, s.resources, s.authorizer)
+	status, err := meterstatus.NewMeterStatusAPI(s.State, s.resources, s.authorizer, loggo.GetLogger("juju.apiserver.meterstatus"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.status = status
 }
@@ -204,7 +205,7 @@ func (s *meterStatusSuite) setupMeterStatusAPI(c *gc.C, fn func(meterStatusAPIMo
 
 	mockAuthorizer.EXPECT().AuthUnitAgent().Return(true)
 
-	status, err := meterstatus.NewMeterStatusAPI(mockState, mockResources, mockAuthorizer)
+	status, err := meterstatus.NewMeterStatusAPI(mockState, mockResources, mockAuthorizer, loggo.GetLogger("juju.apiserver.meterstatus"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	fn(meterStatusAPIMocks{

--- a/apiserver/facades/agent/meterstatus/register.go
+++ b/apiserver/facades/agent/meterstatus/register.go
@@ -20,5 +20,5 @@ func Register(registry facade.FacadeRegistry) {
 func newMeterStatusFacade(ctx facade.Context) (*MeterStatusAPI, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
-	return NewMeterStatusAPI(ctx.State(), resources, authorizer)
+	return NewMeterStatusAPI(ctx.State(), resources, authorizer, ctx.Logger().Child("meterstatus"))
 }

--- a/apiserver/facades/agent/payloadshookcontext/register.go
+++ b/apiserver/facades/agent/payloadshookcontext/register.go
@@ -58,5 +58,5 @@ func newStateFacade(ctx facade.Context) (*UnitFacade, error) {
 		return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
 	}
 
-	return NewHookContextFacade(st, unit)
+	return NewHookContextFacade(st, unit, ctx.Logger().Child("payloadshookcontext"))
 }

--- a/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
@@ -6,6 +6,7 @@ package payloadshookcontext_test
 import (
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -37,7 +38,7 @@ func (s *suite) TestTrack(c *gc.C) {
 	id := "ce5bc2a7-65d8-4800-8199-a7c3356ab309"
 	s.state.stateIDs = []string{id}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 
 	args := params.TrackPayloadArgs{
 		Payloads: []params.Payload{{
@@ -92,7 +93,7 @@ func (s *suite) TestListOne(c *gc.C) {
 		},
 	}}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{
 		Entities: []params.Entity{{
 			Tag: names.NewPayloadTag(id).String(),
@@ -143,7 +144,7 @@ func (s *suite) TestListAll(c *gc.C) {
 		},
 	}}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{}
 	results, err := a.List(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -173,7 +174,7 @@ func (s *suite) TestLookUpOkay(c *gc.C) {
 	id := "ce5bc2a7-65d8-4800-8199-a7c3356ab309"
 	s.state.stateIDs = []string{id}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.LookUpPayloadArgs{
 		Args: []params.LookUpPayloadArg{{
 			Name: "fooID",
@@ -208,7 +209,7 @@ func (s *suite) TestLookUpMixed(c *gc.C) {
 	notFound := errors.NotFoundf("payload")
 	s.stub.SetErrors(nil, notFound, nil)
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.LookUpPayloadArgs{
 		Args: []params.LookUpPayloadArg{{
 			Name: "fooID",
@@ -253,7 +254,7 @@ func (s *suite) TestSetStatus(c *gc.C) {
 	s.state.stateIDs = []string{id}
 	s.state.stateIDs = []string{"ce5bc2a7-65d8-4800-8199-a7c3356ab309"}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.SetPayloadStatusArgs{
 		Args: []params.SetPayloadStatusArg{{
 			Entity: params.Entity{
@@ -283,7 +284,7 @@ func (s *suite) TestUntrack(c *gc.C) {
 	id := "ce5bc2a7-65d8-4800-8199-a7c3356ab309"
 	s.state.stateIDs = []string{id}
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{
 		Entities: []params.Entity{{
 			Tag: names.NewPayloadTag(id).String(),
@@ -306,7 +307,7 @@ func (s *suite) TestUntrack(c *gc.C) {
 }
 
 func (s *suite) TestUntrackEmptyID(c *gc.C) {
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{
 		Entities: []params.Entity{{
 			Tag: "",
@@ -332,7 +333,7 @@ func (s *suite) TestUntrackNoIDs(c *gc.C) {
 	id := "ce5bc2a7-65d8-4800-8199-a7c3356ab309"
 	s.state.id = id
 
-	a := unitfacade.NewUnitFacade(s.state)
+	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{
 		Entities: []params.Entity{},
 	}

--- a/apiserver/facades/agent/provisioner/export_test.go
+++ b/apiserver/facades/agent/provisioner/export_test.go
@@ -5,7 +5,6 @@ package provisioner
 
 import (
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/loggo"
 )
 
 // TODO (manadart 2019-09-26): This file should be deleted via these steps:
@@ -15,7 +14,7 @@ import (
 // - Instantiate these contexts directly instead of requiring these methods.
 
 func NewPrepareOrGetContext(result params.MachineNetworkConfigResults, maintain bool) *prepareOrGetContext {
-	return &prepareOrGetContext{result: result, maintain: maintain, logger: loggo.GetLogger("juju.apiserver.provisioner")}
+	return &prepareOrGetContext{result: result, maintain: maintain}
 }
 
 func NewContainerProfileContext(result params.ContainerProfileResults, modelName string) *containerProfileContext {

--- a/apiserver/facades/agent/provisioner/export_test.go
+++ b/apiserver/facades/agent/provisioner/export_test.go
@@ -3,7 +3,10 @@
 
 package provisioner
 
-import "github.com/juju/juju/rpc/params"
+import (
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/loggo"
+)
 
 // TODO (manadart 2019-09-26): This file should be deleted via these steps:
 // - Rename provisioner_test.go to provisioner_integration_test.go
@@ -12,7 +15,7 @@ import "github.com/juju/juju/rpc/params"
 // - Instantiate these contexts directly instead of requiring these methods.
 
 func NewPrepareOrGetContext(result params.MachineNetworkConfigResults, maintain bool) *prepareOrGetContext {
-	return &prepareOrGetContext{result: result, maintain: maintain}
+	return &prepareOrGetContext{result: result, maintain: maintain, logger: loggo.GetLogger("juju.apiserver.provisioner")}
 }
 
 func NewContainerProfileContext(result params.ContainerProfileResults, modelName string) *containerProfileContext {

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/proxy"
 	jc "github.com/juju/testing/checkers"
@@ -1849,7 +1850,7 @@ func (s *provisionerMockSuite) TestManuallyProvisionedHostsUseDHCPForContainers(
 	ctx := provisioner.NewPrepareOrGetContext(res, false)
 
 	// ProviderCallContext is not required by this logical path and can be nil
-	err := ctx.ProcessOneContainer(s.environ, nil, s.policy, 0, s.host, s.container)
+	err := ctx.ProcessOneContainer(s.environ, nil, s.policy, 0, s.host, s.container, loggo.GetLogger("juju.apiserver.provisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results[0].Config, gc.HasLen, 1)
 
@@ -1903,7 +1904,7 @@ func (s *provisionerMockSuite) TestContainerAlreadyProvisionedError(c *gc.C) {
 
 	// ProviderCallContext and BridgePolicy are not
 	// required by this logical path and can be nil.
-	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container)
+	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container, loggo.GetLogger("juju.apiserver.provisioner"))
 	c.Assert(err, gc.ErrorMatches, `container "0/lxd/0" already provisioned as "juju-8ebd6c-0"`)
 }
 
@@ -1929,7 +1930,7 @@ func (s *provisionerMockSuite) TestGetContainerProfileInfo(c *gc.C) {
 
 	// ProviderCallContext and BridgePolicy are not
 	// required by this logical path and can be nil.
-	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container)
+	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container, loggo.GetLogger("juju.apiserver.provisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.IsNil)
@@ -1959,7 +1960,7 @@ func (s *provisionerMockSuite) TestGetContainerProfileInfoNoProfile(c *gc.C) {
 
 	// ProviderCallContext and BridgePolicy are not
 	// required by this logical path and can be nil.
-	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container)
+	err := ctx.ProcessOneContainer(s.environ, nil, nil, 0, s.host, s.container, loggo.GetLogger("juju.apiserver.provisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.IsNil)

--- a/apiserver/facades/agent/secretsdrain/register.go
+++ b/apiserver/facades/agent/secretsdrain/register.go
@@ -40,5 +40,6 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsDrainAPI, error) {
 		resources:         context.Resources(),
 		secretsConsumer:   context.State(),
 		model:             model,
+		logger:            context.Logger().Child("secretsdrain"),
 	}, nil
 }

--- a/apiserver/facades/agent/secretsdrain/secrets.go
+++ b/apiserver/facades/agent/secretsdrain/secrets.go
@@ -19,8 +19,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.secretsdrain")
-
 // For testing.
 var (
 	GetProvider = secretsprovider.Provider
@@ -33,6 +31,7 @@ type SecretsDrainAPI struct {
 	resources         facade.Resources
 	secretsConsumer   SecretsConsumer
 	authTag           names.Tag
+	logger            loggo.Logger
 
 	model Model
 }
@@ -115,7 +114,7 @@ func toChangeSecretBackendParams(token leadership.Token, uri *coresecrets.URI, a
 // WatchSecretBackendChanged sets up a watcher to notify of changes to the secret backend.
 func (s *SecretsDrainAPI) WatchSecretBackendChanged() (params.NotifyWatchResult, error) {
 	stateWatcher := s.model.WatchForModelConfigChanges()
-	w, err := newSecretBackendModelConfigWatcher(s.model, stateWatcher)
+	w, err := newSecretBackendModelConfigWatcher(s.model, stateWatcher, s.logger)
 	if err != nil {
 		return params.NotifyWatchResult{Error: apiservererrors.ServerError(err)}, nil
 	}

--- a/apiserver/facades/agent/secretsdrain/watcher.go
+++ b/apiserver/facades/agent/secretsdrain/watcher.go
@@ -5,6 +5,7 @@ package secretsdrain
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
@@ -16,15 +17,17 @@ type secretBackendModelConfigWatcher struct {
 	out               chan struct{}
 	src               state.NotifyWatcher
 	modelConfigGetter Model
+	logger            loggo.Logger
 
 	currentSecretBackend string
 }
 
-func newSecretBackendModelConfigWatcher(modelConfigGetter Model, src state.NotifyWatcher) (state.NotifyWatcher, error) {
+func newSecretBackendModelConfigWatcher(modelConfigGetter Model, src state.NotifyWatcher, logger loggo.Logger) (state.NotifyWatcher, error) {
 	w := &secretBackendModelConfigWatcher{
 		out:               make(chan struct{}),
 		src:               src,
 		modelConfigGetter: modelConfigGetter,
+		logger:            logger,
 	}
 	modelConfig, err := w.modelConfigGetter.ModelConfig()
 	if err != nil {
@@ -100,7 +103,7 @@ func (w *secretBackendModelConfigWatcher) isSecretBackendChanged() (bool, error)
 	if w.currentSecretBackend == latest {
 		return false, nil
 	}
-	logger.Tracef("secret backend was changed from %s to %s", w.currentSecretBackend, latest)
+	w.logger.Tracef("secret backend was changed from %s to %s", w.currentSecretBackend, latest)
 	w.currentSecretBackend = latest
 	return true, nil
 }

--- a/apiserver/facades/agent/secretsdrain/watcher_test.go
+++ b/apiserver/facades/agent/secretsdrain/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -97,7 +98,7 @@ func (s *SecretsDrainSuite) TestSecretBackendModelConfigWatcher(c *gc.C) {
 		),
 	)
 
-	w, err := secretsdrain.NewSecretBackendModelConfigWatcher(s.model, s.modelConfigChangesWatcher)
+	w, err := secretsdrain.NewSecretBackendModelConfigWatcher(s.model, s.modelConfigChangesWatcher, loggo.GetLogger("juju.apiserver.secretsdrain"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
 

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/juju/clock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
@@ -14,6 +15,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/leadership"
+	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -62,5 +64,6 @@ func NewTestAPI(
 		crossModelState:     crossModelState,
 		clock:               clock,
 		modelUUID:           coretesting.ModelTag.Id(),
+		logger:              loggo.GetLoggerWithLabels("juju.apiserver.secretsmanager", corelogger.SECRETS),
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common/secrets"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/secrets/provider"
@@ -103,5 +104,6 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		adminConfigGetter:   secretBackendAdminConfigGetter,
 		remoteClientGetter:  remoteClientGetter,
 		crossModelState:     context.State().RemoteEntities(),
+		logger:              context.Logger().ChildWithLabels("secretsmanager", corelogger.SECRETS),
 	}, nil
 }

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -43,5 +43,5 @@ func newFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewStorageProvisionerAPIv4(backend, storageBackend, ctx.Resources(), ctx.Auth(), registry, pm)
+	return NewStorageProvisionerAPIv4(backend, storageBackend, ctx.Resources(), ctx.Auth(), registry, pm, ctx.Logger().Child("storageprovisioner"))
 }

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -23,8 +23,6 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.storageprovisioner")
-
 // StorageProvisionerAPIv4 provides the StorageProvisioner API v4 facade.
 type StorageProvisionerAPIv4 struct {
 	*common.LifeGetter
@@ -43,6 +41,7 @@ type StorageProvisionerAPIv4 struct {
 	getMachineAuthFunc       common.GetAuthFunc
 	getBlockDevicesAuthFunc  common.GetAuthFunc
 	getAttachmentAuthFunc    func() (func(names.Tag, names.Tag) bool, error)
+	logger                   loggo.Logger
 }
 
 // NewStorageProvisionerAPIv4 creates a new server-side StorageProvisioner v3 facade.
@@ -53,6 +52,7 @@ func NewStorageProvisionerAPIv4(
 	authorizer facade.Authorizer,
 	registry storage.ProviderRegistry,
 	poolManager poolmanager.PoolManager,
+	logger loggo.Logger,
 ) (*StorageProvisionerAPIv4, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, apiservererrors.ErrPerm
@@ -217,6 +217,7 @@ func NewStorageProvisionerAPIv4(
 		getAttachmentAuthFunc:    getAttachmentAuthFunc,
 		getMachineAuthFunc:       getMachineAuthFunc,
 		getBlockDevicesAuthFunc:  getBlockDevicesAuthFunc,
+		logger:                   logger,
 	}, nil
 }
 
@@ -1549,7 +1550,7 @@ func (s *StorageProvisionerAPIv4) Remove(args params.Entities) (params.ErrorResu
 			return s.sb.RemoveVolume(tag)
 		default:
 			// should have been picked up by canAccess
-			logger.Debugf("unexpected %v tag", tag.Kind())
+			s.logger.Debugf("unexpected %v tag", tag.Kind())
 			return apiservererrors.ErrPerm
 		}
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -88,7 +89,7 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm)
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm, loggo.GetLogger("juju.apiserver.storageprovisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -120,7 +121,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm)
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm, loggo.GetLogger("juju.apiserver.storageprovisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -129,7 +130,7 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, common.NewResources(), authorizer, nil, nil)
+	_, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, common.NewResources(), authorizer, nil, nil, loggo.GetLogger("juju.apiserver.storageprovisioner"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/charm/v11"
 	"github.com/juju/clock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
@@ -297,7 +298,7 @@ func (s *networkInfoSuite) TestAPIRequestForRelationCAASHostNameNoIngress(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We need to instantiate this with the new CAAS model state.
-	netInfo, err := uniter.NewNetworkInfoForStrategy(st, u.UnitTag(), nil, lookup)
+	netInfo, err := uniter.NewNetworkInfoForStrategy(st, u.UnitTag(), nil, lookup, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := netInfo.ProcessAPIRequest(params.NetworkInfoParams{
@@ -514,7 +515,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	prr := newProReqRelationForApps(c, st, mysql, gitlab)
 
 	// We need to instantiate this with the new CAAS model state.
-	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil)
+	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// First no address.
@@ -534,7 +535,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	// We need a new instance here, because unit addresses
 	// are populated in the constructor.
-	netInfo, err = uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil)
+	netInfo, err = uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -559,7 +560,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelInvalidBinding(c *gc.
 	prr := newProReqRelationForApps(c, st, mySql, gitLab)
 
 	// We need to instantiate this with the new CAAS model state.
-	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil)
+	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, _, err = netInfo.NetworksForRelation("unknown", prr.rel, true)
@@ -624,7 +625,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 		}
 	}
 
-	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.ru0.UnitTag(), retryFactory, nil)
+	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.ru0.UnitTag(), retryFactory, nil, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// At this point we only have a container (local-machine) address.
@@ -645,7 +646,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 
 	// We need a new instance here, because unit addresses
 	// are populated in the constructor.
-	netInfo, err = uniter.NewNetworkInfoForStrategy(st, prr.ru0.UnitTag(), retryFactory, nil)
+	netInfo, err = uniter.NewNetworkInfoForStrategy(st, prr.ru0.UnitTag(), retryFactory, nil, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -831,7 +832,7 @@ func (s *networkInfoSuite) newNetworkInfo(
 		}
 	}
 
-	ni, err := uniter.NewNetworkInfoForStrategy(s.State, tag, retryFactory, lookupHost)
+	ni, err := uniter.NewNetworkInfoForStrategy(s.State, tag, retryFactory, lookupHost, loggo.GetLogger("juju.apiserver.uniter"))
 	c.Assert(err, jc.ErrorIsNil)
 	return ni
 }

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -347,7 +347,7 @@ func (n *NetworkInfoIAAS) populateMachineAddresses() error {
 		var err error
 		privateMachineAddress, err = n.pollForAddress(n.machine.PrivateAddress)
 		if err != nil {
-			logger.Errorf("unable to obtain preferred private address for machine %q: %s", n.machine.Id(), err.Error())
+			n.logger.Errorf("unable to obtain preferred private address for machine %q: %s", n.machine.Id(), err.Error())
 			// Remove this ID to prevent further processing.
 			spaceSet.Remove(network.AlphaSpaceId)
 		}
@@ -376,14 +376,14 @@ func (n *NetworkInfoIAAS) populateMachineAddresses() error {
 		return order1 < order2
 	})
 
-	logger.Debugf("Looking for address from %v in spaces %v", addrs, spaceSet.Values())
+	n.logger.Debugf("Looking for address from %v in spaces %v", addrs, spaceSet.Values())
 
 	var privateLinkLayerAddress NetInfoAddress
 	for _, addr := range addrs {
 		spaceID := addr.SpaceAddr().SpaceID
 
 		if spaceID == "" {
-			logger.Debugf("skipping %s: not linked to a known space.", addr)
+			n.logger.Debugf("skipping %s: not linked to a known space.", addr)
 
 			// For a space-less model, we will not have subnets populated,
 			// and will therefore not find a space for the address.
@@ -435,7 +435,7 @@ func (n *NetworkInfoIAAS) populateMachineAddresses() error {
 
 	for _, id := range spaceSet.Values() {
 		if _, ok := n.machineAddresses[id]; !ok {
-			logger.Warningf("machine %q has no addresses in space %q", n.machine.Id(), id)
+			n.logger.Warningf("machine %q has no addresses in space %q", n.machine.Id(), id)
 		}
 	}
 

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -62,7 +62,7 @@ func newUniterAPI(context facade.Context) (*UniterAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer)
+	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer, context.Logger().Child("meterstatus"))
 	if err != nil {
 		return nil, errors.Annotate(err, "could not create meter status API handler")
 	}
@@ -84,6 +84,7 @@ func newUniterAPI(context facade.Context) (*UniterAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	logger := context.Logger().Child("uniter")
 	return &UniterAPI{
 		LifeGetter:                 common.NewLifeGetter(st, accessUnitOrApplication),
 		DeadEnsurer:                common.NewDeadEnsurer(st, common.RevokeLeadershipFunc(leadershipRevoker), accessUnit),
@@ -114,5 +115,6 @@ func newUniterAPI(context facade.Context) (*UniterAPI, error) {
 		accessCloudSpec:   accessCloudSpec,
 		cloudSpecer:       cloudSpec,
 		StorageAPI:        storageAPI,
+		logger:            logger,
 	}, nil
 }

--- a/apiserver/facades/agent/upgrader/register.go
+++ b/apiserver/facades/agent/upgrader/register.go
@@ -52,11 +52,11 @@ func newUpgraderFacade(ctx facade.Context) (Upgrader, error) {
 	resources := ctx.Resources()
 	switch tag.(type) {
 	case names.MachineTag, names.ControllerAgentTag, names.ApplicationTag, names.ModelTag:
-		return NewUpgraderAPI(ctrlSt, st, resources, auth)
+		return NewUpgraderAPI(ctrlSt, st, resources, auth, ctx.Logger().Child("upgrader"))
 	case names.UnitTag:
 		if model.Type() == state.ModelTypeCAAS {
 			// For sidecar applications.
-			return NewUpgraderAPI(ctrlSt, st, resources, auth)
+			return NewUpgraderAPI(ctrlSt, st, resources, auth, ctx.Logger().Child("upgrader"))
 		}
 		return NewUnitUpgraderAPI(ctx)
 	}

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -59,7 +60,7 @@ func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	}
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	s.upgrader, err = upgrader.NewUpgraderAPI(systemState, s.State, s.resources, s.authorizer)
+	s.upgrader, err = upgrader.NewUpgraderAPI(systemState, s.State, s.resources, s.authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -107,7 +108,7 @@ func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
 	}
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer)
+	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: app.Tag().String()}},
@@ -141,7 +142,7 @@ func (s *upgraderSuite) TestWatchAPIVersionUnit(c *gc.C) {
 	}
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer)
+	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unit.Tag().String()}},
@@ -173,7 +174,7 @@ func (s *upgraderSuite) TestWatchAPIVersionControllerAgent(c *gc.C) {
 	}
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer)
+	upgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{
@@ -204,7 +205,7 @@ func (s *upgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 	anAuthorizer.Tag = names.NewMachineTag("12354")
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer)
+	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Check(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
@@ -229,7 +230,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 	anAuthorizer.Tag = names.NewMachineTag("12354")
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer)
+	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Check(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
@@ -279,7 +280,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 	anAuthorizer.Tag = names.NewMachineTag("12354")
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer)
+	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Check(err, jc.ErrorIsNil)
 	args := params.EntitiesVersion{
 		AgentTools: []params.EntityVersion{{
@@ -334,7 +335,7 @@ func (s *upgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 	anAuthorizer.Tag = names.NewMachineTag("12354")
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer)
+	anUpgrader, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, anAuthorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Check(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
@@ -404,7 +405,7 @@ func (s *upgraderSuite) TestDesiredVersionUnrestrictedForAPIAgents(c *gc.C) {
 	}
 	systemState, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	upgraderAPI, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer)
+	upgraderAPI, err := upgrader.NewUpgraderAPI(systemState, s.State, s.resources, authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.apiMachine.Tag().String()}}}
 	results, err := upgraderAPI.DesiredVersion(args)

--- a/apiserver/facades/agent/upgradeseries/register.go
+++ b/apiserver/facades/agent/upgradeseries/register.go
@@ -24,5 +24,5 @@ func newAPI(ctx facade.Context) (*API, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewUpgradeSeriesAPI(common.UpgradeSeriesState{St: ctx.State()}, ctx.Resources(), ctx.Auth(), leadership)
+	return NewUpgradeSeriesAPI(common.UpgradeSeriesState{St: ctx.State()}, ctx.Resources(), ctx.Auth(), leadership, ctx.Logger().Child("upgradeseries"))
 }

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -18,8 +18,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.upgradeseries")
-
 // API serves methods required by the machine agent upgrade-machine worker.
 type API struct {
 	*common.UpgradeSeriesAPI
@@ -28,6 +26,7 @@ type API struct {
 	auth       facade.Authorizer
 	resources  facade.Resources
 	leadership *common.LeadershipPinning
+	logger     loggo.Logger
 }
 
 // NewUpgradeSeriesAPI creates a new instance of the API server using the
@@ -37,6 +36,7 @@ func NewUpgradeSeriesAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 	leadership *common.LeadershipPinning,
+	logger loggo.Logger,
 ) (*API, error) {
 	if !authorizer.AuthMachineAgent() {
 		return nil, apiservererrors.ErrPerm
@@ -230,7 +230,7 @@ func (a *API) FinishUpgradeSeries(args params.UpdateChannelArgs) (params.ErrorRe
 			argBase = state.Base{OS: mBase.OS, Channel: arg.Channel}.Normalise()
 		}
 		if argBase.String() == mBase.String() {
-			logger.Debugf("%q base is unchanged from %q", arg.Entity.Tag, mBase.DisplayString())
+			a.logger.Debugf("%q base is unchanged from %q", arg.Entity.Tag, mBase.DisplayString())
 		} else {
 			if err := machine.UpdateMachineSeries(argBase); err != nil {
 				result.Results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -5,6 +5,7 @@ package upgradeseries_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -230,7 +231,8 @@ func (s *upgradeSeriesSuite) arrangeTest(c *gc.C) *gomock.Controller {
 	s.backend.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 
 	var err error
-	s.api, err = upgradeseries.NewUpgradeSeriesAPI(s.backend, resources, authorizer, nil)
+	s.api, err = upgradeseries.NewUpgradeSeriesAPI(s.backend, resources, authorizer, nil, loggo.GetLogger("juju.apiserver.upgradeseries"))
+
 	c.Assert(err, jc.ErrorIsNil)
 
 	return ctrl

--- a/apiserver/facades/agent/upgradesteps/register.go
+++ b/apiserver/facades/agent/upgradesteps/register.go
@@ -19,5 +19,5 @@ func Register(registry facade.FacadeRegistry) {
 // newFacadeV2 is used for API registration.
 func newFacadeV2(ctx facade.Context) (*UpgradeStepsAPI, error) {
 	st := &upgradeStepsStateShim{State: ctx.State()}
-	return NewUpgradeStepsAPI(st, ctx.Resources(), ctx.Auth())
+	return NewUpgradeStepsAPI(st, ctx.Resources(), ctx.Auth(), ctx.Logger().Child("upgradesteps"))
 }

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -185,7 +186,7 @@ func (s *upgradeStepsSuite) expectAuthCalls() {
 }
 
 func (s *upgradeStepsSuite) setupFacadeAPI(c *gc.C) {
-	api, err := upgradesteps.NewUpgradeStepsAPI(s.state, s.resources, s.authorizer)
+	api, err := upgradesteps.NewUpgradeStepsAPI(s.state, s.resources, s.authorizer, loggo.GetLogger("juju.apiserver.upgradesteps"))
 	c.Assert(err, gc.IsNil)
 	s.api = api
 }

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,8 +42,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, getFakeControllerInfo,
-		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
-		c.MkDir(),
+		s.mockState, s.mockStatePool, s.authorizer, s.authContext, c.MkDir(), loggo.GetLogger("juju.apiserver.applicationoffers"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -23,8 +23,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.applicationoffers")
-
 type environFromModelFunc func(string) (environs.Environ, error)
 
 // OffersAPI implements the cross model interface and is the concrete
@@ -45,6 +43,7 @@ func createOffersAPI(
 	authorizer facade.Authorizer,
 	authContext *commoncrossmodel.AuthContext,
 	dataDir string,
+	logger loggo.Logger,
 ) (*OffersAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
@@ -61,6 +60,7 @@ func createOffersAPI(
 			StatePool:            statePool,
 			getEnviron:           getEnviron,
 			getControllerInfo:    getControllerInfo,
+			logger:               logger,
 		},
 	}
 	return api, nil

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -57,8 +58,7 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
-		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
-		c.MkDir(),
+		s.mockState, s.mockStatePool, s.authorizer, s.authContext, c.MkDir(), loggo.GetLogger("juju.apiserver.applicationoffers"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
@@ -1150,6 +1150,7 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, s.authContext,
 		c.MkDir(),
+		loggo.GetLogger("juju.apiserver.applicationoffers"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api

--- a/apiserver/facades/client/applicationoffers/register.go
+++ b/apiserver/facades/client/applicationoffers/register.go
@@ -57,5 +57,6 @@ func newOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		ctx.Auth(),
 		authContext.(*commoncrossmodel.AuthContext),
 		ctx.DataDir(),
+		ctx.Logger().Child("applicationoffers"),
 	)
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -646,6 +647,7 @@ func (s *charmsMockSuite) api(c *gc.C) *charms.API {
 		func(services.CharmDownloaderConfig) (charmsinterfaces.Downloader, error) {
 			return s.downloader, nil
 		},
+		loggo.GetLogger("juju.apiserver.charms"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return api

--- a/apiserver/facades/client/charms/clientnormalize_test.go
+++ b/apiserver/facades/client/charms/clientnormalize_test.go
@@ -5,6 +5,7 @@ package charms
 
 import (
 	"github.com/juju/charm/v11"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -30,7 +31,7 @@ func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginNoAll(c *gc.C) {
 		Branch:       &branch,
 		Architecture: "all",
 	}
-	obtained, err := normalizeCharmOrigin(origin, "amd64")
+	obtained, err := normalizeCharmOrigin(origin, "amd64", loggo.GetLogger("juju.apiserver.charms"))
 	c.Assert(err, jc.ErrorIsNil)
 	origin.Architecture = "amd64"
 	c.Assert(obtained, gc.DeepEquals, origin)
@@ -46,7 +47,7 @@ func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginWithEmpty(c *gc.C) 
 		Architecture: "",
 		Base:         params.Base{Channel: "all"},
 	}
-	obtained, err := normalizeCharmOrigin(origin, "amd64")
+	obtained, err := normalizeCharmOrigin(origin, "amd64", loggo.GetLogger("juju.apiserver.charms"))
 	c.Assert(err, jc.ErrorIsNil)
 	origin.Architecture = "amd64"
 	origin.Base.Channel = ""

--- a/apiserver/facades/client/charms/register.go
+++ b/apiserver/facades/client/charms/register.go
@@ -90,5 +90,6 @@ func newFacadeBase(ctx facade.Context) (*API, error) {
 		},
 		tag:             m.ModelTag(),
 		requestRecorder: ctx.RequestRecorder(),
+		logger:          ctx.Logger().Child("charms"),
 	}, nil
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -977,7 +977,7 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, clock.WallClock,
-		newCharmhubClient)
+		newCharmhubClient, loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -55,7 +56,7 @@ func (s *cloudSuite) setup(c *gc.C, userTag names.UserTag) *gomock.Controller {
 	s.ctrlBackend = mocks.NewMockBackend(ctrl)
 	s.ctrlBackend.EXPECT().ControllerTag().Return(coretesting.ControllerTag).AnyTimes()
 
-	api, err := cloudfacade.NewCloudAPI(s.backend, s.ctrlBackend, s.pool, s.authorizer)
+	api, err := cloudfacade.NewCloudAPI(s.backend, s.ctrlBackend, s.pool, s.authorizer, loggo.GetLogger("juju.apiserver.cloud"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 	return ctrl

--- a/apiserver/facades/client/cloud/instance_information_test.go
+++ b/apiserver/facades/client/cloud/instance_information_test.go
@@ -6,6 +6,7 @@ package cloud_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -87,7 +88,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 		context.NewEmptyCloudCallContext(), nil)
 	p.backend.EXPECT().ControllerTag().Return(coretesting.ControllerTag)
 
-	api, err := cloudfacade.NewCloudAPI(p.backend, p.ctrlBackend, p.pool, p.authorizer)
+	api, err := cloudfacade.NewCloudAPI(p.backend, p.ctrlBackend, p.pool, p.authorizer, loggo.GetLogger("juju.apiserver.cloud"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := params.CloudInstanceTypesConstraints{

--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -26,5 +26,5 @@ func newFacadeV7(context facade.Context) (*CloudAPI, error) {
 		return nil, errors.Trace(err)
 	}
 	ctlrSt := NewStateBackend(systemState)
-	return NewCloudAPI(st, ctlrSt, pool, context.Auth())
+	return NewCloudAPI(st, ctlrSt, pool, context.Auth(), context.Logger().Child("cloud"))
 }

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -41,8 +41,6 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.controller")
-
 // ControllerAPI provides the Controller API.
 type ControllerAPI struct {
 	*common.ControllerConfigAPI
@@ -58,6 +56,7 @@ type ControllerAPI struct {
 	hub        facade.Hub
 
 	multiwatcherFactory multiwatcher.Factory
+	logger              loggo.Logger
 }
 
 // LatestAPI is used for testing purposes to create the latest
@@ -79,6 +78,7 @@ func NewControllerAPI(
 	presence facade.Presence,
 	hub facade.Hub,
 	factory multiwatcher.Factory,
+	logger loggo.Logger,
 ) (*ControllerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, errors.Trace(apiservererrors.ErrPerm)
@@ -115,6 +115,7 @@ func NewControllerAPI(
 		presence:            presence,
 		hub:                 hub,
 		multiwatcherFactory: factory,
+		logger:              logger,
 	}, nil
 }
 
@@ -399,7 +400,7 @@ func (c *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 	for uuid, blocks := range modelBlocks {
 		model, ph, err := c.statePool.GetModel(uuid)
 		if err != nil {
-			logger.Debugf("unable to retrieve model %s: %v", uuid, err)
+			c.logger.Debugf("unable to retrieve model %s: %v", uuid, err)
 			continue
 		}
 		results.Models = append(results.Models, params.ModelBlockInfo{

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -34,5 +34,6 @@ func newControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
 		presence,
 		hub,
 		factory,
+		ctx.Logger().Child("controller"),
 	)
 }

--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -44,5 +44,6 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 		st:          st,
 		nodeService: service.NewService(state.NewState(domain.NewDBFactory(ctx.ControllerDB))),
 		authorizer:  authorizer,
+		logger:      ctx.Logger().Child("highavailability"),
 	}, nil
 }

--- a/apiserver/facades/client/keymanager/keymanager.go
+++ b/apiserver/facades/client/keymanager/keymanager.go
@@ -23,8 +23,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.keymanager")
-
 // The comment values used by juju internal ssh keys.
 var internalComments = set.NewStrings("juju-client-key", config.JujuSystemKey)
 
@@ -35,6 +33,7 @@ type KeyManagerAPI struct {
 	check      BlockChecker
 
 	controllerTag names.ControllerTag
+	logger        loggo.Logger
 }
 
 func (api *KeyManagerAPI) checkCanRead(sshUser string) error {
@@ -155,7 +154,7 @@ func (api *KeyManagerAPI) currentKeyDataForAdd() (keys []string, fingerprints se
 	for _, key := range keys {
 		fingerprint, _, err := ssh.KeyFingerprint(key)
 		if err != nil {
-			logger.Warningf("ignoring invalid ssh key %q: %v", key, err)
+			api.logger.Warningf("ignoring invalid ssh key %q: %v", key, err)
 		}
 		fingerprints.Add(fingerprint)
 	}
@@ -323,7 +322,7 @@ func (api *KeyManagerAPI) currentKeyDataForDelete() (
 	for _, key := range currentKeys {
 		fingerprint, comment, err := ssh.KeyFingerprint(key)
 		if err != nil {
-			logger.Debugf("keeping unrecognised existing ssh key %q: %v", key, err)
+			api.logger.Debugf("keeping unrecognised existing ssh key %q: %v", key, err)
 			continue
 		}
 		byFingerprint[fingerprint] = key

--- a/apiserver/facades/client/keymanager/keymanager_test.go
+++ b/apiserver/facades/client/keymanager/keymanager_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -52,7 +53,7 @@ func (s *keyManagerSuite) setup(c *gc.C) *gomock.Controller {
 		Tag: s.apiUser,
 	}
 
-	s.api = keymanager.NewKeyManagerAPI(s.model, s.authorizer, s.blockChecker, coretesting.ControllerTag)
+	s.api = keymanager.NewKeyManagerAPI(s.model, s.authorizer, s.blockChecker, coretesting.ControllerTag, loggo.GetLogger("juju.apiserver.keymanager"))
 
 	return ctrl
 }

--- a/apiserver/facades/client/keymanager/register.go
+++ b/apiserver/facades/client/keymanager/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 )
 
@@ -38,6 +39,7 @@ func newFacadeV1(ctx facade.Context) (*KeyManagerAPI, error) {
 		authorizer,
 		common.NewBlockChecker(st),
 		st.ControllerTag(),
+		ctx.Logger().Child("keymanager"),
 	), nil
 }
 
@@ -46,12 +48,14 @@ func newKeyManagerAPI(
 	authorizer facade.Authorizer,
 	check BlockChecker,
 	controllerTag names.ControllerTag,
+	logger loggo.Logger,
 ) *KeyManagerAPI {
 	return &KeyManagerAPI{
 		model:         model,
 		authorizer:    authorizer,
 		check:         check,
 		controllerTag: controllerTag,
+		logger:        logger,
 	}
 }
 

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -6,6 +6,7 @@ package machinemanager_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -53,6 +54,7 @@ func (s *instanceTypesSuite) setup(c *gc.C) *gomock.Controller {
 		common.NewResources(),
 		s.leadership,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -66,6 +67,7 @@ func (s *MachineManagerSuite) TestNewMachineManagerAPINonClient(c *gc.C) {
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -109,6 +111,7 @@ func (s *AddMachineManagerSuite) setup(c *gc.C) *gomock.Controller {
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -225,6 +228,7 @@ func (s *DestroyMachineManagerSuite) setup(c *gc.C) *gomock.Controller {
 		nil,
 		s.leadership,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -729,6 +733,7 @@ func (s *ProvisioningMachineManagerSuite) setup(c *gc.C) *gomock.Controller {
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl
@@ -977,6 +982,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) setup(c *gc.C) *gomock.Contro
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1232,6 +1238,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) setup(c *gc.C) *gomock.Control
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1333,6 +1340,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) setAPIUser(c *gc.C, user names
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = mm
@@ -1427,6 +1435,7 @@ func (s *UpgradeSeriesCompleteMachineManagerSuite) setup(c *gc.C) *gomock.Contro
 		common.NewResources(),
 		nil,
 		nil,
+		loggo.GetLogger("juju.apiserver.machinemanager"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/modelupgrader/findagents.go
+++ b/apiserver/facades/client/modelupgrader/findagents.go
@@ -42,7 +42,7 @@ func (m *ModelUpgraderAPI) decideVersion(
 		}
 		var targetVersion version.Number
 		targetVersion, packagedAgents = packagedAgents.Newest()
-		logger.Debugf("target version %q is the best version, packagedAgents %v", targetVersion, packagedAgents)
+		m.logger.Debugf("target version %q is the best version, packagedAgents %v", targetVersion, packagedAgents)
 		return targetVersion, nil
 	}
 
@@ -58,7 +58,7 @@ func (m *ModelUpgraderAPI) decideVersion(
 			return version.Zero, errUpToDate
 		}
 		if newestCurrent.Compare(currentVersion) > 0 {
-			logger.Debugf("found more recent agent version %s", newestCurrent)
+			m.logger.Debugf("found more recent agent version %s", newestCurrent)
 			return newestCurrent, nil
 		}
 	}
@@ -112,7 +112,7 @@ func (m *ModelUpgraderAPI) agentVersionsForCAAS(
 	for _, a := range streamsAgents {
 		streamsVersions.Add(a.Version.Number.String())
 	}
-	logger.Tracef("versions from simplestreams %v", streamsVersions)
+	m.logger.Tracef("versions from simplestreams %v", streamsVersions)
 	imageName := podcfg.JujudOCIName
 	tags, err := reg.Tags(imageName)
 	if err != nil {

--- a/apiserver/facades/client/modelupgrader/register.go
+++ b/apiserver/facades/client/modelupgrader/register.go
@@ -66,5 +66,6 @@ func newFacadeV1(ctx facade.Context) (*ModelUpgraderAPI, error) {
 		context.CallContext(st),
 		registry.New,
 		environscloudspecGetter,
+		ctx.Logger().Child("modelupgrader"),
 	)
 }

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -6,6 +6,7 @@ package modelupgrader_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v3"
 	jujutesting "github.com/juju/testing"
@@ -138,6 +139,7 @@ func (s *modelUpgradeSuite) getModelUpgraderAPI(c *gc.C) (*gomock.Controller, *m
 		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return s.cloudSpec.CloudSpec, nil
 		},
+		loggo.GetLogger("juju.apiserver.modelupgrader"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl, api

--- a/apiserver/facades/client/resources/base_test.go
+++ b/apiserver/facades/client/resources/base_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +42,7 @@ func (s *BaseSuite) newFacade(c *gc.C) *resources.API {
 	factoryFunc := func(_ *charm.URL) (resources.NewCharmRepository, error) {
 		return s.factory, nil
 	}
-	facade, err := resources.NewResourcesAPI(s.backend, factoryFunc)
+	facade, err := resources.NewResourcesAPI(s.backend, factoryFunc, loggo.GetLogger("juju.apiserver.resources"))
 	c.Assert(err, jc.ErrorIsNil)
 	return facade
 }

--- a/apiserver/facades/client/resources/server_test.go
+++ b/apiserver/facades/client/resources/server_test.go
@@ -5,6 +5,7 @@ package resources_test
 
 import (
 	"github.com/juju/charm/v11"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -19,18 +20,18 @@ type FacadeSuite struct {
 
 func (s *FacadeSuite) TestNewFacadeOkay(c *gc.C) {
 	defer s.setUpTest(c).Finish()
-	_, err := resources.NewResourcesAPI(s.backend, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil })
+	_, err := resources.NewResourcesAPI(s.backend, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggo.GetLogger("juju.apiserver.resources"))
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *FacadeSuite) TestNewFacadeMissingDataStore(c *gc.C) {
 	defer s.setUpTest(c).Finish()
-	_, err := resources.NewResourcesAPI(nil, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil })
+	_, err := resources.NewResourcesAPI(nil, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggo.GetLogger("juju.apiserver.resources"))
 	c.Check(err, gc.ErrorMatches, `missing data backend`)
 }
 
 func (s *FacadeSuite) TestNewFacadeMissingCSClientFactory(c *gc.C) {
 	defer s.setUpTest(c).Finish()
-	_, err := resources.NewResourcesAPI(s.backend, nil)
+	_, err := resources.NewResourcesAPI(s.backend, nil, loggo.GetLogger("juju.apiserver.resources"))
 	c.Check(err, gc.ErrorMatches, `missing factory for new repository`)
 }

--- a/apiserver/facades/client/spaces/integrity.go
+++ b/apiserver/facades/client/spaces/integrity.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/core/network"
 )
@@ -65,7 +66,8 @@ type affectedNetworks struct {
 	// force originates as a CLI option.
 	// When true, violations of constraints/bindings integrity are logged as
 	// warnings instead of being returned as errors.
-	force bool
+	force  bool
+	logger loggo.Logger
 }
 
 // newAffectedNetworks returns a new affectedNetworks reference for
@@ -73,7 +75,7 @@ type affectedNetworks struct {
 // The input space topology is manipulated to represent the topology that
 // would result from the move.
 func newAffectedNetworks(
-	movingSubnets network.IDSet, spaceName string, currentTopology network.SpaceInfos, force bool,
+	movingSubnets network.IDSet, spaceName string, currentTopology network.SpaceInfos, force bool, logger loggo.Logger,
 ) (*affectedNetworks, error) {
 
 	// We need to indicate that any moving fan underlays include
@@ -99,6 +101,7 @@ func newAffectedNetworks(
 		changingNetworks:  make(map[string][]unitNetwork),
 		unchangedNetworks: make(map[string][]unitNetwork),
 		force:             force,
+		logger:            logger,
 	}, nil
 }
 
@@ -248,7 +251,7 @@ func (n *affectedNetworks) ensureNegativeConstraintIntegrity(appName string, spa
 		if !n.force {
 			return errors.New(msg)
 		}
-		logger.Warningf(msg)
+		n.logger.Warningf(msg)
 	}
 
 	return nil
@@ -287,7 +290,7 @@ func (n *affectedNetworks) ensurePositiveConstraintIntegrity(appName string, spa
 			if !n.force {
 				return errors.New(msg)
 			}
-			logger.Warningf(msg)
+			n.logger.Warningf(msg)
 		}
 	}
 
@@ -350,7 +353,7 @@ func (n *affectedNetworks) ensureApplicationBindingsIntegrity(appName string, ap
 			if !n.force {
 				return errors.New(msg)
 			}
-			logger.Warningf(msg)
+			n.logger.Warningf(msg)
 		}
 	}
 

--- a/apiserver/facades/client/spaces/move.go
+++ b/apiserver/facades/client/spaces/move.go
@@ -216,7 +216,7 @@ func (api *API) getAffectedNetworks(subnets []MovingSubnet, spaceName string, fo
 		return nil, errors.Trace(err)
 	}
 
-	affected, err := newAffectedNetworks(movingSubnetIDs, spaceName, allSpaces, force)
+	affected, err := newAffectedNetworks(movingSubnetIDs, spaceName, allSpaces, force, api.logger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/spaces/register.go
+++ b/apiserver/facades/client/spaces/register.go
@@ -55,5 +55,6 @@ func newAPI(ctx facade.Context) (*API, error) {
 		Resources:       ctx.Resources(),
 		Authorizer:      auth,
 		Factory:         newOpFactory(st),
+		logger:          ctx.Logger().Child("spaces"),
 	})
 }

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -21,8 +21,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.spaces")
-
 // API provides the spaces API facade for version 6.
 type API struct {
 	reloadSpacesAPI ReloadSpaces
@@ -34,6 +32,7 @@ type API struct {
 
 	check     BlockChecker
 	opFactory OpFactory
+	logger    loggo.Logger
 }
 
 type apiConfig struct {
@@ -44,6 +43,7 @@ type apiConfig struct {
 	Resources       facade.Resources
 	Authorizer      facade.Authorizer
 	Factory         OpFactory
+	logger          loggo.Logger
 }
 
 // newAPIWithBacking creates a new server-side Spaces API facade with
@@ -62,6 +62,7 @@ func newAPIWithBacking(cfg apiConfig) (*API, error) {
 		context:         cfg.Context,
 		check:           cfg.Check,
 		opFactory:       cfg.Factory,
+		logger:          cfg.logger,
 	}, nil
 }
 

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/loggo"
 )
 
 // addSubnetsCache holds cached lists of spaces, zones, and subnets, used for
@@ -43,7 +44,7 @@ func NewAddSubnetsCache(api Backing) *addSubnetsCache {
 	}
 }
 
-func allZones(ctx context.ProviderCallContext, api Backing) (params.ZoneResults, error) {
+func allZones(ctx context.ProviderCallContext, api Backing, logger loggo.Logger) (params.ZoneResults, error) {
 	var results params.ZoneResults
 
 	zonesAsString := func(zones network.AvailabilityZones) string {

--- a/apiserver/facades/client/subnets/register.go
+++ b/apiserver/facades/client/subnets/register.go
@@ -26,5 +26,5 @@ func newAPI(ctx facade.Context) (*API, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newAPIWithBacking(stateShim, context.CallContext(st), ctx.Resources(), ctx.Auth())
+	return newAPIWithBacking(stateShim, context.CallContext(st), ctx.Resources(), ctx.Auth(), ctx.Logger().Child("subnets"))
 }

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -93,7 +94,7 @@ func (s *SubnetSuite) setupSubnetsAPI(c *gc.C) *gomock.Controller {
 	s.mockBacking.EXPECT().ModelTag().Return(names.NewModelTag("123"))
 
 	var err error
-	s.api, err = subnets.NewAPIWithBacking(s.mockBacking, s.mockCloudCallContext, s.mockResource, s.mockAuthorizer)
+	s.api, err = subnets.NewAPIWithBacking(s.mockBacking, s.mockCloudCallContext, s.mockResource, s.mockAuthorizer, loggo.GetLogger("juju.apiserver.subnets"))
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl
 }
@@ -148,6 +149,7 @@ func (s *SubnetsSuite) SetUpTest(c *gc.C) {
 		&stubBacking{apiservertesting.BackingInstance},
 		s.callContext,
 		s.resources, s.authorizer,
+		loggo.GetLogger("juju.apiserver.subnets"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.facade, gc.NotNil)
@@ -192,6 +194,7 @@ func (s *SubnetsSuite) TestNewAPIWithBacking(c *gc.C) {
 		&stubBacking{apiservertesting.BackingInstance},
 		s.callContext,
 		s.resources, s.authorizer,
+		loggo.GetLogger("juju.apiserver.subnets"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(facade, gc.NotNil)
@@ -205,6 +208,7 @@ func (s *SubnetsSuite) TestNewAPIWithBacking(c *gc.C) {
 		&stubBacking{apiservertesting.BackingInstance},
 		s.callContext,
 		s.resources, agentAuthorizer,
+		loggo.GetLogger("juju.apiserver.subnets"),
 	)
 	c.Assert(err, jc.DeepEquals, apiservererrors.ErrPerm)
 	c.Assert(facade, gc.IsNil)

--- a/apiserver/facades/client/usermanager/register.go
+++ b/apiserver/facades/client/usermanager/register.go
@@ -49,5 +49,6 @@ func newUserManagerAPI(ctx facade.Context) (*UserManagerAPI, error) {
 		check:      common.NewBlockChecker(st),
 		apiUser:    apiUser,
 		isAdmin:    isAdmin,
+		logger:     ctx.Logger().Child("usermanager"),
 	}, nil
 }

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -20,8 +20,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.usermanager")
-
 // UserManagerAPI implements the user manager interface and is the concrete
 // implementation of the api end point.
 type UserManagerAPI struct {
@@ -31,6 +29,7 @@ type UserManagerAPI struct {
 	check      *common.BlockChecker
 	apiUser    names.UserTag
 	isAdmin    bool
+	logger     loggo.Logger
 }
 
 func (api *UserManagerAPI) hasControllerAdminAccess() (bool, error) {
@@ -229,7 +228,7 @@ func (api *UserManagerAPI) UserInfo(request params.UserInfoRequest) (params.User
 		userLastLogin, err := user.LastLogin()
 		if err != nil {
 			if !state.IsNeverLoggedInError(err) {
-				logger.Debugf("error getting last login: %v", err)
+				api.logger.Debugf("error getting last login: %v", err)
 			}
 		} else {
 			lastLogin = &userLastLogin

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -18,8 +18,6 @@ import (
 	coretools "github.com/juju/juju/tools"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.model")
-
 var (
 	findTools = tools.FindTools
 )
@@ -32,6 +30,7 @@ type AgentToolsAPI struct {
 	// tools lookup
 	findTools        toolsFinder
 	envVersionUpdate envVersionUpdater
+	logger           loggo.Logger
 }
 
 // NewAgentToolsAPI creates a new instance of the Model API.
@@ -41,6 +40,7 @@ func NewAgentToolsAPI(
 	findTools toolsFinder,
 	envVersionUpdate func(*state.Model, version.Number) error,
 	authorizer facade.Authorizer,
+	logger loggo.Logger,
 ) (*AgentToolsAPI, error) {
 	return &AgentToolsAPI{
 		modelGetter:      modelGetter,
@@ -48,6 +48,7 @@ func NewAgentToolsAPI(
 		authorizer:       authorizer,
 		findTools:        findTools,
 		envVersionUpdate: envVersionUpdate,
+		logger:           logger,
 	}, nil
 }
 
@@ -100,7 +101,7 @@ func envVersionUpdate(env *state.Model, ver version.Number) error {
 	return env.UpdateLatestToolsVersion(ver)
 }
 
-func updateToolsAvailability(modelGetter ModelGetter, newEnviron newEnvironFunc, finder toolsFinder, update envVersionUpdater) error {
+func updateToolsAvailability(modelGetter ModelGetter, newEnviron newEnvironFunc, finder toolsFinder, update envVersionUpdater, logger loggo.Logger) error {
 	model, err := modelGetter.Model()
 	if err != nil {
 		return errors.Annotate(err, "cannot get model")
@@ -130,5 +131,5 @@ func (api *AgentToolsAPI) UpdateToolsAvailable() error {
 	if !api.authorizer.AuthController() {
 		return apiservererrors.ErrPerm
 	}
-	return updateToolsAvailability(api.modelGetter, api.newEnviron, api.findTools, api.envVersionUpdate)
+	return updateToolsAvailability(api.modelGetter, api.newEnviron, api.findTools, api.envVersionUpdate, api.logger)
 }

--- a/apiserver/facades/controller/agenttools/agenttools_test.go
+++ b/apiserver/facades/controller/agenttools/agenttools_test.go
@@ -5,6 +5,7 @@ package agenttools
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -128,7 +129,7 @@ func (s *AgentToolsSuite) TestUpdateToolsAvailability(c *gc.C) {
 
 	cfg, err := config.New(config.NoDefaults, coretesting.FakeConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	err = updateToolsAvailability(&mockState{configGetter{cfg}}, getDummyEnviron, fakeToolFinder, fakeUpdate)
+	err = updateToolsAvailability(&mockState{configGetter{cfg}}, getDummyEnviron, fakeToolFinder, fakeUpdate, loggo.GetLogger("juju.apiserver.model"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(ver, gc.Not(gc.Equals), version.Zero)
@@ -158,7 +159,7 @@ func (s *AgentToolsSuite) TestUpdateToolsAvailabilityNoMatches(c *gc.C) {
 
 	cfg, err := config.New(config.NoDefaults, coretesting.FakeConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	err = updateToolsAvailability(&mockState{configGetter{cfg}}, getDummyEnviron, fakeToolFinder, fakeUpdate)
+	err = updateToolsAvailability(&mockState{configGetter{cfg}}, getDummyEnviron, fakeToolFinder, fakeUpdate, loggo.GetLogger("juju.apiserver.model"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/controller/agenttools/register.go
+++ b/apiserver/facades/controller/agenttools/register.go
@@ -30,5 +30,5 @@ func newFacade(ctx facade.Context) (*AgentToolsAPI, error) {
 		newEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
 		return newEnviron(model)
 	}
-	return NewAgentToolsAPI(st, newEnviron, findTools, envVersionUpdate, ctx.Auth())
+	return NewAgentToolsAPI(st, newEnviron, findTools, envVersionUpdate, ctx.Auth(), ctx.Logger().Child("model"))
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	charmresource "github.com/juju/charm/v11/resource"
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -71,7 +72,7 @@ func (s *CAASApplicationProvisionerSuite) SetUpTest(c *gc.C) {
 		return &mockResourceOpener{appName: appName, resources: s.st.resource}, nil
 	}
 	api, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(
-		s.st, s.st, s.resources, newResourceOpener, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock)
+		s.st, s.st, s.resources, newResourceOpener, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock, loggo.GetLogger("juju.apiserver.caasapplicationprovisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -81,7 +82,7 @@ func (s *CAASApplicationProvisionerSuite) TestPermission(c *gc.C) {
 		Tag: names.NewMachineTag("0"),
 	}
 	_, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(
-		s.st, s.st, s.resources, nil, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock)
+		s.st, s.st, s.resources, nil, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock, loggo.GetLogger("juju.apiserver.caasapplicationprovisioner"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -16,6 +16,7 @@ import (
 	multiwatcher "github.com/juju/juju/core/multiwatcher"
 	permission "github.com/juju/juju/core/permission"
 	state "github.com/juju/juju/state"
+	loggo "github.com/juju/loggo"
 	names "github.com/juju/names/v4"
 	worker "github.com/juju/worker/v3"
 )
@@ -446,6 +447,20 @@ func (m *MockContext) MachineTag() names.Tag {
 func (mr *MockContextMockRecorder) MachineTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockContext)(nil).MachineTag))
+}
+
+// Logger mocks base method.
+func (m *MockContext) Logger() loggo.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logger")
+	ret0, _ := ret[0].(loggo.Logger)
+	return ret0
+}
+
+// Logger indicates an expected call of Logger.
+func (mr *MockContextMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockContext)(nil).Logger))
 }
 
 // MultiwatcherFactory mocks base method.

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -17,8 +17,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.caasmodeloperator")
-
 // TODO (manadart 2020-10-21): Remove the ModelUUID method
 // from the next version of this facade.
 
@@ -30,6 +28,7 @@ type API struct {
 	auth      facade.Authorizer
 	ctrlState CAASControllerState
 	state     CAASModelOperatorState
+	logger    loggo.Logger
 }
 
 // NewAPI is alternative means of constructing a controller model facade.
@@ -37,7 +36,9 @@ func NewAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
 	ctrlSt CAASControllerState,
-	st CAASModelOperatorState) (*API, error) {
+	st CAASModelOperatorState,
+	logger loggo.Logger,
+) (*API, error) {
 
 	if !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm
@@ -49,6 +50,7 @@ func NewAPI(
 		PasswordChanger: common.NewPasswordChanger(st, common.AuthFuncForTagKind(names.ModelTagKind)),
 		ctrlState:       ctrlSt,
 		state:           st,
+		logger:          logger,
 	}, nil
 }
 
@@ -90,7 +92,7 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 		return result, errors.Trace(err)
 	}
 	imageInfo := params.NewDockerImageInfo(controllerConf.CAASImageRepo(), registryPath)
-	logger.Tracef("image info %v", imageInfo)
+	a.logger.Tracef("image info %v", imageInfo)
 
 	result = params.ModelOperatorInfo{
 		APIAddresses: apiAddresses.Result,

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -4,6 +4,7 @@
 package caasmodeloperator_test
 
 import (
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -46,7 +47,7 @@ func (m *ModelOperatorSuite) SetUpTest(c *gc.C) {
 
 	c.Logf("m.state.1operatorRepo %q", m.state.operatorRepo)
 
-	api, err := caasmodeloperator.NewAPI(m.authorizer, m.resources, m.state, m.state)
+	api, err := caasmodeloperator.NewAPI(m.authorizer, m.resources, m.state, m.state, loggo.GetLogger("juju.apiserver.caasmodeloperator"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	m.api = api

--- a/apiserver/facades/controller/caasmodeloperator/register.go
+++ b/apiserver/facades/controller/caasmodeloperator/register.go
@@ -28,5 +28,7 @@ func newAPIFromContext(ctx facade.Context) (*API, error) {
 	}
 	return NewAPI(authorizer, resources,
 		stateShim{systemState},
-		stateShim{ctx.State()})
+		stateShim{ctx.State()},
+		ctx.Logger().Child("caasmodeloperator"),
+	)
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -53,7 +54,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 	s.storagePoolManager = &mockStoragePoolManager{}
 	s.registry = &mockStorageRegistry{}
 	api, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(
-		s.resources, s.authorizer, s.st, s.st, s.storagePoolManager, s.registry)
+		s.resources, s.authorizer, s.st, s.st, s.storagePoolManager, s.registry, loggo.GetLogger("juju.apiserver.caasoperatorprovisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -63,7 +64,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 		Tag: names.NewMachineTag("0"),
 	}
 	_, err := caasoperatorprovisioner.NewCAASOperatorProvisionerAPI(
-		s.resources, s.authorizer, s.st, s.st, s.storagePoolManager, s.registry)
+		s.resources, s.authorizer, s.st, s.st, s.storagePoolManager, s.registry, loggo.GetLogger("juju.apiserver.caasoperatorprovisioner"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/register.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/register.go
@@ -57,7 +57,9 @@ func newStateCAASOperatorProvisionerAPI(ctx facade.Context) (*APIGroup, error) {
 	api, err := NewCAASOperatorProvisionerAPI(resources, authorizer,
 		stateShim{systemState},
 		stateShim{ctx.State()},
-		pm, registry)
+		pm, registry,
+		ctx.Logger().Child("caasoperatorprovisioner"),
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/register.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/register.go
@@ -30,5 +30,5 @@ func newStateCAASOperatorUpgraderAPI(ctx facade.Context) (*API, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}
-	return NewCAASOperatorUpgraderAPI(authorizer, broker)
+	return NewCAASOperatorUpgraderAPI(authorizer, broker, ctx.Logger().Child("caasoperatorupgrader"))
 }

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -13,18 +13,18 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.controller.caasoperatorupgrader")
-
 type API struct {
 	auth facade.Authorizer
 
 	broker caas.Upgrader
+	logger loggo.Logger
 }
 
 // NewCAASOperatorUpgraderAPI returns a new CAAS operator upgrader API facade.
 func NewCAASOperatorUpgraderAPI(
 	authorizer facade.Authorizer,
 	broker caas.Upgrader,
+	logger loggo.Logger,
 ) (*API, error) {
 	if !authorizer.AuthController() &&
 		!authorizer.AuthApplicationAgent() &&
@@ -35,6 +35,7 @@ func NewCAASOperatorUpgraderAPI(
 	return &API{
 		auth:   authorizer,
 		broker: broker,
+		logger: logger,
 	}, nil
 }
 
@@ -51,7 +52,7 @@ func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorRe
 		return serverErr(apiservererrors.ErrPerm), nil
 	}
 
-	logger.Debugf("upgrading caas agent for %s", tag)
+	api.logger.Debugf("upgrading caas agent for %s", tag)
 	err = api.broker.Upgrade(arg.AgentTag, arg.Version)
 	if err != nil {
 		return serverErr(err), nil

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -4,6 +4,7 @@
 package caasoperatorupgrader_test
 
 import (
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -34,7 +35,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 		Tag: names.NewApplicationTag("app"),
 	}
 
-	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker, loggo.GetLogger("juju.controller.caasoperatorupgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -43,7 +44,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: names.NewMachineTag("0"),
 	}
-	_, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	_, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker, loggo.GetLogger("juju.controller.caasoperatorupgrader"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -64,7 +65,7 @@ func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
 		Controller: true,
 	}
 
-	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker)
+	api, err := caasoperatorupgrader.NewCAASOperatorUpgraderAPI(s.authorizer, s.broker, loggo.GetLogger("juju.controller.caasoperatorupgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	vers := version.MustParse("6.6.6")

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/charm/v11"
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -106,7 +107,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 
 	facade, err := caasunitprovisioner.NewFacade(
 		s.resources, s.authorizer, s.st, s.storage, s.devices,
-		s.storagePoolManager, s.registry, nil, nil, s.clock)
+		s.storagePoolManager, s.registry, nil, nil, s.clock, loggo.GetLogger("juju.apiserver.controller.caasunitprovisioner"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade
 }
@@ -117,7 +118,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 	}
 	_, err := caasunitprovisioner.NewFacade(
 		s.resources, s.authorizer, s.st, s.storage, s.devices,
-		s.storagePoolManager, s.registry, nil, nil, s.clock)
+		s.storagePoolManager, s.registry, nil, nil, s.clock, loggo.GetLogger("juju.apiserver.controller.caasunitprovisioner"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/register.go
+++ b/apiserver/facades/controller/caasunitprovisioner/register.go
@@ -69,5 +69,6 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 		charmInfoAPI,
 		appCharmInfoAPI,
 		clock.WallClock,
+		ctx.Logger().Child("caasunitprovisioner"),
 	)
 }

--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/charm/v11"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -259,6 +260,7 @@ func (s *charmDownloaderSuite) setupMocks(c *gc.C) *gomock.Controller {
 		func(services.CharmDownloaderConfig) (charmdownloader.Downloader, error) {
 			return s.downloader, nil
 		},
+		loggo.GetLogger("juju.apiserver.charmdownloader"),
 	)
 
 	return ctrl

--- a/apiserver/facades/controller/charmdownloader/register.go
+++ b/apiserver/facades/controller/charmdownloader/register.go
@@ -44,5 +44,6 @@ func newFacadeV1(ctx facade.Context) (*CharmDownloaderAPI, error) {
 		func(cfg services.CharmDownloaderConfig) (Downloader, error) {
 			return services.NewCharmDownloader(cfg)
 		},
+		ctx.Logger().Child("charmdownloader"),
 	), nil
 }

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/charm/v11/resource"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
@@ -54,7 +55,7 @@ type CharmhubRefreshClient interface {
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, now time.Time) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, now time.Time, logger loggo.Logger) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -83,14 +84,14 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 
 	results := make([]charmhubResult, len(responses))
 	for i, response := range responses {
-		results[i] = refreshResponseToCharmhubResult(response, now)
+		results[i] = refreshResponseToCharmhubResult(response, now, logger)
 	}
 	return results, nil
 }
 
 // refreshResponseToCharmhubResult converts a raw RefreshResponse from the
 // charmhub API into a charmhubResult.
-func refreshResponseToCharmhubResult(response transport.RefreshResponse, now time.Time) charmhubResult {
+func refreshResponseToCharmhubResult(response transport.RefreshResponse, now time.Time, logger loggo.Logger) charmhubResult {
 	if response.Error != nil {
 		return charmhubResult{
 			error: errors.Errorf("charmhub API error %s: %s", response.Error.Code, response.Error.Message),

--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/resource"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -173,6 +174,7 @@ type facadeContextShim struct {
 	facade.Context // Make it fulfil the interface, but we only define a couple of methods
 	state          *state.State
 	authorizer     facade.Authorizer
+	logger         loggo.Logger
 }
 
 func (s facadeContextShim) Auth() facade.Authorizer {
@@ -181,4 +183,8 @@ func (s facadeContextShim) Auth() facade.Authorizer {
 
 func (s facadeContextShim) State() *state.State {
 	return s.state
+}
+
+func (s facadeContextShim) Logger() loggo.Logger {
+	return s.logger
 }

--- a/apiserver/facades/controller/charmrevisionupdater/register.go
+++ b/apiserver/facades/controller/charmrevisionupdater/register.go
@@ -27,11 +27,12 @@ func newCharmRevisionUpdaterAPI(ctx facade.Context) (*CharmRevisionUpdaterAPI, e
 	}
 	newCharmhubClient := func(st State) (CharmhubRefreshClient, error) {
 		httpClient := ctx.HTTPClient(facade.CharmhubHTTPClient)
-		return common.CharmhubClient(charmhubClientStateShim{state: st}, httpClient, logger)
+		return common.CharmhubClient(charmhubClientStateShim{state: st}, httpClient, ctx.Logger().Child("charmrevisionupdater"))
 	}
 	return NewCharmRevisionUpdaterAPIState(
 		StateShim{State: ctx.State()},
 		clock.WallClock,
 		newCharmhubClient,
+		ctx.Logger().Child("charmrevisionupdater"),
 	)
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -123,7 +123,9 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
 		s.st, fw, s.resources, s.authorizer,
 		s.authContext, egressAddressWatcher, relationStatusWatcher,
-		offerStatusWatcher, consumedSecretsWatcher, loggo.GetLoggerWithLabels("juju.apiserver.crossmodelrelations", corelogger.CMR))
+		offerStatusWatcher, consumedSecretsWatcher,
+		loggo.GetLoggerWithLabels("juju.apiserver.crossmodelrelations", corelogger.CMR),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/charm/v11"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -28,6 +29,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -121,7 +123,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
 		s.st, fw, s.resources, s.authorizer,
 		s.authContext, egressAddressWatcher, relationStatusWatcher,
-		offerStatusWatcher, consumedSecretsWatcher)
+		offerStatusWatcher, consumedSecretsWatcher, loggo.GetLoggerWithLabels("juju.apiserver.crossmodelrelations", corelogger.CMR))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }

--- a/apiserver/facades/controller/crossmodelrelations/register.go
+++ b/apiserver/facades/controller/crossmodelrelations/register.go
@@ -10,6 +10,7 @@ import (
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facade"
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -41,5 +42,6 @@ func newStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI
 		watchRelationLifeSuspendedStatus,
 		watchOfferStatus,
 		watchConsumedSecrets,
+		ctx.Logger().ChildWithLabels("crossmodelrelations", corelogger.CMR),
 	)
 }

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -21,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets/mocks"
+	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/secrets/provider"
@@ -128,6 +130,7 @@ func (s *CrossModelSecretsSuite) setup(c *gc.C) *gomock.Controller {
 		backendConfigGetter,
 		s.crossModelState,
 		s.stateBackend,
+		loggo.GetLoggerWithLabels("juju.apiserver.crossmodelsecrets", corelogger.SECRETS),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/common/secrets"
 	"github.com/juju/juju/apiserver/facade"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state"
 )
@@ -52,5 +53,6 @@ func newStateCrossModelSecretsAPI(ctx facade.Context) (*CrossModelSecretsAPI, er
 		secretBackendConfigGetter,
 		&crossModelShim{st.RemoteEntities()},
 		&stateBackendShim{st},
+		ctx.Logger().ChildWithLabels("crossmodelsecrets", corelogger.SECRETS),
 	)
 }

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -24,8 +24,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.firewaller")
-
 // FirewallerAPI provides access to the Firewaller API facade.
 type FirewallerAPI struct {
 	*common.LifeGetter
@@ -44,6 +42,7 @@ type FirewallerAPI struct {
 	accessApplication common.GetAuthFunc
 	accessMachine     common.GetAuthFunc
 	accessModel       common.GetAuthFunc
+	logger            loggo.Logger
 
 	// Fetched on demand and memoized
 	spaceInfos          network.SpaceInfos
@@ -57,6 +56,7 @@ func NewStateFirewallerAPI(
 	authorizer facade.Authorizer,
 	cloudSpecAPI cloudspec.CloudSpecer,
 	controllerConfigAPI ControllerConfigAPI,
+	logger loggo.Logger,
 ) (*FirewallerAPI, error) {
 	if !authorizer.AuthController() {
 		// Firewaller must run as a controller.
@@ -121,6 +121,7 @@ func NewStateFirewallerAPI(
 		accessApplication:    accessApplication,
 		accessMachine:        accessMachine,
 		accessModel:          accessModel,
+		logger:               logger,
 	}, nil
 }
 
@@ -325,7 +326,7 @@ func (f *FirewallerAPI) WatchIngressAddressesForRelations(relations params.Entit
 	}
 
 	one := func(tag string) (id string, changes []string, _ error) {
-		logger.Debugf("Watching ingress addresses for %+v from model %v", tag, f.st.ModelUUID())
+		f.logger.Debugf("Watching ingress addresses for %+v from model %v", tag, f.st.ModelUUID())
 
 		relationTag, err := names.ParseRelationTag(tag)
 		if err != nil {

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -64,6 +65,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 		s.authorizer,
 		cloudSpecAPI,
 		controllerConfigAPI,
+		loggo.GetLogger("juju.apiserver.firewaller"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.firewaller = firewallerAPI

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -5,6 +5,7 @@ package firewaller_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -52,7 +53,7 @@ func (s *RemoteFirewallerSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.st = mocks.NewMockState(ctrl)
 	s.cc = mocks.NewMockControllerConfigAPI(ctrl)
-	api, err := firewaller.NewStateFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{}, s.cc)
+	api, err := firewaller.NewStateFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{}, s.cc, loggo.GetLogger("juju.apiserver.firewaller"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 	return ctrl
@@ -152,7 +153,7 @@ func (s *FirewallerSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.st = mocks.NewMockState(ctrl)
 	s.cc = mocks.NewMockControllerConfigAPI(ctrl)
-	api, err := firewaller.NewStateFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{}, s.cc)
+	api, err := firewaller.NewStateFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{}, s.cc, loggo.GetLogger("juju.apiserver.firewaller"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 	return ctrl

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -38,5 +38,12 @@ func newFirewallerAPIV7(context facade.Context) (*FirewallerAPI, error) {
 	controllerConfigAPI := common.NewStateControllerConfig(st)
 
 	stShim := stateShim{st: st, State: firewall.StateShim(st, m)}
-	return NewStateFirewallerAPI(stShim, context.Resources(), context.Auth(), cloudSpecAPI, controllerConfigAPI)
+	return NewStateFirewallerAPI(
+		stShim,
+		context.Resources(),
+		context.Auth(),
+		cloudSpecAPI,
+		controllerConfigAPI,
+		context.Logger().Child("firewaller"),
+	)
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -63,7 +64,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	s.clock = testclock.NewClock(time.Now())
-	s.api, err = instancepoller.NewInstancePollerAPI(nil, nil, s.resources, s.authoriser, s.clock)
+	s.api, err = instancepoller.NewInstancePollerAPI(nil, nil, s.resources, s.authoriser, s.clock, loggo.GetLogger("juju.apiserver.instancepoller"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.machineEntities = params.Entities{
@@ -106,7 +107,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 func (s *InstancePollerSuite) TestNewInstancePollerAPIRequiresController(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Controller = false
-	api, err := instancepoller.NewInstancePollerAPI(nil, nil, s.resources, anAuthoriser, s.clock)
+	api, err := instancepoller.NewInstancePollerAPI(nil, nil, s.resources, anAuthoriser, s.clock, loggo.GetLogger("juju.apiserver.instancepoller"))
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/txn"
 	jujutxn "github.com/juju/txn/v3"
+	"github.com/lxc/lxd/shared/logger"
 
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/core/network"
@@ -30,14 +32,17 @@ type mergeMachineLinkLayerOp struct {
 	// We consult it to ensure that the same provider ID is not being
 	// used for multiple NICs.
 	providerIDs map[network.Id]string
+
+	logger loggo.Logger
 }
 
 func newMergeMachineLinkLayerOp(
-	machine networkingcommon.LinkLayerMachine, incoming network.InterfaceInfos,
+	machine networkingcommon.LinkLayerMachine, incoming network.InterfaceInfos, logger loggo.Logger,
 ) *mergeMachineLinkLayerOp {
 	return &mergeMachineLinkLayerOp{
 		MachineLinkLayerOp: networkingcommon.NewMachineLinkLayerOp("provider", machine, incoming),
 		namelessHWAddrs:    set.NewStrings(),
+		logger:             logger,
 	}
 }
 
@@ -162,7 +167,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// Log a warning if we are changing a provider ID that is already set.
 	providerID := dev.ProviderID()
 	if providerID != "" && providerID != incomingDev.ProviderId {
-		logger.Warningf(
+		o.logger.Warningf(
 			"changing provider ID for device %q from %q to %q",
 			dev.Name(), providerID, incomingDev.ProviderId,
 		)
@@ -191,7 +196,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 		// If the ID is moving from one device to another for whatever reason,
 		// It will be eventually consistent. E.g. removed from the old device
 		// on this pass and added to the new device on the next.
-		logger.Warningf(
+		o.logger.Warningf(
 			"not setting provider ID for device %q to %q; it is assigned to another device",
 			dev.Name(), incomingDev.ProviderId,
 		)

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/txn"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/lxc/lxd/shared/logger"
 
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/core/network"
@@ -281,7 +280,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(
 func (o *mergeMachineLinkLayerOp) processNewDevices() {
 	for _, dev := range o.Incoming() {
 		if !o.IsDevProcessed(dev) {
-			logger.Debugf(
+			o.logger.Debugf(
 				"ignoring unrecognised device %q (%s) with addresses %v",
 				dev.InterfaceName, dev.MACAddress, dev.Addresses,
 			)

--- a/apiserver/facades/controller/instancepoller/register.go
+++ b/apiserver/facades/controller/instancepoller/register.go
@@ -25,5 +25,5 @@ func newFacade(ctx facade.Context) (*InstancePollerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewInstancePollerAPI(st, m, ctx.Resources(), ctx.Auth(), clock.WallClock)
+	return NewInstancePollerAPI(st, m, ctx.Resources(), ctx.Auth(), clock.WallClock, ctx.Logger().Child("instancepoller"))
 }

--- a/apiserver/facades/controller/secretbackendmanager/register.go
+++ b/apiserver/facades/controller/secretbackendmanager/register.go
@@ -38,5 +38,6 @@ func NewSecretBackendsManagerAPI(context facade.Context) (*SecretBackendsManager
 		backendRotate:  context.State(),
 		backendState:   state.NewSecretBackends(context.State()),
 		clock:          clock.WallClock,
+		logger:         context.Logger().Child("secretbackendmanager"),
 	}, nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -24519,7 +24519,9 @@
         "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
-            "machine-agent"
+            "machine-agent",
+            "unit-agent",
+            "model-user"
         ],
         "Schema": {
             "type": "object",
@@ -50920,7 +50922,8 @@
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
-            "unit-agent"
+            "unit-agent",
+            "model-user"
         ],
         "Schema": {
             "type": "object",

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/rpcreflect"
 	"github.com/juju/version/v2"
@@ -584,6 +585,11 @@ func (ctx *facadeContext) DataDir() string {
 // LogDir returns the log directory.
 func (ctx *facadeContext) LogDir() string {
 	return ctx.r.shared.logDir
+}
+
+// Logger returns the apiserver logger instance.
+func (ctx *facadeContext) Logger() loggo.Logger {
+	return ctx.r.shared.logger
 }
 
 // adminRoot dispatches API calls to those available to an anonymous connection


### PR DESCRIPTION
All over our juju codebase we use the loggo loggers instanciated directly on each package as a singleton and provided via a global variable through each package. This is not a very good pattern so this patch removes the singleton declarations in favor of injecting them through the constructors.

This is done by adding a logger on the facade context:

```go
// Logger returns the apiserver logger instance.
func (ctx *facadeContext) Logger() loggo.Logger {
	return ctx.r.shared.logger
}
```
and then injecting it on the facades constructors (usually on the registers):
```go
return NewHookContextFacade(st, unit, ctx.Logger().Child("payloadshookcontext"))
```
where ctx is a `facade.Context`.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Be careful, it can take some time:
```
go test github.com/juju/juju/apiserver/facades/... -gocheck.v 
```

