### PR TITLE
'Correct' ipv6-icmp protocol type to icmp in O7k

### DIFF
--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -881,6 +881,9 @@ func (c *neutronFirewaller) ingressRulesInGroup(ctx context.ProviderCallContext,
 		portRange := corenetwork.PortRange{
 			Protocol: *p.IPProtocol,
 		}
+		if portRange.Protocol == "ipv6-icmp" {
+			portRange.Protocol = "icmp"
+		}
 		// NOTE: Juju firewall rule validation expects that icmp rules have port
 		// values set to -1
 		if p.PortRangeMin != nil {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -3108,7 +3108,15 @@ func (s *localServerSuite) TestICMPFirewallRules(c *gc.C) {
 				ToPort:   -1,
 				Protocol: "icmp",
 			},
-			SourceCIDRs: set.NewStrings("0.0.0.0/0", "::/0"),
+			SourceCIDRs: set.NewStrings("0.0.0.0/0"),
+		},
+		{
+			PortRange: network.PortRange{
+				FromPort: -1,
+				ToPort:   -1,
+				Protocol: "ipv6-icmp",
+			},
+			SourceCIDRs: set.NewStrings("::/0"),
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
OpenStack returns a protocol type of 'ipv6-icmp' for icmp sec group rules open to ipv6 CIDRs. This, however, is not supported by core/portrange

If we receive an ipv6-icmp protocol type, replace with just icmp

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

In comments