### PR TITLE
[JUJU-4032] Fix potential LXD bootstrap panic

### DIFF
--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -63,6 +63,14 @@ func NewServerFactoryWithMocks(localServerFunc func() (Server, error),
 	}
 }
 
+func NewServerFactoryWithError() ServerFactory {
+	return &serverFactory{
+		newLocalServerFunc:  func() (Server, error) { return nil, errors.New("oops") },
+		newRemoteServerFunc: func(lxd.ServerSpec) (Server, error) { return nil, errors.New("oops") },
+		newHTTPClientFunc:   func() *http.Client { return &http.Client{} },
+	}
+}
+
 func ExposeInstContainer(inst *environInstance) *lxd.Container {
 	return inst.container
 }

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -229,14 +229,15 @@ func (s *serverFactory) RemoteServer(spec CloudSpec) (Server, error) {
 		WithHTTPClient(s.newHTTPClientFunc())
 
 	svr, err := s.newRemoteServerFunc(serverSpec)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if spec.Project != "" {
 		svr.UseProject(spec.Project)
 	}
 
-	if err == nil {
-		err = s.bootstrapRemoteServer(svr)
-	}
-	return svr, errors.Trace(err)
+	return svr, errors.Trace(s.bootstrapRemoteServer(svr))
 }
 
 func (s *serverFactory) InsecureRemoteServer(spec CloudSpec) (Server, error) {

--- a/provider/lxd/server_integration_test.go
+++ b/provider/lxd/server_integration_test.go
@@ -455,6 +455,25 @@ func (s *serverIntegrationSuite) TestRemoteServerMissingCertificates(c *gc.C) {
 	c.Assert(errors.Cause(err).Error(), gc.Equals, "credentials not valid")
 }
 
+func (s *serverIntegrationSuite) TestRemoteServerBadServerFuncError(c *gc.C) {
+	factory := lxd.NewServerFactoryWithError()
+
+	creds := cloud.NewCredential("any", map[string]string{
+		"client-cert": "client-cert",
+		"client-key":  "client-key",
+		"server-cert": "server-cert",
+	})
+	svr, err := factory.RemoteServer(
+		lxd.CloudSpec{
+			CloudSpec: environscloudspec.CloudSpec{
+				Endpoint:   "https://10.0.0.9:8443",
+				Credential: &creds,
+			},
+		})
+	c.Assert(svr, gc.IsNil)
+	c.Assert(errors.Cause(err).Error(), gc.Equals, "oops")
+}
+
 func (s *serverIntegrationSuite) TestRemoteServerWithUnSupportedAPIVersion(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
https://github.com/juju/juju/pull/15542 introduced a usage of the LXD server, immediately after acquisition, but before we checked for an error. This results in a bootstrap panic if the LXD server is unreachable.

Here we check the error and add a test to cover this case.

## QA steps

- Stop your LXD Snap, or otherwise render your LXD server unreachable.
- Bootstrap.
- An error should result, instead of a panic.
