### PR TITLE
[JUJU-3928] Add image-id constraint on openstack

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2683,6 +2683,28 @@ type novaInstaceStartedWithOpts interface {
 	NovaInstanceStartedWithOpts() *nova.RunServerOpts
 }
 
+func (s *localServerSuite) TestStartInstanceWithImageIDConstraint(c *gc.C) {
+	env := s.ensureAMDImages(c)
+
+	err := bootstrapEnv(c, env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("image-id=ubuntu-bf2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	res, err := testing.StartInstanceWithParams(env, s.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: s.ControllerUUID,
+		Constraints:    cons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.ImageId, gc.NotNil)
+	c.Assert(runOpts.ImageId, gc.Equals, "ubuntu-bf2")
+}
+
 func (s *localServerSuite) TestStartInstanceVolumeRootBlockDevice(c *gc.C) {
 	// diskSizeGiB should be equal to the openstack.defaultRootDiskSize
 	diskSizeGiB := 30

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -578,7 +578,6 @@ func (e *Environ) neutron() *neutron.Client {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
-	constraints.ImageID,
 }
 
 // ConstraintsValidator is defined on the Environs interface.
@@ -1265,6 +1264,7 @@ func (e *Environ) startInstance(
 		Metadata:           args.InstanceConfig.Tags,
 		AvailabilityZone:   args.AvailabilityZone,
 	}
+
 	err = e.configureRootDisk(ctx, args, spec, &opts)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
@@ -1619,8 +1619,15 @@ func (e *Environ) configureRootDisk(_ context.ProviderCallContext, args environs
 	}
 	switch rootDiskSource {
 	case rootDiskSourceLocal:
-		runOpts.ImageId = spec.Image.Id
+		if args.Constraints.HasImageID() {
+			runOpts.ImageId = *args.Constraints.ImageID
+		} else {
+			runOpts.ImageId = spec.Image.Id
+		}
 	case rootDiskSourceVolume:
+		if args.Constraints.HasImageID() {
+			runOpts.ImageId = *args.Constraints.ImageID
+		}
 		size := uint64(0)
 		if args.Constraints.HasRootDisk() {
 			size = *args.Constraints.RootDisk


### PR DESCRIPTION
We use the `image-id` constraint on MAAS and AWS provider, for selecting custom images at charm deployment and juju machines creation. 
This patch adds the `image-id` constraint on the openstack provider, also removing it from the unsupported constraints list.

_Note: This PR only adds the changes to the provider, leaving the integration test (`/tests`) and validation with openstack clusters will be part of a following PR and jira ticket._

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

First we need to create a custom image on openstack. I simply copied the jammy image and created a new openstack image with: 
```
sudo microstack.openstack image create \
    --file /var/snap/microstack/common/images/jammy.img \
    --container-format=bare --disk-format=qcow2 --public \
    -f value -c id \
    ubuntu-bf2
```  
![image](https://github.com/juju/juju/assets/24507367/ec2f3a37-d33a-475d-9410-2cbc7989ee81)

Then we can add a juju machine using the custom image's id:
```
juju add-machine --constraints "image-id=a72c9e08-872e-4eb1-9e94-c96ac7938864"
```
resulting in the new juju machine with the correct `ubuntu-bf2` image:
![image](https://github.com/juju/juju/assets/24507367/12f17af6-0537-4d14-8270-0d466aecd104)

Run unit tests:
```
go test github.com/juju/juju/provider/openstack/... -gocheck.v
```
