### PR TITLE
[JUJU-4039] Remove jujuconnsuite from status cmd tests

### DIFF
--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -435,20 +435,6 @@ func (mr *MockContextMockRecorder) LogDir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockContext)(nil).LogDir))
 }
 
-// MachineTag mocks base method.
-func (m *MockContext) MachineTag() names.Tag {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names.Tag)
-	return ret0
-}
-
-// MachineTag indicates an expected call of MachineTag.
-func (mr *MockContextMockRecorder) MachineTag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockContext)(nil).MachineTag))
-}
-
 // Logger mocks base method.
 func (m *MockContext) Logger() loggo.Logger {
 	m.ctrl.T.Helper()
@@ -461,6 +447,20 @@ func (m *MockContext) Logger() loggo.Logger {
 func (mr *MockContextMockRecorder) Logger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockContext)(nil).Logger))
+}
+
+// MachineTag mocks base method.
+func (m *MockContext) MachineTag() names.Tag {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MachineTag")
+	ret0, _ := ret[0].(names.Tag)
+	return ret0
+}
+
+// MachineTag indicates an expected call of MachineTag.
+func (mr *MockContextMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockContext)(nil).MachineTag))
 }
 
 // MultiwatcherFactory mocks base method.

--- a/cmd/juju/status/export_test.go
+++ b/cmd/juju/status/export_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
-func NewTestStatusHistoryCommand(api HistoryAPI) cmd.Command {
+func NewStatusHistoryCommandForTest(api HistoryAPI) cmd.Command {
 	return &statusHistoryCommand{api: api}
 }
 
-func NewTestStatusCommand(statusapi statusAPI, storageapi storage.StorageListAPI, clock Clock) cmd.Command {
-	return modelcmd.Wrap(
-		&statusCommand{statusAPI: statusapi, storageAPI: storageapi, clock: clock})
+func NewStatusCommandForTest(store jujuclient.ClientStore, statusapi statusAPI, storageapi storage.StorageListAPI, clock Clock) cmd.Command {
+	cmd := &statusCommand{statusAPI: statusapi, storageAPI: storageapi, clock: clock}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
 }

--- a/cmd/juju/status/history_test.go
+++ b/cmd/juju/status/history_test.go
@@ -78,7 +78,7 @@ func (s *StatusHistorySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *StatusHistorySuite) newCommand() cmd.Command {
-	return statuscmd.NewTestStatusHistoryCommand(s.api)
+	return statuscmd.NewStatusHistoryCommandForTest(s.api)
 }
 
 func (s *StatusHistorySuite) next() *time.Time {

--- a/cmd/juju/status/package_test.go
+++ b/cmd/juju/status/package_test.go
@@ -6,9 +6,9 @@ package status
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -241,7 +241,7 @@ func (c *statusCommand) Init(args []string) error {
 	return nil
 }
 
-var newAPIClientForStatus = func(c *statusCommand) (statusAPI, error) {
+func (c *statusCommand) getStatusAPI() (statusAPI, error) {
 	if c.statusAPI == nil {
 		api, err := c.NewAPIClient()
 		if err != nil {
@@ -252,7 +252,7 @@ var newAPIClientForStatus = func(c *statusCommand) (statusAPI, error) {
 	return c.statusAPI, nil
 }
 
-var newAPIClientForStorage = func(c *statusCommand) (storage.StorageListAPI, error) {
+func (c *statusCommand) getStorageAPI() (storage.StorageListAPI, error) {
 	if c.storageAPI == nil {
 		root, err := c.NewAPIRoot()
 		if err != nil {
@@ -275,7 +275,7 @@ func (c *statusCommand) close() {
 }
 
 func (c *statusCommand) getStatus() (*params.FullStatus, error) {
-	apiclient, err := newAPIClientForStatus(c)
+	apiclient, err := c.getStatusAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -283,7 +283,7 @@ func (c *statusCommand) getStatus() (*params.FullStatus, error) {
 }
 
 func (c *statusCommand) getStorageInfo(ctx *cmd.Context) (*storage.CombinedStorage, error) {
-	apiclient, err := newAPIClientForStorage(c)
+	apiclient, err := c.getStorageAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/canonical/sqlair v0.0.0-20230606092629-0a5ab10a1b54
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
@@ -166,6 +165,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/creack/pty v1.1.15 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dnaeon/go-vcr v1.2.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/testing/base.go
+++ b/testing/base.go
@@ -22,10 +22,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
-	"github.com/juju/juju/core/model"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/jujuclient"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/wrench"
 )
@@ -76,28 +74,6 @@ func (s *JujuOSEnvSuite) TearDownTest(c *gc.C) {
 		os.Setenv(name, value)
 	}
 	err := utils.SetHome(s.oldHomeEnv)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-// SetModelAndController adds a controller, and a model in that controller,
-// and sets the controller as the current controller, and the model as the
-// current model.
-func (s *JujuOSEnvSuite) SetModelAndController(c *gc.C, controllerName, modelName string) {
-	store := jujuclient.NewFileClientStore()
-	err := store.AddController(controllerName, jujuclient.ControllerDetails{
-		ControllerUUID: "fake-uuid",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = store.SetCurrentController(controllerName)
-	c.Assert(err, jc.ErrorIsNil)
-	err = store.SetModels(controllerName, map[string]jujuclient.ModelDetails{
-		modelName: {
-			ModelUUID: "fake-model-uuid",
-			ModelType: model.IAAS,
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = store.SetCurrentModel(controllerName, modelName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Remove JujuConnSuite from the status command tests. The full end to end tests are replaced with tests which generate the FullStatus struct returned over the wire instead of making an api call to the facade.

A number of tests - filtering and model migration - were testing server side behaviour. There are existing tests for this in the relevant apiserver package so these tests are removed here.

The tests use a DDL to set up the status scenario - to avoid rewriting everything, the DDL is modified to update the FullStatus result struct instead of making JujuConnSuite calls.

Also a drive by go mod cleanup.

## QA steps

run the unit tests