### PR TITLE
Change usage of upsert statements.

### DIFF
--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -284,15 +284,16 @@ func upsertCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud cloud.
 	}
 
 	q := `
-		INSERT INTO cloud (uuid, name, cloud_type_id, endpoint, identity_endpoint, storage_endpoint, skip_tls_verify)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-		  ON CONFLICT(uuid) DO UPDATE SET name=?, endpoint=?, identity_endpoint=?, storage_endpoint=?, skip_tls_verify=?`[1:]
+INSERT INTO cloud (uuid, name, cloud_type_id, endpoint, identity_endpoint, storage_endpoint, skip_tls_verify)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
+                                  endpoint=excluded.endpoint,
+                                  identity_endpoint=excluded.identity_endpoint,
+                                  storage_endpoint=excluded.storage_endpoint,
+                                  skip_tls_verify=excluded.skip_tls_verify`[1:]
 
 	if _, err := tx.ExecContext(ctx, q, dbCloud.ID,
-		// insert
 		dbCloud.Name, dbCloud.TypeID, dbCloud.Endpoint, dbCloud.IdentityEndpoint, dbCloud.StorageEndpoint, dbCloud.SkipTLSVerify,
-		// update
-		dbCloud.Name, dbCloud.Endpoint, dbCloud.IdentityEndpoint, dbCloud.StorageEndpoint, dbCloud.SkipTLSVerify,
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -133,9 +133,9 @@ func (st *State) UpdateExternalController(
 		q := `
 INSERT INTO external_controller (uuid, alias, ca_cert)
 VALUES (?, ?, ?)
-  ON CONFLICT(uuid) DO UPDATE SET alias=?, ca_cert=?`[1:]
+  ON CONFLICT(uuid) DO UPDATE SET alias=excluded.alias, ca_cert=excluded.ca_cert`[1:]
 
-		if _, err := tx.ExecContext(ctx, q, cID, ci.Alias, ci.CACert, ci.Alias, ci.CACert); err != nil {
+		if _, err := tx.ExecContext(ctx, q, cID, ci.Alias, ci.CACert); err != nil {
 			return errors.Trace(err)
 		}
 


### PR DESCRIPTION
SQLite offers the excluded built in variable to assist with upsert statements. Changes our current upsert usage to make use of excluded.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run established unit tests.

## Documentation changes
N/A

## Bug reference
N/A
