### PR TITLE
Fix upgrade github action from including $HOME in docker build context.

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -132,14 +132,16 @@ jobs:
           set -euxo pipefail
           
           # Shim in recognition for our CA to jujud-operator
-          cat >~/Dockerfile <<EOL
+          BUILD_TEMP=$(mktemp -d)
+          cp ~/certs/ca.crt $BUILD_TEMP/
+          cat >$BUILD_TEMP/Dockerfile <<EOL
             FROM jujusolutions/jujud-operator:${BASE_JUJU_TAG}
           
-            COPY certs/ca.crt /usr/local/share/ca-certificates/ca.crt
+            COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build ~ -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${BASE_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${BASE_JUJU_TAG}
           docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${BASE_JUJU_TAG}
           
           docker pull jujusolutions/juju-db:${JUJU_DB_TAG}
@@ -240,24 +242,28 @@ jobs:
           make operator-image
           
           # Shim in recognition for our CA to jujud-operator
-          cat >~/Dockerfile <<EOL
+          BUILD_TEMP=$(mktemp -d)
+          cp ~/certs/ca.crt $BUILD_TEMP/
+          cat >$BUILD_TEMP/Dockerfile <<EOL
             FROM jujusolutions/jujud-operator:${UPSTREAM_JUJU_TAG}
           
-            COPY certs/ca.crt /usr/local/share/ca-certificates/ca.crt
+            COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build ~ -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
           docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
           
-          cat >~/Dockerfile <<EOL
+          BUILD_TEMP=$(mktemp -d)
+          cp ~/certs/ca.crt $BUILD_TEMP/
+          cat >$BUILD_TEMP/Dockerfile <<EOL
             FROM jujusolutions/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
           
-            COPY certs/ca.crt /usr/local/share/ca-certificates/ca.crt
+            COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build ~ -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
           docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
 
       - name: Preflight


### PR DESCRIPTION
Introduced in https://github.com/juju/juju/pull/13723 these actions were including the whole of $HOME in the docker build context which could cause some 8Gb+ of data to be sent over the docker unix socket to the container runtime.

Before: `Sending build context to Docker daemon  8.485GB`
After: `Sending build context to Docker daemon  4.096kB`

## QA steps

Successful GHA run.

## Documentation changes

N/A

## Bug reference

N/A