### PR TITLE
[JUJU-3932] Create upgrades schema

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -24,6 +24,7 @@ func ControllerDDL(nodeID uint64) []database.Delta {
 		controllerNodeEntry(nodeID),
 		controllerNodeTriggers,
 		modelMigrationSchema,
+		upgradeInfoSchema,
 	}
 
 	var deltas []database.Delta
@@ -144,7 +145,9 @@ INSERT INTO change_log_namespace VALUES
     (2, 'controller_node'),
     (3, 'controller_config'),
     (4, 'model_migration_status'),
-    (5, 'model_migration_minion_sync');`)
+    (5, 'model_migration_minion_sync'),
+    (6, 'upgrade_info');
+`)
 }
 
 func cloudSchema() database.Delta {
@@ -481,4 +484,54 @@ BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
     VALUES (4, 5, OLD.key, DATETIME('now'));
 END;`)
+}
+
+func upgradeInfoSchema() database.Delta {
+	return database.MakeDelta(`
+CREATE TABLE upgrade_info (
+    uuid             TEXT PRIMARY KEY,
+    previous_version TEXT NOT NULL,
+    target_version   TEXT NOT NULL,
+    created_at       TIMESTAMP NOT NULL,
+    started_at       TIMESTAMP,
+    completed_at     TIMESTAMP
+);
+
+CREATE TABLE upgrade_info_controller_node (
+    uuid                      TEXT PRIMARY KEY,
+    controller_node_id        TEXT NOT NULL,
+    upgrade_info_uuid         TEXT NOT NULL,
+    node_upgrade_completed_at TIMESTAMP,
+    CONSTRAINT                fk_controller_node_id
+        FOREIGN KEY               (controller_node_id)
+        REFERENCES                controller_node(controller_id),
+    CONSTRAINT                fk_upgrade_info
+        FOREIGN KEY               (upgrade_info_uuid)
+        REFERENCES                upgrade_info(uuid)
+);
+
+CREATE UNIQUE INDEX idx_upgrade_info_controller_node
+ON upgrade_info_controller_node (controller_node_id, upgrade_info_uuid);
+
+CREATE TRIGGER trg_changelog_upgradeinfo_insert
+AFTER INSERT ON upgrade_info FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at)
+    VALUES (1, 4, NEW.uuid, DATETIME('now'));
+END;
+
+CREATE TRIGGER trg_changelog_upgradeinfo_update
+AFTER UPDATE ON upgrade_info FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at)
+    VALUES (2, 4, OLD.uuid, DATETIME('now'));
+END;
+
+CREATE TRIGGER trg_changelog_upgradeinfo_delete
+AFTER DELETE ON upgrade_info FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at)
+    VALUES (4, 4, OLD.uuid, DATETIME('now'));
+END;
+`)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -88,6 +88,10 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"model_migration_status",
 		"model_migration_user",
 		"model_migration_minion_sync",
+
+		// Upgrade info
+		"upgrade_info",
+		"upgrade_info_controller_node",
 	)
 	c.Assert(readTableNames(c, s.db), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
Add a schema for the upgrade-info domain, reproducing entries in the `upgradeInfo` collection
https://github.com/juju/juju/blob/3.3/state/upgrade.go

This is so we can start the work backing upgrades with DQLite

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/schema
```