### PR TITLE
The following starts to add import tests to api client

### DIFF
--- a/api/controller/agenttools/package_test.go
+++ b/api/controller/agenttools/package_test.go
@@ -6,9 +6,28 @@ package agenttools_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/agenttools")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"core/instance",
+		"core/life",
+		"core/model",
+		"core/status",
+	})
 }

--- a/api/controller/applicationscaler/package_test.go
+++ b/api/controller/applicationscaler/package_test.go
@@ -6,9 +6,42 @@ package applicationscaler_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/applicationscaler")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/migration",
+		"core/model",
+		"core/network",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/status",
+		"core/watcher",
+		"docker",
+		"environs/context",
+		"proxy",
+		"rpc/params",
+		"storage",
+		"tools",
+	})
 }

--- a/api/controller/caasapplicationprovisioner/package_test.go
+++ b/api/controller/caasapplicationprovisioner/package_test.go
@@ -6,9 +6,28 @@ package caasapplicationprovisioner_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasapplicationprovisioner")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"core/instance",
+		"core/life",
+		"core/model",
+		"core/status",
+	})
 }

--- a/api/controller/caasfirewaller/package_test.go
+++ b/api/controller/caasfirewaller/package_test.go
@@ -6,9 +6,66 @@ package caasfirewaller_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasfirewaller")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"api/common",
+		"api/common/charms",
+		"api/watcher",
+		"charmhub",
+		"charmhub/path",
+		"charmhub/transport",
+		"controller",
+		"core/charm/metrics",
+		"core/config",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/logger",
+		"core/migration",
+		"core/model",
+		"core/network",
+		"core/os",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/series",
+		"core/status",
+		"core/watcher",
+		"docker",
+		"docker/registry",
+		"docker/registry/image",
+		"docker/registry/internal",
+		"environs/config",
+		"environs/context",
+		"environs/tags",
+		"feature",
+		"juju/osenv",
+		"logfwd",
+		"logfwd/syslog",
+		"pki",
+		"proxy",
+		"rpc",
+		"rpc/params",
+		"storage",
+		"tools",
+		"version",
+	})
 }

--- a/api/controller/caasmodelconfigmanager/package_test.go
+++ b/api/controller/caasmodelconfigmanager/package_test.go
@@ -6,9 +6,64 @@ package caasmodelconfigmanager
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasmodelconfigmanager")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"api/common",
+		"api/watcher",
+		"charmhub",
+		"charmhub/path",
+		"charmhub/transport",
+		"controller",
+		"core/charm/metrics",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/logger",
+		"core/migration",
+		"core/model",
+		"core/network",
+		"core/os",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/series",
+		"core/status",
+		"core/watcher",
+		"docker",
+		"docker/registry",
+		"docker/registry/image",
+		"docker/registry/internal",
+		"environs/config",
+		"environs/context",
+		"environs/tags",
+		"feature",
+		"juju/osenv",
+		"logfwd",
+		"logfwd/syslog",
+		"pki",
+		"proxy",
+		"rpc",
+		"rpc/params",
+		"storage",
+		"tools",
+		"version",
+	})
 }

--- a/api/controller/caasmodeloperator/package_test.go
+++ b/api/controller/caasmodeloperator/package_test.go
@@ -6,7 +6,40 @@ package caasmodeloperator_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) { gc.TestingT(t) }
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasmodeloperator")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/model",
+		"core/network",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/status",
+		"docker",
+		"environs/context",
+		"proxy",
+		"rpc/params",
+		"storage",
+		"tools",
+	})
+}

--- a/api/controller/caasoperatorprovisioner/package_test.go
+++ b/api/controller/caasoperatorprovisioner/package_test.go
@@ -6,9 +6,45 @@ package caasoperatorprovisioner_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasoperatorprovisioner")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"api/common/charms",
+		"api/watcher",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/migration",
+		"core/model",
+		"core/network",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/status",
+		"core/watcher",
+		"docker",
+		"environs/context",
+		"proxy",
+		"rpc",
+		"rpc/params",
+		"storage",
+		"tools",
+	})
 }

--- a/api/controller/caasoperatorupgrader/package_test.go
+++ b/api/controller/caasoperatorupgrader/package_test.go
@@ -6,9 +6,40 @@ package caasoperatorupgrader_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasoperatorupgrader")
+
+	c.Assert(found, jc.SameContents, []string{
+		"api/base",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/model",
+		"core/network",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/status",
+		"docker",
+		"environs/context",
+		"proxy",
+		"rpc/params",
+		"storage",
+		"tools",
+	})
 }

--- a/api/controller/caasunitprovisioner/package_test.go
+++ b/api/controller/caasunitprovisioner/package_test.go
@@ -6,9 +6,113 @@ package caasunitprovisioner_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/api/controller/caasunitprovisioner")
+
+	c.Assert(found, jc.SameContents, []string{
+		"agent",
+		"agent/constants",
+		"agent/tools",
+		"api",
+		"api/agent/keyupdater",
+		"api/base",
+		"api/common",
+		"api/common/charms",
+		"api/watcher",
+		"caas",
+		"caas/kubernetes",
+		"caas/kubernetes/pod",
+		"caas/kubernetes/provider/constants",
+		"caas/kubernetes/provider/proxy",
+		"caas/kubernetes/provider/utils",
+		"caas/specs",
+		"charmhub",
+		"charmhub/path",
+		"charmhub/transport",
+		"cloud",
+		"cloudconfig/instancecfg",
+		"cloudconfig/podcfg",
+		"controller",
+		"core/annotations",
+		"core/assumes",
+		"core/charm/metrics",
+		"core/config",
+		"core/constraints",
+		"core/devices",
+		"core/instance",
+		"core/life",
+		"core/logger",
+		"core/lxdprofile",
+		"core/macaroon",
+		"core/machinelock",
+		"core/migration",
+		"core/model",
+		"core/network",
+		"core/network/firewall",
+		"core/os",
+		"core/paths",
+		"core/relation",
+		"core/resources",
+		"core/secrets",
+		"core/series",
+		"core/status",
+		"core/watcher",
+		"docker",
+		"docker/registry",
+		"docker/registry/image",
+		"docker/registry/internal",
+		"environs",
+		"environs/cloudspec",
+		"environs/config",
+		"environs/context",
+		"environs/imagemetadata",
+		"environs/instances",
+		"environs/simplestreams",
+		"environs/storage",
+		"environs/tags",
+		"environs/utils",
+		"feature",
+		"juju/names",
+		"juju/osenv",
+		"jujuclient",
+		"logfwd",
+		"logfwd/syslog",
+		"mongo",
+		"network",
+		"network/debinterfaces",
+		"network/netplan",
+		"packaging",
+		"packaging/dependency",
+		"pki",
+		"provider/lxd/lxdnames",
+		"proxy",
+		"proxy/errors",
+		"proxy/factory",
+		"rpc",
+		"rpc/jsoncodec",
+		"rpc/params",
+		"service",
+		"service/common",
+		"service/snap",
+		"service/systemd",
+		"storage",
+		"tools",
+		"utils/proxy",
+		"utils/scriptrunner",
+		"version",
+	})
 }


### PR DESCRIPTION
In order to understand what each api client brings in from their dependencies the following adds an import test for each package.

This is REALLY worthwhile to do, as it shows that we leak a lot of information that really shouldn't be leaked.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.