### PR TITLE
[JUJU-4049] Fix data race in multiplexer

### DIFF
--- a/worker/changestream/eventmultiplexer/benchmarks_test.go
+++ b/worker/changestream/eventmultiplexer/benchmarks_test.go
@@ -87,7 +87,7 @@ func benchmarkSubscriptions(c *gc.C, numSubs, numEvents int, ns string) {
 	terms := make(chan changestream.Term)
 
 	em, err := New(stream{
-		ch: terms,
+		terms: terms,
 	}, clock.WallClock, loggo.GetLogger("bench"))
 	c.Assert(err, gc.IsNil)
 	defer workertest.CleanKill(c, em)
@@ -211,11 +211,16 @@ func (s *benchSuite) BenchmarkNonMatching_1000_100(c *gc.C) {
 }
 
 type stream struct {
-	ch chan changestream.Term
+	terms chan changestream.Term
+	dying chan struct{}
 }
 
 func (s stream) Terms() <-chan changestream.Term {
-	return s.ch
+	return s.terms
+}
+
+func (s stream) Dying() <-chan struct{} {
+	return s.dying
 }
 
 type term struct {

--- a/worker/changestream/eventmultiplexer/eventmultiplexer.go
+++ b/worker/changestream/eventmultiplexer/eventmultiplexer.go
@@ -20,6 +20,7 @@ import (
 type Logger interface {
 	Errorf(message string, args ...interface{})
 	Infof(message string, args ...interface{})
+	Debugf(message string, args ...interface{})
 	Tracef(message string, args ...interface{})
 	IsTraceEnabled() bool
 }
@@ -200,7 +201,10 @@ func (e *EventMultiplexer) loop() error {
 
 		// If the underlying stream is dying, then we should also exit.
 		case <-e.stream.Dying():
-			return nil
+			e.logger.Debugf("change stream is dying, waiting for catacomb to die")
+
+			<-e.catacomb.Dying()
+			return e.catacomb.ErrDying()
 
 		case term, ok := <-e.stream.Terms():
 			// If the stream is closed, we expect that a new worker will come

--- a/worker/changestream/eventmultiplexer/logger_mock_test.go
+++ b/worker/changestream/eventmultiplexer/logger_mock_test.go
@@ -33,6 +33,23 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
+// Debugf mocks base method.
+func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Debugf", varargs...)
+}
+
+// Debugf indicates an expected call of Debugf.
+func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
+}
+
 // Errorf mocks base method.
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()

--- a/worker/changestream/eventmultiplexer/package_test.go
+++ b/worker/changestream/eventmultiplexer/package_test.go
@@ -54,6 +54,10 @@ func (s *baseSuite) expectAnyLogs() {
 	s.logger.EXPECT().IsTraceEnabled().Return(true).AnyTimes()
 }
 
+func (s *baseSuite) expectStreamDying(ch <-chan struct{}) {
+	s.stream.EXPECT().Dying().Return(ch).AnyTimes()
+}
+
 func (s *baseSuite) expectAfter() {
 	s.clock.EXPECT().After(gomock.Any()).AnyTimes()
 }

--- a/worker/changestream/eventmultiplexer/package_test.go
+++ b/worker/changestream/eventmultiplexer/package_test.go
@@ -45,12 +45,13 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *baseSuite) expectAnyLogs() {
-	s.logger.EXPECT().Errorf(gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Infof(gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Tracef(gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Tracef(gomock.Any(), gomock.Any()).AnyTimes()
+func (s *baseSuite) expectAnyLogs(c *gc.C) {
+	s.logger.EXPECT().Errorf(gomock.Any()).Do(c.Logf).AnyTimes()
+	s.logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Do(c.Logf).AnyTimes()
+	s.logger.EXPECT().Infof(gomock.Any()).Do(c.Logf).AnyTimes()
+	s.logger.EXPECT().Debugf(gomock.Any()).Do(c.Logf).AnyTimes()
+	s.logger.EXPECT().Tracef(gomock.Any()).Do(c.Logf).AnyTimes()
+	s.logger.EXPECT().Tracef(gomock.Any(), gomock.Any()).Do(c.Logf).AnyTimes()
 	s.logger.EXPECT().IsTraceEnabled().Return(true).AnyTimes()
 }
 

--- a/worker/changestream/eventmultiplexer/stream_mock_test.go
+++ b/worker/changestream/eventmultiplexer/stream_mock_test.go
@@ -34,6 +34,20 @@ func (m *MockStream) EXPECT() *MockStreamMockRecorder {
 	return m.recorder
 }
 
+// Dying mocks base method.
+func (m *MockStream) Dying() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Dying")
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// Dying indicates an expected call of Dying.
+func (mr *MockStreamMockRecorder) Dying() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dying", reflect.TypeOf((*MockStream)(nil).Dying))
+}
+
 // Terms mocks base method.
 func (m *MockStream) Terms() <-chan changestream.Term {
 	m.ctrl.T.Helper()

--- a/worker/changestream/eventmultiplexer/subscription.go
+++ b/worker/changestream/eventmultiplexer/subscription.go
@@ -56,7 +56,11 @@ func newSubscription(id uint64, unsubscribeFn func()) *subscription {
 // whilst the dispatch signalling, the unsubscribe will happen after all
 // dispatches have been called.
 func (s *subscription) Unsubscribe() {
-	s.unsubscribeFn()
+	select {
+	case <-s.tomb.Dying():
+	default:
+		s.unsubscribeFn()
+	}
 }
 
 // Changes returns the channel that the subscription will receive events on.

--- a/worker/changestream/stream/stream.go
+++ b/worker/changestream/stream/stream.go
@@ -173,6 +173,11 @@ func (s *Stream) Terms() <-chan changestream.Term {
 	return s.terms
 }
 
+// Dying returns a channel to notify when the stream is dying.
+func (s *Stream) Dying() <-chan struct{} {
+	return s.tomb.Dying()
+}
+
 // Kill is part of the worker.Worker interface.
 func (s *Stream) Kill() {
 	s.tomb.Kill(nil)


### PR DESCRIPTION
The following fixes a data race in the multiplexer where the underlying stream is closed and it closes the subscription channels. Any new subscriptions then get panics about closing on a closed channel.

The solution is to expose the stream dying method, with then allows the underlying stream to expose when it's transitioning to the dead state. We can then prevent subscriptions from being attempted to be unsubscribed.

In addition, we prevent the unsubscribed function from being called if we're already dying.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ go test -v ./worker/changestream/eventmultiplexer -check.v -race -count=10
```

There isn't much of a difference between https://github.com/juju/juju/pull/15596 and the current implementation. 

```sh
$ go test -v ./worker/changestream/eventmultiplexer/... -check.v -count=1 -check.b -check.bmem
```

```sh
PASS: benchmarks_test.go:153: benchSuite.BenchmarkMatching_1000_1            500           3733215 ns/op          720524 B/op       9115 allocs/op
PASS: benchmarks_test.go:157: benchSuite.BenchmarkMatching_1000_10           500           6787103 ns/op         2049268 B/op      13514 allocs/op
PASS: benchmarks_test.go:161: benchSuite.BenchmarkMatching_1000_100           50          30399595 ns/op        14056216 B/op      19712 allocs/op
PASS: benchmarks_test.go:141: benchSuite.BenchmarkMatching_100_1            5000            359128 ns/op           62219 B/op        929 allocs/op
PASS: benchmarks_test.go:145: benchSuite.BenchmarkMatching_100_10           5000            624791 ns/op          165202 B/op       1415 allocs/op
PASS: benchmarks_test.go:149: benchSuite.BenchmarkMatching_100_100           500           3062231 ns/op         1074273 B/op       2565 allocs/op
PASS: benchmarks_test.go:129: benchSuite.BenchmarkMatching_10_1    50000             37199 ns/op            5825 B/op        100 allocs/op
PASS: benchmarks_test.go:133: benchSuite.BenchmarkMatching_10_10           50000             64068 ns/op           13965 B/op        158 allocs/op
PASS: benchmarks_test.go:137: benchSuite.BenchmarkMatching_10_100          10000            278790 ns/op           83209 B/op        370 allocs/op
PASS: benchmarks_test.go:117: benchSuite.BenchmarkMatching_1_1    500000              6738 ns/op             920 B/op         17 allocs/op
PASS: benchmarks_test.go:121: benchSuite.BenchmarkMatching_1_10   200000              9568 ns/op            1472 B/op         30 allocs/op
PASS: benchmarks_test.go:125: benchSuite.BenchmarkMatching_1_100           50000             30123 ns/op            5776 B/op        123 allocs/op
PASS: benchmarks_test.go:201: benchSuite.BenchmarkNonMatching_1000_1     2000000               836 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:205: benchSuite.BenchmarkNonMatching_1000_10    1000000              1337 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:209: benchSuite.BenchmarkNonMatching_1000_100    500000              5704 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:189: benchSuite.BenchmarkNonMatching_100_1      2000000               842 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:193: benchSuite.BenchmarkNonMatching_100_10     1000000              1313 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:197: benchSuite.BenchmarkNonMatching_100_100     500000              5825 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:177: benchSuite.BenchmarkNonMatching_10_1       2000000               846 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:181: benchSuite.BenchmarkNonMatching_10_10      1000000              1317 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:185: benchSuite.BenchmarkNonMatching_10_100      500000              5855 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:165: benchSuite.BenchmarkNonMatching_1_1        2000000               843 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:169: benchSuite.BenchmarkNonMatching_1_10       1000000              1292 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:173: benchSuite.BenchmarkNonMatching_1_100       500000              5838 ns/op              24 B/op          1 allocs/op
PASS: benchmarks_test.go:70: benchSuite.BenchmarkSignal_1        1000000              1683 ns/op             336 B/op          6 allocs/op
PASS: benchmarks_test.go:74: benchSuite.BenchmarkSignal_10       1000000              1689 ns/op             336 B/op          6 allocs/op
PASS: benchmarks_test.go:78: benchSuite.BenchmarkSignal_100      1000000              1703 ns/op             336 B/op          6 allocs/op
PASS: benchmarks_test.go:82: benchSuite.BenchmarkSignal_1000     1000000              1687 ns/op             336 B/op          6 allocs/op
```