### PR TITLE
[JUJU-4056] Fix data race dbaccessor

### DIFF
--- a/testing/logger.go
+++ b/testing/logger.go
@@ -3,17 +3,63 @@
 
 package testing
 
+import (
+	"fmt"
+
+	"github.com/juju/loggo"
+)
+
+// NoopLogger is a loggo.Logger that does nothing.
 type NoopLogger struct{}
 
-func (NoopLogger) Criticalf(string, ...interface{}) {}
-func (NoopLogger) Errorf(string, ...interface{})    {}
-func (NoopLogger) Warningf(string, ...interface{})  {}
-func (NoopLogger) Infof(string, ...interface{})     {}
-func (NoopLogger) Debugf(string, ...interface{})    {}
-func (NoopLogger) Tracef(string, ...interface{})    {}
+func (NoopLogger) Criticalf(string, ...any) {}
+func (NoopLogger) Errorf(string, ...any)    {}
+func (NoopLogger) Warningf(string, ...any)  {}
+func (NoopLogger) Infof(string, ...any)     {}
+func (NoopLogger) Debugf(string, ...any)    {}
+func (NoopLogger) Tracef(string, ...any)    {}
 
 func (NoopLogger) IsErrorEnabled() bool   { return false }
 func (NoopLogger) IsWarningEnabled() bool { return false }
 func (NoopLogger) IsInfoEnabled() bool    { return false }
 func (NoopLogger) IsDebugEnabled() bool   { return false }
 func (NoopLogger) IsTraceEnabled() bool   { return false }
+
+// CheckLog is an interface that can be used to log messages to a
+// *testing.T or *check.C.
+type CheckLog interface {
+	Logf(string, ...any)
+}
+
+// CheckLogger is a loggo.Logger that logs to a *testing.T or *check.C.
+type CheckLogger struct {
+	Log CheckLog
+}
+
+func (c CheckLogger) Criticalf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("CRITICAL: %s", msg), args...)
+}
+func (c CheckLogger) Errorf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("ERROR: %s", msg), args...)
+}
+func (c CheckLogger) Warningf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("WARNING: %s", msg), args...)
+}
+func (c CheckLogger) Infof(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("INFO: %s", msg), args...)
+}
+func (c CheckLogger) Debugf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("DEBUG: %s", msg), args...)
+}
+func (c CheckLogger) Tracef(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("TRACE: %s", msg), args...)
+}
+func (c CheckLogger) Logf(level loggo.Level, msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("%s: %s", level.String(), msg), args...)
+}
+
+func (c CheckLogger) IsErrorEnabled() bool   { return false }
+func (c CheckLogger) IsWarningEnabled() bool { return false }
+func (c CheckLogger) IsInfoEnabled() bool    { return false }
+func (c CheckLogger) IsDebugEnabled() bool   { return false }
+func (c CheckLogger) IsTraceEnabled() bool   { return false }

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -30,7 +30,6 @@ var _ = gc.Suite(&trackedDBWorkerSuite{})
 func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -47,7 +46,6 @@ func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -72,7 +70,6 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -97,7 +94,6 @@ func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -129,7 +125,6 @@ func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -165,7 +160,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -215,7 +209,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) 
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(2)
 
@@ -252,7 +245,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceedsWithDifferentDB(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -325,7 +317,6 @@ loop:
 func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	done := s.expectTimer(1)
 
@@ -359,7 +350,6 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 
@@ -399,7 +389,6 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 func (s *trackedDBWorkerSuite) TestWorkerCancelsTxnNoRetry(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTimer(0)
 

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -15,12 +15,17 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 	"github.com/juju/worker/v3/dependency"
-	"gopkg.in/tomb.v2"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/database/dqlite"
 	"github.com/juju/juju/pubsub/apiserver"
+)
+
+var (
+	// ErrTryAgain indicates that the worker should try again to start the
+	// worker.
+	ErrTryAgain = errors.ConstError("watcher trying again starting up")
 )
 
 // nodeShutdownTimeout is the timeout that we add to the context passed
@@ -194,8 +199,14 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 			// If a worker goes down, we've attempted multiple retries and in
 			// that case we do want to cause the dbaccessor to go down. This
 			// will then bring up a new dqlite app.
-			IsFatal:      func(err error) bool { return true },
-			RestartDelay: time.Second * 30,
+			IsFatal: func(err error) bool {
+				// If there is a rebind during starting up a worker the dbApp
+				// will be nil. In this case, we'll return ErrTryAgain. In this
+				// case we don't want to kill the worker. We'll force the
+				// worker to try again.
+				return !errors.Is(errors.Cause(err), ErrTryAgain)
+			},
+			RestartDelay: time.Second * 10,
 		}),
 		dbReady:          make(chan error),
 		dbRequests:       make(chan dbRequest),
@@ -539,15 +550,29 @@ func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
 // Since GetDB blocks until dbReady is closed, and initialiseDqlite waits for
 // the node to be ready, we can assume that we will never race with a nil dbApp
 // when first starting up.
-// Since the only way we can get into this race is during shutdown, it is safe
-// to return ErrDying if we detect a nil database.
-// This preserves the error that the worker is exiting with, including nil.
+// Since the only way we can get into this race is during shutdown or a rebind.
+// It is safe to return ErrDying if the catacomb is dying when we detect a nil
+// database or ErrTryAgain to force the runner to retry starting the worker
+// again.
 func (w *dbWorker) openDatabase(namespace string) error {
+	// Note: Do not be tempted to create the worker outside of the StartWorker
+	// function. This will create potential data race if openDatabase is called
+	// multiple times for the same namespace.
 	err := w.dbRunner.StartWorker(namespace, func() (worker.Worker, error) {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
 		if w.dbApp == nil {
-			return nil, tomb.ErrDying
+			// If the dbApp is nil, then we're either shutting down or
+			// rebinding the address. In either case, we don't want to
+			// start a new worker. We'll return ErrTryAgain to indicate
+			// that we should try again in a bit. This will continue until
+			// the dbApp is no longer nil.
+			select {
+			case <-w.catacomb.Dying():
+				return nil, w.catacomb.ErrDying()
+			default:
+				return nil, ErrTryAgain
+			}
 		}
 
 		ctx, cancel := w.scopedContext()

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -186,6 +186,7 @@ type dbWorker struct {
 	apiServerChanges chan apiserver.Details
 }
 
+// NewWorker creates a new dbaccessor worker.
 func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 	var err error
 	if err = cfg.Validate(); err != nil {
@@ -207,6 +208,7 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 				return !errors.Is(errors.Cause(err), ErrTryAgain)
 			},
 			RestartDelay: time.Second * 10,
+			Logger:       cfg.Logger,
 		}),
 		dbReady:          make(chan error),
 		dbRequests:       make(chan dbRequest),

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -25,7 +25,7 @@ import (
 var (
 	// ErrTryAgain indicates that the worker should try again to start the
 	// worker.
-	ErrTryAgain = errors.ConstError("watcher trying again starting up")
+	ErrTryAgain = errors.ConstError("DB node is nil, but worker is not dying; rescheduling TrackedDB start attempt")
 )
 
 // nodeShutdownTimeout is the timeout that we add to the context passed
@@ -552,8 +552,8 @@ func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
 // Since GetDB blocks until dbReady is closed, and initialiseDqlite waits for
 // the node to be ready, we can assume that we will never race with a nil dbApp
 // when first starting up.
-// Since the only way we can get into this race is during shutdown or a rebind.
-// It is safe to return ErrDying if the catacomb is dying when we detect a nil
+// Since the only way we can get into this race is during shutdown or a rebind,
+// it is safe to return ErrDying if the catacomb is dying when we detect a nil
 // database or ErrTryAgain to force the runner to retry starting the worker
 // again.
 func (w *dbWorker) openDatabase(namespace string) error {

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/pubsub/apiserver"
 )
 
-var (
+const (
 	// ErrTryAgain indicates that the worker should try again to start the
 	// worker.
 	ErrTryAgain = errors.ConstError("DB node is nil, but worker is not dying; rescheduling TrackedDB start attempt")
@@ -205,7 +205,7 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 				// will be nil. In this case, we'll return ErrTryAgain. In this
 				// case we don't want to kill the worker. We'll force the
 				// worker to try again.
-				return !errors.Is(errors.Cause(err), ErrTryAgain)
+				return !errors.Is(err, ErrTryAgain)
 			},
 			RestartDelay: time.Second * 10,
 			Logger:       cfg.Logger,

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -34,7 +34,6 @@ var _ = gc.Suite(&workerSuite{})
 func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTrackedDBKill()
 
@@ -127,7 +126,6 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTrackedDBKill()
 
@@ -166,7 +164,6 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTrackedDBKill()
 
@@ -229,7 +226,6 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 	s.expectTrackedDBKill()
 
@@ -319,7 +315,6 @@ func (s *workerSuite) TestEnsureNamespaceForController(c *gc.C) {
 func (s *workerSuite) TestEnsureNamespaceForModelNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()
@@ -356,7 +351,6 @@ func (s *workerSuite) TestEnsureNamespaceForModelNotFound(c *gc.C) {
 func (s *workerSuite) TestEnsureNamespaceForModel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()
@@ -409,7 +403,6 @@ func (s *workerSuite) TestEnsureNamespaceForModel(c *gc.C) {
 func (s *workerSuite) TestEnsureNamespaceForModelWithCache(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()
@@ -471,7 +464,6 @@ func (s *workerSuite) TestEnsureNamespaceForModelWithCache(c *gc.C) {
 func (s *workerSuite) TestCloseDatabaseForController(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()
@@ -524,7 +516,6 @@ func (s *workerSuite) TestCloseDatabaseForController(c *gc.C) {
 func (s *workerSuite) TestCloseDatabaseForModel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()
@@ -580,7 +571,6 @@ func (s *workerSuite) TestCloseDatabaseForModel(c *gc.C) {
 func (s *workerSuite) TestCloseDatabaseForUnknownModel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAnyLogs(c)
 	s.expectClock()
 
 	dataDir := c.MkDir()


### PR DESCRIPTION
The following fixes the issue when rebinding the address and a
worker is starting the dbApp can be nil. To fix the problem we
check if the underlying catacomb is dying. If that's the case then
return that error. If it's not dying, force the worker to try again
with the new sentinel error.
As all errors were currently fatal, we add a check to ensure that if
the error is ErrTryAgain, a worker can come around and attempt
to try the worker again. The next time around if the catacomb
is dying, then it will correctly die. If the dbApp is still nil, it
will continue trying, otherwise, it will create a worker.

We're leaning into the way the runner works here to ensure that we
can handle the case of a dbApp worker being nil. Also, you can not
put the worker creation outside of the start worker function, as this
opens up possibilities of a worker being created twice and only one
of them being used.

----

As a driveby we now pass a real testing logger so it's easier
to diagnose errors in the future.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju boostrap lxd test --build-agent
$ juju add-model default
$ juju enable-ha
```

### Testing logger improvements

Apply the following diff:

```diff
diff --git a/worker/dbaccessor/worker_test.go b/worker/dbaccessor/worker_test.go
index dfd6caad97..22e7c6abdd 100644
--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -599,7 +599,7 @@ func (s *workerSuite) TestCloseDatabaseForUnknownModel(c *gc.C) {
        s.ensureStartup(c, dbw, sync)

        err := dbw.closeDatabase("foo")
-       c.Assert(err, gc.ErrorMatches, `stopping worker: worker "foo" not found`)
+       c.Assert(err, gc.ErrorMatches, `stopping worker: worker "foo" not found1`)

        workertest.CleanKill(c, w)
 }
```

The output to the failure becomes:

```
----------------------------------------------------------------------
FAIL: worker_test.go:571: workerSuite.TestCloseDatabaseForUnknownModel

Opening sqlite3 db with: file:/tmp/check-2658019636/4/db.sqlite3?_foreign_keys=1
Executing schema DDL index: 0
Executing schema DDL index: 1
Executing schema DDL index: 2
Executing schema DDL index: 3
Executing schema DDL index: 4
Executing schema DDL index: 5
Executing schema DDL index: 6
Executing schema DDL index: 7
Executing schema DDL index: 8
Executing schema DDL index: 9
Executing schema DDL index: 10
Committing schema DDL
INFO: host is configured as a Dqlite node
DEBUG: start "controller"
INFO: initialized Dqlite application (ID: 666)
INFO: start "controller"
INFO: current cluster: []protocol.NodeInfo(nil)
DEBUG: "controller" started
DEBUG: new API server details: apiserver.Details{Servers:map[string]apiserver.APIServer{"0":apiserver.APIServer{ID:"0", Addresses:[]string(nil), InternalAddress:"10.6.6.6:1234"}}, LocalOnly:false}
DEBUG: new API server details: apiserver.Details{Servers:map[string]apiserver.APIServer{"0":apiserver.APIServer{ID:"0", Addresses:[]string(nil), InternalAddress:""}, "1":apiserver.APIServer{ID:"1", Addresses:[]string(nil), InternalAddress:"10.6.6.7:1234"}, "2":apiserver.APIServer{ID:"2", Addresses:[]string(nil), InternalAddress:"10.6.6.8:1234"}}, LocalOnly:false}
INFO: internal address for this Dqlite node to bind to not found
worker_test.go:602:
    c.Assert(err, gc.ErrorMatches, `stopping worker: worker "foo" not found1`)
... error string = "stopping worker: worker \"foo\" not found"
... regex string = "stopping worker: worker \"foo\" not found1"

DEBUG: killing runner 0xc0006b27e0
INFO: runner is dying
DEBUG: killing "controller"
INFO: stopped "controller", err: <nil>
DEBUG: "controller" done: <nil>
DEBUG: no restart, removing "controller" from known workers

----------------------------------------------------------------------
```


