### PR TITLE
[JUJU-4019] Fix LP1983506, local charm migration failure.

### DIFF
--- a/state/sequence.go
+++ b/state/sequence.go
@@ -143,7 +143,7 @@ func updateSeqWithMin(sequence seqUpdater, minVal int) (int, error) {
 			// Increment an existing sequence document, respecting the
 			// minimum value provided.
 			nextVal := curVal + 1
-			if nextVal < minVal {
+			if nextVal <= minVal {
 				nextVal = minVal + 1
 			}
 			ok, err := sequence.set(curVal, nextVal)

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -123,6 +123,24 @@ func (s *sequenceSuite) TestMultipleSequenceWithMin(c *gc.C) {
 	c.Check(value, gc.Equals, 3)
 }
 
+func (s *sequenceSuite) TestMigrationSequenceWithMin(c *gc.C) {
+	// Test local charm migration where incoming charms may have
+	// the same curl with non-sequential revisions.
+	st := s.State
+
+	value, err := state.SequenceWithMin(st, "foo", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(value, gc.Equals, 0)
+
+	value, err = state.SequenceWithMin(st, "foo", 2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(value, gc.Equals, 2)
+
+	found, err := state.Sequence(st, "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(found, gc.Equals, 3)
+}
+
 func (s *sequenceSuite) TestContention(c *gc.C) {
 	const name = "foo"
 	const goroutines = 2


### PR DESCRIPTION
updateSeqWithMin misbehaved when providing a non 1 minimum value. This caused models with non-sequential local charm revisions to fail model migration. If the nextVal and minVal were the same, the nextVal was used. However the result should have been the minVal plus 1. The sequence saved represents the next value to use. The minVal is the most current value available.

## QA steps

```sh
$ juju bootstrap localhost dst 
$ juju bootstrap localhost src 
$ juju add-model move-me

$ juju deploy ./testcharms/./charms/lxd-profile --series jammy jammy-local
$ juju deploy ./testcharms/./charms/lxd-profile --series jammy jammy-local-two
$ juju refresh  --path ./testcharms/./charms/lxd-profile  jammy-local-two

# verify non-sequential local charms are in use
$ juju status --format yaml | grep " local:"
    charm: local:jammy/lxd-profile-0
    charm: local:jammy/lxd-profile-2

$ juju migrate move-me dst
# verify successful migration

$ juju switch dst:admin/move-me
$ juju refresh  --path ./testcharms/./charms/lxd-profile  jammy-local-two
# should be  local:jammy/lxd-profile-3
$ juju add-machine
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1983506
