### PR TITLE
[JUJU-4051] Generate controller config keys reference doc

### DIFF
--- a/.github/discourse-topic-ids.yaml
+++ b/.github/discourse-topic-ids.yaml
@@ -26,6 +26,7 @@ config: 10139
 constraints: 10060
 consume: 10213
 controller-config: 10237
+controller-config-keys: 7059
 controllers: 10152
 create-backup: 10197
 create-storage-pool: 10093

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  cli:
-    name: Sync CLI docs
+  sync:
+    name: Sync to Discourse
     runs-on: ubuntu-latest
     env:
       TOPIC_IDS: './.github/discourse-topic-ids.yaml'
@@ -29,7 +29,7 @@ jobs:
         run: |
           go install -v ./cmd/juju
 
-      - name: Generate docs
+      - name: Generate CLI docs
         id: gen
         shell: bash
         run: |
@@ -38,6 +38,13 @@ jobs:
           echo "dir=${DOCS_DIR}" >> $GITHUB_OUTPUT
           juju documentation --split --out=$DOCS_DIR --discourse-ids $TOPIC_IDS
         # TODO: save $DOCS_DIR as an artifact
+
+      - name: Generate controller config keys doc
+        env:
+          DOCS_DIR: ${{ steps.gen.outputs.dir }}
+          JUJU_SRC_ROOT: '.'
+        run: |
+          go run ./scripts/md-gen/controller-config
 
       - name: pip install requirements
         run: |

--- a/controller/config.go
+++ b/controller/config.go
@@ -45,7 +45,7 @@ const (
 	// properly.
 	ControllerAPIPort = "controller-api-port"
 
-	// ControllerName is the canonical name for the controller
+	// ControllerName is the canonical name for the controller.
 	ControllerName = "controller-name"
 
 	// ApplicationResourceDownloadLimit limits the number of concurrent resource download
@@ -113,13 +113,13 @@ const (
 	// ControllerUUIDKey is the key for the controller UUID attribute.
 	ControllerUUIDKey = "controller-uuid"
 
-	// LoginTokenRefreshURL sets the url of the login jwt well known endpoint.
+	// LoginTokenRefreshURL sets the URL of the login JWT well-known endpoint.
 	// Use this when authentication/authorisation is done using a JWT in the
 	// login request rather than a username/password or macaroon and a local
 	// permissions model.
 	LoginTokenRefreshURL = "login-token-refresh-url"
 
-	// IdentityURL sets the url of the identity manager.
+	// IdentityURL sets the URL of the identity manager.
 	// Use this when users should be managed externally rather than
 	// created locally on the controller.
 	IdentityURL = "identity-url"
@@ -148,15 +148,16 @@ const (
 	AutocertURLKey = "autocert-url"
 
 	// AllowModelAccessKey sets whether the controller will allow users to
-	// connect to models they have been authorized for even when
+	// connect to models they have been authorized for, even when
 	// they don't have any access rights to the controller itself.
 	AllowModelAccessKey = "allow-model-access"
 
-	// MongoMemoryProfile sets whether mongo uses the least possible memory or the
-	// default.
+	// MongoMemoryProfile sets the memory profile for MongoDB. Valid values are:
+	// - "low": use the least possible memory
+	// - "default": use the default memory profile
 	MongoMemoryProfile = "mongo-memory-profile"
 
-	// JujuDBSnapChannel selects the channel to use when installing mongo
+	// JujuDBSnapChannel selects the channel to use when installing Mongo
 	// snaps for focal or later. The value is ignored for older releases.
 	JujuDBSnapChannel = "juju-db-snap-channel"
 
@@ -164,9 +165,8 @@ const (
 	// debug-log command. If someone starts a debug-log session in a remote
 	// screen for example, it is very easy to disconnect from the screen while
 	// leaving the debug-log process running. This causes unnecessary load on
-	// the API Server. The max debug-log duration has a default of 24 hours,
+	// the API server. The max debug-log duration has a default of 24 hours,
 	// which should be more than enough time for a debugging session.
-	// If the user needs more information, perhaps debug-log isn't the right source.
 	MaxDebugLogDuration = "max-debug-log-duration"
 
 	// AgentLogfileMaxSize is the maximum file size in MB of each
@@ -243,7 +243,7 @@ const (
 	// communicate with controllers.
 	JujuManagementSpace = "juju-mgmt-space"
 
-	// CAASOperatorImagePath sets the url of the docker image
+	// CAASOperatorImagePath sets the URL of the docker image
 	// used for the application operator.
 	// Deprecated: use CAASImageRepo
 	CAASOperatorImagePath = "caas-operator-image-path"
@@ -255,18 +255,20 @@ const (
 	// Features allows a list of runtime changeable features to be updated.
 	Features = "features"
 
-	// MeteringURL is the key for the url to use for metrics
+	// MeteringURL is the URL to use for metrics.
 	MeteringURL = "metering-url"
 
 	// PublicDNSAddress is the public DNS address (and port) of the controller.
 	PublicDNSAddress = "public-dns-address"
 
-	// QueryTracingEnabled returns whether query tracing is enabled.
+	// QueryTracingEnabled returns whether query tracing is enabled. If so, any
+	// queries which take longer than QueryTracingThreshold will be logged.
 	QueryTracingEnabled = "query-tracing-enabled"
 
-	// QueryTracingThreshold returns the threshold for query tracing. The
-	// lower the threshold, the more queries will be output. A value of 0
-	// means all queries will be output.
+	// QueryTracingThreshold returns the "threshold" for query tracing. Any
+	// queries which take longer than this value will be logged (if query tracing
+	// is enabled). The lower the threshold, the more queries will be output. A
+	// value of 0 means all queries will be output.
 	QueryTracingThreshold = "query-tracing-threshold"
 )
 
@@ -395,8 +397,8 @@ const (
 )
 
 var (
-	// ControllerOnlyConfigAttributes are attributes which are only relevant
-	// for a controller, never a model.
+	// ControllerOnlyConfigAttributes lists all the controller config keys, so we
+	// can distinguish these from model config keys when bootstrapping.
 	ControllerOnlyConfigAttributes = []string{
 		AllowModelAccessKey,
 		AgentRateLimitMax,
@@ -512,7 +514,7 @@ var (
 )
 
 // ControllerOnlyAttribute returns true if the specified attribute name
-// is only relevant for a controller.
+// is a controller config key (as opposed to, say, a model config key).
 func ControllerOnlyAttribute(attr string) bool {
 	for _, a := range ControllerOnlyConfigAttributes {
 		if attr == a {
@@ -797,7 +799,7 @@ func (c Config) CACert() (string, bool) {
 	return "", false
 }
 
-// IdentityURL returns the url of the identity manager.
+// IdentityURL returns the URL of the identity manager.
 func (c Config) IdentityURL() string {
 	return c.asString(IdentityURL)
 }
@@ -831,7 +833,7 @@ func (c Config) IdentityPublicKey() *bakery.PublicKey {
 	return &pubKey
 }
 
-// LoginTokenRefreshURL returns the url of the login jwt well known endpoint.
+// LoginTokenRefreshURL returns the URL of the login jwt well known endpoint.
 func (c Config) LoginTokenRefreshURL() string {
 	return c.asString(LoginTokenRefreshURL)
 }
@@ -942,7 +944,7 @@ func (c Config) JujuManagementSpace() string {
 	return c.asString(JujuManagementSpace)
 }
 
-// CAASOperatorImagePath sets the url of the docker image
+// CAASOperatorImagePath sets the URL of the docker image
 // used for the application operator.
 func (c Config) CAASOperatorImagePath() (o docker.ImageRepoDetails) {
 	str := c.asString(CAASOperatorImagePath)
@@ -978,7 +980,7 @@ func validateCAASImageRepo(imageRepo string) (string, error) {
 	return r.ImageRepoDetails().Content(), nil
 }
 
-// CAASImageRepo sets the url of the docker repo
+// CAASImageRepo sets the URL of the docker repo
 // used for the jujud operator and mongo images.
 func (c Config) CAASImageRepo() (o docker.ImageRepoDetails) {
 	str := c.asString(CAASImageRepo)

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -265,7 +265,7 @@ they don't have any access rights to the controller itself`,
 	},
 	CAASOperatorImagePath: {
 		Type: environschema.Tstring,
-		Description: `(deprected) The url of the docker image used for the application operator.
+		Description: `(deprecated) The url of the docker image used for the application operator.
 Use "caas-image-repo" instead.`,
 	},
 	CAASImageRepo: {

--- a/scripts/md-gen/README.md
+++ b/scripts/md-gen/README.md
@@ -1,0 +1,4 @@
+# md-gen
+
+The scripts in this folder are used to generate Markdown documentation based
+on Juju code. They are complementary to the `juju documentation` command.

--- a/scripts/md-gen/controller-config/README.md
+++ b/scripts/md-gen/controller-config/README.md
@@ -1,0 +1,19 @@
+# md-gen/controller-config
+
+This script generates a Markdown reference doc for the controller config keys,
+based on the code in the `github.com/juju/juju/controller` package.
+
+It requires the following environment variables to be set:
+- `DOCS_DIR`: the directory in which to place the outputted Markdown doc
+- `JUJU_SRC_ROOT`: the root directory of a local checked-out copy of the
+  Juju source tree (`github.com/juju/juju`). This is used to locate the
+  `controller` package and parse it into an AST to gather information e.g.
+  doc comments.
+
+Assuming you're in the root of the Juju source tree, you can invoke the script
+like so:
+```bash
+export DOCS_DIR=$(pwd)/docs
+export JUJU_SRC_ROOT=$(pwd)
+go run ./scripts/md-gen/controller-config
+```

--- a/scripts/md-gen/controller-config/main.go
+++ b/scripts/md-gen/controller-config/main.go
@@ -1,0 +1,474 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/schema"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/testing"
+)
+
+// bidirectional mapping between key and constant name
+// e.g. "agent-ratelimit-max" <--> "AgentRateLimitMax"
+// These are filled by iterating through the AST of config.go
+var (
+	keyForConstantName = map[string]string{}
+	constantNameForKey = map[string]string{}
+)
+
+// Generate Markdown documentation based on the contents of the
+// github.com/juju/juju/controller package.
+func main() {
+	outputDir := mustEnv("DOCS_DIR")        // directory to write output to
+	jujuSrcRoot := mustEnv("JUJU_SRC_ROOT") // root of Juju source tree
+
+	data := map[string]*keyInfo{}
+
+	// Gather information from various places
+	fillFromAST(data, jujuSrcRoot)
+	fillFromConfigType(data)
+	fillFromAllowedUpdateConfigAttributes(data)
+	fillFromNewConfig(data)
+
+	_ = os.MkdirAll(outputDir, 0755)
+	render(filepath.Join(outputDir, "controller-config-keys.md"), data)
+}
+
+// keyInfo contains information about a config key.
+type keyInfo struct {
+	Key          string `yaml:"key"`           // e.g. "agent-ratelimit-max"
+	ConstantName string `yaml:"constant-name"` // e.g. "AgentRateLimitMax"
+	Type         string `yaml:"type,omitempty"`
+	Doc          string `yaml:"doc,omitempty"` // from parsing comments in config.go
+	Mutable      bool   `yaml:"mutable"`       // from AllowedUpdateConfigAttributes
+	Deprecated   bool   `yaml:"deprecated,omitempty"`
+
+	// Several ways of getting the default value
+	Default  string `yaml:"default,omitempty"`  // from instantiating NewConfig
+	Default2 string `yaml:"default2,omitempty"` // from reflection on Config type
+}
+
+// render turns the input data into a Markdown document
+func render(filepath string, data map[string]*keyInfo) {
+	// Generate table of contents and main doc separately
+	var tableOfContents, mainDoc string
+
+	anchorForKey := func(key string) string {
+		return "heading--" + key
+	}
+	headingForKey := func(key string) string {
+		return fmt.Sprintf(`<a href="#%[1]s"><h2 id="%[1]s"><code>%[2]s</code></h2></a>`,
+			anchorForKey(key), key)
+	}
+
+	// Sort keys
+	var keys []string
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		info := data[key]
+
+		tableOfContents += fmt.Sprintf("- [`%s`](#%s)\n", key, anchorForKey(key))
+		mainDoc += headingForKey(key) + "\n"
+		if info.Deprecated {
+			mainDoc += "> This key is deprecated.\n"
+		}
+		mainDoc += "\n"
+
+		if info.Doc != "" {
+			// Ensure doc has fullstop/newlines at end
+			mainDoc += strings.TrimRight(info.Doc, ".\n") + ".\n\n"
+		}
+		if info.Type != "" {
+			mainDoc += "**Type:** " + info.Type + "\n\n"
+		}
+		if defaultVal, ok := firstNonzero(info.Default, info.Default2); ok {
+			mainDoc += "**Default value:** " + defaultVal + "\n\n"
+		}
+
+		mainDoc += "**Can be changed after bootstrap:** "
+		if info.Mutable {
+			mainDoc += "yes"
+		} else {
+			mainDoc += "no"
+		}
+		mainDoc += "\n\n\n"
+	}
+
+	err := os.WriteFile(filepath, []byte(fmt.Sprintf(`
+> <small> [Configuration](/t/6659) > List of controller configuration keys</small>
+>
+> See also: [Controller](/t/5455),  [How to manage configuration values for a controller](/t/1111#heading--manage-configuration-values-for-a-controller)
+
+%s
+
+%s
+`[1:], tableOfContents, mainDoc)), 0644)
+	check(err)
+}
+
+// Gather information from the AST parsed from the Go files:
+// ConstantName, Doc, Deprecated, Type
+func fillFromAST(data map[string]*keyInfo, jujuSrcRoot string) {
+	controllerPkgPath := filepath.Join(jujuSrcRoot, "controller")
+
+	// Parse controller package into ASTs
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, controllerPkgPath, nil, parser.ParseComments)
+	check(err)
+
+	controllerConfigDotGo := pkgs["controller"].Files[filepath.Join(controllerPkgPath, "config.go")]
+	configKeys := controllerConfigDotGo.Decls[3].(*ast.GenDecl)
+
+	comments := map[string]string{}
+	// "keys" which should be ignored
+	ignoreKeys := map[string]struct{}{"ReadOnlyMethods": {}}
+
+	for _, spec := range configKeys.Specs {
+		valueSpec := spec.(*ast.ValueSpec)
+		key := strings.Trim(valueSpec.Values[0].(*ast.BasicLit).Value, `"`)
+		if _, ok := ignoreKeys[key]; ok {
+			continue
+		}
+
+		var comment string
+		for _, astComment := range valueSpec.Doc.List {
+			comment += strings.TrimPrefix(astComment.Text, "// ") + "\n"
+		}
+
+		constantName := valueSpec.Names[0].Name
+		keyForConstantName[constantName] = key
+		constantNameForKey[key] = constantName
+		comments[key] = comment
+	}
+
+	// Put information in data map
+	for key, comment := range comments {
+		// Replace constant names with their actual values
+		// e.g. AgentRateLimitMax --> `agent-ratelimit-max`
+
+		// Some constant names are substrings of others. To ensure we replace
+		// correctly, sort the names in descending length order first.
+		constantNames := getKeysInDescLenOrder(keyForConstantName)
+		for _, constantName := range constantNames {
+			replaceKey := keyForConstantName[constantName]
+			comment = strings.ReplaceAll(comment, constantName, fmt.Sprintf("`%s`", replaceKey))
+		}
+
+		ensureDefined(data, key)
+		data[key].ConstantName = constantNameForKey[key]
+		data[key].Doc = comment
+
+		if strings.Contains(comment, "deprecated") || strings.Contains(comment, "Deprecated") {
+			data[key].Deprecated = true
+		}
+	}
+
+	// Pass over to configChecker AST to get types
+	fillFromConfigCheckerAST(data,
+		pkgs["controller"].Files[filepath.Join(controllerPkgPath, "configschema.go")].Decls[1].(*ast.GenDecl),
+	)
+}
+
+// Get key types from parsed configChecker in configschema.go
+func fillFromConfigCheckerAST(data map[string]*keyInfo, configChecker *ast.GenDecl) {
+	v := configChecker.Specs[0].(*ast.ValueSpec).Values[0].(*ast.CallExpr).Args
+	schemaFields := v[0].(*ast.CompositeLit)
+
+	// get key types from schemaFields
+	for _, elt := range schemaFields.Elts {
+		kvExpr := elt.(*ast.KeyValueExpr)
+		constantName := kvExpr.Key.(*ast.Ident).Name
+		key := keyForConstantName[constantName]
+
+		ensureDefined(data, key)
+		data[key].Type = typeForExpr(kvExpr.Value)
+	}
+}
+
+// get type from configChecker expressions
+func typeForExpr(expr ast.Expr) string {
+	niceNames := map[string]string{
+		"Bool":         "boolean",
+		"ForceInt":     "integer",
+		"List":         "list",
+		"String":       "string",
+		"TimeDuration": "duration",
+	}
+	niceNameFor := func(rawType string) string {
+		if nn, ok := niceNames[rawType]; ok {
+			return nn
+		}
+		return rawType
+	}
+
+	callExpr := expr.(*ast.CallExpr)
+	rawType := callExpr.Fun.(*ast.SelectorExpr).Sel.Name
+	dataType := niceNameFor(rawType)
+
+	if len(callExpr.Args) > 0 {
+		// add parameter types
+		dataType += "["
+		for i, arg := range callExpr.Args {
+			if i > 0 {
+				dataType += ", "
+			}
+			dataType += typeForExpr(arg)
+		}
+		dataType += "]"
+	}
+
+	return dataType
+}
+
+// Check whether key is mutable in AllowedUpdateConfigAttributes slice
+func fillFromAllowedUpdateConfigAttributes(data map[string]*keyInfo) {
+	for key := range controller.AllowedUpdateConfigAttributes {
+		ensureDefined(data, key)
+		data[key].Mutable = true
+	}
+}
+
+// keys for which a default value doesn't make sense
+var skipDefault = set.NewStrings(
+	controller.AuditLogExcludeMethods, // "[ReadOnlyMethods]" - not useful
+	controller.CACertKey,
+	controller.ControllerUUIDKey,
+)
+
+// Get default values using reflection on controller.Config type
+func fillFromNewConfig(data map[string]*keyInfo) {
+	config, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	check(err)
+	for key, defaultVal := range config {
+		if skipDefault.Contains(key) {
+			continue
+		}
+
+		ensureDefined(data, key)
+		data[key].Default = fmt.Sprint(defaultVal)
+	}
+}
+
+// Get default values using reflection on controller.Config type
+// Used as a fallback where fillFromNewConfig can't produce a value
+func fillFromConfigType(data map[string]*keyInfo) {
+	// Don't get defaults from these methods - generally bogus values
+	skipMethods := set.NewStrings(
+		"CAASImageRepo",
+		"CAASOperatorImagePath",
+		"ControllerAPIPort",
+		"Features",
+		"IdentityPublicKey",
+		"Validate", // not a config key
+	)
+
+	constantNameForMethod := func(methodName string) string {
+		name := strings.TrimSuffix(methodName, "MB")
+
+		rename := map[string]string{
+			"NUMACtlPreference": "SetNUMAControlPolicyKey",
+		}
+		if rn, ok := rename[name]; ok {
+			name = rn
+		}
+
+		return name
+	}
+
+	config, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
+	check(err)
+	t := reflect.TypeOf(config)
+	v := reflect.ValueOf(config)
+
+	for i := 0; i < t.NumMethod(); i++ {
+		method := t.Method(i)
+		methodValue := v.Method(i)
+
+		if skipMethods.Contains(method.Name) {
+			continue
+		}
+		if method.Type.NumIn() == 1 {
+			defaultVal := methodValue.Call([]reflect.Value{})[0]
+
+			constantName := constantNameForMethod(method.Name)
+			key, ok := keyForConstantName[constantName]
+			if !ok {
+				// Try adding "Key" suffix
+				key, ok = keyForConstantName[constantName+"Key"]
+				if !ok {
+					panic(method.Name)
+				}
+			}
+			if skipDefault.Contains(key) {
+				continue
+			}
+
+			ensureDefined(data, key)
+			data[key].Default2 = fmt.Sprint(defaultVal)
+		}
+	}
+}
+
+// UTILITY FUNCTIONS
+
+// Returns the value of the given environment variable, panicking if the var
+// is not set.
+func mustEnv(key string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("env var %q not set", key))
+	}
+	return val
+}
+
+// Return the first value that is defined / not-zero, and "true"
+// if such a value is found.
+func firstNonzero(vals ...string) (string, bool) {
+	for _, val := range vals {
+		if val != "" {
+			return val, true
+		}
+	}
+	return "", false
+}
+
+// Ensure that the data map has an entry for key.
+func ensureDefined(data map[string]*keyInfo, key string) {
+	if data[key] == nil {
+		data[key] = &keyInfo{
+			Key: key,
+		}
+	}
+}
+
+// check panics if the provided error is nil.
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// return keys of the given map in descending length order
+func getKeysInDescLenOrder[T any](m map[string]T) (keys []string) {
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+	return
+}
+
+// UNUSED
+// Alternative ways to gather data that didn't make the cut. Leaving here for
+// interest, or in case they become useful in the future
+
+// //go:linkname configChecker github.com/juju/juju/controller.configChecker
+var configChecker schema.Checker
+
+// Get default values by reflection on controller.configChecker
+func fillFromConfigChecker(data map[string]*keyInfo) {
+	schemaOmitVal := reflect.ValueOf(schema.Omit)
+
+	iter := reflect.ValueOf(configChecker).FieldByName("defaults").MapRange()
+	for iter.Next() {
+		defaultVal := iter.Value()
+		if defaultVal.Equal(schemaOmitVal) {
+			continue
+		}
+
+		key := iter.Key().String()
+		ensureDefined(data, key)
+		data[key].Default = fmt.Sprint(defaultVal)
+	}
+}
+
+// Get default values from "DefaultX" constants defined in config.go
+func fillFromDefaultConstants(data map[string]*keyInfo, defaults ast.Decl, keyForConstantName map[string]string) {
+	renameKeys := map[string]string{
+		"MaxTxnLogCollection": "MaxTxnLogSize",
+		"NUMAControlPolicy":   "SetNUMAControlPolicyKey",
+	}
+	rename := func(raw string) string {
+		if rn, ok := renameKeys[raw]; ok {
+			return rn
+		}
+		return raw
+	}
+
+	for _, spec := range defaults.(*ast.GenDecl).Specs {
+		valueSpec := spec.(*ast.ValueSpec)
+		defConstName := valueSpec.Names[0].Name // e.g. DefaultAgentRateLimitMax
+
+		// handle the case where this value is in MB
+		var suffix string
+		if strings.HasSuffix(defConstName, "MB") {
+			suffix = "M"
+			defConstName = strings.TrimSuffix(defConstName, "MB")
+		}
+
+		keyConstName := strings.TrimPrefix(defConstName, "Default") // e.g. AgentRateLimitMax
+		keyConstName = rename(keyConstName)
+		key := keyForConstantName[keyConstName]
+
+		ensureDefined(data, key)
+		data[key].Default = parseValue(valueSpec.Values[0]) + suffix
+	}
+}
+
+// parse default values from ast.Expr into a reasonable string
+func parseValue(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		return v.Value
+
+	case *ast.BinaryExpr:
+		// TODO: if these are all numbers then evaluate
+		return parseValue(v.X) + " " + parseValue(v.Y)
+
+	case *ast.SelectorExpr: // always time.something
+		if v.X.(*ast.Ident).Name != "time" {
+			panic("can't handle *ast.SelectorExpr that isn't time.something")
+		}
+		// TODO: nice strings for time units (e.g. Hour -> h)
+		return v.Sel.Name
+
+	case *ast.Ident:
+		return v.Name
+
+	default:
+		panic(fmt.Sprintf("can't handle type %T\n", v))
+	}
+}
+
+// Get type / description based on controller.ConfigSchema
+func fillFromConfigSchema(data map[string]*keyInfo) {
+	configSchema := controller.ConfigSchema
+
+	for key, attr := range configSchema {
+		ensureDefined(data, key)
+		data[key].Type = string(attr.Type)
+		data[key].Doc = attr.Description
+
+		if strings.Contains(attr.Description, "deprecated") || strings.Contains(attr.Description, "Deprecated") {
+			data[key].Deprecated = true
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new script to generate a Markdown reference doc of controller config keys, based on the code in the `github.com/juju/juju/controller` package. You can see the output of the script [here](https://discourse.charmhub.io/t/controller-config1-md/7059).

The generation can be split into two phases:
1. Collect information on the config keys. Several methods are used to do this (the various `fillFromX` functions):
   - using variables imported directly from the `controller` package
   - using reflection on types defined in the `controller` package
   - parsing the `controller` package with the `go/parser` library, and iterating over the AST
2. Use this information to generate a Markdown document (the `render` function).

The information generated in (1) can be dumped to YAML for debugging purposes.

Further changes included in this PR:
- improve some doc comments in the `controller` package
- integrate the generation of this doc (`controller-config-keys.md`) with the Discourse docs sync workflow. 

## TODO
- [x] Add ~`controller-only` and~ `mutable` information to the output
- [ ] Add versioning info (e.g. which keys exist in which versions)
  - This is nontrivial, especially for data generated by importing Go variables - how can we do this for different versions? Maybe we'll leave this for later work.
- [x] clean up the code
- [x] add this to the "Docs" GitHub Action