### PR TITLE
[JUJU-4058] Domain TxnRunner Factories

### DIFF
--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -42,7 +42,7 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 
 	return &HighAvailabilityAPI{
 		st:          st,
-		nodeService: service.NewService(state.NewState(domain.NewDBFactory(ctx.ControllerDB))),
+		nodeService: service.NewService(state.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB))),
 		authorizer:  authorizer,
 		logger:      ctx.Logger().Child("highavailability"),
 	}, nil

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -70,7 +70,7 @@ func newFacadeV9(ctx facade.Context) (*ModelManagerAPI, error) {
 		backend,
 		common.NewModelManagerBackend(ctrlModel, pool),
 		modelmanagerservice.NewService(
-			modelmanagerstate.NewState(domain.NewDBFactory(ctx.ControllerDB)),
+			modelmanagerstate.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB)),
 			ctx.DBDeleter()),
 		toolsFinder,
 		caas.New,

--- a/apiserver/facades/controller/externalcontrollerupdater/register.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/register.go
@@ -27,6 +27,6 @@ func newStateAPI(ctx facade.Context) (*ExternalControllerUpdaterAPI, error) {
 		ctx.Auth(),
 		ctx.Resources(),
 		state.NewExternalControllers(ctx.State()),
-		ecservice.NewService(ecstate.NewState(domain.NewDBFactory(ctx.ControllerDB))),
+		ecservice.NewService(ecstate.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB))),
 	)
 }

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -23,7 +23,7 @@ type State struct {
 }
 
 // NewState creates a state to access the database.
-func NewState(factory domain.DBFactory) *State {
+func NewState(factory domain.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -18,7 +18,7 @@ type State struct {
 }
 
 // NewState returns a new State for interacting with the underlying state.
-func NewState(factory domain.DBFactory) *State {
+func NewState(factory domain.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -19,7 +19,7 @@ type State struct {
 
 // NewState returns a new controller node state
 // based on the input database factory method.
-func NewState(factory domain.DBFactory) *State {
+func NewState(factory domain.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -22,7 +22,7 @@ type State struct {
 	*domain.StateBase
 }
 
-func NewState(factory domain.DBFactory) *State {
+func NewState(factory domain.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/modelmanager/state/state.go
+++ b/domain/modelmanager/state/state.go
@@ -20,7 +20,7 @@ type State struct {
 }
 
 // NewState returns a new State for interacting with the underlying state.
-func NewState(factory domain.DBFactory) *State {
+func NewState(factory domain.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -11,25 +11,25 @@ import (
 	"github.com/juju/juju/database/testing"
 )
 
-type dbFactorySuite struct {
+type stateSuite struct {
 	testing.ControllerSuite
 }
 
-var _ = gc.Suite(&dbFactorySuite{})
+var _ = gc.Suite(&stateSuite{})
 
-func (s *dbFactorySuite) TestTxnRunnerFactory(c *gc.C) {
+func (s *stateSuite) TestTxnRunnerFactory(c *gc.C) {
 	db, err := NewTxnRunnerFactory(s.getWatchableDB)()
 	c.Assert(err, gc.IsNil)
 	c.Assert(db, gc.NotNil)
 }
 
-func (s *dbFactorySuite) TestTxnRunnerFactoryForNamespace(c *gc.C) {
+func (s *stateSuite) TestTxnRunnerFactoryForNamespace(c *gc.C) {
 	db, err := NewTxnRunnerFactoryForNamespace(s.getWatchableDBForNameSpace, "any-old-namespace")()
 	c.Assert(err, gc.IsNil)
 	c.Assert(db, gc.NotNil)
 }
 
-func (s *dbFactorySuite) TestStateBaseGetDB(c *gc.C) {
+func (s *stateSuite) TestStateBaseGetDB(c *gc.C) {
 	f := testing.TxnRunnerFactory(s.TxnRunner())
 	base := NewStateBase(f)
 	db, err := base.DB()
@@ -37,24 +37,24 @@ func (s *dbFactorySuite) TestStateBaseGetDB(c *gc.C) {
 	c.Assert(db, gc.NotNil)
 }
 
-func (s *dbFactorySuite) TestStateBaseGetDBNilFactory(c *gc.C) {
+func (s *stateSuite) TestStateBaseGetDBNilFactory(c *gc.C) {
 	base := NewStateBase(nil)
 	_, err := base.DB()
 	c.Assert(err, gc.ErrorMatches, `nil getDB`)
 }
 
-func (s *dbFactorySuite) TestStateBaseGetDBNilDB(c *gc.C) {
+func (s *stateSuite) TestStateBaseGetDBNilDB(c *gc.C) {
 	f := testing.TxnRunnerFactory(nil)
 	base := NewStateBase(f)
 	_, err := base.DB()
 	c.Assert(err, gc.ErrorMatches, `invoking getDB: nil db`)
 }
 
-func (s *dbFactorySuite) getWatchableDB() (changestream.WatchableDB, error) {
+func (s *stateSuite) getWatchableDB() (changestream.WatchableDB, error) {
 	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
 }
 
-func (s *dbFactorySuite) getWatchableDBForNameSpace(_ string) (changestream.WatchableDB, error) {
+func (s *stateSuite) getWatchableDBForNameSpace(_ string) (changestream.WatchableDB, error) {
 	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
 }
 


### PR DESCRIPTION
This does 2 things:
- Renames `DBFactory` and associations in `domain` to `TxnRunnerFactory`. This more accurately reflects the relationship to existing types.
- Adds a new factory constructor, `NewTxnRunnerFactoryForNamespace` for use when we are creating states for model databases. It uses partial calling to provide a late-binding for name-spaced DBs.

## QA steps

There are no functional changes to existing logic. Tests pass.
