### PR TITLE
Fix TestWatchRawK8sSpec expecting coalescing with sstxn changestream.

### DIFF
--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -259,6 +259,8 @@ func (s *PodSpecSuite) TestWatchRawK8sSpec(c *gc.C) {
 	// Multiple changes coalesced.
 	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("raw spec 1"))
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO(quiescence): these two changes should be one event.
+	wc.AssertOneChange()
 	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("raw spec 2"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()


### PR DESCRIPTION
Since juju 3.0, we have used the changestream from mongo which doesn't give us coalescing. This test was still expecting it.

## QA steps

```
$ cd state
$ go test -c
# run the test a bunch
$ while ./state.test -check.f=TestWatchRawK8sSpec; do :; done
```

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/1270/consoleFull