### PR TITLE
Allow trust to be optionally set on charm refresh.

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -93,7 +93,7 @@ func (d *deployCharm) deploy(
 	}
 
 	// Process the --config args.
-	appConfig, configYAML, err := utils.ProcessConfig(ctx, d.model.Filesystem(), d.configOptions, d.trust)
+	appConfig, configYAML, err := utils.ProcessConfig(ctx, d.model.Filesystem(), d.configOptions, &d.trust)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/juju/charm/v10"
 	"github.com/juju/cmd/v3"
@@ -154,7 +155,7 @@ type refreshCommand struct {
 	// Trust signifies that the charm should have access to trusted credentials.
 	// That is, hooks run by the charm can access cloud credentials and other
 	// trusted access credentials.
-	Trust bool
+	Trust *bool
 }
 
 const refreshDoc = `
@@ -268,7 +269,38 @@ func (c *refreshCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(storageFlag{&c.Storage, nil}, "storage", "Charm storage constraints")
 	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
-	f.BoolVar(&c.Trust, "trust", false, "Allows charm to run hooks that require access credentials")
+	f.Var(newOptBoolValue(&c.Trust), "trust", "Allows charm to run hooks that require access credentials")
+}
+
+type optBoolValue struct {
+	target **bool
+}
+
+func newOptBoolValue(p **bool) *optBoolValue {
+	return &optBoolValue{
+		target: p,
+	}
+}
+
+func (b *optBoolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b.target = &v
+	return err
+}
+
+func (b *optBoolValue) Get() interface{} {
+	if *b.target != nil {
+		return **b.target
+	}
+	return "unset"
+}
+
+func (b *optBoolValue) String() string {
+	return fmt.Sprintf("%v", b.Get())
+}
+
+func (b *optBoolValue) IsBoolFlag() bool {
+	return true
 }
 
 func (c *refreshCommand) Init(args []string) error {

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -257,7 +257,7 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 		StorageConstraints: map[string]storage.Constraints{
 			"bar": {Pool: "baz", Count: 1},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -283,7 +283,7 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 			},
 		},
 		ConfigSettingsYAML: "foo:{}",
-		ConfigSettings:     map[string]string{"trust": "false"},
+		ConfigSettings:     map[string]string{},
 		EndpointBindings:   map[string]string{},
 	})
 }
@@ -304,6 +304,26 @@ func (s *RefreshSuite) TestConfigSettingsWithTrust(c *gc.C) {
 			},
 		},
 		ConfigSettings:   map[string]string{"trust": "true", "foo": "bar"},
+		EndpointBindings: map[string]string{},
+	})
+}
+
+func (s *RefreshSuite) TestConfigSettingsWithTrustFalse(c *gc.C) {
+	_, err := s.runRefresh(c, "foo", "--trust=false", "--config", "foo=bar")
+	c.Assert(err, jc.ErrorIsNil)
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
+
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
+		ApplicationName: "foo",
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				ID:     "testing",
+				Source: "charm-hub",
+				Risk:   "stable",
+			},
+		},
+		ConfigSettings:   map[string]string{"trust": "false", "foo": "bar"},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -374,7 +394,7 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 				Risk:   "stable",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: expectedBindings,
 	})
 }
@@ -620,7 +640,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 				Risk:   "beta",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -645,7 +665,7 @@ func (s *RefreshSuite) TestUpgradeWithChannelNoNewCharmURL(c *gc.C) {
 				Risk:   "beta",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -672,7 +692,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 				Risk:   "beta",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -711,7 +731,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 				Risk:         "stable",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 	})
 	var curl *charm.URL
@@ -952,7 +972,7 @@ func (s *RefreshSuite) TestUpgradeSameVersionWithResourceUpload(c *gc.C) {
 				Risk:   "stable",
 			},
 		},
-		ConfigSettings:   map[string]string{"trust": "false"},
+		ConfigSettings:   map[string]string{},
 		EndpointBindings: map[string]string{},
 		ResourceIDs:      map[string]string{"bar": "barId"},
 	})

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -288,7 +288,7 @@ type configFlag interface {
 // We may also have key/value pairs representing
 // charm settings which overrides anything in the YAML file.
 // If more than one file is specified, that is an error.
-func ProcessConfig(ctx *cmd.Context, filesystem modelcmd.Filesystem, configOptions configFlag, trust bool) (map[string]string, string, error) {
+func ProcessConfig(ctx *cmd.Context, filesystem modelcmd.Filesystem, configOptions configFlag, trust *bool) (map[string]string, string, error) {
 	var configYAML []byte
 	files, err := configOptions.AbsoluteFileNames(ctx)
 	if err != nil {
@@ -323,6 +323,8 @@ func ProcessConfig(ctx *cmd.Context, filesystem modelcmd.Filesystem, configOptio
 	}
 
 	// Expand the trust flag into the appConfig
-	appConfig[app.TrustConfigOptionName] = strconv.FormatBool(trust)
+	if trust != nil {
+		appConfig[app.TrustConfigOptionName] = strconv.FormatBool(*trust)
+	}
 	return appConfig, string(configYAML), nil
 }


### PR DESCRIPTION
Previous PR https://github.com/juju/juju/pull/15219 would reset trust to false when refreshing a charm when it wasn't explicitly set to false.

## QA steps

- Deploy charm with --trust
- Refresh charm
- Check trust is still set

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2019924
https://bugs.launchpad.net/juju/+bug/2017157