### PR TITLE
[JUJU-4058] Generic namespaced TxnRunner factory

### DIFF
--- a/domain/state.go
+++ b/domain/state.go
@@ -29,9 +29,9 @@ func NewTxnRunnerFactory(f func() (changestream.WatchableDB, error)) TxnRunnerFa
 	}
 }
 
-// NewTxnRunnerFactoryForNamespace returns a TxnRunnerFactory for the input
-// namespaced changestream.WatchableDB factory function and namespace.
-func NewTxnRunnerFactoryForNamespace(f func(string) (changestream.WatchableDB, error), ns string) TxnRunnerFactory {
+// NewTxnRunnerFactoryForNamespace returns a TxnRunnerFactory
+// for the input namespaced factory function and namespace.
+func NewTxnRunnerFactoryForNamespace[T database.TxnRunner](f func(string) (T, error), ns string) TxnRunnerFactory {
 	return func() (database.TxnRunner, error) {
 		r, err := f(ns)
 		return r, errors.Trace(err)

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -24,7 +24,14 @@ func (s *stateSuite) TestTxnRunnerFactory(c *gc.C) {
 }
 
 func (s *stateSuite) TestTxnRunnerFactoryForNamespace(c *gc.C) {
-	db, err := NewTxnRunnerFactoryForNamespace(s.getWatchableDBForNameSpace, "any-old-namespace")()
+	// Test multiple function return signatures to verify the generic behaviour.
+	db, err := NewTxnRunnerFactoryForNamespace(func(string) (database.TxnRunner, error) {
+		return s.TxnRunner(), nil
+	}, "any-old-namespace")()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	db, err = NewTxnRunnerFactoryForNamespace(s.getWatchableDBForNameSpace, "any-old-namespace")()
 	c.Assert(err, gc.IsNil)
 	c.Assert(db, gc.NotNil)
 }


### PR DESCRIPTION
This makes the name-spaced runner factory constructor generic, so that it can be use with a function that returns anything implementing `TxnRunner`.

This means that getters for both `WatchableDB` and `TxnRunner` can be passed as arguments.

## QA steps

See modified test.
