### PR TITLE
[JUJU-4005] Bases in compose suggestions

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/series"
 	coreseries "github.com/juju/juju/core/series"
 )
 
@@ -652,12 +653,7 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, origin corecharm.Origin) []string {
 	channelSeries := make(map[string][]string)
 	for _, release := range releases {
-		base := corecharm.Platform{
-			Architecture: release.Base.Architecture,
-			OS:           release.Base.Name,
-			Channel:      release.Base.Channel,
-		}
-		arch := base.Architecture
+		arch := release.Base.Architecture
 		if arch == "all" {
 			arch = origin.Platform.Architecture
 		}
@@ -665,24 +661,24 @@ func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, or
 			continue
 		}
 		var (
-			series string
-			err    error
+			base coreseries.Base
+			err  error
 		)
-		track, err := corecharm.ChannelTrack(base.Channel)
+		track, err := corecharm.ChannelTrack(release.Base.Channel)
 		if err != nil {
-			c.logger.Errorf("invalid base channel %v: %s", base.Channel, err)
+			c.logger.Errorf("invalid base channel %v: %s", release.Base.Channel, err)
 			continue
 		}
-		if track == "all" || base.OS == "all" {
-			series, err = coreseries.GetSeriesFromChannel(origin.Platform.OS, origin.Platform.Channel)
+		if track == "all" || release.Base.Name == "all" {
+			base, err = series.ParseBase(origin.Platform.OS, origin.Platform.Channel)
 		} else {
-			series, err = coreseries.GetSeriesFromChannel(base.OS, base.Channel)
+			base, err = series.ParseBase(release.Base.Name, release.Base.Channel)
 		}
 		if err != nil {
-			c.logger.Errorf("converting version to series: %s", err)
+			c.logger.Errorf("converting version to base: %s", err)
 			continue
 		}
-		channelSeries[release.Channel] = append(channelSeries[release.Channel], series)
+		channelSeries[release.Channel] = append(channelSeries[release.Channel], base.DisplayString())
 	}
 
 	var suggestions []string
@@ -691,13 +687,13 @@ func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, or
 	for _, r := range charm.Risks {
 		risk := string(r)
 		if values, ok := channelSeries[risk]; ok {
-			suggestions = append(suggestions, fmt.Sprintf("channel %q: available series are: %s", risk, strings.Join(values, ", ")))
+			suggestions = append(suggestions, fmt.Sprintf("channel %q: available bases are: %s", risk, strings.Join(values, ", ")))
 			delete(channelSeries, risk)
 		}
 	}
 
 	for channel, values := range channelSeries {
-		suggestions = append(suggestions, fmt.Sprintf("channel %q: available series are: %s", channel, strings.Join(values, ", ")))
+		suggestions = append(suggestions, fmt.Sprintf("channel %q: available bases are: %s", channel, strings.Join(values, ", ")))
 	}
 	return suggestions
 }

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -261,7 +261,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 	c.Assert(err, gc.ErrorMatches,
 		`(?m)selecting releases: charm or bundle not found for channel "", platform "amd64"
 available releases are:
-  channel "stable": available series are: focal`)
+  channel "stable": available bases are: ubuntu@20.04`)
 }
 
 func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
@@ -869,7 +869,7 @@ func (s *selectNextBaseSuite) TestSelectNextBasesFromReleasesSuggestion(c *gc.C)
 	c.Assert(err, gc.ErrorMatches,
 		`charm or bundle not found for channel "", platform "arch"
 available releases are:
-  channel "stable": available series are: focal`)
+  channel "stable": available bases are: ubuntu@20.04`)
 }
 
 func (s *selectNextBaseSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -924,7 +924,7 @@ func (s *composeSuggestionsSuite) TestSuggestion(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		`channel "stable": available series are: focal`,
+		`channel "stable": available bases are: ubuntu@20.04`,
 	})
 }
 
@@ -944,7 +944,7 @@ func (s *composeSuggestionsSuite) TestSuggestionWithRisk(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		`channel "stable": available series are: focal`,
+		`channel "stable": available bases are: ubuntu@20.04`,
 	})
 }
 
@@ -985,8 +985,8 @@ func (s *composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		`channel "stable": available series are: focal, bionic`,
-		`channel "2.0/stable": available series are: bionic`,
+		`channel "stable": available bases are: ubuntu@20.04, ubuntu@18.04`,
+		`channel "2.0/stable": available bases are: ubuntu@18.04`,
 	})
 }
 
@@ -1006,7 +1006,7 @@ func (s *composeSuggestionsSuite) TestCentosSuggestion(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		`channel "stable": available series are: centos7`,
+		`channel "stable": available bases are: centos@7`,
 	})
 }
 


### PR DESCRIPTION
This is part of the work to replace series with bases in the Juju codebase

Parse a base from the provided os and channel, and then print out it's display string. 

Another alternative would be to just format a string with the OS and Channel, insead of going via a `series.Base`. However, I think it's worth the extra branch required by the error to delegate the stringifying to a base struct 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/core/repository
```
