### PR TITLE
[JUJU-2024] Fix 2024783 - do not panic on invalid task|operation ID

### DIFF
--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -48,6 +48,11 @@ func (c *cancelCommand) Info() *cmd.Info {
 }
 
 func (c *cancelCommand) Init(args []string) error {
+	for _, arg := range args {
+		if !names.IsValidAction(arg) {
+			return errors.NotValidf("task ID %q", arg)
+		}
+	}
 	c.requestedIDs = args
 	return nil
 }

--- a/cmd/juju/action/cancel_test.go
+++ b/cmd/juju/action/cancel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -26,6 +27,15 @@ var _ = gc.Suite(&CancelSuite{})
 func (s *CancelSuite) SetUpTest(c *gc.C) {
 	s.BaseActionSuite.SetUpTest(c)
 	s.subcommand, _ = action.NewCancelCommandForTest(s.store)
+}
+
+func (s *CancelSuite) TestInit(c *gc.C) {
+	for _, modelFlag := range s.modelFlags {
+		cmd, _ := action.NewCancelCommandForTest(s.store)
+		args := append([]string{modelFlag, "admin"}, "test")
+		err := cmdtesting.InitCommand(cmd, args)
+		c.Check(errors.Is(err, errors.NotValid), jc.IsTrue)
+	}
 }
 
 func (s *CancelSuite) TestRun(c *gc.C) {

--- a/cmd/juju/action/showoperation.go
+++ b/cmd/juju/action/showoperation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	actionapi "github.com/juju/juju/api/client/action"
 	jujucmd "github.com/juju/juju/cmd"
@@ -95,6 +96,9 @@ func (c *showOperationCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no operation ID specified")
 	case 1:
+		if !names.IsValidOperation(args[0]) {
+			return errors.NotValidf("operation ID %q", args[0])
+		}
 		c.requestedID = args[0]
 		return nil
 	default:

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -40,6 +40,10 @@ func (s *ShowOperationSuite) TestInit(c *gc.C) {
 		args:        []string{},
 		expectError: "no operation ID specified",
 	}, {
+		should:      "fail with invalid operation ID",
+		args:        []string{"test"},
+		expectError: "operation ID \"test\" not valid",
+	}, {
 		should:      "fail with multiple args",
 		args:        []string{"12345", "54321"},
 		expectError: `unrecognized args: \["54321"\]`,

--- a/cmd/juju/action/showtask.go
+++ b/cmd/juju/action/showtask.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	actionapi "github.com/juju/juju/api/client/action"
 	jujucmd "github.com/juju/juju/cmd"
@@ -106,6 +107,9 @@ func (c *showTaskCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no task ID specified")
 	case 1:
+		if !names.IsValidAction(args[0]) {
+			return errors.NotValidf("task ID %q", args[0])
+		}
 		c.requestedId = args[0]
 		return nil
 	default:

--- a/cmd/juju/action/showtask_test.go
+++ b/cmd/juju/action/showtask_test.go
@@ -40,6 +40,10 @@ func (s *ShowTaskSuite) TestInit(c *gc.C) {
 		args:        []string{},
 		expectError: "no task ID specified",
 	}, {
+		should:      "fail with invalid task ID",
+		args:        []string{"test"},
+		expectError: "task ID \"test\" not valid",
+	}, {
 		should:      "fail with multiple args",
 		args:        []string{"12345", "54321"},
 		expectError: `unrecognized args: \["54321"\]`,


### PR DESCRIPTION
Correctly validate task and operation IDs in command Init methods to avoid panics later. 
names.New functions do not return errors. 

## QA steps


```sh
$ juju show-task t
ERROR task ID "t" not valid
$ juju cancel-task j
ERROR task ID "j" not valid
$ juju show-operation n
ERROR operation ID "n" not valid

# Pass valid task/operation IDs. The following should pass thru and return not found as
# no tasks/operations have been run.
$ juju cancel-task 89
actions:
- action: ""
  completed at: n/a
  error: action "89" not found
  id: "89"
  status: ""
  unit: ""
$ juju show-task 89
ERROR id not found
$ juju show-operation 89
{}
ERROR operation 89 not found
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2024783
