### PR TITLE
[JUJU-4098] Changelog changed

### DIFF
--- a/core/changestream/change.go
+++ b/core/changestream/change.go
@@ -25,8 +25,10 @@ type ChangeEvent interface {
 	// Namespace returns the namespace of the change. This is normally the
 	// table name.
 	Namespace() string
-	// ChangedUUID returns the entity UUID of the change.
-	ChangedUUID() string
+	// Changed returns the changed value of event. This logically can be
+	// the primary key of the row that was changed or the field of the change
+	// that was changed.
+	Changed() string
 }
 
 // Term represents a set of changes that are bounded by a coalesced set.

--- a/core/watcher/eventsource/key.go
+++ b/core/watcher/eventsource/key.go
@@ -44,7 +44,7 @@ func (w *KeyWatcher) loop() error {
 	defer close(w.out)
 
 	opt := changestream.FilteredNamespace(w.tableName, changestream.All, func(e changestream.ChangeEvent) bool {
-		return e.ChangedUUID() == w.keyValue
+		return e.Changed() == w.keyValue
 	})
 	subscription, err := w.watchableDB.Subscribe(opt)
 	if err != nil {

--- a/core/watcher/eventsource/key_test.go
+++ b/core/watcher/eventsource/key_test.go
@@ -62,7 +62,7 @@ func (s *keysSuite) TestNotificationsSent(c *gc.C) {
 	case deltas <- []changestream.ChangeEvent{changeEvent{
 		changeType: 0,
 		namespace:  "random_namespace",
-		uuid:       "some-key-value",
+		changed:    "some-key-value",
 	}}:
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out dispatching change event")

--- a/core/watcher/eventsource/keys.go
+++ b/core/watcher/eventsource/keys.go
@@ -99,7 +99,7 @@ func (w *KeysWatcher) loop() error {
 			}
 
 			// We have changes. Tick over to dispatch mode.
-			changes = transform.Slice(subChanges, func(c changestream.ChangeEvent) string { return c.ChangedUUID() })
+			changes = transform.Slice(subChanges, func(c changestream.ChangeEvent) string { return c.Changed() })
 			in = nil
 			out = w.out
 		case out <- changes:

--- a/core/watcher/eventsource/keys_test.go
+++ b/core/watcher/eventsource/keys_test.go
@@ -118,7 +118,7 @@ func (s *keysSuite) TestDeltasSent(c *gc.C) {
 	case deltas <- []changestream.ChangeEvent{changeEvent{
 		changeType: 0,
 		namespace:  "external_controller",
-		uuid:       "some-ec-uuid",
+		changed:    "some-ec-uuid",
 	}}:
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out dispatching change event")

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -80,7 +80,7 @@ func (m subscriptionOptionMatcher) String() string {
 type changeEvent struct {
 	changeType changestream.ChangeType
 	namespace  string
-	uuid       string
+	changed    string
 }
 
 func (e changeEvent) Type() changestream.ChangeType {
@@ -91,6 +91,6 @@ func (e changeEvent) Namespace() string {
 	return e.namespace
 }
 
-func (e changeEvent) ChangedUUID() string {
-	return e.uuid
+func (e changeEvent) Changed() string {
+	return e.changed
 }

--- a/domain/schema/changelog.go
+++ b/domain/schema/changelog.go
@@ -40,7 +40,7 @@ CREATE TABLE change_log (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     edit_type_id        INT NOT NULL,
     namespace_id        INT NOT NULL,
-    changed_uuid        TEXT NOT NULL,
+    changed             TEXT NOT NULL,
     created_at          DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT          fk_change_log_edit_type
             FOREIGN KEY (edit_type_id)
@@ -72,19 +72,19 @@ func changeLogTriggersForTable(table, primaryKey string, namespaceId int) func()
 CREATE TRIGGER trg_log_%[1]s_insert
 AFTER INSERT ON %[1]s FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (1, %[2]d, NEW.%[3]s, DATETIME('now'));
 END;
 CREATE TRIGGER trg_log_%[1]s_update
 AFTER UPDATE ON %[1]s FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[3]s, DATETIME('now'));
 END;
 CREATE TRIGGER trg_log_%[1]s_delete
 AFTER DELETE ON %[1]s FOR EACH ROW
 BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid, created_at) 
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (4, %[2]d, OLD.%[3]s, DATETIME('now'));
 END;`[1:], table, namespaceId, primaryKey))
 	}

--- a/domain/schema/changelog.go
+++ b/domain/schema/changelog.go
@@ -29,8 +29,9 @@ INSERT INTO change_log_edit_type VALUES
     (4, 'delete');
 
 CREATE TABLE change_log_namespace (
-    id        INT PRIMARY KEY,
-    namespace TEXT
+    id          INT PRIMARY KEY,
+    namespace   TEXT,
+    description TEXT
 );
 
 CREATE UNIQUE INDEX idx_change_log_namespace_namespace

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -94,12 +94,12 @@ ON lease_pin (lease_uuid);`)
 func changeLogControllerNamespaces() database.Delta {
 	return database.MakeDelta(`
 INSERT INTO change_log_namespace VALUES
-    (1, 'external_controller'),
-    (2, 'controller_node'),
-    (3, 'controller_config'),
-    (4, 'model_migration_status'),
-    (5, 'model_migration_minion_sync'),
-    (6, 'upgrade_info');
+    (1, 'external_controller', 'external controller changes based on the UUID'),
+    (2, 'controller_node', 'controller node changes based on the controller ID'),
+    (3, 'controller_config', 'controller config changes based on the key'),
+    (4, 'model_migration_status', 'model migration status changes based on the UUID'),
+    (5, 'model_migration_minion_sync', 'model migration minion sync changes based on the UUID'),
+    (6, 'upgrade_info', 'upgrade info changes based on the UUID');
 `)
 }
 

--- a/worker/changestream/doc.go
+++ b/worker/changestream/doc.go
@@ -35,7 +35,7 @@
 // then send the changes to the appropriate subscription.
 //
 // To aid with performance the stream worker will coalesce changes from the
-// database change log. So if a change from the same namespace and changed_uuid
+// database change log. So if a change from the same namespace and changed value
 // is received within a polling request, then the changes will be coalesced into
 // a single change.
 //
@@ -62,7 +62,7 @@
 //
 //   - The change type (CREATE, UPDATE, DELETE)
 //   - The namespace (generally the table name, but not guaranteed)
-//   - The changed_uuid (the primary key of the row that changed)
+//   - The changed (this could be the primary key of the row that changed)
 //
 // It's not useful to provide additional information about the change, because
 // in an eventual system, the change may be considered stale by the time it

--- a/worker/changestream/eventmultiplexer/benchmarks_test.go
+++ b/worker/changestream/eventmultiplexer/benchmarks_test.go
@@ -45,9 +45,9 @@ func create(size int) ChangeSet {
 	changes := make(ChangeSet, size)
 	for i := 0; i < size; i++ {
 		changes[i] = &changeEvent{
-			ctype: changestream.Update,
-			ns:    "test",
-			uuid:  fmt.Sprintf("uuid-%d", i),
+			ctype:   changestream.Update,
+			ns:      "test",
+			changed: fmt.Sprintf("uuid-%d", i),
 		}
 	}
 	return changes

--- a/worker/changestream/eventmultiplexer/eventmultiplexer_test.go
+++ b/worker/changestream/eventmultiplexer/eventmultiplexer_test.go
@@ -67,9 +67,9 @@ func (s *eventMultiplexerSuite) TestDispatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 
@@ -83,7 +83,7 @@ func (s *eventMultiplexerSuite) TestDispatch(c *gc.C) {
 	c.Assert(changes, gc.HasLen, 1)
 	c.Check(changes[0].Type(), jc.DeepEquals, changestream.Create)
 	c.Check(changes[0].Namespace(), jc.DeepEquals, "topic")
-	c.Check(changes[0].ChangedUUID(), gc.Equals, "1")
+	c.Check(changes[0].Changed(), gc.Equals, "1")
 
 	s.unsubscribe(c, sub)
 
@@ -134,9 +134,9 @@ func (s *eventMultiplexerSuite) testMultipleDispatch(c *gc.C, opts ...changestre
 	defer workertest.CleanKill(c, queue)
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Update,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Update,
+		ns:      "topic",
+		changed: "1",
 	})
 
 	subs := make([]changestream.Subscription, 10)
@@ -202,9 +202,9 @@ func (s *eventMultiplexerSuite) TestUnsubscribeTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 
@@ -237,9 +237,9 @@ func (s *eventMultiplexerSuite) TestTopicDoesNotMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectEmptyTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "foo",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "foo",
+		changed: "1",
 	})
 	done := s.dispatchTerm(c, terms)
 	select {
@@ -279,9 +279,9 @@ func (s *eventMultiplexerSuite) TestTopicMatchesOne(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	done := s.dispatchTerm(c, terms)
 	select {
@@ -325,9 +325,9 @@ func (s *eventMultiplexerSuite) TestSubscriptionDoneWhenEventQueueKilled(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	done := s.dispatchTerm(c, terms)
 	select {
@@ -365,9 +365,9 @@ func (s *eventMultiplexerSuite) TestUnsubscribeOfOtherSubscription(c *gc.C) {
 	}
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 
@@ -426,9 +426,9 @@ func (s *eventMultiplexerSuite) TestUnsubscribeOfOtherSubscriptionInAnotherGorou
 	}
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 
@@ -490,9 +490,9 @@ func (s *eventMultiplexerSuite) TestStreamDying(c *gc.C) {
 	}
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 
@@ -557,9 +557,9 @@ func (s *eventMultiplexerSuite) TestStreamDyingWhilstDispatching(c *gc.C) {
 	}
 
 	s.expectTerm(c, changeEvent{
-		ctype: changestream.Create,
-		ns:    "topic",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "topic",
+		changed: "1",
 	})
 	s.dispatchTerm(c, terms)
 

--- a/worker/changestream/eventmultiplexer/package_test.go
+++ b/worker/changestream/eventmultiplexer/package_test.go
@@ -95,8 +95,8 @@ func (s *baseSuite) dispatchTerm(c *gc.C, terms chan<- changestream.Term) <-chan
 }
 
 type changeEvent struct {
-	ctype    changestream.ChangeType
-	ns, uuid string
+	ctype       changestream.ChangeType
+	ns, changed string
 }
 
 // Type returns the type of change (create, update, delete).
@@ -110,9 +110,11 @@ func (c changeEvent) Namespace() string {
 	return c.ns
 }
 
-// ChangedUUID returns the entity UUID of the change.
-func (c changeEvent) ChangedUUID() string {
-	return c.uuid
+// Changed returns the changed value of event. This logically can be
+// the primary key of the row that was changed or the field of the change
+// that was changed.
+func (c changeEvent) Changed() string {
+	return c.changed
 }
 
 type waitGroup struct {

--- a/worker/changestream/eventmultiplexer/subscription_test.go
+++ b/worker/changestream/eventmultiplexer/subscription_test.go
@@ -59,9 +59,9 @@ func (s *subscriptionSuite) TestSubscriptionWitnessChanges(c *gc.C) {
 	defer workertest.CleanKill(c, sub)
 
 	changes := ChangeSet{changeEvent{
-		ctype: changestream.Create,
-		ns:    "foo",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "foo",
+		changed: "1",
 	}}
 
 	go func() {
@@ -91,9 +91,9 @@ func (s *subscriptionSuite) TestSubscriptionDoesNoteWitnessChangesWithCancelledC
 	defer workertest.CleanKill(c, sub)
 
 	changes := ChangeSet{changeEvent{
-		ctype: changestream.Create,
-		ns:    "foo",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "foo",
+		changed: "1",
 	}}
 
 	syncPoint := make(chan struct{})
@@ -132,9 +132,9 @@ func (s *subscriptionSuite) TestSubscriptionDoesNotWitnessChangesWithUnsub(c *gc
 	defer workertest.CleanKill(c, sub)
 
 	changes := ChangeSet{changeEvent{
-		ctype: changestream.Create,
-		ns:    "foo",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "foo",
+		changed: "1",
 	}}
 
 	syncPoint := make(chan struct{})
@@ -177,9 +177,9 @@ func (s *subscriptionSuite) TestSubscriptionDoesNotWitnessChangesWithDying(c *gc
 	defer workertest.CleanKill(c, sub)
 
 	changes := ChangeSet{changeEvent{
-		ctype: changestream.Create,
-		ns:    "foo",
-		uuid:  "1",
+		ctype:   changestream.Create,
+		ns:      "foo",
+		changed: "1",
 	}}
 
 	syncPoint := make(chan struct{})

--- a/worker/changestream/stream/stream.go
+++ b/worker/changestream/stream/stream.go
@@ -387,12 +387,12 @@ const (
 	// If the namespace is later deleted, you'll no longer locate that during
 	// a select.
 	selectQuery = `
-SELECT MAX(c.id), c.edit_type_id, n.namespace, changed_uuid, created_at
+SELECT MAX(c.id), c.edit_type_id, n.namespace, changed, created_at
 	FROM change_log c
 		JOIN change_log_edit_type t ON c.edit_type_id = t.id
 		JOIN change_log_namespace n ON c.namespace_id = n.id
 	WHERE c.id > ?
-	GROUP BY c.namespace_id, c.changed_uuid 
+	GROUP BY c.namespace_id, c.changed
 	ORDER BY c.id;
 `
 )

--- a/worker/changestream/stream/stream.go
+++ b/worker/changestream/stream/stream.go
@@ -401,11 +401,11 @@ SELECT MAX(c.id), c.edit_type_id, n.namespace, changed, created_at
 // struct instead of an interface. We should work out if this is a good idea
 // or not.
 type changeEvent struct {
-	id          int64
-	changeType  int
-	namespace   string
-	changedUUID string
-	createdAt   string
+	id         int64
+	changeType int
+	namespace  string
+	changed    string
+	createdAt  string
 }
 
 // Type returns the type of change (create, update, delete).
@@ -419,9 +419,11 @@ func (e changeEvent) Namespace() string {
 	return e.namespace
 }
 
-// ChangedUUID returns the entity UUID of the change.
-func (e changeEvent) ChangedUUID() string {
-	return e.changedUUID
+// Changed returns the changed value of event. This logically can be
+// the primary key of the row that was changed or the field of the change
+// that was changed.
+func (e changeEvent) Changed() string {
+	return e.changed
 }
 
 func (s *Stream) readChanges() ([]changeEvent, error) {
@@ -444,7 +446,7 @@ func (s *Stream) readChanges() ([]changeEvent, error) {
 				&changes[i].id,
 				&changes[i].changeType,
 				&changes[i].namespace,
-				&changes[i].changedUUID,
+				&changes[i].changed,
 				&changes[i].createdAt,
 			}
 		}

--- a/worker/changestream/stream/stream_test.go
+++ b/worker/changestream/stream/stream_test.go
@@ -527,7 +527,7 @@ func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 	c.Assert(results, gc.HasLen, 8)
 	for i, result := range results {
 		c.Check(result.Namespace(), gc.Equals, "foo")
-		c.Check(result.ChangedUUID(), gc.Equals, inserts[i].uuid)
+		c.Check(result.Changed(), gc.Equals, inserts[i].uuid)
 	}
 
 	workertest.CleanKill(c, stream)
@@ -576,7 +576,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 			namespace = "bar"
 		}
 		c.Check(result.Namespace(), gc.Equals, namespace)
-		c.Check(result.ChangedUUID(), gc.Equals, inserts[i].uuid)
+		c.Check(result.Changed(), gc.Equals, inserts[i].uuid)
 	}
 
 	workertest.CleanKill(c, stream)
@@ -640,7 +640,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 			namespace = "bar"
 		}
 		c.Check(result.Namespace(), gc.Equals, namespace)
-		c.Check(result.ChangedUUID(), gc.Equals, inserts[i].uuid)
+		c.Check(result.Changed(), gc.Equals, inserts[i].uuid)
 	}
 
 	workertest.CleanKill(c, stream)
@@ -714,7 +714,7 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) 
 			namespace = "baz"
 		}
 		c.Check(result.Namespace(), gc.Equals, namespace)
-		c.Check(result.ChangedUUID(), gc.Equals, inserts[i].uuid)
+		c.Check(result.Changed(), gc.Equals, inserts[i].uuid)
 	}
 
 	workertest.CleanKill(c, stream)
@@ -772,7 +772,7 @@ func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
 
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Namespace(), gc.Equals, "foo")
-	c.Check(results[0].ChangedUUID(), gc.Equals, first.uuid)
+	c.Check(results[0].Changed(), gc.Equals, first.uuid)
 
 	workertest.CleanKill(c, stream)
 }
@@ -1091,7 +1091,7 @@ func (s *streamSuite) TestReadChangesWithOneChange(c *gc.C) {
 
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Namespace(), gc.Equals, "foo")
-	c.Check(results[0].ChangedUUID(), gc.Equals, first.uuid)
+	c.Check(results[0].Changed(), gc.Equals, first.uuid)
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *gc.C) {
@@ -1113,7 +1113,7 @@ func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *gc.C) {
 
 	c.Assert(results, gc.HasLen, 1)
 	c.Assert(results[0].Namespace(), gc.Equals, "foo")
-	c.Assert(results[0].ChangedUUID(), gc.Equals, uuid)
+	c.Assert(results[0].Changed(), gc.Equals, uuid)
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleChanges(c *gc.C) {
@@ -1137,7 +1137,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChanges(c *gc.C) {
 	c.Assert(results, gc.HasLen, 10)
 	for i := range results {
 		c.Check(results[i].Namespace(), gc.Equals, "foo")
-		c.Check(results[i].ChangedUUID(), gc.Equals, changes[i].uuid)
+		c.Check(results[i].Changed(), gc.Equals, changes[i].uuid)
 	}
 }
 
@@ -1170,7 +1170,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesGroupsCorrectly(c *gc.C)
 	c.Assert(results, gc.HasLen, 10)
 	for i := range results {
 		c.Check(results[i].Namespace(), gc.Equals, "foo")
-		c.Check(results[i].ChangedUUID(), gc.Equals, changes[i].uuid)
+		c.Check(results[i].Changed(), gc.Equals, changes[i].uuid)
 	}
 }
 
@@ -1261,7 +1261,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesInterweavedGroupsCorrect
 		c.Logf("expected %v", expected[i])
 		c.Check(results[i].Type(), gc.Equals, expected[i].changeType)
 		c.Check(results[i].Namespace(), gc.Equals, expected[i].namespace)
-		c.Check(results[i].ChangedUUID(), gc.Equals, expected[i].uuid)
+		c.Check(results[i].Changed(), gc.Equals, expected[i].uuid)
 	}
 }
 
@@ -1408,9 +1408,9 @@ func (s *streamSuite) newStream() *Stream {
 
 func (s *streamSuite) insertNamespace(c *gc.C, id int, name string) {
 	q := `
-INSERT INTO change_log_namespace VALUES (?, ?);
+INSERT INTO change_log_namespace VALUES (?, ?, ?);
 `[1:]
-	_, err := s.DB().Exec(q, id, name)
+	_, err := s.DB().Exec(q, id, name, "blah")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1443,7 +1443,7 @@ func expectChanges(c *gc.C, expected []change, obtained []changestream.ChangeEve
 
 	for i, chg := range expected {
 		c.Check(obtained[i].Namespace(), gc.Equals, "foo")
-		c.Check(obtained[i].ChangedUUID(), gc.Equals, chg.uuid)
+		c.Check(obtained[i].Changed(), gc.Equals, chg.uuid)
 	}
 }
 

--- a/worker/changestream/stream/stream_test.go
+++ b/worker/changestream/stream/stream_test.go
@@ -1424,7 +1424,7 @@ func (s *streamSuite) insertChange(c *gc.C, changes ...change) {
 }
 
 func (s *streamSuite) insertChangeForType(c *gc.C, changeType changestream.ChangeType, changes ...change) {
-	q := `INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid) VALUES (?, ?, ?)`
+	q := `INSERT INTO change_log (edit_type_id, namespace_id, changed) VALUES (?, ?, ?)`
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		for _, v := range changes {
 			c.Logf("Executing insert change: edit-type: %d, %v %v", changeType, v.id, v.uuid)

--- a/worker/changestreampruner/worker_test.go
+++ b/worker/changestreampruner/worker_test.go
@@ -494,7 +494,7 @@ VALUES ($M.ctrl_id, $M.lower_bound, $M.updated_at)
 
 func (s *workerSuite) insertChangeLogItems(c *gc.C, runner coredatabase.TxnRunner, amount int, now time.Time) {
 	query, err := sqlair.Prepare(`
-INSERT INTO change_log (id, edit_type_id, namespace_id, changed_uuid, created_at)
+INSERT INTO change_log (id, edit_type_id, namespace_id, changed, created_at)
 VALUES ($M.id, 4, 2, 0, $M.created_at);
 			`, sqlair.M{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -534,7 +534,7 @@ SELECT (controller_id, lower_bound, updated_at) AS &Watermark.* FROM change_log_
 
 func (s *workerSuite) expectChangeLogItems(c *gc.C, runner coredatabase.TxnRunner, amount, lowerBound, upperBound int) {
 	query, err := sqlair.Prepare(`
-SELECT (id, edit_type_id, namespace_id, changed_uuid, created_at) AS &ChangeLogItem.* FROM change_log;
+SELECT (id, edit_type_id, namespace_id, changed, created_at) AS &ChangeLogItem.* FROM change_log;
 	`, ChangeLogItem{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -554,7 +554,7 @@ SELECT (id, edit_type_id, namespace_id, changed_uuid, created_at) AS &ChangeLogI
 
 			c.Check(item.EditTypeID, gc.Equals, 4)
 			c.Check(item.Namespace, gc.Equals, 2)
-			c.Check(item.UUID, gc.Equals, 0)
+			c.Check(item.Changed, gc.Equals, 0)
 		}
 
 		return nil
@@ -577,6 +577,6 @@ type ChangeLogItem struct {
 	ID         int       `db:"id"`
 	EditTypeID int       `db:"edit_type_id"`
 	Namespace  int       `db:"namespace_id"`
-	UUID       int       `db:"changed_uuid"`
+	Changed    int       `db:"changed"`
 	CreatedAt  time.Time `db:"created_at"`
 }


### PR DESCRIPTION
This change is to allow us to talk about changes that are not
specifically about uuid changes. This becomes pertinent when wanting
to know if a given field (column) in a given namespace (table) has
changed without knowing the specifics of each row. Removing the
_uuid suffix then ensures our modeling is correct.

In addition, the change_log namespace is explicitly tied to the changed 
key that is being returned via the changed namespace. The following 
updates the change_log_namespace to add a description to ensure 
that if you were checking the table rows it explained what they did?

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```
