### PR TITLE
[JUJU-4005] Improve unhelpful error

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -268,7 +268,11 @@ func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmURL *charm.UR
 	}
 
 	if len(bases) == 0 {
-		return nil, errors.Wrap(resErr, errors.Errorf("no releases found for channel %q", origin.Channel.String()))
+		ch := origin.Channel.String()
+		if ch == "" {
+			ch = "stable"
+		}
+		return nil, errors.Wrap(resErr, errors.Errorf("no releases found for channel %q", ch))
 	}
 	base := bases[0]
 


### PR DESCRIPTION
Improve unhelpful error

Beforehand, when no channel is provided this error would result in the
empty string being printed. Change this to the default channel

e.g. `juju deploy mysql --base ubuntu@16.04`

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju deploy mysql --base ubuntu@16.04
ERROR no releases found for channel "stable"
```