### PR TITLE
[JUJU-4052] - Do markObsoleteRevisionOps only if consumer revision changed;

### DIFF
--- a/state/package_test.go
+++ b/state/package_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/secrets"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -112,4 +113,13 @@ func (st *State) ReadBackendRefCount(backendID string) (int, error) {
 
 	key := secretBackendRefCountKey(backendID)
 	return nsRefcounts.read(refCountCollection, key)
+}
+
+func (st *State) IsSecretRevisionObsolete(c *gc.C, uri *secrets.URI, rev int) bool {
+	col, closer := st.db().GetCollection(secretRevisionsC)
+	defer closer()
+	var doc secretRevisionDoc
+	err := col.FindId(secretRevisionKey(uri, rev)).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	return doc.Obsolete
 }


### PR DESCRIPTION
This PR ensures we only mark obsolete revision if there is consumer revision change.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju --show-log deploy hello-kubecon hello

juju --show-log deploy nginx-ingress-integrator nginx

juju --show-log integrate nginx hello

juju --show-log trust nginx --scope=cluster

juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0
secret://42022b73-9739-4a66-890d-f4df231ce55f/cid6tkuffbas7af0e0eg

juju exec --unit hello/0 -- secret-add owned-by=hello-app
secret://42022b73-9739-4a66-890d-f4df231ce55f/cid6toeffbas7af0e0f0

juju exec --unit hello/0 -- secret-get cid6tkuffbas7af0e0eg
owned-by: hello/0

juju exec --unit hello/0 -- secret-get cid6toeffbas7af0e0f0
owned-by: hello-app

juju exec --unit hello/0 -- secret-info-get cid6tkuffbas7af0e0eg --format json
{"cid6tkuffbas7af0e0eg":{"revision":1,"label":"","owner":"unit","rotation":"never"}}

juju exec --unit hello/0 -- secret-info-get cid6toeffbas7af0e0f0 --format json
{"cid6toeffbas7af0e0f0":{"revision":1,"label":"","owner":"application","rotation":"never"}}

juju exec --unit hello/0 -- secret-grant cid6tkuffbas7af0e0eg -r 0

juju exec --unit hello/0 -- secret-grant cid6toeffbas7af0e0f0 -r 0

juju exec --unit nginx/0 -- secret-get cid6tkuffbas7af0e0eg
owned-by: hello/0

juju exec --unit nginx/0 -- secret-get cid6toeffbas7af0e0f0
owned-by: hello-app

juju:PRIMARY> db.secretRevisions.find().pretty()
{
	"_id" : "42022b73-9739-4a66-890d-f4df231ce55f:cid6tkuffbas7af0e0eg/1",
	"txn-revno" : 2,
	"revision" : 1,
	"create-time" : ISODate("2023-06-27T05:08:36Z"),
	"update-time" : ISODate("2023-06-27T05:08:36Z"),
	"obsolete" : false,
	"data" : {

	},
	"value-reference" : {
		"backend-id" : "42022b73-9739-4a66-890d-f4df231ce55f",
		"revision-id" : "cid6tkuffbas7af0e0eg-1"
	},
	"pending-delete" : false,
	"owner-tag" : "unit-hello-0",
	"model-uuid" : "42022b73-9739-4a66-890d-f4df231ce55f"
}
{
	"_id" : "42022b73-9739-4a66-890d-f4df231ce55f:cid6toeffbas7af0e0f0/1",
	"txn-revno" : 2,
	"revision" : 1,
	"create-time" : ISODate("2023-06-27T05:08:51Z"),
	"update-time" : ISODate("2023-06-27T05:08:51Z"),
	"obsolete" : false,
	"data" : {

	},
	"value-reference" : {
		"backend-id" : "42022b73-9739-4a66-890d-f4df231ce55f",
		"revision-id" : "cid6toeffbas7af0e0f0-1"
	},
	"pending-delete" : false,
	"owner-tag" : "application-hello",
	"model-uuid" : "42022b73-9739-4a66-890d-f4df231ce55f"
}

juju exec --unit hello/0 -- secret-set cid6toeffbas7af0e0f0 owned-by=hello-app-updated

juju show-status-log nginx/0
Time                        Type       Status     Message
...
27 Jun 2023 15:15:55+10:00  juju-unit  executing  running secret-changed hook for secret:cid6toeffbas7af0e0f0/2
27 Jun 2023 15:15:55+10:00  juju-unit  idle
27 Jun 2023 15:16:53+10:00  juju-unit  executing  running action juju-exec
27 Jun 2023 15:16:55+10:00  juju-unit  idle

juju exec --unit nginx/0 -- secret-get cid6toeffbas7af0e0f0
owned-by: hello-app

juju exec --unit nginx/0 -- secret-get cid6toeffbas7af0e0f0 --refresh
owned-by: hello-app-updated

db.secretRevisions.find().pretty()
{
	"_id" : "42022b73-9739-4a66-890d-f4df231ce55f:cid6tkuffbas7af0e0eg/1",
	"txn-revno" : 2,
	"revision" : 1,
	"create-time" : ISODate("2023-06-27T05:08:36Z"),
	"update-time" : ISODate("2023-06-27T05:08:36Z"),
	"obsolete" : false,
	"data" : {

	},
	"value-reference" : {
		"backend-id" : "42022b73-9739-4a66-890d-f4df231ce55f",
		"revision-id" : "cid6tkuffbas7af0e0eg-1"
	},
	"pending-delete" : false,
	"owner-tag" : "unit-hello-0",
	"model-uuid" : "42022b73-9739-4a66-890d-f4df231ce55f"
}
{
	"_id" : "42022b73-9739-4a66-890d-f4df231ce55f:cid6toeffbas7af0e0f0/1",
	"txn-revno" : NumberLong(3),
	"revision" : 1,
	"create-time" : ISODate("2023-06-27T05:08:51Z"),
	"update-time" : ISODate("2023-06-27T05:08:51Z"),
	"obsolete" : true,
	"data" : {

	},
	"value-reference" : {
		"backend-id" : "42022b73-9739-4a66-890d-f4df231ce55f",
		"revision-id" : "cid6toeffbas7af0e0f0-1"
	},
	"pending-delete" : false,
	"owner-tag" : "application-hello",
	"model-uuid" : "42022b73-9739-4a66-890d-f4df231ce55f"
}
{
	"_id" : "42022b73-9739-4a66-890d-f4df231ce55f:cid6toeffbas7af0e0f0/2",
	"txn-revno" : 2,
	"revision" : 2,
	"create-time" : ISODate("2023-06-27T05:15:55Z"),
	"update-time" : ISODate("2023-06-27T05:15:55Z"),
	"obsolete" : false,
	"data" : {

	},
	"value-reference" : {
		"backend-id" : "42022b73-9739-4a66-890d-f4df231ce55f",
		"revision-id" : "cid6toeffbas7af0e0f0-2"
	},
	"pending-delete" : false,
	"owner-tag" : "application-hello",
	"model-uuid" : "42022b73-9739-4a66-890d-f4df231ce55f"
}

juju show-status-log hello/0
Time                        Type       Status     Message
...
27 Jun 2023 15:15:55+10:00  juju-unit  executing  running secret-changed hook for secret:cid6toeffbas7af0e0f0/2
27 Jun 2023 15:15:55+10:00  juju-unit  idle
27 Jun 2023 15:16:13+10:00  juju-unit  executing  running action juju-exec
27 Jun 2023 15:16:13+10:00  juju-unit  idle
27 Jun 2023 15:16:28+10:00  juju-unit  executing  running action juju-exec
27 Jun 2023 15:16:28+10:00  juju-unit  idle
27 Jun 2023 15:18:16+10:00  juju-unit  executing  running secret-remove hook for secret:cid6toeffbas7af0e0f0/1
27 Jun 2023 15:18:16+10:00  juju-unit  idle

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2023364
