### PR TITLE
[JUJU-4012] Wire up watcher registry secrets

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -230,7 +230,7 @@ func AllFacades() *facade.Registry {
 	registry.MustRegister("EntityWatcher", 2, newEntitiesWatcher, reflect.TypeOf((*srvEntitiesWatcher)(nil)))
 	registry.MustRegister("MigrationStatusWatcher", 1, newMigrationStatusWatcher, reflect.TypeOf((*srvMigrationStatusWatcher)(nil)))
 	registry.MustRegister("ModelSummaryWatcher", 1, newModelSummaryWatcher, reflect.TypeOf((*SrvModelSummaryWatcher)(nil)))
-	registry.MustRegister("SecretsTriggerWatcher", 1, newSecretTriggerWatcher, reflect.TypeOf((*srvSecretTriggerWatcher)(nil)))
+	registry.MustRegister("SecretsTriggerWatcher", 1, newSecretsTriggerWatcher, reflect.TypeOf((*srvSecretTriggerWatcher)(nil)))
 	registry.MustRegister("SecretBackendsRotateWatcher", 1, newSecretBackendsRotateWatcher, reflect.TypeOf((*srvSecretBackendsRotateWatcher)(nil)))
 	registry.MustRegister("SecretsRevisionWatcher", 1, newSecretsRevisionWatcher, reflect.TypeOf((*srvSecretsRevisionWatcher)(nil)))
 

--- a/apiserver/facades/agent/secretsdrain/package_test.go
+++ b/apiserver/facades/agent/secretsdrain/package_test.go
@@ -27,7 +27,7 @@ func TestPackage(t *testing.T) {
 
 func NewTestAPI(
 	authorizer facade.Authorizer,
-	resources facade.Resources,
+	watcherRegistry facade.WatcherRegistry,
 	leadership leadership.Checker,
 	secretsState SecretsState,
 	model Model,
@@ -40,7 +40,7 @@ func NewTestAPI(
 
 	return &SecretsDrainAPI{
 		authTag:           authTag,
-		resources:         resources,
+		watcherRegistry:   watcherRegistry,
 		leadershipChecker: leadership,
 		secretsState:      secretsState,
 		model:             model,

--- a/apiserver/facades/agent/secretsdrain/register.go
+++ b/apiserver/facades/agent/secretsdrain/register.go
@@ -37,7 +37,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsDrainAPI, error) {
 		authTag:           context.Auth().GetAuthTag(),
 		leadershipChecker: leadershipChecker,
 		secretsState:      state.NewSecrets(context.State()),
-		resources:         context.Resources(),
+		watcherRegistry:   context.WatcherRegistry(),
 		secretsConsumer:   context.State(),
 		model:             model,
 		logger:            context.Logger().Child("secretsdrain"),

--- a/apiserver/facades/agent/secretsdrain/secrets_test.go
+++ b/apiserver/facades/agent/secretsdrain/secrets_test.go
@@ -27,8 +27,8 @@ import (
 type SecretsDrainSuite struct {
 	testing.IsolationSuite
 
-	authorizer *facademocks.MockAuthorizer
-	resources  *facademocks.MockResources
+	authorizer      *facademocks.MockAuthorizer
+	watcherRegistry *facademocks.MockWatcherRegistry
 
 	provider                  *mocks.MockSecretBackendProvider
 	leadership                *mocks.MockChecker
@@ -55,7 +55,7 @@ func (s *SecretsDrainSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.authorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.resources = facademocks.NewMockResources(ctrl)
+	s.watcherRegistry = facademocks.NewMockWatcherRegistry(ctrl)
 
 	s.provider = mocks.NewMockSecretBackendProvider(ctrl)
 	s.leadership = mocks.NewMockChecker(ctrl)
@@ -69,7 +69,7 @@ func (s *SecretsDrainSuite) setup(c *gc.C) *gomock.Controller {
 	s.PatchValue(&secretsdrain.GetProvider, func(string) (provider.SecretBackendProvider, error) { return s.provider, nil })
 
 	var err error
-	s.facade, err = secretsdrain.NewTestAPI(s.authorizer, s.resources, s.leadership, s.secretsState, s.model, s.secretsConsumer, s.authTag)
+	s.facade, err = secretsdrain.NewTestAPI(s.authorizer, s.watcherRegistry, s.leadership, s.secretsState, s.model, s.secretsConsumer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return ctrl
@@ -344,7 +344,7 @@ func (s *SecretsDrainSuite) TestWatchSecretBackendChanged(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.model.EXPECT().ModelConfig().Return(cfg, nil).Times(2)
 
-	s.resources.EXPECT().Register(gomock.Any()).Return("11")
+	s.watcherRegistry.EXPECT().Register(gomock.Any()).Return("11", nil)
 
 	result, err := s.facade.WatchSecretBackendChanged()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -35,7 +35,7 @@ func TestPackage(t *testing.T) {
 
 func NewTestAPI(
 	authorizer facade.Authorizer,
-	resources facade.Resources,
+	watcherRegistry facade.WatcherRegistry,
 	leadership leadership.Checker,
 	secretsState SecretsState,
 	consumer SecretsConsumer,
@@ -54,7 +54,7 @@ func NewTestAPI(
 
 	return &SecretsManagerAPI{
 		authTag:             authTag,
-		resources:           resources,
+		watcherRegistry:     watcherRegistry,
 		leadershipChecker:   leadership,
 		secretsState:        secretsState,
 		secretsConsumer:     consumer,

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -116,7 +116,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		authTag:             context.Auth().GetAuthTag(),
 		leadershipChecker:   leadershipChecker,
 		secretsState:        state.NewSecrets(context.State()),
-		resources:           context.Resources(),
+		watcherRegistry:     context.WatcherRegistry(),
 		secretsTriggers:     context.State(),
 		secretsConsumer:     context.State(),
 		clock:               clock.WallClock,

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -34,8 +34,8 @@ import (
 type SecretsManagerSuite struct {
 	testing.IsolationSuite
 
-	authorizer *facademocks.MockAuthorizer
-	resources  *facademocks.MockResources
+	authorizer      *facademocks.MockAuthorizer
+	watcherRegistry *facademocks.MockWatcherRegistry
 
 	provider              *mocks.MockSecretBackendProvider
 	leadership            *mocks.MockChecker
@@ -65,7 +65,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.authorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.resources = facademocks.NewMockResources(ctrl)
+	s.watcherRegistry = facademocks.NewMockWatcherRegistry(ctrl)
 
 	s.provider = mocks.NewMockSecretBackendProvider(ctrl)
 	s.leadership = mocks.NewMockChecker(ctrl)
@@ -140,7 +140,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 
 	var err error
 	s.facade, err = secretsmanager.NewTestAPI(
-		s.authorizer, s.resources, s.leadership, s.secretsState, s.secretsConsumer,
+		s.authorizer, s.watcherRegistry, s.leadership, s.secretsState, s.secretsConsumer,
 		s.secretTriggers, backendConfigGetter, adminConfigGetter,
 		drainConfigGetter, remoteClientGetter,
 		s.crossModelState, s.authTag, s.clock,
@@ -1450,7 +1450,7 @@ func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	s.secretsConsumer.EXPECT().WatchConsumedSecretsChanges(names.NewUnitTag("mariadb/0")).Return(
 		s.secretsWatcher, nil,
 	)
-	s.resources.EXPECT().Register(s.secretsWatcher).Return("1")
+	s.watcherRegistry.EXPECT().Register(s.secretsWatcher).Return("1", nil)
 
 	uri := coresecrets.NewURI()
 	watchChan := make(chan []string, 1)
@@ -1523,7 +1523,7 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsWatcher, nil,
 	)
-	s.resources.EXPECT().Register(s.secretsWatcher).Return("1")
+	s.watcherRegistry.EXPECT().Register(s.secretsWatcher).Return("1", nil)
 
 	uri := coresecrets.NewURI()
 	watchChan := make(chan []string, 1)
@@ -1553,7 +1553,7 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsTriggerWatcher, nil,
 	)
-	s.resources.EXPECT().Register(s.secretsTriggerWatcher).Return("1")
+	s.watcherRegistry.EXPECT().Register(s.secretsTriggerWatcher).Return("1", nil)
 
 	next := time.Now().Add(time.Hour)
 	uri := coresecrets.NewURI()
@@ -1702,7 +1702,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsTriggerWatcher, nil,
 	)
-	s.resources.EXPECT().Register(s.secretsTriggerWatcher).Return("1")
+	s.watcherRegistry.EXPECT().Register(s.secretsTriggerWatcher).Return("1", nil)
 
 	next := time.Now().Add(time.Hour)
 	uri := coresecrets.NewURI()

--- a/apiserver/facades/client/secretbackends/register.go
+++ b/apiserver/facades/client/secretbackends/register.go
@@ -32,6 +32,6 @@ func newSecretBackendsAPI(context facade.Context) (*SecretBackendsAPI, error) {
 		clock:          clock.WallClock,
 		backendState:   state.NewSecretBackends(context.State()),
 		secretState:    state.NewSecrets(context.State()),
-		statePool:      &statePoolShim{context.StatePool()},
+		statePool:      &statePoolShim{pool: context.StatePool()},
 	}, nil
 }

--- a/apiserver/facades/controller/secretbackendmanager/backends_test.go
+++ b/apiserver/facades/controller/secretbackendmanager/backends_test.go
@@ -27,8 +27,8 @@ import (
 type SecretsManagerSuite struct {
 	testing.IsolationSuite
 
-	authorizer *facademocks.MockAuthorizer
-	resources  *facademocks.MockResources
+	authorizer      *facademocks.MockAuthorizer
+	watcherRegistry *facademocks.MockWatcherRegistry
 
 	provider             *mocks.MockSecretBackendProvider
 	backendState         *mocks.MockBackendState
@@ -45,7 +45,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.authorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.resources = facademocks.NewMockResources(ctrl)
+	s.watcherRegistry = facademocks.NewMockWatcherRegistry(ctrl)
 
 	s.provider = mocks.NewMockSecretBackendProvider(ctrl)
 	s.backendState = mocks.NewMockBackendState(ctrl)
@@ -57,7 +57,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 
 	var err error
 	s.facade, err = secretbackendmanager.NewTestAPI(
-		s.authorizer, s.resources, s.backendState, s.backendRotate, s.clock)
+		s.authorizer, s.watcherRegistry, s.backendState, s.backendRotate, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return ctrl
@@ -77,7 +77,7 @@ func (s *SecretsManagerSuite) TestWatchBackendRotateChanges(c *gc.C) {
 	s.backendRotate.EXPECT().WatchSecretBackendRotationChanges().Return(
 		s.backendRotateWatcher, nil,
 	)
-	s.resources.EXPECT().Register(s.backendRotateWatcher).Return("1")
+	s.watcherRegistry.EXPECT().Register(s.backendRotateWatcher).Return("1", nil)
 
 	next := time.Now().Add(time.Hour)
 	rotateChan := make(chan []corewatcher.SecretBackendRotateChange, 1)

--- a/apiserver/facades/controller/secretbackendmanager/package_test.go
+++ b/apiserver/facades/controller/secretbackendmanager/package_test.go
@@ -25,7 +25,7 @@ func TestPackage(t *testing.T) {
 
 func NewTestAPI(
 	authorizer facade.Authorizer,
-	resources facade.Resources,
+	watcherRegistry facade.WatcherRegistry,
 	secretsState BackendState,
 	backendrotate BackendRotate,
 	clock clock.Clock,
@@ -35,9 +35,9 @@ func NewTestAPI(
 	}
 
 	return &SecretBackendsManagerAPI{
-		resources:     resources,
-		backendState:  secretsState,
-		backendRotate: backendrotate,
-		clock:         clock,
+		watcherRegistry: watcherRegistry,
+		backendState:    secretsState,
+		backendRotate:   backendrotate,
+		clock:           clock,
 	}, nil
 }

--- a/apiserver/facades/controller/secretbackendmanager/register.go
+++ b/apiserver/facades/controller/secretbackendmanager/register.go
@@ -31,13 +31,13 @@ func NewSecretBackendsManagerAPI(context facade.Context) (*SecretBackendsManager
 		return nil, errors.Trace(err)
 	}
 	return &SecretBackendsManagerAPI{
-		resources:      context.Resources(),
-		controllerUUID: model.ControllerUUID(),
-		modelUUID:      model.UUID(),
-		modelName:      model.Name(),
-		backendRotate:  context.State(),
-		backendState:   state.NewSecretBackends(context.State()),
-		clock:          clock.WallClock,
-		logger:         context.Logger().Child("secretbackendmanager"),
+		watcherRegistry: context.WatcherRegistry(),
+		controllerUUID:  model.ControllerUUID(),
+		modelUUID:       model.UUID(),
+		modelName:       model.Name(),
+		backendRotate:   context.State(),
+		backendState:    state.NewSecretBackends(context.State()),
+		clock:           clock.WallClock,
+		logger:          context.Logger().Child("secretbackendmanager"),
 	}, nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1683,9 +1683,6 @@
         "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 4,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "controller-user"
         ],
         "Schema": {
@@ -1746,9 +1743,6 @@
         "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 3,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "model-user"
         ],
         "Schema": {
@@ -28791,9 +28785,6 @@
         "Description": "SrvModelSummaryWatcher defines the API methods on a ModelSummaryWatcher.",
         "Version": 1,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "controller-user"
         ],
         "Schema": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1680,7 +1680,7 @@
     },
     {
         "Name": "AllModelWatcher",
-        "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
+        "Description": "SrvAllWatcher defines the API methods on a state.Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 4,
         "AvailableTo": [
             "controller-user"
@@ -1740,7 +1740,7 @@
     },
     {
         "Name": "AllWatcher",
-        "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
+        "Description": "SrvAllWatcher defines the API methods on a state.Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 3,
         "AvailableTo": [
             "model-user"
@@ -29087,7 +29087,7 @@
     },
     {
         "Name": "OfferStatusWatcher",
-        "Description": "srvOfferStatusWatcher defines the API wrapping a crossmodelrelations.OfferStatusWatcher.",
+        "Description": "srvOfferStatusWatcher defines the API wrapping a\ncrossmodelrelations.OfferStatusWatcher.",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1683,6 +1683,9 @@
         "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 4,
         "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
             "controller-user"
         ],
         "Schema": {
@@ -1743,6 +1746,9 @@
         "Description": "SrvAllWatcher defines the API methods on a Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
         "Version": 3,
         "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
             "model-user"
         ],
         "Schema": {
@@ -28785,6 +28791,9 @@
         "Description": "SrvModelSummaryWatcher defines the API methods on a ModelSummaryWatcher.",
         "Version": 1,
         "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
             "controller-user"
         ],
         "Schema": {

--- a/apiserver/internal/watcher_mock_test.go
+++ b/apiserver/internal/watcher_mock_test.go
@@ -7,6 +7,7 @@ package internal_test
 import (
 	reflect "reflect"
 
+	worker "github.com/juju/worker/v3"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -71,4 +72,42 @@ func (m *MockWatcher[T]) Wait() error {
 func (mr *MockWatcherMockRecorder[T]) Wait() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockWatcher[T])(nil).Wait))
+}
+
+// MockWatcherRegistry is a mock of WatcherRegistry interface.
+type MockWatcherRegistry struct {
+	ctrl     *gomock.Controller
+	recorder *MockWatcherRegistryMockRecorder
+}
+
+// MockWatcherRegistryMockRecorder is the mock recorder for MockWatcherRegistry.
+type MockWatcherRegistryMockRecorder struct {
+	mock *MockWatcherRegistry
+}
+
+// NewMockWatcherRegistry creates a new mock instance.
+func NewMockWatcherRegistry(ctrl *gomock.Controller) *MockWatcherRegistry {
+	mock := &MockWatcherRegistry{ctrl: ctrl}
+	mock.recorder = &MockWatcherRegistryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWatcherRegistry) EXPECT() *MockWatcherRegistryMockRecorder {
+	return m.recorder
+}
+
+// Register mocks base method.
+func (m *MockWatcherRegistry) Register(w worker.Worker) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Register", w)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Register indicates an expected call of Register.
+func (mr *MockWatcherRegistryMockRecorder) Register(w interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockWatcherRegistry)(nil).Register), w)
 }

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -57,14 +57,10 @@ func (w *watcherCommon) Stop() error {
 // have been removed, this can be removed too.
 func GetWatcherByID(watcherRegistry facade.WatcherRegistry, resources facade.Resources, id string) (worker.Worker, error) {
 	watcher, err := watcherRegistry.Get(id)
-	if err != nil {
-		if errors.Is(err, errors.NotFound) {
-			return resources.Get(id), nil
-		} else {
-			return nil, errors.Trace(err)
-		}
+	if err == nil {
+		return watcher, nil
 	}
-	return watcher, nil
+	return resources.Get(id), nil
 }
 
 // SrvAllWatcher defines the API methods on a state.Multiwatcher.

--- a/core/watcher/registry/registry.go
+++ b/core/watcher/registry/registry.go
@@ -67,9 +67,8 @@ func NewRegistry(clock clock.Clock, opts ...Option) (*Registry, error) {
 		runner: worker.NewRunner(worker.RunnerParams{
 			// Prevent the runner from restarting the worker, if one of the
 			// workers dies, we want to stop the whole thing.
-			IsFatal:       func(err error) bool { return false },
-			ShouldRestart: func(err error) bool { return false },
-			Clock:         clock,
+			IsFatal: func(err error) bool { return false },
+			Clock:   clock,
 		}),
 		watcherWrapper: watcherLogDecorator(o.logger),
 	}

--- a/core/watcher/registry/registry.go
+++ b/core/watcher/registry/registry.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"fmt"
 	"strconv"
 	"sync/atomic"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
+)
+
+const (
+	// DefaultNamespace is the default namespace for watchers.
+	DefaultNamespace = "watcher"
 )
 
 // Logger is the interface we need to log when a worker finishes.
@@ -104,7 +110,7 @@ func (r *Registry) Get(id string) (worker.Worker, error) {
 // watcher.
 func (r *Registry) Register(w worker.Worker) (string, error) {
 	nsCounter := atomic.AddInt64(&r.namespaceCounter, 1)
-	namespace := strconv.Itoa(int(nsCounter))
+	namespace := fmt.Sprintf("%s-%d", DefaultNamespace, nsCounter)
 
 	err := r.register(namespace, w)
 	if err != nil {

--- a/core/watcher/registry/registry.go
+++ b/core/watcher/registry/registry.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// DefaultNamespace is the default namespace for watchers.
-	DefaultNamespace = "watcher"
+	DefaultNamespace = "w"
 )
 
 // Logger is the interface we need to log when a worker finishes.

--- a/core/watcher/registry/registry.go
+++ b/core/watcher/registry/registry.go
@@ -67,8 +67,9 @@ func NewRegistry(clock clock.Clock, opts ...Option) (*Registry, error) {
 		runner: worker.NewRunner(worker.RunnerParams{
 			// Prevent the runner from restarting the worker, if one of the
 			// workers dies, we want to stop the whole thing.
-			IsFatal: func(err error) bool { return false },
-			Clock:   clock,
+			IsFatal:       func(err error) bool { return false },
+			ShouldRestart: func(err error) bool { return false },
+			Clock:         clock,
 		}),
 		watcherWrapper: watcherLogDecorator(o.logger),
 	}

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0
-	github.com/juju/worker/v3 v3.2.0
+	github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.11

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0
-	github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c
+	github.com/juju/worker/v3 v3.3.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.11

--- a/go.sum
+++ b/go.sum
@@ -906,8 +906,8 @@ github.com/juju/viddy v0.0.0-beta5/go.mod h1:5Yvv+opdIEDt15Tt0++8YvccVykcGJeVXxq
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c h1:Ldlcz+3ILHsuwdRySrGw4poDVZiuwwI64S8vV7ifiJ0=
-github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
+github.com/juju/worker/v3 v3.3.0 h1:HFEQm/xNrzS5ZBGTOE43MIfcdO/graBk6ShtmomoEl0=
+github.com/juju/worker/v3 v3.3.0/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/go.sum
+++ b/go.sum
@@ -906,8 +906,8 @@ github.com/juju/viddy v0.0.0-beta5/go.mod h1:5Yvv+opdIEDt15Tt0++8YvccVykcGJeVXxq
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v3 v3.2.0 h1:u2D0bc8r6AEuUR6B8he1nErJcZE04uKr6Gtj1KGargA=
-github.com/juju/worker/v3 v3.2.0/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
+github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c h1:Ldlcz+3ILHsuwdRySrGw4poDVZiuwwI64S8vV7ifiJ0=
+github.com/juju/worker/v3 v3.2.1-0.20230626153735-e43ac123ef3c/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=


### PR DESCRIPTION
The following wires up all watchers to primarily look in the watcher registry before looking at the resource. We're moving all watchers to the watcher registry so that the lifecycle of a watcher is correctly managed. Previously, if a watcher terminates, then the resources would still hold a reference to the dead watcher. The only way to release it would be to close the connection and reopen it. The watcher registry is different in that it can let go of watchers if they die. The watcher registry will return not found to indicate that the watcher it's no longer available.

In addition, we no longer attempt to restart the watcher upon failure. This mirrors the old behaviour for now, but it might be worthwhile exploring if that's correct. It might be helpful to restart a watcher if for instance there is a db error. Retrying from the client will prevent excessive churn.

Note: we've hardcoded the juju/worker revision here until someone can make a release.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ cd tests
$ ./main.sh secrets_iaas
```
