### PR TITLE
[JUJU-3929] Add openstack image-id constraint integration test

### DIFF
--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -13,6 +13,9 @@ test_constraints_common() {
 		"lxd" | "lxd-remote" | "localhost")
 			run "run_constraints_lxd"
 			;;
+		"openstack")
+			run "run_constraints_openstack"
+			;;
 		"ec2")
 			run "run_constraints_aws"
 			;;

--- a/tests/suites/constraints/constraints_openstack.sh
+++ b/tests/suites/constraints/constraints_openstack.sh
@@ -1,0 +1,30 @@
+run_constraints_openstack() {
+	name="constraints-openstack"
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+	check_dependencies openstack
+
+	file="${TEST_DIR}/constraints-openstack.txt"
+
+	ensure "${name}" "${file}"
+
+	# The openstack cluster must contain an image named 'jammy', otherwise
+	# the test cannot run.
+	echo "Ensure there is an image with name 'jammy'"
+	jammy_id=$(openstack image list -f json --name jammy | jq -r '.[] | .ID')
+	if [[ -z ${jammy_id} ]]; then
+		echo "No image available with name 'jammy' on openstack"
+		exit 1
+	fi
+
+	juju add-machine --constraints "image-id=${jammy_id}"
+
+	wait_for_machine_agent_status "0" "started"
+
+	echo "Ensure machine 0 uses the correct image ID from image-id constraint"
+	juju_machine_name=$(juju show-machine --format json | jq -r '.["machines"]["0"]["hostname"]')
+	openstack server list -f json --name ${juju_machine_name} | jq -r '.[] | .Image' | check "jammy"
+
+	destroy_model "${name}"
+}


### PR DESCRIPTION
This commit adds one integration test for openstack when using image-id constraint. This is a particular test because the user needs to make sure that an image is present in the openstack cluster, instead of creating it automatically.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [X] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

In order to QA this, you will need to have access to an openstack cluster and add an image named `jammy`, since the test uses this image to retrieve it's id and then pass it to the constraint `image-id`.

```
./main.sh -v -c openstack -p openstack constraints
```
