### PR TITLE
Fix schema gen output

### DIFF
--- a/apiserver/facade/registry_test.go
+++ b/apiserver/facade/registry_test.go
@@ -27,7 +27,7 @@ var (
 
 func (s *RegistrySuite) TestRegister(c *gc.C) {
 	registry := &facade.Registry{}
-	err := registry.Register("myfacade", 123, testFacade, interfaceType)
+	err := registry.Register("myfacade", 123, facade.AlwaysAllowed, testFacade, interfaceType)
 	c.Assert(err, jc.ErrorIsNil)
 
 	factory, err := registry.GetFactory("myfacade", 123)
@@ -39,10 +39,10 @@ func (s *RegistrySuite) TestRegister(c *gc.C) {
 
 func (s *RegistrySuite) TestListDetails(c *gc.C) {
 	registry := &facade.Registry{}
-	err := registry.Register("f2", 6, testFacade, interfaceType)
+	err := registry.Register("f2", 6, facade.AlwaysAllowed, testFacade, interfaceType)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = registry.Register("f1", 9, validIdFactory, intPtrType)
+	err = registry.Register("f1", 9, facade.AlwaysAllowed, validIdFactory, intPtrType)
 	c.Assert(err, jc.ErrorIsNil)
 
 	details := registry.ListDetails()
@@ -119,7 +119,7 @@ func (*RegistrySuite) TestRegisterAlreadyPresent(c *gc.C) {
 		var i = 200
 		return &i, nil
 	}
-	err := registry.Register("name", 0, secondIdFactory, intPtrType)
+	err := registry.Register("name", 0, facade.AlwaysAllowed, secondIdFactory, intPtrType)
 	c.Assert(err, gc.ErrorMatches, `object "name\(0\)" already registered`)
 
 	factory, err := registry.GetFactory("name", 0)
@@ -191,7 +191,7 @@ func assertRegister(c *gc.C, registry *facade.Registry, name string, version int
 }
 
 func assertRegisterFlag(c *gc.C, registry *facade.Registry, name string, version int) {
-	err := registry.Register(name, version, validIdFactory, intPtrType)
+	err := registry.Register(name, version, facade.AlwaysAllowed, validIdFactory, intPtrType)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/apiserver/facades/client/action/register.go
+++ b/apiserver/facades/client/action/register.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/juju/errors"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 )
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Action", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Action", 7, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newActionAPIV7(ctx)
 	}, reflect.TypeOf((*APIv7)(nil)))
 }
@@ -25,4 +26,11 @@ func newActionAPIV7(ctx facade.Context) (*APIv7, error) {
 		return nil, errors.Trace(err)
 	}
 	return &APIv7{api}, nil
+}
+
+func authorizeCheck(auth facade.Authorizer) error {
+	if !auth.AuthClient() {
+		return apiservererrors.ErrPerm
+	}
+	return nil
 }

--- a/apiserver/facades/client/annotations/register.go
+++ b/apiserver/facades/client/annotations/register.go
@@ -14,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Annotations", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Annotations", 2, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }
@@ -35,4 +35,11 @@ func newAPI(ctx facade.Context) (*API, error) {
 		access:     getState(st, m),
 		authorizer: authorizer,
 	}, nil
+}
+
+func authorizeCheck(auth facade.Authorizer) error {
+	if !auth.AuthClient() {
+		return apiservererrors.ErrPerm
+	}
+	return nil
 }

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -8,24 +8,25 @@ import (
 
 	"github.com/juju/errors"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 )
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Application", 15, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Application", 15, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV15(ctx)
 	}, reflect.TypeOf((*APIv15)(nil)))
-	registry.MustRegister("Application", 16, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Application", 16, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV16(ctx) // DestroyApplication & DestroyUnit gains dry-run
 	}, reflect.TypeOf((*APIv16)(nil)))
-	registry.MustRegister("Application", 17, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Application", 17, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV17(ctx) // Drop deprecated DestroyUnits & Destroy facades
 	}, reflect.TypeOf((*APIv17)(nil)))
-	registry.MustRegister("Application", 18, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Application", 18, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV18(ctx) // Added new DeployFromRepository
 	}, reflect.TypeOf((*APIv18)(nil)))
-	registry.MustRegister("Application", 19, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegisterWithAuth("Application", 19, authorizeCheck, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV19(ctx) // Added new DeployFromRepository
 	}, reflect.TypeOf((*APIv19)(nil)))
 }
@@ -68,4 +69,11 @@ func newFacadeV15(ctx facade.Context) (*APIv15, error) {
 		return nil, errors.Trace(err)
 	}
 	return &APIv15{api}, nil
+}
+
+func authorizeCheck(auth facade.Authorizer) error {
+	if !auth.AuthClient() {
+		return apiservererrors.ErrPerm
+	}
+	return nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1993,9 +1993,6 @@
         "Description": "APIv19 provides the Application API facade for version 19.",
         "Version": 19,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "model-user"
         ],
         "Schema": {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -468,6 +468,19 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 		if objValue, ok := r.objectCache[objKey]; ok {
 			return objValue, nil
 		}
+
+		// Check if the caller is allowed to access this facade, before
+		// creating the object.
+		allower, err := r.facades.GetAllower(rootName, version)
+		if allower != nil {
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if err := allower(r.authorizer); err != nil {
+				return reflect.Value{}, err
+			}
+		}
+
 		// Now that we have the write lock, check one more time in case
 		// someone got the write lock before us.
 		factory, err := r.facades.GetFactory(rootName, version)

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -153,9 +153,9 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	expectedType := reflect.TypeOf((*testingType)(nil))
 
 	registry := new(facade.Registry)
-	registry.Register("my-testing-facade", 0, myBadFacade, expectedType)
-	registry.Register("my-testing-facade", 1, myGoodFacade, expectedType)
-	registry.Register("my-testing-facade", 2, myErrFacade, expectedType)
+	registry.Register("my-testing-facade", 0, facade.AlwaysAllowed, myBadFacade, expectedType)
+	registry.Register("my-testing-facade", 1, facade.AlwaysAllowed, myGoodFacade, expectedType)
+	registry.Register("my-testing-facade", 2, facade.AlwaysAllowed, myErrFacade, expectedType)
 	srvRoot := apiserver.TestingAPIRoot(registry)
 
 	// Now, myGoodFacade returns the right type, so calling it should work
@@ -248,7 +248,7 @@ func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
 	}
 	registry := new(facade.Registry)
 	reflectType := reflect.TypeOf((*countingType)(nil))
-	registry.Register("my-counting-facade", 0, newIdCounter, reflectType)
+	registry.Register("my-counting-facade", 0, facade.AlwaysAllowed, newIdCounter, reflectType)
 	srvRoot := apiserver.TestingAPIRoot(registry)
 
 	// The first time we call FindMethod, it should lookup a facade, and
@@ -279,7 +279,7 @@ func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
 	}
 	reflectType := reflect.TypeOf((*countingType)(nil))
 	registry := new(facade.Registry)
-	registry.Register("my-counting-facade", 0, newIdCounter, reflectType)
+	registry.Register("my-counting-facade", 0, facade.AlwaysAllowed, newIdCounter, reflectType)
 	srvRoot := apiserver.TestingAPIRoot(registry)
 
 	caller, err := srvRoot.FindMethod("my-counting-facade", 0, "Count")

--- a/generate/schemagen/gen/describeapi_mock.go
+++ b/generate/schemagen/gen/describeapi_mock.go
@@ -190,15 +190,15 @@ func (m *MockLinker) EXPECT() *MockLinkerMockRecorder {
 }
 
 // Links mocks base method.
-func (m *MockLinker) Links(arg0 string, arg1 facade.Factory) []string {
+func (m *MockLinker) Links(arg0 string, arg1 facade.Allower, arg2 facade.Factory) []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Links", arg0, arg1)
+	ret := m.ctrl.Call(m, "Links", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
 // Links indicates an expected call of Links.
-func (mr *MockLinkerMockRecorder) Links(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockLinkerMockRecorder) Links(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Links", reflect.TypeOf((*MockLinker)(nil).Links), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Links", reflect.TypeOf((*MockLinker)(nil).Links), arg0, arg1, arg2)
 }

--- a/generate/schemagen/gen/generator.go
+++ b/generate/schemagen/gen/generator.go
@@ -20,8 +20,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package gen -destination describeapi_mock.go -write_package_comment=false github.com/juju/juju/generate/schemagen/gen APIServer,Registry,PackageRegistry,Linker
-
 type APIServer interface {
 	AllFacades() Registry
 	AdminFacadeDetails() []facade.Details
@@ -38,7 +36,7 @@ type PackageRegistry interface {
 }
 
 type Linker interface {
-	Links(string, facade.Factory) []string
+	Links(string, facade.Allower, facade.Factory) []string
 }
 
 // Option to be passed to Connect to customize the resulting instance.
@@ -129,7 +127,7 @@ func Generate(pkgRegistry PackageRegistry, linker Linker, client APIServer, opti
 
 		result[i].Name = facade.Name
 		result[i].Version = version
-		result[i].AvailableTo = linker.Links(facade.Name, facade.Factory)
+		result[i].AvailableTo = linker.Links(facade.Name, facade.Allower, facade.Factory)
 
 		var objType *rpcreflect.ObjType
 		kind, err := registry.GetType(facade.Name, version)

--- a/generate/schemagen/gen/generator_test.go
+++ b/generate/schemagen/gen/generator_test.go
@@ -83,7 +83,7 @@ func (s *GenSuite) expectList() {
 
 func (s *GenSuite) expectLinker() {
 	aExp := s.linker.EXPECT()
-	aExp.Links(gomock.Any(), gomock.Any()).Return([]string{})
+	aExp.Links(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{})
 }
 
 func (s *GenSuite) expectLoadPackage() {

--- a/generate/schemagen/gen/package_test.go
+++ b/generate/schemagen/gen/package_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package gen -destination describeapi_mock.go -write_package_comment=false github.com/juju/juju/generate/schemagen/gen APIServer,Registry,PackageRegistry,Linker
+
 func TestPackage(t *stdtesting.T) {
 	testing.MgoTestPackage(t)
 }


### PR DESCRIPTION
The following starts to fix the schema gen output by forcing an allower to check if the facade is allowed to be created before creating the facade.

Unfortunately, we have to brute force a fake facade context through the start of each facade. This doesn't work because of nil pointer exceptions (panics) which can result in misleading result set.

The fix is simple, we move all the facade setup auth checks up front in an allower check. This will prevent the construction of a context and other mindless objects before being told that you're not allowed.

This should improve the security posture of juju and is probably worthwhile doing. It's just a lot of work.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
```

```sh
$ make rebuild-schema
```
