### PR TITLE
Revert 15398

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -794,7 +794,6 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 			ApplicationOfferDetails: arg.Offer,
 			ApplicationAlias:        arg.ApplicationAlias,
 			Macaroon:                arg.Macaroon,
-			AuthToken:               arg.AuthToken,
 		}},
 	}
 	if arg.ControllerInfo != nil {

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -595,7 +595,6 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 				ApplicationAlias:        "alias",
 				ApplicationOfferDetails: offer,
 				Macaroon:                mac,
-				AuthToken:               "auth-token",
 				ControllerInfo:          controllerInfo,
 			},
 		},
@@ -608,7 +607,6 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		Offer:            offer,
 		ApplicationAlias: "alias",
 		Macaroon:         mac,
-		AuthToken:        "auth-token",
 		ControllerInfo: &crossmodel.ControllerInfo{
 			ControllerTag: coretesting.ControllerTag,
 			Alias:         "controller-alias",

--- a/api/client/applicationoffers/client.go
+++ b/api/client/applicationoffers/client.go
@@ -289,7 +289,6 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 	return params.ConsumeOfferDetails{
 		Offer:          theOne.Offer,
 		Macaroon:       theOne.Macaroon,
-		AuthToken:      theOne.AuthToken,
 		ControllerInfo: theOne.ControllerInfo,
 	}, nil
 }

--- a/api/client/applicationoffers/client_test.go
+++ b/api/client/applicationoffers/client_test.go
@@ -496,7 +496,6 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 				ConsumeOfferDetails: params.ConsumeOfferDetails{
 					Offer:          &offer,
 					Macaroon:       mac,
-					AuthToken:      "auth-token",
 					ControllerInfo: controllerInfo,
 				},
 			},
@@ -511,7 +510,6 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 	c.Assert(details, jc.DeepEquals, params.ConsumeOfferDetails{
 		Offer:          &offer,
 		Macaroon:       mac,
-		AuthToken:      "auth-token",
 		ControllerInfo: controllerInfo,
 	})
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -408,7 +408,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 	srv.shared.cancel = srv.tomb.Dying()
 
 	// The auth context for authenticating access to application offers.
-	srv.offerAuthCtxt, err = newOfferAuthContext(cfg.StatePool, srv.jwtAuthenticator)
+	srv.offerAuthCtxt, err = newOfferAuthcontext(cfg.StatePool)
 	if err != nil {
 		unsubscribeControllerConfig()
 		return nil, errors.Trace(err)

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -74,7 +74,7 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,7 +94,7 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = authContext.CheckOfferAccessCaveat("different-caveat " + permCheckDetails)
 	c.Assert(err, gc.ErrorMatches, ".*caveat not recognized.*")
@@ -108,7 +108,7 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:]
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, gc.ErrorMatches, `source-model-uuid "invalid" not valid`)
@@ -122,7 +122,7 @@ func (s *authSuite) TestCheckLocalAccessRequest(c *gc.C) {
 			"mysql-uuid:mary": permission.ConsumeAccess,
 		},
 	}
-	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -151,7 +151,7 @@ func (s *authSuite) TestCheckLocalAccessRequestControllerAdmin(c *gc.C) {
 			coretesting.ControllerTag.Id() + ":mary": permission.SuperuserAccess,
 		},
 	}
-	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -174,7 +174,7 @@ func (s *authSuite) TestCheckLocalAccessRequestModelAdmin(c *gc.C) {
 			uuid.String() + ":mary": permission.AdminAccess,
 		},
 	}
-	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -195,7 +195,7 @@ func (s *authSuite) TestCheckLocalAccessRequestNoPermission(c *gc.C) {
 		tag:         names.NewModelTag(uuid.String()),
 		permissions: make(map[string]permission.Access),
 	}
-	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(st, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -215,7 +215,7 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
@@ -228,7 +228,7 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 }
 
 func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := authContext.CreateRemoteRelationMacaroon(
 		context.TODO(),
@@ -244,7 +244,7 @@ func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
 		context.TODO(),
@@ -273,7 +273,7 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
 		context.TODO(),
@@ -299,7 +299,7 @@ func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
 		context.TODO(),
@@ -321,7 +321,7 @@ func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
 	authContext = authContext.WithClock(clock)
@@ -348,7 +348,7 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
@@ -373,7 +373,7 @@ func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
@@ -401,7 +401,7 @@ func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
@@ -425,7 +425,7 @@ func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery, nil, nil)
+	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
 	authContext = authContext.WithClock(clock)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -79,7 +79,7 @@ func TestingAPIRoot(facades *facade.Registry) rpc.Root {
 func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHandler, *common.Resources) {
 	authenticator, err := stateauthenticator.NewAuthenticator(pool, clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
-	offerAuthCtxt, err := newOfferAuthContext(pool, nil)
+	offerAuthCtxt, err := newOfferAuthcontext(pool)
 	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
 		httpAuthenticators:  []authentication.HTTPAuthenticator{authenticator},

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2081,7 +2081,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 	if appName == "" {
 		appName = arg.OfferName
 	}
-	_, err = api.saveRemoteApplication(sourceModelTag, appName, externalControllerUUID, arg.ApplicationOfferDetails, arg.Macaroon, arg.AuthToken)
+	_, err = api.saveRemoteApplication(sourceModelTag, appName, externalControllerUUID, arg.ApplicationOfferDetails, arg.Macaroon)
 	return err
 }
 
@@ -2093,7 +2093,6 @@ func (api *APIBase) saveRemoteApplication(
 	externalControllerUUID string,
 	offer params.ApplicationOfferDetails,
 	mac *macaroon.Macaroon,
-	authToken string,
 ) (RemoteApplication, error) {
 	remoteEps := make([]charm.Relation, len(offer.Endpoints))
 	for j, ep := range offer.Endpoints {
@@ -2140,7 +2139,6 @@ func (api *APIBase) saveRemoteApplication(
 		Spaces:                 remoteSpaces,
 		Bindings:               offer.Bindings,
 		Macaroon:               mac,
-		AuthToken:              authToken,
 	})
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -134,7 +134,6 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 		Endpoints:   []charm.Relation{{Name: "database", Interface: "mysql", Role: "provider"}},
 		Spaces:      []*environs.ProviderSpaceInfo{},
 		Macaroon:    testMac,
-		AuthToken:   "auth-token",
 	}
 
 	s.consumeApplicationArgs = params.ConsumeApplicationArgs{
@@ -147,8 +146,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 				Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",
 			},
-			Macaroon:  testMac,
-			AuthToken: "auth-token",
+			Macaroon: testMac,
 		}},
 	}
 }

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -40,7 +40,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery, nil, nil)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 
 	api, err := applicationoffers.CreateOffersAPI(

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -57,7 +57,7 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.bakery = &mockBakeryService{caveats: make(map[string][]checkers.Caveat)}
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery, nil, nil)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
@@ -1150,7 +1150,7 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery, nil, nil)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
@@ -1193,14 +1193,14 @@ func (s *consumeSuite) TestConsumeDetailsNoPermission(c *gc.C) {
 }
 
 func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
-	s.assertConsumeDetailsWithPermission(c, false, "")
+	s.assertConsumeDetailsWithPermission(c, false)
 }
 
 func (s *consumeSuite) TestConsumeDetailsSpecifiedUser(c *gc.C) {
-	s.assertConsumeDetailsWithPermission(c, true, "")
+	s.assertConsumeDetailsWithPermission(c, true)
 }
 
-func (s *consumeSuite) assertConsumeDetailsWithPermission(c *gc.C, specifiedUser bool, authToken string) {
+func (s *consumeSuite) assertConsumeDetailsWithPermission(c *gc.C, specifiedUser bool) {
 	s.setupOffer()
 	st := s.mockStatePool.st[testing.ModelTag.Id()]
 	st.(*mockState).users["someone"] = &mockUser{"someone"}
@@ -1251,11 +1251,6 @@ func (s *consumeSuite) assertConsumeDetailsWithPermission(c *gc.C, specifiedUser
 		Addrs:         []string{"192.168.1.1:17070"},
 		CACert:        testing.CACert,
 	})
-	c.Assert(results.Results[0].AuthToken, gc.Equals, authToken)
-	if authToken != "" {
-		c.Assert(results.Results[0].Macaroon, gc.IsNil)
-		return
-	}
 	c.Assert(results.Results[0].Macaroon.Id(), jc.DeepEquals, []byte("id"))
 
 	cav := s.bakery.caveats[string(results.Results[0].Macaroon.Id())]

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -95,7 +95,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = commoncrossmodel.NewAuthContext(s.st, thirdPartyKey, s.bakery, nil, nil)
+	s.authContext, err = commoncrossmodel.NewAuthContext(s.st, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
 		s.st, fw, s.resources, s.authorizer,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -88,7 +88,7 @@ func (s *CrossModelSecretsSuite) SetUpTest(c *gc.C) {
 		OpsAuthorizer: crossmodel.CrossModelAuthorizer{},
 	})
 	s.bakery = &mockBakery{bakery}
-	s.authContext, err = crossmodel.NewAuthContext(nil, key, s.bakery, nil, nil)
+	s.authContext, err = crossmodel.NewAuthContext(nil, key, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3270,9 +3270,6 @@
                         "application-description": {
                             "type": "string"
                         },
-                        "auth-token": {
-                            "type": "string"
-                        },
                         "bindings": {
                             "type": "object",
                             "patternProperties": {
@@ -4762,9 +4759,6 @@
                 "ConsumeOfferDetails": {
                     "type": "object",
                     "properties": {
-                        "auth-token": {
-                            "type": "string"
-                        },
                         "external-controller": {
                             "$ref": "#/definitions/ExternalControllerInfo"
                         },
@@ -4797,9 +4791,6 @@
                     "properties": {
                         "ConsumeOfferDetails": {
                             "$ref": "#/definitions/ConsumeOfferDetails"
-                        },
-                        "auth-token": {
-                            "type": "string"
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
@@ -20421,9 +20412,6 @@
                     "type": "object",
                     "properties": {
                         "application-token": {
-                            "type": "string"
-                        },
-                        "auth-token": {
                             "type": "string"
                         },
                         "bakery-version": {

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/apiserverhttp"
-	"github.com/juju/juju/apiserver/authentication/jwt"
 	"github.com/juju/juju/apiserver/bakeryutil"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/core/macaroon"
@@ -43,7 +42,7 @@ func addOfferAuthHandlers(offerAuthCtxt *crossmodel.AuthContext, mux *apiserverh
 	_ = mux.AddHandler("GET", localOfferAccessLocationPath+"/publickey", appOfferDischargeMux)
 }
 
-func newOfferAuthContext(pool *state.StatePool, tokenParser jwt.TokenParser) (*crossmodel.AuthContext, error) {
+func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error) {
 	// Create a bakery service for discharging third-party caveats for
 	// local offer access authentication. This service does not persist keys;
 	// its macaroons should be very short-lived.
@@ -81,7 +80,7 @@ func newOfferAuthContext(pool *state.StatePool, tokenParser jwt.TokenParser) (*c
 		localOfferBakery, location, localOfferBakeryKey, store, locator,
 	}
 	authCtx, err := crossmodel.NewAuthContext(
-		crossmodel.GetBackend(st), key, offerBakery, tokenParser, jwt.PermissionFromToken)
+		crossmodel.GetBackend(st), key, offerBakery)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -22,7 +22,6 @@ type FakeAuthorizer struct {
 	AdminTag      names.UserTag
 	HasConsumeTag names.UserTag
 	HasWriteTag   names.UserTag
-	AuthToken     string
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag names.Tag) bool {
@@ -156,9 +155,4 @@ func (fa FakeAuthorizer) EntityHasPermission(entity names.Tag, operation permiss
 		return nil
 	}
 	return errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission)
-}
-
-// AuthTokenString returns the jwt passed to login.
-func (fa FakeAuthorizer) AuthTokenString() string {
-	return fa.AuthToken
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -164,7 +164,6 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.applicationAlias,
 		Macaroon:         consumeDetails.Macaroon,
-		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -112,7 +112,6 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 			Offer:            params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "ctrl:bob/booster.uke"},
 			ApplicationAlias: alias,
 			Macaroon:         mac,
-			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
 				Alias:         "controller-alias",
@@ -158,9 +157,8 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		return params.ConsumeOfferDetails{}, err
 	}
 	return params.ConsumeOfferDetails{
-		Offer:     &params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "bob/booster.uke"},
-		Macaroon:  mac,
-		AuthToken: "auth-token",
+		Offer:    &params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "bob/booster.uke"},
+		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
 			Alias:         "controller-alias",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -970,8 +970,7 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 			OfferName: "mysql",
 			OfferURL:  "admin/default.mysql",
 		},
-		Macaroon:  mac,
-		AuthToken: "auth-token",
+		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
 			Addrs:         []string{"192.168.1.0"},
@@ -988,7 +987,6 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 			},
 			ApplicationAlias: "mysql",
 			Macaroon:         mac,
-			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
 				Alias:         "controller-alias",

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1486,7 +1486,6 @@ func (h *bundleHandler) consumeOffer(change *bundlechanges.ConsumeOfferChange) e
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: p.ApplicationName,
 		Macaroon:         consumeDetails.Macaroon,
-		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -343,7 +343,6 @@ func (c *addRelationCommand) maybeConsumeOffer(targetClient applicationAddRelati
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.remoteEndpoint.ApplicationName,
 		Macaroon:         consumeDetails.Macaroon,
-		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/integrateremote_test.go
+++ b/cmd/juju/application/integrateremote_test.go
@@ -49,7 +49,6 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
-			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: testing.ControllerTag,
 				Addrs:         []string{"192.168.1.0"},
@@ -71,7 +70,6 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
-			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: testing.ControllerTag,
 				Addrs:         []string{"192.168.1.0"},
@@ -240,8 +238,7 @@ func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferD
 			OfferName: "hosted-mysql",
 			OfferURL:  "bob/prod.hosted-mysql",
 		},
-		Macaroon:  m.mac,
-		AuthToken: "auth-token",
+		Macaroon: m.mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: testing.ControllerTag.String(),
 			Addrs:         []string{"192.168.1.0"},

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -66,9 +66,6 @@ type ConsumeApplicationArgs struct {
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon
 
-	// AuthToken is the JWT used for auth.
-	AuthToken string
-
 	// ControllerInfo contains connection details to the controller
 	// hosting the offer.
 	ControllerInfo *ControllerInfo

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -184,9 +184,6 @@ type ConsumeApplicationArg struct {
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 
-	// AuthToken is the JWT used for auth.
-	AuthToken string `json:"auth-token,omitempty"`
-
 	// ControllerInfo contains connection details to the controller
 	// hosting the offer.
 	ControllerInfo *ExternalControllerInfo `json:"external-controller,omitempty"`
@@ -545,9 +542,6 @@ type RegisterRemoteRelationArg struct {
 
 	// BakeryVersion is the version of the bakery used to mint macaroons.
 	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
-
-	// AuthToken is the JWT used for auth.
-	AuthToken string `json:"auth-token,omitempty"`
 }
 
 // RegisterRemoteRelationArgs holds args used to add remote relations.
@@ -629,7 +623,6 @@ type RemoteApplicationInfoResults struct {
 type ConsumeOfferDetails struct {
 	Offer          *ApplicationOfferDetails `json:"offer,omitempty"`
 	Macaroon       *macaroon.Macaroon       `json:"macaroon,omitempty"`
-	AuthToken      string                   `json:"auth-token,omitempty"`
 	ControllerInfo *ExternalControllerInfo  `json:"external-controller,omitempty"`
 }
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-uuid"
 	"github.com/juju/charm/v10"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -86,13 +85,9 @@ func ApplicationOfferEndpoint(offer crossmodel.ApplicationOffer, relationName st
 }
 
 // TODO(wallyworld) - remove when we use UUID everywhere
-func applicationOfferUUID(st *State, offerNameOrUUID string) (string, error) {
-	_, err := uuid.ParseUUID(offerNameOrUUID)
-	if err == nil {
-		return offerNameOrUUID, nil
-	}
+func applicationOfferUUID(st *State, offerName string) (string, error) {
 	appOffers := &applicationOffers{st: st}
-	offer, err := appOffers.ApplicationOffer(offerNameOrUUID)
+	offer, err := appOffers.ApplicationOffer(offerName)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2435,8 +2435,6 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 		},
 		// Macaroon not exported.
 		Macaroon: mac,
-		// AuthToken not exported.
-		AuthToken: "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
@@ -2616,8 +2614,6 @@ func (s *MigrationExportSuite) TestRemoteRelationSettingsForUnitsInCMR(c *gc.C) 
 		},
 		// Macaroon not exported.
 		Macaroon: mac,
-		// AuthToken not exported.
-		AuthToken: "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -47,7 +47,6 @@ type remoteApplicationDoc struct {
 	IsConsumerProxy      bool                `bson:"is-consumer-proxy"`
 	Version              int                 `bson:"version"`
 	Macaroon             string              `bson:"macaroon,omitempty"`
-	AuthToken            string              `bson:"auth-token,omitempty"`
 }
 
 // remoteEndpointDoc represents the internal state of a remote application endpoint in MongoDB.
@@ -823,11 +822,6 @@ func (a *RemoteApplication) Macaroon() (*macaroon.Macaroon, error) {
 	return &mac, nil
 }
 
-// AuthToken returns the encoded JWT.
-func (s *RemoteApplication) AuthToken() string {
-	return s.doc.AuthToken
-}
-
 // String returns the application name.
 func (a *RemoteApplication) String() string {
 	return a.doc.Name
@@ -900,9 +894,6 @@ type AddRemoteApplicationParams struct {
 
 	// Macaroon is used for authentication on the offering side.
 	Macaroon *macaroon.Macaroon
-
-	// AuthToken is the JWT used for auth.
-	AuthToken string
 }
 
 // Validate returns an error if there's a problem with the
@@ -971,7 +962,6 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		IsConsumerProxy:      args.IsConsumerProxy,
 		Version:              args.ConsumeVersion,
 		Macaroon:             macJSON,
-		AuthToken:            args.AuthToken,
 	}
 	if !args.IsConsumerProxy {
 		if appDoc.Version, err = sequenceWithMin(st, args.OfferUUID, 1); err != nil {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -118,7 +118,6 @@ func (s *remoteApplicationSuite) makeRemoteApplication(c *gc.C, name, url string
 		Spaces:                 spaces,
 		Bindings:               bindings,
 		Macaroon:               mac,
-		AuthToken:              "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -356,13 +355,12 @@ func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 	c.Assert(eps, gc.DeepEquals, []state.Endpoint{serverEP, adminEp, loggingEp})
 }
 
-func (s *remoteApplicationSuite) TestAuth(c *gc.C) {
+func (s *remoteApplicationSuite) TestMacaroon(c *gc.C) {
 	mac, err := newMacaroon("test")
 	c.Assert(err, jc.ErrorIsNil)
 	appMac, err := s.application.Macaroon()
 	c.Assert(err, jc.ErrorIsNil)
 	assertMacaroonEquals(c, appMac, mac)
-	c.Assert(s.application.AuthToken(), gc.Equals, "auth-token")
 }
 
 func (s *remoteApplicationSuite) TestApplicationRefresh(c *gc.C) {


### PR DESCRIPTION
Revert https://github.com/juju/juju/pull/15398

Conflicts:
```
- apiserver/admin.go
- apiserver/apiserver.go
- apiserver/common/crossmodel/auth.go
- apiserver/export_test.go
- apiserver/facade/interface.go
- apiserver/facades/client/applicationoffers/applicationoffers.go
- apiserver/facades/client/applicationoffers/applicationoffers_test.go
- apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
- apiserver/localofferauth.go
- apiserver/root.go
- apiserver/testing/fakeauthorizer.go

```