### PR TITLE
Improvements to check-merge-conflicts action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -32,14 +32,18 @@ jobs:
 
       - name: Attempt to merge
         id: merge
+        env:
+          SOURCE_BRANCH: ${{ steps.branch.outputs.source }}
         run: |
           set -x
+          git fetch origin "$SOURCE_BRANCH"
+          git branch "$SOURCE_BRANCH" "origin/$SOURCE_BRANCH"
           # Need to set Git username/email to do the merge (yawn)
           git config user.name 'jujubot'
           git config user.email 'fake@address.me'
           
           set +e
-          git merge origin/${{ steps.branch.outputs.source }}
+          git merge "$SOURCE_BRANCH"
           case $? in
           0)
             echo "conflicts=false" >> "$GITHUB_OUTPUT"
@@ -52,29 +56,24 @@ jobs:
             ;;
           esac
 
+      - name: Generate notification message
+        if: steps.merge.outputs.conflicts == 'true'
+        id: message
+        env:
+          SOURCE_BRANCH: ${{ steps.branch.outputs.source }}
+          TARGET_BRANCH: ${{ steps.branch.outputs.target }}
+          EMAIL_TO_MM_USER: ${{ secrets.EMAIL_TO_MM_USER }}
+          IGNORE_EMAILS: ${{ secrets.MERGE_NOTIFY_IGNORE_EMAILS }}
+        run: |
+          MESSAGE=$(go run ./scripts/try-merge errmsg)
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+
       - name: Notify if merge has conflicts
         if: steps.merge.outputs.conflicts == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MM_TOKEN: ${{ secrets.MM_TOKEN }}
-          MM_USERS: ${{ secrets.MM_USERS }}
+          MESSAGE: ${{ steps.message.outputs.message }}
         run: |
-          set -ex
-          SOURCE_BRANCH=${{ steps.branch.outputs.source }}
-          TARGET_BRANCH=${{ steps.branch.outputs.target }}
-          
-          # Get PR info
-          PR_INFO=$(gh pr list --search="${{ github.sha }}" --state=merged --base="$SOURCE_BRANCH" --json='number,author')
-          PR_NUMBER=$(echo "$PR_INFO" | jq '.[].number')
-          
-          PR_AUTHOR=$(echo "$PR_INFO" | jq -r '.[].author.login')
-          MM_USER=$(echo "$MM_USERS" | jq -r ".\"$PR_AUTHOR\"")
-          if [[ $MM_USER == '' || $MM_USER == null ]]; then
-            MM_USER=$PR_AUTHOR
-          fi
-          
-          MESSAGE="@$MM_USER your PR [#$PR_NUMBER](https://github.com/juju/juju/pull/$PR_NUMBER) has created merge conflicts - please merge $SOURCE_BRANCH into $TARGET_BRANCH and resolve the conflicts. Thanks! :)"
-          
           # install mmctl
           curl https://github.com/mattermost/mmctl/releases/download/v7.8.5/linux_amd64.tar -Lo mmctl.tar
           tar -xvf mmctl.tar

--- a/scripts/try-merge/execute.go
+++ b/scripts/try-merge/execute.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+type executeArgs struct {
+	command string
+	args    []string
+	dir     string
+}
+
+type executeResults struct {
+	runError error
+	exitCode int
+
+	stdout, stderr []byte
+}
+
+func execute(args executeArgs) (res executeResults) {
+	cmd := exec.Command(args.command, args.args...)
+	cmd.Dir = args.dir
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+
+	err := cmd.Run()
+	res.runError = err
+	if e := (&exec.ExitError{}); errors.As(err, &e) {
+		res.exitCode = e.ProcessState.ExitCode()
+	}
+	res.stdout, res.stderr = stdout.Bytes(), stderr.Bytes()
+	return
+}
+
+func handleExecuteError(res executeResults) {
+	if res.exitCode > 0 {
+		stderrf("command failed with exit code %d\n", res.exitCode)
+	}
+	if err := res.runError; err != nil {
+		stderrf("stderr: %s\n", res.stderr)
+		panic(err)
+	}
+}

--- a/scripts/try-merge/main.go
+++ b/scripts/try-merge/main.go
@@ -1,0 +1,181 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/juju/collections/set"
+)
+
+// Environment variables to configure script
+var (
+	sourceBranch string // branch containing changes (e.g. 2.9)
+	targetBranch string // branch to merge into (e.g. 3.1)
+	gitDir       string // location of checked out branch. Git commands will be run here
+
+	emailToMMUser map[string]string // mapping of email address -> Mattermost username
+	ignoreEmails  set.Strings       // email addresses to ignore (e.g. bot accounts)
+)
+
+func main() {
+	// Get configuration from environment
+	sourceBranch = os.Getenv("SOURCE_BRANCH")
+	targetBranch = os.Getenv("TARGET_BRANCH")
+	gitDir = os.Getenv("GIT_DIR")
+	fillEmailToMMUserMap()
+	fillIgnoreEmails()
+
+	if len(os.Args) < 2 {
+		fatalf("no command provided")
+	}
+	switch cmd := os.Args[1]; cmd {
+	// TODO: migrate the merging logic from merge.yml to here
+	//case "try-merge":
+	//	tryMerge()
+	case "errmsg":
+		printErrMsg()
+	default:
+		fatalf("unrecognised command %q", cmd)
+	}
+}
+
+// Get the contents of the EMAIL_TO_MM_USER environment variable, which is
+// a JSON mapping of email addresses to Mattermost usernames. Parse this into
+// the emailToMMUser map.
+func fillEmailToMMUserMap() {
+	emailToMMUser = map[string]string{}
+	jsonMap := os.Getenv("EMAIL_TO_MM_USER")
+	err := json.Unmarshal([]byte(jsonMap), &emailToMMUser)
+	if err != nil {
+		// No need to fail - we can still use the commit author name.
+		// Just log a warning.
+		stderrf("WARNING: couldn't parse EMAIL_TO_MM_USER: %v\n", err)
+	}
+}
+
+// Get the contents of the IGNORE_EMAILS environment variable, which is
+// a JSON list of email addresses to ignore / not notify. Parse this into
+// the ignoreEmails set.
+func fillIgnoreEmails() {
+	jsonList := os.Getenv("IGNORE_EMAILS")
+
+	var ignoreEmailsList []string
+	err := json.Unmarshal([]byte(jsonList), &ignoreEmailsList)
+	if err != nil {
+		// No need to fail here
+		stderrf("WARNING: couldn't parse IGNORE_EMAILS: %v\n", err)
+	}
+
+	ignoreEmails = set.NewStrings(ignoreEmailsList...)
+}
+
+// After a failed merge, generate a nice notification message that will be
+// sent to Mattermost.
+func printErrMsg() {
+	// Check required env variables are set
+	if sourceBranch == "" {
+		fatalf("fatal: SOURCE_BRANCH not set")
+	}
+	if targetBranch == "" {
+		fatalf("fatal: TARGET_BRANCH not set")
+	}
+
+	badCommits := findOffendingCommits()
+
+	// Iterate through commits and find people to notify
+	peopleToNotify := set.NewStrings()
+	for _, commit := range badCommits {
+		if ignoreEmails.Contains(commit.Email) {
+			continue
+		}
+
+		_, ok := emailToMMUser[commit.Email]
+		if ok {
+			peopleToNotify.Add("@" + emailToMMUser[commit.Email])
+		} else {
+			// Don't have a username for this email - just use commit author name
+			stderrf("WARNING: no MM username found for email %q\n", commit.Email)
+			peopleToNotify.Add(commit.Author)
+		}
+	}
+
+	// Construct the message
+	taggedUsers := strings.Join(peopleToNotify.Values(), ", ")
+	message := fmt.Sprintf(
+		"%[1]s: your recent changes to `%[2]s` have caused merge conflicts. Please merge `%[2]s` into `%[3]s` and resolve the conflicts.",
+		taggedUsers, sourceBranch, targetBranch)
+	stdoutf(message)
+}
+
+// findOffendingCommits returns a list of commits that may be causing merge
+// conflicts. This only works if Git is currently inside a failed merge.
+func findOffendingCommits() []commitInfo {
+	// Call `git log` to get commit info
+	gitLogRes := execute(executeArgs{
+		command: "git",
+		args: []string{"log",
+			// Restrict to commits which are present in source branch, but not target
+			fmt.Sprintf("%s..%s", targetBranch, sourceBranch),
+			"--merge",     // show refs that touch files having a conflict
+			"--no-merges", // ignore merge commits
+			"--format=" + gitLogJSONFormat,
+		},
+		dir: gitDir,
+	})
+	handleExecuteError(gitLogRes)
+	stderrf("DEBUG: offending commits are\n%s\n", gitLogRes.stdout)
+	gitLogInfo := gitLogOutputToValidJSON(gitLogRes.stdout)
+
+	var commits []commitInfo
+	check(json.Unmarshal(gitLogInfo, &commits))
+	return commits
+}
+
+var gitLogJSONFormat = `{"sha":"%H","author":"%an","email":"%ae"}`
+
+// Transforms the output of `git log` into a valid JSON array.
+func gitLogOutputToValidJSON(raw []byte) []byte {
+	rawString := string(raw)
+	lines := strings.Split(rawString, "\n")
+	// Remove empty last line
+	filteredLines := lines[:len(lines)-1]
+	joinedLines := strings.Join(filteredLines, ",")
+	array := "[" + joinedLines + "]"
+	return []byte(array)
+}
+
+type commitInfo struct {
+	SHA    string `json:"sha"`
+	Author string `json:"author"`
+	Email  string `json:"email"`
+}
+
+func check(err error) {
+	if err != nil {
+		stderrf("%#v\n", err)
+		panic(err)
+	}
+}
+
+// Print to stdout. Only the actual result should go here (the generated
+// notification message).
+func stdoutf(f string, v ...any) {
+	_, _ = fmt.Fprintf(os.Stdout, f, v...)
+}
+
+// Print to stderr. Logging/debug info should go here, so that it is kept
+// separate from the actual output.
+func stderrf(f string, v ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, f, v...)
+}
+
+// Print to stderr and then exit.
+func fatalf(f string, v ...any) {
+	stderrf(f, v...)
+	os.Exit(1)
+}


### PR DESCRIPTION
Add a Go script which parses the git log and determines who might have created merge conflicts. It will determine which files are conflicted, and notify the authors of any commit which touched these files.

Also add the ability to ignore certain commit authors (e.g. jujubot, dependabot).

## Example run

A test run of the new workflow is [here](https://github.com/barrettj12/juju/actions/runs/5407952219/jobs/9826511030).

1. It attempts to merge the current branch (`merge-check-blame`) into the merge target branch (`3.3`). The merge encounters conflicts and is unsuccessful.

2. We then go through the git log, looking at all the files that are conflicted (`--merge` flag), and determine all commits since the last merge that have touched these files.
   ```
   {"sha":"b048634105eba3d66ade23b0a64c69d1097dbd81","author":"Harry Pidcock","email":"harry.pidcock@canonical.com"}
   {"sha":"498f6ff9c0f83704d19b863b8f59269297e6841f","author":"Jack Shaw","email":"jack.shaw@canonical.com"}
   {"sha":"874fd8ed70fb0c0939faa0cd7d1b68d02df27771","author":"Harry Pidcock","email":"harry.pidcock@canonical.com"}
   {"sha":"69548bce394c6f47055e14db663afe35a028ad3e","author":"Harry Pidcock","email":"harry.pidcock@canonical.com"}
   ```

3. We determine the authors of these commits (removing duplicates), map their emails to Mattermost usernames, and generate a nice notification message to be sent to Juju Watercooler.
   > @\hpidcock, @\jack-shaw: your recent changes to `merge-check-blame` have caused merge conflicts. Please merge `merge-check-blame` into `3.3` and resolve the conflicts.