### PR TITLE
Add go-licenses check github action to verify license compat.

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,33 @@
+name: "Licenses"
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/license.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  go-license-check:
+    name: "go.mod license check"
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+    - name: Check Licenses
+      run: |
+        go install github.com/google/go-licenses@latest
+        # Before adding new licenses check with https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses
+        # NOTE: GPL-2.0 is not included due to the possibility it can't be relicensed under a newer version.
+        go-licenses check github.com/juju/juju/... --allowed_licenses AGPL-3.0,LGPL-3.0,GPL-3.0,LGPL-2.1,Apache-2.0,BSD-3-Clause,BSD-2-Clause,MIT,Unlicense,ISC,MPL-2.0


### PR DESCRIPTION
Run https://github.com/google/go-licenses on `github.com/juju/juju/...` to verify licenses used by go dependencies are compatible with AGPL-3.0.

## QA steps

- Confirm licenses listed conform to AGPL-3.0.
- Action passes.

## Documentation changes

N/A

## Bug reference

N/A