### PR TITLE
Use golangci-lint-action for linting in CI

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -75,6 +75,26 @@ jobs:
         STATIC_ANALYSIS_JOB=test_static_analysis_go make static-analysis
       shell: bash
 
+    - name: Run golangci-lint
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52
+        args: -v -c .github/golangci-lint.config.yaml
+
+    - name: Run golangci-lint experimental
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52
+        args: -v -c .github/golangci-lint.config.experimental.yaml
+
+    - name: Run other Go static analysis (go mod tidy)
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
+      run: |
+        # TODO
+      shell: bash
+
     - name: "Static Analysis: Python Check"
       if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.python == 'true'
       run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
-        cache: true
+        cache: false # caching done by golangci step
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -48,7 +48,6 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.1
         sudo snap install shfmt
         sudo apt install expect
     

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,6 +80,7 @@ jobs:
       with:
         version: v1.52
         args: -v -c .github/golangci-lint.config.experimental.yaml
+        skip-cache: true # caching done by previous step
 
     - name: Run other Go static analysis (go mod tidy)
       if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -67,14 +67,6 @@ jobs:
         STATIC_ANALYSIS_JOB=test_static_analysis_shell make static-analysis
       shell: bash
 
-    - name: "Static Analysis: Go Check"
-      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
-      run: |
-        # Explicitly set GOROOT to avoid golangci-lint/issues/3107
-        export "GOROOT=$(go env GOROOT)"
-        STATIC_ANALYSIS_JOB=test_static_analysis_go make static-analysis
-      shell: bash
-
     - name: Run golangci-lint
       if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
       uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Go linting in CI takes 20+ minutes on a PR. This is way too slow and is definitely holding things up.

Instead, use the [`golangci-lint-action`](https://github.com/golangci/golangci-lint-action) GitHub action to run our Go linters. This has been designed for good performance and includes built-in caching of `golangci-lint` artifacts.

**Positive:** brings our linting runs from 20+ mins down to **under 5 minutes.** See
https://github.com/barrettj12/juju/actions/runs/5409238605/jobs/9829133078

**Negative:** the `golangci-lint` cache is 1.9GB, and we only have 10GB of cache space available.