### PR TITLE
[JUJU-4130] Add 'integrations' to juju status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -507,7 +507,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		return a.Provider < b.Provider
 	})
 
-	w := startSection(tw, false, "Relation provider", "Requirer", "Interface", "Type", "Message")
+	w := startSection(tw, false, "Integration provider", "Requirer", "Interface", "Type", "Message")
 
 	for _, r := range relations {
 		provider := strings.Split(r.Provider, ":")

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -64,8 +64,9 @@ type statusCommand struct {
 	color   bool
 	noColor bool
 
-	// relations indicates if 'relations' section is displayed
-	relations bool
+	// integrations indicates if the integrations/relations section is displayed
+	integrations bool
+	relations    bool
 
 	// checkProvidedIgnoredFlagF indicates whether ignored options were provided by the user
 	checkProvidedIgnoredFlagF func() set.Strings
@@ -93,7 +94,7 @@ time.
 
     (<machine>|<unit>|<application>)[*]
 
-When an entity that matches <selector> is related to other applications, the 
+When an entity that matches <selector> is integrated with other applications, the 
 status of those applications will also be presented. By default (without a 
 <selector>) the status of all applications and their units will be displayed.
 
@@ -105,7 +106,7 @@ The '--format' option allows you to specify how the status report is formatted.
   --format=tabular  (default)
                     Display information about all aspects of the model in a 
                     human-centric manner. Omits some information by default.
-                    Use the '--relations' and '--storage' options to include
+                    Use the '--integrations' and '--storage' options to include
                     all available information.
 
   --format=line
@@ -135,8 +136,8 @@ Examples:
     # Report the status for applications that start with nova-
     juju status nova-*
 
-    # Include information about storage and relations in output
-    juju status --storage --relations
+    # Include information about storage and integrations in output
+    juju status --storage --integrations
 
     # Provide output as valid JSON
     juju status --format=json
@@ -174,7 +175,8 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 
 	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in tabular output")
 	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in tabular output")
-	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section in tabular output")
+	f.BoolVar(&c.integrations, "integrations", false, "Show 'integrations' section in tabular output")
+	f.BoolVar(&c.relations, "relations", false, "The same as '--integrations'")
 	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section in tabular output")
 
 	f.IntVar(&c.retryCount, "retry-count", 3, "Number of times to retry API failures")
@@ -184,6 +186,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 
 	c.checkProvidedIgnoredFlagF = func() set.Strings {
 		ignoredFlagForNonTabularFormat := set.NewStrings(
+			"integrations",
 			"relations",
 			"storage",
 		)
@@ -327,10 +330,10 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	showRelations := c.relations
+	showIntegrations := c.integrations || c.relations
 	showStorage := c.storage
 	if c.out.Name() != "tabular" {
-		showRelations = true
+		showIntegrations = true
 		showStorage = true
 		providedIgnoredFlags := c.checkProvidedIgnoredFlagF()
 		if !providedIgnoredFlags.IsEmpty() {
@@ -349,7 +352,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		ControllerName: controllerName,
 		OutputName:     c.out.Name(),
 		ISOTime:        c.isoTime,
-		ShowRelations:  showRelations,
+		ShowRelations:  showIntegrations,
 		ActiveBranch:   activeBranch,
 	}
 	if showStorage {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5287,7 +5287,7 @@ Machine  State    Address   Inst id       Base          AZ          Message
 Offer         Application  Charm  Rev  Connected  Endpoint  Interface  Role
 hosted-mysql  mysql        mysql  1    1/1        server    mysql      provider
 
-Relation provider      Requirer                   Interface  Type         Message
+Integration provider   Requirer                   Interface  Type         Message
 mysql:juju-info        logging:info               juju-info  subordinate  
 mysql:server           wordpress:db               mysql      regular      suspended  
 wordpress:logging-dir  logging:logging-directory  logging    subordinate  
@@ -5775,8 +5775,8 @@ Machine  State   Address       Inst id  Base          AZ  Message
 0        active  10.53.62.100           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 0/lxd/0  active  10.53.62.101           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 
-Relation provider  Requirer     Interface  Type  Message
-foo:cluster        bar:cluster  baz                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
+Integration provider  Requirer     Interface  Type  Message
+foo:cluster           bar:cluster  baz                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 `[1:])
 }
 
@@ -6523,7 +6523,7 @@ func (s *StatusSuite) TestTabularNoRelations(c *gc.C) {
 
 	_, stdout, stderr := runStatus(c, "--no-color")
 	c.Assert(stderr, gc.IsNil)
-	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsFalse)
+	c.Assert(strings.Contains(string(stdout), "Integration provider"), jc.IsFalse)
 }
 
 func (s *StatusSuite) TestTabularDisplayRelations(c *gc.C) {
@@ -6532,7 +6532,7 @@ func (s *StatusSuite) TestTabularDisplayRelations(c *gc.C) {
 
 	_, stdout, stderr := runStatus(c, "--no-color", "--relations")
 	c.Assert(stderr, gc.IsNil)
-	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "Integration provider"), jc.IsTrue)
 }
 
 func (s *StatusSuite) TestNonTabularDisplayRelations(c *gc.C) {


### PR DESCRIPTION
Now that we're moving over to the term 'integration' instead of 'relation', the option '--integrations' should be added alongside '--relations'

Also, in tabular output use the term 'integration' instead of 'relation'. Keep 'relation' in json/yaml output as this would be a breaking change.

This should probably be changed to follow suit in juju 4

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ juju deploy wordpress
$ juju deploy mysql --base ubuntu@20.04 --force
$ juju integrate mysql wordpress
$ juju status --integrations
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.1.5    unsupported  12:58:29+01:00

App        Version          Status  Scale  Charm      Channel     Rev  Exposed  Message
mysql      8.0.32-0ubun...  active      1  mysql      8.0/stable  151  no       Primary
wordpress                   error       1  wordpress  stable        0  no       hook failed: "install"

Unit          Workload  Agent  Machine  Public address  Ports           Message
mysql/0*      active    idle   7        10.219.211.47   3306,33060/tcp  Primary
wordpress/0*  error     idle   8        10.219.211.109                  hook failed: "install"

Machine  State    Address         Inst id        Base          AZ  Message
7        started  10.219.211.47   juju-e4f837-7  ubuntu@22.04      Running
8        started  10.219.211.109  juju-e4f837-8  ubuntu@20.04      Running

Integration provider    Requirer                Interface     Type     Message
mysql:database-peers    mysql:database-peers    mysql_peers   peer     
mysql:mysql             wordpress:db            mysql         regular  
wordpress:loadbalancer  wordpress:loadbalancer  reversenginx  peer     joining  
```

```
$ juju status -h | grep rela
--relations  (= false)
```

## Documentation changes

Will be automatically updated on release

## Bug reference

https://bugs.launchpad.net/juju/+bug/2024589