### PR TITLE
[JUJU-3878] - Fix/update secret backend

### DIFF
--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -163,7 +163,7 @@ func (s *SecretBackendsAPI) updateBackend(arg params.UpdateSecretBackendArg) err
 				cfg[k] = defaultVal
 			}
 		}
-		err = configValidator.ValidateConfig(nil, cfg)
+		err = configValidator.ValidateConfig(existing.Config, cfg)
 		if err != nil {
 			return errors.Annotatef(err, "invalid config for provider %q", existing.BackendType)
 		}

--- a/secrets/provider/vault/config.go
+++ b/secrets/provider/vault/config.go
@@ -143,7 +143,7 @@ func (p vaultProvider) ValidateConfig(oldCfg, newCfg provider.ConfigAttrs) error
 		oldV := oldValidCfg.validAttrs[n]
 		newV := newValidCfg.validAttrs[n]
 		if oldV != newV {
-			return errors.Errorf("cannot change config %q from %q to %q", n, oldV, newV)
+			return errors.Errorf("cannot change immutable field %q", n)
 		}
 	}
 	return nil

--- a/secrets/provider/vault/config_test.go
+++ b/secrets/provider/vault/config_test.go
@@ -34,7 +34,7 @@ func (s *configSuite) TestValidateConfig(c *gc.C) {
 	}, {
 		cfg:    map[string]interface{}{"endpoint": "newep"},
 		oldCfg: map[string]interface{}{"endpoint": "oldep"},
-		err:    `cannot change config "endpoint" from "oldep" to "newep"`,
+		err:    `cannot change immutable field "endpoint"`,
 	}, {
 		cfg: map[string]interface{}{"endpoint": "newep", "client-cert": "aaa"},
 		err: `vault config missing client key not valid`,

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -3154,19 +3154,11 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mCfg.SecretBackend(), jc.DeepEquals, "myvault")
 
-	newModel, newSt := s.importModel(c, s.State, func(map[string]interface{}) {
-		// Rename the backend.
-		err := backendStore.UpdateSecretBackend(state.UpdateSecretBackendParams{
-			ID:         backendID,
-			NameChange: ptr("myvault-1"),
-		})
-		c.Assert(err, jc.ErrorIsNil)
-	})
+	newModel, newSt := s.importModel(c, s.State)
 
-	// After import, the backend should be changed to "myvault-1".
 	mCfg, err = newModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mCfg.SecretBackend(), jc.DeepEquals, "myvault-1")
+	c.Assert(mCfg.SecretBackend(), jc.DeepEquals, "myvault")
 
 	backendRefCount, err = s.State.ReadBackendRefCount(backendID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3195,7 +3187,7 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 			BackendID:  backendID,
 			RevisionID: "rev-id",
 		},
-		BackendName: ptr("myvault-1"),
+		BackendName: ptr("myvault"),
 		CreateTime:  now,
 		UpdateTime:  now,
 	}})

--- a/state/secretbackends_test.go
+++ b/state/secretbackends_test.go
@@ -21,7 +21,6 @@ type SecretBackendsSuite struct {
 	testing.StateSuite
 	storage state.SecretBackendsStorage
 	store   state.SecretsStore
-	owner   *state.Application
 }
 
 var _ = gc.Suite(&SecretBackendsSuite{})
@@ -30,7 +29,6 @@ func (s *SecretBackendsSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 	s.storage = state.NewSecretBackends(s.State)
 	s.store = state.NewSecrets(s.State)
-	s.owner = s.Factory.MakeApplication(c, nil)
 }
 
 func (s *SecretBackendsSuite) TestCreate(c *gc.C) {
@@ -395,10 +393,11 @@ func (s *SecretBackendsSuite) TestUpdateNameForInUseBackend(c *gc.C) {
 	b, err := s.storage.GetSecretBackend("myvault")
 	c.Assert(err, jc.ErrorIsNil)
 
+	owner := s.Factory.MakeApplication(c, nil)
 	uri := secrets.NewURI()
 	cp := state.CreateSecretParams{
 		Version: 1,
-		Owner:   s.owner.Tag(),
+		Owner:   owner.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
 			ValueRef:    &secrets.ValueRef{BackendID: b.ID},


### PR DESCRIPTION
This PR ensures:
- the secret backend endpoint read-only;
- disallowed to change the backend name if the backend is in use for any model;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju add-secret-backend myvault vault --config ./vault.yaml

juju model-config secret-backend=myvault

juju deploy snappass-test

juju exec --unit snappass-test/0 -- secret-add owned-by=easyrsa-app
secret://025ca458-bb1c-4640-8ba4-15ba62fa7559/cih7fueffbas7akd0lng

juju update-secret-backend myvault name=myvault2
ERROR cannot rename a secret backend that is in use

juju update-secret-backend myvault endpoint=http://10.180.97.1:8201
ERROR invalid config for provider "vault": cannot change immutable field "endpoint"

```

## Documentation changes

No

## Bug reference

No
