### PR TITLE
[JUJU-4097] Allow container agent building

### DIFF
--- a/apiserver/facades/agent/uniter/access.go
+++ b/apiserver/facades/agent/uniter/access.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/facades/client/application"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/state"
 )
 
@@ -90,7 +90,7 @@ func cloudSpecAccessor(authorizer facade.Authorizer, st *state.State) func() (fu
 			return nil, errors.Trace(err)
 		}
 		return func() bool {
-			return config.GetBool(application.TrustConfigOptionName, false)
+			return config.GetBool(coreapplication.TrustConfigOptionName, false)
 		}, nil
 	}
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
-	"github.com/juju/juju/apiserver/facades/client/application"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/controller"
+	coreapplication "github.com/juju/juju/core/application"
 	coreconfig "github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
@@ -5104,9 +5104,9 @@ func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
 
 	// Update the application config for wordpress so that it is authorised to
 	// retrieve its cloud spec.
-	conf := map[string]interface{}{application.TrustConfigOptionName: true}
-	fields := map[string]environschema.Attr{application.TrustConfigOptionName: {Type: environschema.Tbool}}
-	defaults := map[string]interface{}{application.TrustConfigOptionName: false}
+	conf := map[string]interface{}{coreapplication.TrustConfigOptionName: true}
+	fields := map[string]environschema.Attr{coreapplication.TrustConfigOptionName: {Type: environschema.Tbool}}
+	defaults := map[string]interface{}{coreapplication.TrustConfigOptionName: false}
 	err := s.wordpress.UpdateApplicationConfig(conf, nil, fields, defaults)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/application/trust.go
+++ b/apiserver/facades/client/application/trust.go
@@ -7,14 +7,14 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
+
+	"github.com/juju/juju/core/application"
 )
 
-// TrustConfigOptionName is the option name used to set trust level in application configuration.
-const TrustConfigOptionName = "trust"
 const defaultTrustLevel = false
 
 var trustFields = environschema.Fields{
-	TrustConfigOptionName: {
+	application.TrustConfigOptionName: {
 		Description: "Does this application have access to trusted credentials",
 		Type:        environschema.Tbool,
 		Group:       environschema.JujuGroup,
@@ -22,7 +22,7 @@ var trustFields = environschema.Fields{
 }
 
 var trustDefaults = schema.Defaults{
-	TrustConfigOptionName: defaultTrustLevel,
+	application.TrustConfigOptionName: defaultTrustLevel,
 }
 
 // AddTrustSchemaAndDefaults adds trust schema fields and defaults to an existing set of schema fields and defaults.

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	appFacade "github.com/juju/juju/apiserver/facades/client/application"
+	coreapplication "github.com/juju/juju/core/application"
 	bundlechanges "github.com/juju/juju/core/bundle/changes"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -589,7 +589,7 @@ func (b *BundleAPI) bundleDataApplications(
 		// If this application has been trusted by the operator, set the
 		// Trust field of the ApplicationSpec to true
 		if appConfig := application.ApplicationConfig(); appConfig != nil {
-			newApplication.RequiresTrust = appConfig[appFacade.TrustConfigOptionName] == true
+			newApplication.RequiresTrust = appConfig[coreapplication.TrustConfigOptionName] == true
 		}
 
 		// Populate offer list

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 
-	appFacade "github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/facades/client/bundle"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/rpc/params"
@@ -932,7 +932,7 @@ func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 
 	appArgs := s.minimalApplicationArgs(description.IAAS)
 	appArgs.ApplicationConfig = map[string]interface{}{
-		appFacade.TrustConfigOptionName: true,
+		coreapplication.TrustConfigOptionName: true,
 	}
 
 	app := s.st.model.AddApplication(appArgs)

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -23,11 +23,11 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/caas"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
@@ -366,7 +366,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		ImageRepo:            params.NewDockerImageInfo(cfg.CAASImageRepo(), imagePath),
 		CharmModifiedVersion: app.CharmModifiedVersion(),
 		CharmURL:             *charmURL,
-		Trust:                appConfig.GetBool(application.TrustConfigOptionName, false),
+		Trust:                appConfig.GetBool(coreapplication.TrustConfigOptionName, false),
 		Scale:                app.GetScale(),
 	}, nil
 }

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -20,11 +20,11 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/facades/controller/caasoperatorprovisioner"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tags"
@@ -247,7 +247,7 @@ func (f *Facade) applicationTrust(tagString string) (bool, error) {
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	return cfg.GetBool(application.TrustConfigOptionName, false), nil
+	return cfg.GetBool(coreapplication.TrustConfigOptionName, false), nil
 }
 
 // WatchApplicationsTrustHash starts a StringsWatcher to watch changes

--- a/cmd/containeragent/unit/errors.go
+++ b/cmd/containeragent/unit/errors.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/worker/lifeflag"
+)
+
+// ErrRemoved may be returned by some worker started from Manifolds to
+// indicate that the model under management no longer exists.
+const ErrRemoved = errors.ConstError("model removed")
+
+// LifeFilter is used with the lifeflag manifolds -- which do not depend
+// on runFlag -- to return appropriate errors for consumption by the
+// enclosing dependency.Engine (and/or its IsFatal check).
+func LifeFilter(err error) error {
+	switch {
+	case errors.Is(err, lifeflag.ErrNotFound):
+		return ErrRemoved
+	case errors.Is(err, lifeflag.ErrValueChanged):
+		return dependency.ErrBounce
+	}
+	return err
+}

--- a/cmd/containeragent/unit/errors_test.go
+++ b/cmd/containeragent/unit/errors_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/dependency"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/model"
+	"github.com/juju/juju/worker/lifeflag"
+)
+
+type ErrorsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ErrorsSuite{})
+
+func (*ErrorsSuite) TestLifeFilter_Nil(c *gc.C) {
+	result := model.LifeFilter(nil)
+	c.Check(result, jc.ErrorIsNil)
+}
+
+func (*ErrorsSuite) TestLifeFilter_Random(c *gc.C) {
+	err := errors.New("whatever")
+	result := model.LifeFilter(err)
+	c.Check(result, gc.Equals, err)
+}
+
+func (*ErrorsSuite) TestLifeFilter_ValueChanged_Exact(c *gc.C) {
+	err := lifeflag.ErrValueChanged
+	result := model.LifeFilter(err)
+	c.Check(result, gc.Equals, dependency.ErrBounce)
+}
+
+func (*ErrorsSuite) TestLifeFilter_ValueChanged_Traced(c *gc.C) {
+	err := errors.Trace(lifeflag.ErrValueChanged)
+	result := model.LifeFilter(err)
+	c.Check(result, gc.Equals, dependency.ErrBounce)
+}
+
+func (*ErrorsSuite) TestLifeFilter_NotFound_Exact(c *gc.C) {
+	err := lifeflag.ErrNotFound
+	result := model.LifeFilter(err)
+	c.Check(result, gc.Equals, model.ErrRemoved)
+}
+
+func (*ErrorsSuite) TestLifeFilter_NotFound_Traced(c *gc.C) {
+	err := errors.Trace(lifeflag.ErrNotFound)
+	result := model.LifeFilter(err)
+	c.Check(result, gc.Equals, model.ErrRemoved)
+}

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -21,7 +21,6 @@ import (
 	agentlifeflag "github.com/juju/juju/api/agent/lifeflag"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
-	cmdmodel "github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
@@ -203,7 +202,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			APICallerName:  apiCallerName,
 			AgentName:      agentName,
 			Result:         life.IsDead,
-			Filter:         cmdmodel.LifeFilter,
+			Filter:         LifeFilter,
 			NotFoundIsDead: true,
 			NewFacade: func(b base.APICaller) (lifeflag.Facade, error) {
 				return agentlifeflag.NewClient(b), nil
@@ -215,7 +214,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 			AgentName:     agentName,
 			Result:        life.IsNotDead,
-			Filter:        cmdmodel.LifeFilter,
+			Filter:        LifeFilter,
 			NewFacade: func(b base.APICaller) (lifeflag.Facade, error) {
 				return agentlifeflag.NewClient(b), nil
 			},

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -27,10 +27,10 @@ import (
 	"github.com/juju/juju/api/client/charms"
 	"github.com/juju/juju/api/client/resources"
 	commoncharm "github.com/juju/juju/api/common/charm"
-	app "github.com/juju/juju/apiserver/facades/client/application"
 	appbundle "github.com/juju/juju/cmd/juju/application/bundle"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
+	coreapplication "github.com/juju/juju/core/application"
 	bundlechanges "github.com/juju/juju/core/bundle/changes"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -836,7 +836,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 			p.Options = make(map[string]interface{})
 		}
 
-		p.Options[app.TrustConfigOptionName] = strconv.FormatBool(h.trust)
+		p.Options[coreapplication.TrustConfigOptionName] = strconv.FormatBool(h.trust)
 	}
 
 	// Handle application configuration.

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -18,9 +18,9 @@ import (
 	applicationapi "github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/api/client/resources"
 	commoncharm "github.com/juju/juju/api/common/charm"
-	app "github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
+	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -101,7 +101,7 @@ func (d *deployCharm) deploy(
 	}
 	// At deploy time, there's no need to include "trust=false" as missing is the same thing.
 	if !d.trust {
-		delete(appConfig, app.TrustConfigOptionName)
+		delete(appConfig, coreapplication.TrustConfigOptionName)
 	}
 
 	if id.URL != nil && id.URL.Schema != "local" && len(charmInfo.Meta.Terms) > 0 {

--- a/cmd/juju/application/trust.go
+++ b/cmd/juju/application/trust.go
@@ -11,10 +11,10 @@ import (
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/api/client/application"
-	appfacade "github.com/juju/juju/apiserver/facades/client/application"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/model"
 )
 
@@ -115,7 +115,7 @@ func (c *trustCommand) Run(ctx *cmd.Context) error {
 	defer func() { _ = client.Close() }()
 
 	err = client.SetConfig("", c.applicationName, "",
-		map[string]string{appfacade.TrustConfigOptionName: fmt.Sprint(!c.removeTrust)},
+		map[string]string{coreapplication.TrustConfigOptionName: fmt.Sprint(!c.removeTrust)},
 	)
 	return errors.Trace(block.ProcessBlockedError(err, block.BlockChange))
 }

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -19,8 +19,8 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api/client/application"
-	app "github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/cmd/modelcmd"
+	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/resources"
@@ -325,7 +325,7 @@ func ProcessConfig(ctx *cmd.Context, filesystem modelcmd.Filesystem, configOptio
 
 	// Expand the trust flag into the appConfig
 	if trust != nil {
-		appConfig[app.TrustConfigOptionName] = strconv.FormatBool(*trust)
+		appConfig[coreapplication.TrustConfigOptionName] = strconv.FormatBool(*trust)
 	}
 	return appConfig, string(configYAML), nil
 }

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/charms/interfaces"
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	"github.com/juju/juju/charmhub"
+	coreapplication "github.com/juju/juju/core/application"
 	corearch "github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
@@ -319,12 +320,12 @@ func addControllerApplication(
 	}
 
 	configSchema := environschema.Fields{
-		application.TrustConfigOptionName: {
+		coreapplication.TrustConfigOptionName: {
 			Type: environschema.Tbool,
 		},
 	}
 	appCfg, err := config.NewConfig(nil, configSchema, schema.Defaults{
-		application.TrustConfigOptionName: true,
+		coreapplication.TrustConfigOptionName: true,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/core/application/trust.go
+++ b/core/application/trust.go
@@ -1,0 +1,7 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+// TrustConfigOptionName is the option name used to set trust level in application configuration.
+const TrustConfigOptionName = "trust"


### PR DESCRIPTION
The following removes the app facade from all the places it shouldn't be and moves the const to the core package.

There are problem more locations this could be done, for now I've done the minimum.

Also note we save 3mb on the binary size of the container agent.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ make install
```
