### PR TITLE
Improve downgrade error message in core/bundle/changes.

### DIFF
--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -321,7 +321,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 	}
 	if resolvedRev != -1 && resolvedRev < existingApp.Revision {
 		// For charmhub charms, we currently don't support downgrades.
-		return false, errors.Errorf("downgrades are not currently supported")
+		return false, errors.Errorf("application %q: downgrades are not currently supported: deployed revision %v is newer than requested revision %v", existingApp.Name, existingApp.Revision, resolvedRev)
 	}
 	// Same revision, no upgrade required.
 	return false, nil

--- a/core/bundle/changes/handlers_test.go
+++ b/core/bundle/changes/handlers_test.go
@@ -56,6 +56,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameChannel(c *gc.C) {
 
 func (s *resolverSuite) TestAllowUpgradeWithDowngrades(c *gc.C) {
 	existing := &Application{
+		Name:     "ubuntu",
 		Charm:    "ch:ubuntu",
 		Channel:  "stable",
 		Revision: 2,
@@ -73,7 +74,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDowngrades(c *gc.C) {
 		},
 	}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `downgrades are not currently supported`)
+	c.Assert(err, gc.ErrorMatches, `application "ubuntu": downgrades are not currently supported: deployed revision 2 is newer than requested revision 1`)
 	c.Assert(ok, jc.IsFalse)
 }
 


### PR DESCRIPTION
Previous error message was ambiguous, especially with large bundles that have many applications/charmhub charms deployed.

## QA steps

Unit tests and/or refresh bundle that downgrades a charmhub charm.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1999700