### PR TITLE
Fixes juju controller application status on k8s.

### DIFF
--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/rpc/params"
 )
 
 type appNotifyWorker interface {
@@ -41,6 +41,7 @@ type appWorker struct {
 	password    string
 	lastApplied caas.ApplicationConfig
 	life        life.Value
+	statusOnly  bool
 }
 
 type AppWorkerConfig struct {
@@ -52,6 +53,7 @@ type AppWorkerConfig struct {
 	Logger     Logger
 	UnitFacade CAASUnitProvisionerFacade
 	Ops        ApplicationOps
+	StatusOnly bool
 }
 
 const tryAgain errors.ConstError = "try again"
@@ -76,6 +78,7 @@ func NewAppWorker(config AppWorkerConfig) func() (worker.Worker, error) {
 			changes:    changes,
 			unitFacade: config.UnitFacade,
 			ops:        ops,
+			statusOnly: config.StatusOnly,
 		}
 		err := catacomb.Invoke(catacomb.Plan{
 			Site: &a.catacomb,
@@ -115,39 +118,43 @@ func (a *appWorker) loop() error {
 	}
 	a.life = appLife
 	if appLife == life.Dead {
-		err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
-		if err != nil {
-			return errors.Annotatef(err, "deleting application %q", a.name)
-		}
-		err = a.ops.AppDead(a.name, app, a.broker, a.facade, a.unitFacade, a.clock, a.logger)
-		if err != nil {
-			return errors.Annotatef(err, "deleting application %q", a.name)
+		if !a.statusOnly {
+			err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
+			if err != nil {
+				return errors.Annotatef(err, "deleting application %q", a.name)
+			}
+			err = a.ops.AppDead(a.name, app, a.broker, a.facade, a.unitFacade, a.clock, a.logger)
+			if err != nil {
+				return errors.Annotatef(err, "deleting application %q", a.name)
+			}
 		}
 		return nil
 	}
 
-	// Ensure the charm is upgraded to a v2 charm (or wait for that).
-	shouldExit, err := a.ops.VerifyCharmUpgraded(a.name, a.facade, &a.catacomb, a.logger)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if shouldExit {
-		return nil
-	}
+	if !a.statusOnly {
+		// Ensure the charm is upgraded to a v2 charm (or wait for that).
+		shouldExit, err := a.ops.VerifyCharmUpgraded(a.name, a.facade, &a.catacomb, a.logger)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if shouldExit {
+			return nil
+		}
 
-	err = a.ops.UpgradePodSpec(a.name, a.broker, a.clock, &a.catacomb, a.logger)
-	if err != nil {
-		return errors.Trace(err)
-	}
+		err = a.ops.UpgradePodSpec(a.name, a.broker, a.clock, &a.catacomb, a.logger)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-	// Update the password once per worker start to avoid it changing too frequently.
-	a.password, err = utils.RandomPassword()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = a.facade.SetPassword(a.name, a.password)
-	if err != nil {
-		return errors.Annotate(err, "failed to set application api passwords")
+		// Update the password once per worker start to avoid it changing too frequently.
+		a.password, err = utils.RandomPassword()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = a.facade.SetPassword(a.name, a.password)
+		if err != nil {
+			return errors.Annotate(err, "failed to set application api passwords")
+		}
 	}
 
 	var appChanges watcher.NotifyChannel
@@ -163,20 +170,12 @@ func (a *appWorker) loop() error {
 		return errors.Annotatef(err, "failed to watch for application %q scale changes", a.name)
 	}
 
-	var trustChanges watcher.StringsChannel
-	// The out of the box "controller" application is set up at bootstrap and does
-	// not use the same roles and cluster roles as "normal" applications.
-	// So we don't want to process trust changes.
-	if a.name != bootstrap.ControllerApplicationName {
-		appTrustWatcher, err := a.unitFacade.WatchApplicationTrustHash(a.name)
-		if err != nil {
-			return errors.Annotatef(err, "creating application %q trust watcher", a.name)
-		}
-
-		if err := a.catacomb.Add(appTrustWatcher); err != nil {
-			return errors.Annotatef(err, "failed to watch for application %q trust changes", a.name)
-		}
-		trustChanges = appTrustWatcher.Changes()
+	appTrustWatcher, err := a.unitFacade.WatchApplicationTrustHash(a.name)
+	if err != nil {
+		return errors.Annotatef(err, "creating application %q trust watcher", a.name)
+	}
+	if err := a.catacomb.Add(appTrustWatcher); err != nil {
+		return errors.Annotatef(err, "failed to watch for application %q trust changes", a.name)
 	}
 
 	var appUnitsWatcher watcher.StringsWatcher
@@ -220,8 +219,16 @@ func (a *appWorker) loop() error {
 				return errors.Trace(err)
 			}
 			if ps != nil && ps.Scaling {
-				scaleChan = a.clock.After(0)
-				reconcileDeadChan = a.clock.After(0)
+				if a.statusOnly {
+					// Clear provisioning state for status only app.
+					err = a.facade.SetProvisioningState(a.name, params.CAASApplicationProvisioningState{})
+					if err != nil {
+						return errors.Trace(err)
+					}
+				} else {
+					scaleChan = a.clock.After(0)
+					reconcileDeadChan = a.clock.After(0)
+				}
 			}
 		}
 		switch appLife {
@@ -236,13 +243,15 @@ func (a *appWorker) loop() error {
 				}
 				appProvisionChanges = appProvisionWatcher.Changes()
 			}
-			err = a.ops.AppAlive(a.name, app, a.password, &a.lastApplied, a.facade, a.clock, a.logger)
-			if errors.Is(err, errors.NotProvisioned) {
-				// State not ready for this application to be provisioned yet.
-				// Usually because the charm has not yet been downloaded.
-				break
-			} else if err != nil {
-				return errors.Trace(err)
+			if !a.statusOnly {
+				err = a.ops.AppAlive(a.name, app, a.password, &a.lastApplied, a.facade, a.clock, a.logger)
+				if errors.Is(err, errors.NotProvisioned) {
+					// State not ready for this application to be provisioned yet.
+					// Usually because the charm has not yet been downloaded.
+					break
+				} else if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			if appChanges == nil {
 				appWatcher, err := app.Watch()
@@ -265,18 +274,22 @@ func (a *appWorker) loop() error {
 				replicaChanges = replicaWatcher.Changes()
 			}
 		case life.Dying:
-			err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
-			if err != nil {
-				return errors.Trace(err)
+			if !a.statusOnly {
+				err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		case life.Dead:
-			err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			err = a.ops.AppDead(a.name, app, a.broker, a.facade, a.unitFacade, a.clock, a.logger)
-			if err != nil {
-				return errors.Trace(err)
+			if !a.statusOnly {
+				err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				err = a.ops.AppDead(a.name, app, a.broker, a.facade, a.unitFacade, a.clock, a.logger)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			done = true
 			return nil
@@ -299,6 +312,10 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-scaleChan:
+			if a.statusOnly {
+				scaleChan = nil
+				break
+			}
 			err := a.ops.EnsureScale(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
 			if errors.Is(err, errors.NotFound) {
 				if scaleTries >= maxRetries {
@@ -315,7 +332,7 @@ func (a *appWorker) loop() error {
 			} else {
 				scaleChan = nil
 			}
-		case _, ok := <-trustChanges:
+		case _, ok := <-appTrustWatcher.Changes():
 			if !ok {
 				return fmt.Errorf("application %q trust watcher closed channel", a.name)
 			}
@@ -325,6 +342,10 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-trustChan:
+			if a.statusOnly {
+				trustChan = nil
+				break
+			}
 			err := a.ops.EnsureTrust(a.name, app, a.unitFacade, a.logger)
 			if errors.Is(err, errors.NotFound) {
 				if trustTries >= maxRetries {
@@ -347,6 +368,10 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-reconcileDeadChan:
+			if a.statusOnly {
+				reconcileDeadChan = nil
+				break
+			}
 			err := a.ops.ReconcileDeadUnitScale(a.name, app, a.facade, a.logger)
 			if errors.Is(err, errors.NotFound) {
 				reconcileDeadChan = a.clock.After(retryDelay)

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/caasapplicationprovisioner"
 	"github.com/juju/juju/worker/caasapplicationprovisioner/mocks"
@@ -59,6 +60,7 @@ func (s *ApplicationWorkerSuite) startAppWorker(
 	broker caasapplicationprovisioner.CAASBroker,
 	unitFacade caasapplicationprovisioner.CAASUnitProvisionerFacade,
 	ops caasapplicationprovisioner.ApplicationOps,
+	statusOnly bool,
 ) worker.Worker {
 	config := caasapplicationprovisioner.AppWorkerConfig{
 		Name:       "test",
@@ -69,6 +71,7 @@ func (s *ApplicationWorkerSuite) startAppWorker(
 		Logger:     s.logger,
 		UnitFacade: unitFacade,
 		Ops:        ops,
+		StatusOnly: statusOnly,
 	}
 	startFunc := caasapplicationprovisioner.NewAppWorker(config)
 	c.Assert(startFunc, gc.NotNil)
@@ -95,7 +98,7 @@ func (s *ApplicationWorkerSuite) TestLifeNotFound(c *gc.C) {
 			return "", errors.NotFoundf("test charm")
 		}),
 	)
-	appWorker := s.startAppWorker(c, nil, facade, broker, nil, ops)
+	appWorker := s.startAppWorker(c, nil, facade, broker, nil, ops, false)
 
 	s.waitDone(c, done)
 	workertest.CleanKill(c, appWorker)
@@ -123,7 +126,7 @@ func (s *ApplicationWorkerSuite) TestLifeDead(c *gc.C) {
 			return nil
 		}),
 	)
-	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops)
+	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, false)
 
 	s.waitDone(c, done)
 	workertest.CleanKill(c, appWorker)
@@ -158,7 +161,7 @@ func (s *ApplicationWorkerSuite) TestUpgradePodSpec(c *gc.C) {
 		}),
 	)
 
-	appWorker := s.startAppWorker(c, clk, facade, broker, nil, ops)
+	appWorker := s.startAppWorker(c, clk, facade, broker, nil, ops, false)
 
 	s.waitDone(c, done)
 	workertest.DirtyKill(c, appWorker)
@@ -263,7 +266,82 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 		}),
 	)
 
-	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops)
+	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, false)
+	appWorker.(appNotifyWorker).Notify()
+
+	s.waitDone(c, done)
+	workertest.CheckKill(c, appWorker)
+}
+
+func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	broker := mocks.NewMockCAASBroker(ctrl)
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	unitFacade := mocks.NewMockCAASUnitProvisionerFacade(ctrl)
+	ops := mocks.NewMockApplicationOps(ctrl)
+	done := make(chan struct{})
+
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
+
+	scaleChan := make(chan struct{}, 1)
+	trustChan := make(chan []string, 1)
+	provisioningInfoChan := make(chan struct{}, 1)
+	appUnitsChan := make(chan []string, 1)
+	appChan := make(chan struct{}, 1)
+	appReplicasChan := make(chan struct{}, 1)
+
+	ops.EXPECT().RefreshApplicationStatus("test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
+
+	gomock.InOrder(
+		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+
+		unitFacade.EXPECT().WatchApplicationScale("test").Return(watchertest.NewMockNotifyWatcher(scaleChan), nil),
+		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(watchertest.NewMockStringsWatcher(trustChan), nil),
+		facade.EXPECT().WatchUnits("test").Return(watchertest.NewMockStringsWatcher(appUnitsChan), nil),
+
+		// handleChange
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+		facade.EXPECT().ProvisioningState("test").Return(&params.CAASApplicationProvisioningState{Scaling: true, ScaleTarget: 1}, nil),
+		facade.EXPECT().SetProvisioningState("test", params.CAASApplicationProvisioningState{}).Return(nil),
+		facade.EXPECT().WatchProvisioningInfo("test").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
+		app.EXPECT().Watch().Return(watchertest.NewMockNotifyWatcher(appChan), nil),
+		app.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
+			appChan <- struct{}{}
+			return watchertest.NewMockNotifyWatcher(appReplicasChan), nil
+		}),
+
+		// appChan fired
+		ops.EXPECT().UpdateState("test", app, gomock.Any(), broker, facade, unitFacade, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) (map[string]status.StatusInfo, error) {
+			appReplicasChan <- struct{}{}
+			return nil, nil
+		}),
+		// appReplicasChan fired
+		ops.EXPECT().UpdateState("test", app, gomock.Any(), broker, facade, unitFacade, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) (map[string]status.StatusInfo, error) {
+			provisioningInfoChan <- struct{}{}
+			return nil, nil
+		}),
+
+		// provisioningInfoChan fired
+		facade.EXPECT().Life("test").DoAndReturn(func(_ string) (life.Value, error) {
+			provisioningInfoChan <- struct{}{}
+			return life.Alive, nil
+		}),
+		facade.EXPECT().Life("test").DoAndReturn(func(_ string) (life.Value, error) {
+			provisioningInfoChan <- struct{}{}
+			return life.Dying, nil
+		}),
+		facade.EXPECT().Life("test").DoAndReturn(func(_ string) (life.Value, error) {
+			provisioningInfoChan <- struct{}{}
+			close(done)
+			return life.Dead, nil
+		}),
+	)
+
+	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, true)
 	appWorker.(appNotifyWorker).Notify()
 
 	s.waitDone(c, done)

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -183,9 +183,6 @@ func (p *provisioner) loop() error {
 				return errors.New("app watcher closed channel")
 			}
 			for _, appName := range apps {
-				if unmanagedApps.Contains(appName) {
-					continue
-				}
 				_, err := p.facade.Life(appName)
 				if err != nil && !errors.IsNotFound(err) {
 					return errors.Trace(err)
@@ -219,6 +216,7 @@ func (p *provisioner) loop() error {
 					Clock:      p.clock,
 					Logger:     p.logger.Child(appName),
 					UnitFacade: p.unitFacade,
+					StatusOnly: unmanagedApps.Contains(appName),
 				}
 				startFunc := p.newAppWorker(config)
 				p.logger.Debugf("starting app worker %q", appName)


### PR DESCRIPTION
A previous PR disabled the caasapplicationprovisioner to prevent it from dealing with controller concerns (since the controller app is a sidecar of the juju controller pods). This rolls that back partially to allow the caasapplicationprovisioner to work in a readonly mode, only updating status as it sees changes.

## QA steps

Bootstrap k8s, switch to controller model, check status of juju controller app and unit is nice.

## Documentation changes

N/A

## Bug reference

N/A