### PR TITLE
Explicitly remove created SAAS in cmr tests

### DIFF
--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -56,8 +56,9 @@ run_offer_consume() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-offer
-	# wait for relation removed.
-	wait_for null '.applications["dummy-sink"] | .relations.source[0]'
+	juju remove-saas dummy-offer
+	# wait for saas to be removed.
+	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "model-offer"
@@ -115,8 +116,9 @@ run_offer_consume_cross_controller() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-source
-	# wait for relation removed.
-	wait_for null '.applications["dummy-sink"] | .relations.source[0]'
+	juju remove-saas dummy-source
+	# wait for saas to be removed.
+	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "${offer_controller}:model-offer"


### PR DESCRIPTION
Occasionally we fail to remove the secondary controller in the cross_controller cmr test. Explicilty remoing the SAAS before destroying helps to resolve this

https://jenkins.juju.canonical.com/job/test-cmr-test-offer-consume-lxd/731/

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c lxd -p lxd cmr
```