### PR TITLE
Add more logging to help diagnose upgrade issue

### DIFF
--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -94,11 +94,12 @@ exec_simplestream_metadata() {
 
 	attempt=0
 	while true; do
-		UPDATED=$(juju machines -m controller --format=json | jq -r '.machines | .["0"] | .["juju-status"] | .version' || echo "${CURRENT}")
+		UPDATED=$(timeout 30 juju machines -m controller --format=json | jq -r '.machines | .["0"] | .["juju-status"] | .version' || echo "${CURRENT}")
 		if [ "$CURRENT" != "$UPDATED" ]; then
 			break
 		fi
 		echo "[+] (attempt ${attempt}) polling machines"
+		timeout 30 juju status -m controller || true
 		sleep 10
 		attempt=$((attempt + 1))
 		if [ "$attempt" -eq 48 ]; then
@@ -111,11 +112,12 @@ exec_simplestream_metadata() {
 	juju switch test-upgrade-"${test_name}"
 	juju upgrade-model
 	while true; do
-		UPDATED=$(juju machines --format=json | jq -r '.machines | .["0"] | .["juju-status"] | .version' || echo "${CURRENT}")
+		UPDATED=$(timeout 30 juju machines --format=json | jq -r '.machines | .["0"] | .["juju-status"] | .version' || echo "${CURRENT}")
 		if [ "$CURRENT" != "$UPDATED" ]; then
 			break
 		fi
 		echo "[+] (attempt ${attempt}) polling machines"
+		timeout 30 juju status -m test-upgrade-"${test_name}" || true
 		sleep 10
 		attempt=$((attempt + 1))
 		if [ "$attempt" -eq 48 ]; then


### PR DESCRIPTION
The following adds some timeout + full status whilst it attempts to upgrade. We may need to crack open lxd to see the full server logs to see what's actually happening. For now, see if this helps.

## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

```sh
$ cd tests && ./main.sh -v upgrade test_upgrade_simplestream
```

I've run this multiple times and the output is the same.

```
==> Checking for dependencies
==> Using Juju located at /home/simon/go/bin/juju
==> Running subtest test_upgrade_simplestream for upgrade suite
==> TEST BEGIN: upgrade (tmp.H1T)
==> Checking for dependencies
===> [   ] Running: simplestream metadata last stable
===> Using jujud version 3.2.2-ubuntu-amd64
===> Testing against stable version 3.2.0
Finding agent binaries in /home/simon/go/src/github.com/juju/juju/tests/suites/upgrade/streams for stream released.

    | 17:19:30 INFO  juju.cmd supercommand.go:56 running juju [3.2.2 1f8427fb0daa94c31bac35d8cc5c52e12cec11c9 gc go1.20.3]
    | 17:19:30 INFO  cmd cloudcredential.go:47 updating credential store
    | 17:19:31 INFO  cmd authkeys.go:113 Adding contents of "/home/simon/.local/share/juju/ssh/juju_id_rsa.pub" to authorized-keys
    | 17:19:31 INFO  cmd authkeys.go:113 Adding contents of "/home/simon/.ssh/id_ed25519.pub" to authorized-keys
    | Creating Juju controller "test-upgrade-stable-stream" on lxd/default
    | 17:19:31 INFO  juju.cmd.juju.commands bootstrap.go:1026 combined bootstrap constraints:
    | 17:19:31 INFO  cmd bootstrap.go:403 Loading image metadata
    | Looking for packaged Juju agent version 3.2.0 for amd64
    | 17:19:31 INFO  juju.environs.bootstrap tools.go:78 looking for bootstrap agent binaries: version=3.2.0
    | 17:19:31 INFO  juju.environs.bootstrap tools.go:80 found 1 packaged agent binaries
    | Located Juju agent version 3.2.0-ubuntu-amd64 at https://streams.canonical.com/juju/tools/agent/3.2.0/juju-3.2.0-linux-amd64.tgz
    | 17:19:31 INFO  cmd bootstrap.go:580 Starting new instance for initial controller
    | To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/
    | Launching controller instance(s) on lxd/default...
17:19:31 INFO  juju.container.lxd container.go:294 starting new container "juju-1a89a5-0" (image "")
17:19:34 INFO  juju.provider.lxd environ_broker.go:48 started instance "juju-1a89a5-0"
    | - juju-1a89a5-0 (arch=amd64)
    | 17:19:34 INFO  juju.environs.bootstrap bootstrap.go:1005 newest version: 3.2.0
    | 17:19:34 INFO  juju.environs.bootstrap bootstrap.go:1012 failed to find 3.2.2 agent binaries, will attempt to use 3.2.0
    | 17:19:34 INFO  juju.environs.bootstrap bootstrap.go:1020 picked bootstrap agent binary version: 3.2.0
    | Installing Juju agent on bootstrap instance
    | Waiting for address
    | Attempting to connect to 240.60.0.112:22
    | Connected to 240.60.0.112
    | 17:19:50 INFO  juju.cloudconfig userdatacfg_unix.go:615 Fetching agent: curl -sSf --retry 10 -o $bin/tools.tar.gz <[https://streams.canonical.com/juju/tools/agent/3.2.0/juju-3.2.0-linux-amd64.tgz]>
    | Running machine configuration script...
    | Bootstrap agent now started
    | 17:20:32 INFO  juju.juju api.go:340 API endpoints changed from [] to [240.60.0.112:17070]
    | Contacting Juju controller at 240.60.0.112 to verify accessibility...
    | 17:20:32 INFO  juju.juju api.go:86 connecting to API addresses: [240.60.0.112:17070]
    | 17:20:36 INFO  juju.api apiclient.go:702 connection established to "wss://240.60.0.112:17070/model/8ad7547d-3d62-46a0-8f02-c74da21a89a5/api"

    | Bootstrap complete, controller "test-upgrade-stable-stream" is now available
    | Controller machines are in the "controller" model

    | Now you can run
    | juju add-model <model-name>
    | to create a new model to deploy workloads.
    | 17:20:36 INFO  cmd supercommand.go:555 command finished

Added 'test-upgrade-stable' model on lxd/default with credential 'lxd' for user 'admin'
Located charm "jameinel-ubuntu-lite" in charm-hub, revision 10
Deploying "jameinel-ubuntu-lite" from charm-hub charm "jameinel-ubuntu-lite", revision 10 in channel stable on ubuntu@20.04/stable
[+] (attempt 0) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:20:40+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 1) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:20:45+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 2) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:20:50+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 3) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:20:56+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 4) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:01+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 5) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:06+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 6) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:11+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 7) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:17+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 8) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:22+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 9) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:27+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 10) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:32+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 11) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:37+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 12) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:43+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 13) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:48+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 14) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:53+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04
[+] (attempt 15) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:21:58+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id  Base          AZ  Message
    | 0        pending           pending  ubuntu@20.04      Creating container
[+] (attempt 16) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:22:04+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id        Base          AZ  Message
    | 0        pending           juju-9d0eac-0  ubuntu@20.04      Container started
[+] (attempt 17) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:22:09+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id        Base          AZ  Message
    | 0        pending           juju-9d0eac-0  ubuntu@20.04      Container started
[+] (attempt 18) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:22:14+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0                               waiting for machine
    |
    | Machine  State    Address  Inst id        Base          AZ  Message
    | 0        pending           juju-9d0eac-0  ubuntu@20.04      Container started
[+] (attempt 19) polling status for .applications | select((.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["juju-status"] | .current == "idle") and (.["ubuntu-lite"] | .units | .["ubuntu-lite/0"] | .["workload-status"] | .current != "error")) | keys[0] => ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:22:19+01:00
    |
    | App          Version  Status   Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite           waiting    0/1  jameinel-ubuntu-lite  stable    10  no       waiting for machine
    |
    | Unit           Workload  Agent       Machine  Public address  Ports  Message
    | ubuntu-lite/0  waiting   allocating  0        240.60.0.61            waiting for machine
    |
    | Machine  State    Address      Inst id        Base          AZ  Message
    | 0        pending  240.60.0.61  juju-9d0eac-0  ubuntu@20.04      Running
[+] Completed polling status for ubuntu-lite
    | Model                Controller                  Cloud/Region  Version  SLA          Timestamp
    | test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.0    unsupported  17:22:25+01:00
    |
    | App          Version  Status  Scale  Charm                 Channel  Rev  Exposed  Message
    | ubuntu-lite  20.04    active      1  jameinel-ubuntu-lite  stable    10  no       ready
    |
    | Unit            Workload  Agent  Machine  Public address  Ports  Message
    | ubuntu-lite/0*  active    idle   0        240.60.0.61            ready
    |
    | Machine  State    Address      Inst id        Base          AZ  Message
    | 0        started  240.60.0.61  juju-9d0eac-0  ubuntu@20.04      Running
==> Current juju version 3.2.0
best version:
    3.2.2
started upgrade to 3.2.2
[+] (attempt 0) polling machines
Model       Controller                  Cloud/Region  Version  SLA          Timestamp
controller  test-upgrade-stable-stream  lxd/default   3.2.2    unsupported  17:22:30+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.2/stable   14  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        240.60.0.112

Machine  State    Address       Inst id        Base          AZ  Message
0        started  240.60.0.112  juju-1a89a5-0  ubuntu@22.04      Running
test-upgrade-stable-stream:admin/test-upgrade-stable (no change)
best version:
    3.2.2
started upgrade to 3.2.2
[+] (attempt 1) polling machines
Model                Controller                  Cloud/Region  Version  SLA          Timestamp
test-upgrade-stable  test-upgrade-stable-stream  lxd/default   3.2.2    unsupported  17:22:51+01:00

App          Version  Status  Scale  Charm                 Channel  Rev  Exposed  Message
ubuntu-lite  20.04    active      1  jameinel-ubuntu-lite  stable    10  no       ready

Unit            Workload  Agent  Machine  Public address  Ports  Message
ubuntu-lite/0*  active    idle   0        240.60.0.61            ready

Machine  State    Address      Inst id        Base          AZ  Message
0        started  240.60.0.61  juju-9d0eac-0  ubuntu@20.04      Running
===> [ ✔ ] Success: simplestream metadata last stable (233s)
suites/upgrade/streams.sh: line 1: 2941430 Killed                  tail -f "${TEST_DIR}/${TEST_CURRENT}.log" 2> /dev/null
==> SKIP: Asked to skip stream (previous) tests
==> TEST DONE: upgrade (233s)
==> Cleaning up
====> Cleaning up jujus
====> Introspection gathering
====> Introspection gathered
====> Removing offers
====> Removed offers
====> Destroying juju (test-upgrade-stable-stream)

    | WARNING This command will destroy the "test-upgrade-stable-stream" controller and all its resources
    | Destroying controller
    | Waiting for model resources to be reclaimed
    | Waiting for 1 model, 1 machine, 2 applications
    | Waiting for 1 model, 1 machine
    | Waiting for 1 model, 1 machine
    | Waiting for 1 model, 1 machine
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | Waiting for 1 model
    | All models reclaimed, cleaning up controller machines

====> Destroyed juju (test-upgrade-stable-stream)
====> Completed cleaning up jujus
====> Running clean up func: remove_upgrade_tools
==> Removing tools
==> Removed tools
====> Finished cleaning up func: remove_upgrade_tools
====> Running clean up func: remove_upgrade_metadata
==> Removing metadata
==> Removed metadata
====> Finished cleaning up func: remove_upgrade_metadata
====> Running clean up func: kill_server
==> Killing server
==> Killed server (PID is 2941572)
====> Finished cleaning up func: kill_server

==> Test result: success
==> Tests Removed: /home/simon/go/src/github.com/juju/juju/tests/tmp.H1T
==> TEST COMPLETE
```
