### PR TITLE
Fix cleaner not running when the model is dying.

### DIFF
--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -28,7 +28,6 @@ var (
 		"environ-upgraded-flag",
 		"not-alive-flag",
 		"not-dead-flag",
-		"alive-flag",
 		"valid-credential-flag",
 	}
 	requireValidCredentialModelWorkers = []string{

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -36,7 +36,6 @@ func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
 		"action-pruner",
 		"agent",
-		"alive-flag",
 		"api-caller",
 		"api-config-watcher",
 		"application-scaler",
@@ -85,7 +84,6 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 	c.Check(actual.SortedValues(), jc.DeepEquals, []string{
 		"action-pruner",
 		"agent",
-		"alive-flag",
 		"api-caller",
 		"api-config-watcher",
 		"caas-application-provisioner",
@@ -128,7 +126,6 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"is-responsible-flag",
 		"not-alive-flag",
 		"not-dead-flag",
-		"alive-flag",
 		// model upgrade manifolds are run on all
 		// controller agents, "responsible" or not.
 		"environ-upgrade-gate",
@@ -377,18 +374,16 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 
 	"environ-upgrader": {
 		"agent",
-		"alive-flag",
 		"api-caller",
 		"environ-upgrade-gate",
 		"is-responsible-flag",
+		"not-dead-flag",
 		"valid-credential-flag",
 	},
 
 	"not-alive-flag": {"agent", "api-caller"},
 
 	"not-dead-flag": {"agent", "api-caller"},
-
-	"alive-flag": {"agent", "api-caller"},
 
 	"remote-relations": {
 		"agent",
@@ -616,19 +611,17 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 
 	"environ-upgrader": {
 		"agent",
-		"alive-flag",
 		"api-caller",
 		"environ-tracker",
 		"environ-upgrade-gate",
 		"is-responsible-flag",
+		"not-dead-flag",
 		"valid-credential-flag",
 	},
 
 	"not-alive-flag": {"agent", "api-caller"},
 
 	"not-dead-flag": {"agent", "api-caller"},
-
-	"alive-flag": {"agent", "api-caller"},
 
 	"remote-relations": {
 		"agent",


### PR DESCRIPTION
#15328 made a miss-step in making the upgrader only run when the model is alive, since many things hang off the upgraded flag, including the cleaner worker, which needs to run during model destruction.

## QA steps

`./main.sh -v -s '"test_block_commands,test_display_clouds,test_model_config,test_model_defaults,test_unregister"' cli test_local_charms`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-cli-test-local-charms-lxd/1336/consoleText