### PR TITLE
[JUJU-4164] Revisit wait-for command errors

### DIFF
--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -234,7 +234,7 @@ func (m ApplicationScope) GetIdentValue(name string) (query.Box, error) {
 	case "workload-version":
 		return query.NewString(m.ApplicationInfo.WorkloadVersion), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on ApplicationInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on ApplicationInfo", name)
 }
 
 func deriveApplicationStatus(currentStatus status.Status, units map[string]*params.UnitInfo) status.Status {

--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -124,7 +124,7 @@ func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 			c.primeCache()
 		}
 	})
-	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext, ctx))
+	err = strategy.Run(ctx, c.name, c.query, c.waitFor(c.query, scopedContext, ctx), emptyNotify)
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -186,8 +186,6 @@ func (c *applicationCommand) waitFor(input string, ctx ScopeContext, logger Logg
 			} else if found {
 				return true, nil
 			}
-
-			logger.Infof("application %q found with %q, waiting...", name, currentStatus)
 		} else {
 			logger.Infof("application %q not found, waiting...", name)
 			return false, nil

--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -4,7 +4,6 @@
 package waitfor
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -31,7 +30,7 @@ func newApplicationCommand() cmd.Command {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return watchAllAPIShim{
+		return modelAllWatchShim{
 			Client: client,
 		}, nil
 	}
@@ -57,9 +56,9 @@ type applicationCommand struct {
 	timeout time.Duration
 	summary bool
 
-	found   bool
-	appInfo params.ApplicationInfo
-	units   map[string]*params.UnitInfo
+	appInfo  *params.ApplicationInfo
+	units    map[string]*params.UnitInfo
+	machines map[string]*params.MachineInfo
 }
 
 // Info implements Command.Info.
@@ -111,7 +110,7 @@ func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 			ctx.Infof("Application %q is being removed", c.name)
 		default:
 			ctx.Infof("Application %q is running", c.name)
-			outputApplicationSummary(ctx.Stdout, scopedContext, &c.appInfo, c.units)
+			outputApplicationSummary(ctx.Stdout, scopedContext, c.appInfo, c.units, c.machines)
 		}
 	}()
 
@@ -122,7 +121,6 @@ func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 	strategy.Subscribe(func(event EventType) {
 		switch event {
 		case WatchAllStarted:
-			fmt.Println("!!!")
 			c.primeCache()
 		}
 	})
@@ -132,9 +130,19 @@ func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 
 func (c *applicationCommand) primeCache() {
 	c.units = make(map[string]*params.UnitInfo)
+	c.machines = make(map[string]*params.MachineInfo)
 }
 
 func (c *applicationCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+	run := func(q query.Query) (bool, error) {
+		scope := MakeApplicationScope(ctx, c.appInfo, c.units, c.machines)
+		if done, err := runQuery(input, q, scope); err != nil {
+			return false, errors.Trace(err)
+		} else if done {
+			return true, nil
+		}
+		return c.appInfo.Life == life.Dead, nil
+	}
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -148,16 +156,7 @@ func (c *applicationCommand) waitFor(input string, ctx ScopeContext) func(string
 					return false, errors.Errorf("application %v removed", name)
 				}
 
-				c.appInfo = *entityInfo
-
-				scope := MakeApplicationScope(ctx, entityInfo, c.units)
-				if done, err := runQuery(input, q, scope); err != nil {
-					return false, errors.Trace(err)
-				} else if done {
-					return true, nil
-				}
-
-				c.found = entityInfo.Life != life.Dead
+				c.appInfo = entityInfo
 
 			case *params.UnitInfo:
 				if delta.Removed {
@@ -167,31 +166,31 @@ func (c *applicationCommand) waitFor(input string, ctx ScopeContext) func(string
 				if entityInfo.Application == name {
 					c.units[entityInfo.Name] = entityInfo
 				}
+
+			case *params.MachineInfo:
+				if delta.Removed {
+					delete(c.machines, entityInfo.Id)
+					break
+				}
+				c.machines[entityInfo.Id] = entityInfo
 			}
 		}
 
-		if !c.found {
+		currentStatus := c.appInfo.Status.Current
+		c.appInfo.Status.Current = deriveApplicationStatus(currentStatus, c.units)
+
+		if c.appInfo != nil {
+			if found, err := run(q); err != nil {
+				return false, errors.Trace(err)
+			} else if found {
+				return true, nil
+			}
+		} else {
 			logger.Infof("application %q not found, waiting...", name)
 			return false, nil
 		}
 
-		currentStatus := c.appInfo.Status.Current
-		logOutput := currentStatus.String() != "unset" && len(c.units) > 0
-
-		appInfo := c.appInfo
-		appInfo.Status.Current = deriveApplicationStatus(currentStatus, c.units)
-
-		scope := MakeApplicationScope(ctx, &appInfo, c.units)
-		if done, err := runQuery(input, q, scope); err != nil {
-			return false, errors.Trace(err)
-		} else if done {
-			return true, nil
-		}
-
-		if logOutput {
-			logger.Infof("application %q found with %q, waiting for goal state", name, currentStatus)
-		}
-
+		logger.Infof("application %q found with %q, waiting...", name, currentStatus)
 		return false, nil
 	}
 }
@@ -201,21 +200,27 @@ type ApplicationScope struct {
 	ctx             ScopeContext
 	ApplicationInfo *params.ApplicationInfo
 	UnitInfos       map[string]*params.UnitInfo
+	MachineInfos    map[string]*params.MachineInfo
 }
 
 // MakeApplicationScope creates an ApplicationScope from an ApplicationInfo
-func MakeApplicationScope(ctx ScopeContext, appInfo *params.ApplicationInfo, unitInfos map[string]*params.UnitInfo) ApplicationScope {
+func MakeApplicationScope(ctx ScopeContext,
+	appInfo *params.ApplicationInfo,
+	unitInfos map[string]*params.UnitInfo,
+	machineInfos map[string]*params.MachineInfo,
+) ApplicationScope {
 	return ApplicationScope{
 		ctx:             ctx,
 		ApplicationInfo: appInfo,
 		UnitInfos:       unitInfos,
+		MachineInfos:    machineInfos,
 	}
 }
 
 // GetIdents returns the identifiers with in a given scope.
 func (m ApplicationScope) GetIdents() []string {
 	idents := set.NewStrings(getIdents(m.ApplicationInfo)...)
-	return set.NewStrings("units").Union(idents).SortedValues()
+	return set.NewStrings("units", "machines").Union(idents).SortedValues()
 }
 
 // GetIdentValue returns the value of the identifier in a given scope.
@@ -242,11 +247,32 @@ func (m ApplicationScope) GetIdentValue(name string) (query.Box, error) {
 	case "units":
 		scopes := make(map[string]query.Scope)
 		for k, unit := range m.UnitInfos {
-			scopes[k] = MakeUnitScope(m.ctx.Child(name, unit.Name), unit)
+			machines := make(map[string]*params.MachineInfo)
+			for n, machine := range m.MachineInfos {
+				if machine.Id == unit.MachineId {
+					machines[n] = machine
+				}
+			}
+
+			scopes[k] = MakeUnitScope(m.ctx.Child(name, unit.Name), unit, machines)
 		}
 		return NewScopedBox(scopes), nil
+	case "machines":
+		scopes := make(map[string]query.Scope)
+		for k, machine := range m.MachineInfos {
+			var found bool
+			for _, unit := range m.UnitInfos {
+				if unit.Application == m.ApplicationInfo.Name && unit.MachineId == machine.Id {
+					found = true
+					break
+				}
+			}
+			if found {
+				scopes[k] = MakeMachineScope(m.ctx.Child(name, machine.Id), machine)
+			}
+		}
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on ApplicationInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name, m), "%q on ApplicationInfo", name)
 }
 
 func deriveApplicationStatus(currentStatus status.Status, units map[string]*params.UnitInfo) status.Status {
@@ -267,11 +293,20 @@ func deriveApplicationStatus(currentStatus status.Status, units map[string]*para
 	return derived.Status
 }
 
-func outputApplicationSummary(writer io.Writer, scopedContext ScopeContext, appInfo *params.ApplicationInfo, units map[string]*params.UnitInfo) {
+func outputApplicationSummary(writer io.Writer,
+	scopedContext ScopeContext,
+	appInfo *params.ApplicationInfo,
+	units map[string]*params.UnitInfo,
+	machines map[string]*params.MachineInfo,
+) {
 	result := struct {
-		Elements map[string]interface{} `yaml:"properties"`
+		Properties map[string]any            `yaml:"properties"`
+		Units      map[string]map[string]any `yaml:"units,omitempty"`
+		Machines   map[string]map[string]any `yaml:"machines,omitempty"`
 	}{
-		Elements: make(map[string]interface{}),
+		Properties: make(map[string]any),
+		Units:      make(map[string]map[string]any),
+		Machines:   make(map[string]map[string]any),
 	}
 
 	idents := scopedContext.RecordedIdents()
@@ -282,16 +317,50 @@ func outputApplicationSummary(writer io.Writer, scopedContext ScopeContext, appI
 		if ident == "status" {
 			currentStatus := appInfo.Status.Current
 			currentStatus = deriveApplicationStatus(currentStatus, units)
-			result.Elements[ident] = currentStatus.String()
+			result.Properties[ident] = currentStatus.String()
 			continue
 		}
 
-		scope := MakeApplicationScope(scopedContext, appInfo, units)
+		scope := MakeApplicationScope(scopedContext, appInfo, units, machines)
 		box, err := scope.GetIdentValue(ident)
 		if err != nil {
 			continue
 		}
-		result.Elements[ident] = box.Value()
+		result.Properties[ident] = box.Value()
+	}
+	for entity, scopes := range scopedContext.children {
+		for name, sctx := range scopes {
+			idents := sctx.RecordedIdents()
+
+			switch entity {
+			case "units":
+				unitInfo := units[name]
+				scope := MakeUnitScope(scopedContext, unitInfo, machines)
+
+				result.Units[name] = make(map[string]any)
+				for _, ident := range idents {
+					box, err := scope.GetIdentValue(ident)
+					if err != nil {
+						continue
+					}
+					result.Units[name][ident] = box.Value()
+				}
+
+			case "machines":
+				machineInfo := machines[name]
+				scope := MakeMachineScope(scopedContext, machineInfo)
+
+				result.Machines[name] = make(map[string]any)
+
+				for _, ident := range idents {
+					box, err := scope.GetIdentValue(ident)
+					if err != nil {
+						continue
+					}
+					result.Machines[name][ident] = box.Value()
+				}
+			}
+		}
 	}
 
 	_ = yaml.NewEncoder(writer).Encode(result)

--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -94,11 +94,11 @@ func (c *applicationCommand) Init(args []string) (err error) {
 	return nil
 }
 
-func (c *applicationCommand) Run(ctx *cmd.Context) error {
+func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 	scopedContext := MakeScopeContext()
 
 	defer func() {
-		if !c.summary {
+		if err != nil || !c.summary {
 			return
 		}
 
@@ -123,7 +123,7 @@ func (c *applicationCommand) Run(ctx *cmd.Context) error {
 			c.primeCache()
 		}
 	})
-	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/application.go
+++ b/cmd/juju/waitfor/application.go
@@ -123,7 +123,7 @@ func (c *applicationCommand) Run(ctx *cmd.Context) (err error) {
 			c.primeCache()
 		}
 	})
-	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext))
 	return errors.Trace(err)
 }
 
@@ -131,7 +131,7 @@ func (c *applicationCommand) primeCache() {
 	c.units = make(map[string]*params.UnitInfo)
 }
 
-func (c *applicationCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+func (c *applicationCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -148,7 +148,7 @@ func (c *applicationCommand) waitFor(ctx ScopeContext) func(string, []params.Del
 				c.appInfo = *entityInfo
 
 				scope := MakeApplicationScope(ctx, entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
+				if done, err := runQuery(input, q, scope); err != nil {
 					return false, errors.Trace(err)
 				} else if done {
 					return true, nil
@@ -179,7 +179,7 @@ func (c *applicationCommand) waitFor(ctx ScopeContext) func(string, []params.Del
 		appInfo.Status.Current = deriveApplicationStatus(currentStatus, c.units)
 
 		scope := MakeApplicationScope(ctx, &appInfo)
-		if done, err := runQuery(q, scope); err != nil {
+		if done, err := runQuery(input, q, scope); err != nil {
 			return false, errors.Trace(err)
 		} else if done {
 			return true, nil

--- a/cmd/juju/waitfor/application_test.go
+++ b/cmd/juju/waitfor/application_test.go
@@ -70,6 +70,6 @@ func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ApplicationInfo: &params.ApplicationInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ApplicationInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on ApplicationInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -3,22 +3,31 @@ package waitfor
 import (
 	"bufio"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/juju/waitfor/query"
 )
 
-func HelpDisplay(err error, input string) error {
-	cause := errors.Cause(err)
-	if !query.IsSyntaxError(cause) {
+func HelpDisplay(err error, input string, idents []string) error {
+	switch {
+	case query.IsSyntaxError(err):
+		return syntaxErrDisplay(err, input)
+	case query.IsInvalidIdentifierErr(err):
+		return invalidIdentifierDisplay(err, input, idents)
+	default:
+		fmt.Println()
 		return err
 	}
+}
 
-	var builder strings.Builder
-
+func syntaxErrDisplay(err error, input string) error {
+	cause := errors.Cause(err)
 	syntaxErr := cause.(*query.SyntaxError)
 
+	var builder strings.Builder
 	builder.WriteString("Cannot parse query:")
 	builder.WriteString(" ")
 	builder.WriteString(helpReason(syntaxErr.Expectations))
@@ -27,19 +36,7 @@ func HelpDisplay(err error, input string) error {
 	builder.WriteString("\n")
 	builder.WriteString("\n")
 
-	ledger := fmt.Sprintf("%d | ", syntaxErr.Pos.Line)
-	builder.WriteString(ledger)
-
-	builder.WriteString(getLine(input, syntaxErr.Pos.Line))
-	builder.WriteString("\n")
-	builder.WriteString(strings.Repeat(" ", len(ledger)+(syntaxErr.Pos.Column-1)))
-
-	offset := 1
-	if syntaxErr.Pos.Offset > 0 {
-		offset = syntaxErr.Pos.Offset
-	}
-	builder.WriteString(strings.Repeat("^", offset))
-	builder.WriteString("\n")
+	builder.WriteString(helpLineError(input, syntaxErr.Pos))
 
 	builder.WriteString(helpMessage(input, syntaxErr.Pos, syntaxErr.Expectations))
 	builder.WriteString(".")
@@ -79,6 +76,37 @@ func helpMessage(input string, pos query.Position, exps []query.TokenType) strin
 	}
 }
 
+func helpLineError(input string, pos query.Position) string {
+	var builder strings.Builder
+	ledger := fmt.Sprintf("%d | ", pos.Line)
+	builder.WriteString(ledger)
+
+	builder.WriteString(getLine(input, pos.Line))
+	builder.WriteString("\n")
+	builder.WriteString(strings.Repeat(" ", len(ledger)+(pos.Column-1)))
+
+	offset := 1
+	if pos.Offset > 0 {
+		offset = pos.Offset
+	}
+	builder.WriteString(strings.Repeat("^", offset))
+	builder.WriteString("\n")
+
+	return builder.String()
+}
+
+func helpLineErrors(input string) string {
+	var builder strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for i := 0; scanner.Scan(); i++ {
+		builder.WriteString(fmt.Sprintf("%d | ", i+1))
+		builder.WriteString(scanner.Text())
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\n")
+	return builder.String()
+}
+
 func getLine(input string, line int) string {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	for i := 0; scanner.Scan(); i++ {
@@ -87,4 +115,129 @@ func getLine(input string, line int) string {
 		}
 	}
 	return ""
+}
+
+func invalidIdentifierDisplay(err error, input string, idents []string) error {
+	cause := errors.Cause(err)
+	identErr := cause.(*query.InvalidIdentifierError)
+
+	var builder strings.Builder
+	builder.WriteString("Cannot execute query: invalid identifier.")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	builder.WriteString(helpLineErrors(input))
+
+	builder.WriteString("No possible matches for")
+	builder.WriteString(" ")
+	builder.WriteString(err.Error())
+	builder.WriteString("\n")
+
+	first, other, ok := orderPotentialMatches(identErr.Name(), idents)
+	if !ok {
+		return fmt.Errorf(builder.String())
+	}
+
+	if first != "" {
+		builder.WriteString("Did you mean:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("    %s", first))
+		builder.WriteString("\n")
+	}
+
+	if len(other) > 0 {
+		builder.WriteString("\n")
+		builder.WriteString("Other possible matches:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString("    - ")
+		builder.WriteString(strings.Join(other, "\n    - "))
+	}
+
+	return fmt.Errorf(builder.String())
+}
+
+func orderPotentialMatches(name string, possible []string) (string, []string, bool) {
+	// Remove any duplicates.
+	possibleSet := set.NewStrings(possible...)
+	if possibleSet.Size() == 0 {
+		return "", nil, false
+	}
+
+	type Indexed = struct {
+		Name  string
+		Value int
+	}
+
+	possible = possibleSet.SortedValues()
+	matches := make([]Indexed, 0, len(possible))
+	for _, ident := range possible {
+		matches = append(matches, Indexed{
+			Name:  ident,
+			Value: levenshteinDistance(name, ident),
+		})
+	}
+	// Find the smallest levenshtein distance. If two values are the same,
+	// fallback to sorting on the name, which should give predictable results.
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Value < matches[j].Value {
+			return true
+		}
+		if matches[i].Value > matches[j].Value {
+			return false
+		}
+		return matches[i].Name < matches[j].Name
+	})
+
+	if len(matches) == 0 {
+		return "", nil, false
+	}
+
+	matchedName := matches[0].Name
+	matchedValue := matches[0].Value
+	if matchedName != "" && matchedValue <= len(matchedName)+1 {
+		others := set.NewStrings(possible...)
+		others.Remove(matchedName)
+		return matchedName, others.SortedValues(), true
+	}
+
+	return "", possible, false
+}
+
+// levenshteinDistance
+// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
+// (no min, compute lengths once, 2 rows array)
+// fastest profiled
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+	d := make([]int, la+1)
+	var lastdiag, olddiag, temp int
+
+	for i := 1; i <= la; i++ {
+		d[i] = i
+	}
+	for i := 1; i <= lb; i++ {
+		d[0] = i
+		lastdiag = i - 1
+		for j := 1; j <= la; j++ {
+			olddiag = d[j]
+			min := d[j] + 1
+			if (d[j-1] + 1) < min {
+				min = d[j-1] + 1
+			}
+			if a[j-1] == b[i-1] {
+				temp = 0
+			} else {
+				temp = 1
+			}
+			if (lastdiag + temp) < min {
+				min = lastdiag + temp
+			}
+			d[j] = min
+			lastdiag = olddiag
+		}
+	}
+	return d[la]
 }

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -1,0 +1,49 @@
+package waitfor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/juju/waitfor/query"
+)
+
+// ColumnPrefix is the prefix used for column errors. By default the prefix
+// for all errors from the cmd line is ERROR.
+const ColumnPrefix = "ERROR "
+
+func HelpDisplay(err error, input []rune) error {
+	cause := errors.Cause(err)
+	if !query.IsSyntaxError(cause) {
+		return err
+	}
+
+	var builder strings.Builder
+
+	syntaxErr := cause.(*query.SyntaxError)
+
+	builder.WriteString("Cannot parse query:")
+	builder.WriteString(" ")
+	if len(syntaxErr.Expectations) == 0 {
+		builder.WriteString("unexpected character")
+	} else {
+		builder.WriteString("expected ")
+		builder.WriteString(syntaxErr.Expectations[0].String())
+	}
+	builder.WriteString(".")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	ledger := fmt.Sprintf("%d | ", syntaxErr.Pos.Line)
+	builder.WriteString(ledger)
+
+	builder.WriteString(string(input))
+	builder.WriteString("\n")
+	builder.WriteString(strings.Repeat(" ", len(ledger)+(syntaxErr.Pos.Column-1)))
+	builder.WriteString(strings.Repeat("^", syntaxErr.Pos.Offset))
+	builder.WriteString("\n")
+
+	builder.WriteString(fmt.Sprintf("wait-for doesn't support %q. Maybe try removing the character and try again.", input[syntaxErr.Pos.Column-1]))
+
+	return fmt.Errorf(builder.String())
+}

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/juju/waitfor/query"
 )
 

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/cmd/juju/waitfor/query"
 )
 
-func HelpDisplay(err error, input []rune) error {
+func HelpDisplay(err error, input string) error {
 	cause := errors.Cause(err)
 	if !query.IsSyntaxError(cause) {
 		return err
@@ -21,14 +21,7 @@ func HelpDisplay(err error, input []rune) error {
 
 	builder.WriteString("Cannot parse query:")
 	builder.WriteString(" ")
-	if len(syntaxErr.Expectations) == 0 {
-		builder.WriteString("unexpected character")
-	} else if exp := syntaxErr.Expectations[0]; exp == query.STRING {
-		builder.WriteString("string not correctly terminated")
-	} else {
-		builder.WriteString("expected ")
-		builder.WriteString(syntaxErr.Expectations[0].String())
-	}
+	builder.WriteString(helpReason(syntaxErr.Expectations))
 
 	builder.WriteString(".")
 	builder.WriteString("\n")
@@ -37,21 +30,53 @@ func HelpDisplay(err error, input []rune) error {
 	ledger := fmt.Sprintf("%d | ", syntaxErr.Pos.Line)
 	builder.WriteString(ledger)
 
-	builder.WriteString(getLine(string(input), syntaxErr.Pos.Line))
+	builder.WriteString(getLine(input, syntaxErr.Pos.Line))
 	builder.WriteString("\n")
 	builder.WriteString(strings.Repeat(" ", len(ledger)+(syntaxErr.Pos.Column-1)))
-	builder.WriteString(strings.Repeat("^", syntaxErr.Pos.Offset))
+
+	offset := 1
+	if syntaxErr.Pos.Offset > 0 {
+		offset = syntaxErr.Pos.Offset
+	}
+	builder.WriteString(strings.Repeat("^", offset))
 	builder.WriteString("\n")
 
-	if len(syntaxErr.Expectations) == 0 {
-		builder.WriteString(fmt.Sprintf("wait-for doesn't support %q. Maybe try removing the character and try again.", input[syntaxErr.Pos.Column-1]))
-	} else if exp := syntaxErr.Expectations[0]; exp == query.STRING {
-		builder.WriteString("Try adding a closing quote to the string.")
-	} else {
-		builder.WriteString("The type doesn't match the expected syntax. Maybe try removing the character and try again.")
-	}
+	builder.WriteString(helpMessage(input, syntaxErr.Pos, syntaxErr.Expectations))
+	builder.WriteString(".")
 
 	return fmt.Errorf(builder.String())
+}
+
+func helpReason(exps []query.TokenType) string {
+	if len(exps) == 0 {
+		return "unexpected character"
+	}
+	switch exps[0] {
+	case query.STRING:
+		return "string is not correctly terminated"
+	case query.CONDAND:
+		return "invalid AND (&&) operator"
+	case query.CONDOR:
+		return "invalid OR (||) operator"
+	default:
+		return fmt.Sprintf("expected %s", exps[0].String())
+	}
+}
+
+func helpMessage(input string, pos query.Position, exps []query.TokenType) string {
+	if len(exps) == 0 {
+		return fmt.Sprintf("wait-for doesn't support %q. Maybe try removing the character and try again", input[pos.Column-1])
+	}
+	switch exps[0] {
+	case query.STRING:
+		return "Try adding a closing quote to the string"
+	case query.CONDAND:
+		return "Ensure that each side of the && operator can be evaluated to a boolean"
+	case query.CONDOR:
+		return "Ensure that each side of the || operator can be evaluated to a boolean"
+	default:
+		return "The type doesn't match the expected syntax. Maybe try removing the character and try again"
+	}
 }
 
 func getLine(input string, line int) string {

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package waitfor
 
 import (

--- a/cmd/juju/waitfor/machine.go
+++ b/cmd/juju/waitfor/machine.go
@@ -117,11 +117,11 @@ func (c *machineCommand) Run(ctx *cmd.Context) (err error) {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.id, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.id, c.query, c.waitFor(c.query, scopedContext))
 	return errors.Trace(err)
 }
 
-func (c *machineCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+func (c *machineCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
 	return func(id string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -139,7 +139,7 @@ func (c *machineCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, 
 				c.machineInfo = *entityInfo
 
 				scope := MakeMachineScope(ctx, entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
+				if done, err := runQuery(input, q, scope); err != nil {
 					return false, errors.Trace(err)
 				} else if done {
 					return true, nil

--- a/cmd/juju/waitfor/machine.go
+++ b/cmd/juju/waitfor/machine.go
@@ -103,11 +103,11 @@ func (c *machineCommand) Run(ctx *cmd.Context) (err error) {
 
 		switch c.machineInfo.Life {
 		case life.Dead:
-			ctx.Infof("Machine %q has been removed", c.id)
+			ctx.Infof("machine %q has been removed", c.id)
 		case life.Dying:
-			ctx.Infof("Machine %q is being removed", c.id)
+			ctx.Infof("machine %q is being removed", c.id)
 		default:
-			ctx.Infof("Machine %q is running", c.id)
+			ctx.Infof("machine %q is running", c.id)
 			outputMachineSummary(ctx.Stdout, scopedContext, c.machineInfo)
 		}
 	}()

--- a/cmd/juju/waitfor/machine.go
+++ b/cmd/juju/waitfor/machine.go
@@ -116,7 +116,7 @@ func (c *machineCommand) Run(ctx *cmd.Context) (err error) {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.id, c.query, c.waitFor(c.query, scopedContext, ctx))
+	err = strategy.Run(ctx, c.id, c.query, c.waitFor(c.query, scopedContext, ctx), emptyNotify)
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/machine.go
+++ b/cmd/juju/waitfor/machine.go
@@ -94,11 +94,11 @@ func (c *machineCommand) Init(args []string) (err error) {
 	return nil
 }
 
-func (c *machineCommand) Run(ctx *cmd.Context) error {
+func (c *machineCommand) Run(ctx *cmd.Context) (err error) {
 	scopedContext := MakeScopeContext()
 
 	defer func() {
-		if !c.summary {
+		if err != nil || !c.summary {
 			return
 		}
 
@@ -117,7 +117,7 @@ func (c *machineCommand) Run(ctx *cmd.Context) error {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err := strategy.Run(c.id, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.id, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/machine.go
+++ b/cmd/juju/waitfor/machine.go
@@ -203,7 +203,7 @@ func (m MachineScope) GetIdentValue(name string) (query.Box, error) {
 		}
 		return query.NewSliceString(containerTypes), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on MachineInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on MachineInfo", name)
 }
 
 func outputMachineSummary(writer io.Writer, scopedContext ScopeContext, machineInfo *params.MachineInfo) {

--- a/cmd/juju/waitfor/machine_test.go
+++ b/cmd/juju/waitfor/machine_test.go
@@ -72,6 +72,6 @@ func (s *machineScopeSuite) TestGetIdentValueError(c *gc.C) {
 		MachineInfo: &params.MachineInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on MachineInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on MachineInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -100,11 +100,11 @@ func (c *modelCommand) Init(args []string) (err error) {
 	return nil
 }
 
-func (c *modelCommand) Run(ctx *cmd.Context) error {
+func (c *modelCommand) Run(ctx *cmd.Context) (err error) {
 	scopedContext := MakeScopeContext()
 
 	defer func() {
-		if c.model == nil || !c.summary {
+		if err != nil || c.model == nil || !c.summary {
 			return
 		}
 
@@ -129,7 +129,7 @@ func (c *modelCommand) Run(ctx *cmd.Context) error {
 			c.primeCache()
 		}
 	})
-	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -129,7 +129,7 @@ func (c *modelCommand) Run(ctx *cmd.Context) (err error) {
 			c.primeCache()
 		}
 	})
-	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext))
 	return errors.Trace(err)
 }
 
@@ -139,7 +139,7 @@ func (c *modelCommand) primeCache() {
 	c.units = make(map[string]*params.UnitInfo)
 }
 
-func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+func (c *modelCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -181,7 +181,7 @@ func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, qu
 
 		if c.model != nil {
 			scope := MakeModelScope(ctx, c)
-			if done, err := runQuery(q, scope); err != nil {
+			if done, err := runQuery(input, q, scope); err != nil {
 				return false, errors.Trace(err)
 			} else if done {
 				return true, nil

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -115,11 +115,11 @@ func (c *modelCommand) Run(ctx *cmd.Context) (err error) {
 
 		switch c.model.Life {
 		case life.Dead:
-			ctx.Infof("Model %q has been removed", c.name)
+			ctx.Infof("model %q has been removed", c.name)
 		case life.Dying:
-			ctx.Infof("Model %q is being removed", c.name)
+			ctx.Infof("model %q is being removed", c.name)
 		default:
-			ctx.Infof("Model %q is running", c.name)
+			ctx.Infof("model %q is running", c.name)
 			outputModelSummary(ctx.Stdout, scopedContext, c.model, c.applications, c.units, c.machines)
 		}
 	}()

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -269,7 +269,7 @@ func (m ModelScope) GetIdentValue(name string) (query.Box, error) {
 		}
 		return NewScopedBox(scopes), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on ModelInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on ModelInfo", name)
 }
 
 // ScopedBox defines a scoped box of scopes.

--- a/cmd/juju/waitfor/model_test.go
+++ b/cmd/juju/waitfor/model_test.go
@@ -62,6 +62,6 @@ func (s *modelScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ModelInfo: &params.ModelUpdate{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ModelInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on ModelInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/query/box.go
+++ b/cmd/juju/waitfor/query/box.go
@@ -177,7 +177,7 @@ func (o *BoxBool) Equal(other Ord) bool {
 
 // IsZero returns if the underlying value is zero.
 func (o *BoxBool) IsZero() bool {
-	return o.value == false
+	return !o.value
 }
 
 // Value defines the shadow type value of the Box.

--- a/cmd/juju/waitfor/query/box.go
+++ b/cmd/juju/waitfor/query/box.go
@@ -26,7 +26,7 @@ type Box interface {
 	IsZero() bool
 
 	// Value defines the shadow type value of the Box.
-	Value() interface{}
+	Value() any
 }
 
 // BoxInteger defines an ordered integer.
@@ -61,12 +61,12 @@ func (o *BoxInteger) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxInteger) Value() interface{} {
+func (o *BoxInteger) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxInteger) ForEach(fn func(interface{}) bool) {
+func (o *BoxInteger) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -102,12 +102,12 @@ func (o *BoxFloat) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxFloat) Value() interface{} {
+func (o *BoxFloat) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxFloat) ForEach(fn func(interface{}) bool) {
+func (o *BoxFloat) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -143,12 +143,12 @@ func (o *BoxString) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxString) Value() interface{} {
+func (o *BoxString) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxString) ForEach(fn func(interface{}) bool) {
+func (o *BoxString) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -181,22 +181,22 @@ func (o *BoxBool) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxBool) Value() interface{} {
+func (o *BoxBool) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxBool) ForEach(fn func(interface{}) bool) {
+func (o *BoxBool) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
-// BoxMapStringInterface defines an ordered map[string]interface{}.
+// BoxMapStringInterface defines an ordered map[string]any.
 type BoxMapStringInterface struct {
-	value map[string]interface{}
+	value map[string]any
 }
 
 // NewMapStringInterface creates a new Box value
-func NewMapStringInterface(value map[string]interface{}) *BoxMapStringInterface {
+func NewMapStringInterface(value map[string]any) *BoxMapStringInterface {
 	return &BoxMapStringInterface{value: value}
 }
 
@@ -219,12 +219,12 @@ func (o *BoxMapStringInterface) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxMapStringInterface) Value() interface{} {
+func (o *BoxMapStringInterface) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxMapStringInterface) ForEach(fn func(interface{}) bool) {
+func (o *BoxMapStringInterface) ForEach(fn func(any) bool) {
 	names := set.NewStrings()
 	for k := range o.value {
 		names.Add(k)
@@ -236,13 +236,13 @@ func (o *BoxMapStringInterface) ForEach(fn func(interface{}) bool) {
 	}
 }
 
-// BoxMapInterfaceInterface defines an ordered map[interface{}]interface{}.
+// BoxMapInterfaceInterface defines an ordered map[any]any.
 type BoxMapInterfaceInterface struct {
-	value map[interface{}]interface{}
+	value map[any]any
 }
 
 // NewMapInterfaceInterface creates a new Box value
-func NewMapInterfaceInterface(value map[interface{}]interface{}) *BoxMapInterfaceInterface {
+func NewMapInterfaceInterface(value map[any]any) *BoxMapInterfaceInterface {
 	return &BoxMapInterfaceInterface{value: value}
 }
 
@@ -265,12 +265,12 @@ func (o *BoxMapInterfaceInterface) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxMapInterfaceInterface) Value() interface{} {
+func (o *BoxMapInterfaceInterface) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxMapInterfaceInterface) ForEach(fn func(interface{}) bool) {
+func (o *BoxMapInterfaceInterface) ForEach(fn func(any) bool) {
 	for _, v := range o.value {
 		if !fn(v) {
 			return
@@ -307,12 +307,12 @@ func (o *BoxSliceString) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxSliceString) Value() interface{} {
+func (o *BoxSliceString) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxSliceString) ForEach(fn func(interface{}) bool) {
+func (o *BoxSliceString) ForEach(fn func(any) bool) {
 	for _, v := range o.value {
 		if !fn(v) {
 			return
@@ -350,7 +350,7 @@ func (o *BoxLambda) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxLambda) Value() interface{} {
+func (o *BoxLambda) Value() any {
 	return o
 }
 
@@ -364,7 +364,7 @@ func (o *BoxLambda) Call(scope Scope) ([]Box, error) {
 	return o.fn(scope)
 }
 
-func expectStringIndex(i interface{}) (*BoxString, error) {
+func expectStringIndex(i any) (*BoxString, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected string, but got %T", i)
@@ -378,7 +378,7 @@ func expectStringIndex(i interface{}) (*BoxString, error) {
 	return idx, nil
 }
 
-func expectIntegerIndex(i interface{}) (*BoxInteger, error) {
+func expectIntegerIndex(i any) (*BoxInteger, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected int, but got %T", i)
@@ -392,7 +392,7 @@ func expectIntegerIndex(i interface{}) (*BoxInteger, error) {
 	return idx, nil
 }
 
-func expectBoxIndex(i interface{}) (Box, error) {
+func expectBoxIndex(i any) (Box, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected box, but got %T", i)
@@ -412,9 +412,9 @@ func shadowType(box Box) string {
 	case *BoxString:
 		return "string"
 	case *BoxMapInterfaceInterface:
-		return "map[interface{}]interface{}"
+		return "map[any]any"
 	case *BoxMapStringInterface:
-		return "map[string]interface{}"
+		return "map[string]any"
 	case *BoxSliceString:
 		return "[]string"
 	}

--- a/cmd/juju/waitfor/query/box.go
+++ b/cmd/juju/waitfor/query/box.go
@@ -29,6 +29,44 @@ type Box interface {
 	Value() any
 }
 
+// BoxScope defines an ordered integer.
+type BoxScope struct {
+	value Scope
+}
+
+// NewScope creates a new Box value
+func NewScope(value Scope) *BoxScope {
+	return &BoxScope{value: value}
+}
+
+// Less checks if a BoxScope is less than another BoxScope.
+func (o *BoxScope) Less(other Ord) bool {
+	return false
+}
+
+// Equal checks if an BoxScope is equal to another BoxScope.
+func (o *BoxScope) Equal(other Ord) bool {
+	if i, ok := other.(*BoxScope); ok {
+		return o.value == i.value
+	}
+	return false
+}
+
+// IsZero returns if the underlying value is zero.
+func (o *BoxScope) IsZero() bool {
+	return o.value == nil
+}
+
+// Value defines the shadow type value of the Box.
+func (o *BoxScope) Value() any {
+	return o.value
+}
+
+// ForEach iterates over each value in the box.
+func (o *BoxScope) ForEach(fn func(any) bool) {
+	fn(o.value)
+}
+
 // BoxInteger defines an ordered integer.
 type BoxInteger struct {
 	value int64

--- a/cmd/juju/waitfor/query/errors.go
+++ b/cmd/juju/waitfor/query/errors.go
@@ -11,8 +11,9 @@ import (
 
 // InvalidIdentifierError creates an invalid error.
 type InvalidIdentifierError struct {
-	name string
-	err  error
+	name  string
+	err   error
+	scope Scope
 }
 
 func (e *InvalidIdentifierError) Error() string {
@@ -27,10 +28,15 @@ func (e *InvalidIdentifierError) Name() string {
 	return e.name
 }
 
+func (e *InvalidIdentifierError) Scope() Scope {
+	return e.scope
+}
+
 // ErrInvalidIdentifier defines a sentinel error for invalid identifiers.
-func ErrInvalidIdentifier(name string) error {
+func ErrInvalidIdentifier(name string, scope Scope) error {
 	return &InvalidIdentifierError{
-		name: name,
+		name:  name,
+		scope: scope,
 	}
 }
 

--- a/cmd/juju/waitfor/query/errors.go
+++ b/cmd/juju/waitfor/query/errors.go
@@ -50,10 +50,10 @@ func (e *RuntimeError) Error() string {
 	return e.err.Error()
 }
 
-// RuntimeErrorf defines a sentinel error for invalid index.
+// RuntimeErrorf defines a sentinel error for runtime errors.
 func RuntimeErrorf(msg string, args ...interface{}) error {
 	return &RuntimeError{
-		err: errors.Errorf("Runtime Error: "+msg, args...),
+		err: errors.Errorf(msg, args...),
 	}
 }
 
@@ -61,6 +61,33 @@ func RuntimeErrorf(msg string, args ...interface{}) error {
 func IsRuntimeError(err error) bool {
 	err = errors.Cause(err)
 	_, ok := err.(*RuntimeError)
+	return ok
+}
+
+// RuntimeSyntaxError creates an invalid error.
+type RuntimeSyntaxError struct {
+	err     error
+	Name    string
+	Options []string
+}
+
+func (e *RuntimeSyntaxError) Error() string {
+	return e.err.Error()
+}
+
+// ErrRuntimeSyntax defines a sentinel error for runtime syntax error.
+func ErrRuntimeSyntax(msg, name string, options []string) error {
+	return &RuntimeSyntaxError{
+		err:     errors.Errorf(msg),
+		Name:    name,
+		Options: options,
+	}
+}
+
+// IsRuntimeSyntaxError returns if the error is an ErrInvalidIndex error
+func IsRuntimeSyntaxError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*RuntimeSyntaxError)
 	return ok
 }
 

--- a/cmd/juju/waitfor/query/errors.go
+++ b/cmd/juju/waitfor/query/errors.go
@@ -16,6 +16,9 @@ type InvalidIdentifierError struct {
 }
 
 func (e *InvalidIdentifierError) Error() string {
+	if e.err == nil {
+		return ""
+	}
 	return e.err.Error()
 }
 
@@ -28,7 +31,6 @@ func (e *InvalidIdentifierError) Name() string {
 func ErrInvalidIdentifier(name string) error {
 	return &InvalidIdentifierError{
 		name: name,
-		err:  errors.Errorf("invalid identifier"),
 	}
 }
 

--- a/cmd/juju/waitfor/query/errors.go
+++ b/cmd/juju/waitfor/query/errors.go
@@ -3,7 +3,11 @@
 
 package query
 
-import "github.com/juju/errors"
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+)
 
 // InvalidIdentifierError creates an invalid error.
 type InvalidIdentifierError struct {
@@ -55,5 +59,34 @@ func RuntimeErrorf(msg string, args ...interface{}) error {
 func IsRuntimeError(err error) bool {
 	err = errors.Cause(err)
 	_, ok := err.(*RuntimeError)
+	return ok
+}
+
+// SyntaxError creates an invalid error.
+type SyntaxError struct {
+	Pos          Position
+	TokenType    TokenType
+	Expectations []TokenType
+}
+
+func (e *SyntaxError) Error() string {
+	if len(e.Expectations) == 0 {
+		return fmt.Sprintf("Syntax Error: %v invalid character '%s' found", e.Pos, e.TokenType)
+	}
+	return fmt.Sprintf("Syntax Error: %v expected token to be %s, got %s instead", e.Pos, e.Expectations[0], e.TokenType)
+}
+
+func ErrSyntaxError(pos Position, tokenType TokenType, expectations ...TokenType) error {
+	return &SyntaxError{
+		Pos:          pos,
+		TokenType:    tokenType,
+		Expectations: expectations,
+	}
+}
+
+// IsSyntaxError returns if the error is an ErrSyntaxError error
+func IsSyntaxError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*SyntaxError)
 	return ok
 }

--- a/cmd/juju/waitfor/query/lexer.go
+++ b/cmd/juju/waitfor/query/lexer.go
@@ -179,9 +179,9 @@ func (l *Lexer) readRunesToken() Token {
 		tok.Literal = l.readIdentifier()
 		switch strings.ToLower(tok.Literal) {
 		case "true":
-			tok.Type = TRUE
+			tok.Type = BOOL
 		case "false":
-			tok.Type = FALSE
+			tok.Type = BOOL
 		case "_":
 			tok.Type = UNDERSCORE
 		default:

--- a/cmd/juju/waitfor/query/lexer.go
+++ b/cmd/juju/waitfor/query/lexer.go
@@ -189,11 +189,11 @@ func (l *Lexer) readRunesToken() Token {
 		}
 		return tok
 	case isQuote(l.char):
-		if s, err := l.readString(l.char); err == nil {
-			tok.Type = STRING
-			tok.Literal = s
-			return tok
-		}
+		s, err := l.readString(l.char)
+		tok.Type = STRING
+		tok.Literal = s
+		tok.Terminated = err == nil
+		return tok
 	}
 	l.ReadNext()
 	return MakeToken(UNKNOWN, l.char)

--- a/cmd/juju/waitfor/query/lexer.go
+++ b/cmd/juju/waitfor/query/lexer.go
@@ -269,5 +269,5 @@ func isDigit(char rune) bool {
 }
 
 func isQuote(char rune) bool {
-	return char == 34
+	return char == 34 || char == 39
 }

--- a/cmd/juju/waitfor/query/lexer.go
+++ b/cmd/juju/waitfor/query/lexer.go
@@ -26,14 +26,12 @@ type Lexer struct {
 
 // NewLexer creates a new Lexer from a given input.
 func NewLexer(input string) *Lexer {
-	lex := &Lexer{
+	return &Lexer{
 		input:  []rune(input),
 		char:   ' ',
 		line:   1,
 		column: 1,
 	}
-
-	return lex
 }
 
 // ReadNext will attempt to read the next character and correctly setup the

--- a/cmd/juju/waitfor/query/lexer_test.go
+++ b/cmd/juju/waitfor/query/lexer_test.go
@@ -164,7 +164,7 @@ func (p *lexerSuite) TestReadNextBool(c *gc.C) {
 			Type: -1,
 		}, {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    TRUE,
+			Type:    BOOL,
 			Literal: "true",
 		}},
 	}, {
@@ -173,7 +173,7 @@ func (p *lexerSuite) TestReadNextBool(c *gc.C) {
 			Type: -1,
 		}, {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    FALSE,
+			Type:    BOOL,
 			Literal: "false",
 		}},
 	}}

--- a/cmd/juju/waitfor/query/lexer_test.go
+++ b/cmd/juju/waitfor/query/lexer_test.go
@@ -267,9 +267,10 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 		Expected: []Token{{
 			Type: -1,
 		}, {
-			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    STRING,
-			Literal: ``,
+			Pos:        Position{Offset: 0, Line: 1, Column: 1},
+			Type:       STRING,
+			Literal:    ``,
+			Terminated: true,
 		}},
 	}, {
 		Input: `"abc"`,
@@ -279,6 +280,8 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
 			Type:    STRING,
 			Literal: "abc",
+
+			Terminated: true,
 		}},
 	}, {
 		Input: `"abc with a space"`,
@@ -288,6 +291,8 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
 			Type:    STRING,
 			Literal: "abc with a space",
+
+			Terminated: true,
 		}},
 	}}
 

--- a/cmd/juju/waitfor/query/parser.go
+++ b/cmd/juju/waitfor/query/parser.go
@@ -317,8 +317,7 @@ func (p *Parser) parseLambda(left Expression) (Expression, error) {
 		expressions = append(expressions, next)
 	}
 	if !p.isPeekToken(EOF) && !p.isPeekToken(RPAREN) {
-		p.expectPeek(RPAREN)
-		return nil, nil
+		return nil, p.expectPeek(RPAREN)
 	}
 
 	return &LambdaExpression{

--- a/cmd/juju/waitfor/query/parser.go
+++ b/cmd/juju/waitfor/query/parser.go
@@ -36,6 +36,7 @@ var precedence = map[TokenType]int{
 type Parser struct {
 	lex *Lexer
 
+	prevToken    Token
 	currentToken Token
 	peekToken    Token
 
@@ -100,6 +101,9 @@ func (p *Parser) parseIdentifier() (Expression, error) {
 }
 
 func (p *Parser) parseString() (Expression, error) {
+	if !p.currentToken.Terminated {
+		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, STRING)
+	}
 	return &String{
 		Token: p.currentToken,
 	}, nil
@@ -362,6 +366,7 @@ func (p *Parser) isCurrentToken(t TokenType) bool {
 }
 
 func (p *Parser) nextToken() {
+	p.prevToken = p.currentToken
 	p.currentToken = p.peekToken
 	p.peekToken = p.lex.NextToken()
 }

--- a/cmd/juju/waitfor/query/parser.go
+++ b/cmd/juju/waitfor/query/parser.go
@@ -108,7 +108,7 @@ func (p *Parser) parseString() (Expression, error) {
 func (p *Parser) parseBool() (Expression, error) {
 	value, err := strconv.ParseBool(p.currentToken.Literal)
 	if err != nil {
-		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, FLOAT)
+		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, BOOL)
 	}
 	return &Bool{
 		Token: p.currentToken,

--- a/cmd/juju/waitfor/query/parser.go
+++ b/cmd/juju/waitfor/query/parser.go
@@ -4,11 +4,7 @@
 package query
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
-
-	"github.com/juju/errors"
 )
 
 const (
@@ -40,8 +36,6 @@ var precedence = map[TokenType]int{
 type Parser struct {
 	lex *Lexer
 
-	errors []string
-
 	currentToken Token
 	peekToken    Token
 
@@ -49,8 +43,8 @@ type Parser struct {
 	infix  map[TokenType]InfixFunc
 }
 
-type PrefixFunc func() Expression
-type InfixFunc func(Expression) Expression
+type PrefixFunc func() (Expression, error)
+type InfixFunc func(Expression) (Expression, error)
 
 // NewParser creates a parser for consuming a lexer tokens.
 func NewParser(lex *Lexer) *Parser {
@@ -64,8 +58,7 @@ func NewParser(lex *Lexer) *Parser {
 		FLOAT:      p.parseFloat,
 		STRING:     p.parseString,
 		LPAREN:     p.parseGroup,
-		TRUE:       p.parseBool,
-		FALSE:      p.parseBool,
+		BOOL:       p.parseBool,
 	}
 	p.infix = map[TokenType]InfixFunc{
 		EQ:       p.parseInfixExpression,
@@ -90,221 +83,260 @@ func NewParser(lex *Lexer) *Parser {
 func (p *Parser) Run() (*QueryExpression, error) {
 	var exp QueryExpression
 	for p.currentToken.Type != EOF {
-		exp.Expressions = append(exp.Expressions, p.parseExpressionStatement())
+		expr, err := p.parseExpressionStatement()
+		if err != nil {
+			return nil, err
+		}
+		exp.Expressions = append(exp.Expressions, expr)
 		p.nextToken()
-	}
-	var err error
-	if len(p.errors) > 0 {
-		err = errors.Errorf(strings.Join(p.errors, "\n"))
-		return nil, errors.Trace(err)
 	}
 	return &exp, nil
 }
 
-func (p *Parser) parseIdentifier() Expression {
+func (p *Parser) parseIdentifier() (Expression, error) {
 	return &Identifier{
 		Token: p.currentToken,
-	}
+	}, nil
 }
 
-func (p *Parser) parseString() Expression {
+func (p *Parser) parseString() (Expression, error) {
 	return &String{
 		Token: p.currentToken,
-	}
+	}, nil
 }
 
-func (p *Parser) parseBool() Expression {
+func (p *Parser) parseBool() (Expression, error) {
 	value, err := strconv.ParseBool(p.currentToken.Literal)
 	if err != nil {
-		msg := fmt.Sprintf("Syntax Error:%v could not parse %q as bool", p.currentToken.Pos, p.currentToken.Literal)
-		p.errors = append(p.errors, msg)
+		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, FLOAT)
 	}
 	return &Bool{
 		Token: p.currentToken,
 		Value: value,
-	}
+	}, nil
 }
 
-func (p *Parser) parseInteger() Expression {
+func (p *Parser) parseInteger() (Expression, error) {
 	value, err := strconv.ParseInt(p.currentToken.Literal, 10, 64)
 	if err != nil {
-		msg := fmt.Sprintf("Syntax Error:%v could not parse %q as integer", p.currentToken.Pos, p.currentToken.Literal)
-		p.errors = append(p.errors, msg)
+		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, INT)
 	}
 	return &Integer{
 		Token: p.currentToken,
 		Value: value,
-	}
+	}, nil
 }
 
-func (p *Parser) parseFloat() Expression {
+func (p *Parser) parseFloat() (Expression, error) {
 	value, err := strconv.ParseFloat(p.currentToken.Literal, 64)
 	if err != nil {
-		msg := fmt.Sprintf("Syntax Error:%v could not parse %q as float", p.currentToken.Pos, p.currentToken.Literal)
-		p.errors = append(p.errors, msg)
+		return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type, FLOAT)
 	}
 	return &Float{
 		Token: p.currentToken,
 		Value: value,
-	}
+	}, nil
 }
 
-func (p *Parser) parseExpressionStatement() Expression {
+func (p *Parser) parseExpressionStatement() (Expression, error) {
 	stmt := &ExpressionStatement{
 		Token: p.currentToken,
 	}
-
-	stmt.Expression = p.parseExpression(LOWEST)
+	expr, err := p.parseExpression(LOWEST)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Expression = expr
 
 	if p.isPeekToken(SEMICOLON) {
 		p.nextToken()
 	}
-	return stmt
+	return stmt, nil
 }
 
-func (p *Parser) parseExpression(precedence int) Expression {
+func (p *Parser) parseExpression(precedence int) (Expression, error) {
 	prefix := p.prefix[p.currentToken.Type]
 	if prefix == nil {
 		if p.currentToken.Type != EOF {
-			msg := fmt.Sprintf("Syntax Error:%v invalid character '%s' found", p.currentToken.Pos, p.currentToken.Type)
-			p.errors = append(p.errors, msg)
+			return nil, ErrSyntaxError(p.currentToken.Pos, p.currentToken.Type)
 		}
-		return nil
+		return nil, nil
 	}
-	leftExp := prefix()
-
+	leftExp, err := prefix()
+	if err != nil {
+		return nil, err
+	}
 	// Run the infix function until the next token has
 	// a higher precedence.
 	for !p.isPeekToken(SEMICOLON) && precedence < p.peekPrecedence() {
 		infix := p.infix[p.peekToken.Type]
 		if infix == nil {
-			return leftExp
+			return leftExp, nil
 		}
 		p.nextToken()
-		leftExp = infix(leftExp)
+		if leftExp, err = infix(leftExp); err != nil {
+			return nil, err
+		}
 	}
 
-	return leftExp
+	return leftExp, nil
 }
 
-func (p *Parser) parseInfixExpression(left Expression) Expression {
-	expression := &InfixExpression{
+func (p *Parser) parseInfixExpression(left Expression) (Expression, error) {
+	expr := &InfixExpression{
 		Token:    p.currentToken,
 		Operator: p.currentToken.Literal,
 		Left:     left,
 	}
 	precedence := p.currentPrecedence()
 	p.nextToken()
-	expression.Right = p.parseExpression(precedence)
-	return expression
+	right, err := p.parseExpression(precedence)
+	if err != nil {
+		return nil, err
+	}
+
+	expr.Right = right
+	return expr, nil
 }
 
-func (p *Parser) parseGroup() Expression {
+func (p *Parser) parseGroup() (Expression, error) {
 	p.nextToken()
 	if p.currentToken.Type == LPAREN && p.isCurrentToken(RPAREN) {
-		// This is an empty group, not sure what we should do here.
 		return &Empty{
 			Token: p.currentToken,
-		}
+		}, nil
 	}
 
-	exp := p.parseExpression(LOWEST)
-	if !p.expectPeek(RPAREN) {
-		return nil
+	exp, err := p.parseExpression(LOWEST)
+	if err != nil {
+		return nil, err
 	}
-	return exp
+	if err := p.expectPeek(RPAREN); err != nil {
+		return nil, err
+	}
+	return exp, nil
 }
 
-func (p *Parser) parseIndex(left Expression) Expression {
+func (p *Parser) parseIndex(left Expression) (Expression, error) {
 	p.nextToken()
 
+	index, err := p.parseExpression(LOWEST)
+	if err != nil {
+		return nil, err
+	}
 	expression := &IndexExpression{
 		Token: p.currentToken,
 		Left:  left,
-		Index: p.parseExpression(LOWEST),
+		Index: index,
 	}
-	if !p.expectPeek(RBRACKET) {
-		return nil
+	if err := p.expectPeek(RBRACKET); err != nil {
+		return nil, err
 	}
-	return expression
+	return expression, nil
 }
 
-func (p *Parser) parseCall(left Expression) Expression {
+func (p *Parser) parseCall(left Expression) (Expression, error) {
 	if p.isPeekToken(RPAREN) {
 		currentToken := p.currentToken
 		p.nextToken()
 		return &CallExpression{
 			Token: currentToken,
 			Name:  left,
-		}
+		}, nil
 	}
 
 	p.nextToken()
 
+	first, err := p.parseExpression(LOWEST)
+	if err != nil {
+		return nil, err
+	}
 	arguments := []Expression{
-		p.parseExpression(LOWEST),
+		first,
 	}
 	for p.isPeekToken(COMMA) {
 		p.nextToken()
 		p.nextToken()
-		arguments = append(arguments, p.parseExpression(LOWEST))
+
+		next, err := p.parseExpression(LOWEST)
+		if err != nil {
+			return nil, err
+		}
+		arguments = append(arguments, next)
 	}
-	if !p.expectPeek(RPAREN) {
-		return nil
+	if err := p.expectPeek(RPAREN); err != nil {
+		return nil, err
 	}
 
 	return &CallExpression{
 		Token:     p.currentToken,
 		Name:      left,
 		Arguments: arguments,
-	}
+	}, nil
 }
 
-func (p *Parser) parseLambda(left Expression) Expression {
+func (p *Parser) parseLambda(left Expression) (Expression, error) {
 	if p.isPeekToken(UNDERSCORE) {
 		currentToken := p.currentToken
 		p.nextToken()
+
+		expr, err := p.parseExpression(LOWEST)
+		if err != nil {
+			return nil, err
+		}
+
 		return &LambdaExpression{
 			Token:    currentToken,
 			Argument: left,
 			Expressions: []Expression{
-				p.parseExpression(LOWEST),
+				expr,
 			},
-		}
+		}, nil
 	}
 
 	p.nextToken()
 
+	first, err := p.parseExpression(LOWEST)
+	if err != nil {
+		return nil, err
+	}
 	expressions := []Expression{
-		p.parseExpression(LOWEST),
+		first,
 	}
 	for p.isPeekToken(SEMICOLON) {
 		p.nextToken()
 		p.nextToken()
-		expressions = append(expressions, p.parseExpression(LOWEST))
+		next, err := p.parseExpression(LOWEST)
+		if err != nil {
+			return nil, err
+		}
+		expressions = append(expressions, next)
 	}
 	if !p.isPeekToken(EOF) && !p.isPeekToken(RPAREN) {
 		p.expectPeek(RPAREN)
-		return nil
+		return nil, nil
 	}
 
 	return &LambdaExpression{
 		Token:       p.currentToken,
 		Argument:    left,
 		Expressions: expressions,
-	}
+	}, nil
 }
 
-func (p *Parser) parseAccessor(left Expression) Expression {
+func (p *Parser) parseAccessor(left Expression) (Expression, error) {
 	precedence := p.currentPrecedence()
 	p.nextToken()
-	right := p.parseExpression(precedence)
+	right, err := p.parseExpression(precedence)
+	if err != nil {
+		return nil, err
+	}
 
 	return &AccessorExpression{
 		Token: p.currentToken,
 		Left:  left,
 		Right: right,
-	}
+	}, nil
 }
 
 func (p *Parser) currentPrecedence() int {
@@ -334,12 +366,10 @@ func (p *Parser) nextToken() {
 	p.peekToken = p.lex.NextToken()
 }
 
-func (p *Parser) expectPeek(t TokenType) bool {
+func (p *Parser) expectPeek(t TokenType) error {
 	if p.isPeekToken(t) {
 		p.nextToken()
-		return true
+		return nil
 	}
-	msg := fmt.Sprintf("Syntax Error: %v expected token to be %s, got %s instead", p.currentToken.Pos, t, p.peekToken.Type)
-	p.errors = append(p.errors, msg)
-	return false
+	return ErrSyntaxError(p.currentToken.Pos, p.peekToken.Type, t)
 }

--- a/cmd/juju/waitfor/query/parser_test.go
+++ b/cmd/juju/waitfor/query/parser_test.go
@@ -92,15 +92,17 @@ func (p *parserSuite) TestParserString(c *gc.C) {
 			&ExpressionStatement{
 				Expression: &String{
 					Token: Token{
-						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    STRING,
-						Literal: "abc",
+						Pos:        Position{Line: 1, Column: 1, Offset: 0},
+						Type:       STRING,
+						Literal:    "abc",
+						Terminated: true,
 					},
 				},
 				Token: Token{
-					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    STRING,
-					Literal: "abc",
+					Pos:        Position{Line: 1, Column: 1, Offset: 0},
+					Type:       STRING,
+					Literal:    "abc",
+					Terminated: true,
 				},
 			},
 		},

--- a/cmd/juju/waitfor/query/parser_test.go
+++ b/cmd/juju/waitfor/query/parser_test.go
@@ -176,14 +176,14 @@ func (p *parserSuite) TestParserBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    TRUE,
+						Type:    BOOL,
 						Literal: "true",
 					},
 					Value: true,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -191,14 +191,14 @@ func (p *parserSuite) TestParserBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 6, Offset: 5},
-						Type:    FALSE,
+						Type:    BOOL,
 						Literal: "false",
 					},
 					Value: false,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 6, Offset: 5},
-					Type:    FALSE,
+					Type:    BOOL,
 					Literal: "false",
 				},
 			},
@@ -247,7 +247,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -256,7 +256,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -269,7 +269,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -291,7 +291,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -300,7 +300,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -313,7 +313,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},

--- a/cmd/juju/waitfor/query/query.go
+++ b/cmd/juju/waitfor/query/query.go
@@ -75,7 +75,7 @@ func (q Query) Run(fnScope FuncScope, scope Scope) (bool, error) {
 
 func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (any, error) {
 	// Useful for debugging.
-	fmt.Printf("%[1]T %[1]v\n", e)
+	// fmt.Printf("%[1]T %[1]v\n", e)
 
 	switch node := e.(type) {
 	case *QueryExpression:
@@ -185,7 +185,7 @@ func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (any, error) {
 			}
 			num := int(idx.Value().(int64))
 			if num < 0 || num >= len(t.value) {
-				return nil, RuntimeErrorf("%s %v range error accessing slice", shadowType(t), node.Left.Pos(), num)
+				return nil, RuntimeErrorf("%s %v range %d accessing slice", shadowType(t), node.Left.Pos(), num)
 			}
 			return ConvertRawResult(t.value[num])
 

--- a/cmd/juju/waitfor/query/query.go
+++ b/cmd/juju/waitfor/query/query.go
@@ -354,6 +354,9 @@ func ConvertRawResult(value any) (Box, error) {
 	if box, ok := value.(Box); ok {
 		return box, nil
 	}
+	if scope, ok := value.(Scope); ok {
+		return NewScope(scope), nil
+	}
 
 	switch t := value.(type) {
 	case string:

--- a/cmd/juju/waitfor/query/query.go
+++ b/cmd/juju/waitfor/query/query.go
@@ -42,8 +42,8 @@ type Scope interface {
 
 // FuncScope is used to call functions for a given identifier.
 type FuncScope interface {
-	Add(string, interface{})
-	Call(*Identifier, []Box) (interface{}, error)
+	Add(string, any)
+	Call(*Identifier, []Box) (any, error)
 }
 
 // BuiltinsRun runs the query with a set of builtin functions.
@@ -73,9 +73,9 @@ func (q Query) Run(fnScope FuncScope, scope Scope) (bool, error) {
 	return !ref.IsZero(), nil
 }
 
-func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (interface{}, error) {
+func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (any, error) {
 	// Useful for debugging.
-	// fmt.Printf("%[1]T %[1]v\n", e)
+	fmt.Printf("%[1]T %[1]v\n", e)
 
 	switch node := e.(type) {
 	case *QueryExpression:
@@ -210,7 +210,7 @@ func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (interface{}, e
 			return nil, errors.Trace(err)
 		}
 
-		var right interface{}
+		var right any
 		switch node.Token.Type {
 		case CONDAND, CONDOR:
 			// Don't compute the right handside for a logical operator.
@@ -318,7 +318,7 @@ func (q *Query) getName(node Expression, fnScope FuncScope, scope Scope) (string
 	return raw, nil
 }
 
-func equality(left, right interface{}) bool {
+func equality(left, right any) bool {
 	a, ok1 := left.(Box)
 	b, ok2 := right.(Box)
 
@@ -328,7 +328,7 @@ func equality(left, right interface{}) bool {
 	return a.Equal(b)
 }
 
-func lessThan(left, right interface{}) bool {
+func lessThan(left, right any) bool {
 	a, ok1 := left.(Box)
 	b, ok2 := right.(Box)
 
@@ -339,7 +339,7 @@ func lessThan(left, right interface{}) bool {
 	return a.Less(b)
 }
 
-func lessThanOrEqual(left, right interface{}) bool {
+func lessThanOrEqual(left, right any) bool {
 	a, ok1 := left.(Box)
 	b, ok2 := right.(Box)
 
@@ -350,7 +350,7 @@ func lessThanOrEqual(left, right interface{}) bool {
 	return a.Less(b) || a.Equal(b)
 }
 
-func ConvertRawResult(value interface{}) (Box, error) {
+func ConvertRawResult(value any) (Box, error) {
 	if box, ok := value.(Box); ok {
 		return box, nil
 	}
@@ -366,9 +366,9 @@ func ConvertRawResult(value interface{}) (Box, error) {
 		return NewBool(t), nil
 	case float64:
 		return NewFloat(t), nil
-	case map[interface{}]interface{}:
+	case map[any]any:
 		return NewMapInterfaceInterface(t), nil
-	case map[string]interface{}:
+	case map[string]any:
 		return NewMapStringInterface(t), nil
 	case []string:
 		return NewSliceString(t), nil

--- a/cmd/juju/waitfor/query/query.go
+++ b/cmd/juju/waitfor/query/query.go
@@ -244,7 +244,7 @@ func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (any, error) {
 		case bool:
 			leftOp = op
 		default:
-			return nil, RuntimeErrorf("%T %v logical AND only allowed on boolean values", left, node.Left.Pos())
+			return nil, ErrSyntaxError(node.Left.Pos(), node.Token.Type, node.Token.Type)
 		}
 
 		// Ensure we don't call the right hand expression unless we need to.
@@ -271,7 +271,7 @@ func (q Query) run(e Expression, fnScope FuncScope, scope Scope) (any, error) {
 		case bool:
 			rightOp = op
 		default:
-			return nil, RuntimeErrorf("%T %v logical AND only allowed on boolean values", right, node.Right.Pos())
+			return nil, ErrSyntaxError(node.Right.Pos(), node.Token.Type, node.Token.Type)
 		}
 
 		return rightOp, nil

--- a/cmd/juju/waitfor/query/query_test.go
+++ b/cmd/juju/waitfor/query/query_test.go
@@ -242,14 +242,14 @@ func (s *querySuite) TestRunBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    TRUE,
+						Type:    BOOL,
 						Literal: "true",
 					},
 					Value: true,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -276,7 +276,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -285,7 +285,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -298,7 +298,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -325,7 +325,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -334,7 +334,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "false",
 						},
 						Value: false,
@@ -347,7 +347,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},

--- a/cmd/juju/waitfor/query/scope.go
+++ b/cmd/juju/waitfor/query/scope.go
@@ -84,6 +84,32 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 				}
 				return result, nil
 			},
+			"startsWith": func(v, prefix any) (bool, error) {
+				if _, ok := prefix.(string); !ok {
+					return false, RuntimeErrorf("requires string to be passed to startsWith, got %T", prefix)
+				}
+
+				val := reflect.ValueOf(v)
+				switch val.Kind() {
+				case reflect.String:
+					return strings.HasPrefix(val.String(), prefix.(string)), nil
+				default:
+					return false, RuntimeErrorf("unexpected type %T passed to startsWith", v)
+				}
+			},
+			"endsWith": func(v, suffix any) (bool, error) {
+				if _, ok := suffix.(string); !ok {
+					return false, RuntimeErrorf("requires string to be passed to endsWith, got %T", suffix)
+				}
+
+				val := reflect.ValueOf(v)
+				switch val.Kind() {
+				case reflect.String:
+					return strings.HasSuffix(val.String(), suffix.(string)), nil
+				default:
+					return false, RuntimeErrorf("unexpected type %T passed to endsWith", v)
+				}
+			},
 		},
 	}
 }
@@ -108,7 +134,7 @@ func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (any, error) {
 
 	f := reflect.ValueOf(fn)
 	if len(params) != f.Type().NumIn() {
-		return nil, RuntimeErrorf("number of params for a function call to be %d, but got: %d", f.Type().NumIn(), len(params))
+		return nil, RuntimeErrorf("number of arguments for a function call to be %d, but got: %d", f.Type().NumIn(), len(params))
 	}
 	if f.Type().NumOut() != 2 {
 		return nil, RuntimeErrorf("number of results for a given function call must be 2")

--- a/cmd/juju/waitfor/query/scope.go
+++ b/cmd/juju/waitfor/query/scope.go
@@ -15,15 +15,15 @@ import (
 // on a set of arguments.
 type GlobalFuncScope struct {
 	scope Scope
-	funcs map[string]interface{}
+	funcs map[string]any
 }
 
 // NewGlobalFuncScope creates a new scope for executing functions.
 func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 	return &GlobalFuncScope{
 		scope: scope,
-		funcs: map[string]interface{}{
-			"len": func(v interface{}) (int, error) {
+		funcs: map[string]any{
+			"len": func(v any) (int, error) {
 				val := reflect.ValueOf(v)
 				switch val.Kind() {
 				case reflect.Map, reflect.Slice, reflect.String:
@@ -32,11 +32,11 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 					return -1, RuntimeErrorf("unexpected type %T passed to len", v)
 				}
 			},
-			"print": func(v interface{}) (interface{}, error) {
+			"print": func(v any) (any, error) {
 				fmt.Printf("%+v\n", v)
 				return v, nil
 			},
-			"forEach": func(values, expr interface{}) (interface{}, error) {
+			"forEach": func(values, expr any) (any, error) {
 				scopes, ok := values.(Box)
 				if !ok {
 					return nil, RuntimeErrorf("unexpected lambda values %T", values)
@@ -51,7 +51,7 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 					called bool
 					result = true
 				)
-				ForEach(scopes, func(value interface{}) bool {
+				ForEach(scopes, func(value any) bool {
 					called = true
 
 					nestedScope, ok := value.(Scope)
@@ -88,12 +88,12 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 }
 
 // Add a function to the global scope.
-func (s *GlobalFuncScope) Add(name string, fn interface{}) {
+func (s *GlobalFuncScope) Add(name string, fn any) {
 	s.funcs[name] = fn
 }
 
 // Call a function with a set of arguments.
-func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (interface{}, error) {
+func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (any, error) {
 	name := ident.Token.Literal
 	fn, ok := s.funcs[name]
 	if !ok {
@@ -183,15 +183,15 @@ func (o *BoxNestedScope) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxNestedScope) Value() interface{} {
+func (o *BoxNestedScope) Value() any {
 	return o.value
 }
 
 // ForEach will call the function on every value within a Box.
 // If a Box isn't an iterable then we perform a no-op.
-func ForEach(box Box, fn func(value interface{}) bool) {
+func ForEach(box Box, fn func(value any) bool) {
 	type iterable interface {
-		ForEach(func(interface{}) bool)
+		ForEach(func(any) bool)
 	}
 	if e, ok := box.(iterable); ok {
 		e.ForEach(fn)

--- a/cmd/juju/waitfor/query/token.go
+++ b/cmd/juju/waitfor/query/token.go
@@ -39,8 +39,7 @@ const (
 	BITOR   // |
 	CONDAND // &&
 	CONDOR  // ||
-	TRUE    // TRUE
-	FALSE   // FALSE
+	BOOL    // BOOL
 
 	LAMBDA     // =>
 	UNDERSCORE // _
@@ -101,10 +100,8 @@ func (t TokenType) String() string {
 		return "||"
 	case STRING:
 		return `""`
-	case TRUE:
-		return "true"
-	case FALSE:
-		return "false"
+	case BOOL:
+		return "BOOL"
 	default:
 		return "<UNKNOWN>"
 	}

--- a/cmd/juju/waitfor/query/token.go
+++ b/cmd/juju/waitfor/query/token.go
@@ -121,9 +121,10 @@ func (p Position) String() string {
 // Token defines a token found with in a query, along with the position and what
 // type it is.
 type Token struct {
-	Pos     Position
-	Type    TokenType
-	Literal string
+	Pos        Position
+	Type       TokenType
+	Literal    string
+	Terminated bool
 }
 
 // MakeToken creates a new token value.

--- a/cmd/juju/waitfor/strategy.go
+++ b/cmd/juju/waitfor/strategy.go
@@ -128,7 +128,7 @@ func isWatcherStopped(e *rpc.RequestError) bool {
 
 // GenericScope allows the query to introspect an entity.
 type GenericScope struct {
-	scopes map[string]interface{}
+	scopes map[string]any
 }
 
 // GetIdents returns the names of all the available idents.
@@ -175,13 +175,13 @@ func (m *GenericScope) GetIdentValue(name string) (query.Box, error) {
 }
 
 // SetIdentValue sets a new ident and it's value on a given scope.
-func (m *GenericScope) SetIdentValue(name string, value interface{}) {
+func (m *GenericScope) SetIdentValue(name string, value any) {
 	m.scopes[name] = value
 }
 
 // Clone a given scope.
 func (m *GenericScope) Clone() query.Scope {
-	scopes := make(map[string]interface{}, len(m.scopes))
+	scopes := make(map[string]any, len(m.scopes))
 	for k, v := range m.scopes {
 		scopes[k] = v
 	}

--- a/cmd/juju/waitfor/strategy.go
+++ b/cmd/juju/waitfor/strategy.go
@@ -106,7 +106,8 @@ func (s *Strategy) run(q query.Query, name string, input string, fn StrategyFunc
 			}
 		}
 
-		if done, err := fn(name, deltas, q); err != nil {
+		done, err := fn(name, deltas, q)
+		if err != nil {
 			return errors.Trace(err)
 		} else if done {
 			return nil

--- a/cmd/juju/waitfor/strategy.go
+++ b/cmd/juju/waitfor/strategy.go
@@ -52,7 +52,7 @@ func (s *Strategy) Subscribe(sub Callback) {
 func (s *Strategy) Run(name string, input string, fn StrategyFunc) error {
 	q, err := query.Parse(input)
 	if err != nil {
-		return HelpDisplay(err, input)
+		return HelpDisplay(err, input, nil)
 	}
 
 	return retry.Call(retry.CallArgs{

--- a/cmd/juju/waitfor/strategy.go
+++ b/cmd/juju/waitfor/strategy.go
@@ -52,7 +52,7 @@ func (s *Strategy) Subscribe(sub Callback) {
 func (s *Strategy) Run(name string, input string, fn StrategyFunc) error {
 	q, err := query.Parse(input)
 	if err != nil {
-		return errors.Trace(err)
+		return HelpDisplay(err, []rune(input))
 	}
 
 	return retry.Call(retry.CallArgs{

--- a/cmd/juju/waitfor/strategy.go
+++ b/cmd/juju/waitfor/strategy.go
@@ -52,7 +52,7 @@ func (s *Strategy) Subscribe(sub Callback) {
 func (s *Strategy) Run(name string, input string, fn StrategyFunc) error {
 	q, err := query.Parse(input)
 	if err != nil {
-		return HelpDisplay(err, []rune(input))
+		return HelpDisplay(err, input)
 	}
 
 	return retry.Call(retry.CallArgs{

--- a/cmd/juju/waitfor/strategy_test.go
+++ b/cmd/juju/waitfor/strategy_test.go
@@ -4,6 +4,7 @@
 package waitfor
 
 import (
+	"context"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -49,11 +50,11 @@ func (s *strategySuite) TestRun(c *gc.C) {
 		},
 		Timeout: time.Minute,
 	}
-	err := strategy.Run("generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
+	err := strategy.Run(context.Background(), "generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
 		executed = true
 		deltas = d
 		return true, nil
-	})
+	}, emptyNotify)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executed, jc.IsTrue)
 	c.Assert(deltas, gc.DeepEquals, expected)
@@ -87,9 +88,9 @@ func (s *strategySuite) TestRunWithCallback(c *gc.C) {
 	strategy.Subscribe(func(event EventType) {
 		eventType = event
 	})
-	err := strategy.Run("generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
+	err := strategy.Run(context.Background(), "generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
 		return true, nil
-	})
+	}, emptyNotify)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(eventType, gc.Equals, WatchAllStarted)
 }
@@ -105,10 +106,10 @@ func (s *strategySuite) TestRunWithInvalidQuery(c *gc.C) {
 		},
 		Timeout: time.Minute,
 	}
-	err := strategy.Run("generic", `life=="ac`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
+	err := strategy.Run(context.Background(), "generic", `life=="ac`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
 		c.FailNow()
 		return false, nil
-	})
+	}, emptyNotify)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `
 Cannot parse query: string is not correctly terminated.

--- a/cmd/juju/waitfor/strategy_test.go
+++ b/cmd/juju/waitfor/strategy_test.go
@@ -109,7 +109,13 @@ func (s *strategySuite) TestRunWithInvalidQuery(c *gc.C) {
 		c.FailNow()
 		return false, nil
 	})
-	c.Assert(err, gc.ErrorMatches, `Syntax Error:<:1:7> invalid character '<UNKNOWN>' found`)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.Error(), gc.Equals, `
+Cannot parse query: string is not correctly terminated.
+
+1 | life=="ac
+          ^
+Try adding a closing quote to the string.`[1:])
 }
 
 type MockEntityInfo struct {

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -105,11 +105,11 @@ func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 
 		switch c.unitInfo.Life {
 		case life.Dead:
-			ctx.Infof("Unit %q has been removed", c.name)
+			ctx.Infof("unit %q has been removed", c.name)
 		case life.Dying:
-			ctx.Infof("Unit %q is being removed", c.name)
+			ctx.Infof("unit %q is being removed", c.name)
 		default:
-			ctx.Infof("Unit %q is running", c.name)
+			ctx.Infof("unit %q is running", c.name)
 			outputUnitSummary(ctx.Stdout, scopedContext, c.unitInfo, c.machines)
 		}
 	}()

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -94,11 +94,11 @@ func (c *unitCommand) Init(args []string) (err error) {
 	return nil
 }
 
-func (c *unitCommand) Run(ctx *cmd.Context) error {
+func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 	scopedContext := MakeScopeContext()
 
 	defer func() {
-		if !c.summary {
+		if err != nil || !c.summary {
 			return
 		}
 
@@ -117,7 +117,7 @@ func (c *unitCommand) Run(ctx *cmd.Context) error {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -117,11 +117,11 @@ func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext))
 	return errors.Trace(err)
 }
 
-func (c *unitCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+func (c *unitCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -139,7 +139,7 @@ func (c *unitCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, que
 				c.unitInfo = *entityInfo
 
 				scope := MakeUnitScope(ctx, entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
+				if done, err := runQuery(input, q, scope); err != nil {
 					return false, errors.Trace(err)
 				} else if done {
 					return true, nil

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -210,7 +210,7 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on UnitInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on UnitInfo", name)
 }
 
 func outputUnitSummary(writer io.Writer, scopedContext ScopeContext, unitInfo *params.UnitInfo) {

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -124,7 +124,7 @@ func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 			c.primeCache()
 		}
 	})
-	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext, ctx))
+	err = strategy.Run(ctx, c.name, c.query, c.waitFor(c.query, scopedContext, ctx), emptyNotify)
 	return errors.Trace(err)
 }
 

--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd/v3"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
@@ -28,7 +29,7 @@ func newUnitCommand() cmd.Command {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return watchAllAPIShim{
+		return modelAllWatchShim{
 			Client: client,
 		}, nil
 	}
@@ -54,10 +55,10 @@ type unitCommand struct {
 	name    string
 	query   string
 	timeout time.Duration
-	found   bool
 	summary bool
 
-	unitInfo params.UnitInfo
+	unitInfo *params.UnitInfo
+	machines map[string]*params.MachineInfo
 }
 
 // Info implements Command.Info.
@@ -109,7 +110,7 @@ func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 			ctx.Infof("Unit %q is being removed", c.name)
 		default:
 			ctx.Infof("Unit %q is running", c.name)
-			outputUnitSummary(ctx.Stdout, scopedContext, &c.unitInfo)
+			outputUnitSummary(ctx.Stdout, scopedContext, c.unitInfo, c.machines)
 		}
 	}()
 
@@ -117,11 +118,30 @@ func (c *unitCommand) Run(ctx *cmd.Context) (err error) {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
+	strategy.Subscribe(func(event EventType) {
+		switch event {
+		case WatchAllStarted:
+			c.primeCache()
+		}
+	})
 	err = strategy.Run(c.name, c.query, c.waitFor(c.query, scopedContext))
 	return errors.Trace(err)
 }
 
+func (c *unitCommand) primeCache() {
+	c.machines = make(map[string]*params.MachineInfo)
+}
+
 func (c *unitCommand) waitFor(input string, ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+	run := func(q query.Query) (bool, error) {
+		scope := MakeUnitScope(ctx, c.unitInfo, c.machines)
+		if done, err := runQuery(input, q, scope); err != nil {
+			return false, errors.Trace(err)
+		} else if done {
+			return true, nil
+		}
+		return c.unitInfo.Life == life.Dead, nil
+	}
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
 			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
@@ -136,20 +156,24 @@ func (c *unitCommand) waitFor(input string, ctx ScopeContext) func(string, []par
 					return false, errors.Errorf("unit %v removed", name)
 				}
 
-				c.unitInfo = *entityInfo
+				c.unitInfo = entityInfo
 
-				scope := MakeUnitScope(ctx, entityInfo)
-				if done, err := runQuery(input, q, scope); err != nil {
-					return false, errors.Trace(err)
-				} else if done {
-					return true, nil
+			case *params.MachineInfo:
+				if delta.Removed {
+					delete(c.machines, entityInfo.Id)
+					break
 				}
-
-				c.found = entityInfo.Life != life.Dead
+				c.machines[entityInfo.Id] = entityInfo
 			}
 		}
 
-		if !c.found {
+		if c.unitInfo != nil {
+			if found, err := run(q); err != nil {
+				return false, errors.Trace(err)
+			} else if found {
+				return true, nil
+			}
+		} else {
 			logger.Infof("unit %q not found, waiting...", name)
 			return false, nil
 		}
@@ -161,21 +185,24 @@ func (c *unitCommand) waitFor(input string, ctx ScopeContext) func(string, []par
 
 // UnitScope allows the query to introspect a unit entity.
 type UnitScope struct {
-	ctx      ScopeContext
-	UnitInfo *params.UnitInfo
+	ctx          ScopeContext
+	UnitInfo     *params.UnitInfo
+	MachineInfos map[string]*params.MachineInfo
 }
 
 // MakeUnitScope creates an UnitScope from an UnitInfo
-func MakeUnitScope(ctx ScopeContext, info *params.UnitInfo) UnitScope {
+func MakeUnitScope(ctx ScopeContext, info *params.UnitInfo, machineInfos map[string]*params.MachineInfo) UnitScope {
 	return UnitScope{
-		ctx:      ctx,
-		UnitInfo: info,
+		ctx:          ctx,
+		UnitInfo:     info,
+		MachineInfos: machineInfos,
 	}
 }
 
 // GetIdents returns the identifiers with in a given scope.
 func (m UnitScope) GetIdents() []string {
-	return getIdents(m.UnitInfo)
+	idents := set.NewStrings(getIdents(m.UnitInfo)...)
+	return set.NewStrings("machines").Union(idents).SortedValues()
 }
 
 // GetIdentValue returns the value of the identifier in a given scope.
@@ -209,25 +236,57 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewString(m.UnitInfo.WorkloadStatus.Message), nil
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
+	case "machines":
+		scopes := make(map[string]query.Scope)
+		for k, machine := range m.MachineInfos {
+			if machine.Id == m.UnitInfo.MachineId {
+				scopes[k] = MakeMachineScope(m.ctx.Child(name, machine.Id), machine)
+			}
+		}
+		return NewScopedBox(scopes), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "%q on UnitInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name, m), "%q on UnitInfo", name)
 }
 
-func outputUnitSummary(writer io.Writer, scopedContext ScopeContext, unitInfo *params.UnitInfo) {
+func outputUnitSummary(writer io.Writer, scopedContext ScopeContext, units *params.UnitInfo, machines map[string]*params.MachineInfo) {
 	result := struct {
-		Elements map[string]interface{} `yaml:"properties"`
+		Properties map[string]any            `yaml:"properties"`
+		Machines   map[string]map[string]any `yaml:"machines,omitempty"`
 	}{
-		Elements: make(map[string]interface{}),
+		Properties: make(map[string]any),
+		Machines:   make(map[string]map[string]any),
 	}
 
 	idents := scopedContext.RecordedIdents()
 	for _, ident := range idents {
-		scope := MakeUnitScope(scopedContext, unitInfo)
+		scope := MakeUnitScope(scopedContext, units, machines)
 		box, err := scope.GetIdentValue(ident)
 		if err != nil {
 			continue
 		}
-		result.Elements[ident] = box.Value()
+		result.Properties[ident] = box.Value()
+	}
+
+	for entity, scopes := range scopedContext.children {
+		for name, sctx := range scopes {
+			idents := sctx.RecordedIdents()
+
+			switch entity {
+			case "machines":
+				machineInfo := machines[name]
+				scope := MakeMachineScope(scopedContext, machineInfo)
+
+				result.Machines[name] = make(map[string]any)
+
+				for _, ident := range idents {
+					box, err := scope.GetIdentValue(ident)
+					if err != nil {
+						continue
+					}
+					result.Machines[name][ident] = box.Value()
+				}
+			}
+		}
 	}
 
 	_ = yaml.NewEncoder(writer).Encode(result)

--- a/cmd/juju/waitfor/unit_test.go
+++ b/cmd/juju/waitfor/unit_test.go
@@ -102,6 +102,6 @@ func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
 		UnitInfo: &params.UnitInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on UnitInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `"bad" on UnitInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/waitfor.go
+++ b/cmd/juju/waitfor/waitfor.go
@@ -19,6 +19,7 @@ defined by the supplied query.
 Examples:
 	juju wait-for unit mysql/0
 	juju wait-for application mysql --query='name=="mysql" && (status=="active" || status=="idle")'
+	juju wait-for model default --query='forEach(units, unit => startsWith(unit.name, "ubuntu"))'
 
 `
 

--- a/cmd/juju/waitfor/waitfor.go
+++ b/cmd/juju/waitfor/waitfor.go
@@ -5,12 +5,15 @@ package waitfor
 
 import (
 	"github.com/juju/cmd/v3"
-	"github.com/juju/loggo"
 
 	_ "github.com/juju/juju/provider/all"
 )
 
-var logger = loggo.GetLogger("juju.plugins.waitfor")
+// Logger is the interface used by the wait-for command to log messages.
+type Logger interface {
+	Infof(string, ...any)
+	Verbosef(string, ...any)
+}
 
 var waitForDoc = `
 Waits for a specified model, machine, application or unit to reach a state

--- a/cmd/juju/waitfor/waitforbase.go
+++ b/cmd/juju/waitfor/waitforbase.go
@@ -32,11 +32,11 @@ func (s watchAllAPIShim) WatchAll() (api.AllWatcher, error) {
 
 // runQuery handles the more complex error handling of a query with a given
 // scope.
-func runQuery(q query.Query, scope query.Scope) (bool, error) {
+func runQuery(input string, q query.Query, scope query.Scope) (bool, error) {
 	if res, err := q.BuiltinsRun(scope); query.IsInvalidIdentifierErr(err) {
 		return false, invalidIdentifierError(scope, err)
-	} else if query.IsRuntimeError(err) {
-		return false, errors.Trace(err)
+	} else if query.IsRuntimeError(err) || query.IsSyntaxError(err) {
+		return false, HelpDisplay(err, input)
 	} else if res && err == nil {
 		return true, nil
 	} else if err != nil {

--- a/cmd/juju/waitfor/waitforbase.go
+++ b/cmd/juju/waitfor/waitforbase.go
@@ -19,11 +19,11 @@ type waitForCommandBase struct {
 	newWatchAllAPIFunc func() (api.WatchAllAPI, error)
 }
 
-type watchAllAPIShim struct {
+type modelAllWatchShim struct {
 	*apiclient.Client
 }
 
-func (s watchAllAPIShim) WatchAll() (api.AllWatcher, error) {
+func (s modelAllWatchShim) WatchAll() (api.AllWatcher, error) {
 	return s.Client.WatchAll()
 }
 

--- a/cmd/juju/waitfor/waitforbase.go
+++ b/cmd/juju/waitfor/waitforbase.go
@@ -5,10 +5,7 @@ package waitfor
 
 import (
 	"reflect"
-	"sort"
 	"strings"
-
-	"github.com/juju/errors"
 
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/cmd/juju/waitfor/api"
@@ -33,16 +30,11 @@ func (s watchAllAPIShim) WatchAll() (api.AllWatcher, error) {
 // runQuery handles the more complex error handling of a query with a given
 // scope.
 func runQuery(input string, q query.Query, scope query.Scope) (bool, error) {
-	if res, err := q.BuiltinsRun(scope); query.IsInvalidIdentifierErr(err) {
-		return false, invalidIdentifierError(scope, err)
-	} else if query.IsRuntimeError(err) || query.IsSyntaxError(err) {
-		return false, HelpDisplay(err, input)
-	} else if res && err == nil {
-		return true, nil
-	} else if err != nil {
-		logger.Errorf("%v", err)
+	res, err := q.BuiltinsRun(scope)
+	if err != nil {
+		return false, HelpDisplay(err, input, scope.GetIdents())
 	}
-	return false, nil
+	return res, nil
 }
 
 func getIdents(q interface{}) []string {
@@ -60,88 +52,4 @@ func getIdents(q interface{}) []string {
 		}
 	}
 	return res
-}
-
-func invalidIdentifierError(scope query.Scope, err error) error {
-	if !query.IsInvalidIdentifierErr(err) {
-		return errors.Trace(err)
-	}
-
-	identErr := errors.Cause(err).(*query.InvalidIdentifierError)
-	name := identErr.Name()
-
-	idents := scope.GetIdents()
-
-	type Indexed = struct {
-		Name  string
-		Value int
-	}
-	matches := make([]Indexed, 0, len(idents))
-	for _, ident := range idents {
-		matches = append(matches, Indexed{
-			Name:  ident,
-			Value: levenshteinDistance(name, ident),
-		})
-	}
-	// Find the smallest levenshtein distance. If two values are the same,
-	// fallback to sorting on the name, which should give predictable results.
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].Value < matches[j].Value {
-			return true
-		}
-		if matches[i].Value > matches[j].Value {
-			return false
-		}
-		return matches[i].Name < matches[j].Name
-	})
-	matchedName := matches[0].Name
-	matchedValue := matches[0].Value
-
-	if matchedName != "" && matchedValue <= len(matchedName)+1 {
-		additional := errors.Errorf(`%s
-
-Did you mean:
-	%s
-`, err.Error(), matchedName)
-		return errors.Wrap(err, additional)
-	}
-
-	return errors.Trace(err)
-}
-
-// levenshteinDistance
-// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
-// (no min, compute lengths once, 2 rows array)
-// fastest profiled
-func levenshteinDistance(a, b string) int {
-	la := len(a)
-	lb := len(b)
-	d := make([]int, la+1)
-	var lastdiag, olddiag, temp int
-
-	for i := 1; i <= la; i++ {
-		d[i] = i
-	}
-	for i := 1; i <= lb; i++ {
-		d[0] = i
-		lastdiag = i - 1
-		for j := 1; j <= la; j++ {
-			olddiag = d[j]
-			min := d[j] + 1
-			if (d[j-1] + 1) < min {
-				min = d[j-1] + 1
-			}
-			if a[j-1] == b[i-1] {
-				temp = 0
-			} else {
-				temp = 1
-			}
-			if (lastdiag + temp) < min {
-				min = lastdiag + temp
-			}
-			d[j] = min
-			lastdiag = olddiag
-		}
-	}
-	return d[la]
 }


### PR DESCRIPTION
The following PR attempts to improve the error messages and consistency
of the wait-for command. The wait-for command was originally intended for
use by the integration test suite and be delivered as part of the plugin 
architecture that juju offers. The wait-for command was upgraded to a 
first-class citizen last year but was never revisited to improve the error 
messages.

A reminder, that as long a query in the wait-for command returns anything
other than falsy, a query is determined as successful. It's all based on boolean
logic. So if `true && true` is fine, but `true && false` is not. The latter will wait
until the timeout is reached. To build up a larger query, it's possible to do the
following o a model with `juju deploy ubuntu -n 3`:

```sh
juju wait-for model --query="forEach(applications, app => forEach(app.units, unit => forEach(unit.machines, machine => int(machine.id) < 4)))" default
```

This states that for all machine ids for a given application is below 4, then
return true. This satisfies the boolean logic. The following would fail given the
same setup:

```sh
juju wait-for model --query="forEach(applications, app => forEach(app.units, unit => forEach(unit.machines, machine => int(machine.id) >= 4)))" default
```

-----

I had planned to improve them as time went on, but never got around to a lot
of the shortcomings. The following aims to start improving the error
messages for all the commands by explaining what went wrong, but more
importantly, how to help fix it. There are a lot of error messages, but the
most common ones have been updated.

In addition, it's now possible to correctly specify a model in the model command
by using the same `<controller>:<model>` or `<model>` syntax as other commands
in juju. Other commands can still use `-m`, it's just that the model command only
accepts the model as an argument.

New functions have also been added, this gives an example of how flexible the
addition of new functions can be. New functions can be added as we go, so PRs
are accepted with good suggestions.

Lastly, the nesting of `forEach` loops is fixed, this was an oversight, but should
at least works correctly now (see QA steps).

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu -n 3
```

### Model not found

```sh
$ juju wait-for model blah
model "blah4" not found, waiting...
```

Then in another process

```sh
$ juju add-model blah
```

This should then return the following from the first process.

```sh
model "blah" is running
properties:
  life: alive
  status: available
```


### Not a valid model name

```sh
$ juju wait-for model blah!
ERROR "blah!" is not valid model name
```

### Target controller using model name

```sh
$ juju wait-for model test:default
```

### Quotation

```sh
$ juju wait-for model --query='"life"' default
$ juju wait-for model --query="'life'" default
$ juju wait-for model --query="\"life\"" default
```

### Quotation error

```sh
juju wait-for model --query="\"life" default
ERROR Cannot parse query: string is not correctly terminated.

1 | "life
    ^
Try adding a closing quote to the string.
```

### Wrong identifier error

```sh
$ juju wait-for model --query="unit" default
ERROR Cannot execute query: invalid identifier.

1 | unit

No possible matches for "unit" on ModelInfo:
Did you mean:

    units

Other possible matches:

    - applications
    - controller-uuid
    - is-controller
    - life
    - machines
    - model-uuid
    - name
    - owner
```

### Invalid AND operator (&&)

```sh
$ juju wait-for model --query="1 && true" default
ERROR Cannot parse query: invalid AND (&&) operator.

1 | 1 && true
    ^
Ensure that each side of the && operator can be evaluated to a boolean.
```

### Invalid OR operator (||)

```sh
$ juju wait-for model --query="1 || true" default
ERROR Cannot parse query: invalid OR (||) operator.

1 | 1 || true
    ^
Ensure that each side of the || operator can be evaluated to a boolean.
```

### Len of machines

```sh
$ juju wait-for model --query="len(machines) > 3" default
$ juju add-machine
```

### Unknow function

```sh
$ juju wait-for model --query="no(units)" default
ERROR Cannot execute query: runtime syntax error.

1 | no(units)

wait-for has no function "no".
Did you mean:

    int

Other possible matches:

    - endsWith
    - forEach
    - len
    - print
    - startsWith
```

### Nested forEach loop

#### Models

```sh
$ juju wait-for model --query="forEach(applications, app => forEach(app.units, unit => forEach(unit.machines, machine => int(machine.id) < 4)))" default
```

#### Applications

```sh
$ juju wait-for application --query="forEach(units, unit => print(unit))" ubuntu
```

#### Units

```sh
$ juju wait-for unit --query="forEach(machines, machine => print(machine))" ubuntu/0
```

#### Whitespace doesn't matter

```sh
juju wait-for model --query="
forEach(
    applications,
    app => forEach(
        app.units,
        unit => forEach(
            unit.machines,
            machine => int(machine.id) < 4
        )
    )
)" default
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/2019516
