### PR TITLE
Fix TestManageModelRunsInstancePoller by extending timeout.

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -357,7 +357,11 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	}
 	dummy.SetInstanceStatus(insts[0], "running")
 
-	for attempt := coretesting.LongAttempt.Start(); attempt.Next(); {
+	strategy := &utils.AttemptStrategy{
+		Total: 60 * time.Second,
+		Delay: testing.ShortWait,
+	}
+	for attempt := strategy.Start(); attempt.Next(); {
 		if !attempt.HasNext() {
 			c.Logf("final machine addresses: %#v", m.Addresses())
 			c.Fatalf("timed out waiting for machine to get address")


### PR DESCRIPTION
TestManageModelRunsInstancePoller on a machine under some load causes the test to fail due to instance poller taking a while to startup. This extends the timeout for the polling strategy for machine addresses added via instance poller.

## QA steps

- install golang.org/x/tools/cmd/stress@latest
- cd to cmd/jujud/agent package
- `go test -race -c`
- `stress ./agent.test -check.f=TestManageModelRunsInstancePoller -check.v`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/1341/consoleText