### PR TITLE
AKS cleanup appears to now work with destroy-controller.

### DIFF
--- a/tests/suites/deploy_aks/task.sh
+++ b/tests/suites/deploy_aks/task.sh
@@ -21,7 +21,6 @@ test_deploy_aks() {
 
 	test_deploy_aks_charms
 
-	export KILL_CONTROLLER=true
 	destroy_controller "test-deploy-aks"
 
 	juju remove-k8s --client aks-k8s-cloud


### PR DESCRIPTION
Destroy-controller should now correctly clean up aks since the undertaker was fixed. This will avoid the issue with kill-controller causing the aks test to fail (will look into that separately).

## QA steps

`./main.sh -v -s '""' deploy_aks ''`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-deploy_aks-test-deploy-aks-charms-azure/462/consoleText