### PR TITLE
Retry fetching public ssh keys for a machine.

### DIFF
--- a/api/client/sshclient/facade.go
+++ b/api/client/sshclient/facade.go
@@ -98,7 +98,7 @@ func (facade *Facade) PublicKeys(target string) ([]string, error) {
 		return nil, countError(len(out.Results))
 	}
 	if err := out.Results[0].Error; err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return out.Results[0].PublicKeys, nil
 }

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -56,7 +56,7 @@ func (m *monitor) pingWithTimeout() bool {
 		}
 		return err == nil
 	case <-m.clock.After(m.pingTimeout):
-		logger.Errorf("health ping timed out after %s", m.pingTimeout)
+		logger.Warningf("health ping timed out after %s", m.pingTimeout)
 		return false
 	}
 }

--- a/cmd/juju/commands/debugcode.go
+++ b/cmd/juju/commands/debugcode.go
@@ -13,10 +13,11 @@ import (
 	"github.com/juju/juju/network/ssh"
 )
 
-func newDebugCodeCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
+func newDebugCodeCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugCodeCommand)
 	c.hostChecker = hostChecker
-	c.retryStrategy = defaultSSHRetryStrategy
+	c.retryStrategy = retryStrategy
+	c.publicKeyRetryStrategy = publicKeyRetryStrategy
 	return modelcmd.Wrap(c)
 }
 

--- a/cmd/juju/commands/debugcode_test.go
+++ b/cmd/juju/commands/debugcode_test.go
@@ -27,7 +27,7 @@ func (s *DebugCodeSuite) TestArgFormatting(c *gc.C) {
 	}
 	s.setupModel(c)
 	s.setHostChecker(validAddresses("0.public"))
-	ctx, err := cmdtesting.RunCommand(c, newDebugCodeCommand(s.hostChecker, baseTestingRetryStrategy),
+	ctx, err := cmdtesting.RunCommand(c, newDebugCodeCommand(s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy),
 		"--at=foo,bar", "mysql/0", "install", "start")
 	c.Assert(err, jc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -27,10 +27,11 @@ import (
 	unitdebug "github.com/juju/juju/worker/uniter/runner/debug"
 )
 
-func newDebugHooksCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
+func newDebugHooksCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugHooksCommand)
 	c.hostChecker = hostChecker
 	c.retryStrategy = retryStrategy
+	c.publicKeyRetryStrategy = publicKeyRetryStrategy
 	return modelcmd.Wrap(c)
 }
 

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -154,7 +154,7 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(t.error))
 		} else {
@@ -172,7 +172,7 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 	}
 	s.setupModel(c)
 	s.setHostChecker(validAddresses("0.public"))
-	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy),
+	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy),
 		"mysql/0", "install", "start")
 	c.Check(err, jc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -374,12 +374,12 @@ func registerCommands(r commandRegistry) {
 		r.Register(newDefaultRunCommand(nil))
 	}
 	r.Register(newDefaultExecCommand(nil))
-	r.Register(newSCPCommand(nil, defaultSSHRetryStrategy))
-	r.Register(newSSHCommand(nil, nil, defaultSSHRetryStrategy))
+	r.Register(newSCPCommand(nil, defaultSSHRetryStrategy, defaultSSHPublicKeyRetryStrategy))
+	r.Register(newSSHCommand(nil, nil, defaultSSHRetryStrategy, defaultSSHPublicKeyRetryStrategy))
 	r.Register(application.NewResolvedCommand())
 	r.Register(newDebugLogCommand(nil))
-	r.Register(newDebugHooksCommand(nil, defaultSSHRetryStrategy))
-	r.Register(newDebugCodeCommand(nil, defaultSSHRetryStrategy))
+	r.Register(newDebugHooksCommand(nil, defaultSSHRetryStrategy, defaultSSHPublicKeyRetryStrategy))
+	r.Register(newDebugCodeCommand(nil, defaultSSHRetryStrategy, defaultSSHPublicKeyRetryStrategy))
 
 	// Configuration commands.
 	r.Register(model.NewModelGetConstraintsCommand())

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -113,10 +113,11 @@ See also:
 	ssh
 `
 
-func newSCPCommand(hostChecker jujussh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
+func newSCPCommand(hostChecker jujussh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
 	c := new(scpCommand)
 	c.hostChecker = hostChecker
 	c.retryStrategy = retryStrategy
+	c.publicKeyRetryStrategy = publicKeyRetryStrategy
 	return modelcmd.Wrap(c)
 }
 
@@ -133,7 +134,8 @@ type scpCommand struct {
 
 	hostChecker jujussh.ReachableChecker
 
-	retryStrategy retry.CallArgs
+	retryStrategy          retry.CallArgs
+	publicKeyRetryStrategy retry.CallArgs
 }
 
 func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -166,6 +168,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 	c.provider.setArgs(args)
 	c.provider.setHostChecker(c.hostChecker)
 	c.provider.setRetryStrategy(c.retryStrategy)
+	c.provider.setPublicKeyRetryStrategy(c.publicKeyRetryStrategy)
 	return nil
 }
 

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -73,7 +73,7 @@ var scpTests = []struct {
 		about:       "scp when no keys available",
 		args:        []string{"foo", "1:"},
 		hostChecker: validAddresses("1.public"),
-		error:       `retrieving SSH host keys for "1": keys not found`,
+		error:       `attempt count exceeded: retrieving SSH host keys for "1": keys not found`,
 	}, {
 		about:       "scp when no keys available, with --no-host-key-checks",
 		args:        []string{"--no-host-key-checks", "foo", "1:"},
@@ -221,18 +221,18 @@ func (s *SCPSuiteLegacy) TestSCPCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := cmdtesting.RunCommand(c, newSCPCommand(s.hostChecker, baseTestingRetryStrategy), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newSCPCommand(s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy), t.args...)
 		if t.error != "" {
-			c.Check(err, gc.ErrorMatches, t.error)
+			c.Assert(err, gc.ErrorMatches, t.error, gc.Commentf("test %d", i))
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
 			// we suppress stdout from scp, so get the scp args used
 			// from the "scp.args" file that the fake scp executable
 			// installed by SSHMachineSuite generates.
-			c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
-			c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
+			c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "", gc.Commentf("test %d", i))
+			c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "", gc.Commentf("test %d", i))
 			actual, err := ioutil.ReadFile(filepath.Join(s.binDir, "scp.args"))
-			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(err, jc.ErrorIsNil, gc.Commentf("test %d", i))
 			t.expected.check(c, string(actual))
 		}
 	}

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -136,11 +136,13 @@ func newSSHCommand(
 	hostChecker jujussh.ReachableChecker,
 	isTerminal func(interface{}) bool,
 	retryStrategy retry.CallArgs,
+	publicKeyRetryStrategy retry.CallArgs,
 ) cmd.Command {
 	c := &sshCommand{
-		hostChecker:   hostChecker,
-		isTerminal:    isTerminal,
-		retryStrategy: retryStrategy,
+		hostChecker:            hostChecker,
+		isTerminal:             isTerminal,
+		retryStrategy:          retryStrategy,
+		publicKeyRetryStrategy: publicKeyRetryStrategy,
 	}
 	return modelcmd.Wrap(c)
 }
@@ -149,6 +151,14 @@ var defaultSSHRetryStrategy = retry.CallArgs{
 	Clock:       clock.WallClock,
 	MaxDuration: SSHTimeout,
 	Delay:       SSHRetryDelay,
+}
+
+var defaultSSHPublicKeyRetryStrategy = retry.CallArgs{
+	Clock:       clock.WallClock,
+	MaxDelay:    60 * time.Second,
+	Delay:       1 * time.Second,
+	Attempts:    10,
+	BackoffFunc: retry.DoubleDelay,
 }
 
 // sshCommand is responsible for launching a ssh shell on a given unit or machine.
@@ -165,7 +175,8 @@ type sshCommand struct {
 	isTerminal  func(interface{}) bool
 	pty         autoBoolValue
 
-	retryStrategy retry.CallArgs
+	retryStrategy          retry.CallArgs
+	publicKeyRetryStrategy retry.CallArgs
 }
 
 func (c *sshCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -200,6 +211,7 @@ func (c *sshCommand) Init(args []string) (err error) {
 	c.provider.setArgs(args[1:])
 	c.provider.setHostChecker(c.hostChecker)
 	c.provider.setRetryStrategy(c.retryStrategy)
+	c.provider.setPublicKeyRetryStrategy(c.publicKeyRetryStrategy)
 	return nil
 }
 
@@ -233,6 +245,7 @@ type sshProvider interface {
 	setArgs(Args []string)
 
 	setRetryStrategy(retry.CallArgs)
+	setPublicKeyRetryStrategy(retry.CallArgs)
 }
 
 // Run resolves the given target to a machine or unit, then opens

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -130,6 +130,8 @@ func (c *sshContainer) setArgs(args []string) {
 
 func (c *sshContainer) setRetryStrategy(_ retry.CallArgs) {}
 
+func (c *sshContainer) setPublicKeyRetryStrategy(_ retry.CallArgs) {}
+
 func (c *sshContainer) getModelType() model.ModelType {
 	return c.modelType
 }

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -7,8 +7,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/wrench"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -68,6 +70,9 @@ func (w *hostkeyreporter) Wait() error {
 }
 
 func (w *hostkeyreporter) run() error {
+	if wrench.IsActive("hostkeyreporter", "delay") {
+		time.Sleep(time.Minute)
+	}
 	keys, err := w.readSSHKeys()
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
If you use `juju ssh` too fast after creating a machine, it may have addresses, but not yet have reported its host keys back to the controller. This allows the ssh command to wait a reasonable time for those keys.

## QA steps

- Bootstrap LXD
- Create model config yaml file
```
$ cat wrench.yaml
cloudinit-userdata: |
  write_files:
  - content: |
        delay
    path: /var/lib/juju/wrench/hostkeyreporter
```
- `$ juju model-config wrench.yaml`
- `$ juju add-machine --series jammy`
- `$ juju ssh 0`
- ssh should take up to a minute to resolve, but should connect successfully or return `ERROR retrieving SSH host keys for "0": keys not found`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-controller-test-metrics-lxd/2/consoleText