### PR TITLE
Extend TestEnvironDestroyTimeoutForce timeout as it was too short.

### DIFF
--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -282,7 +282,7 @@ func (s *UndertakerSuite) TestEnvironDestroyTimeout(c *gc.C) {
 }
 
 func (s *UndertakerSuite) TestEnvironDestroyTimeoutForce(c *gc.C) {
-	timeout := time.Millisecond
+	timeout := time.Second
 	s.fix.info.Result.DestroyTimeout = &timeout
 	s.fix.info.Result.ForceDestroyed = true
 	s.fix.dirty = true


### PR DESCRIPTION
Extend TestEnvironDestroyTimeoutForce timeout as 1 millisecond is too short, as the code will consistently skip Destroy and go straight to force destruction.

## QA steps

- install golang.org/x/tools/cmd/stress
- `cd worker/undertaker`
- `go test -race -c`
- `stress ./undertaker.test -check.f=TestEnvironDestroyTimeoutForce`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/1346/consoleText