### PR TITLE
Use jammy for dummy source and sink testing charms.

### DIFF
--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -22,7 +22,7 @@ run_offer_consume() {
 	ensure "model-offer" "${file}"
 
 	echo "Deploy consumed workload and create the offer"
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-source --series jammy
 	juju offer dummy-source:sink dummy-offer
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -33,7 +33,7 @@ run_offer_consume() {
 	echo "Deploy workload in consume model"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -87,7 +87,7 @@ run_offer_consume_cross_controller() {
 
 	echo "Deploy consumed workload and create the offer"
 	juju switch "${offer_controller}"
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-source --series jammy
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -96,7 +96,7 @@ run_offer_consume_cross_controller() {
 	juju switch "controller-consume"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 

--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -7,8 +7,8 @@ run_deploy_aks_charms() {
 	juju add-model "test-deploy-aks-charms"
 
 	echo "Deploy some charms"
-	juju deploy juju-qa-dummy-sink
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-source --series jammy
 
 	juju relate dummy-sink dummy-source
 

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -155,14 +155,14 @@ run_model_migration_saas_common() {
 	bootstrap_alt_controller "alt-model-migration-saas"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-source --series jammy
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju add-model blog
 	juju switch blog
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -222,13 +222,13 @@ run_model_migration_saas_external() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-source --series jammy
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -287,14 +287,14 @@ run_model_migration_saas_consumer() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source
+	juju deploy juju-qa-dummy-source --series jammy
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
 	juju add-model "model-migration-consumer"
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 

--- a/tests/suites/model/multi.sh
+++ b/tests/suites/model/multi.sh
@@ -28,8 +28,8 @@ deploy_stack() {
 
 	juju switch "${name}"
 
-	juju deploy juju-qa-dummy-source
-	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-sink --series jammy
 
 	juju add-relation dummy-source dummy-sink
 	juju expose dummy-sink


### PR DESCRIPTION
There seems to be an issue with xenial on AWS, which seems to happen frequently in these jobs. Trying jammy to see if it is actually a xenial issue.

## QA steps

Run tests.

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-cmr-test-offer-consume-aws/761/consoleText