### PR TITLE
[JUJU-4151] - Fix/lp 2025960

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1521,7 +1521,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		AutomountServiceAccountToken:  &automountToken,
 		ServiceAccountName:            a.serviceAccountName(),
 		ImagePullSecrets:              imagePullSecrets,
-		TerminationGracePeriodSeconds: pointer.Int64Ptr(300),
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(1),
 		InitContainers: []corev1.Container{{
 			Name:            constants.ApplicationInitContainer,
 			ImagePullPolicy: corev1.PullIfNotPresent,

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1521,7 +1521,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		AutomountServiceAccountToken:  &automountToken,
 		ServiceAccountName:            a.serviceAccountName(),
 		ImagePullSecrets:              imagePullSecrets,
-		TerminationGracePeriodSeconds: pointer.Int64Ptr(1),
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(300),
 		InitContainers: []corev1.Container{{
 			Name:            constants.ApplicationInitContainer,
 			ImagePullPolicy: corev1.PullIfNotPresent,

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -186,8 +186,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 		return nil, errors.Trace(err)
 	}
 
-	ns, err := findControllerNamespace(
-		k8sClient, args.ControllerUUID)
+	ns, err := findControllerNamespace(k8sClient, args.ControllerUUID)
 	if errors.IsNotFound(err) {
 		// The controller is currently bootstrapping.
 		return newK8sBroker(

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
+	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 )
 
 // AppNameForServiceAccount returns the juju application name associated with a
@@ -407,6 +408,40 @@ func (k *kubernetesClient) listRoles(selector k8slabels.Selector) ([]rbacv1.Role
 	return rList.Items, nil
 }
 
+func (k *kubernetesClient) createClusterRole(clusterrole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
+	utils.PurifyResource(clusterrole)
+	out, err := k.client().RbacV1().ClusterRoles().Create(context.TODO(), clusterrole, v1.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		return nil, errors.AlreadyExistsf("clusterrole %q", clusterrole.GetName())
+	}
+	return out, errors.Trace(err)
+}
+
+func (k *kubernetesClient) updateClusterRole(clusterrole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
+	out, err := k.client().RbacV1().ClusterRoles().Update(context.TODO(), clusterrole, v1.UpdateOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, errors.NotFoundf("clusterrole %q", clusterrole.GetName())
+	}
+	return out, errors.Trace(err)
+}
+
+func (k *kubernetesClient) getClusterRole(name string) (*rbacv1.ClusterRole, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
+	out, err := k.client().RbacV1().ClusterRoles().Get(context.TODO(), name, v1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, errors.NotFoundf("clusterrole %q", name)
+	}
+	return out, errors.Trace(err)
+}
+
 func (k *kubernetesClient) deleteClusterRoles(selector k8slabels.Selector) error {
 	err := k.client().RbacV1().ClusterRoles().DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
@@ -622,12 +657,85 @@ func (k *kubernetesClient) EnsureSecretAccessToken(tag names.Tag, owned, read, r
 		return "", errors.Annotatef(err, "cannot ensure service account %q", sa.GetName())
 	}
 
-	role, err := k.ensureRoleForSecretAccessToken(objMeta, owned, read, removed)
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot ensure role %q", role.GetName())
+	if err := k.ensureBindingForSecretAccessToken(sa, objMeta, owned, read, removed); err != nil {
+		return "", errors.Trace(err)
 	}
 
-	roleBinding := &rbacv1.RoleBinding{
+	treq := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expiresInSeconds,
+		},
+	}
+	tr, err := k.client().CoreV1().ServiceAccounts(k.namespace).CreateToken(context.TODO(), sa.Name, treq, v1.CreateOptions{})
+	if err != nil {
+		return "", errors.Annotatef(err, "cannot request a token for %q", sa.Name)
+	}
+	return tr.Status.Token, nil
+}
+
+func (k *kubernetesClient) ensureBindingForSecretAccessToken(sa *core.ServiceAccount, objMeta v1.ObjectMeta, owned, read, removed []string) error {
+	isControllerModel := k.Config().Name() == environsbootstrap.ControllerModelName
+	if isControllerModel {
+		clusterRole, err := k.getClusterRole(objMeta.Name)
+		if err != nil && !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+		if errors.Is(err, errors.NotFound) {
+			clusterRole, err = k.createClusterRole(
+				&rbacv1.ClusterRole{
+					ObjectMeta: objMeta,
+					Rules:      k.rulesForSecretAccess(true, nil, owned, read, removed),
+				},
+			)
+		} else {
+			clusterRole.Rules = k.rulesForSecretAccess(true, clusterRole.Rules, owned, read, removed)
+			clusterRole, err = k.updateClusterRole(clusterRole)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+		binding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: objMeta,
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     clusterRole.Name,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      sa.Name,
+					Namespace: sa.Namespace,
+				},
+			},
+		}
+		// _, _, err = k.ensureClusterRoleBinding(binding)
+		// _, err = k.createClusterRoleBinding(binding)
+		_, err = k.client().RbacV1().ClusterRoleBindings().Create(context.TODO(), binding, v1.CreateOptions{})
+		if err != nil {
+			return errors.Annotatef(err, "cannot ensure cluster role binding %q", binding.Name)
+		}
+	}
+
+	role, err := k.getRole(objMeta.Name)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	if errors.Is(err, errors.NotFound) {
+		role, err = k.createRole(
+			&rbacv1.Role{
+				ObjectMeta: objMeta,
+				Rules:      k.rulesForSecretAccess(false, nil, owned, read, removed),
+			},
+		)
+	} else {
+		role.Rules = k.rulesForSecretAccess(false, role.Rules, owned, read, removed)
+		role, err = k.updateRole(role)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	binding := &rbacv1.RoleBinding{
 		ObjectMeta: objMeta,
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -642,38 +750,8 @@ func (k *kubernetesClient) EnsureSecretAccessToken(tag names.Tag, owned, read, r
 			},
 		},
 	}
-
-	_, _, err = k.ensureRoleBinding(roleBinding)
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot ensure role binding %q", roleBinding.Name)
-	}
-	treq := &authenticationv1.TokenRequest{
-		Spec: authenticationv1.TokenRequestSpec{
-			ExpirationSeconds: &expiresInSeconds,
-		},
-	}
-	tr, err := k.client().CoreV1().ServiceAccounts(k.namespace).CreateToken(context.TODO(), sa.Name, treq, v1.CreateOptions{})
-	if err != nil {
-		return "", errors.Annotatef(err, "cannot request a token for %q", sa.Name)
-	}
-	return tr.Status.Token, nil
-}
-
-func (k *kubernetesClient) ensureRoleForSecretAccessToken(objMeta v1.ObjectMeta, owned, read, removed []string) (*rbacv1.Role, error) {
-	role, err := k.getRole(objMeta.Name)
-	if errors.Is(err, errors.NotFound) {
-		return k.createRole(
-			&rbacv1.Role{
-				ObjectMeta: objMeta,
-				Rules:      rulesForSecretAccess(k.namespace, nil, owned, read, removed),
-			},
-		)
-	}
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	role.Rules = rulesForSecretAccess(k.namespace, role.Rules, owned, read, removed)
-	return k.updateRole(role)
+	_, _, err = k.ensureRoleBinding(binding)
+	return errors.Annotatef(err, "cannot ensure role binding %q", binding.Name)
 }
 
 func cleanRules(existing []rbacv1.PolicyRule, shouldRemove func(string) bool) []rbacv1.PolicyRule {
@@ -692,15 +770,9 @@ func cleanRules(existing []rbacv1.PolicyRule, shouldRemove func(string) bool) []
 	return existing[:i]
 }
 
-func rulesForSecretAccess(namespace string, existing []rbacv1.PolicyRule, owned, read, removed []string) []rbacv1.PolicyRule {
+func (k *kubernetesClient) rulesForSecretAccess(isControllerModel bool, existing []rbacv1.PolicyRule, owned, read, removed []string) []rbacv1.PolicyRule {
 	if len(existing) == 0 {
 		existing = []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{rbacv1.APIGroupAll},
-				Resources:     []string{"namespaces"},
-				Verbs:         []string{"get", "list"},
-				ResourceNames: []string{namespace},
-			},
 			{
 				APIGroups: []string{rbacv1.APIGroupAll},
 				Resources: []string{"secrets"},
@@ -709,6 +781,22 @@ func rulesForSecretAccess(namespace string, existing []rbacv1.PolicyRule, owned,
 					"patch", // TODO: we really should only allow "create" but not patch  but currently we uses .Apply() which requres patch!!!
 				},
 			},
+		}
+		if isControllerModel {
+			// We need to be able to list/get all namespaces for units' in controller model.
+			existing = append(existing, rbacv1.PolicyRule{
+				APIGroups: []string{rbacv1.APIGroupAll},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get", "list"},
+			})
+		} else {
+			// We just need to be able to list/get our own namespace for units' in other models.
+			existing = append(existing, rbacv1.PolicyRule{
+				APIGroups:     []string{rbacv1.APIGroupAll},
+				Resources:     []string{"namespaces"},
+				Verbs:         []string{"get", "list"},
+				ResourceNames: []string{k.namespace},
+			})
 		}
 	}
 

--- a/caas/kubernetes/provider/rbac_test.go
+++ b/caas/kubernetes/provider/rbac_test.go
@@ -12,9 +12,14 @@ import (
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas/kubernetes/provider"
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	environsbootstrap "github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&rbacSuite{})
@@ -43,15 +48,15 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 		ObjectMeta: objMeta,
 		Rules: []rbacv1.PolicyRule{
 			{
+				Verbs:     []string{"create", "patch"},
+				APIGroups: []string{"*"},
+				Resources: []string{"secrets"},
+			},
+			{
 				Verbs:         []string{"get", "list"},
 				APIGroups:     []string{"*"},
 				Resources:     []string{"namespaces"},
 				ResourceNames: []string{"test"},
-			},
-			{
-				Verbs:     []string{"create", "patch"},
-				APIGroups: []string{"*"},
-				Resources: []string{"secrets"},
 			},
 		},
 	}
@@ -81,8 +86,95 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 			Return(sa, nil),
 		s.mockRoles.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
 		s.mockRoles.EXPECT().Create(gomock.Any(), role, v1.CreateOptions{}).Return(role, nil),
-		s.mockRoleBindings.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
-		s.mockRoleBindings.EXPECT().Create(gomock.Any(), roleBinding, v1.CreateOptions{}).Return(roleBinding, nil),
+		s.mockRoleBindings.EXPECT().Patch(
+			gomock.Any(), "unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockRoleBindings.EXPECT().Create(gomock.Any(), roleBinding, v1.CreateOptions{FieldManager: "juju"}).Return(roleBinding, nil),
+		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
+			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
+		),
+	)
+
+	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token, gc.Equals, "token")
+}
+
+func (s *rbacSuite) switchToControllerModel(c *gc.C) {
+	cfg, err := config.New(config.UseDefaults, coretesting.FakeConfig().Merge(coretesting.Attrs{
+		config.NameKey:                  environsbootstrap.ControllerModelName,
+		k8sconstants.OperatorStorageKey: "",
+		k8sconstants.WorkloadStorageKey: "",
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	s.cfg = cfg
+	s.namespace = "controller-k1"
+}
+
+func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
+	s.switchToControllerModel(c)
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	tag := names.NewUnitTag("gitlab/0")
+
+	objMeta := v1.ObjectMeta{
+		Name:      tag.String(),
+		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
+		Namespace: s.namespace,
+	}
+	automountServiceAccountToken := true
+	sa := &core.ServiceAccount{
+		ObjectMeta:                   objMeta,
+		AutomountServiceAccountToken: &automountServiceAccountToken,
+	}
+	objMeta.Name = s.namespace + "-" + tag.String()
+	clusterrole := &rbacv1.ClusterRole{
+		ObjectMeta: objMeta,
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"create", "patch"},
+				APIGroups: []string{"*"},
+				Resources: []string{"secrets"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{"*"},
+				Resources: []string{"namespaces"},
+			},
+		},
+	}
+	clusterroleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: objMeta,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterrole.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		},
+	}
+	expiresInSeconds := int64(60 * 10)
+	treq := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expiresInSeconds,
+		},
+	}
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(sa, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoles.EXPECT().Create(gomock.Any(), clusterrole, v1.CreateOptions{}).Return(clusterrole, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), "controller-k1-unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), clusterroleBinding, v1.CreateOptions{FieldManager: "juju"}).Return(clusterroleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),
@@ -113,15 +205,15 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 		ObjectMeta: objMeta,
 		Rules: []rbacv1.PolicyRule{
 			{
+				Verbs:     []string{"create", "patch"},
+				APIGroups: []string{"*"},
+				Resources: []string{"secrets"},
+			},
+			{
 				Verbs:         []string{"get", "list"},
 				APIGroups:     []string{"*"},
 				Resources:     []string{"namespaces"},
 				ResourceNames: []string{"test"},
-			},
-			{
-				Verbs:     []string{"create", "patch"},
-				APIGroups: []string{"*"},
-				Resources: []string{"secrets"},
 			},
 		},
 	}
@@ -156,7 +248,85 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 			Return(sa, nil),
 		s.mockRoles.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(role, nil),
 		s.mockRoles.EXPECT().Update(gomock.Any(), role, v1.UpdateOptions{}).Return(role, nil),
-		s.mockRoleBindings.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(roleBinding, nil),
+		s.mockRoleBindings.EXPECT().Patch(
+			gomock.Any(), "unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(roleBinding, nil),
+		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
+			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
+		),
+	)
+
+	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token, gc.Equals, "token")
+}
+
+func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
+	s.switchToControllerModel(c)
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	tag := names.NewUnitTag("gitlab/0")
+
+	objMeta := v1.ObjectMeta{
+		Name:      tag.String(),
+		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
+		Namespace: s.namespace,
+	}
+	automountServiceAccountToken := true
+	sa := &core.ServiceAccount{
+		ObjectMeta:                   objMeta,
+		AutomountServiceAccountToken: &automountServiceAccountToken,
+	}
+	objMeta.Name = s.namespace + "-" + tag.String()
+	clusterrole := &rbacv1.ClusterRole{
+		ObjectMeta: objMeta,
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"create", "patch"},
+				APIGroups: []string{"*"},
+				Resources: []string{"secrets"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{"*"},
+				Resources: []string{"namespaces"},
+			},
+		},
+	}
+	clusterroleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: objMeta,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterrole.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		},
+	}
+	expiresInSeconds := int64(60 * 10)
+	treq := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expiresInSeconds,
+		},
+	}
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().List(gomock.Any(), v1.ListOptions{
+			LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=gitlab",
+		}).Return(&core.ServiceAccountList{Items: []core.ServiceAccount{*sa}}, nil),
+		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), sa, v1.UpdateOptions{}).
+			Return(sa, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(clusterrole, nil),
+		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole, v1.UpdateOptions{}).Return(clusterrole, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(clusterroleBinding, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), clusterroleBinding, v1.UpdateOptions{FieldManager: "juju"}).Return(clusterroleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),
@@ -170,8 +340,13 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 func (s *rbacSuite) TestRulesForSecretAccessNew(c *gc.C) {
 	owned := []string{"owned-secret-1"}
 	read := []string{"read-secret-1"}
-	newPolicies := provider.RulesForSecretAccess("test", nil, owned, read, nil)
+	newPolicies := provider.RulesForSecretAccess("test", false, nil, owned, read, nil)
 	c.Assert(newPolicies, gc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+		},
 		{
 			Verbs:         []string{"get", "list"},
 			APIGroups:     []string{"*"},
@@ -179,9 +354,34 @@ func (s *rbacSuite) TestRulesForSecretAccessNew(c *gc.C) {
 			ResourceNames: []string{"test"},
 		},
 		{
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"owned-secret-1"},
+		},
+		{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"read-secret-1"},
+		},
+	})
+}
+
+func (s *rbacSuite) TestRulesForSecretAccessControllerModelNew(c *gc.C) {
+	owned := []string{"owned-secret-1"}
+	read := []string{"read-secret-1"}
+	newPolicies := provider.RulesForSecretAccess("test", true, nil, owned, read, nil)
+	c.Assert(newPolicies, gc.DeepEquals, []rbacv1.PolicyRule{
+		{
 			Verbs:     []string{"create", "patch"},
 			APIGroups: []string{"*"},
 			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"get", "list"},
+			APIGroups: []string{"*"},
+			Resources: []string{"namespaces"},
 		},
 		{
 			Verbs:         []string{"*"},
@@ -201,15 +401,15 @@ func (s *rbacSuite) TestRulesForSecretAccessNew(c *gc.C) {
 func (s *rbacSuite) TestRulesForSecretAccessUpdate(c *gc.C) {
 	existing := []rbacv1.PolicyRule{
 		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+		},
+		{
 			Verbs:         []string{"get", "list"},
 			APIGroups:     []string{"*"},
 			Resources:     []string{"namespaces"},
 			ResourceNames: []string{"test"},
-		},
-		{
-			Verbs:     []string{"create", "patch"},
-			APIGroups: []string{"*"},
-			Resources: []string{"secrets"},
 		},
 		{
 			Verbs:         []string{"*"},
@@ -241,8 +441,13 @@ func (s *rbacSuite) TestRulesForSecretAccessUpdate(c *gc.C) {
 	read := []string{"read-secret-1", "read-secret-2"}
 	removed := []string{"removed-owned-secret", "removed-read-secret"}
 
-	newPolicies := provider.RulesForSecretAccess("test", existing, owned, read, removed)
+	newPolicies := provider.RulesForSecretAccess("test", false, existing, owned, read, removed)
 	c.Assert(newPolicies, gc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+		},
 		{
 			Verbs:         []string{"get", "list"},
 			APIGroups:     []string{"*"},
@@ -250,9 +455,85 @@ func (s *rbacSuite) TestRulesForSecretAccessUpdate(c *gc.C) {
 			ResourceNames: []string{"test"},
 		},
 		{
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"owned-secret-1"},
+		},
+		{
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"owned-secret-2"},
+		},
+		{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"read-secret-1"},
+		},
+		{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"read-secret-2"},
+		},
+	})
+}
+
+func (s *rbacSuite) TestRulesForSecretAccessControllerModelUpdate(c *gc.C) {
+	existing := []rbacv1.PolicyRule{
+		{
 			Verbs:     []string{"create", "patch"},
 			APIGroups: []string{"*"},
 			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"get", "list"},
+			APIGroups: []string{"*"},
+			Resources: []string{"namespaces"},
+		},
+		{
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"owned-secret-1"},
+		},
+		{
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"removed-owned-secret"},
+		},
+		{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"read-secret-1"},
+		},
+		{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"removed-read-secret"},
+		},
+	}
+
+	owned := []string{"owned-secret-1", "owned-secret-2"}
+	read := []string{"read-secret-1", "read-secret-2"}
+	removed := []string{"removed-owned-secret", "removed-read-secret"}
+
+	newPolicies := provider.RulesForSecretAccess("test", true, existing, owned, read, removed)
+	c.Assert(newPolicies, gc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"create", "patch"},
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+		},
+		{
+			Verbs:     []string{"get", "list"},
+			APIGroups: []string{"*"},
+			Resources: []string{"namespaces"},
 		},
 		{
 			Verbs:         []string{"*"},


### PR DESCRIPTION
This PR adds secret support for the k8s controller model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju switch k1:controller
k1 (controller) -> k1:admin/controller

juju exec --unit controller/0 -- secret-add foo=bar
secret://a38b6cd2-b37d-4766-890d-acc62e414139/cijsiv6ffbas7adlb97g

juju exec --unit controller/0 -- secret-add foo=bar
secret://a38b6cd2-b37d-4766-890d-acc62e414139/cijsj0mffbas7adlb98g

juju exec --unit controller/0 -- secret-get cijsj0mffbas7adlb98g
foo: bar

juju exec --unit controller/0 -- secret-get cijsiv6ffbas7adlb97g
foo: bar

juju add-model t1
Added 't1' model on microk8s/localhost with credential 'microk8s' for user 'admin'

juju deploy snappass-test
Located charm "snappass-test" in charm-hub, revision 9
Deploying "snappass-test" from charm-hub charm "snappass-test", revision 9 in channel stable on ubuntu@20.04/stable

juju exec --unit snappass-test/0 -- secret-add foo=bar
secret://8d6b9148-8ed7-4461-89d8-c549fbdadc7f/cijsjbuffbas7adlb990

juju exec --unit snappass-test/0 -- secret-add foo=bar
secret://8d6b9148-8ed7-4461-89d8-c549fbdadc7f/cijsjcmffbas7adlb99g

juju exec --unit snappass-test/0 -- secret-get cijsjbuffbas7adlb990
foo: bar

juju exec --unit snappass-test/0 -- secret-get cijsjcmffbas7adlb99g
foo: bar

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2025960
