### PR TITLE
Improve modelcmd error message

### DIFF
--- a/cmd/juju/application/scaleapplication_test.go
+++ b/cmd/juju/application/scaleapplication_test.go
@@ -76,7 +76,7 @@ func (s *ScaleApplicationSuite) TestScaleApplicationBlocked(c *gc.C) {
 func (s *ScaleApplicationSuite) TestScaleApplicationWrongModel(c *gc.C) {
 	store := jujuclienttesting.MinimalStore()
 	_, err := cmdtesting.RunCommand(c, NewScaleCommandForTest(s.mockAPI, store), "foo", "2")
-	c.Assert(err, gc.ErrorMatches, `Juju command "scale-application" not supported on non-container models`)
+	c.Assert(err, gc.ErrorMatches, `Juju command "scale-application" only supported on k8s container models`)
 }
 
 func (s *ScaleApplicationSuite) TestInvalidArgs(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -599,7 +599,7 @@ func (w *modelCommandWrapper) validateCommandForModelType(runStarted bool) error
 		err = errors.Errorf("Juju command %q not supported on container models", w.Info().Name)
 	}
 	if modelType == model.IAAS && caasOnly {
-		err = errors.Errorf("Juju command %q not supported on non-container models", w.Info().Name)
+		err = errors.Errorf("Juju command %q only supported on k8s container models", w.Info().Name)
 	}
 
 	if c, ok := w.inner().(modelSpecificCommand); ok {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -335,7 +335,7 @@ func (s *ModelCommandSuite) TestCAASOnlyCommandIAASModel(c *gc.C) {
 	s.setupIAASModel(c)
 
 	_, err := runCaasCommand(c, s.store)
-	c.Assert(err, gc.ErrorMatches, `Juju command "caas-command" not supported on non-container models`)
+	c.Assert(err, gc.ErrorMatches, `Juju command "caas-command" only supported on k8s container models`)
 }
 
 func (s *ModelCommandSuite) TestAllowedCommandCAASModel(c *gc.C) {


### PR DESCRIPTION
*Why this change is needed and what it does.*

If one inadvertently runs `juju scale-application <app_name> <scale_num>` while using an LXD container controller/model, the existing error message could be considered confusing.
```
ERROR Juju command "scale-application" not supported on non-container models
```
This change tries to make it a bit more clear that the commands like it are not supported outside of k8s.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
juju bootstrap localhost <lxd-controller-name>
juju add-model test
juju model-config logging-config="<root>=INFO;unit=DEBUG"
juju deploy <charmname>
juju scale-application <charmname> 2 
juju debug-log --replay

```



