### PR TITLE
Drop double notification on caasapplicationprovisioner in TestWorker and TestWorkerStatusOnly

### DIFF
--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -267,8 +267,6 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	)
 
 	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, false)
-	appWorker.(appNotifyWorker).Notify()
-
 	s.waitDone(c, done)
 	workertest.CheckKill(c, appWorker)
 }
@@ -342,8 +340,6 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 	)
 
 	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, true)
-	appWorker.(appNotifyWorker).Notify()
-
 	s.waitDone(c, done)
 	workertest.CheckKill(c, appWorker)
 }

--- a/worker/caasapplicationprovisioner/mock_test.go
+++ b/worker/caasapplicationprovisioner/mock_test.go
@@ -40,8 +40,3 @@ func (t *mockTomb) ErrDying() error {
 		return tomb.ErrStillAlive
 	}
 }
-
-type appNotifyWorker interface {
-	worker.Worker
-	Notify()
-}


### PR DESCRIPTION
Fixes race condition on buffered channel send sometimes notifying twice.

Similar to #15879

## QA steps

- install golang.org/x/tools/cmd/stress@latest
- `cd worker/caasapplicationprovisioner`
- `go test -c -race`
- `stress ./caasapplicationprovisioner.test`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/github-make-check-juju/7644/consoleText