### PR TITLE
Add k8s target to scale-application entry in juju help commands

### DIFF
--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -55,7 +55,7 @@ func (c *scaleApplicationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "scale-application",
 		Args:    "<application> <scale>",
-		Purpose: "Set the desired number of application units.",
+		Purpose: "Set the desired number of k8s application units.",
 		Doc:     scaleApplicationDoc,
 	})
 }


### PR DESCRIPTION
*Why this change is needed and what it does.*

When checking the available juju commands, it can be nice to see that some of them apply to k8s only, quickly. 

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
juju help commands | grep scale
```

