### PR TITLE
Improvements to check-merge action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -64,6 +64,7 @@ jobs:
           TARGET_BRANCH: ${{ steps.branch.outputs.target }}
           EMAIL_TO_MM_USER: ${{ secrets.EMAIL_TO_MM_USER }}
           IGNORE_EMAILS: ${{ secrets.MERGE_NOTIFY_IGNORE_EMAILS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           MESSAGE=$(go run ./scripts/try-merge errmsg)
           echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"

--- a/scripts/try-merge/execute.go
+++ b/scripts/try-merge/execute.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os/exec"
 )
 
@@ -20,6 +21,15 @@ type executeResults struct {
 	exitCode int
 
 	stdout, stderr []byte
+}
+
+func (res executeResults) String() string {
+	var str string
+	str += fmt.Sprintf("runError: %v\n", res.runError)
+	str += fmt.Sprintf("exitCode: %d\n", res.exitCode)
+	str += fmt.Sprintf("stdout: %s\n", res.stdout)
+	str += fmt.Sprintf("stderr: %s", res.stderr)
+	return str
 }
 
 func execute(args executeArgs) (res executeResults) {


### PR DESCRIPTION
Notify the *committer* instead of the commit *author*. This should fix the case where e.g. person X (committer) backports person Y's (author) commits. Person X should be notified here.

Furthermore, for each commit, check if it is already part of an open merge, and skip in this case.

Finally, some small QoL improvements to error log formatting.

Tested my changes locally and [here](https://github.com/barrettj12/juju/actions/runs/5502076733/jobs/10026091361).