### PR TITLE
Use model-constraints command instead of set-model-constraints.

### DIFF
--- a/tests/suites/cli/model_constraints.sh
+++ b/tests/suites/cli/model_constraints.sh
@@ -2,8 +2,7 @@ run_model_constraints() {
 	echo
 
 	juju set-model-constraints "cores=2 mem=6G"
-	juju get-model-constraints | check "cores=2 mem=6144M"
-
+	juju model-constraints | check "cores=2 mem=6144M"
 }
 
 test_model_constraints() {


### PR DESCRIPTION
Model constraints command in 3.x was changed from `get-model-constraints` to `model-constraints`. This fixes a newly introduced integration test.

## QA steps

Run integration test.

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-cli-test-model-constraints-lxd/20/consoleText