### PR TITLE
Extend dialer timeout for juju ssh connectivity checks.

### DIFF
--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -127,9 +127,9 @@ func (c *sshMachine) setArgs(args []string) {
 }
 
 // defaultReachableChecker returns a jujussh.ReachableChecker with a connection
-// timeout of SSHRetryDelay and an overall timout of SSHTimeout
+// timeout of SSHTimeout/2 and an overall timout of SSHTimeout
 func defaultReachableChecker() jujussh.ReachableChecker {
-	return jujussh.NewReachableChecker(&net.Dialer{Timeout: SSHRetryDelay}, SSHTimeout)
+	return jujussh.NewReachableChecker(&net.Dialer{Timeout: SSHTimeout / 2}, SSHTimeout)
 }
 
 func (c *sshMachine) setHostChecker(checker jujussh.ReachableChecker) {


### PR DESCRIPTION
500ms timeout for dialling a tcp connection is not quite enough, especially when trying to run ssh connectivity checks. Considering all the ssh connectivity checks run concurrently, half the total timeout should be more than sufficient (2.5s currently).

## QA steps

Check juju ssh still works.

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-hooks-test-start-hook-fires-after-reboot-aws/1359/console