### PR TITLE
Fix addLocalCharm base handling. Improve error messages.

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -711,9 +711,13 @@ func (h *bundleHandler) addLocalCharm(chParams bundlechanges.AddCharmParams, chB
 		charmPath = filepath.Join(h.bundleDir, charmPath)
 	}
 
-	chSeries, err := series.GetSeriesFromBase(chBase)
-	if err != nil {
-		return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
+	var chSeries string
+	if !chBase.Empty() {
+		var err error
+		chSeries, err = series.GetSeriesFromBase(chBase)
+		if err != nil {
+			return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
+		}
 	}
 	ch, curl, err := corecharm.NewCharmAtPathForceSeries(charmPath, chSeries, h.force)
 	if err != nil {

--- a/core/charm/baseselector.go
+++ b/core/charm/baseselector.go
@@ -4,7 +4,6 @@
 package charm
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -99,10 +98,10 @@ func (s BaseSelector) validate(supportedCharmBases, supportedJujuBases []series.
 		return nil, errors.Forbiddenf("base must be explicitly provided when image-id constraint is used")
 	}
 	if len(supportedCharmBases) == 0 {
-		return nil, errors.NotValidf("charm does not define any bases,")
+		return nil, errors.NewNotValid(nil, "charm does not define any bases")
 	}
 	if len(supportedJujuBases) == 0 {
-		return nil, errors.NotValidf("no juju supported bases")
+		return nil, errors.NewNotValid(nil, "charm does not define any juju supported bases")
 	}
 	// Verify that the charm supported bases include at least one juju
 	// supported base.
@@ -181,7 +180,7 @@ func (s BaseSelector) userRequested(requestedBase series.Base) (series.Base, err
 		base = requestedBase
 	} else if err != nil {
 		if !s.jujuSupportedBases.Contains(requestedBase.String()) {
-			return series.Base{}, errors.NewNotSupported(nil, fmt.Sprintf("base: %s", requestedBase))
+			return series.Base{}, errors.NotSupportedf("base %s", requestedBase)
 		}
 		if IsUnsupportedBaseError(err) {
 			return series.Base{}, errors.Errorf(

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -54,7 +54,7 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 				requestedBase:  precise,
 				supportedBases: []series.Base{bionic, cosmic},
 			},
-			err: `base: ubuntu@14.04/stable`,
+			err: `base ubuntu@14.04/stable not supported`,
 		},
 		{
 			title: "juju deploy simple --base=ubuntu@18.04   # user provided base takes precedence over default base ",
@@ -83,7 +83,7 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 				defaultBase:         precise,
 				explicitDefaultBase: true,
 			},
-			err: `base: ubuntu@14.04/stable`,
+			err: `base ubuntu@14.04/stable not supported`,
 		},
 		{
 			title: "juju deploy multiseries   # use model base defaults if supported by charm",
@@ -108,7 +108,7 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 				requestedBase:  bionic,
 				supportedBases: []series.Base{utopic, vivid},
 			},
-			err: `base: ubuntu@18.04/stable`,
+			err: `base ubuntu@18.04/stable not supported`,
 		},
 		{
 			title: "juju deploy multiseries    # fallback to series.LatestLTSBase()",
@@ -166,7 +166,7 @@ func (s *baseSelectorSuite) TestValidate(c *gc.C) {
 		// Simple selectors first, no supported bases, check we're validating
 		title:    "juju deploy simple   # no default base, no supported base",
 		selector: BaseSelector{},
-		err:      "charm does not define any bases, not valid",
+		err:      "charm does not define any bases",
 	}, {
 		title: "should fail when image-id constraint is used and no base is explicitly set",
 		selector: BaseSelector{
@@ -289,5 +289,5 @@ func (s *baseSelectorSuite) TestConfigureBaseSelectorDefaultBaseFail(c *gc.C) {
 	baseSelector, err := ConfigureBaseSelector(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = baseSelector.CharmBase()
-	c.Assert(err, gc.ErrorMatches, `base: ubuntu@18.04/stable`)
+	c.Assert(err, gc.ErrorMatches, `base ubuntu@18.04/stable not supported`)
 }


### PR DESCRIPTION
addLocalCharm was reporting an error when no base is specified in bundle.

Other various fixes to errors to add more context.

## QA steps

Run unit tests.

## Documentation changes

N/A

## Bug reference

N/A