### PR TITLE
[JUJU-4141] Bump sqlair to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
 	github.com/canonical/go-dqlite v1.11.9
 	github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7
-	github.com/canonical/sqlair v0.0.0-20230606092629-0a5ab10a1b54
+	github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.2+incompatible
@@ -44,7 +44,6 @@ require (
 	github.com/gorilla/schema v0.0.0-20160426231512-08023a0215e7
 	github.com/gorilla/websocket v1.5.0
 	github.com/gosuri/uitable v0.0.1
-	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/im7mortal/kmutex v1.0.1
 	github.com/juju/ansiterm v1.0.0
@@ -203,6 +202,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/canonical/go-dqlite v1.11.9 h1:aO7GG3QohddXsT+C7yEetdRHhhPUWNBKavz+/J
 github.com/canonical/go-dqlite v1.11.9/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7 h1:/L2OgTX7McauPmggZfYNWEu6D/QiPHcNDQ60grftM04=
 github.com/canonical/pebble v0.0.0-20230307221844-5842ea68c9c7/go.mod h1:j3uyWpPkuWf8u0kB2v7n/XGVpYIg4luGetpSngCvzac=
-github.com/canonical/sqlair v0.0.0-20230606092629-0a5ab10a1b54 h1:Z1lS2ubz/NpKeJ+yhaSykCk8Dpk1/+6+N5xjUHS2DqQ=
-github.com/canonical/sqlair v0.0.0-20230606092629-0a5ab10a1b54/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c h1:xeaBPftOYj0W/GsLZ5W97oE9Xq4hEd+NeKtor24reKA=
+github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 h1:bey1JgA3D2EBabr2a7kWKj+JlEPxX1akv8rcRromotA=
 github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43/go.mod h1:A0/Jvt7qKuCDss37TYRNXSscVyS+tLWM5kBYipQOpWQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
This updates the latest version of sqlair to SHA[1]. This gives us the following changes:

 - Mixed types output exprs (https://github.com/canonical/sqlair/pull/#73)
 - Set to zero on NULL (https://github.com/canonical/sqlair/pull/#80)
 - GetAll not accepting slices of maps (https://github.com/canonical/sqlair/pull/#85)

 1. 6f89ebb4ac5c76df75b7b824cdb0e00704e14b

## QA steps

All tests should pass and you can bootstrap.

```sh
$ juju bootstrap lxd src --build-agent
$ juju add-model default
$ juju enable-ha
$ juju deploy ubuntu -n 3
```

```sh
$ juju bootstrap lxd target --build-agent
```

```sh
$ juju switch src:default
$ juju migrate default target
```