### PR TITLE
[JUJU-4044] Domain for updating bootstrap node bind address

### DIFF
--- a/domain/controllernode/service/package_mock_test.go
+++ b/domain/controllernode/service/package_mock_test.go
@@ -47,3 +47,17 @@ func (mr *MockStateMockRecorder) CurateNodes(arg0, arg1, arg2 interface{}) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurateNodes", reflect.TypeOf((*MockState)(nil).CurateNodes), arg0, arg1, arg2)
 }
+
+// UpdateBootstrapNodeBindAddress mocks base method.
+func (m *MockState) UpdateBootstrapNodeBindAddress(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBootstrapNodeBindAddress", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBootstrapNodeBindAddress indicates an expected call of UpdateBootstrapNodeBindAddress.
+func (mr *MockStateMockRecorder) UpdateBootstrapNodeBindAddress(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBootstrapNodeBindAddress", reflect.TypeOf((*MockState)(nil).UpdateBootstrapNodeBindAddress), arg0, arg1)
+}

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -13,6 +13,7 @@ import (
 // methods for controller node concerns.
 type State interface {
 	CurateNodes(context.Context, []string, []string) error
+	UpdateBootstrapNodeBindAddress(context.Context, string) error
 }
 
 // Service provides the API for working with controller nodes.
@@ -30,4 +31,11 @@ func NewService(st State) *Service {
 func (s *Service) CurateNodes(ctx context.Context, toAdd, toRemove []string) error {
 	err := s.st.CurateNodes(ctx, toAdd, toRemove)
 	return errors.Annotatef(err, "curating controller codes; adding %v, removing %v", toAdd, toRemove)
+}
+
+// UpdateBootstrapNodeBindAddress sets the input address as the Dqlite
+// bind address of the original bootstrapped controller node.
+func (s *Service) UpdateBootstrapNodeBindAddress(ctx context.Context, addr string) error {
+	err := s.st.UpdateBootstrapNodeBindAddress(ctx, addr)
+	return errors.Annotatef(err, "updating bootstrap node bind address to %q", addr)
 }

--- a/domain/controllernode/service/service_test.go
+++ b/domain/controllernode/service/service_test.go
@@ -29,6 +29,15 @@ func (s *serviceSuite) TestUpdateExternalControllerSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *serviceSuite) TestUpdateBootstrapNodeBindAddress(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().UpdateBootstrapNodeBindAddress(gomock.Any(), "192.168.5.60")
+
+	err := NewService(s.state).UpdateBootstrapNodeBindAddress(context.Background(), "192.168.5.60")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -46,3 +46,18 @@ func (s *stateSuite) TestCurateNodes(c *gc.C) {
 	c.Check(ids.Contains("2"), jc.IsTrue)
 	c.Check(ids.Contains("3"), jc.IsTrue)
 }
+
+func (s *stateSuite) TestUpdateBootstrapNodeBindAddress(c *gc.C) {
+	err := NewState(testing.TxnRunnerFactory(s.TxnRunner())).UpdateBootstrapNodeBindAddress(
+		context.Background(), "192.168.5.60")
+	c.Assert(err, jc.ErrorIsNil)
+
+	row := s.DB().QueryRow("SELECT bind_address FROM controller_node WHERE controller_id = 0")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+
+	var addr string
+	err = row.Scan(&addr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(addr, gc.Equals, "192.168.5.60")
+}

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1045,7 +1045,7 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 	fw := s.newFirewaller(c, ctrl)
 
 	app := s.addApplication(ctrl, "wordpress", true)
-	u, m, unitsCh := s.addUnit(c, ctrl, app)
+	u, m, _ := s.addUnit(c, ctrl, app)
 	s.startInstance(c, ctrl, m)
 	s.mustOpenPortRanges(c, u, allEndpoints, []network.PortRange{
 		network.MustParsePortRange("80/tcp"),
@@ -1055,13 +1055,6 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), firewall.AllNetworksIPV4CIDR),
 	}
 	s.assertIngressRules(c, m.Tag().Id(), rules1)
-
-	// Remove unit and application, also tested without. Has no effect.
-	u.EXPECT().Life().Return(life.Dead).AnyTimes()
-	unitsCh <- []string{u.Tag().Id()}
-
-	app.EXPECT().ExposeInfo().Return(false, nil, errors.NotFoundf(app.Name()))
-	s.applicationsCh <- struct{}{}
 
 	// Kill machine.
 	s.deadMachines.Add(m.Tag().Id())


### PR DESCRIPTION
This is the beginning of adding to the `controllerdomain`, logic used by the `dbaccessor` worker to update the Dqlite node topology.

Here we add the logic for updating the original bootstrap node's bind address when entering into HA.

## QA steps

Unit tests verify this change. QA steps will accompany a subsequent patch when the domain is recruited.
