### PR TITLE
[JUJU-4141] Bump musl 1.2.3 to 1.2.4

### DIFF
--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -4,7 +4,7 @@ set -e
 
 source "$(dirname $0)/../env.sh"
 
-MUSL_VERSION="1.2.3"
+MUSL_VERSION="1.2.4"
 MUSL_PRECOMPILED=${MUSL_PRECOMPILED:-"1"}
 MUSL_CROSS_COMPILE=${MUSL_CROSS_COMPILE:-"1"}
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,7 @@ parts:
     source: snap/local
 
   musl:
-    source: https://musl.libc.org/releases/musl-1.2.3.tar.gz
+    source: https://musl.libc.org/releases/musl-1.2.4.tar.gz
     source-type: tar
     plugin: autotools
     build-packages:


### PR DESCRIPTION
The following bumps the musl used version from 1.2.3 to 1.2.4. It would be good for someone to ensure that this matches the supplied signature.

## QA steps

This will require the jenkins job to pass for this to be fulfilled.