### PR TITLE
[JUJU-4044] Use the domain to determing whether models exist

### DIFF
--- a/domain/controllernode/service/package_mock_test.go
+++ b/domain/controllernode/service/package_mock_test.go
@@ -48,6 +48,21 @@ func (mr *MockStateMockRecorder) CurateNodes(arg0, arg1, arg2 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurateNodes", reflect.TypeOf((*MockState)(nil).CurateNodes), arg0, arg1, arg2)
 }
 
+// SelectModelUUID mocks base method.
+func (m *MockState) SelectModelUUID(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectModelUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectModelUUID indicates an expected call of SelectModelUUID.
+func (mr *MockStateMockRecorder) SelectModelUUID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectModelUUID", reflect.TypeOf((*MockState)(nil).SelectModelUUID), arg0, arg1)
+}
+
 // UpdateBootstrapNodeBindAddress mocks base method.
 func (m *MockState) UpdateBootstrapNodeBindAddress(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -41,6 +41,8 @@ func (s *Service) UpdateBootstrapNodeBindAddress(ctx context.Context, addr strin
 	return errors.Annotatef(err, "updating bootstrap node bind address to %q", addr)
 }
 
+// IsModelKnownToController returns true if the input
+// model UUID is one managed by this controller.
 func (s *Service) IsModelKnownToController(ctx context.Context, modelUUID string) (bool, error) {
 	uuid, err := s.st.SelectModelUUID(ctx, modelUUID)
 	if err != nil {

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -14,6 +14,7 @@ import (
 type State interface {
 	CurateNodes(context.Context, []string, []string) error
 	UpdateBootstrapNodeBindAddress(context.Context, string) error
+	SelectModelUUID(context.Context, string) (string, error)
 }
 
 // Service provides the API for working with controller nodes.
@@ -38,4 +39,15 @@ func (s *Service) CurateNodes(ctx context.Context, toAdd, toRemove []string) err
 func (s *Service) UpdateBootstrapNodeBindAddress(ctx context.Context, addr string) error {
 	err := s.st.UpdateBootstrapNodeBindAddress(ctx, addr)
 	return errors.Annotatef(err, "updating bootstrap node bind address to %q", addr)
+}
+
+func (s *Service) IsModelKnownToController(ctx context.Context, modelUUID string) (bool, error) {
+	uuid, err := s.st.SelectModelUUID(ctx, modelUUID)
+	if err != nil {
+		if !errors.Is(err, errors.NotFound) {
+			return false, errors.Annotatef(err, "determining model existence")
+		}
+	}
+
+	return uuid == modelUUID, nil
 }

--- a/domain/controllernode/service/service_test.go
+++ b/domain/controllernode/service/service_test.go
@@ -5,9 +5,9 @@ package service
 
 import (
 	"context"
-	"github.com/juju/errors"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 
 	"github.com/juju/collections/set"
+	jujuerrors "github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	jujuerrors "github.com/juju/errors"
 
 	"github.com/juju/juju/database/testing"
 )


### PR DESCRIPTION
In the interest of isolating domain concerns (and their SQL) to the domain sub-packages, this changes the db-accessor worker to use the `controllernode` domain instead of executing SQL directly in the worker.

## QA steps

Bootstrap a controller.
