### PR TITLE
[merge-check] pre-compile try merge script

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,6 +30,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.branch.outputs.target }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+        # We need to do this before trying to merge, because if the merge
+        # creates conflicts in go.mod, we won't be able to use the go command.
+      - name: Pre-compile try-merge script
+        run: |
+          go install ./scripts/try-merge
+
       - name: Attempt to merge
         id: merge
         env:
@@ -66,7 +78,7 @@ jobs:
           IGNORE_EMAILS: ${{ secrets.MERGE_NOTIFY_IGNORE_EMAILS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          MESSAGE=$(go run ./scripts/try-merge errmsg)
+          MESSAGE=$(try-merge errmsg)
           echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
 
       - name: Notify if merge has conflicts


### PR DESCRIPTION
The "check for merge conflicts" action is failing when there are `go.mod` conflicts. This is because we:
1. try to git merge
2. if that fails, `go run ./scripts/try-merge` to generate the error message

The problem is, if the merge creates conflicts in `go.mod`, then the `go` command in step 2 will fail
```
go: errors parsing go.mod:
/home/runner/work/juju/juju/go.mod:29: malformed module path "<<<<<<<": invalid char '<'
/home/runner/work/juju/juju/go.mod:32: usage: require module/path v1.2.3
/home/runner/work/juju/juju/go.mod:34: malformed module path ">>>>>>>": invalid char '>'
##***error***Process completed with exit code 1.
```

Example failure [here](https://github.com/juju/juju/actions/runs/5536906346/jobs/10105159433).

To avoid this, pre-compile the Go script and run the compiled binary afterwards.

Also added a missing `setup-go` step to the workflow - not sure how it was passing without this :-)

## QA

Test run [here](https://github.com/barrettj12/juju/actions/runs/5538008033/jobs/10107485406). I added a commit to the branch which introduced a `go.mod` conflict, and checked that the "Generate notification message" step passes. (the overall workflow still fails cause I haven't provided a Mattermost token on my fork).