### PR TITLE
More forgiving retry for AWS calls.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -75,8 +75,10 @@ var (
 	// Use shortRetryStrategy to poll for short-term events or for retrying API calls.
 	shortRetryStrategy = retry.CallArgs{
 		Clock:       clock.WallClock,
-		MaxDuration: 5 * time.Second,
+		MaxDuration: 60 * time.Second,
 		Delay:       200 * time.Millisecond,
+		MaxDelay:    5 * time.Second,
+		BackoffFunc: retry.DoubleDelay,
 	}
 
 	// aliveInstanceStates are the states which we filter by when listing


### PR DESCRIPTION
Hammering AWS API every 200ms, on top of the AWS SDK retry is bound to yield poor results.

1. We don't back-off at all.
2. The AWS SDK could already retrying, especially if it gets a retry-able error.
3. AWS may implement negative caching.

Waiting up-to a minute with back-off will give the operation a chance to succeed.

## QA steps

Bootstrap AWS... start some machines.

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-charmhub-test-charmhub-download-aws/1384/console