### PR TITLE
[WIP] [JUJU-4242] Remove SAAS with force in test

### DIFF
--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -22,7 +22,7 @@ run_offer_consume() {
 	ensure "model-offer" "${file}"
 
 	echo "Deploy consumed workload and create the offer"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink dummy-offer
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -33,7 +33,7 @@ run_offer_consume() {
 	echo "Deploy workload in consume model"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -56,7 +56,7 @@ run_offer_consume() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-offer
-	juju remove-saas dummy-offer
+	juju remove-saas dummy-offer --force
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
@@ -87,7 +87,7 @@ run_offer_consume_cross_controller() {
 
 	echo "Deploy consumed workload and create the offer"
 	juju switch "${offer_controller}"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -96,7 +96,7 @@ run_offer_consume_cross_controller() {
 	juju switch "controller-consume"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -116,7 +116,7 @@ run_offer_consume_cross_controller() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-source
-	juju remove-saas dummy-source
+	juju remove-saas dummy-source --force
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.


### PR DESCRIPTION
Occasionally a SAAS fails to be removed in our integration tests. As a compromise, remove the SAAS by force to clean up after the test to resolve this

This is a fallback if I can't find a way to resolve this another way

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -p ec2 cmr
```