### PR TITLE
Fix test_user_register.

### DIFF
--- a/tests/suites/user/register.sh
+++ b/tests/suites/user/register.sh
@@ -16,7 +16,7 @@ run_user_register() {
 
 	rm -rf /tmp/bob || true
 	mkdir -p /tmp/bob
-	printf 'secret\nsecret\ntest\nsecret' | JUJU_DATA=/tmp/bob ${REG_CMD}
+	printf 'secret\nsecret\ntest\nsecret\n' | JUJU_DATA=/tmp/bob ${REG_CMD}
 	MODELS=$(JUJU_DATA=/tmp/bob juju models)
 	check_contains "${MODELS}" "admin/test-user"
 }


### PR DESCRIPTION
Fix test_user_register due to missing newline before stdin is closed. readPassword needs a newline before it finishes reading characters from stdin, without it we can sometimes get an EOF.

## QA steps

`./main.sh -v -s '"test_user_login_password,test_user_manage"' user test_user_register`

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/test-user-test-user-register-aws/42/consoleText