### PR TITLE
[JUJU-4242] Increase rev of juju-qa-test in bundle

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -15,7 +15,7 @@ applications:
   juju-qa-test:
     charm: juju-qa-test
     channel: stable
-    revision: 4
+    revision: 19
     resources:
       foo-file: 2
     num_units: 1


### PR DESCRIPTION
Increase revision of juju-qa-jenkins to deploy in one of our test bundles

This fixes a failure in run_deploy_exported_charmhub_bundle_with_fixed_revisions

It seems something has broken with the old revision

The fixed revision of juju-qa-jenkins was really old, but the test still functions as expected if we increase this rev, so long as we keep it fixed

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
./main.sh -v -c aws -p ec2 deploy test_deploy_bundles
```