### PR TITLE
Return correct error variable in ResolveForDeploy

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -69,7 +69,7 @@ func (c *CharmHubRepository) ResolveForDeploy(arg corecharm.CharmID) (corecharm.
 
 	essMeta, err := transformRefreshResult(resultURL, resp)
 	if err != nil {
-		return corecharm.ResolvedDataForDeploy{}, errors.Trace(resolveErr)
+		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
 	essMeta.ResolvedOrigin = resolvedOrigin
 
@@ -83,7 +83,7 @@ func (c *CharmHubRepository) ResolveForDeploy(arg corecharm.CharmID) (corecharm.
 	// then not. However, that does not mean that the charm has no resources.
 	resourceResults, err := transformResourceRevision(resp.Entity.Resources)
 	if err != nil {
-		return corecharm.ResolvedDataForDeploy{}, errors.Trace(resolveErr)
+		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
 
 	thing := corecharm.ResolvedDataForDeploy{
@@ -91,7 +91,7 @@ func (c *CharmHubRepository) ResolveForDeploy(arg corecharm.CharmID) (corecharm.
 		EssentialMetadata: essMeta,
 		Resources:         resourceResults,
 	}
-	return thing, errors.Trace(err)
+	return thing, nil
 }
 
 // There are a few things to note in the attempt to resolve the charm and it's


### PR DESCRIPTION
It seems due to a copy and paste mistake the incorrect error var was being returned. Fix this

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`juju deploy ubuntu`