### PR TITLE
Fix firewaller relation worker restart. Add logger to all worker.Runner.

### DIFF
--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -122,6 +122,7 @@ func (op *CaasOperatorAgent) Init(args []string) error {
 		IsFatal:       agenterrors.IsFatal,
 		MoreImportant: agenterrors.MoreImportant,
 		RestartDelay:  jworker.RestartDelay,
+		Logger:        logger,
 	})
 	return nil
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -283,6 +283,7 @@ func MachineAgentFactoryFn(
 				IsFatal:       agenterrors.IsFatal,
 				MoreImportant: agenterrors.MoreImportant,
 				RestartDelay:  jworker.RestartDelay,
+				Logger:        logger,
 			}),
 			looputil.NewLoopDeviceManager(),
 			newIntrospectionSocketName,

--- a/cmd/jujud/agent/model.go
+++ b/cmd/jujud/agent/model.go
@@ -74,6 +74,7 @@ func (m *ModelCommand) Init(args []string) error {
 		IsFatal:       agenterrors.IsFatal,
 		MoreImportant: agenterrors.MoreImportant,
 		RestartDelay:  jworker.RestartDelay,
+		Logger:        logger,
 	})
 	return nil
 }

--- a/state/pool.go
+++ b/state/pool.go
@@ -173,8 +173,7 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 	// noticed. The clocks in the runner and the txn watcher are used to
 	// control polling, and never return the actual times.
 	pool.watcherRunner = worker.NewRunner(worker.RunnerParams{
-		// TODO add a Logger parameter to RunnerParams:
-		// Logger: loggo.GetLogger(logger.Name() + ".txnwatcher"),
+		Logger:       loggo.GetLogger("juju.state.pool.txnwatcher"),
 		IsFatal:      func(err error) bool { return errors.Cause(err) == errPoolClosed },
 		RestartDelay: time.Second,
 		Clock:        args.Clock,

--- a/state/workers.go
+++ b/state/workers.go
@@ -35,8 +35,7 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 		state: st,
 		hub:   hub,
 		Runner: worker.NewRunner(worker.RunnerParams{
-			// TODO add a Logger parameter to RunnerParams:
-			// Logger: loggo.GetLogger(logger.Name() + ".workers"),
+			Logger:       loggo.GetLogger("juju.state.watcher"),
 			IsFatal:      func(err error) bool { return err == jworker.ErrRestartAgent },
 			RestartDelay: time.Second,
 			Clock:        st.clock(),

--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -133,6 +133,7 @@ func NewNestedContext(config ContextConfig) (Context, error) {
 		units:  make(map[string]*UnitAgent),
 		errors: make(map[string]error),
 		runner: worker.NewRunner(worker.RunnerParams{
+			Logger:        config.Logger,
 			IsFatal:       agenterrors.IsFatal,
 			MoreImportant: agenterrors.MoreImportant,
 			RestartDelay:  jworker.RestartDelay,

--- a/worker/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/worker/externalcontrollerupdater/externalcontrollerupdater.go
@@ -74,6 +74,7 @@ func New(
 			// If the API connection fails, try again in 1 minute.
 			RestartDelay: time.Minute,
 			Clock:        clock,
+			Logger:       logger,
 		}),
 	}
 	if err := catacomb.Invoke(catacomb.Plan{

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -203,7 +203,8 @@ func NewFirewaller(cfg Config) (worker.Worker, error) {
 		pollClock:                  clk,
 		logger:                     cfg.Logger,
 		relationWorkerRunner: worker.NewRunner(worker.RunnerParams{
-			Clock: clk,
+			Clock:  clk,
+			Logger: cfg.Logger,
 
 			// One of the remote relation workers failing should not
 			// prevent the others from running.
@@ -1439,6 +1440,7 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 	// Start the worker which will watch the remote relation for things like new networks.
 	// We use ReplaceWorker since the relation may have been removed and we are re-adding it.
 	if err := fw.relationWorkerRunner.StartWorker(tag.Id(), func() (worker.Worker, error) {
+		data.catacomb = catacomb.Catacomb{}
 		if err := catacomb.Invoke(catacomb.Plan{
 			Site: &data.catacomb,
 			Work: data.watchLoop,

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1440,6 +1440,9 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 	// Start the worker which will watch the remote relation for things like new networks.
 	// We use ReplaceWorker since the relation may have been removed and we are re-adding it.
 	if err := fw.relationWorkerRunner.StartWorker(tag.Id(), func() (worker.Worker, error) {
+		// This may be a restart after an api error, so ensure any previous
+		// worker is killed and the catacomb is reset.
+		data.Kill()
 		data.catacomb = catacomb.Catacomb{}
 		if err := catacomb.Invoke(catacomb.Plan{
 			Site: &data.catacomb,

--- a/worker/metricworker/manifold.go
+++ b/worker/metricworker/manifold.go
@@ -16,6 +16,9 @@ import (
 // Logger represents the methods used by the worker to log details.
 type Logger interface {
 	Warningf(string, ...interface{})
+	Debugf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Infof(string, ...interface{})
 }
 
 // ManifoldConfig describes the resources used by metrics workers.

--- a/worker/metricworker/metricmanager.go
+++ b/worker/metricworker/metricmanager.go
@@ -23,6 +23,7 @@ func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan s
 	runner := worker.NewRunner(worker.RunnerParams{
 		IsFatal:      isFatal,
 		RestartDelay: jworker.RestartDelay,
+		Logger:       logger,
 	})
 	err := runner.StartWorker("sender", func() (worker.Worker, error) {
 		return newSender(client, notify, logger), nil

--- a/worker/modelworkermanager/manifold.go
+++ b/worker/modelworkermanager/manifold.go
@@ -22,6 +22,8 @@ import (
 type Logger interface {
 	Debugf(string, ...interface{})
 	Warningf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Infof(string, ...interface{})
 }
 
 // ManifoldConfig holds the information necessary to run a model worker manager

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -176,6 +176,7 @@ func (m *modelWorkerManager) loop() error {
 		IsFatal:       neverFatal,
 		MoreImportant: neverImportant,
 		RestartDelay:  m.config.ErrorDelay,
+		Logger:        m.config.Logger,
 	})
 	if err := m.catacomb.Add(m.runner); err != nil {
 		return errors.Trace(err)

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -164,7 +164,8 @@ func New(config Config) (*Worker, error) {
 	runner := config.Runner
 	if runner == nil {
 		runner = worker.NewRunner(worker.RunnerParams{
-			Clock: config.Clock,
+			Clock:  config.Clock,
+			Logger: config.Logger,
 
 			// One of the remote application workers failing should not
 			// prevent the others from running.


### PR DESCRIPTION
remoteRelationData in worker/firewaller would never restart if it crashed due to reusing the catacomb. This fixes that, plus this PR ensures *all worker.Runner instances* have a logger, this problem has been masked for years because the workers were silently restarting.

## QA steps

Difficult to test. Need to cause the remoteRelationData worker to crash, it should restart.

## Documentation changes

N/A

## Bug reference

N/A