### PR TITLE
[JUJU-3969] Allow migration from 3.1

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   migrate:
-    name: 2.9-to-3.x via ${{ matrix.client }} client
+    name: 3.x-to-4.x via ${{ matrix.client }} client
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
@@ -26,8 +26,8 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
-        channel: ["2.9/stable"]
-        client: ['2.9', '3.x']
+        channel: ["3.1/stable"]
+        client: ['3.x', '4.x']
 
     steps:
       - name: Checkout code
@@ -37,17 +37,17 @@ jobs:
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@v0.1.1
 
-      - name: Install Juju 2.9
+      - name: Install Juju 3.x
         run: |
           sudo snap install juju --classic --channel ${{ matrix.channel }}
 
-      - name: Bootstrap a 2.9 controller and model
+      - name: Bootstrap a 3.x controller and model
         run: |
           /snap/bin/juju version
-          /snap/bin/juju bootstrap lxd test29
+          /snap/bin/juju bootstrap lxd test3x
           /snap/bin/juju add-model test-migrate
           /snap/bin/juju deploy ubuntu
-          
+
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
 
@@ -59,46 +59,46 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      - name: Upgrade client to 3.x
+      - name: Upgrade client to 4.x
         run: |
           make go-install &>/dev/null
 
-      - name: Bootstrap 3.x controller
+      - name: Bootstrap 4.x controller
         run: |
           juju version
-          juju bootstrap lxd test3x
+          juju bootstrap lxd test4x --build-agent
           juju switch controller
           juju wait-for application controller
 
         # TODO: create backup and juju restore
 
-      - name: Migrate default model to 3.x controller
+      - name: Migrate default model to 4.x controller
         run: |
           # Determine which Juju client to use
           JUJU='juju'
-          if [[ ${{ matrix.client }} == '2.9' ]]; then
+          if [[ ${{ matrix.client }} == '3.x' ]]; then
             JUJU='/snap/bin/juju'
           fi
-          
-          $JUJU switch test29
-          
+
+          $JUJU switch test3x
+
           # Ensure application is fully deployed
           # We have to use the old client to speak to the new controller, as
           # this is blocked otherwise.
-          /snap/bin/juju wait-for application ubuntu
+          $JUJU wait-for application ubuntu
 
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
 
           $JUJU version
-          $JUJU migrate test-migrate test3x
+          $JUJU migrate test-migrate test4x
 
       - name: Check the migration was successful
         run: |
           set -x
-          juju switch test3x
-          
+          juju switch test4x
+
           # Wait for 'test-migrate' model to come through
           attempt=0
           while true; do
@@ -113,9 +113,9 @@ jobs:
               exit 1
             fi
           done
-          
+
           juju switch test-migrate
           juju wait-for application ubuntu
-          
+
           juju deploy ubuntu yet-another-ubuntu
           juju wait-for application yet-another-ubuntu

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upgrade client to 4.x
         run: |
-          make go-install &>/dev/null
+          make juju >/dev/null
 
       - name: Bootstrap 4.x controller
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -69,6 +69,8 @@ jobs:
           juju bootstrap lxd test4x --build-agent
           juju switch controller
           juju wait-for application controller
+        env:
+          JUJU_SRC_PATH: /home/runner/work/juju/juju
 
         # TODO: create backup and juju restore
 

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -119,15 +119,16 @@ func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
 	c.Assert(caller, gc.IsNil)
 }
 
-func (r *restrictNewerClientSuite) TestWhitelistedClient(c *gc.C) {
-	// Ensure we're allowed to migrate from 2.9.x min release to 3.1.0.
-	r.assertWhitelistedClient(c, "2.9.41", "3.2.0", false)
-	r.assertWhitelistedClient(c, "2.9.42", "3.2.0", true)
-	r.assertWhitelistedClient(c, "2.9.42", "3.2.5", true)
-	r.assertWhitelistedClient(c, "2.9.42", "3.3.0", true)
+func (r *restrictNewerClientSuite) TestAllowedListedClient(c *gc.C) {
+	// Ensure we're allowed to migrate from 3.1.x min release to 4.0.0.
+	r.assertAllowedListedClient(c, "2.9.0", "4.0.0", false)
+	r.assertAllowedListedClient(c, "3.0.0", "4.0.0", true)
+	r.assertAllowedListedClient(c, "3.1.0", "4.0.0", true)
+	r.assertAllowedListedClient(c, "3.1.0", "4.0.9", true)
+	r.assertAllowedListedClient(c, "3.1.0", "4.1.0", true)
 }
 
-func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, callerVers, serverVers string, allowed bool) {
+func (r *restrictNewerClientSuite) assertAllowedListedClient(c *gc.C, callerVers, serverVers string, allowed bool) {
 	r.PatchValue(&jujuversion.Current, version.MustParse(serverVers))
 	r.callerVersion = version.MustParse(callerVers)
 	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.callerVersion)
@@ -142,11 +143,11 @@ func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, callerVers, 
 }
 
 func (r *restrictNewerClientSuite) TestAgentMethod(c *gc.C) {
-	// Ensure we're allowed to migrate from 2.9.x min release to 3.1.0.
-	r.assertAgentMethod(c, "2.9.42", "3.2.0", false)
-	r.assertAgentMethod(c, "2.9.43", "3.2.0", true)
-	r.assertAgentMethod(c, "2.9.43", "3.2.5", true)
-	r.assertAgentMethod(c, "2.9.43", "3.3.0", true)
+	// Ensure we're allowed to migrate from 3.1.x min release to 4.0.0.
+	r.assertAgentMethod(c, "3.0.0", "4.0.0", false)
+	r.assertAgentMethod(c, "3.1.0", "4.0.0", true)
+	r.assertAgentMethod(c, "3.1.0", "4.0.9", true)
+	r.assertAgentMethod(c, "3.1.0", "4.1.0", true)
 }
 
 func (r *restrictNewerClientSuite) assertAgentMethod(c *gc.C, agentVers, serverVers string, allowed bool) {

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -274,10 +274,13 @@ func buildJujus(dir string) error {
 	}
 
 	// When using integration tests, you can't build jujud from outside of the
-	// root package. So if the GOPATH is set, we'll use that as the working
-	// directory to rebuild jujud.
+	// root package. So if the JUJU_SRC_PATH is set we'll use that, falling
+	// back to the GOPATH if it is set. If no other values are set we'll assume
+	// it's in the root location.
 	var cmdDir string
-	if path, ok := os.LookupEnv("GOPATH"); ok && path != "" {
+	if jujuPath, ok := os.LookupEnv("JUJU_SRC_PATH"); ok && jujuPath != "" {
+		cmdDir = jujuPath
+	} else if path, ok := os.LookupEnv("GOPATH"); ok && path != "" {
 		cmdDir = filepath.Join(path, "src", "github.com", "juju", "juju")
 	}
 

--- a/internal/migration/precheck.go
+++ b/internal/migration/precheck.go
@@ -105,7 +105,7 @@ func TargetPrecheck(ctx context.Context, backend PrecheckBackend, pool Pool, mod
 	// to a controller running a newer Juju version.
 	allowed, minVer, err := upgradevalidation.MigrateToAllowed(modelInfo.AgentVersion, controllerVersion)
 	if err != nil {
-		return errors.Maskf(err, "unknown target controller version %v", controllerVersion)
+		return errors.Annotatef(err, "model must be upgraded")
 	}
 	if !allowed {
 		return errors.Errorf("model must be upgraded to at least version %s before being migrated to a controller with version %s", minVer, controllerVersion)

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -529,21 +529,39 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 
 	origBackendBinary := backendVersionBinary
 	origBackend := backendVersion
-	backendVersionBinary = version.MustParseBinary("3.0.0-ubuntu-amd64")
+	backendVersionBinary = version.MustParseBinary("4.0.0-ubuntu-amd64")
 	backendVersion = backendVersionBinary.Number
 	defer func() {
 		backendVersionBinary = origBackendBinary
 		backendVersion = origBackend
 	}()
 
-	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
+	s.modelInfo.AgentVersion = version.MustParse("3.0.0")
 	err := s.runPrecheck(backend, nil)
 	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.43 before being migrated to a controller with version 3.0.0`)
+		`model must be upgraded to at least version 3.1.0 before being migrated to a controller with version 4.0.0`)
 
-	s.modelInfo.AgentVersion = version.MustParse("2.9.43")
+	s.modelInfo.AgentVersion = version.MustParse("3.1.0")
 	err = s.runPrecheck(backend, nil)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *TargetPrecheckSuite) TestModelMinimumVersion2_9(c *gc.C) {
+	backend := newFakeBackend()
+
+	origBackendBinary := backendVersionBinary
+	origBackend := backendVersion
+	backendVersionBinary = version.MustParseBinary("4.0.0-ubuntu-amd64")
+	backendVersion = backendVersionBinary.Number
+	defer func() {
+		backendVersionBinary = origBackendBinary
+		backendVersion = origBackend
+	}()
+
+	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
+	err := s.runPrecheck(backend, nil)
+	c.Assert(err.Error(), gc.Equals,
+		`model must be upgraded: migrate to "4.0.0" is not supported from "2.9.0"`)
 }
 
 func (s *TargetPrecheckSuite) TestSourceControllerMajorAhead(c *gc.C) {
@@ -1011,7 +1029,7 @@ func (m *fakeModel) MigrationMode() state.MigrationMode {
 
 func (m *fakeModel) AgentVersion() (version.Number, error) {
 	if m.agentVersion == nil {
-		return version.MustParse("2.9.32"), nil
+		return version.MustParse("3.1.0"), nil
 	}
 	return *m.agentVersion, nil
 }

--- a/upgrades/upgradevalidation/interfaces.go
+++ b/upgrades/upgradevalidation/interfaces.go
@@ -19,7 +19,6 @@ type StatePool interface {
 
 // State represents a point of use interface for modelling a current model.
 type State interface {
-	AllCharmURLs() ([]*string, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)
 	MongoCurrentStatus() (*replicaset.Status, error)

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -18,6 +18,5 @@ func ValidatorsForModelMigrationSource(
 		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
-		checkForCharmStoreCharms,
 	}
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -4,7 +4,6 @@
 package upgradevalidation_test
 
 import (
-	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -118,8 +117,6 @@ func (s *migrateSuite) setupMocks(c *gc.C) (*gomock.Controller, environscloudspe
 	// - check if the model has win machines;
 	s.st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 
 	return ctrl, cloudSpec.CloudSpec
 }

--- a/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/upgrades/upgradevalidation/mocks/state_mock.go
@@ -75,21 +75,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllCharmURLs mocks base method.
-func (m *MockState) AllCharmURLs() ([]*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllCharmURLs")
-	ret0, _ := ret[0].([]*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllCharmURLs indicates an expected call of AllCharmURLs.
-func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
-}
-
 // HasUpgradeSeriesLocks mocks base method.
 func (m *MockState) HasUpgradeSeriesLocks() (bool, error) {
 	m.ctrl.T.Helper()

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -25,5 +25,4 @@ var (
 	CheckMongoStatusForControllerUpgrade        = checkMongoStatusForControllerUpgrade
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
-	CheckForCharmStoreCharms                    = checkForCharmStoreCharms
 )

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -16,7 +16,7 @@ func ValidatorsForControllerUpgrade(
 	isControllerModel bool, targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
 ) []Validator {
 	if isControllerModel {
-		validators := []Validator{
+		return []Validator{
 			getCheckTargetVersionForControllerModel(targetVersion),
 			checkMongoStatusForControllerUpgrade,
 			checkMongoVersionForControllerModel,
@@ -24,23 +24,15 @@ func ValidatorsForControllerUpgrade(
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
 		}
-		if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-			validators = append(validators, checkForCharmStoreCharms)
-		}
-		return validators
 	}
 
-	validators := []Validator{
+	return []Validator{
 		getCheckTargetVersionForModel(targetVersion, UpgradeControllerAllowed),
 		checkModelMigrationModeForControllerUpgrade,
 		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
 	}
-	if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-		validators = append(validators, checkForCharmStoreCharms)
-	}
-	return validators
 }
 
 // ValidatorsForModelUpgrade returns a list of validators for model upgrade.
@@ -48,14 +40,10 @@ func ValidatorsForControllerUpgrade(
 func ValidatorsForModelUpgrade(
 	force bool, targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
 ) []Validator {
-	validators := []Validator{
+	return []Validator{
 		getCheckUpgradeSeriesLockForModel(force),
 		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
 	}
-	if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-		validators = append(validators, checkForCharmStoreCharms)
-	}
-	return validators
 }

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -4,7 +4,6 @@
 package upgradevalidation_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v3"
 	jc "github.com/juju/testing/checkers"
@@ -75,8 +74,6 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	ctrlState.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -88,8 +85,6 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check if the model has win machines;
 	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	state1.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v11"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/replicaset/v3"
@@ -212,39 +210,6 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	if len(result) > 0 {
 		return NewBlocker("the model hosts deprecated ubuntu machine(s): %s",
 			stringifyMachineCounts(result),
-		), nil
-	}
-	return nil, nil
-}
-
-func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
-	curls, err := st.AllCharmURLs()
-	if errors.Is(err, errors.NotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	result := set.NewStrings()
-	for _, curlStr := range curls {
-		if curlStr == nil {
-			return nil, errors.New("malformed charm in database with no URL")
-		}
-		curl, err := charm.ParseURL(*curlStr)
-		if err != nil {
-			logger.Errorf("error from ParseURL: %s", err)
-			return nil, errors.New(fmt.Sprintf("malformed charm url in database: %q", *curlStr))
-		}
-		// TODO 6-dec-2022
-		// Update check once charm's ValidateSchema rejects charm store charms.
-		if !charm.CharmHub.Matches(curl.Schema) && !charm.Local.Matches(curl.Schema) {
-			c := curl.WithSeries("").WithArchitecture("")
-			result.Add(c.String())
-		}
-	}
-	if !result.IsEmpty() {
-		return NewBlocker("the model hosts deprecated charm store charms(s): %s",
-			strings.Join(result.SortedValues(), ", "),
 		), nil
 	}
 	return nil, nil

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -401,26 +401,3 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsNotFound(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
-
-	blocker, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker, gc.IsNil)
-}
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsError(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.BadRequestf("charm urls"))
-
-	_, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
-}

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -14,7 +14,7 @@ var logger = loggo.GetLogger("juju.upgrades.validations")
 // MinAgentVersions defines the minimum agent version
 // allowed to make a call to a controller with the major version.
 var MinAgentVersions = map[int]version.Number{
-	3: version.MustParse("2.9.43"),
+	4: version.MustParse("3.1.0"),
 }
 
 // MinClientVersions defines the minimum user client version
@@ -22,7 +22,7 @@ var MinAgentVersions = map[int]version.Number{
 // or the minimum controller version needed to accept a call from a
 // client with the major version.
 var MinClientVersions = map[int]version.Number{
-	3: version.MustParse("2.9.42"),
+	4: version.MustParse("3.1.0"),
 }
 
 // MinMajorMigrateVersions defines the minimum version the model
@@ -62,6 +62,13 @@ func versionCheck(
 	if !ok {
 		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
 	}
+
+	// We don't want to allow upgrades from a version that is lower than the
+	// minimum major version (for example, 2.9.0 to 4.0.0).
+	if from.Major < minVer.Major {
+		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
+	}
+
 	// Allow upgrades from rc etc.
 	from.Tag = ""
 	return from.Compare(minVer) >= 0, minVer, nil

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -86,30 +86,35 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 	for i, t := range []versionCheckTC{
 		{
 			from:    "2.8.0",
-			to:      "3.0.0",
+			to:      "4.0.0",
 			allowed: false,
-			minVers: "2.9.43",
+			minVers: "0.0.0",
+			err:     `migrate to "4.0.0" is not supported from "2.8.0"`,
 		}, {
-			from:    "2.9.43",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.43",
-		}, {
-			from:    "2.9.44",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.43",
-		},
-		{
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
 			err:     `migrate to "4.0.0" is not supported from "2.9.0"`,
-		},
-		{
+		}, {
+			from:    "2.9.44",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `migrate to "4.0.0" is not supported from "2.9.44"`,
+		}, {
 			from:    "3.0.0",
-			to:      "2.0.0",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "3.1.0",
+		}, {
+			from:    "3.1.0",
+			to:      "4.0.0",
+			allowed: true,
+			minVers: "3.1.0",
+		}, {
+			from:    "4.0.0",
+			to:      "3.1.0",
 			allowed: false,
 			minVers: "0.0.0",
 			err:     `downgrade is not allowed`,


### PR DESCRIPTION
The following updates the precheck migrations from 3.1.0 to 4.0. We
don't allow 2.9 and 3.0 explicitly. If we believe 3.1 is to early, we can
change that at a later date.

This also removes the charmstore checks. There is no way a charmstore
charm can get into 3.1 one now that we block it at the deploy level and never
allow it from a migration standpoint (both source and target checks). So
we can remove it from the 4.x source code. In theory, we could also remove it
in 3.2 or later, but we can decide to back port that at a later date.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

### Attempting to migrate a 2.9 model should fail.

```sh
$ sudo snap install juju --channel 2.9/stable --classic
$ juju bootstrap lxd test29
$ juju add-model default
$ juju deploy ubuntu
$ sudo snap remove juju --purge
$ make go-install
$ juju bootstrap lxd test40
$ juju switch controller
$ juju wait-for application controller
$ juju switch test29
$ juju wait-for application ubuntu
$ sleep 10
$ juju migrate default test40
ERROR looking up model users in target controller: source prechecks failed: migrate to "4.0-beta1.1" is not supported from "2.9.42"
```

### Attempting to migrate a 3.1 model should succeed

Note this will only work with a local build of juju, because we haven't released 3.1 with the updated source checking.

```sh
$ snap install juju --channel=3.1/edge
$ /snap/bin/juju bootstrap lxd test31
$ /snap/bin/juju add-model m31
$ /snap/bin/juju deploy ubuntu
$ # wait for ubuntu to deploy 
$ juju bootstrap lxd test40 --build-agent
$ juju migrate m31 test40
$ juju switch test40:m31
```

