### PR TITLE
add Discourse topics for wait-for subcommands

### DIFF
--- a/.github/discourse-topic-ids.yaml
+++ b/.github/discourse-topic-ids.yaml
@@ -193,4 +193,8 @@ upgrade-model: 10073
 users: 10175
 version: 10127
 wait-for: 10122
+wait-for_application: 11181
+wait-for_machine: 11183
+wait-for_model: 11182
+wait-for_unit: 11184
 whoami: 10148


### PR DESCRIPTION
In preparation for juju/cmd#102, add Discourse topics for the `wait-for` subcommands.