### PR TITLE
[JUJU-4125] Move convenient factory methods for TxRunner and WatchableDB to core

### DIFF
--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -10,7 +10,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/domain"
+	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/domain/controllernode/service"
 	"github.com/juju/juju/domain/controllernode/state"
 	oldstate "github.com/juju/juju/state"
@@ -42,7 +42,7 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 
 	return &HighAvailabilityAPI{
 		st:          st,
-		nodeService: service.NewService(state.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB))),
+		nodeService: service.NewService(state.NewState(changestream.NewTxnRunnerFactory(ctx.ControllerDB))),
 		authorizer:  authorizer,
 		logger:      ctx.Logger().Child("highavailability"),
 	}, nil

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -13,7 +13,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/domain"
+	"github.com/juju/juju/core/changestream"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 	modelmanagerstate "github.com/juju/juju/domain/modelmanager/state"
 	"github.com/juju/juju/environs/context"
@@ -70,7 +70,7 @@ func newFacadeV9(ctx facade.Context) (*ModelManagerAPI, error) {
 		backend,
 		common.NewModelManagerBackend(ctrlModel, pool),
 		modelmanagerservice.NewService(
-			modelmanagerstate.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB)),
+			modelmanagerstate.NewState(changestream.NewTxnRunnerFactory(ctx.ControllerDB)),
 			ctx.DBDeleter()),
 		toolsFinder,
 		caas.New,

--- a/apiserver/facades/controller/externalcontrollerupdater/register.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/register.go
@@ -8,6 +8,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/domain"
 	ecservice "github.com/juju/juju/domain/externalcontroller/service"
 	ecstate "github.com/juju/juju/domain/externalcontroller/state"
@@ -29,7 +30,7 @@ func newStateAPI(ctx facade.Context) (*ExternalControllerUpdaterAPI, error) {
 	return NewAPI(
 		ctx.Resources(),
 		ecservice.NewService(
-			ecstate.NewState(domain.NewTxnRunnerFactory(ctx.ControllerDB)),
+			ecstate.NewState(changestream.NewTxnRunnerFactory(ctx.ControllerDB)),
 			domain.NewWatcherFactory(
 				ctx.ControllerDB,
 				ctx.Logger().Child("externalcontrollerupdater"),

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -112,7 +112,7 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error {
 // Import takes a serialized Juju model, deserializes it, and
 // recreates it in the receiving controller.
 func (api *API) Import(ctx context.Context, serialized params.SerializedModel) error {
-	scope := modelmigration.NewScope(api.controllerDB, nil)
+	scope := modelmigration.NewScope(database.ConstFactory(api.controllerDB), nil)
 
 	controller := state.NewController(api.pool)
 	_, st, err := migration.ImportModel(ctx, controller, scope, serialized.Bytes)

--- a/core/changestream/eventsource_test.go
+++ b/core/changestream/eventsource_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package changestream
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/database"
+	databasetesting "github.com/juju/juju/database/testing"
+)
+
+type changestreamSuite struct {
+	databasetesting.DqliteSuite
+}
+
+var _ = gc.Suite(&changestreamSuite{})
+
+func (s *changestreamSuite) TestTxnRunnerFactory(c *gc.C) {
+	db, err := NewTxnRunnerFactory(s.getWatchableDB)()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+}
+
+func (s *changestreamSuite) TestTxnRunnerFactoryForNamespace(c *gc.C) {
+	// Test multiple function return signatures to verify the generic behaviour.
+	db, err := database.NewTxnRunnerFactoryForNamespace(func(string) (database.TxnRunner, error) {
+		return s.TxnRunner(), nil
+	}, "any-old-namespace")()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	db, err = database.NewTxnRunnerFactoryForNamespace(s.getWatchableDBForNameSpace, "any-old-namespace")()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+}
+
+func (s *changestreamSuite) getWatchableDB() (WatchableDB, error) {
+	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
+}
+
+func (s *changestreamSuite) getWatchableDBForNameSpace(_ string) (WatchableDB, error) {
+	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
+}
+
+type stubWatchableDB struct {
+	database.TxnRunner
+	EventSource
+}

--- a/core/changestream/package_test.go
+++ b/core/changestream/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package changestream
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/modelmigration/coordinator.go
+++ b/core/modelmigration/coordinator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/description/v4"
 	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/database"
 )
 
@@ -60,12 +59,12 @@ type Operation interface {
 // Scope is a collection of database txn runners that can be used by the
 // operations.
 type Scope struct {
-	controllerDB database.TxnRunner
-	modelDB      database.TxnRunner
+	controllerDB database.TxnRunnerFactory
+	modelDB      database.TxnRunnerFactory
 }
 
 // NewScope creates a new scope with the given database txn runners.
-func NewScope(controllerDB, modelDB database.TxnRunner) Scope {
+func NewScope(controllerDB, modelDB database.TxnRunnerFactory) Scope {
 	return Scope{
 		controllerDB: controllerDB,
 		modelDB:      modelDB,
@@ -73,12 +72,12 @@ func NewScope(controllerDB, modelDB database.TxnRunner) Scope {
 }
 
 // ControllerDB returns the database txn runner for the controller.
-func (s Scope) ControllerDB() database.TxnRunner {
+func (s Scope) ControllerDB() database.TxnRunnerFactory {
 	return s.controllerDB
 }
 
 // ModelDB returns the database txn runner for the model.
-func (s Scope) ModelDB() database.TxnRunner {
+func (s Scope) ModelDB() database.TxnRunnerFactory {
 	return s.modelDB
 }
 

--- a/core/modelmigration/coordinator_test.go
+++ b/core/modelmigration/coordinator_test.go
@@ -115,7 +115,7 @@ func (s *migrationSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.txnRunner = NewMockTxnRunner(ctrl)
 	s.model = NewMockModel(ctrl)
 
-	s.scope = NewScope(s.txnRunner, s.txnRunner)
+	s.scope = NewScope(nil, nil)
 
 	return ctrl
 }

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/cloud"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database"
 	"github.com/juju/juju/domain"
 )
@@ -23,7 +24,7 @@ type State struct {
 }
 
 // NewState creates a state to access the database.
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 )
 
@@ -18,7 +19,7 @@ type State struct {
 }
 
 // NewState returns a new State for interacting with the underlying state.
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory database.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 )
 
@@ -19,7 +20,7 @@ type State struct {
 
 // NewState returns a new controller node state
 // based on the input database factory method.
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory database.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/externalcontroller/modelmigration/export.go
+++ b/domain/externalcontroller/modelmigration/export.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/modelmigration"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/externalcontroller/service"
 	"github.com/juju/juju/domain/externalcontroller/state"
 )
@@ -51,7 +50,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	e.service = service.NewService(
-		state.NewState(domain.ConstFactory(scope.ControllerDB())), nil)
+		state.NewState(scope.ControllerDB()), nil)
 	return nil
 }
 

--- a/domain/externalcontroller/modelmigration/import.go
+++ b/domain/externalcontroller/modelmigration/import.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/modelmigration"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/externalcontroller/service"
 	"github.com/juju/juju/domain/externalcontroller/state"
 )
@@ -41,7 +40,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	i.service = service.NewService(
-		state.NewState(domain.ConstFactory(scope.ControllerDB())), nil)
+		state.NewState(scope.ControllerDB()), nil)
 	return nil
 }
 

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/core/crossmodel"
+	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database"
 	"github.com/juju/juju/domain"
 )
@@ -21,7 +22,7 @@ type State struct {
 	*domain.StateBase
 }
 
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory coreDB.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/modelmigration"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/lease/service"
 	"github.com/juju/juju/domain/lease/state"
 )
@@ -58,7 +57,7 @@ type importOperation struct {
 // Setup is called before the operation is executed. It should return an
 // error if the operation cannot be performed.
 func (o *importOperation) Setup(scope modelmigration.Scope) error {
-	o.service = service.NewService(state.NewState(domain.ConstFactory(scope.ControllerDB()), o.logger))
+	o.service = service.NewService(state.NewState(scope.ControllerDB(), o.logger))
 	return nil
 }
 

--- a/domain/lease/state/state.go
+++ b/domain/lease/state/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3"
 
+	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/database"
 	"github.com/juju/juju/database/txn"
@@ -32,7 +33,7 @@ type State struct {
 }
 
 // NewState returns a new state reference.
-func NewState(factory domain.TxnRunnerFactory, logger Logger) *State {
+func NewState(factory coreDB.TxnRunnerFactory, logger Logger) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 		logger:    logger,

--- a/domain/modelmanager/state/state.go
+++ b/domain/modelmanager/state/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/modelmanager/service"
 )
@@ -20,7 +21,7 @@ type State struct {
 }
 
 // NewState returns a new State for interacting with the underlying state.
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory database.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/domain/state.go
+++ b/domain/state.go
@@ -8,54 +8,19 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 )
-
-// TxnRunnerFactory aliases a function that
-// returns a database.TxnRunner or an error.
-type TxnRunnerFactory = func() (database.TxnRunner, error)
-
-// NewTxnRunnerFactory returns a TxnRunnerFactory for the input
-// changestream.WatchableDB factory function.
-// This ensures that we never pass the ability to access the
-// change-stream into a state object.
-// State objects should only be concerned with persistence and retrieval.
-// Watchers are the concern of the service layer.
-func NewTxnRunnerFactory(f func() (changestream.WatchableDB, error)) TxnRunnerFactory {
-	return func() (database.TxnRunner, error) {
-		r, err := f()
-		return r, errors.Trace(err)
-	}
-}
-
-// NewTxnRunnerFactoryForNamespace returns a TxnRunnerFactory
-// for the input namespaced factory function and namespace.
-func NewTxnRunnerFactoryForNamespace[T database.TxnRunner](f func(string) (T, error), ns string) TxnRunnerFactory {
-	return func() (database.TxnRunner, error) {
-		r, err := f(ns)
-		return r, errors.Trace(err)
-	}
-}
-
-// ConstFactory returns a TxnRunnerFactory that always returns the
-// same database.TxnRunner.
-func ConstFactory(r database.TxnRunner) TxnRunnerFactory {
-	return func() (database.TxnRunner, error) {
-		return r, nil
-	}
-}
 
 // StateBase defines a base struct for requesting a database. This will cache
 // the database for the lifetime of the struct.
 type StateBase struct {
 	mu    sync.Mutex
-	getDB TxnRunnerFactory
+	getDB database.TxnRunnerFactory
 	db    database.TxnRunner
 }
 
 // NewStateBase returns a new StateBase.
-func NewStateBase(getDB TxnRunnerFactory) *StateBase {
+func NewStateBase(getDB database.TxnRunnerFactory) *StateBase {
 	return &StateBase{
 		getDB: getDB,
 	}

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -4,8 +4,6 @@
 package domain
 
 import (
-	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/database"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/database/testing"
@@ -17,25 +15,6 @@ type stateSuite struct {
 }
 
 var _ = gc.Suite(&stateSuite{})
-
-func (s *stateSuite) TestTxnRunnerFactory(c *gc.C) {
-	db, err := NewTxnRunnerFactory(s.getWatchableDB)()
-	c.Assert(err, gc.IsNil)
-	c.Assert(db, gc.NotNil)
-}
-
-func (s *stateSuite) TestTxnRunnerFactoryForNamespace(c *gc.C) {
-	// Test multiple function return signatures to verify the generic behaviour.
-	db, err := NewTxnRunnerFactoryForNamespace(func(string) (database.TxnRunner, error) {
-		return s.TxnRunner(), nil
-	}, "any-old-namespace")()
-	c.Assert(err, gc.IsNil)
-	c.Assert(db, gc.NotNil)
-
-	db, err = NewTxnRunnerFactoryForNamespace(s.getWatchableDBForNameSpace, "any-old-namespace")()
-	c.Assert(err, gc.IsNil)
-	c.Assert(db, gc.NotNil)
-}
 
 func (s *stateSuite) TestStateBaseGetDB(c *gc.C) {
 	f := testing.TxnRunnerFactory(s.TxnRunner())
@@ -56,17 +35,4 @@ func (s *stateSuite) TestStateBaseGetDBNilDB(c *gc.C) {
 	base := NewStateBase(f)
 	_, err := base.DB()
 	c.Assert(err, gc.ErrorMatches, `invoking getDB: nil db`)
-}
-
-func (s *stateSuite) getWatchableDB() (changestream.WatchableDB, error) {
-	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
-}
-
-func (s *stateSuite) getWatchableDBForNameSpace(_ string) (changestream.WatchableDB, error) {
-	return &stubWatchableDB{TxnRunner: s.TxnRunner()}, nil
-}
-
-type stubWatchableDB struct {
-	database.TxnRunner
-	changestream.EventSource
 }

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 )
 
@@ -21,7 +22,7 @@ type State struct {
 }
 
 // NewState creates a state to access the database.
-func NewState(factory domain.TxnRunnerFactory) *State {
+func NewState(factory database.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/database"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/resources"
@@ -54,7 +55,7 @@ func (s *ImportSuite) SetUpTest(c *gc.C) {
 func (s *ImportSuite) TestBadBytes(c *gc.C) {
 	bytes := []byte("not a model")
 	controller := state.NewController(s.StatePool)
-	scope := modelmigration.NewScope(s.TxnRunner(), nil)
+	scope := modelmigration.NewScope(database.ConstFactory(s.TxnRunner()), nil)
 	model, st, err := migration.ImportModel(context.Background(), controller, scope, bytes)
 	c.Check(st, gc.IsNil)
 	c.Check(model, gc.IsNil)
@@ -78,7 +79,7 @@ func (s *ImportSuite) exportImport(c *gc.C, leaders map[string]string) *state.St
 	c.Check(err, jc.ErrorIsNil)
 
 	controller := state.NewController(s.StatePool)
-	scope := modelmigration.NewScope(s.TxnRunner(), nil)
+	scope := modelmigration.NewScope(database.ConstFactory(s.TxnRunner()), nil)
 	dbModel, dbState, err := migration.ImportModel(context.Background(), controller, scope, bytes)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { dbState.Close() })

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -15,10 +15,10 @@ import (
 	"github.com/juju/worker/v3/catacomb"
 	"github.com/juju/worker/v3/dependency"
 
+	"github.com/juju/juju/core/database"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/database/dqlite"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/controllernode/service"
 	"github.com/juju/juju/domain/controllernode/state"
 	"github.com/juju/juju/pubsub/apiserver"
@@ -856,7 +856,7 @@ func (w *dbWorker) ensureNamespace(namespace string) error {
 	defer cancel()
 
 	known, err := service.NewService(
-		state.NewState(domain.NewTxnRunnerFactoryForNamespace(w.GetDB, coredatabase.ControllerNS)),
+		state.NewState(database.NewTxnRunnerFactoryForNamespace(w.GetDB, coredatabase.ControllerNS)),
 	).IsModelKnownToController(ctx, namespace)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/lease/manifold.go
+++ b/worker/lease/manifold.go
@@ -13,9 +13,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/database"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/lease/service"
 	"github.com/juju/juju/domain/lease/state"
 	"github.com/juju/juju/worker/common"
@@ -146,6 +146,6 @@ func NewWorker(config ManagerConfig) (worker.Worker, error) {
 
 // NewStore returns a new lease store based on the input config.
 func NewStore(dbGetter coredatabase.DBGetter, logger Logger) lease.Store {
-	factory := domain.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, coredatabase.ControllerNS)
+	factory := database.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, coredatabase.ControllerNS)
 	return service.NewService(state.NewState(factory, logger))
 }

--- a/worker/leaseexpiry/manifold.go
+++ b/worker/leaseexpiry/manifold.go
@@ -9,9 +9,9 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 
+	"github.com/juju/juju/core/database"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/lease/service"
 	"github.com/juju/juju/domain/lease/state"
 )
@@ -96,6 +96,6 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 
 // NewStore returns a new lease store based on the input config.
 func NewStore(dbGetter coredatabase.DBGetter, logger Logger) lease.ExpiryStore {
-	factory := domain.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, coredatabase.ControllerNS)
+	factory := database.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, coredatabase.ControllerNS)
 	return service.NewService(state.NewState(factory, logger))
 }


### PR DESCRIPTION
This patch originates on this comment https://github.com/juju/juju/pull/15927#discussion_r1265082002 and it results in the need to have factories both in domain/state as in migrations packages.

We used to have factory methods for creating `TxnRunnerFactory`s on domain/state.go but since we are now also going to be using them in the migration package, it's better to have them at core. NewTxnRunnerFactoryForNamespace will now be in the core/database package (core/database/runner.go), and NewTxnRunnerFactory will be on core/changestream package (core/changestream/eventsource.go) since it depends on WatchableDB and we cannot have cyclic references on it from core/database.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

