### PR TITLE
[JUJU-4242] juju-qa-test supports focal with arm64

### DIFF
--- a/testcharms/charm-hub/charms/juju-qa-test/README.md
+++ b/testcharms/charm-hub/charms/juju-qa-test/README.md
@@ -6,7 +6,7 @@ A container-based V2 metadata charm to use in testing juju.
 
 ## Usage
 
-Basic deploy: 
+Basic deploy:
 `juju deploy juju-qa-test`
 
 Set the unit status to the first line of the resource, if available, one time:
@@ -19,7 +19,7 @@ Get your fortune
 ## Version, Channel, Series and History
 | Version    | Revision | Channel          | Series                               |
 | ---------- | -------- | ---------------- | ------------------------------------ |
-| 1.1-stable | 19       | latest/stable    | focal, bionic, xenial                |
+| 1.1-stable | 26       | latest/stable    | focal, bionic, xenial                |
 | 1.4-cand   | 20       | latest/candidate | jammy, focal, bionic, xenial         |
 | 2.0-edge   | 21       | latest/edge      | groovy, jammy, focal, bionic, xenial |
 | 2.0-stable | 22       | 2.0/stable       | disco, bionic, xenial, trusty        |

--- a/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
@@ -1,14 +1,29 @@
 type: charm
+parts:
+  charm:
+    prime:
+      - dispatch
+      - hooks
+      - README.md
+      - LICENSE
+      - version
+      - src
+      - actions.yaml
+      - metadata.yaml
+      - config.yaml
 bases:
     - build-on:
         - name: "ubuntu"
           channel: "20.04"
         - name: "ubuntu"
           channel: "22.04"
-      run-on: 
+      run-on:
         - name: "ubuntu"
           channel: "16.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "18.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "20.04"
+          architectures: ["amd64", "arm64"]

--- a/testcharms/charm-hub/charms/juju-qa-test/stable/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/stable/charmcraft.yaml
@@ -17,10 +17,13 @@ bases:
           channel: "20.04"
         - name: "ubuntu"
           channel: "22.04"
-      run-on: 
+      run-on:
         - name: "ubuntu"
           channel: "16.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "18.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "20.04"
+          architectures: ["amd64", "arm64"]


### PR DESCRIPTION
Our arm bundle unit tests were failing with arch arm64 because our test charm juju-qa-test doesn't support any series more recent than Bionic

Edit the charm to support both amd and arm, and submit another revision

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

On an arm machine run:

```sh
BOOTSTRAP_ARCH=arm64 MODEL_ARCH=arm64 ./main.sh -v deploy test_deploy_bundles
```

NOTE: There is some funniness around constraints I can't quite figure out to get this to work locally. Important thing is it succeeds in Jenkins, which it does here:
https://jenkins.juju.canonical.com/view/ci-runs/job/ci-gating-tests/1447/

and 
```
$ juju info juju-qa-test --arch arm64
name: juju-qa-test
publisher: Juju Engineering
summary: |
  A container-based V2 metadata charm to use in testing juju.
description: |
  A container-based V2 metadata charm to use in testing juju.
  It has config, actions, resources, and a relation.
store-url: https://charmhub.io/juju-qa-test
charm-id: Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ
supports: ubuntu@16.04, ubuntu@18.04, ubuntu@20.04
subordinate: false
relations:
  provides: {}
  requires:
    info: juju-info
channels: |
  latest/stable:     1.1-stable  2023-07-18  (26)  2MB    ubuntu@16.04, ubuntu@18.04, ubuntu@20.04
  latest/candidate:  14          2021-02-26  (14)  824kB  ubuntu@20.04, ubuntu@18.04, ubuntu@16.04
  latest/beta:       ↑
  latest/edge:       20  2021-02-26  (15)  824kB  ubuntu@20.10, ubuntu@20.04, ubuntu@18.04, ubuntu@16.04
  2.0/stable:        8   2021-02-26  (8)   824kB  ubuntu@19.04, ubuntu@18.04, ubuntu@16.04, ubuntu@14.04
  2.0/candidate:     ↑
  2.0/beta:          ↑
  2.0/edge:          10  2021-02-26  (9)  824kB  ubuntu@19.04, ubuntu@18.04, ubuntu@16.04, ubuntu@14.04
```