### PR TITLE
[JUJU-4246] - Validate series before creating lock doc;

### DIFF
--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
@@ -100,7 +101,7 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeries
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return result.Error
+		return apiservererrors.RestoreError(result.Error)
 	}
 	return nil
 }

--- a/apiserver/facades/client/machinemanager/upgradeseries.go
+++ b/apiserver/facades/client/machinemanager/upgradeseries.go
@@ -189,6 +189,11 @@ func (a *UpgradeSeriesAPI) Prepare(tag, series string, force bool) (retErr error
 		unitNames[i] = unit.UnitTag().Id()
 	}
 
+	// Validate the machine applications for a given series.
+	if err := a.validateApplication(machine, series, force); err != nil {
+		return errors.Trace(err)
+	}
+
 	// TODO 2018-06-28 managed series upgrade
 	// improve error handling based on error type, there will be cases where retrying
 	// the hooks is needed etc.
@@ -207,11 +212,6 @@ func (a *UpgradeSeriesAPI) Prepare(tag, series string, force bool) (retErr error
 			retErr = errors.Annotatef(retErr, "%s occurred while cleaning up from", err)
 		}
 	}()
-
-	// Validate the machine applications for a given series.
-	if err := a.validateApplication(machine, series, force); err != nil {
-		return errors.Trace(err)
-	}
 
 	// Once validated, set the machine status to started.
 	message := fmt.Sprintf("started upgrade series from %q to %q", machine.Series(), series)
@@ -378,24 +378,26 @@ func (s upgradeSeriesValidator) ValidateMachine(machine Machine) error {
 	}
 
 	// If we've already got a series lock on upgrade, don't go any further.
-	if locked, err := machine.IsLockedForSeriesUpgrade(); errors.IsNotFound(errors.Cause(err)) {
+	locked, err := machine.IsLockedForSeriesUpgrade()
+	if err != nil {
 		return errors.Trace(err)
-	} else if locked {
-		// Grab the status from upgrade series and add it to the error.
-		status, err := machine.UpgradeSeriesStatus()
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		// Additionally add the status to the underlying params error. This
-		// gives a typed error to the client, which can then decode ths
-		// optional information later on.
-		return &apiservererrors.UpgradeSeriesValidationError{
-			Cause:  errors.Errorf("upgrade series lock found for %q; series upgrade is in the %q state", machine.Id(), status),
-			Status: status.String(),
-		}
 	}
-	return nil
+	if !locked {
+		return nil
+	}
+	// Grab the status from upgrade series and add it to the error.
+	status, err := machine.UpgradeSeriesStatus()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Additionally add the status to the underlying params error. This
+	// gives a typed error to the client, which can then decode ths
+	// optional information later on.
+	return &apiservererrors.UpgradeSeriesValidationError{
+		Cause:  errors.Errorf("upgrade series lock found for %q; series upgrade is in the %q state", machine.Id(), status),
+		Status: status.String(),
+	}
 }
 
 // ValidateUnits validates a given set of units.

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -4,6 +4,8 @@
 package uniter
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 )
@@ -37,5 +39,6 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 
 // setUpgradeSeriesStatus sets the upgrade series status.
 func setUpgradeSeriesStatus(u *Uniter, status model.UpgradeSeriesStatus, reason string) error {
-	return u.unit.SetUpgradeSeriesStatus(status, reason)
+	err := u.unit.SetUpgradeSeriesStatus(status, reason)
+	return errors.Annotatef(err, "cannot set upgrade series status to %q with reason: %q", status, reason)
 }


### PR DESCRIPTION
Currently, the Prepare facade creates a loc doc first and then validates the series. Now, the uniter may start to run the prepare hook. Then the lock doc maybe gets deleted if the series validation failed which causes the uniter got the lock doc not-found error or lock doc status conflict error.

This PR moves the series validation before creating the lock doc. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju upgrade-series 0 prepare jammy
WARNING: This command will mark machine "0" as being upgraded to series "jammy".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - hacluster/0
  - keystone/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - hacluster
  - keystone

Continue [y/N]?y
ERROR charm "hacluster" does not support jammy, force not used

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2008509
