### PR TITLE
[JUJU-4275] Backport the setting of foreign keys via pragma

### DIFF
--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/database/app"
+	"github.com/juju/juju/database/pragma"
 	"github.com/juju/juju/database/schema"
 )
 
@@ -73,6 +74,10 @@ func BootstrapDqlite(ctx context.Context, opt bootstrapOptFactory, logger Logger
 			logger.Errorf("closing controller database: %v", err)
 		}
 	}()
+
+	if err := pragma.SetPragma(ctx, db, pragma.ForeignKeysPragma, true); err != nil {
+		return errors.Annotate(err, "setting foreign keys pragma")
+	}
 
 	if err := NewDBMigration(db, logger, schema.ControllerDDL()).Apply(); err != nil {
 		return errors.Annotate(err, "creating controller database schema")

--- a/database/pragma/pragma.go
+++ b/database/pragma/pragma.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pragma
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/juju/errors"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/database/txn"
+)
+
+// Pragma is the name of a pragma.
+type Pragma string
+
+const (
+	// ForeignKeysPragma is the name of the foreign keys pragma.
+	ForeignKeysPragma Pragma = "foreign_keys"
+)
+
+// GetPragma returns whether the given pragma is enabled.
+func GetPragma[T any](ctx context.Context, txn coredatabase.TrackedDB, pragam Pragma) (T, error) {
+	var value T
+	err := txn.Txn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		query := fmt.Sprintf("PRAGMA %s", pragam)
+		err := tx.QueryRowContext(ctx, query).Scan(&value)
+		return errors.Trace(err)
+	})
+	if err != nil {
+		return value, fmt.Errorf("failed to get %q pragma: %w", pragam, err)
+	}
+	return value, nil
+}
+
+var (
+	// Reuse the txn runner for retries as they're consistent. We can't use
+	// the database package directly, as that causes import cycle error.
+	runner = txn.NewTransactionRunner()
+)
+
+// SetPragma sets the given pragma to the given value.
+func SetPragma[T any](ctx context.Context, db *sql.DB, pragma Pragma, value T) error {
+	query := fmt.Sprintf("PRAGMA %s = %v", pragma, value)
+	err := runner.Retry(ctx, func() error {
+		_, err := db.ExecContext(ctx, query)
+		return errors.Trace(err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set %q pragma %w", pragma, errors.Hide(err))
+	}
+	return nil
+}

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -4,6 +4,8 @@
 package dbaccessor
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -51,7 +53,7 @@ type ManifoldConfig struct {
 	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
 	NewApp               func(string, ...app.Option) (DBApp, error)
-	NewDBWorker          func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
+	NewDBWorker          func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 	NewMetricsCollector  func() *Collector
 }
 

--- a/worker/dbaccessor/manifold_test.go
+++ b/worker/dbaccessor/manifold_test.go
@@ -4,6 +4,8 @@
 package dbaccessor
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -73,7 +75,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return nil, nil
 		},
 		NewMetricsCollector: func() *Collector {

--- a/worker/dbaccessor/tracker_test.go
+++ b/worker/dbaccessor/tracker_test.go
@@ -36,7 +36,7 @@ func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
-	w, err := NewTrackedDBWorker(s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
+	w, err := NewTrackedDBWorker(context.Background(), s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer workertest.DirtyKill(c, w)
@@ -53,7 +53,7 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
-	w, err := NewTrackedDBWorker(s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
+	w, err := NewTrackedDBWorker(context.Background(), s.dbApp, "controller", WithClock(s.clock), WithLogger(s.logger))
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer workertest.DirtyKill(c, w)
@@ -364,7 +364,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 
 func (s *trackedDBWorkerSuite) newTrackedDBWorker(pingFn func(context.Context, *sql.DB) error) (TrackedDB, error) {
 	collector := NewMetricsCollector()
-	return NewTrackedDBWorker(s.dbApp, "controller",
+	return NewTrackedDBWorker(context.Background(), s.dbApp, "controller",
 		WithClock(s.clock),
 		WithLogger(s.logger),
 		WithPingDBFunc(pingFn),

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -113,7 +113,7 @@ type WorkerConfig struct {
 	Hub         Hub
 	Logger      Logger
 	NewApp      func(string, ...app.Option) (DBApp, error)
-	NewDBWorker func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
+	NewDBWorker func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 
 	// ControllerID uniquely identifies the controller that this
 	// worker is running on. It is equivalent to the machine ID.
@@ -474,7 +474,10 @@ func (w *dbWorker) openDatabase(namespace string) error {
 			}
 		}
 
-		return w.cfg.NewDBWorker(w.dbApp, namespace,
+		ctx, cancel := w.scopedContext()
+		defer cancel()
+
+		return w.cfg.NewDBWorker(ctx, w.dbApp, namespace,
 			WithClock(w.cfg.Clock),
 			WithLogger(w.cfg.Logger),
 			WithMetricsCollector(w.cfg.MetricsCollector),

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -4,6 +4,7 @@
 package dbaccessor
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -338,7 +339,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return s.trackedDB, nil
 		},
 		MetricsCollector: &Collector{},


### PR DESCRIPTION
The following forces the setting of the foreign keys pragma upon opening the database. This ensures that we never attempt to run a db without setting this key functionality.

This potentially can cause issues with existing foreign keys, but only leases are avaiable in this release. The foreign key usage is extremely small. It is used in two places:

  1. The lease type id, which ensures that the lease is either a singular-controller or an application-leader. Neither of those is allowed to be user-defined, so we can ensure that it's either one of those.
  2. The second type is based on the pinned lease. This also requires no user input and is set by code. This is a direct link to the lease table uuid.

The change log tables are not used or set, so we can ignore that schema. This should have been removed from the release as we ended up moving that to the main branch.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Ensure no errors.

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```
