### PR TITLE
Merge 3.1 to 3.2

### DIFF
--- a/.github/golangci-lint.config.yaml
+++ b/.github/golangci-lint.config.yaml
@@ -46,3 +46,6 @@ run:
 skip-dirs:
   - acceptancetests
   - _deps
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.github/golangci-lint.config.yaml
+++ b/.github/golangci-lint.config.yaml
@@ -1,4 +1,10 @@
 linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - Prefix(github.com/juju/juju)
+    skip-generated: true
   gofmt:
     simplify: true
   govet:
@@ -26,9 +32,9 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - gci
     - govet
     - gofmt
-    - goimports
     - ineffassign
     - misspell
     - unconvert

--- a/api/agent/deployer/deployer.go
+++ b/api/agent/deployer/deployer.go
@@ -4,11 +4,12 @@
 package deployer
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 const deployerFacade = "Deployer"

--- a/api/agent/deployer/machine.go
+++ b/api/agent/deployer/machine.go
@@ -6,10 +6,11 @@ package deployer
 import (
 	"fmt"
 
+	"github.com/juju/names/v4"
+
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 // Machine represents a juju machine as seen by the deployer worker.

--- a/api/agent/deployer/unit.go
+++ b/api/agent/deployer/unit.go
@@ -4,11 +4,12 @@
 package deployer
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 // Unit represents a juju unit as seen by the deployer worker.

--- a/api/agent/diskmanager/diskmanager.go
+++ b/api/agent/diskmanager/diskmanager.go
@@ -4,10 +4,11 @@
 package diskmanager
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
-	"github.com/juju/names/v4"
 )
 
 const diskManagerFacade = "DiskManager"

--- a/api/agent/hostkeyreporter/facade.go
+++ b/api/agent/hostkeyreporter/facade.go
@@ -4,9 +4,10 @@
 package hostkeyreporter
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 // Facade provides access to the HostKeyReporter API facade.

--- a/api/agent/instancemutater/export_test.go
+++ b/api/agent/instancemutater/export_test.go
@@ -4,9 +4,10 @@
 package instancemutater
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/life"
-	"github.com/juju/names/v4"
 )
 
 func NewMachine(facadeCaller base.FacadeCaller, tag names.MachineTag, life life.Value) *Machine {

--- a/api/agent/logger/logger.go
+++ b/api/agent/logger/logger.go
@@ -6,11 +6,12 @@ package logger
 import (
 	"fmt"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 // State provides access to an logger worker's view of the state.

--- a/api/agent/uniter/goal-state_test.go
+++ b/api/agent/uniter/goal-state_test.go
@@ -6,7 +6,6 @@ package uniter_test
 import (
 	"time"
 
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/rpc/params"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type goalStateSuite struct {

--- a/api/agent/upgradeseries/export_test.go
+++ b/api/agent/upgradeseries/export_test.go
@@ -4,9 +4,10 @@
 package upgradeseries
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
-	"github.com/juju/names/v4"
 )
 
 func NewStateFromCaller(caller base.FacadeCaller, authTag names.Tag) *Client {

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -36,12 +36,11 @@ import (
 
 	"github.com/juju/juju/api/base"
 	coremacaroon "github.com/juju/juju/core/macaroon"
-	"github.com/juju/juju/rpc/params"
-
 	"github.com/juju/juju/core/network"
 	jujuproxy "github.com/juju/juju/proxy"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
+	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
 )

--- a/api/client/modelconfig/modelconfig_test.go
+++ b/api/client/modelconfig/modelconfig_test.go
@@ -10,7 +10,6 @@ import (
 
 	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/modelconfig"
-
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"

--- a/api/client/resources/client_listresources_test.go
+++ b/api/client/resources/client_listresources_test.go
@@ -5,9 +5,8 @@ package resources_test
 
 import (
 	"github.com/juju/errors"
-	"go.uber.org/mock/gomock"
-
 	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base/mocks"

--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
@@ -100,7 +101,7 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeries
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return result.Error
+		return apiservererrors.RestoreError(result.Error)
 	}
 	return nil
 }

--- a/api/common/watch.go
+++ b/api/common/watch.go
@@ -6,11 +6,12 @@ package common
 import (
 	"fmt"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v4"
 )
 
 // Watch starts a NotifyWatcher for the entity with the specified tag.

--- a/api/connector/clientstoreconnector.go
+++ b/api/connector/clientstoreconnector.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -4,9 +4,10 @@
 package connector
 
 import (
-	"github.com/juju/juju/api"
 	"github.com/juju/names/v4"
 	"gopkg.in/macaroon.v2"
+
+	"github.com/juju/juju/api"
 )
 
 // SimpleConfig aims to provide the same API surface as pilot juju for

--- a/api/controller/controller/identity_url.go
+++ b/api/controller/controller/identity_url.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/api/controller/controller/mongo.go
+++ b/api/controller/controller/mongo.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/api/controller/crossmodelrelations/macarooncache_test.go
+++ b/api/controller/crossmodelrelations/macarooncache_test.go
@@ -6,12 +6,12 @@ package crossmodelrelations_test
 import (
 	"time"
 
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/clock/testclock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/juju/api/controller/crossmodelrelations"
 	apitesting "github.com/juju/juju/api/testing"
 	coretesting "github.com/juju/juju/testing"

--- a/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -11,14 +11,13 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
+	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/controller/crossmodelsecrets"
 	apitesting "github.com/juju/juju/api/testing"
 	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/secrets"
 	secretsprovider "github.com/juju/juju/secrets/provider"
-
-	"github.com/juju/juju/api/base/testing"
-	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/api/controller/firewaller/relation.go
+++ b/api/controller/firewaller/relation.go
@@ -4,8 +4,9 @@
 package firewaller
 
 import (
-	"github.com/juju/juju/core/life"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/life"
 )
 
 // Relation represents a juju relation as seen by the firewaller worker.

--- a/api/controller/instancepoller/export_test.go
+++ b/api/controller/instancepoller/export_test.go
@@ -4,9 +4,10 @@
 package instancepoller
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/life"
-	"github.com/juju/names/v4"
 )
 
 func NewMachine(caller base.APICaller, tag names.MachineTag, life life.Value) *Machine {

--- a/api/controller/pubsub/pubsub_test.go
+++ b/api/controller/pubsub/pubsub_test.go
@@ -9,12 +9,12 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base"
 	apipubsub "github.com/juju/juju/api/controller/pubsub"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/testing"
 )
 
 type PubSubSuite struct {

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	jujuproxy "github.com/juju/juju/proxy"
 	"github.com/juju/names/v4"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/network"
+	jujuproxy "github.com/juju/juju/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
 )
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -45,10 +45,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/action"
 	"github.com/juju/juju/apiserver/facades/client/annotations" // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/application"
-	"github.com/juju/juju/apiserver/facades/client/modelupgrader"
-	"github.com/juju/juju/apiserver/facades/client/secretbackends"
-	"github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets"
-
 	// ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/facades/client/backups" // ModelUser Write
@@ -67,8 +63,10 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"    // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/modelgeneration"
 	"github.com/juju/juju/apiserver/facades/client/modelmanager" // ModelUser Write
+	"github.com/juju/juju/apiserver/facades/client/modelupgrader"
 	"github.com/juju/juju/apiserver/facades/client/payloads"
 	"github.com/juju/juju/apiserver/facades/client/resources"
+	"github.com/juju/juju/apiserver/facades/client/secretbackends"
 	"github.com/juju/juju/apiserver/facades/client/secrets"
 	"github.com/juju/juju/apiserver/facades/client/spaces"    // ModelUser Write
 	"github.com/juju/juju/apiserver/facades/client/sshclient" // ModelUser Write
@@ -90,6 +88,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/cleaner"
 	"github.com/juju/juju/apiserver/facades/controller/crosscontroller"
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelrelations"
+	"github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets"
 	"github.com/juju/juju/apiserver/facades/controller/environupgrader"
 	"github.com/juju/juju/apiserver/facades/controller/externalcontrollerupdater"
 	"github.com/juju/juju/apiserver/facades/controller/firewaller"

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -45,13 +45,11 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
-
 	"github.com/juju/juju/core/resources"
-
-	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/pubsub/apiserver"
 	controllermsg "github.com/juju/juju/pubsub/controller"
 	"github.com/juju/juju/resource"

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -5,6 +5,7 @@ package networkingcommon
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
-
-	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/mocks"

--- a/apiserver/facades/agent/caasapplication/register.go
+++ b/apiserver/facades/agent/caasapplication/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/state/stateenvirons"

--- a/apiserver/facades/agent/caasoperator/register.go
+++ b/apiserver/facades/agent/caasoperator/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common/unitcommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"

--- a/apiserver/facades/agent/hostkeyreporter/register.go
+++ b/apiserver/facades/agent/hostkeyreporter/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/leadership/register.go
+++ b/apiserver/facades/agent/leadership/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/machine/register.go
+++ b/apiserver/facades/agent/machine/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/migrationflag/register.go
+++ b/apiserver/facades/agent/migrationflag/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/provisioner/register.go
+++ b/apiserver/facades/agent/provisioner/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/proxyupdater/register.go
+++ b/apiserver/facades/agent/proxyupdater/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/agent/retrystrategy/register.go
+++ b/apiserver/facades/agent/retrystrategy/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"

--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/mock_test.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/mock_test.go
@@ -5,9 +5,9 @@ package filesystemwatcher_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/state"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher/watchertest"
 )
 

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/environs"

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"github.com/juju/charm/v10"
 	"github.com/juju/errors"
-
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 

--- a/apiserver/facades/agent/upgradeseries/register.go
+++ b/apiserver/facades/agent/upgradeseries/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 )

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -9,13 +9,12 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/status"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/mocks"
 	"github.com/juju/juju/apiserver/facades/agent/upgradeseries"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -11,16 +11,15 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/controller"
-	jujutesting "github.com/juju/juju/testing"
-
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/agent/upgradesteps"
 	"github.com/juju/juju/apiserver/facades/agent/upgradesteps/mocks"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 type upgradeStepsSuite struct {

--- a/apiserver/facades/client/action/package_test.go
+++ b/apiserver/facades/client/action/package_test.go
@@ -9,9 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/core/leadership"
-
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/client/block/register.go
+++ b/apiserver/facades/client/block/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 )

--- a/apiserver/facades/client/block/state.go
+++ b/apiserver/facades/client/block/state.go
@@ -4,8 +4,9 @@
 package block
 
 import (
-	"github.com/juju/juju/state"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/state"
 )
 
 type blockAccess interface {

--- a/apiserver/facades/client/bundle/register.go
+++ b/apiserver/facades/client/bundle/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -13,8 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	coreseries "github.com/juju/juju/core/series"
-
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
@@ -25,6 +23,7 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"

--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/client/controller/backend.go
+++ b/apiserver/facades/client/controller/backend.go
@@ -9,7 +9,6 @@ import (
 
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/permission"
-
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/facades/client/keymanager/register.go
+++ b/apiserver/facades/client/keymanager/register.go
@@ -7,12 +7,13 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
-	"github.com/juju/names/v4"
 )
 
 // Register is called to expose a package of facades onto a given registry.

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -10,17 +10,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/state/binarystorage"
-
-	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/binarystorage"
 )
 
 // StateBackend wraps a state.

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -10,11 +10,10 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/cache"
-
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/client/modelgeneration"
 	"github.com/juju/juju/apiserver/facades/client/modelgeneration/mocks"
+	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/rpc/params"

--- a/apiserver/facades/client/modelgeneration/register.go
+++ b/apiserver/facades/client/modelgeneration/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/client/modelgeneration/shim.go
+++ b/apiserver/facades/client/modelgeneration/shim.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/cache"
-
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/facades/client/spaces/register.go
+++ b/apiserver/facades/client/spaces/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs/context"

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"

--- a/apiserver/facades/client/subnets/register.go
+++ b/apiserver/facades/client/subnets/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs/context"
 )

--- a/apiserver/facades/controller/actionpruner/register.go
+++ b/apiserver/facades/controller/actionpruner/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 )

--- a/apiserver/facades/controller/agenttools/register.go
+++ b/apiserver/facades/controller/agenttools/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state/stateenvirons"

--- a/apiserver/facades/controller/caasmodeloperator/register.go
+++ b/apiserver/facades/controller/caasmodeloperator/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/controller/caasoperatorupgrader/register.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/state/stateenvirons"

--- a/apiserver/facades/controller/charmdownloader/register.go
+++ b/apiserver/facades/controller/charmdownloader/register.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	"github.com/juju/juju/state/storage"

--- a/apiserver/facades/controller/externalcontrollerupdater/mock_test.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/mock_test.go
@@ -4,9 +4,9 @@
 package externalcontrollerupdater_test
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/tomb.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 )

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/firewall"

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -11,14 +11,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/apiserver/common/networkingcommon"
-
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facades/controller/instancepoller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"

--- a/apiserver/facades/controller/instancepoller/register.go
+++ b/apiserver/facades/controller/instancepoller/register.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/network"
-
 	"github.com/juju/description/v4"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -26,7 +23,9 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/migrationmaster"
 	"github.com/juju/juju/apiserver/facades/controller/migrationmaster/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/controller"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/presence"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/rpc/params"

--- a/apiserver/facades/controller/singular/register.go
+++ b/apiserver/facades/controller/singular/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 

--- a/apiserver/observer/observer.go
+++ b/apiserver/observer/observer.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/juju/juju/rpc"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/rpc"
 )
 
 // Observer defines a type which will observe API server events as

--- a/apiserver/stateauthenticator/export_test.go
+++ b/apiserver/stateauthenticator/export_test.go
@@ -5,7 +5,6 @@ package stateauthenticator
 
 import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
-
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/authentication"

--- a/caas/kubernetes/clientconfig/plugins_test.go
+++ b/caas/kubernetes/clientconfig/plugins_test.go
@@ -16,9 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/juju/juju/testing"
-
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/testing"
 )
 
 type k8sRawClientSuite struct {

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -13,12 +13,11 @@ import (
 	gc "gopkg.in/check.v1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-
-	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
 )

--- a/cloudconfig/cloudinit/utils.go
+++ b/cloudconfig/cloudinit/utils.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	jujupackaging "github.com/juju/juju/packaging"
 	"github.com/juju/packaging/v2"
 	"github.com/juju/packaging/v2/config"
 	"github.com/juju/utils/v3"
+
+	jujupackaging "github.com/juju/juju/packaging"
 )
 
 // addPackageSourceCmds is a helper function that returns the corresponding

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	stdtesting "testing"
 
-	"github.com/juju/juju/cloudconfig/cloudinit"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"

--- a/cmd/containeragent/main_nix.go
+++ b/cmd/containeragent/main_nix.go
@@ -29,11 +29,10 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/utils/proxy"
-	"github.com/juju/juju/worker/logsender"
-
 	// Import the secret providers.
 	_ "github.com/juju/juju/secrets/provider/all"
+	"github.com/juju/juju/utils/proxy"
+	"github.com/juju/juju/worker/logsender"
 )
 
 var logger = loggo.GetLogger("juju.cmd.containeragent")

--- a/cmd/juju/application/binding_test.go
+++ b/cmd/juju/application/binding_test.go
@@ -6,10 +6,10 @@ package application
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/testing"
-
-	"github.com/juju/juju/core/network"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
 )
 
 type ParseBindSuite struct {

--- a/cmd/juju/application/deployer/bundle_test.go
+++ b/cmd/juju/application/deployer/bundle_test.go
@@ -5,9 +5,10 @@ package deployer
 
 import (
 	"github.com/juju/charm/v10"
-	"github.com/juju/juju/core/constraints"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/constraints"
 )
 
 type bundleSuite struct {

--- a/cmd/juju/application/scaleapplication_test.go
+++ b/cmd/juju/application/scaleapplication_test.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/client/application"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/application/suspendrelation.go
+++ b/cmd/juju/application/suspendrelation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/api/client/application"

--- a/cmd/juju/block/export_test.go
+++ b/cmd/juju/block/export_test.go
@@ -5,9 +5,9 @@ package block
 
 import (
 	"github.com/juju/cmd/v3"
-	"github.com/juju/juju/jujuclient"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
+	"github.com/juju/juju/jujuclient"
 )
 
 type fakeCredentialStore struct {

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -24,10 +24,9 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/rpc/params"
-
 	// To allow a maas cloud type to be parsed in the test data.
 	_ "github.com/juju/juju/provider/maas"
+	"github.com/juju/juju/rpc/params"
 )
 
 type updateCAASSuite struct {

--- a/cmd/juju/charmhub/unicode.go
+++ b/cmd/juju/charmhub/unicode.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juju/juju/cmd/output"
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/juju/juju/cmd/output"
 )
 
 // OSEnviron represents an interface around the os environment.

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -64,8 +64,8 @@ var listCloudsDoc = "" +
 	"Further reading:\n " +
 	"\n" +
 	"    Documentation:   https://juju.is/docs/olm/manage-clouds\n" +
-	"    microk8s:        https://microk8s.io/\n" +
-	"    LXD hypervisor:  https://linuxcontainers.org/lxd/\n" +
+	"    microk8s:        https://microk8s.io/docs\n" +
+	"    LXD hypervisor:  https://documentation.ubuntu.com/lxd\n" +
 	listCloudsDocExamples
 
 var listCloudsDocExamples = `

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -28,6 +28,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+	k8scmd "k8s.io/client-go/tools/clientcmd"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/cmdtest"
@@ -61,8 +63,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
-	gc "gopkg.in/check.v1"
-	k8scmd "k8s.io/client-go/tools/clientcmd"
 )
 
 type BootstrapSuite struct {

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	"github.com/juju/loggo/loggocolor"
 	"github.com/juju/names/v4"
@@ -26,6 +25,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
 )
 
 // defaultLineCount is the default number of lines to

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
@@ -192,11 +193,21 @@ func (m jujuMain) Run(args []string) int {
 	// There's special processing to call the inbuilt version command if the
 	// --version flag is set. But we want to invoke the juju version command.
 	cmdArgs := make([]string, len(args)-1)
+	flagIdx := -1
+	cmdIdx := -1
 	for i, arg := range args[1:] {
 		if arg == "--version" {
-			arg = "version"
+			flagIdx = i
+		}
+		if cmdIdx == -1 && !strings.HasPrefix(arg, "--") && arg != "help" && arg != "version" {
+			cmdIdx = i
 		}
 		cmdArgs[i] = arg
+	}
+	// If there is a command before the --version flag, don't change the flag
+	// to the version command.
+	if flagIdx != -1 && (cmdIdx > flagIdx || cmdIdx == -1) {
+		cmdArgs[flagIdx] = "version"
 	}
 	jcmd := NewJujuCommand(ctx, jujuMsg)
 	return cmd.Main(jcmd, ctx, cmdArgs)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -63,6 +63,10 @@ func configHelpText() string {
 	return helpText(application.NewConfigCommand(), "juju config")
 }
 
+func versionHelpText() string {
+	return helpText(newVersionCommand(), "juju version")
+}
+
 func syncToolsHelpText() string {
 	return helpText(newSyncAgentBinaryCommand(), "juju sync-agent-binary")
 }
@@ -159,6 +163,26 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		args:    []string{"--version"},
 		code:    0,
 		out:     testing.CurrentVersion().String() + "\n",
+	}, {
+		summary: "--version option after command is not changed to version command",
+		args:    []string{"bootstrap", "--version"},
+		code:    0,
+		out:     "ERROR option provided but not defined: --version\n",
+	}, {
+		summary: "check command is identified as an unrecognised option after --version option",
+		args:    []string{"--version", "bootstrap"},
+		code:    0,
+		out:     "ERROR unrecognized args: [\"bootstrap\"]\n",
+	}, {
+		summary: "juju help --version shows the same help as 'help version'",
+		args:    []string{"help", "--version"},
+		code:    0,
+		out:     versionHelpText(),
+	}, {
+		summary: "juju --version --help shows the same help as 'help version'",
+		args:    []string{"--version", "--help"},
+		code:    0,
+		out:     versionHelpText(),
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		out := badrun(c, t.code, t.args...)

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -16,9 +16,8 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/modelcmd"
-
 	"github.com/juju/juju/cmd/juju/commands/mocks"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/sync"
 	toolstesting "github.com/juju/juju/environs/tools/testing"

--- a/cmd/juju/commands/version_test.go
+++ b/cmd/juju/commands/version_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd/v3/cmdtesting"
-	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	coreos "github.com/juju/juju/core/os"
 	jujuversion "github.com/juju/juju/version"
 )
 

--- a/cmd/juju/dashboard/export_test.go
+++ b/cmd/juju/dashboard/export_test.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/juju/cmd/v3"
 
-	"github.com/juju/juju/jujuclient"
-
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
 var (

--- a/cmd/juju/firewall/setrule_test.go
+++ b/cmd/juju/firewall/setrule_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/firewall"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/testing"
 )
 
 type SetRuleSuite struct {

--- a/cmd/juju/model/grantrevokecloud.go
+++ b/cmd/juju/model/grantrevokecloud.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/client/cloud"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/api/client/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"

--- a/cmd/juju/model/listcommits_test.go
+++ b/cmd/juju/model/listcommits_test.go
@@ -7,12 +7,11 @@ import (
 	"errors"
 	"time"
 
-	"go.uber.org/mock/gomock"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"

--- a/cmd/juju/model/showcommit_test.go
+++ b/cmd/juju/model/showcommit_test.go
@@ -7,12 +7,11 @@ import (
 	"errors"
 	"time"
 
-	"go.uber.org/mock/gomock"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/juju/model/mocks"

--- a/cmd/juju/space/move_test.go
+++ b/cmd/juju/space/move_test.go
@@ -4,11 +4,11 @@
 package space_test
 
 import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/juju/space"
-	jc "github.com/juju/testing/checkers"
 )
 
 type MoveSuite struct {

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/juju/ansiterm"
-
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/juju/cmd/output"
-
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
@@ -25,6 +23,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -9,9 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/model"
-
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/core/model"
 	_ "github.com/juju/juju/provider/dummy"
 )
 

--- a/cmd/juju/waitfor/application_test.go
+++ b/cmd/juju/waitfor/application_test.go
@@ -70,6 +70,6 @@ func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ApplicationInfo: &params.ApplicationInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ApplicationInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on ApplicationInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -1,0 +1,321 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package waitfor
+
+import (
+	"bufio"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/juju/waitfor/query"
+)
+
+func HelpDisplay(err error, input string, idents []string) error {
+	switch {
+	case query.IsSyntaxError(err):
+		return syntaxErrDisplay(err, input)
+	case query.IsInvalidIdentifierErr(err):
+		return invalidIdentifierDisplay(err, input, idents)
+	case query.IsRuntimeError(err):
+		return runtimeErrDisplay(err, input)
+	case query.IsRuntimeSyntaxError(err):
+		return runtimeSyntaxErrDisplay(err, input)
+	default:
+		fmt.Println()
+		return err
+	}
+}
+
+func syntaxErrDisplay(err error, input string) error {
+	cause := errors.Cause(err)
+	syntaxErr := cause.(*query.SyntaxError)
+
+	var builder strings.Builder
+	builder.WriteString("Cannot parse query:")
+	builder.WriteString(" ")
+	builder.WriteString(helpReason(syntaxErr.Expectations))
+
+	builder.WriteString(".")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	builder.WriteString(helpLineError(input, syntaxErr.Pos))
+
+	builder.WriteString(helpMessage(input, syntaxErr.Pos, syntaxErr.Expectations))
+	builder.WriteString(".")
+
+	return fmt.Errorf(builder.String())
+}
+
+func helpReason(exps []query.TokenType) string {
+	if len(exps) == 0 {
+		return "unexpected character"
+	}
+	switch exps[0] {
+	case query.STRING:
+		return "string is not correctly terminated"
+	case query.CONDAND:
+		return "invalid AND (&&) operator"
+	case query.CONDOR:
+		return "invalid OR (||) operator"
+	default:
+		return fmt.Sprintf("expected %s", exps[0].String())
+	}
+}
+
+func helpMessage(input string, pos query.Position, exps []query.TokenType) string {
+	if len(exps) == 0 {
+		return fmt.Sprintf("wait-for doesn't support %q. Maybe try removing the character and try again", input[pos.Column-1])
+	}
+	switch exps[0] {
+	case query.STRING:
+		return "Try adding a closing quote to the string"
+	case query.CONDAND:
+		return "Ensure that each side of the && operator can be evaluated to a boolean"
+	case query.CONDOR:
+		return "Ensure that each side of the || operator can be evaluated to a boolean"
+	default:
+		return "The type doesn't match the expected syntax. Maybe try removing the character and try again"
+	}
+}
+
+func helpLineError(input string, pos query.Position) string {
+	var builder strings.Builder
+	ledger := fmt.Sprintf("%d | ", pos.Line)
+	builder.WriteString(ledger)
+
+	builder.WriteString(getLine(input, pos.Line))
+	builder.WriteString("\n")
+
+	leading := len(ledger) + (pos.Column - 1)
+	builder.WriteString(strings.Repeat(" ", leading))
+
+	offset := 1
+	if pos.Offset > 0 {
+		offset = pos.Offset
+	}
+	if leading+offset > len(input) {
+		offset = leading - len(input)
+	}
+	builder.WriteString(strings.Repeat("^", offset))
+	builder.WriteString("\n")
+
+	return builder.String()
+}
+
+func helpLineErrors(input string) string {
+	var builder strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for i := 0; scanner.Scan(); i++ {
+		builder.WriteString(fmt.Sprintf("%d | ", i+1))
+		builder.WriteString(scanner.Text())
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+func getLine(input string, line int) string {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for i := 0; scanner.Scan(); i++ {
+		if i == line-1 {
+			return scanner.Text()
+		}
+	}
+	return ""
+}
+
+func invalidIdentifierDisplay(err error, input string, defaultIdents []string) error {
+	cause := errors.Cause(err)
+	identErr := cause.(*query.InvalidIdentifierError)
+
+	var builder strings.Builder
+	builder.WriteString("Cannot execute query: invalid identifier.")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	builder.WriteString(helpLineErrors(input))
+
+	builder.WriteString("No possible matches for")
+	builder.WriteString(" ")
+	builder.WriteString(err.Error())
+	builder.WriteString("\n")
+
+	idents := defaultIdents
+	if identErr.Scope() != nil {
+		idents = identErr.Scope().GetIdents()
+	}
+
+	first, other, ok := orderPotentialMatches(identErr.Name(), idents)
+	if !ok {
+		return fmt.Errorf(builder.String())
+	}
+
+	if first != "" {
+		builder.WriteString("Did you mean:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("    %s", first))
+		builder.WriteString("\n")
+	}
+
+	if len(other) > 0 {
+		builder.WriteString("\n")
+		builder.WriteString("Other possible matches:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString("    - ")
+		builder.WriteString(strings.Join(other, "\n    - "))
+	}
+
+	return fmt.Errorf(builder.String())
+}
+
+func orderPotentialMatches(name string, possible []string) (string, []string, bool) {
+	// Remove any duplicates.
+	possibleSet := set.NewStrings(possible...)
+	if possibleSet.Size() == 0 {
+		return "", nil, false
+	}
+
+	type Indexed = struct {
+		Name  string
+		Value int
+	}
+
+	possible = possibleSet.SortedValues()
+	matches := make([]Indexed, 0, len(possible))
+	for _, ident := range possible {
+		matches = append(matches, Indexed{
+			Name:  ident,
+			Value: levenshteinDistance(name, ident),
+		})
+	}
+	// Find the smallest levenshtein distance. If two values are the same,
+	// fallback to sorting on the name, which should give predictable results.
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Value < matches[j].Value {
+			return true
+		}
+		if matches[i].Value > matches[j].Value {
+			return false
+		}
+		return matches[i].Name < matches[j].Name
+	})
+
+	if len(matches) == 0 {
+		return "", nil, false
+	}
+
+	matchedName := matches[0].Name
+	matchedValue := matches[0].Value
+	if matchedName != "" && matchedValue <= len(matchedName)+1 {
+		others := set.NewStrings(possible...)
+		others.Remove(matchedName)
+		return matchedName, others.SortedValues(), true
+	}
+
+	return "", possible, false
+}
+
+func runtimeErrDisplay(err error, input string) error {
+	cause := errors.Cause(err)
+	runErr := cause.(*query.RuntimeError)
+
+	var builder strings.Builder
+	builder.WriteString("Cannot execute query: runtime error.")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	builder.WriteString(helpLineErrors(input))
+
+	builder.WriteString("wait-for requires the ")
+	builder.WriteString(runErr.Error())
+	builder.WriteString("\n")
+	builder.WriteString("Maybe try removing the character and try again.")
+
+	return fmt.Errorf(builder.String())
+}
+
+func runtimeSyntaxErrDisplay(err error, input string) error {
+	cause := errors.Cause(err)
+	runErr := cause.(*query.RuntimeSyntaxError)
+
+	var builder strings.Builder
+	builder.WriteString("Cannot execute query: runtime syntax error.")
+	builder.WriteString("\n")
+	builder.WriteString("\n")
+
+	builder.WriteString(helpLineErrors(input))
+
+	builder.WriteString("wait-for has ")
+	builder.WriteString(runErr.Error())
+	builder.WriteString(".")
+	builder.WriteString("\n")
+
+	first, other, ok := orderPotentialMatches(runErr.Name, runErr.Options)
+	if !ok {
+		return fmt.Errorf(builder.String())
+	}
+
+	if first != "" {
+		builder.WriteString("Did you mean:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString(fmt.Sprintf("    %s", first))
+		builder.WriteString("\n")
+	}
+
+	if len(other) > 0 {
+		builder.WriteString("\n")
+		builder.WriteString("Other possible matches:")
+		builder.WriteString("\n")
+		builder.WriteString("\n")
+		builder.WriteString("    - ")
+		builder.WriteString(strings.Join(other, "\n    - "))
+	}
+
+	return fmt.Errorf(builder.String())
+}
+
+// levenshteinDistance
+// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
+// (no min, compute lengths once, 2 rows array)
+// fastest profiled
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+	d := make([]int, la+1)
+	var lastdiag, olddiag, temp int
+
+	for i := 1; i <= la; i++ {
+		d[i] = i
+	}
+	for i := 1; i <= lb; i++ {
+		d[0] = i
+		lastdiag = i - 1
+		for j := 1; j <= la; j++ {
+			olddiag = d[j]
+			min := d[j] + 1
+			if (d[j-1] + 1) < min {
+				min = d[j-1] + 1
+			}
+			if a[j-1] == b[i-1] {
+				temp = 0
+			} else {
+				temp = 1
+			}
+			if (lastdiag + temp) < min {
+				min = lastdiag + temp
+			}
+			d[j] = min
+			lastdiag = olddiag
+		}
+	}
+	return d[la]
+}

--- a/cmd/juju/waitfor/machine_test.go
+++ b/cmd/juju/waitfor/machine_test.go
@@ -72,6 +72,6 @@ func (s *machineScopeSuite) TestGetIdentValueError(c *gc.C) {
 		MachineInfo: &params.MachineInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on MachineInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on MachineInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -4,13 +4,19 @@
 package waitfor
 
 import (
+	"context"
+	"fmt"
 	"io"
+	"os"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	"github.com/juju/retry"
 	"gopkg.in/yaml.v2"
 
 	jujucmd "github.com/juju/juju/cmd"
@@ -28,11 +34,14 @@ func newModelCommand() cmd.Command {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return watchAllAPIShim{
+		return modelAllWatchShim{
 			Client: client,
 		}, nil
 	}
-	return modelcmd.Wrap(cmd)
+	return modelcmd.Wrap(cmd,
+		modelcmd.WrapSkipModelInit,
+		modelcmd.WrapSkipModelFlags,
+	)
 }
 
 const modelCommandDoc = `
@@ -57,9 +66,6 @@ type modelCommand struct {
 	summary bool
 	found   bool
 
-	// TODO (stickupkid): Generalize this to become a local cache, similar to
-	// the model cache but not with the hierarchy or complexity (for example,
-	// we don't need the mark+sweep gc).
 	model        *params.ModelUpdate
 	applications map[string]*params.ApplicationInfo
 	machines     map[string]*params.MachineInfo
@@ -92,30 +98,34 @@ func (c *modelCommand) Init(args []string) (err error) {
 	if len(args) != 1 {
 		return errors.New("only one model name can be supplied as an argument to this command")
 	}
-	if ok := names.IsValidModelName(args[0]); !ok {
-		return errors.Errorf("%q is not valid model name", args[0])
+	controller, model := modelcmd.SplitModelName(args[0])
+	if controller != "" && !names.IsValidControllerName(controller) {
+		return errors.Errorf("%q is not valid controller name", controller)
 	}
-	c.name = args[0]
+	if !names.IsValidModelName(model) {
+		return errors.Errorf("%q is not valid model name", model)
+	}
 
-	return nil
+	c.name = model
+	return c.locateModel(args[0])
 }
 
-func (c *modelCommand) Run(ctx *cmd.Context) error {
+func (c *modelCommand) Run(ctx *cmd.Context) (err error) {
 	scopedContext := MakeScopeContext()
 
 	defer func() {
-		if c.model == nil || !c.summary {
+		if err != nil || c.model == nil || !c.summary {
 			return
 		}
 
 		switch c.model.Life {
 		case life.Dead:
-			ctx.Infof("Model %q has been removed", c.name)
+			ctx.Infof("model %q has been removed", c.name)
 		case life.Dying:
-			ctx.Infof("Model %q is being removed", c.name)
+			ctx.Infof("model %q is being removed", c.name)
 		default:
-			ctx.Infof("Model %q is running", c.name)
-			outputModelSummary(ctx.Stdout, scopedContext, c)
+			ctx.Infof("model %q is running", c.name)
+			outputModelSummary(ctx.Stdout, scopedContext, c.model, c.applications, c.units, c.machines)
 		}
 	}()
 
@@ -129,8 +139,39 @@ func (c *modelCommand) Run(ctx *cmd.Context) error {
 			c.primeCache()
 		}
 	})
-	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	err = strategy.Run(ctx, c.name, c.query, c.waitFor(c.query, scopedContext, ctx), func(err error, attempt int) {
+		if errors.Is(err, errors.NotFound) {
+			ctx.Infof("model %q not found, waiting...", c.name)
+		}
+	})
 	return errors.Trace(err)
+}
+
+func (c *modelCommand) locateModel(name string) error {
+	timeoutContext, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	if err := retry.Call(retry.CallArgs{
+		Clock:       clock.WallClock,
+		Delay:       1 * time.Second,
+		Attempts:    200,
+		MaxDelay:    10 * time.Second,
+		MaxDuration: c.timeout,
+		BackoffFunc: retry.DoubleDelay,
+		Stop:        timeoutContext.Done(),
+		IsFatalError: func(err error) bool {
+			return !errors.Is(err, errors.NotFound)
+		},
+		NotifyFunc: func(err error, attempt int) {
+			fmt.Fprintf(os.Stderr, "model %q not found, waiting...\n", c.name)
+		},
+		Func: func() error {
+			return c.SetModelIdentifier(name, true)
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to locate model %q%w", c.name, errors.Hide(err))
+	}
+	return nil
 }
 
 func (c *modelCommand) primeCache() {
@@ -139,10 +180,19 @@ func (c *modelCommand) primeCache() {
 	c.units = make(map[string]*params.UnitInfo)
 }
 
-func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+func (c *modelCommand) waitFor(input string, ctx ScopeContext, logger Logger) func(string, []params.Delta, query.Query) (bool, error) {
+	run := func(q query.Query) (bool, error) {
+		scope := MakeModelScope(ctx, c.model, c.applications, c.units, c.machines)
+		if done, err := runQuery(input, q, scope); err != nil {
+			return false, errors.Trace(err)
+		} else if done {
+			return true, nil
+		}
+		return c.model.Life == life.Dead, nil
+	}
 	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
 		for _, delta := range deltas {
-			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+			logger.Verbosef("delta %T: %v", delta.Entity, delta.Entity)
 
 			switch entityInfo := delta.Entity.(type) {
 			case *params.ApplicationInfo:
@@ -180,15 +230,12 @@ func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, qu
 		}
 
 		if c.model != nil {
-			scope := MakeModelScope(ctx, c)
-			if done, err := runQuery(q, scope); err != nil {
+			if done, err := run(q); err != nil {
 				return false, errors.Trace(err)
 			} else if done {
 				return true, nil
 			}
-		}
-
-		if !c.found {
+		} else {
 			logger.Infof("model %q not found, waiting...", name)
 			return false, nil
 		}
@@ -200,23 +247,33 @@ func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, qu
 
 // ModelScope allows the query to introspect a model entity.
 type ModelScope struct {
-	ctx       ScopeContext
-	ModelInfo *params.ModelUpdate
-	Model     *modelCommand
+	ctx              ScopeContext
+	ModelInfo        *params.ModelUpdate
+	ApplicationInfos map[string]*params.ApplicationInfo
+	UnitInfos        map[string]*params.UnitInfo
+	MachineInfos     map[string]*params.MachineInfo
 }
 
 // MakeModelScope creates a ModelScope from a ModelUpdate
-func MakeModelScope(ctx ScopeContext, model *modelCommand) ModelScope {
+func MakeModelScope(ctx ScopeContext,
+	modelInfo *params.ModelUpdate,
+	applicationInfos map[string]*params.ApplicationInfo,
+	unitInfos map[string]*params.UnitInfo,
+	machineInfos map[string]*params.MachineInfo,
+) ModelScope {
 	return ModelScope{
-		ctx:       ctx,
-		ModelInfo: model.model,
-		Model:     model,
+		ctx:              ctx,
+		ModelInfo:        modelInfo,
+		ApplicationInfos: applicationInfos,
+		UnitInfos:        unitInfos,
+		MachineInfos:     machineInfos,
 	}
 }
 
 // GetIdents returns the identifiers with in a given scope.
 func (m ModelScope) GetIdents() []string {
-	return getIdents(m.ModelInfo)
+	idents := set.NewStrings(getIdents(m.ModelInfo)...)
+	return set.NewStrings("applications", "machines", "units").Union(idents).SortedValues()
 }
 
 // GetIdentValue returns the value of the identifier in a given scope.
@@ -239,10 +296,17 @@ func (m ModelScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewMapStringInterface(m.ModelInfo.Config), nil
 	case "applications":
 		scopes := make(map[string]query.Scope)
-		for k, app := range m.Model.applications {
+		for k, app := range m.ApplicationInfos {
 			units := make(map[string]*params.UnitInfo)
-			for n, unit := range m.Model.units {
+			machines := make(map[string]*params.MachineInfo)
+			for n, unit := range m.UnitInfos {
 				if unit.Application == app.Name {
+					for m, machine := range m.MachineInfos {
+						if machine.Id == unit.MachineId {
+							machines[m] = machine
+						}
+					}
+
 					units[n] = unit
 				}
 			}
@@ -253,23 +317,30 @@ func (m ModelScope) GetIdentValue(name string) (query.Box, error) {
 			appInfo := app
 			appInfo.Status.Current = newStatus
 
-			scopes[k] = MakeApplicationScope(m.ctx.Child(name, app.Name), appInfo)
+			scopes[k] = MakeApplicationScope(m.ctx.Child(name, app.Name), appInfo, units, machines)
 		}
 		return NewScopedBox(scopes), nil
 	case "machines":
 		scopes := make(map[string]query.Scope)
-		for k, machine := range m.Model.machines {
+		for k, machine := range m.MachineInfos {
 			scopes[k] = MakeMachineScope(m.ctx.Child(name, machine.Id), machine)
 		}
 		return NewScopedBox(scopes), nil
 	case "units":
 		scopes := make(map[string]query.Scope)
-		for k, unit := range m.Model.units {
-			scopes[k] = MakeUnitScope(m.ctx.Child(name, unit.Name), unit)
+		for k, unit := range m.UnitInfos {
+			machines := make(map[string]*params.MachineInfo)
+			for n, machine := range m.MachineInfos {
+				if machine.Id == unit.MachineId {
+					machines[n] = machine
+				}
+			}
+
+			scopes[k] = MakeUnitScope(m.ctx.Child(name, unit.Name), unit, machines)
 		}
 		return NewScopedBox(scopes), nil
 	}
-	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on ModelInfo", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name, m), "%q on ModelInfo", name)
 }
 
 // ScopedBox defines a scoped box of scopes.
@@ -301,12 +372,12 @@ func (o *ScopedBox) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *ScopedBox) Value() interface{} {
+func (o *ScopedBox) Value() any {
 	return o
 }
 
 // ForEach iterates over each value in the box.
-func (o *ScopedBox) ForEach(fn func(interface{}) bool) {
+func (o *ScopedBox) ForEach(fn func(any) bool) {
 	for _, v := range o.scopes {
 		if !fn(v) {
 			return
@@ -314,27 +385,33 @@ func (o *ScopedBox) ForEach(fn func(interface{}) bool) {
 	}
 }
 
-func outputModelSummary(writer io.Writer, scopedContext ScopeContext, c *modelCommand) {
+func outputModelSummary(writer io.Writer,
+	scopedContext ScopeContext,
+	modelInfo *params.ModelUpdate,
+	applications map[string]*params.ApplicationInfo,
+	units map[string]*params.UnitInfo,
+	machines map[string]*params.MachineInfo,
+) {
 	result := struct {
-		Elements     map[string]interface{}            `yaml:"properties"`
-		Applications map[string]map[string]interface{} `yaml:"applications,omitempty"`
-		Machines     map[string]map[string]interface{} `yaml:"machines,omitempty"`
-		Units        map[string]map[string]interface{} `yaml:"units,omitempty"`
+		Properties   map[string]any            `yaml:"properties"`
+		Applications map[string]map[string]any `yaml:"applications,omitempty"`
+		Units        map[string]map[string]any `yaml:"units,omitempty"`
+		Machines     map[string]map[string]any `yaml:"machines,omitempty"`
 	}{
-		Elements:     make(map[string]interface{}),
-		Applications: make(map[string]map[string]interface{}),
-		Machines:     make(map[string]map[string]interface{}),
-		Units:        make(map[string]map[string]interface{}),
+		Properties:   make(map[string]any),
+		Applications: make(map[string]map[string]any),
+		Units:        make(map[string]map[string]any),
+		Machines:     make(map[string]map[string]any),
 	}
 
 	idents := scopedContext.RecordedIdents()
 	for _, ident := range idents {
-		scope := MakeModelScope(scopedContext, c)
+		scope := MakeModelScope(scopedContext, modelInfo, applications, units, machines)
 		box, err := scope.GetIdentValue(ident)
 		if err != nil {
 			continue
 		}
-		result.Elements[ident] = box.Value()
+		result.Properties[ident] = box.Value()
 	}
 	for entity, scopes := range scopedContext.children {
 		for name, sctx := range scopes {
@@ -342,10 +419,10 @@ func outputModelSummary(writer io.Writer, scopedContext ScopeContext, c *modelCo
 
 			switch entity {
 			case "applications":
-				appInfo := c.applications[name]
-				scope := MakeApplicationScope(scopedContext, appInfo)
+				appInfo := applications[name]
+				scope := MakeApplicationScope(scopedContext, appInfo, units, machines)
 
-				result.Applications[name] = make(map[string]interface{})
+				result.Applications[name] = make(map[string]any)
 
 				for _, ident := range idents {
 					box, err := scope.GetIdentValue(ident)
@@ -354,11 +431,25 @@ func outputModelSummary(writer io.Writer, scopedContext ScopeContext, c *modelCo
 					}
 					result.Applications[name][ident] = box.Value()
 				}
+
+			case "units":
+				unitInfo := units[name]
+				scope := MakeUnitScope(scopedContext, unitInfo, machines)
+
+				result.Units[name] = make(map[string]any)
+				for _, ident := range idents {
+					box, err := scope.GetIdentValue(ident)
+					if err != nil {
+						continue
+					}
+					result.Units[name][ident] = box.Value()
+				}
+
 			case "machines":
-				machineInfo := c.machines[name]
+				machineInfo := machines[name]
 				scope := MakeMachineScope(scopedContext, machineInfo)
 
-				result.Machines[name] = make(map[string]interface{})
+				result.Machines[name] = make(map[string]any)
 
 				for _, ident := range idents {
 					box, err := scope.GetIdentValue(ident)
@@ -366,18 +457,6 @@ func outputModelSummary(writer io.Writer, scopedContext ScopeContext, c *modelCo
 						continue
 					}
 					result.Machines[name][ident] = box.Value()
-				}
-			case "units":
-				unitInfo := c.units[name]
-				scope := MakeUnitScope(scopedContext, unitInfo)
-
-				result.Units[name] = make(map[string]interface{})
-				for _, ident := range idents {
-					box, err := scope.GetIdentValue(ident)
-					if err != nil {
-						continue
-					}
-					result.Units[name][ident] = box.Value()
 				}
 			}
 		}

--- a/cmd/juju/waitfor/model_test.go
+++ b/cmd/juju/waitfor/model_test.go
@@ -62,6 +62,6 @@ func (s *modelScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ModelInfo: &params.ModelUpdate{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ModelInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `.*"bad" on ModelInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/query/box.go
+++ b/cmd/juju/waitfor/query/box.go
@@ -26,7 +26,45 @@ type Box interface {
 	IsZero() bool
 
 	// Value defines the shadow type value of the Box.
-	Value() interface{}
+	Value() any
+}
+
+// BoxScope defines an ordered integer.
+type BoxScope struct {
+	value Scope
+}
+
+// NewScope creates a new Box value
+func NewScope(value Scope) *BoxScope {
+	return &BoxScope{value: value}
+}
+
+// Less checks if a BoxScope is less than another BoxScope.
+func (o *BoxScope) Less(other Ord) bool {
+	return false
+}
+
+// Equal checks if an BoxScope is equal to another BoxScope.
+func (o *BoxScope) Equal(other Ord) bool {
+	if i, ok := other.(*BoxScope); ok {
+		return o.value == i.value
+	}
+	return false
+}
+
+// IsZero returns if the underlying value is zero.
+func (o *BoxScope) IsZero() bool {
+	return o.value == nil
+}
+
+// Value defines the shadow type value of the Box.
+func (o *BoxScope) Value() any {
+	return o.value
+}
+
+// ForEach iterates over each value in the box.
+func (o *BoxScope) ForEach(fn func(any) bool) {
+	fn(o.value)
 }
 
 // BoxInteger defines an ordered integer.
@@ -61,12 +99,12 @@ func (o *BoxInteger) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxInteger) Value() interface{} {
+func (o *BoxInteger) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxInteger) ForEach(fn func(interface{}) bool) {
+func (o *BoxInteger) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -102,12 +140,12 @@ func (o *BoxFloat) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxFloat) Value() interface{} {
+func (o *BoxFloat) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxFloat) ForEach(fn func(interface{}) bool) {
+func (o *BoxFloat) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -143,12 +181,12 @@ func (o *BoxString) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxString) Value() interface{} {
+func (o *BoxString) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxString) ForEach(fn func(interface{}) bool) {
+func (o *BoxString) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
@@ -177,26 +215,26 @@ func (o *BoxBool) Equal(other Ord) bool {
 
 // IsZero returns if the underlying value is zero.
 func (o *BoxBool) IsZero() bool {
-	return o.value == false
+	return !o.value
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxBool) Value() interface{} {
+func (o *BoxBool) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxBool) ForEach(fn func(interface{}) bool) {
+func (o *BoxBool) ForEach(fn func(any) bool) {
 	fn(o.value)
 }
 
-// BoxMapStringInterface defines an ordered map[string]interface{}.
+// BoxMapStringInterface defines an ordered map[string]any.
 type BoxMapStringInterface struct {
-	value map[string]interface{}
+	value map[string]any
 }
 
 // NewMapStringInterface creates a new Box value
-func NewMapStringInterface(value map[string]interface{}) *BoxMapStringInterface {
+func NewMapStringInterface(value map[string]any) *BoxMapStringInterface {
 	return &BoxMapStringInterface{value: value}
 }
 
@@ -219,12 +257,12 @@ func (o *BoxMapStringInterface) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxMapStringInterface) Value() interface{} {
+func (o *BoxMapStringInterface) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxMapStringInterface) ForEach(fn func(interface{}) bool) {
+func (o *BoxMapStringInterface) ForEach(fn func(any) bool) {
 	names := set.NewStrings()
 	for k := range o.value {
 		names.Add(k)
@@ -236,13 +274,13 @@ func (o *BoxMapStringInterface) ForEach(fn func(interface{}) bool) {
 	}
 }
 
-// BoxMapInterfaceInterface defines an ordered map[interface{}]interface{}.
+// BoxMapInterfaceInterface defines an ordered map[any]any.
 type BoxMapInterfaceInterface struct {
-	value map[interface{}]interface{}
+	value map[any]any
 }
 
 // NewMapInterfaceInterface creates a new Box value
-func NewMapInterfaceInterface(value map[interface{}]interface{}) *BoxMapInterfaceInterface {
+func NewMapInterfaceInterface(value map[any]any) *BoxMapInterfaceInterface {
 	return &BoxMapInterfaceInterface{value: value}
 }
 
@@ -265,12 +303,12 @@ func (o *BoxMapInterfaceInterface) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxMapInterfaceInterface) Value() interface{} {
+func (o *BoxMapInterfaceInterface) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxMapInterfaceInterface) ForEach(fn func(interface{}) bool) {
+func (o *BoxMapInterfaceInterface) ForEach(fn func(any) bool) {
 	for _, v := range o.value {
 		if !fn(v) {
 			return
@@ -307,12 +345,12 @@ func (o *BoxSliceString) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxSliceString) Value() interface{} {
+func (o *BoxSliceString) Value() any {
 	return o.value
 }
 
 // ForEach iterates over each value in the box.
-func (o *BoxSliceString) ForEach(fn func(interface{}) bool) {
+func (o *BoxSliceString) ForEach(fn func(any) bool) {
 	for _, v := range o.value {
 		if !fn(v) {
 			return
@@ -350,7 +388,7 @@ func (o *BoxLambda) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxLambda) Value() interface{} {
+func (o *BoxLambda) Value() any {
 	return o
 }
 
@@ -364,7 +402,7 @@ func (o *BoxLambda) Call(scope Scope) ([]Box, error) {
 	return o.fn(scope)
 }
 
-func expectStringIndex(i interface{}) (*BoxString, error) {
+func expectStringIndex(i any) (*BoxString, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected string, but got %T", i)
@@ -378,7 +416,7 @@ func expectStringIndex(i interface{}) (*BoxString, error) {
 	return idx, nil
 }
 
-func expectIntegerIndex(i interface{}) (*BoxInteger, error) {
+func expectIntegerIndex(i any) (*BoxInteger, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected int, but got %T", i)
@@ -392,7 +430,7 @@ func expectIntegerIndex(i interface{}) (*BoxInteger, error) {
 	return idx, nil
 }
 
-func expectBoxIndex(i interface{}) (Box, error) {
+func expectBoxIndex(i any) (Box, error) {
 	box, ok := i.(Box)
 	if !ok {
 		return nil, RuntimeErrorf("expected box, but got %T", i)
@@ -412,9 +450,9 @@ func shadowType(box Box) string {
 	case *BoxString:
 		return "string"
 	case *BoxMapInterfaceInterface:
-		return "map[interface{}]interface{}"
+		return "map[any]any"
 	case *BoxMapStringInterface:
-		return "map[string]interface{}"
+		return "map[string]any"
 	case *BoxSliceString:
 		return "[]string"
 	}

--- a/cmd/juju/waitfor/query/lexer.go
+++ b/cmd/juju/waitfor/query/lexer.go
@@ -26,14 +26,12 @@ type Lexer struct {
 
 // NewLexer creates a new Lexer from a given input.
 func NewLexer(input string) *Lexer {
-	lex := &Lexer{
+	return &Lexer{
 		input:  []rune(input),
 		char:   ' ',
 		line:   1,
 		column: 1,
 	}
-
-	return lex
 }
 
 // ReadNext will attempt to read the next character and correctly setup the
@@ -181,9 +179,9 @@ func (l *Lexer) readRunesToken() Token {
 		tok.Literal = l.readIdentifier()
 		switch strings.ToLower(tok.Literal) {
 		case "true":
-			tok.Type = TRUE
+			tok.Type = BOOL
 		case "false":
-			tok.Type = FALSE
+			tok.Type = BOOL
 		case "_":
 			tok.Type = UNDERSCORE
 		default:
@@ -191,11 +189,11 @@ func (l *Lexer) readRunesToken() Token {
 		}
 		return tok
 	case isQuote(l.char):
-		if s, err := l.readString(l.char); err == nil {
-			tok.Type = STRING
-			tok.Literal = s
-			return tok
-		}
+		s, err := l.readString(l.char)
+		tok.Type = STRING
+		tok.Literal = s
+		tok.Terminated = err == nil
+		return tok
 	}
 	l.ReadNext()
 	return MakeToken(UNKNOWN, l.char)
@@ -271,5 +269,5 @@ func isDigit(char rune) bool {
 }
 
 func isQuote(char rune) bool {
-	return char == 34
+	return char == 34 || char == 39
 }

--- a/cmd/juju/waitfor/query/lexer_test.go
+++ b/cmd/juju/waitfor/query/lexer_test.go
@@ -164,7 +164,7 @@ func (p *lexerSuite) TestReadNextBool(c *gc.C) {
 			Type: -1,
 		}, {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    TRUE,
+			Type:    BOOL,
 			Literal: "true",
 		}},
 	}, {
@@ -173,7 +173,7 @@ func (p *lexerSuite) TestReadNextBool(c *gc.C) {
 			Type: -1,
 		}, {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    FALSE,
+			Type:    BOOL,
 			Literal: "false",
 		}},
 	}}
@@ -267,9 +267,10 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 		Expected: []Token{{
 			Type: -1,
 		}, {
-			Pos:     Position{Offset: 0, Line: 1, Column: 1},
-			Type:    STRING,
-			Literal: ``,
+			Pos:        Position{Offset: 0, Line: 1, Column: 1},
+			Type:       STRING,
+			Literal:    ``,
+			Terminated: true,
 		}},
 	}, {
 		Input: `"abc"`,
@@ -279,6 +280,8 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
 			Type:    STRING,
 			Literal: "abc",
+
+			Terminated: true,
 		}},
 	}, {
 		Input: `"abc with a space"`,
@@ -288,6 +291,8 @@ func (p *lexerSuite) TestReadNextString(c *gc.C) {
 			Pos:     Position{Offset: 0, Line: 1, Column: 1},
 			Type:    STRING,
 			Literal: "abc with a space",
+
+			Terminated: true,
 		}},
 	}}
 

--- a/cmd/juju/waitfor/query/parser_test.go
+++ b/cmd/juju/waitfor/query/parser_test.go
@@ -92,15 +92,17 @@ func (p *parserSuite) TestParserString(c *gc.C) {
 			&ExpressionStatement{
 				Expression: &String{
 					Token: Token{
-						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    STRING,
-						Literal: "abc",
+						Pos:        Position{Line: 1, Column: 1, Offset: 0},
+						Type:       STRING,
+						Literal:    "abc",
+						Terminated: true,
 					},
 				},
 				Token: Token{
-					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    STRING,
-					Literal: "abc",
+					Pos:        Position{Line: 1, Column: 1, Offset: 0},
+					Type:       STRING,
+					Literal:    "abc",
+					Terminated: true,
 				},
 			},
 		},
@@ -176,14 +178,14 @@ func (p *parserSuite) TestParserBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    TRUE,
+						Type:    BOOL,
 						Literal: "true",
 					},
 					Value: true,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -191,14 +193,14 @@ func (p *parserSuite) TestParserBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 6, Offset: 5},
-						Type:    FALSE,
+						Type:    BOOL,
 						Literal: "false",
 					},
 					Value: false,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 6, Offset: 5},
-					Type:    FALSE,
+					Type:    BOOL,
 					Literal: "false",
 				},
 			},
@@ -247,7 +249,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -256,7 +258,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -269,7 +271,7 @@ func (p *parserSuite) TestParserInfixLogicalAND(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -291,7 +293,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -300,7 +302,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -313,7 +315,7 @@ func (p *parserSuite) TestParserInfixLogicalOR(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},

--- a/cmd/juju/waitfor/query/query_test.go
+++ b/cmd/juju/waitfor/query/query_test.go
@@ -242,14 +242,14 @@ func (s *querySuite) TestRunBool(c *gc.C) {
 				Expression: &Bool{
 					Token: Token{
 						Pos:     Position{Line: 1, Column: 1, Offset: 0},
-						Type:    TRUE,
+						Type:    BOOL,
 						Literal: "true",
 					},
 					Value: true,
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -276,7 +276,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -285,7 +285,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -298,7 +298,7 @@ func (s *querySuite) TestRunInfixLogicalAND(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},
@@ -325,7 +325,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 					Left: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 1, Offset: 0},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "true",
 						},
 						Value: true,
@@ -334,7 +334,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 					Right: &Bool{
 						Token: Token{
 							Pos:     Position{Line: 1, Column: 9, Offset: 8},
-							Type:    TRUE,
+							Type:    BOOL,
 							Literal: "false",
 						},
 						Value: false,
@@ -347,7 +347,7 @@ func (s *querySuite) TestRunInfixLogicalOR(c *gc.C) {
 				},
 				Token: Token{
 					Pos:     Position{Line: 1, Column: 1, Offset: 0},
-					Type:    TRUE,
+					Type:    BOOL,
 					Literal: "true",
 				},
 			},

--- a/cmd/juju/waitfor/query/scope.go
+++ b/cmd/juju/waitfor/query/scope.go
@@ -6,6 +6,8 @@ package query
 import (
 	"fmt"
 	"reflect"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -15,28 +17,36 @@ import (
 // on a set of arguments.
 type GlobalFuncScope struct {
 	scope Scope
-	funcs map[string]interface{}
+	funcs map[string]any
 }
 
 // NewGlobalFuncScope creates a new scope for executing functions.
 func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 	return &GlobalFuncScope{
 		scope: scope,
-		funcs: map[string]interface{}{
-			"len": func(v interface{}) (int, error) {
+		funcs: map[string]any{
+			"len": func(v any) (int, error) {
 				val := reflect.ValueOf(v)
 				switch val.Kind() {
 				case reflect.Map, reflect.Slice, reflect.String:
 					return val.Len(), nil
 				default:
+					if box, ok := v.(Box); ok {
+						var num int
+						ForEach(box, func(value any) bool {
+							num++
+							return true
+						})
+						return num, nil
+					}
 					return -1, RuntimeErrorf("unexpected type %T passed to len", v)
 				}
 			},
-			"print": func(v interface{}) (interface{}, error) {
+			"print": func(v any) (any, error) {
 				fmt.Printf("%+v\n", v)
 				return v, nil
 			},
-			"forEach": func(values, expr interface{}) (interface{}, error) {
+			"forEach": func(values, expr any) (any, error) {
 				scopes, ok := values.(Box)
 				if !ok {
 					return nil, RuntimeErrorf("unexpected lambda values %T", values)
@@ -51,7 +61,7 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 					called bool
 					result = true
 				)
-				ForEach(scopes, func(value interface{}) bool {
+				ForEach(scopes, func(value any) bool {
 					called = true
 
 					nestedScope, ok := value.(Scope)
@@ -83,29 +93,69 @@ func NewGlobalFuncScope(scope Scope) *GlobalFuncScope {
 				}
 				return result, nil
 			},
+			"startsWith": func(v, prefix any) (bool, error) {
+				if _, ok := prefix.(string); !ok {
+					return false, RuntimeErrorf("requires string to be passed to startsWith, got %T", prefix)
+				}
+
+				val := reflect.ValueOf(v)
+				switch val.Kind() {
+				case reflect.String:
+					return strings.HasPrefix(val.String(), prefix.(string)), nil
+				default:
+					return false, RuntimeErrorf("unexpected type %T passed to startsWith", v)
+				}
+			},
+			"endsWith": func(v, suffix any) (bool, error) {
+				if _, ok := suffix.(string); !ok {
+					return false, RuntimeErrorf("requires string to be passed to endsWith, got %T", suffix)
+				}
+
+				val := reflect.ValueOf(v)
+				switch val.Kind() {
+				case reflect.String:
+					return strings.HasSuffix(val.String(), suffix.(string)), nil
+				default:
+					return false, RuntimeErrorf("unexpected type %T passed to endsWith", v)
+				}
+			},
+			"int": func(v any) (int, error) {
+				val := reflect.ValueOf(v)
+				switch val.Kind() {
+				case reflect.String:
+					return strconv.Atoi(val.String())
+				default:
+					return -1, RuntimeErrorf("unexpected type %T passed to int", v)
+				}
+			},
 		},
 	}
 }
 
 // Add a function to the global scope.
-func (s *GlobalFuncScope) Add(name string, fn interface{}) {
+func (s *GlobalFuncScope) Add(name string, fn any) {
 	s.funcs[name] = fn
 }
 
 // Call a function with a set of arguments.
-func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (interface{}, error) {
+func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (any, error) {
 	name := ident.Token.Literal
 	fn, ok := s.funcs[name]
 	if !ok {
-		return nil, RuntimeErrorf("no function %q", name)
+		names := make([]string, 0, len(s.funcs))
+		for name := range s.funcs {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return nil, ErrRuntimeSyntax(fmt.Sprintf("no function %q", name), name, names)
 	}
 
 	f := reflect.ValueOf(fn)
 	if len(params) != f.Type().NumIn() {
-		return nil, RuntimeErrorf("number of params not valid for function call, wanted: %d, received: %d", f.Type().NumIn(), len(params))
+		return nil, RuntimeErrorf("number of arguments for a function call to be %d, but got: %d", f.Type().NumIn(), len(params))
 	}
 	if f.Type().NumOut() != 2 {
-		return nil, RuntimeErrorf("number of results is not value for function call")
+		return nil, RuntimeErrorf("number of results for a given function call must be 2")
 	}
 
 	var args []reflect.Value
@@ -115,7 +165,7 @@ func (s *GlobalFuncScope) Call(ident *Identifier, params []Box) (interface{}, er
 
 	results := f.Call(args)
 	if len(results) != 2 {
-		return nil, RuntimeErrorf("number of results does not match expected function call results set")
+		return nil, RuntimeErrorf("number of results to match the number of results from the function call")
 	}
 	if err, ok := results[1].Interface().(error); ok && err != nil {
 		return nil, err
@@ -183,15 +233,15 @@ func (o *BoxNestedScope) IsZero() bool {
 }
 
 // Value defines the shadow type value of the Box.
-func (o *BoxNestedScope) Value() interface{} {
+func (o *BoxNestedScope) Value() any {
 	return o.value
 }
 
 // ForEach will call the function on every value within a Box.
 // If a Box isn't an iterable then we perform a no-op.
-func ForEach(box Box, fn func(value interface{}) bool) {
+func ForEach(box Box, fn func(value any) bool) {
 	type iterable interface {
-		ForEach(func(interface{}) bool)
+		ForEach(func(any) bool)
 	}
 	if e, ok := box.(iterable); ok {
 		e.ForEach(fn)

--- a/cmd/juju/waitfor/query/token.go
+++ b/cmd/juju/waitfor/query/token.go
@@ -39,8 +39,7 @@ const (
 	BITOR   // |
 	CONDAND // &&
 	CONDOR  // ||
-	TRUE    // TRUE
-	FALSE   // FALSE
+	BOOL    // BOOL
 
 	LAMBDA     // =>
 	UNDERSCORE // _
@@ -101,10 +100,8 @@ func (t TokenType) String() string {
 		return "||"
 	case STRING:
 		return `""`
-	case TRUE:
-		return "true"
-	case FALSE:
-		return "false"
+	case BOOL:
+		return "BOOL"
 	default:
 		return "<UNKNOWN>"
 	}
@@ -124,9 +121,10 @@ func (p Position) String() string {
 // Token defines a token found with in a query, along with the position and what
 // type it is.
 type Token struct {
-	Pos     Position
-	Type    TokenType
-	Literal string
+	Pos        Position
+	Type       TokenType
+	Literal    string
+	Terminated bool
 }
 
 // MakeToken creates a new token value.

--- a/cmd/juju/waitfor/unit_test.go
+++ b/cmd/juju/waitfor/unit_test.go
@@ -102,6 +102,6 @@ func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
 		UnitInfo: &params.UnitInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on UnitInfo: invalid identifier`)
+	c.Assert(err, gc.ErrorMatches, `"bad" on UnitInfo.*`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/juju/waitfor/waitfor.go
+++ b/cmd/juju/waitfor/waitfor.go
@@ -5,12 +5,15 @@ package waitfor
 
 import (
 	"github.com/juju/cmd/v3"
-	"github.com/juju/loggo"
 
 	_ "github.com/juju/juju/provider/all"
 )
 
-var logger = loggo.GetLogger("juju.plugins.waitfor")
+// Logger is the interface used by the wait-for command to log messages.
+type Logger interface {
+	Infof(string, ...any)
+	Verbosef(string, ...any)
+}
 
 var waitForDoc = `
 Waits for a specified model, machine, application or unit to reach a state
@@ -19,6 +22,7 @@ defined by the supplied query.
 Examples:
 	juju wait-for unit mysql/0
 	juju wait-for application mysql --query='name=="mysql" && (status=="active" || status=="idle")'
+	juju wait-for model default --query='forEach(units, unit => startsWith(unit.name, "ubuntu"))'
 
 `
 

--- a/cmd/juju/waitfor/waitforbase.go
+++ b/cmd/juju/waitfor/waitforbase.go
@@ -5,10 +5,7 @@ package waitfor
 
 import (
 	"reflect"
-	"sort"
 	"strings"
-
-	"github.com/juju/errors"
 
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/cmd/juju/waitfor/api"
@@ -22,27 +19,22 @@ type waitForCommandBase struct {
 	newWatchAllAPIFunc func() (api.WatchAllAPI, error)
 }
 
-type watchAllAPIShim struct {
+type modelAllWatchShim struct {
 	*apiclient.Client
 }
 
-func (s watchAllAPIShim) WatchAll() (api.AllWatcher, error) {
+func (s modelAllWatchShim) WatchAll() (api.AllWatcher, error) {
 	return s.Client.WatchAll()
 }
 
 // runQuery handles the more complex error handling of a query with a given
 // scope.
-func runQuery(q query.Query, scope query.Scope) (bool, error) {
-	if res, err := q.BuiltinsRun(scope); query.IsInvalidIdentifierErr(err) {
-		return false, invalidIdentifierError(scope, err)
-	} else if query.IsRuntimeError(err) {
-		return false, errors.Trace(err)
-	} else if res && err == nil {
-		return true, nil
-	} else if err != nil {
-		logger.Errorf("%v", err)
+func runQuery(input string, q query.Query, scope query.Scope) (bool, error) {
+	res, err := q.BuiltinsRun(scope)
+	if err != nil {
+		return false, HelpDisplay(err, input, scope.GetIdents())
 	}
-	return false, nil
+	return res, nil
 }
 
 func getIdents(q interface{}) []string {
@@ -60,88 +52,4 @@ func getIdents(q interface{}) []string {
 		}
 	}
 	return res
-}
-
-func invalidIdentifierError(scope query.Scope, err error) error {
-	if !query.IsInvalidIdentifierErr(err) {
-		return errors.Trace(err)
-	}
-
-	identErr := errors.Cause(err).(*query.InvalidIdentifierError)
-	name := identErr.Name()
-
-	idents := scope.GetIdents()
-
-	type Indexed = struct {
-		Name  string
-		Value int
-	}
-	matches := make([]Indexed, 0, len(idents))
-	for _, ident := range idents {
-		matches = append(matches, Indexed{
-			Name:  ident,
-			Value: levenshteinDistance(name, ident),
-		})
-	}
-	// Find the smallest levenshtein distance. If two values are the same,
-	// fallback to sorting on the name, which should give predictable results.
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].Value < matches[j].Value {
-			return true
-		}
-		if matches[i].Value > matches[j].Value {
-			return false
-		}
-		return matches[i].Name < matches[j].Name
-	})
-	matchedName := matches[0].Name
-	matchedValue := matches[0].Value
-
-	if matchedName != "" && matchedValue <= len(matchedName)+1 {
-		additional := errors.Errorf(`%s
-
-Did you mean:
-	%s
-`, err.Error(), matchedName)
-		return errors.Wrap(err, additional)
-	}
-
-	return errors.Trace(err)
-}
-
-// levenshteinDistance
-// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
-// (no min, compute lengths once, 2 rows array)
-// fastest profiled
-func levenshteinDistance(a, b string) int {
-	la := len(a)
-	lb := len(b)
-	d := make([]int, la+1)
-	var lastdiag, olddiag, temp int
-
-	for i := 1; i <= la; i++ {
-		d[i] = i
-	}
-	for i := 1; i <= lb; i++ {
-		d[0] = i
-		lastdiag = i - 1
-		for j := 1; j <= la; j++ {
-			olddiag = d[j]
-			min := d[j] + 1
-			if (d[j-1] + 1) < min {
-				min = d[j-1] + 1
-			}
-			if a[j-1] == b[i-1] {
-				temp = 0
-			} else {
-				temp = 1
-			}
-			if (lastdiag + temp) < min {
-				min = lastdiag + temp
-			}
-			d[j] = min
-			lastdiag = olddiag
-		}
-	}
-	return d[la]
 }

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -122,6 +122,7 @@ func (op *CaasOperatorAgent) Init(args []string) error {
 		IsFatal:       agenterrors.IsFatal,
 		MoreImportant: agenterrors.MoreImportant,
 		RestartDelay:  jworker.RestartDelay,
+		Logger:        logger,
 	})
 	return nil
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -284,6 +284,7 @@ func MachineAgentFactoryFn(
 				IsFatal:       agenterrors.IsFatal,
 				MoreImportant: agenterrors.MoreImportant,
 				RestartDelay:  jworker.RestartDelay,
+				Logger:        logger,
 			}),
 			looputil.NewLoopDeviceManager(),
 			newIntrospectionSocketName,

--- a/cmd/jujud/agent/model.go
+++ b/cmd/jujud/agent/model.go
@@ -74,6 +74,7 @@ func (m *ModelCommand) Init(args []string) error {
 		IsFatal:       agenterrors.IsFatal,
 		MoreImportant: agenterrors.MoreImportant,
 		RestartDelay:  jworker.RestartDelay,
+		Logger:        logger,
 	})
 	return nil
 }

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -41,17 +41,15 @@ import (
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
+	// Import the providers.
+	_ "github.com/juju/juju/provider/all"
+	// Import the secret providers.
+	_ "github.com/juju/juju/secrets/provider/all"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
-
-	// Import the providers.
-	_ "github.com/juju/juju/provider/all"
-
-	// Import the secret providers.
-	_ "github.com/juju/juju/secrets/provider/all"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud")

--- a/cmd/output/output_test.go
+++ b/cmd/output/output_test.go
@@ -5,9 +5,10 @@ package output_test
 
 import (
 	"github.com/juju/ansiterm"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/status"
-	gc "gopkg.in/check.v1"
 )
 
 type OutputSuite struct{}

--- a/cmd/output/progress/ansimeter_test.go
+++ b/cmd/output/progress/ansimeter_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"go.uber.org/mock/gomock"
-
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/output/progress"

--- a/cmd/output/progress/progress_test.go
+++ b/cmd/output/progress/progress_test.go
@@ -21,11 +21,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"go.uber.org/mock/gomock"
-
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/clock"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/output/progress"
 	"github.com/juju/juju/cmd/output/progress/mocks"

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/juju/juju/core/paths"
-	"github.com/juju/juju/packaging"
-	"github.com/juju/juju/packaging/dependency"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/paths"
+	"github.com/juju/juju/packaging"
+	"github.com/juju/juju/packaging/dependency"
 )
 
 type initialisationInternalSuite struct {

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -12,9 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/paths"
-
 	. "github.com/juju/juju/container/kvm"
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -163,7 +163,7 @@ func (s *Server) GetContainerProfiles(name string) ([]string, error) {
 }
 
 // UseProject ensures that this server will use the input project.
-// See: https://linuxcontainers.org/lxd/docs/master/projects.
+// See: https://documentation.ubuntu.com/lxd/en/latest/projects.
 func (s *Server) UseProject(project string) {
 	s.InstanceServer = s.InstanceServer.UseProject(project)
 }

--- a/container/lxd/shared_test.go
+++ b/container/lxd/shared_test.go
@@ -6,8 +6,9 @@ package lxd
 import (
 	"encoding/pem"
 
-	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	gc "gopkg.in/check.v1"
+
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
 )
 
 type sharedSuite struct {

--- a/core/auditlog/auditlog_test.go
+++ b/core/auditlog/auditlog_test.go
@@ -8,14 +8,13 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/juju/juju/core/paths"
-
 	"github.com/juju/clock/testclock"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/auditlog"
+	"github.com/juju/juju/core/paths"
 )
 
 type AuditLogSuite struct {

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/charm/v10"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/series"
 )
 

--- a/core/cache/charmconfigwatcher_test.go
+++ b/core/cache/charmconfigwatcher_test.go
@@ -5,11 +5,12 @@ package cache
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/settings"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/settings"
 )
 
 const (

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/juju/testing"
-
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -18,6 +16,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/testing"
 )
 
 type machineSuite struct {

--- a/core/instance/hardwarecharacteristics.go
+++ b/core/instance/hardwarecharacteristics.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/arch"
 )
 

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -4,11 +4,11 @@
 package lxdprofile_test
 
 import (
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/lxdprofile"
-	"github.com/juju/testing"
 )
 
 type LXDProfileNameSuite struct {

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -6,10 +6,10 @@ package network_test
 import (
 	"sort"
 
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
-	"github.com/juju/testing"
 )
 
 type NetworkSuite struct {

--- a/core/settings/package_test.go
+++ b/core/settings/package_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *testing.T) {

--- a/core/snap/assertions_test.go
+++ b/core/snap/assertions_test.go
@@ -9,8 +9,9 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/juju/juju/core/snap"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/snap"
 )
 
 var (

--- a/core/workerpool/workerpool_test.go
+++ b/core/workerpool/workerpool_test.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&ProvisionerWorkerPoolSuite{})

--- a/database/txn/transaction_test.go
+++ b/database/txn/transaction_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/mattn/go-sqlite3"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/database/testing"
 	"github.com/juju/juju/database/txn"
 )

--- a/environs/testing/polling.go
+++ b/environs/testing/polling.go
@@ -6,10 +6,9 @@ package testing
 import (
 	"time"
 
-	"github.com/juju/utils/v3"
-
 	"github.com/juju/clock"
 	"github.com/juju/retry"
+	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/common"

--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	facade "github.com/juju/juju/apiserver/facade"
 	"github.com/juju/rpcreflect"
+
+	facade "github.com/juju/juju/apiserver/facade"
 )
 
 // FacadeGroup defines the grouping you want to export.

--- a/jujuclient/jujuclienttesting/simple.go
+++ b/jujuclient/jujuclienttesting/simple.go
@@ -4,10 +4,10 @@
 package jujuclienttesting
 
 import (
-	"github.com/juju/juju/core/model"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 )
 

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/juju/state"
-
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -19,6 +17,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
 )
 
 var logger = loggo.GetLogger("juju.network.containerizer")

--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/juju/utils/scriptrunner"
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/utils/scriptrunner"
 )
 
 var logger = loggo.GetLogger("juju.network.debinterfaces")

--- a/network/debinterfaces/bridge_test.go
+++ b/network/debinterfaces/bridge_test.go
@@ -4,9 +4,8 @@
 package debinterfaces_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network/debinterfaces"
 )

--- a/network/network.go
+++ b/network/network.go
@@ -8,9 +8,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	corenetwork "github.com/juju/juju/core/network"

--- a/observability/probe/prober_test.go
+++ b/observability/probe/prober_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/observability/probe"
 )
 

--- a/pki/signer_test.go
+++ b/pki/signer_test.go
@@ -4,9 +4,9 @@
 package pki_test
 
 import (
-	"github.com/juju/juju/pki"
-
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/pki"
 )
 
 type SignerSuite struct {

--- a/provider/ec2/cloud_test.go
+++ b/provider/ec2/cloud_test.go
@@ -6,10 +6,10 @@ package ec2
 import (
 	"sort"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
-	jc "github.com/juju/testing/checkers"
 )
 
 type cloudSuite struct {

--- a/provider/equinix/credentials.go
+++ b/provider/equinix/credentials.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )

--- a/provider/equinix/environ_network.go
+++ b/provider/equinix/environ_network.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/packethost/packngo"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/names/v4"
-	"github.com/packethost/packngo"
 )
 
 var _ environs.Networking = (*environ)(nil)

--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -6,13 +6,12 @@ package equinix
 import (
 	"context"
 
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"github.com/packethost/packngo"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
-
-	jtesting "github.com/juju/testing"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"

--- a/provider/equinix/instance.go
+++ b/provider/equinix/instance.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/packethost/packngo"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	corenetwork "github.com/juju/juju/core/network"
@@ -15,8 +17,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/common"
-
-	"github.com/packethost/packngo"
 )
 
 type equinixDevice struct {

--- a/provider/equinix/provider.go
+++ b/provider/equinix/provider.go
@@ -11,15 +11,15 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
+	"github.com/juju/schema"
+	"github.com/packethost/packngo"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/version"
-	"github.com/juju/schema"
-
-	"github.com/packethost/packngo"
 )
 
 var _ environs.CloudEnvironProvider = (*environProvider)(nil)

--- a/provider/equinix/provider_test.go
+++ b/provider/equinix/provider_test.go
@@ -4,13 +4,13 @@
 package equinix_test
 
 import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/equinix"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 )
 
 type providerSuite struct {

--- a/provider/equinix/testing_test.go
+++ b/provider/equinix/testing_test.go
@@ -4,12 +4,13 @@
 package equinix_test
 
 import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/cloud"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 func fakeConfig(c *gc.C, attrs ...testing.Attrs) *config.Config {

--- a/provider/equinix/userdata.go
+++ b/provider/equinix/userdata.go
@@ -5,10 +5,10 @@ package equinix
 
 import (
 	"github.com/juju/errors"
-	jujuos "github.com/juju/juju/core/os"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
+	jujuos "github.com/juju/juju/core/os"
 )
 
 type EquinixRenderer struct{}

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -29,7 +29,7 @@ import (
 
 var _ environs.HardwareCharacteristicsDetector = (*environ)(nil)
 
-const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/`
+const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/`
 
 type baseProvider interface {
 	// BootstrapEnv bootstraps a Juju environment.

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -106,7 +106,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 	c.Check(result.CloudBootstrapFinalizer, gc.NotNil)
 
 	out := cmdtesting.Stderr(ctx)
-	c.Assert(out, gc.Equals, "To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/\n")
+	c.Assert(out, gc.Matches, "To configure your system to better support LXD containers, please see: .*\n")
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	lxdclient "github.com/canonical/lxd/client"
+	lxdapi "github.com/canonical/lxd/shared/api"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
@@ -28,9 +30,6 @@ import (
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/utils/proxy"
-
-	lxdclient "github.com/canonical/lxd/client"
-	lxdapi "github.com/canonical/lxd/shared/api"
 )
 
 // Server defines an interface of all localized methods that the environment
@@ -89,7 +88,7 @@ type Server interface {
 	GetInstanceState(name string) (*lxdapi.InstanceState, string, error)
 
 	// UseProject ensures that this server will use the input project.
-	// See: https://linuxcontainers.org/lxd/docs/master/projects.
+	// See: https://documentation.ubuntu.com/lxd/en/latest/projects.
 	UseProject(string)
 }
 

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/core/paths"
 )

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/juju/core/status"
-
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi/v2"
+
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/context"
 )
 

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -4,10 +4,10 @@
 package maas
 
 import (
+	"github.com/juju/gomaasapi/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/gomaasapi/v2"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"

--- a/provider/oci/common/client_test.go
+++ b/provider/oci/common/client_test.go
@@ -6,11 +6,11 @@ package common_test
 import (
 	"fmt"
 
-	ocitesting "github.com/juju/juju/provider/oci/testing"
-	"github.com/juju/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/provider/oci/common"
+	ocitesting "github.com/juju/juju/provider/oci/testing"
+	"github.com/juju/juju/testing"
 )
 
 type clientSuite struct {

--- a/provider/oci/common/errors_test.go
+++ b/provider/oci/common/errors_test.go
@@ -6,11 +6,10 @@ package common_test
 import (
 	"fmt"
 
-	ocicommon "github.com/oracle/oci-go-sdk/v65/common"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	ocicommon "github.com/oracle/oci-go-sdk/v65/common"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/provider/oci/common"
 	"github.com/juju/juju/testing"

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -14,6 +14,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 	"github.com/kr/pretty"
+	ociCommon "github.com/oracle/oci-go-sdk/v65/common"
+	ociCore "github.com/oracle/oci-go-sdk/v65/core"
+	ociIdentity "github.com/oracle/oci-go-sdk/v65/identity"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -32,10 +35,6 @@ import (
 	providerCommon "github.com/juju/juju/provider/oci/common"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
-
-	ociCommon "github.com/oracle/oci-go-sdk/v65/common"
-	ociCore "github.com/oracle/oci-go-sdk/v65/core"
-	ociIdentity "github.com/oracle/oci-go-sdk/v65/identity"
 )
 
 type Environ struct {

--- a/provider/oci/instance.go
+++ b/provider/oci/instance.go
@@ -13,11 +13,10 @@ import (
 	"github.com/juju/errors"
 	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 
-	"github.com/juju/juju/core/network/firewall"
-	"github.com/juju/juju/core/status"
-
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/firewall"
+	"github.com/juju/juju/core/status"
 	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/common"

--- a/provider/oci/storage_volumes.go
+++ b/provider/oci/storage_volumes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 
 	"github.com/juju/juju/core/instance"
 	envcontext "github.com/juju/juju/environs/context"
@@ -18,8 +19,6 @@ import (
 	allProvidersCommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/oci/common"
 	"github.com/juju/juju/storage"
-
-	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 )
 
 func mibToGib(m uint64) uint64 {

--- a/provider/oci/storage_volumes_test.go
+++ b/provider/oci/storage_volumes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
@@ -17,8 +18,6 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/provider/oci"
 	"github.com/juju/juju/storage"
-
-	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 )
 
 type storageVolumeSuite struct {

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -5,7 +5,6 @@ package openstack
 
 import (
 	"github.com/go-goose/goose/v5/nova"
-
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs/imagemetadata"

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -5,6 +5,7 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"

--- a/rpc/params/proxy.go
+++ b/rpc/params/proxy.go
@@ -5,6 +5,7 @@ package params
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/proxy"
 )
 

--- a/scripts/charmhub/locate-series-less-charms.go
+++ b/scripts/charmhub/locate-series-less-charms.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/juju/juju/charmhub"
 	"github.com/juju/loggo"
 	"gopkg.in/yaml.v3"
+
+	"github.com/juju/juju/charmhub"
 )
 
 // The following program attempts to locate series-less charms on charmhub.

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -13,9 +13,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/juju/scripts/juju-inspect/rules"
 	"github.com/juju/version/v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/scripts/juju-inspect/rules"
 )
 
 func main() {

--- a/state/application_ops.go
+++ b/state/application_ops.go
@@ -4,11 +4,12 @@
 package state
 
 import (
-	"github.com/juju/juju/core/leadership"
-	mgoutils "github.com/juju/juju/mongo/utils"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
 	jujutxn "github.com/juju/txn/v3"
+
+	"github.com/juju/juju/core/leadership"
+	mgoutils "github.com/juju/juju/mongo/utils"
 )
 
 type updateLeaderSettingsOperation struct {

--- a/state/bakerystorage/rootkeys.go
+++ b/state/bakerystorage/rootkeys.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
-
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
 // Functions defined as variables so they can be overidden

--- a/state/devices_test.go
+++ b/state/devices_test.go
@@ -4,9 +4,8 @@
 package state_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 )

--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -11,10 +11,9 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state/mocks"
-
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/mocks"
 )
 
 type bindingsSuite struct {

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -4,8 +4,9 @@
 package state
 
 import (
-	"github.com/juju/juju/mongo"
 	jujutxn "github.com/juju/txn/v3"
+
+	"github.com/juju/juju/mongo"
 )
 
 // environMongo implements state/lease.Mongo to expose environ-filtered mongo

--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -4,11 +4,10 @@
 package state_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/leadership"

--- a/state/pool.go
+++ b/state/pool.go
@@ -179,8 +179,7 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 	// noticed. The clocks in the runner and the txn watcher are used to
 	// control polling, and never return the actual times.
 	pool.watcherRunner = worker.NewRunner(worker.RunnerParams{
-		// TODO add a Logger parameter to RunnerParams:
-		// Logger: loggo.GetLogger(logger.Name() + ".txnwatcher"),
+		Logger:       loggo.GetLogger("juju.state.pool.txnwatcher"),
 		IsFatal:      func(err error) bool { return errors.Cause(err) == errPoolClosed },
 		RestartDelay: time.Second,
 		Clock:        args.Clock,

--- a/state/relationnetworks_test.go
+++ b/state/relationnetworks_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/bson"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/state"
 )
 

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -6,11 +6,11 @@ package stateenvirons_test
 import (
 	"context"
 
-	"github.com/juju/juju/caas"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"

--- a/state/stateenvirons/features.go
+++ b/state/stateenvirons/features.go
@@ -5,6 +5,7 @@ package stateenvirons
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/environs"

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/errors"
+
 	stateerrors "github.com/juju/juju/state/errors"
 )
 

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -6,11 +6,11 @@ package state
 import (
 	"strings"
 
+	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/testing"
-	"github.com/juju/names/v4"
 )
 
 type internalUserSuite struct {

--- a/state/workers.go
+++ b/state/workers.go
@@ -37,8 +37,7 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 		state: st,
 		hub:   hub,
 		Runner: worker.NewRunner(worker.RunnerParams{
-			// TODO add a Logger parameter to RunnerParams:
-			// Logger: loggo.GetLogger(logger.Name() + ".workers"),
+			Logger:       loggo.GetLogger("juju.state.watcher"),
 			IsFatal:      func(err error) bool { return err == jworker.ErrRestartAgent },
 			RestartDelay: time.Second,
 			Clock:        st.clock(),

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,9 +4,10 @@
 package storage
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/names/v4"
 )
 
 // ProviderType uniquely identifies a storage provider, such as "ebs" or "loop".

--- a/storage/provider/k8s_validation.go
+++ b/storage/provider/k8s_validation.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/storage"
 	"github.com/juju/schema"
+
+	"github.com/juju/juju/storage"
 )
 
 // checkK8sConfig checks that the attributes in a configuration

--- a/testcharms/charm-hub/charms/juju-qa-test/README.md
+++ b/testcharms/charm-hub/charms/juju-qa-test/README.md
@@ -6,7 +6,7 @@ A container-based V2 metadata charm to use in testing juju.
 
 ## Usage
 
-Basic deploy: 
+Basic deploy:
 `juju deploy juju-qa-test`
 
 Set the unit status to the first line of the resource, if available, one time:
@@ -19,7 +19,7 @@ Get your fortune
 ## Version, Channel, Series and History
 | Version    | Revision | Channel          | Series                               |
 | ---------- | -------- | ---------------- | ------------------------------------ |
-| 1.1-stable | 19       | latest/stable    | focal, bionic, xenial                |
+| 1.1-stable | 26       | latest/stable    | focal, bionic, xenial                |
 | 1.4-cand   | 20       | latest/candidate | jammy, focal, bionic, xenial         |
 | 2.0-edge   | 21       | latest/edge      | groovy, jammy, focal, bionic, xenial |
 | 2.0-stable | 22       | 2.0/stable       | disco, bionic, xenial, trusty        |

--- a/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
@@ -1,14 +1,29 @@
 type: charm
+parts:
+  charm:
+    prime:
+      - dispatch
+      - hooks
+      - README.md
+      - LICENSE
+      - version
+      - src
+      - actions.yaml
+      - metadata.yaml
+      - config.yaml
 bases:
     - build-on:
         - name: "ubuntu"
           channel: "20.04"
         - name: "ubuntu"
           channel: "22.04"
-      run-on: 
+      run-on:
         - name: "ubuntu"
           channel: "16.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "18.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "20.04"
+          architectures: ["amd64", "arm64"]

--- a/testcharms/charm-hub/charms/juju-qa-test/stable/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/stable/charmcraft.yaml
@@ -17,10 +17,13 @@ bases:
           channel: "20.04"
         - name: "ubuntu"
           channel: "22.04"
-      run-on: 
+      run-on:
         - name: "ubuntu"
           channel: "16.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "18.04"
+          architectures: ["amd64", "arm64"]
         - name: "ubuntu"
           channel: "20.04"
+          architectures: ["amd64", "arm64"]

--- a/upgrades/upgrade.go
+++ b/upgrades/upgrade.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-
 	"github.com/juju/loggo"
 	"github.com/juju/version/v2"
 )

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -12,20 +12,19 @@ import (
 	"github.com/juju/version/v2"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/worker/fortress"
-
 	"github.com/juju/juju/agent"
 	caasoperatorapi "github.com/juju/juju/api/agent/caasoperator"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/downloader"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/caasoperator"
+	"github.com/juju/juju/worker/fortress"
 )
 
 var (

--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -7,8 +7,9 @@ package caasoperator
 import (
 	"path/filepath"
 
-	"github.com/juju/juju/agent/tools"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/agent/tools"
 )
 
 // Paths represents the set of filesystem paths a caasoperator worker has reason to

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -12,12 +12,11 @@ import (
 	"time"
 
 	"github.com/juju/charm/v10"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
-
-	"github.com/juju/clock/testclock"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"

--- a/worker/changestream/eventqueue/eventqueue.go
+++ b/worker/changestream/eventqueue/eventqueue.go
@@ -6,11 +6,11 @@ package eventqueue
 import (
 	"sync/atomic"
 
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3/catacomb"
 	"gopkg.in/tomb.v2"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/worker/v3/catacomb"
 )
 
 // Logger represents the logging methods called.

--- a/worker/changestream/worker_test.go
+++ b/worker/changestream/worker_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	coredatabase "github.com/juju/juju/core/database"
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/testing"
 )
 
 type workerSuite struct {

--- a/worker/common/reboot/monitor.go
+++ b/worker/common/reboot/monitor.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/paths/transientfile"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/paths/transientfile"
 )
 
 // Monitor leverages juju's transient file mechanism to deliver one-off

--- a/worker/dbaccessor/shim.go
+++ b/worker/dbaccessor/shim.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/database/dqlite"
 )

--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -133,6 +133,7 @@ func NewNestedContext(config ContextConfig) (Context, error) {
 		units:  make(map[string]*UnitAgent),
 		errors: make(map[string]error),
 		runner: worker.NewRunner(worker.RunnerParams{
+			Logger:        config.Logger,
 			IsFatal:       agenterrors.IsFatal,
 			MoreImportant: agenterrors.MoreImportant,
 			RestartDelay:  jworker.RestartDelay,

--- a/worker/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/worker/externalcontrollerupdater/externalcontrollerupdater.go
@@ -74,6 +74,7 @@ func New(
 			// If the API connection fails, try again in 1 minute.
 			RestartDelay: time.Minute,
 			Clock:        clock,
+			Logger:       logger,
 		}),
 	}
 	if err := catacomb.Invoke(catacomb.Plan{

--- a/worker/fanconfigurer/manifold.go
+++ b/worker/fanconfigurer/manifold.go
@@ -4,11 +4,11 @@
 package fanconfigurer
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 
-	"github.com/juju/clock"
 	apifanconfigurer "github.com/juju/juju/api/agent/fanconfigurer"
 	"github.com/juju/juju/api/base"
 )

--- a/worker/filenotifywatcher/watcher_test.go
+++ b/worker/filenotifywatcher/watcher_test.go
@@ -10,10 +10,11 @@ import (
 	"path/filepath"
 	time "time"
 
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
 )
 
 type watcherSuite struct {

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -1528,6 +1528,9 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 	// Start the worker which will watch the remote relation for things like new networks.
 	// We use ReplaceWorker since the relation may have been removed and we are re-adding it.
 	if err := fw.relationWorkerRunner.StartWorker(tag.Id(), func() (worker.Worker, error) {
+		// This may be a restart after an api error, so ensure any previous
+		// worker is killed and the catacomb is reset.
+		data.Kill()
 		data.catacomb = catacomb.Catacomb{}
 		if err := catacomb.Invoke(catacomb.Plan{
 			Site: &data.catacomb,

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/wrench"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/wrench"
 )
 
 var logger = loggo.GetLogger("juju.worker.hostkeyreporter")

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -14,9 +14,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
-	gc "gopkg.in/check.v1"
-
 	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/instance"

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -8,11 +8,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/juju/clock"
-	"github.com/juju/loggo"
-
 	corecharm "github.com/juju/charm/v10"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -11,11 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/agent/metricsadder"
-	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/worker/metrics/sender"
-	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -24,6 +19,12 @@ import (
 	dt "github.com/juju/worker/v3/dependency/testing"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/httprequest.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/agent/metricsadder"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker/metrics/sender"
+	"github.com/juju/juju/worker/metrics/spool"
 )
 
 type ManifoldSuite struct {

--- a/worker/metrics/spool/listener_test.go
+++ b/worker/metrics/spool/listener_test.go
@@ -9,11 +9,10 @@ import (
 	"net"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/worker/metrics/spool"
 )

--- a/worker/metrics/spool/metrics.go
+++ b/worker/metrics/spool/metrics.go
@@ -19,9 +19,8 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v3"
 
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
-
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 var logger = loggo.GetLogger("juju.worker.uniter.metrics")

--- a/worker/metricworker/manifold.go
+++ b/worker/metricworker/manifold.go
@@ -16,6 +16,9 @@ import (
 // Logger represents the methods used by the worker to log details.
 type Logger interface {
 	Warningf(string, ...interface{})
+	Debugf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Infof(string, ...interface{})
 }
 
 // ManifoldConfig describes the resources used by metrics workers.

--- a/worker/metricworker/metricmanager.go
+++ b/worker/metricworker/metricmanager.go
@@ -23,6 +23,7 @@ func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan s
 	runner := worker.NewRunner(worker.RunnerParams{
 		IsFatal:      isFatal,
 		RestartDelay: jworker.RestartDelay,
+		Logger:       logger,
 	})
 	err := runner.StartWorker("sender", func() (worker.Worker, error) {
 		return newSender(client, notify, logger), nil

--- a/worker/modelworkermanager/manifold.go
+++ b/worker/modelworkermanager/manifold.go
@@ -22,6 +22,8 @@ import (
 type Logger interface {
 	Debugf(string, ...interface{})
 	Warningf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Infof(string, ...interface{})
 }
 
 // ManifoldConfig holds the information necessary to run a model worker manager

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -8,11 +8,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/juju/loggo"
-	"github.com/juju/names/v4"
-
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
@@ -176,6 +175,7 @@ func (m *modelWorkerManager) loop() error {
 		IsFatal:       neverFatal,
 		MoreImportant: neverImportant,
 		RestartDelay:  m.config.ErrorDelay,
+		Logger:        m.config.Logger,
 	})
 	if err := m.catacomb.Add(m.runner); err != nil {
 		return errors.Trace(err)

--- a/worker/muxhttpserver/package_test.go
+++ b/worker/muxhttpserver/package_test.go
@@ -6,9 +6,10 @@ package muxhttpserver_test
 import (
 	"testing"
 
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/pki"
 	pki_test "github.com/juju/juju/pki/test"
-	gc "gopkg.in/check.v1"
 )
 
 func TestSuite(t *testing.T) { gc.TestingT(t) }

--- a/worker/peergrouper/publish_test.go
+++ b/worker/peergrouper/publish_test.go
@@ -4,11 +4,11 @@
 package peergrouper
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
 )
 
 type publishSuite struct {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -172,7 +172,8 @@ func New(config Config) (*Worker, error) {
 	runner := config.Runner
 	if runner == nil {
 		runner = worker.NewRunner(worker.RunnerParams{
-			Clock: config.Clock,
+			Clock:  config.Clock,
+			Logger: config.Logger,
 
 			// One of the remote application workers failing should not
 			// prevent the others from running.

--- a/worker/syslogger/worker.go
+++ b/worker/syslogger/worker.go
@@ -11,10 +11,10 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-
-	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
+
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 // NewLogger is a factory function to create a new syslog logger.

--- a/worker/undertaker/manifold_test.go
+++ b/worker/undertaker/manifold_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/caas"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -16,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/undertaker"

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -4,6 +4,8 @@
 package uniter
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 )
@@ -37,5 +39,6 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 
 // setUpgradeSeriesStatus sets the upgrade series status.
 func setUpgradeSeriesStatus(u *Uniter, status model.UpgradeSeriesStatus, reason string) error {
-	return u.unit.SetUpgradeSeriesStatus(status, reason)
+	err := u.unit.SetUpgradeSeriesStatus(status, reason)
+	return errors.Annotatef(err, "cannot set upgrade series status to %q with reason: %q", status, reason)
 }

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -8,9 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/juju/loggo"
-
 	corecharm "github.com/juju/charm/v10"
+	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
-
 	gc "gopkg.in/check.v1"
 
 	apiuniter "github.com/juju/juju/api/agent/uniter"

--- a/worker/uniter/runner/context/storage.go
+++ b/worker/uniter/runner/context/storage.go
@@ -4,8 +4,9 @@
 package context
 
 import (
-	"github.com/juju/juju/storage"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/storage"
 )
 
 // contextStorage is an implementation of hooks.ContextStorageAttachment.

--- a/worker/uniter/runner/jujuc/jujuctesting/storageattachment.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/storageattachment.go
@@ -4,8 +4,9 @@
 package jujuctesting
 
 import (
-	"github.com/juju/juju/storage"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/storage"
 )
 
 // StorageAttachment holds the data for the test double.

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -12,9 +12,8 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/core/secrets"
-
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/secrets"
 )
 
 type secretUpsertCommand struct {

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -16,7 +16,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coresecrets "github.com/juju/juju/core/secrets"
-
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 

--- a/worker/uniter/runner/jujuc/secret-set_test.go
+++ b/worker/uniter/runner/jujuc/secret-set_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coresecrets "github.com/juju/juju/core/secrets"
-
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 

--- a/worker/uniter/runner/jujuc/state-delete.go
+++ b/worker/uniter/runner/jujuc/state-delete.go
@@ -5,6 +5,7 @@ package jujuc
 
 import (
 	"github.com/juju/cmd/v3"
+
 	jujucmd "github.com/juju/juju/cmd"
 )
 

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -6,9 +6,10 @@ package jujuc_test
 import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 type statusSetSuite struct {

--- a/worker/uniter/storage/mock_test.go
+++ b/worker/uniter/storage/mock_test.go
@@ -6,11 +6,12 @@ package storage_test
 import (
 	"fmt"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
-	"github.com/juju/names/v4"
 )
 
 type mockStorageAccessor struct {

--- a/worker/upgradedatabase/manifold_test.go
+++ b/worker/upgradedatabase/manifold_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
-
 	"github.com/juju/juju/worker/upgradedatabase"
 	. "github.com/juju/juju/worker/upgradedatabase/mocks"
 )

--- a/worker/upgradeseries/testing_test.go
+++ b/worker/upgradeseries/testing_test.go
@@ -5,9 +5,8 @@ package upgradeseries_test
 
 import (
 	"github.com/juju/loggo"
-	"github.com/juju/worker/v3"
-
 	"github.com/juju/names/v4"
+	"github.com/juju/worker/v3"
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/api/base"

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -6,6 +6,7 @@ package upgradeseries_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -13,8 +14,6 @@ import (
 	"github.com/juju/worker/v3/workertest"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -6,18 +6,16 @@ package upgradesteps
 import (
 	"time"
 
-	apiagent "github.com/juju/juju/api/agent/agent"
-
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
-
-	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	apiagent "github.com/juju/juju/api/agent/agent"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/worker/gate"


### PR DESCRIPTION
Forward ports:
- #15938
- #15924
- #15946
- #15948
- #15950
- #15949
- #15952
- #15841
- #15868

Conflicts:
-	api/controller/raftlease/raftlease.go
-	api/controller/raftlease/raftlease_test.go
-	apiserver/apiserver.go
-	apiserver/facades/client/firewallrules/register.go
-	apiserver/facades/controller/raftlease/register.go
-	apiserver/testing/fakeauthorizer.go
-	cmd/juju/commands/bootstrap_test.go
-	cmd/juju/commands/version_test.go
-	cmd/juju/firewall/setrule_test.go
-	core/arch/arches_test.go
-	core/raft/queue/opqueue.go
-	core/raftlease/client.go
-	provider/azure/internal/imageutils/images_test.go
-	provider/oci/common/errors_test.go
-	provider/oci/common_test.go
-	provider/oci/environ.go
-	provider/oci/images.go
-	provider/oci/instance.go
-	provider/oci/storage_volumes.go
-	provider/oci/storage_volumes_test.go
-	state/migration_export_test.go
-	state/podspec_test.go
-	worker/firewaller/firewaller.go
-	worker/raft/mock_test.go
-	worker/raft/rafttransport/mock_test.go