### PR TITLE
Fix executing many secret set and a remove in a hook

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/charm/v10"
 	"github.com/juju/charm/v10/hooks"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -978,15 +977,6 @@ func (ctx *HookContext) RemoveSecret(uri *coresecrets.URI, revision *int) error 
 // SecretMetadata gets the secret ids and their labels and latest revisions created by the charm.
 // The result includes any pending updates.
 func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error) {
-	pendingUpdatesByID := make(map[string]uniter.SecretUpsertArg)
-	for _, u := range ctx.secretChanges.pendingUpdates {
-		pendingUpdatesByID[u.URI.ID] = u.SecretUpsertArg
-	}
-	pendingDeletes := set.NewStrings()
-	for _, r := range ctx.secretChanges.pendingDeletes {
-		pendingDeletes.Add(r.URI.ID)
-	}
-
 	result := make(map[string]jujuc.SecretMetadata)
 	for _, c := range ctx.secretChanges.pendingCreates {
 		md := jujuc.SecretMetadata{
@@ -1008,10 +998,10 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 		result[c.URI.ID] = md
 	}
 	for id, v := range ctx.secretMetadata {
-		if pendingDeletes.Contains(id) {
+		if _, ok := ctx.secretChanges.pendingDeletes[id]; ok {
 			continue
 		}
-		if u, ok := pendingUpdatesByID[id]; ok {
+		if u, ok := ctx.secretChanges.pendingUpdates[id]; ok {
 			if u.Label != nil {
 				v.Label = *u.Label
 			}
@@ -1520,14 +1510,19 @@ func (ctx *HookContext) doFlush(process string) error {
 			return errors.Trace(err)
 		}
 	}
-	var cleanups []coresecrets.ValueRef
-	pendingCreates := make([]uniter.SecretCreateArg, len(ctx.secretChanges.pendingCreates))
-	pendingUpdates := make([]uniter.SecretUpsertArg, len(ctx.secretChanges.pendingUpdates))
-	pendingDeletes := make([]uniter.SecretDeleteArg, len(ctx.secretChanges.pendingDeletes))
-	for i, c := range ctx.secretChanges.pendingCreates {
+
+	var (
+		cleanups       []coresecrets.ValueRef
+		pendingCreates []uniter.SecretCreateArg
+		pendingUpdates []uniter.SecretUpsertArg
+		pendingDeletes []uniter.SecretDeleteArg
+		pendingGrants  []uniter.SecretGrantRevokeArgs
+		pendingRevokes []uniter.SecretGrantRevokeArgs
+	)
+	for _, c := range ctx.secretChanges.pendingCreates {
 		ref, err := secretsBackend.SaveContent(c.URI, 1, c.Value)
-		if errors.IsNotSupported(err) {
-			pendingCreates[i] = c
+		if errors.Is(err, errors.NotSupported) {
+			pendingCreates = append(pendingCreates, c)
 			continue
 		}
 		if err != nil {
@@ -1536,18 +1531,18 @@ func (ctx *HookContext) doFlush(process string) error {
 		cleanups = append(cleanups, ref)
 		c.ValueRef = &ref
 		c.Value = nil
-		pendingCreates[i] = c
+		pendingCreates = append(pendingCreates, c)
 	}
-	for i, u := range ctx.secretChanges.pendingUpdates {
+	for _, u := range ctx.secretChanges.pendingUpdates {
 		// Juju checks that the current revision is stable when updating metadata so it's
 		// safe to increment here knowing the same value will be saved in Juju.
 		if u.Value.IsEmpty() {
-			pendingUpdates[i] = u.SecretUpsertArg
+			pendingUpdates = append(pendingUpdates, u.SecretUpsertArg)
 			continue
 		}
 		ref, err := secretsBackend.SaveContent(u.URI, u.CurrentRevision+1, u.Value)
-		if errors.IsNotSupported(err) {
-			pendingUpdates[i] = u.SecretUpsertArg
+		if errors.Is(err, errors.NotSupported) {
+			pendingUpdates = append(pendingUpdates, u.SecretUpsertArg)
 			continue
 		}
 		if err != nil {
@@ -1556,11 +1551,11 @@ func (ctx *HookContext) doFlush(process string) error {
 		cleanups = append(cleanups, ref)
 		u.ValueRef = &ref
 		u.Value = nil
-		pendingUpdates[i] = u.SecretUpsertArg
+		pendingUpdates = append(pendingUpdates, u.SecretUpsertArg)
 	}
 
-	for i, d := range ctx.secretChanges.pendingDeletes {
-		pendingDeletes[i] = d
+	for _, d := range ctx.secretChanges.pendingDeletes {
+		pendingDeletes = append(pendingDeletes, d)
 		md, ok := ctx.secretMetadata[d.URI.ID]
 		if !ok {
 			continue
@@ -1574,7 +1569,7 @@ func (ctx *HookContext) doFlush(process string) error {
 		ctx.logger.Debugf("deleting secret %q provider ids: %v", d.URI.String(), toDelete)
 		for _, rev := range toDelete {
 			if err := secretsBackend.DeleteContent(d.URI, rev); err != nil {
-				if errors.IsNotFound(err) {
+				if errors.Is(err, errors.NotFound) {
 					continue
 				}
 				return errors.Annotatef(err, "cannot delete secret %q revision %d from backend: %v", d.URI.ID, rev, err)
@@ -1582,11 +1577,19 @@ func (ctx *HookContext) doFlush(process string) error {
 		}
 	}
 
+	for _, g := range ctx.secretChanges.pendingGrants {
+		pendingGrants = append(pendingGrants, g)
+	}
+
+	for _, r := range ctx.secretChanges.pendingRevokes {
+		pendingRevokes = append(pendingRevokes, r)
+	}
+
 	b.AddSecretCreates(pendingCreates)
 	b.AddSecretUpdates(pendingUpdates)
 	b.AddSecretDeletes(pendingDeletes)
-	b.AddSecretGrants(ctx.secretChanges.pendingGrants)
-	b.AddSecretRevokes(ctx.secretChanges.pendingRevokes)
+	b.AddSecretGrants(pendingGrants)
+	b.AddSecretRevokes(pendingRevokes)
 
 	if ctx.modelType == model.CAAS {
 		if err := ctx.addCommitHookChangesForCAAS(b, process); err != nil {
@@ -1602,7 +1605,7 @@ func (ctx *HookContext) doFlush(process string) error {
 		cleanupDone:
 			for _, secretId := range cleanups {
 				if err2 := secretsBackend.DeleteExternalContent(secretId); err2 != nil {
-					if errors.IsNotSupported(err) {
+					if errors.Is(err, errors.NotSupported) {
 						break cleanupDone
 					}
 					ctx.logger.Errorf("cannot cleanup secret %q: %v", secretId, err2)

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -329,30 +329,30 @@ func (ctx *HookContext) SLALevel() string {
 	return ctx.slaLevel
 }
 
-func (ctx *HookContext) PendingSecretRemoves() []uniter.SecretDeleteArg {
+func (ctx *HookContext) PendingSecretRemoves() map[string]uniter.SecretDeleteArg {
 	return ctx.secretChanges.pendingDeletes
 }
 
-func (ctx *HookContext) PendingSecretCreates() []uniter.SecretCreateArg {
+func (ctx *HookContext) PendingSecretCreates() map[string]uniter.SecretCreateArg {
 	return ctx.secretChanges.pendingCreates
 }
 
-func (ctx *HookContext) PendingSecretUpdates() []uniter.SecretUpdateArg {
+func (ctx *HookContext) PendingSecretUpdates() map[string]uniter.SecretUpdateArg {
 	return ctx.secretChanges.pendingUpdates
 }
 
-func (ctx *HookContext) SetPendingSecretCreates(in []uniter.SecretCreateArg) {
+func (ctx *HookContext) SetPendingSecretCreates(in map[string]uniter.SecretCreateArg) {
 	ctx.secretChanges.pendingCreates = in
 }
 
-func (ctx *HookContext) SetPendingSecretUpdates(in []uniter.SecretUpdateArg) {
+func (ctx *HookContext) SetPendingSecretUpdates(in map[string]uniter.SecretUpdateArg) {
 	ctx.secretChanges.pendingUpdates = in
 }
 
-func (ctx *HookContext) PendingSecretGrants() []uniter.SecretGrantRevokeArgs {
+func (ctx *HookContext) PendingSecretGrants() map[string]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingGrants
 }
 
-func (ctx *HookContext) PendingSecretRevokes() []uniter.SecretGrantRevokeArgs {
+func (ctx *HookContext) PendingSecretRevokes() map[string]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingRevokes
 }


### PR DESCRIPTION
Inside a hook, doing multiple secret-set calls and then a secret-remove would crash the agent.
This PR fixes the caching of pending operations so that each create, update, remove, grant, revoke is stored in a map keyed on id, allowing removes to efficiently clear any previously pending creates, updates etc.

## QA steps

```sh
$ URI=$(juju exec --unit controller/0 -- secret-add key1=value1 key2=value2 key3=value3)
$ juju exec --unit controller/0 -- secret-get $URI
key1: value1
key2: value2
key3: value3
$ juju exec --unit controller/0 -- "secret-set $URI key1=value1 && secret-set $URI key2=value2 && secret-remove $URI"
$ juju exec --unit controller/0 -- secret-get $URI
ERROR secret "secret://9e88b817-34b6-4e2d-8ffb-1db357fc8505/cisat31bauss75lmo3kg" not found
```
Previously doing multiple sets and a remove in a hook would crash the unit agent.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2028094
