### PR TITLE
[JUJU-4277] Dqlite Back-stop

### DIFF
--- a/database/node.go
+++ b/database/node.go
@@ -146,6 +146,20 @@ func (m *NodeManager) SetClusterServers(ctx context.Context, servers []dqlite.No
 	return errors.Annotate(store.Set(ctx, servers), "writing servers to Dqlite node store")
 }
 
+// NodeInfo reads the local node information file in the Dqlite directory
+// and returns the dqlite.NodeInfo represented by its contents.
+func (m *NodeManager) NodeInfo() (dqlite.NodeInfo, error) {
+	var node dqlite.NodeInfo
+
+	data, err := os.ReadFile(path.Join(m.dataDir, "info.yaml"))
+	if err != nil {
+		return node, errors.Annotate(err, "reading info.yaml")
+	}
+
+	err = yaml.Unmarshal(data, &node)
+	return node, errors.Annotate(err, "decoding NodeInfo")
+}
+
 // SetNodeInfo rewrites the local node information file in the Dqlite
 // data directory, so that it matches the input NodeInfo.
 // This should only be called on a stopped Dqlite node.

--- a/database/node.go
+++ b/database/node.go
@@ -119,6 +119,19 @@ func (m *NodeManager) EnsureDataDir() (string, error) {
 	return m.dataDir, nil
 }
 
+// SetClusterToLocalNode reconfigures the Dqlite cluster so that it has the
+// local node as its only member.
+// This is intended as a disaster recovery utility, and should only be called:
+// 1. At great need.
+// 2. With steadfast guarantees of data integrity.
+func (m *NodeManager) SetClusterToLocalNode(ctx context.Context) error {
+	node, err := m.NodeInfo()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(m.SetClusterServers(ctx, []dqlite.NodeInfo{node}))
+}
+
 // ClusterServers returns the node information for
 // Dqlite nodes configured to be in the cluster.
 func (m *NodeManager) ClusterServers(ctx context.Context) ([]dqlite.NodeInfo, error) {

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -201,7 +201,7 @@ func (s *nodeManagerSuite) TestSetClusterServersSuccess(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, servers)
 }
 
-func (s *nodeManagerSuite) TestSetNodeInfoSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestSetGetNodeInfoSuccess(c *gc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
 	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
@@ -213,7 +213,7 @@ func (s *nodeManagerSuite) TestSetNodeInfoSuccess(c *gc.C) {
 
 	infoFile := path.Join(dataDir, "info.yaml")
 
-	// Write a cluster.yaml file into the Dqlite data directory.
+	// Write an info.yaml file into the Dqlite data directory.
 	data := []byte(`
 Address: 127.0.0.1:17666
 ID: 3297041220608546238
@@ -236,8 +236,7 @@ Role: 0
 	c.Assert(err, jc.ErrorIsNil)
 
 	// info.yaml should reflect the new node info.
-	var result dqlite.NodeInfo
-	err = yaml.Unmarshal(data, &result)
+	result, err := m.NodeInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, server)
 }

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -214,6 +214,7 @@ func (s *nodeManagerSuite) TestSetGetNodeInfoSuccess(c *gc.C) {
 	infoFile := path.Join(dataDir, "info.yaml")
 
 	// Write an info.yaml file into the Dqlite data directory.
+	// We'll update it with a different address.
 	data := []byte(`
 Address: 127.0.0.1:17666
 ID: 3297041220608546238
@@ -230,9 +231,6 @@ Role: 0
 	}
 
 	err = m.SetNodeInfo(server)
-	c.Assert(err, jc.ErrorIsNil)
-
-	data, err = os.ReadFile(infoFile)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// info.yaml should reflect the new node info.

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -9,7 +9,7 @@ wait_for_controller_machines() {
 		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))
 
-		# Wait for roughly 16 minutes for a enable-ha. In the field it's know
+		# Wait for roughly 16 minutes for a enable-ha. In the field it's known
 		# that enable-ha can take this long.
 		if [[ ${attempt} -gt 200 ]]; then
 			echo "enable-ha failed waiting for machines to start"

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -360,6 +360,20 @@ func (mr *MockNodeManagerMockRecorder) SetClusterServers(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterServers", reflect.TypeOf((*MockNodeManager)(nil).SetClusterServers), arg0, arg1)
 }
 
+// SetClusterToLocalNode mocks base method.
+func (m *MockNodeManager) SetClusterToLocalNode(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetClusterToLocalNode", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetClusterToLocalNode indicates an expected call of SetClusterToLocalNode.
+func (mr *MockNodeManagerMockRecorder) SetClusterToLocalNode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterToLocalNode", reflect.TypeOf((*MockNodeManager)(nil).SetClusterToLocalNode), arg0)
+}
+
 // SetNodeInfo mocks base method.
 func (m *MockNodeManager) SetNodeInfo(arg0 dqlite.NodeInfo) error {
 	m.ctrl.T.Helper()

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -668,6 +668,8 @@ func (w *dbWorker) bindAddrFromServerDetails(apiDetails apiserver.Details) (stri
 // reinitialised either directly or by bouncing the agent reasonably
 // soon after calling this method.
 func (w *dbWorker) shutdownDqlite(ctx context.Context, handover bool) {
+	w.cfg.Logger.Infof("shutting down Dqlite node")
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -683,6 +685,8 @@ func (w *dbWorker) shutdownDqlite(ctx context.Context, handover bool) {
 		if err := w.dbApp.Handover(ctx); err != nil {
 			w.cfg.Logger.Errorf("handing off Dqlite responsibilities: %v", err)
 		}
+	} else {
+		w.cfg.Logger.Infof("skipping Dqlite handover")
 	}
 
 	if err := w.dbApp.Close(); err != nil {


### PR DESCRIPTION
It has been observed in our integration tests for HA, that going from HA-n to HA-1 causes the Dqlite cluster to become non-functional. This does not happen when going to HA-2.

This is due to the single node (still in a cluster of n) being unable to get quorum and agree on the leader of the cluster. At this point we go into a spiral, unable to take remedial steps.

This patch adds a back-stop to the worker logic such that we will reconfigure the cluster to be constituted by only the local node in the event that:
- we are an existing, previously clustered node,
- Dqlite itself failed to become ready and;
- we received API server details over pub/sub that indicate us as the only controller.

## QA steps

- Bootstrap and `enable-ha`.
- Once up, verify on a controller that _/var/lib/juju/dqlite/cluster.yaml_ shows 3 nodes with role 0 (voter). This may take more time than it takes for HA completeness to be indicated by status.
- Remove two of the machines.
- After some time the logs for `dbaccessor` will include entries along the lines of:
```
2023-07-20 10:25:34 DEBUG juju.worker.dbaccessor worker.go:525 new API server details: apiserver.Details{Servers:map[string]apiserver.APIServer{"0":apiserver.APIServer{ID:"0", Addresses:[]string{"10.246.27.34:17070
"}, InternalAddress:"10.246.27.34:17070"}}, LocalOnly:true}
2023-07-20 10:25:34 WARNING juju.worker.dbaccessor worker.go:588 reconfiguring Dqlite cluster with this node as the only member
2023-07-20 10:25:34 INFO juju.worker.dbaccessor worker.go:593 successfully reconfigured Dqlite; restarting worker
2023-07-20 10:25:34 INFO juju.worker.dbaccessor worker.go:709 shutting down Dqlite node
2023-07-20 10:25:34 INFO juju.worker.dbaccessor worker.go:369 host is configured as a Dqlite node
2023-07-20 10:25:34 DEBUG juju.worker.dbaccessor app.go:727 new connection from 10.246.27.34:44592
2023-07-20 10:25:35 DEBUG juju.worker.dbaccessor connector.go:77 attempt 1: server 10.246.27.34:17666: connected
2023-07-20 10:25:35 DEBUG juju.worker.dbaccessor app.go:727 new connection from 10.246.27.34:44596
2023-07-20 10:25:35 INFO juju.worker.dbaccessor worker.go:445 initialized Dqlite application (ID: 3297041220608546238)
2023-07-20 10:25:35 INFO juju.worker.dbaccessor worker.go:449 current cluster: []protocol.NodeInfo{protocol.NodeInfo{ID:0x2dc171858c3155be, Address:"10.246.27.34:17666", Role:0}}
```
- Juju status will indicate a single healthy controller.
- Check that _/var/lib/juju/dqlite/cluster.yaml_ on that controller indicates a single node.
- Check that HA can be re-established via `enable-ha`.
