### PR TITLE
Make Maintenance (us busy) higher-priority than Waiting (them busy)

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -373,8 +373,8 @@ func DeriveStatus(statuses []StatusInfo) StatusInfo {
 var statusSeverities = map[Status]int{
 	Error:       100,
 	Blocked:     90,
-	Waiting:     80,
-	Maintenance: 70,
+	Maintenance: 80, // Maintenance (us busy) is higher than Waiting (someone else busy)
+	Waiting:     70,
 	Active:      60,
 	Terminated:  50,
 	Unknown:     40,

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -124,7 +124,7 @@ func (s *StatusSuite) TestDerivedStatusBringsAllDetails(c *gc.C) {
 func (s *StatusSuite) TestDerivedStatusPriority(c *gc.C) {
 	for _, t := range []struct{ status1, status2, expected status.Status }{
 		{status.Active, status.Waiting, status.Waiting},
-		{status.Maintenance, status.Waiting, status.Waiting},
+		{status.Maintenance, status.Waiting, status.Maintenance},
 		{status.Active, status.Blocked, status.Blocked},
 		{status.Waiting, status.Blocked, status.Blocked},
 		{status.Maintenance, status.Blocked, status.Blocked},


### PR DESCRIPTION
Per @jameinel's [suggestion on Mattermost](https://chat.charmhub.io/charmhub/pl/59gsuisc6jdi9mxnhej7pethjr), we should prioritize Maintenance (which means "we're busy") above Waiting ("someone else is busy").

> I highly doubt that anyone has code that uses the fact that Maintenance is lower priority than Waiting to make a decision out in the wild.

See also: https://github.com/canonical/operator/pull/954#discussion_r1265424670
