### PR TITLE
Wait for the MODEL not the APPLICATION

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -64,7 +64,7 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for application controller
+          juju wait-for model controller
 
         # TODO: create backup and juju restore
 
@@ -159,7 +159,7 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for application controller
+          juju wait-for model controller
 
         # TODO: create backup and juju restore
 


### PR DESCRIPTION
The following waits for the model and not the application when trying to see if the controller is around.


## QA steps

Migration github action should pass.

