### PR TITLE
[JUJU-4277] Throw an error in potential Dqlite backstop scenarios when conditions not met

### DIFF
--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -567,31 +567,30 @@ func (w *dbWorker) processAPIServerChange(apiDetails apiserver.Details) error {
 			return dependency.ErrBounce
 		}
 
-		// If we are an existing, previously clustered node, but the node is
-		// not running, check if we're the only API server.
-		// If we are, then we have gone from HA-n to HA-1 and have a broken
-		// cluster. Attempt to reconfigure the cluster with just ourselves
-		// as a member.
+		// If we are an existing, previously clustered node,
+		// and the node is running, we have nothing to do.
 		w.mu.RLock()
 		running := w.dbApp != nil
 		w.mu.RUnlock()
-
-		if serverCount > 1 || running {
+		if running {
 			return nil
 		}
 
-		// Be super careful and check that the sole node is actually us.
-		if _, ok := apiDetails.Servers[w.cfg.ControllerID]; !ok {
-			return errors.Errorf("unable to reconcile current controller and Dqlite cluster status")
+		// Make absolutely sure. We only reconfigure the cluster if the details
+		// indicate exactly one controller machine, and that machine is us.
+		if _, ok := apiDetails.Servers[w.cfg.ControllerID]; ok && serverCount == 1 {
+			log.Warningf("reconfiguring Dqlite cluster with this node as the only member")
+			if err := w.cfg.NodeManager.SetClusterToLocalNode(ctx); err != nil {
+				return errors.Annotatef(err, "reconfiguring Dqlite cluster")
+			}
+
+			log.Infof("successfully reconfigured Dqlite; restarting worker")
+			return dependency.ErrBounce
 		}
 
-		log.Warningf("reconfiguring Dqlite cluster with this node as the only member")
-		if err := w.cfg.NodeManager.SetClusterToLocalNode(ctx); err != nil {
-			return errors.Annotatef(err, "reconfiguring Dqlite cluster")
-		}
-
-		log.Infof("successfully reconfigured Dqlite; restarting worker")
-		return dependency.ErrBounce
+		// Otherwise there is no deterministic course of action.
+		// Play it safe and throw out.
+		return errors.Errorf("unable to reconcile current controller and Dqlite cluster status")
 	}
 
 	// Otherwise this is a node added by enabling HA,

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -29,7 +29,7 @@ type workerSuite struct {
 
 var _ = gc.Suite(&workerSuite{})
 
-func (s *workerSuite) TestStartupTimeoutSingleServerReconfigure(c *gc.C) {
+func (s *workerSuite) TestStartupTimeoutSingleControllerReconfigure(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectAnyLogs()
@@ -38,8 +38,8 @@ func (s *workerSuite) TestStartupTimeoutSingleServerReconfigure(c *gc.C) {
 
 	mgrExp := s.nodeManager.EXPECT()
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
-	mgrExp.IsExistingNode().Return(true, nil).Times(3)
-	mgrExp.IsBootstrappedNode(gomock.Any()).Return(false, nil).Times(4)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsBootstrappedNode(gomock.Any()).Return(false, nil).Times(3)
 	mgrExp.WithTLSOption().Return(nil, nil)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -57,7 +57,48 @@ func (s *workerSuite) TestStartupTimeoutSingleServerReconfigure(c *gc.C) {
 	w := s.newWorker(c)
 	defer w.Kill()
 
-	// If there are multiple servers reported, we do nothing.
+	// Topology is just us. We should reconfigure the node and shut down.
+	select {
+	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{"0": {ID: "0", InternalAddress: "10.6.6.6:1234"}},
+	}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	err := workertest.CheckKilled(c, w)
+	c.Assert(errors.Is(err, dependency.ErrBounce), jc.IsTrue)
+}
+
+func (s *workerSuite) TestStartupTimeoutMultipleControllerError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+	s.expectTrackedDBKill()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsBootstrappedNode(gomock.Any()).Return(false, nil).Times(3)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	// App gets started, we time out waiting, then we close it.
+	appExp := s.dbApp.EXPECT()
+	appExp.Ready(gomock.Any()).Return(context.DeadlineExceeded)
+	appExp.Close().Return(nil)
+
+	// We expect to request API details.
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+	s.hub.EXPECT().Publish(apiserver.DetailsRequestTopic, gomock.Any()).Return(func() {}, nil)
+
+	w := s.newWorker(c)
+	defer w.Kill()
+
+	// If there are multiple servers reported, we can't reason about our
+	// current state in a discrete fashion. The worker throws an error.
 	select {
 	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
 		Servers: map[string]apiserver.APIServer{
@@ -69,21 +110,8 @@ func (s *workerSuite) TestStartupTimeoutSingleServerReconfigure(c *gc.C) {
 		c.Fatal("timed out waiting for cluster change to be processed")
 	}
 
-	workertest.CheckAlive(c, w)
-
-	// Now it's just us. We should reconfigure the node and shut down.
-	select {
-	case w.(*dbWorker).apiServerChanges <- apiserver.Details{
-		Servers: map[string]apiserver.APIServer{
-			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
-		},
-	}:
-	case <-time.After(testing.LongWait):
-		c.Fatal("timed out waiting for cluster change to be processed")
-	}
-
 	err := workertest.CheckKilled(c, w)
-	c.Assert(errors.Is(err, dependency.ErrBounce), jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "unable to reconcile current controller and Dqlite cluster status")
 }
 
 func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {


### PR DESCRIPTION
This is a follow up to #15959.

One of the flows through that logic is as follows:
- Dqlite fails to become ready within the set time-out.
- We request API server details.
- Server details are published with more than one controller.
- Since we are not the only controller, we do not reconfigure Dqlite, and keep waiting.

This is undesirable, as it makes possible a situation where the worker is waiting for a specific message that may not come.

Here, we change the behaviour of the final step to be worker exit with an error. If running in a dependency engine, it simply means this worker will be restarted, and will reassess its state from scratch.

## QA steps

Same as for #15959.
