### PR TITLE
[JUJU-4306] Fix migration check

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -64,21 +64,21 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for model controller
+          juju wait-for application controller
 
         # TODO: create backup and juju restore
 
       - name: Migrate default model to 3.x controller
         run: |
           /snap/bin/juju switch test29
-          
+
           # Ensure application is fully deployed
           /snap/bin/juju wait-for application ubuntu
           
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
-          
+
           /snap/bin/juju version
           /snap/bin/juju migrate test-migrate test3x
 
@@ -138,7 +138,7 @@ jobs:
           /snap/bin/juju bootstrap lxd test29
           /snap/bin/juju add-model test-migrate
           /snap/bin/juju deploy ubuntu
-          
+
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
 
@@ -159,7 +159,7 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for model controller
+          juju wait-for application controller
 
         # TODO: create backup and juju restore
 
@@ -171,7 +171,7 @@ jobs:
           # We have to use the old client to speak to the new controller, as
           # this is blocked otherwise.
           /snap/bin/juju wait-for application ubuntu
-          
+
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -64,7 +64,7 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for application controller
+          juju wait-for model controller
 
         # TODO: create backup and juju restore
 
@@ -159,7 +159,7 @@ jobs:
           juju version
           juju bootstrap lxd test3x
           juju switch controller
-          juju wait-for application controller
+          juju wait-for model controller
 
         # TODO: create backup and juju restore
 

--- a/cmd/juju/waitfor/application_test.go
+++ b/cmd/juju/waitfor/application_test.go
@@ -73,3 +73,59 @@ func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*"bad" on ApplicationInfo.*`)
 	c.Assert(result, gc.IsNil)
 }
+
+func (s *applicationScopeSuite) TestDeriveApplicationStatus(c *gc.C) {
+	tests := []struct {
+		status   status.Status
+		units    map[string]*params.UnitInfo
+		expected string
+	}{{
+		status:   status.Unset,
+		units:    nil,
+		expected: "unknown",
+	}, {
+		status: status.Unset,
+		units: map[string]*params.UnitInfo{
+			"foo": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+		},
+		expected: "active",
+	}, {
+		status: status.Unset,
+		units: map[string]*params.UnitInfo{
+			"foo1": {WorkloadStatus: params.StatusInfo{Current: status.Error}},
+			"foo2": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+			"foo3": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+		},
+		expected: "error",
+	}, {
+		status: status.Unset,
+		units: map[string]*params.UnitInfo{
+			"foo1": {WorkloadStatus: params.StatusInfo{Current: status.Terminated}},
+			"foo2": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+			"foo3": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+		},
+		expected: "active",
+	}, {
+		status:   status.Unknown,
+		units:    nil,
+		expected: "unknown",
+	}, {
+		status: status.Error,
+		units: map[string]*params.UnitInfo{
+			"foo": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+		},
+		expected: "error",
+	}, {
+		status: status.Active,
+		units: map[string]*params.UnitInfo{
+			"foo1": {WorkloadStatus: params.StatusInfo{Current: status.Error}},
+			"foo2": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+			"foo3": {WorkloadStatus: params.StatusInfo{Current: status.Active}},
+		},
+		expected: "active",
+	}}
+	for _, test := range tests {
+		status := deriveApplicationStatus(test.status, test.units)
+		c.Check(status.String(), gc.Equals, test.expected)
+	}
+}

--- a/cmd/juju/waitfor/model.go
+++ b/cmd/juju/waitfor/model.go
@@ -311,11 +311,8 @@ func (m ModelScope) GetIdentValue(name string) (query.Box, error) {
 				}
 			}
 
-			currentStatus := app.Status.Current
-			newStatus := deriveApplicationStatus(currentStatus, units)
-
 			appInfo := app
-			appInfo.Status.Current = newStatus
+			appInfo.Status.Current = deriveApplicationStatus(appInfo.Status.Current, units)
 
 			scopes[k] = MakeApplicationScope(m.ctx.Child(name, app.Name), appInfo, units, machines)
 		}


### PR DESCRIPTION
The following resets the app info status to the prior value once
the query has run. This is because the order of the deltas is not
guaranteed. Prior to this change we would only ever run the query
if the application had changed, not if the units had changed.

In workflows that don't chain the wait-for commands together and
after the application was created then you would get the
following (see below) where the appInfo would be somewhat near the
end of the deltas messages we received:

 - unitInfo
 - unitInfo
 - machineInfo
 - machineInfo
 - appInfo

If you attempt to do this before the application is created, then
the ordering is different, as one would expect:

 - appInfo
 - unitInfo
 - machineInfo
 - unitInfo
 - machineInfo

The problem here is that the status of the appInfo was overridden
from `unset` to the derived status of the unit's status. The
fix, for now, is to put the value back after each run request. This
then allows us to monitor the unset along with the status if it is
set.

The question is, why now? Why did this break now? It's clear that
a race was occurring, between the wait-for and the application being
registered. Either something has got slower or something has got
faster. The problem was that the wait-for wasn't robust enough to
manage the out-of-order appInfo. We now don't care if it is.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

It's important that you switch and wait for the controller application before
the application is created, otherwise this won't trigger the failure.

```sh
$ make juju && juju bootstrap lxd test --build-agent && juju switch controller && juju wait-for application controller
```

The migration tests should now pass.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2028328
