### PR TITLE
[JUJU-4242] Subsitute juju-qa-test charm for postrgesql in charmhub test

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,11 +6,11 @@ run_charmhub_download() {
 
 	ensure "${name}" "${file}"
 
-	output=$(juju download postgresql --base ubuntu@20.04 --filepath="${TEST_DIR}/postgresql.charm" 2>&1 || true)
-	check_contains "${output}" 'Fetching charm "postgresql"'
+	output=$(juju download juju-qa-test --filepath="${TEST_DIR}/juju-qa-test.charm" 2>&1 || true)
+	check_contains "${output}" 'Fetching charm "juju-qa-test"'
 
-	juju deploy "${TEST_DIR}/postgresql.charm" postgresql
-	juju wait-for application --timeout=15m postgresql
+	juju deploy "${TEST_DIR}/juju-qa-test.charm" juju-qa-test
+	juju wait-for application --timeout=15m juju-qa-test
 
 	destroy_model "${name}"
 }


### PR DESCRIPTION
Postgresql was taking a very long time to become active leading to false negatives due to timeouts

Switch out for a more consistant juju controlled test charm

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v charmhub test_charmhub_download
```