### PR TITLE
[JUJU-4099] Enforce single active upgrade

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -376,6 +376,9 @@ CREATE TABLE upgrade_info (
     completed_at     TIMESTAMP
 );
 
+-- A unique constraint over a contant index ensures only 1 entry matching the condition can exist
+CREATE UNIQUE INDEX idx_singleton_active_upgrade ON upgrade_info ((1)) WHERE completed_at IS NULL;
+
 CREATE TABLE upgrade_info_controller_node (
     uuid                      TEXT PRIMARY KEY,
     controller_node_id        TEXT NOT NULL,

--- a/domain/upgrade/service/package_mock_test.go
+++ b/domain/upgrade/service/package_mock_test.go
@@ -35,19 +35,19 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// ActiveUpgrades mocks base method.
-func (m *MockState) ActiveUpgrades(arg0 context.Context) ([]string, error) {
+// ActiveUpgrade mocks base method.
+func (m *MockState) ActiveUpgrade(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActiveUpgrades", arg0)
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "ActiveUpgrade", arg0)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ActiveUpgrades indicates an expected call of ActiveUpgrades.
-func (mr *MockStateMockRecorder) ActiveUpgrades(arg0 interface{}) *gomock.Call {
+// ActiveUpgrade indicates an expected call of ActiveUpgrade.
+func (mr *MockStateMockRecorder) ActiveUpgrade(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveUpgrades", reflect.TypeOf((*MockState)(nil).ActiveUpgrades), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveUpgrade", reflect.TypeOf((*MockState)(nil).ActiveUpgrade), arg0)
 }
 
 // AllProvisionedControllersReady mocks base method.


### PR DESCRIPTION
It doesn't really make sense to have multiple upgrades running at a same time. So we may as well explictly enforce this to simplify other operations (particularly the yet-to-be-implemented watcher)

This meant changing the ActiveUpgrades to ActiveUpgrade, and changing it's signature to return a single string, erroring with "NotFound" if none exist

CreateUpgrade now checks if an upgrade exists before inserting a new one

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure unit tests pass

```sh
go test github.com/juju/juju/domain/upgrade/...
```