### PR TITLE
[JUJU-4308] Injects ctrlConfigService in apiserver worker

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -612,6 +612,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Presence:                          config.PresenceRecorder,
 			NewWorker:                         apiserver.NewWorker,
 			NewMetricsCollector:               apiserver.NewMetricsCollector,
+			NewControllerConfigService:        apiserver.NewControllerConfigService,
 		}),
 
 		charmhubHTTPClientName: dependency.Manifold{

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -4,12 +4,14 @@
 package apiserver
 
 import (
+	stdcontext "context"
 	"net/http"
 	"strings"
 
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -20,12 +22,16 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/authentication/macaroon"
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/domain"
+	ccservice "github.com/juju/juju/domain/controllerconfig/service"
+	ccstate "github.com/juju/juju/domain/controllerconfig/state"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/gate"
@@ -55,8 +61,9 @@ type ManifoldConfig struct {
 	Hub                               *pubsub.StructuredHub
 	Presence                          presence.Recorder
 
-	NewWorker           func(Config) (worker.Worker, error)
-	NewMetricsCollector func() *apiserver.Collector
+	NewWorker                  func(Config) (worker.Worker, error)
+	NewMetricsCollector        func() *apiserver.Collector
+	NewControllerConfigService func(changestream.WatchableDBGetter, Logger) ControllerConfigGetter
 }
 
 // Validate validates the manifold configuration.
@@ -117,6 +124,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.NewMetricsCollector == nil {
 		return errors.NotValidf("nil NewMetricsCollector")
+	}
+	if config.NewControllerConfigService == nil {
+		return errors.NotValidf("nil NewControllerConfigService")
 	}
 	return nil
 }
@@ -234,6 +244,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
+	ctrlConfigService := config.NewControllerConfigService(dbGetter, loggo.GetLogger("juju.apiserver"))
+
+	controllerConfig, err := ctrlConfigService.ControllerConfig(stdcontext.Background())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	w, err := config.NewWorker(Config{
 		AgentConfig:                       agent.CurrentConfig(),
 		Clock:                             clock,
@@ -252,6 +269,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		EmbeddedCommand:                   execEmbeddedCommand,
 		SysLogger:                         sysLogger,
 		CharmhubHTTPClient:                charmhubHTTPClient,
+		ControllerConfig:                  controllerConfig,
 		DBGetter:                          dbGetter,
 		DBDeleter:                         dbDeleter,
 	})
@@ -272,4 +290,31 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		_ = stTracker.Done()
 		_ = config.PrometheusRegisterer.Unregister(metricsCollector)
 	}), nil
+}
+
+// ControllerConfigGetter is an interface that provides the controller
+// configuration.
+type ControllerConfigGetter interface {
+	ControllerConfig(context stdcontext.Context) (controller.Config, error)
+}
+
+// Logger defines the logging methods used by the worker.
+type Logger interface {
+	Debugf(string, ...interface{})
+}
+
+// NewControllerConfigService returns a new ControllerConfigService.
+func NewControllerConfigService(dbGetter changestream.WatchableDBGetter, logger Logger) ControllerConfigGetter {
+	return ccservice.NewService(
+		ccstate.NewState(coredatabase.NewTxnRunnerFactoryForNamespace(
+			dbGetter.GetWatchableDB,
+			coredatabase.ControllerNS,
+		)),
+		domain.NewWatcherFactory(
+			func() (changestream.WatchableDB, error) {
+				return dbGetter.GetWatchableDB(coredatabase.ControllerNS)
+			},
+			logger,
+		),
+	)
 }

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
@@ -371,6 +372,15 @@ type fakeMultiwatcherFactory struct {
 	multiwatcher.Factory
 }
 
+type stubWatchableDB struct {
+	changestream.EventSource
+	database.TxnRunner
+}
+
+type stubWatchableDBGetter struct {
+	db stubWatchableDB
+}
+
 type stubDBDeleter struct{}
 
 func (s stubDBDeleter) DeleteDB(namespace string) error {
@@ -380,11 +390,9 @@ func (s stubDBDeleter) DeleteDB(namespace string) error {
 	return nil
 }
 
-type stubWatchableDBGetter struct{}
-
 func (s stubWatchableDBGetter) GetWatchableDB(namespace string) (changestream.WatchableDB, error) {
 	if namespace != "controller" {
 		return nil, errors.Errorf(`expected a request for "controller" DB; got %q`, namespace)
 	}
-	return nil, nil
+	return s.db, nil
 }

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -18,16 +18,18 @@ import (
 	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
+	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/apiserver"
 	"github.com/juju/juju/worker/syslogger"
 )
 
 type workerFixture struct {
-	testing.IsolationSuite
+	schematesting.ControllerSuite
 	agentConfig          mockAgentConfig
 	authenticator        *mockAuthenticator
 	clock                *testclock.Clock
@@ -41,12 +43,12 @@ type workerFixture struct {
 	multiwatcherFactory  multiwatcher.Factory
 	sysLogger            syslogger.SysLogger
 	charmhubHTTPClient   *http.Client
-	dbGetter             stubWatchableDBGetter
+	dbGetter             changestream.WatchableDBGetter
 	dbDeleter            stubDBDeleter
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
+	s.ControllerSuite.SetUpTest(c)
 
 	s.agentConfig = mockAgentConfig{
 		dataDir: c.MkDir(),
@@ -65,6 +67,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.sysLogger = &mockSysLogger{}
 	s.charmhubHTTPClient = &http.Client{}
 	s.stub.ResetCalls()
+	s.dbGetter = stubWatchableDBGetter{db: stubWatchableDB{TxnRunner: s.TxnRunner()}}
 
 	s.config = apiserver.Config{
 		AgentConfig:                       &s.agentConfig,


### PR DESCRIPTION
This PR injects ctrlConfigService in apiserver worker.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing

## QA steps

```sh
 go test github.com/juju/juju/worker/apiserver/... -gocheck.v
```
