### PR TITLE
Revert early unlock of mutex when starting DB tracker workers

### DIFF
--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -472,9 +472,8 @@ func (w *dbWorker) openDatabase(namespace string) error {
 	// multiple times for the same namespace.
 	err := w.dbRunner.StartWorker(namespace, func() (worker.Worker, error) {
 		w.mu.RLock()
-		running := w.dbApp != nil
-		w.mu.RUnlock()
-		if !running {
+		defer w.mu.RUnlock()
+		if w.dbApp == nil {
 			// If the dbApp is nil, then we're either shutting down or
 			// rebinding the address. In either case, we don't want to
 			// start a new worker. We'll return ErrTryAgain to indicate


### PR DESCRIPTION
This reverts a prior change that unlocked the `dbaccessor` worker mutex protecting the Dqlite `App` early.

The lock needs to be held for the duration of the method, not just the check for nil, because the app is used later to open the specified database.

## QA steps

Tests for the `dbaccessor` worker now pass with `-race`.
