### PR TITLE
[JUJU-4321] Remove apiserver restart pubsub message

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -11,14 +11,12 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/worker/v3/dependency"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
 	apitesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	psapiserver "github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/testing"
 )
 
@@ -30,20 +28,6 @@ var _ = gc.Suite(&apiserverSuite{})
 
 func (s *apiserverSuite) TestCleanStop(c *gc.C) {
 	workertest.CleanKill(c, s.Server)
-}
-
-func (s *apiserverSuite) TestRestartMessage(c *gc.C) {
-	hub := apiserver.CentralHub(s.Server)
-	_, err := hub.Publish(psapiserver.RestartTopic, psapiserver.Restart{
-		LocalOnly: true,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = workertest.CheckKilled(c, s.Server)
-	c.Assert(err, gc.ErrorMatches, "restart immediately")
-
-	err = workertest.CheckKilled(c, s.Server)
-	c.Assert(err, gc.Equals, dependency.ErrBounce)
-	s.Server = nil
 }
 
 func (s *apiserverSuite) getHealth(c *gc.C) (string, int) {

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -91,10 +91,6 @@ type PresenceResponse struct {
 // topics.
 type OriginTarget common.OriginTarget
 
-// RestartTopic is used by the API server to listen for events that should
-// cause the API server to be bounced.
-const RestartTopic = "apiserver.restart"
-
 // Restart message only contains the local-only indicator as the restart
 // is only ever for the same agent.
 type Restart common.LocalOnly


### PR DESCRIPTION
There is no code that causes the apiserver to force restart, so we should just remove the code. This is the start of the work to remove apiserver pubsub inter-remote communication. We no longer need this communication since raft leases was removed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju enable-ha
```
