### PR TITLE
Pass in the controller config into set api host ports

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -534,7 +534,12 @@ func initAPIHostPorts(st *state.State, pAddrs corenetwork.ProviderAddresses, api
 		return errors.Trace(err)
 	}
 	hostPorts := corenetwork.SpaceAddressesWithPort(addrs, apiPort)
-	return st.SetAPIHostPorts([]corenetwork.SpaceHostPorts{hostPorts})
+
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return st.SetAPIHostPorts([]corenetwork.SpaceHostPorts{hostPorts}, controllerConfig)
 }
 
 // machineJobFromParams returns the job corresponding to model.MachineJob.

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -288,8 +288,11 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*gotHW, gc.DeepEquals, expectHW)
 
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Check that the API host ports are initialised correctly.
-	apiHostPorts, err := st.APIHostPortsForClients()
+	apiHostPorts, err := st.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
 		corenetwork.SpaceAddressesWithPort(filteredAddrs, 1234),

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/api/client/usermanager"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -75,7 +76,7 @@ func (s *stateSuite) TestAPIHostPortsAlwaysIncludesTheConnection(c *gc.C) {
 	// We intentionally set this to invalid values
 	badServers := network.NewSpaceHostPorts(1234, "0.1.2.3")
 	badServers[0].Scope = network.ScopeMachineLocal
-	err := s.ControllerModel(c).State().SetAPIHostPorts([]network.SpaceHostPorts{badServers})
+	err := s.ControllerModel(c).State().SetAPIHostPorts([]network.SpaceHostPorts{badServers}, controller.Config{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	conn2 := s.openAPI(c)
@@ -276,7 +277,12 @@ func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {
 			},
 		},
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(current)
+
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(current, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	conn2 := s.OpenControllerAPI(c)

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -14,7 +15,7 @@ import (
 // APIAddressAccessor describes methods that allow agents to maintain
 // up-to-date information on how to connect to the Juju API server.
 type APIAddressAccessor interface {
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
 }
 
@@ -37,8 +38,8 @@ func NewAPIAddresser(getter APIAddressAccessor, resources facade.Resources) *API
 }
 
 // APIHostPorts returns the API server addresses.
-func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
-	sSvrs, err := a.getter.APIHostPortsForAgents()
+func (a *APIAddresser) APIHostPorts(controllerConfig controller.Config) (params.APIHostPortsResult, error) {
+	sSvrs, err := a.getter.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return params.APIHostPortsResult{}, err
 	}
@@ -66,8 +67,8 @@ func (a *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
-	addrs, err := apiAddresses(a.getter)
+func (a *APIAddresser) APIAddresses(controllerConfig controller.Config) (params.StringsResult, error) {
+	addrs, err := apiAddresses(a.getter, controllerConfig)
 	if err != nil {
 		return params.StringsResult{}, err
 	}
@@ -76,8 +77,8 @@ func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
 	}, nil
 }
 
-func apiAddresses(getter APIHostPortsForAgentsGetter) ([]string, error) {
-	apiHostPorts, err := getter.APIHostPortsForAgents()
+func apiAddresses(getter APIHostPortsForAgentsGetter, controllerConfig controller.Config) ([]string, error) {
+	apiHostPorts, err := getter.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -35,7 +35,7 @@ func (s *apiAddresserSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *apiAddresserSuite) TestAPIAddresses(c *gc.C) {
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(controller.Config{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Result, gc.DeepEquals, []string{"apiaddresses:1", "apiaddresses:2"})
 }
@@ -59,7 +59,7 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 		}
 	}
 
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(controller.Config{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Result, gc.DeepEquals, []string{
@@ -82,7 +82,7 @@ func (fakeAddresses) ControllerConfig() (controller.Config, error) {
 	return coretesting.FakeControllerConfig(), nil
 }
 
-func (f fakeAddresses) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (f fakeAddresses) APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error) {
 	return f.hostPorts, nil
 }
 

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -135,11 +135,11 @@ func (s *ControllerConfigAPI) getModelControllerInfo(ctx context.Context, model 
 
 // StateControllerInfo returns the local controller details for the given State.
 func StateControllerInfo(st controllerInfoState) (addrs []string, caCert string, _ error) {
-	addr, err := apiAddresses(st)
+	controllerConfig, err := st.ControllerConfig()
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	controllerConfig, err := st.ControllerConfig()
+	addr, err := apiAddresses(st, controllerConfig)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -138,11 +138,11 @@ type ControllerConfigState interface {
 
 	ModelExists(string) (bool, error)
 	NewExternalControllers() state.ExternalControllers
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	CompletedMigrationForModel(string) (state.ModelMigration, error)
 }
 
 type controllerInfoState interface {
 	ControllerConfig() (controller.Config, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -42,7 +42,7 @@ type APIHostPortsForAgentsGetter interface {
 	// APIHostPortsForAgents returns the HostPorts for each API server that
 	// are suitable for agent-to-controller API communication based on the
 	// configured (if any) controller management space.
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }
 
 // ToolsStorageGetter is an interface providing the ToolsStorage method.

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -126,3 +126,26 @@ func getAllUnits(st *state.State, tag names.Tag) ([]string, error) {
 	}
 	return nil, fmt.Errorf("cannot obtain units of machine %q: %v", tag, watch.Err())
 }
+
+// APIHostPorts returns the API server addresses.
+func (d *DeployerAPI) APIHostPorts() (params.APIHostPortsResult, error) {
+	controllerConfig, err := d.st.ControllerConfig()
+	if err != nil {
+		return params.APIHostPortsResult{}, err
+	}
+	return d.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// WatchAPIHostPorts watches the API server addresses.
+func (d *DeployerAPI) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
+	return d.APIAddresser.WatchAPIHostPorts()
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (d *DeployerAPI) APIAddresses() (params.StringsResult, error) {
+	controllerConfig, err := d.st.ControllerConfig()
+	if err != nil {
+		return params.StringsResult{}, err
+	}
+	return d.APIAddresser.APIAddresses(controllerConfig)
+}

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -327,7 +327,10 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
-	err := s.machine0.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopePublic)),
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine0.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopePublic)),
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -335,7 +338,7 @@ func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
 	hostPorts := network.NewSpaceHostPorts(1234, "0.1.2.3", "1.2.3.4")
 	hostPorts[1].Scope = network.ScopeCloudLocal
 
-	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts})
+	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts}, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.DeployerConnectionValues{

--- a/apiserver/facades/client/machinemanager/instanceconfig.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig.go
@@ -82,7 +82,7 @@ func InstanceConfig(ctrlSt ControllerBackend, st InstanceConfigBackend, machineI
 	caCert, _ := controllerConfig.CACert()
 
 	// Get the API connection info; attempt all API addresses.
-	apiHostPorts, err := ctrlSt.APIHostPortsForAgents()
+	apiHostPorts, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting API addresses")
 	}

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -54,7 +54,7 @@ type BackendState interface {
 type ControllerBackend interface {
 	ControllerTag() names.ControllerTag
 	ControllerConfig() (controller.Config, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }
 
 type Pool interface {

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -979,7 +979,7 @@ type migrationBackend interface {
 // migrationBackend defines controller State functionality required by the
 // migration watchers.
 type controllerBackend interface {
-	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
+	APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error)
 	ControllerConfig() (controller.Config, error)
 }
 
@@ -1066,7 +1066,12 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 }
 
 func (w *srvMigrationStatusWatcher) getLocalHostPorts() ([]string, error) {
-	hostports, err := w.ctrlSt.APIHostPortsForClients()
+	controllerConfig, err := w.ctrlSt.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	hostports, err := w.ctrlSt.APIHostPortsForClients(controllerConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -186,7 +186,7 @@ func (b *fakeMigrationBackend) LatestMigration() (state.ModelMigration, error) {
 	return new(fakeModelMigration), nil
 }
 
-func (b *fakeMigrationBackend) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (b *fakeMigrationBackend) APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{
 		{
 			network.SpaceHostPort{SpaceAddress: network.NewSpaceAddress("1.2.3.4"), NetPort: 5},

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -256,7 +256,11 @@ func (s *ApiServerSuite) setupControllerModel(c *gc.C, controllerCfg controller.
 	}}
 	st, err := ctrl.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.SetAPIHostPorts(sHsPs)
+
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(sHsPs, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.controllerModelUUID = st.ControllerModelUUID()

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -441,7 +441,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 		sHsPs[i] = sHPs
 	}
 
-	err = s.State.SetAPIHostPorts(sHsPs)
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.SetAPIHostPorts(sHsPs, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Make sure the controller store has the controller api endpoint address set

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -28,7 +28,11 @@ func AddControllerMachine(c *gc.C, st *state.State) *state.Machine {
 	c.Assert(err, jc.ErrorIsNil)
 
 	hostPorts := []network.SpaceHostPorts{network.NewSpaceHostPorts(1234, "0.1.2.3")}
-	err = st.SetAPIHostPorts(hostPorts)
+
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(hostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return machine

--- a/state/address.go
+++ b/state/address.go
@@ -15,6 +15,7 @@ import (
 	jujutxn "github.com/juju/txn/v3"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo"
 )
@@ -37,7 +38,7 @@ type apiHostPortsDoc struct {
 //     to the controller management space configuration.
 //
 // Each server is represented by one element in the top level slice.
-func (st *State) SetAPIHostPorts(newHostPorts []network.SpaceHostPorts) error {
+func (st *State) SetAPIHostPorts(newHostPorts []network.SpaceHostPorts, controllerConfig controller.Config) error {
 	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 
@@ -47,7 +48,7 @@ func (st *State) SetAPIHostPorts(newHostPorts []network.SpaceHostPorts) error {
 			return nil, errors.Trace(err)
 		}
 
-		newHostPortsForAgents, err := st.filterHostPortsForManagementSpace(newHostPorts)
+		newHostPortsForAgents, err := st.filterHostPortsForManagementSpace(newHostPorts, controllerConfig)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -117,14 +118,10 @@ func (st *State) getOpsForHostPortsChange(
 // want to cut off communication to the controller based on erroneous config.
 func (st *State) filterHostPortsForManagementSpace(
 	apiHostPorts []network.SpaceHostPorts,
+	controllerConfig controller.Config,
 ) ([]network.SpaceHostPorts, error) {
-	config, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	var hostPortsForAgents []network.SpaceHostPorts
-	if mgmtSpace := config.JujuManagementSpace(); mgmtSpace != "" {
+	if mgmtSpace := controllerConfig.JujuManagementSpace(); mgmtSpace != "" {
 		sp, err := st.SpaceByName(mgmtSpace)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -150,14 +147,14 @@ func (st *State) filterHostPortsForManagementSpace(
 }
 
 // APIHostPortsForClients returns the collection of *all* known API addresses.
-func (st *State) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (st *State) APIHostPortsForClients(controllerConfig controller.Config) ([]network.SpaceHostPorts, error) {
 	isCAASCtrl, err := st.isCAASController()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if isCAASCtrl {
 		// TODO(caas): add test for this once we have the replacement for Jujuconnsuite.
-		return st.apiHostPortsForCAAS(true)
+		return st.apiHostPortsForCAAS(true, controllerConfig)
 	}
 
 	hp, err := st.apiHostPortsForKey(apiHostPortsKey)
@@ -176,21 +173,21 @@ func (st *State) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
 // APIHostPortsForClients.
 // Otherwise the returned addresses will correspond with the management net space.
 // If there is no document at all, we simply fall back to APIHostPortsForClients.
-func (st *State) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (st *State) APIHostPortsForAgents(controllerConfig controller.Config) ([]network.SpaceHostPorts, error) {
 	isCAASCtrl, err := st.isCAASController()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if isCAASCtrl {
 		// TODO(caas): add test for this once we have the replacement for Jujuconnsuite.
-		return st.apiHostPortsForCAAS(false)
+		return st.apiHostPortsForCAAS(false, controllerConfig)
 	}
 
 	hps, err := st.apiHostPortsForKey(apiHostPortsForAgentsKey)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			logger.Debugf("No document for %s; using %s", apiHostPortsForAgentsKey, apiHostPortsKey)
-			return st.APIHostPortsForClients()
+			return st.APIHostPortsForClients(controllerConfig)
 		}
 		return nil, errors.Trace(err)
 	}
@@ -205,18 +202,13 @@ func (st *State) isCAASController() (bool, error) {
 	return m.IsControllerModel() && m.Type() == ModelTypeCAAS, nil
 }
 
-func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHostPorts, err error) {
+func (st *State) apiHostPortsForCAAS(public bool, controllerConfig controller.Config) (addresses []network.SpaceHostPorts, err error) {
 	defer func() {
 		logger.Debugf("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
 	}()
 
 	if st.ModelUUID() != st.controllerModelTag.Id() {
 		return nil, errors.Errorf("CAAS API host ports only available on the controller model, not %q", st.ModelUUID())
-	}
-
-	controllerConfig, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 
 	apiPort := controllerConfig.APIPort()

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -68,7 +68,10 @@ func (s *ControllerAddressesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -82,16 +85,16 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 		SpaceAddress: network.NewSpaceAddress("0.6.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}}}
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(newHostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForClients()
+	gotHostPorts, err := ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
@@ -99,19 +102,22 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      13,
 	}}}
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(newHostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
-	gotHostPorts, err = s.State.APIHostPortsForClients()
+	gotHostPorts, err = s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	hostPorts := []network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
@@ -128,7 +134,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(
 	var prevRevno int64
 	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.SetAPIHostPorts(hostPorts)
+		err := s.State.SetAPIHostPorts(hostPorts, controllerConfig)
 		c.Assert(err, jc.ErrorIsNil)
 		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
@@ -138,7 +144,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(
 		prevAgentsRevno = revno
 	}).Check()
 
-	err := s.State.SetAPIHostPorts(hostPorts)
+	err = s.State.SetAPIHostPorts(hostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
 
@@ -152,6 +158,9 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	hostPorts0 := []network.SpaceHostPort{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
@@ -169,7 +178,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 	var prevRevno int64
 	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts0})
+		err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts0}, controllerConfig)
 		c.Assert(err, jc.ErrorIsNil)
 		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
@@ -179,7 +188,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 		prevAgentsRevno = revno
 	}).Check()
 
-	err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts1})
+	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts1}, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
 
@@ -193,22 +202,25 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	hostPorts, err := ctrlSt.APIHostPortsForClients()
+	hostPorts, err := ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostPorts, gc.DeepEquals, []network.SpaceHostPorts{hostPorts1})
 
-	hostPorts, err = ctrlSt.APIHostPortsForAgents()
+	hostPorts, err = ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostPorts, gc.DeepEquals, []network.SpaceHostPorts{hostPorts1})
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.SetJujuManagementSpace(c, "mgmt01")
 
-	addrs, err := s.State.APIHostPortsForClients()
+	addrs, err := s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -233,16 +245,16 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	}
 	newHostPorts := []network.SpaceHostPorts{{hostPort1, hostPort2}, {hostPort3}}
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(newHostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForClients()
+	gotHostPorts, err := ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	// First slice filtered down to the address in the management space.
 	// Second filtered to zero elements, so retains the supplied slice.
@@ -250,7 +262,10 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -266,18 +281,21 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(col.FindId(key).One(&bson.D{}), gc.Equals, mgo.ErrNotFound)
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(newHostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
 func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -286,7 +304,7 @@ func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) 
 		NetPort:      1,
 	}}}
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(newHostPorts, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Delete the addresses for agents document after setting.
@@ -298,12 +316,15 @@ func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) 
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	w := s.State.WatchAPIHostPortsForClients()
 	defer workertest.CleanKill(c, w)
 
@@ -311,7 +332,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, w)
 	wc.AssertOneChange()
 
-	err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{network.NewSpaceHostPorts(99, "0.1.2.3")})
+	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{network.NewSpaceHostPorts(99, "0.1.2.3")}, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertOneChange()
@@ -322,6 +343,9 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -346,7 +370,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		NetPort: 2,
 	}
 
-	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{{mgmtHP}})
+	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{{mgmtHP}}, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -358,7 +382,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 			SpaceAddress: network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopeCloudLocal)),
 			NetPort:      99,
 		},
-	}})
+	}}, controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -382,6 +406,9 @@ func (s *CAASAddressesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CAASAddressesSuite) TestAPIHostPortsCloudLocalOnly(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	machineAddr := network.MachineAddress{
 		Value: "10.10.10.10",
 		Type:  network.IPv4Address,
@@ -410,7 +437,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsCloudLocalOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := ctrlSt.APIHostPortsForAgents()
+	addrs, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
@@ -418,12 +445,15 @@ func (s *CAASAddressesSuite) TestAPIHostPortsCloudLocalOnly(c *gc.C) {
 		SpaceAddress: network.SpaceAddress{MachineAddress: machineAddr},
 		NetPort:      17777,
 	}}}
-	addrs, err = ctrlSt.APIHostPortsForClients()
+	addrs, err = ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
 
 func (s *CAASAddressesSuite) TestAPIHostPortsPublicOnly(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	machineAddr := network.MachineAddress{
 		Value: "10.10.10.10",
 		Type:  network.IPv4Address,
@@ -452,7 +482,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsPublicOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := ctrlSt.APIHostPortsForAgents()
+	addrs, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
@@ -460,12 +490,15 @@ func (s *CAASAddressesSuite) TestAPIHostPortsPublicOnly(c *gc.C) {
 		SpaceAddress: network.SpaceAddress{MachineAddress: machineAddr},
 		NetPort:      17777,
 	}}}
-	addrs, err = ctrlSt.APIHostPortsForClients()
+	addrs, err = ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
 
 func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	machineAddr1 := network.MachineAddress{
 		Value: "10.10.10.1",
 		Type:  network.IPv4Address,
@@ -506,7 +539,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	addrs, err := ctrlSt.APIHostPortsForAgents()
+	addrs, err := ctrlSt.APIHostPortsForAgents(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local-cloud addresses must come first.
@@ -540,7 +573,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	c.Assert(addrs[0][3:], jc.SameContents, exp)
 
 	// Only the public ones should be returned.
-	addrs, err = ctrlSt.APIHostPortsForClients()
+	addrs, err = ctrlSt.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, []network.SpaceHostPorts{exp})
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -193,7 +193,10 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
 
-	addrs, err := s.State.APIHostPortsForClients()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 


### PR DESCRIPTION
The following passes in the controller config to set the api host ports. Unfortunately, this is a requirement, and we can't wrap it as we need the logic to be in state. The following is a partial fix to allow controller config to be passed.

There are a lot more call sites to be fixed here.

*Why this change is needed and what it does.*

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

*Commands to run to verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

## Bug reference

*Link to Launchpad bug. Delete section if not applicable.*
