### PR TITLE
[JUJU-4341] Move cmr --via check to server side

### DIFF
--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2700,14 +2700,39 @@ func (s *ApplicationSuite) TestApplicationUpdateBasePermissionDenied(c *gc.C) {
 func (s *ApplicationSuite) TestRemoteRelationBadCIDR(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	s.backend.EXPECT().InferEndpoints("wordpress", "hosted-mysql:nope").Return([]state.Endpoint{{
+		ApplicationName: "wordpress",
+	}, {
+		ApplicationName: "hosted-mysql",
+	}}, nil)
 	endpoints := []string{"wordpress", "hosted-mysql:nope"}
 	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"bad.cidr"}})
 	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: bad.cidr`)
 }
 
+func (s *ApplicationSuite) TestNonRemoteRelationCIDR(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.backend.EXPECT().InferEndpoints("wordpress", "mysql").Return([]state.Endpoint{{
+		ApplicationName: "wordpress",
+	}, {
+		ApplicationName: "mysql",
+	}}, nil)
+	s.backend.EXPECT().RemoteApplication("wordpress").Return(nil, errors.NotFound)
+	s.backend.EXPECT().RemoteApplication("mysql").Return(nil, errors.NotFound)
+	endpoints := []string{"wordpress", "mysql"}
+	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"10.10.0.0/16"}})
+	c.Assert(err, gc.ErrorMatches, `integration via subnets for non cross model relations not supported`)
+}
+
 func (s *ApplicationSuite) TestRemoteRelationDisAllowedCIDR(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	s.backend.EXPECT().InferEndpoints("wordpress", "hosted-mysql:nope").Return([]state.Endpoint{{
+		ApplicationName: "wordpress",
+	}, {
+		ApplicationName: "hosted-mysql",
+	}}, nil)
 	endpoints := []string{"wordpress", "hosted-mysql:nope"}
 	_, err := s.api.AddRelation(params.AddRelation{Endpoints: endpoints, ViaCIDRs: []string{"0.0.0.0/0"}})
 	c.Assert(err, gc.ErrorMatches, `CIDR "0.0.0.0/0" not allowed`)

--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -218,9 +218,6 @@ func (c *addRelationCommand) Init(args []string) error {
 	if err := c.validateCIDRs(); err != nil {
 		return err
 	}
-	if c.remoteEndpoint == nil && len(c.viaCIDRs) > 0 {
-		return errors.New("the --via option can only be used when integrating with offers in a different model")
-	}
 	return nil
 }
 


### PR DESCRIPTION
The `relate --via` option can only be used for cross model relations. If an offer is consumed first, then related to, we were incorrectly erroring as if the relation were between 2 local apps, when that's not the case. To fix the issue, the check needed to be moved server side.

## QA steps

juju consume someoffer
juju relate somelocalapp someoffer --via 10.10.0.0/16

Previously this would fail.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1844264
