### PR TITLE
[JUJU-4343] Remove JujuConnSuite from environs

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
@@ -495,7 +495,7 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, modelTag names.ModelTag,
 
 type fakeProvider struct {
 	environs.EnvironProvider
-	gitjujutesting.Stub
+	jujutesting.Stub
 	environ *fakeEnviron
 }
 
@@ -523,7 +523,7 @@ func (p *fakeProvider) Version() int {
 
 type fakeEnviron struct {
 	environs.Environ
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 	provider *fakeProvider
 
 	callCtxUsed context.ProviderCallContext

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -108,7 +108,7 @@ type Model interface {
 	CloudName() string
 	Cloud() (cloud.Cloud, error)
 	CloudCredentialTag() (names.CloudCredentialTag, bool)
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 	CloudRegion() string
 	Users() ([]permission.UserAccess, error)
 	Destroy(state.DestroyModelParams) error

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -192,10 +192,10 @@ func (mr *MockCredentialMockRecorder) Attributes() *gomock.Call {
 }
 
 // AuthType mocks base method.
-func (m *MockCredential) AuthType() string {
+func (m *MockCredential) AuthType() cloud.AuthType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthType")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(cloud.AuthType)
 	return ret0
 }
 

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -309,7 +309,7 @@ func cloudSpecForModel(m Model) (cloudspec.CloudSpec, error) {
 		return cloudspec.CloudSpec{}, errors.NotValidf("cloud credential for %s is empty", m.UUID())
 	}
 	cloudCredential := cloud.NewCredential(
-		cloud.AuthType(cred.AuthType()),
+		cred.AuthType(),
 		cred.Attributes(),
 	)
 	return cloudspec.MakeCloudSpec(c, "", &cloudCredential)

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -183,7 +183,7 @@ func (s *secretsSuite) assertAdminBackendConfigInfoDefault(
 			IsControllerCloud: true,
 		}
 		cred := mocks.NewMockCredential(ctrl)
-		cred.EXPECT().AuthType().Return("access-key")
+		cred.EXPECT().AuthType().Return(cloud.AccessKeyAuthType)
 		cred.EXPECT().Attributes().Return(map[string]string{"foo": "bar"})
 		model.EXPECT().Cloud().Return(cld, nil)
 		model.EXPECT().CloudCredential().Return(cred, nil)

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -54,7 +54,7 @@ type SecretsMetaState interface {
 
 // Credential represents a cloud credential.
 type Credential interface {
-	AuthType() string
+	AuthType() cloud.AuthType
 	Attributes() map[string]string
 }
 
@@ -75,19 +75,7 @@ func (m *modelShim) CloudCredential() (Credential, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &credentialShim{cred}, nil
-}
-
-type credentialShim struct {
-	state.Credential
-}
-
-func (c *credentialShim) AuthType() string {
-	return c.Credential.AuthType
-}
-
-func (c *credentialShim) Attributes() map[string]string {
-	return c.Credential.Attributes
+	return cred, nil
 }
 
 type SecretsGetter interface {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -223,7 +223,7 @@ type Model interface {
 	Config() (*config.Config, error)
 	CloudName() string
 	Cloud() (cloud.Cloud, error)
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 	CloudRegion() string
 	ControllerUUID() string
 }

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -398,10 +398,10 @@ func (mr *MockModelMockRecorder) Cloud() *gomock.Call {
 }
 
 // CloudCredential mocks base method.
-func (m *MockModel) CloudCredential() (state.Credential, bool, error) {
+func (m *MockModel) CloudCredential() (cloud.Credential, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential")
-	ret0, _ := ret[0].(state.Credential)
+	ret0, _ := ret[0].(cloud.Credential)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -728,10 +728,10 @@ func (mr *MockModelMockRecorder) Cloud() *gomock.Call {
 }
 
 // CloudCredential mocks base method.
-func (m *MockModel) CloudCredential() (state.Credential, bool, error) {
+func (m *MockModel) CloudCredential() (cloud.Credential, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential")
-	ret0, _ := ret[0].(state.Credential)
+	ret0, _ := ret[0].(cloud.Credential)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/apiserver/facades/client/charms/interfaces/state.go
+++ b/apiserver/facades/client/charms/interfaces/state.go
@@ -19,7 +19,7 @@ type BackendModel interface {
 	Config() (*config.Config, error)
 	ModelTag() names.ModelTag
 	Cloud() (cloud.Cloud, error)
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 	CloudRegion() string
 	ControllerUUID() string
 	Type() state.ModelType

--- a/apiserver/facades/client/charms/mocks/state_mock.go
+++ b/apiserver/facades/client/charms/mocks/state_mock.go
@@ -245,10 +245,10 @@ func (mr *MockBackendModelMockRecorder) Cloud() *gomock.Call {
 }
 
 // CloudCredential mocks base method.
-func (m *MockBackendModel) CloudCredential() (state.Credential, bool, error) {
+func (m *MockBackendModel) CloudCredential() (cloud.Credential, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential")
-	ret0, _ := ret[0].(state.Credential)
+	ret0, _ := ret[0].(cloud.Credential)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -78,7 +78,7 @@ type Model interface {
 	UUID() string
 	CloudName() string
 	Cloud() (cloud.Cloud, error)
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 	CloudRegion() string
 }
 

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -33,7 +33,7 @@ import (
 )
 
 type cloudSuite struct {
-	gitjujutesting.LoggingCleanupSuite
+	jujutesting.LoggingCleanupSuite
 	backend     *mocks.MockBackend
 	ctrlBackend *mocks.MockBackend
 	pool        *mocks.MockModelPoolBackend

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -483,10 +483,10 @@ func (mr *MockModelMockRecorder) Cloud() *gomock.Call {
 }
 
 // CloudCredential mocks base method.
-func (m *MockModel) CloudCredential() (state.Credential, bool, error) {
+func (m *MockModel) CloudCredential() (cloud0.Credential, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential")
-	ret0, _ := ret[0].(state.Credential)
+	ret0, _ := ret[0].(cloud0.Credential)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/apiserver/facades/client/imagemetadatamanager/package_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/package_test.go
@@ -7,7 +7,7 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -71,7 +71,7 @@ const (
 
 func (s *baseImageMetadataSuite) constructState(cfg *config.Config) *mockState {
 	return &mockState{
-		Stub: &gitjujutesting.Stub{},
+		Stub: &jujutesting.Stub{},
 		findMetadata: func(f cloudimagemetadata.MetadataFilter) (map[string][]cloudimagemetadata.Metadata, error) {
 			return nil, nil
 		},
@@ -91,7 +91,7 @@ func (s *baseImageMetadataSuite) constructState(cfg *config.Config) *mockState {
 }
 
 type mockState struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 
 	findMetadata   func(f cloudimagemetadata.MetadataFilter) (map[string][]cloudimagemetadata.Metadata, error)
 	saveMetadata   func(m []cloudimagemetadata.Metadata) error

--- a/apiserver/facades/client/machinemanager/mocks/types_mock.go
+++ b/apiserver/facades/client/machinemanager/mocks/types_mock.go
@@ -389,10 +389,10 @@ func (mr *MockModelMockRecorder) Cloud() *gomock.Call {
 }
 
 // CloudCredential mocks base method.
-func (m *MockModel) CloudCredential() (state.Credential, bool, error) {
+func (m *MockModel) CloudCredential() (cloud.Credential, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential")
-	ret0, _ := ret[0].(state.Credential)
+	ret0, _ := ret[0].(cloud.Credential)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -69,7 +69,7 @@ type Model interface {
 	ControllerUUID() string
 	Type() state.ModelType
 	Cloud() (cloud.Cloud, error)
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 	CloudRegion() string
 	Config() (*config.Config, error)
 }

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -29,7 +29,7 @@ import (
 )
 
 type ListModelsWithInfoSuite struct {
-	gitjujutesting.IsolationSuite
+	jujutesting.IsolationSuite
 
 	st *mockState
 

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -1165,7 +1165,7 @@ type mockModel struct {
 	controllerUUID      string
 	isController        bool
 	cloud               cloud.Cloud
-	cred                state.Credential
+	cred                cloud.Credential
 	setCloudCredentialF func(tag names.CloudCredentialTag) (bool, error)
 }
 
@@ -1219,7 +1219,7 @@ func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return names.NewCloudCredentialTag("some-cloud/bob/some-credential"), true
 }
 
-func (m *mockModel) CloudCredential() (state.Credential, bool, error) {
+func (m *mockModel) CloudCredential() (cloud.Credential, bool, error) {
 	m.MethodCall(m, "CloudCredential")
 	return m.cred, true, nil
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"go.uber.org/mock/gomock"
@@ -60,7 +60,7 @@ func createArgs(owner names.UserTag) params.ModelCreateArgs {
 }
 
 type modelManagerSuite struct {
-	gitjujutesting.IsolationSuite
+	jtesting.IsolationSuite
 	statetesting.StateSuite
 	st            *mockState
 	ctlrSt        *mockState
@@ -750,7 +750,7 @@ func (s *modelManagerSuite) TestDumpModelMissingModel(c *gc.C) {
 	tag := names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f000")
 	models := params.DumpModelRequest{Entities: []params.Entity{{Tag: tag.String()}}}
 	results := s.api.DumpModels(stdcontext.Background(), models)
-	s.st.CheckCalls(c, []gitjujutesting.StubCall{
+	s.st.CheckCalls(c, []jtesting.StubCall{
 		{FuncName: "ControllerTag", Args: nil},
 		{FuncName: "GetBackend", Args: []interface{}{tag.Id()}},
 	})
@@ -807,7 +807,7 @@ func (s *modelManagerSuite) TestDumpModelsDBMissingModel(c *gc.C) {
 	models := params.Entities{Entities: []params.Entity{{Tag: tag.String()}}}
 	results := s.api.DumpModelsDB(models)
 
-	s.st.CheckCalls(c, []gitjujutesting.StubCall{
+	s.st.CheckCalls(c, []jtesting.StubCall{
 		{FuncName: "ControllerTag", Args: nil},
 		{FuncName: "ModelTag", Args: nil},
 		{FuncName: "GetBackend", Args: []interface{}{tag.Id()}},

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -42,7 +42,7 @@ func (suite *PluginSuite) SetUpTest(c *gc.C) {
 		path = "/bin:/usr/bin:%s"
 	}
 
-	os.Setenv("PATH", fmt.Sprintf(path, gitjujutesting.HomePath()))
+	os.Setenv("PATH", fmt.Sprintf(path, jujutesting.HomePath()))
 
 	jujuclienttesting.SetupMinimalFileStore(c)
 }
@@ -235,7 +235,7 @@ func (suite *PluginSuite) TestJujuControllerEnvVars(c *gc.C) {
 }
 
 func (suite *PluginSuite) makePlugin(fullName, script string, perm os.FileMode) {
-	filename := gitjujutesting.HomePath(fullName)
+	filename := jujutesting.HomePath(fullName)
 	content := fmt.Sprintf("#!/bin/bash --norc\n%s", script)
 	os.WriteFile(filename, []byte(content), perm)
 }
@@ -297,13 +297,13 @@ func (suite *PluginSuite) makeFullPlugin(params PluginParams) {
 	// Create a new template and parse the plugin into it.
 	t := template.Must(template.New("plugin").Parse(pluginTemplate))
 	content := &bytes.Buffer{}
-	filename := gitjujutesting.HomePath("juju-" + params.Name)
+	filename := jujutesting.HomePath("juju-" + params.Name)
 	// Create the files in the temp dirs, so we don't pollute the working space
 	if params.Creates != "" {
-		params.Creates = gitjujutesting.HomePath(params.Creates)
+		params.Creates = jujutesting.HomePath(params.Creates)
 	}
 	if params.DependsOn != "" {
-		params.DependsOn = gitjujutesting.HomePath(params.DependsOn)
+		params.DependsOn = jujutesting.HomePath(params.DependsOn)
 	}
 	t.Execute(content, params)
 	os.WriteFile(filename, content.Bytes(), 0755)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -405,7 +405,7 @@ func (s *AddModelSuite) TestDefaultCloudRegionPassedThrough(c *gc.C) {
 	_, err := s.run(c, "test", "us-west-1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.fakeCloudAPI.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fakeCloudAPI.CheckCalls(c, []jujutesting.StubCall{
 		{"Cloud", []interface{}{names.NewCloudTag("us-west-1")}},
 		{"Clouds", nil},
 		{"Cloud", []interface{}{names.NewCloudTag("aws")}},
@@ -423,7 +423,7 @@ func (s *AddModelSuite) TestNoDefaultCloudRegion(c *gc.C) {
 you do not have add-model access to any clouds on this controller.
 Please ask the controller administrator to grant you add-model permission
 for a particular cloud to which you want to add a model.`[1:])
-	s.fakeCloudAPI.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fakeCloudAPI.CheckCalls(c, []jujutesting.StubCall{
 		{"Cloud", []interface{}{names.NewCloudTag("us-west-1")}},
 		{"Clouds", nil},
 	})
@@ -446,7 +446,7 @@ Cloud  Regions
 aws    us-east-1, us-west-1
 lxd    
 `[1:])
-	s.fakeCloudAPI.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fakeCloudAPI.CheckCalls(c, []jujutesting.StubCall{
 		{"Cloud", []interface{}{names.NewCloudTag("us-west-1")}},
 		{"Clouds", nil},
 		{"Cloud", []interface{}{names.NewCloudTag("aws")}},
@@ -741,7 +741,7 @@ type fakeCloudAPI struct {
 	clouds map[names.CloudTag]cloud.Cloud
 	cloud  *cloud.Cloud
 	controller.CloudAPI
-	gitjujutesting.Stub
+	jujutesting.Stub
 	authTypes   []cloud.AuthType
 	credentials []names.CloudCredentialTag
 }
@@ -791,7 +791,7 @@ func (c *fakeCloudAPI) AddCredential(tag string, credential cloud.Credential) er
 }
 
 type fakeProviderRegistry struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	environs.ProviderRegistry
 	provider environs.EnvironProvider
 }
@@ -802,7 +802,7 @@ func (r *fakeProviderRegistry) Provider(providerType string) (environs.EnvironPr
 }
 
 type fakeProvider struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	environs.EnvironProvider
 	detected *cloud.CloudCredential
 }

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -60,7 +60,7 @@ type baseDestroySuite struct {
 
 // fakeDestroyAPI mocks out the controller API
 type fakeDestroyAPI struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	cloud        environscloudspec.CloudSpec
 	env          map[string]interface{}
 	blocks       []params.ModelBlockInfo
@@ -626,7 +626,7 @@ func (s *DestroySuite) TestDestroyWithInvalidCredentialCallbackFailingToCloseAPI
 }
 
 type mockCredentialAPI struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 }
 
 func (m *mockCredentialAPI) InvalidateModelCredential(reason string) error {

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -35,7 +35,7 @@ type ModelsSuite struct {
 var _ = gc.Suite(&ModelsSuite{})
 
 type fakeModelMgrAPIClient struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 
 	err   error
 	infos []params.ModelInfoResult
@@ -215,7 +215,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.api = &fakeModelMgrAPIClient{
-		Stub: &gitjujutesting.Stub{},
+		Stub: &jujutesting.Stub{},
 	}
 	s.api.infos = convert(models)
 
@@ -622,7 +622,7 @@ func (s *ModelsSuite) TestModelsWithOneModelInError(c *gc.C) {
 
 func (s *ModelsSuite) TestAllModels(c *gc.C) {
 	assertAPICallsArgs := func(all bool) {
-		s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		s.api.CheckCalls(c, []jujutesting.StubCall{{
 			"ListModelSummaries", []interface{}{"admin", all},
 		}, {
 			"Close", []interface{}{},

--- a/cmd/juju/model/dump_test.go
+++ b/cmd/juju/model/dump_test.go
@@ -6,7 +6,7 @@ package model_test
 import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -25,7 +25,7 @@ type DumpCommandSuite struct {
 var _ = gc.Suite(&DumpCommandSuite{})
 
 type fakeDumpClient struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 }
 
 func (f *fakeDumpClient) Close() error {
@@ -65,7 +65,7 @@ func (s *DumpCommandSuite) SetUpTest(c *gc.C) {
 func (s *DumpCommandSuite) TestDump(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewDumpCommandForTest(&s.fake, s.store))
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
 		{"DumpModel", []interface{}{testing.ModelTag}},
 		{"Close", nil},
 	})
@@ -77,7 +77,7 @@ func (s *DumpCommandSuite) TestDump(c *gc.C) {
 func (s *DumpCommandSuite) TestDumpSimple(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewDumpCommandForTest(&s.fake, s.store), "--simplified")
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
 		{"DumpModel", []interface{}{testing.ModelTag}},
 		{"Close", nil},
 	})

--- a/cmd/juju/model/dumpdb_test.go
+++ b/cmd/juju/model/dumpdb_test.go
@@ -6,7 +6,7 @@ package model_test
 import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -44,7 +44,7 @@ func (s *DumpDBCommandSuite) SetUpTest(c *gc.C) {
 func (s *DumpDBCommandSuite) TestDumpDB(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewDumpDBCommandForTest(&s.fake, s.store))
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
 		{"DumpModelDB", []interface{}{testing.ModelTag}},
 		{"Close", nil},
 	})
@@ -58,7 +58,7 @@ models:
 }
 
 type fakeDumpDBClient struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 }
 
 func (f *fakeDumpDBClient) Close() error {

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -133,7 +133,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 func (s *ShowCommandSuite) TestShow(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newShowCommand())
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
 		{"ModelInfo", []interface{}{[]names.ModelTag{testing.ModelTag}}},
 		{"Close", nil},
 	})
@@ -142,7 +142,7 @@ func (s *ShowCommandSuite) TestShow(c *gc.C) {
 func (s *ShowCommandSuite) TestShowWithPartModelUUID(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newShowCommand(), "deadbeef")
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+	s.fake.CheckCalls(c, []jujutesting.StubCall{
 		{"ModelInfo", []interface{}{[]names.ModelTag{testing.ModelTag}}},
 		{"Close", nil},
 	})
@@ -764,7 +764,7 @@ func noOpRefresh(_ jujuclient.ClientStore, _ string) error {
 type attrs map[string]interface{}
 
 type fakeModelShowClient struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	info  params.ModelInfo
 	err   *params.Error
 	infos []params.ModelInfoResult

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -23,7 +23,7 @@ import (
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v4"
 	osseries "github.com/juju/os/v2/series"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -95,7 +95,7 @@ var _ = gc.Suite(&BootstrapSuite{})
 
 func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	storageDir := c.MkDir()
-	restorer := gitjujutesting.PatchValue(&envtools.DefaultBaseURL, storageDir)
+	restorer := jtesting.PatchValue(&envtools.DefaultBaseURL, storageDir)
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
 	s.toolsStorage = stor

--- a/cmd/plugins/juju-metadata/deleteimage_test.go
+++ b/cmd/plugins/juju-metadata/deleteimage_test.go
@@ -6,7 +6,7 @@ package main
 import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -35,7 +35,7 @@ func (s *deleteImageSuite) SetUpTest(c *gc.C) {
 			s.deletedIds = append(s.deletedIds, imageId)
 			return nil
 		},
-		Stub: &gitjujutesting.Stub{},
+		Stub: &jujutesting.Stub{},
 	}
 }
 
@@ -86,7 +86,7 @@ func (s *deleteImageSuite) assertDeleteImageMetadataErr(c *gc.C, errorMsg string
 }
 
 type mockDeleteAPI struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 
 	delete func(imageId string) error
 }

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -91,7 +91,7 @@ func (f *fakeAddr) String() string {
 var _ net.Addr = (*fakeAddr)(nil)
 
 type fakeAPI struct {
-	*gitjujutesting.Stub
+	*jtesting.Stub
 
 	fakeContainerConfig params.ContainerConfig
 	fakeInterfaceInfo   corenetwork.InterfaceInfo
@@ -133,7 +133,7 @@ func fakeContainerConfig() params.ContainerConfig {
 
 func NewFakeAPI() *fakeAPI {
 	return &fakeAPI{
-		Stub:                &gitjujutesting.Stub{},
+		Stub:                &jtesting.Stub{},
 		fakeContainerConfig: fakeContainerConfig(),
 		fakeInterfaceInfo:   fakeInterfaceInfo,
 	}
@@ -210,7 +210,7 @@ func (f *fakeAPI) GetContainerProfileInfo(containerTag names.MachineTag) ([]*api
 }
 
 type fakeContainerManager struct {
-	gitjujutesting.Stub
+	jtesting.Stub
 }
 
 func (m *fakeContainerManager) CreateContainer(instanceConfig *instancecfg.InstanceConfig,

--- a/container/broker/host_preparer_test.go
+++ b/container/broker/host_preparer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mutex/v2"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -22,7 +22,7 @@ import (
 )
 
 type fakePrepareAPI struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 	requestedBridges []network.DeviceToBridge
 	reconfigureDelay int
 }
@@ -46,17 +46,17 @@ func (api *fakePrepareAPI) SetHostMachineNetworkConfig(tag names.MachineTag, con
 }
 
 type hostPreparerSuite struct {
-	Stub *gitjujutesting.Stub
+	Stub *jujutesting.Stub
 }
 
 var _ = gc.Suite(&hostPreparerSuite{})
 
 func (s *hostPreparerSuite) SetUpTest(c *gc.C) {
-	s.Stub = &gitjujutesting.Stub{}
+	s.Stub = &jujutesting.Stub{}
 }
 
 type stubReleaser struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 }
 
 func (r *stubReleaser) Release() {
@@ -75,7 +75,7 @@ func (s *hostPreparerSuite) acquireStubLock(_ string, _ <-chan struct{}) (func()
 }
 
 type stubBridger struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 }
 
 var _ network.Bridger = (*stubBridger)(nil)
@@ -99,7 +99,7 @@ func (s *hostPreparerSuite) createStubBridger() (network.Bridger, error) {
 }
 
 type cannedNetworkObserver struct {
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 	config []params.NetworkConfig
 }
 
@@ -141,7 +141,7 @@ func (s *hostPreparerSuite) TestPrepareHostNoChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// If HostChangesForContainer returns nothing to change, then we don't
 	// instantiate a Bridger, or do any bridging.
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -201,7 +201,7 @@ func (s *hostPreparerSuite) TestPrepareHostCreateBridge(c *gc.C) {
 	// This should be the normal flow if there are changes necessary. We read
 	// the changes, grab a bridger, then acquire a lock, do the bridging,
 	// observe the results, report the results, and release the lock.
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -233,7 +233,7 @@ func (s *hostPreparerSuite) TestPrepareHostNothingObserved(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -266,7 +266,7 @@ func (s *hostPreparerSuite) TestPrepareHostChangesUnsupported(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Assert(err, gc.ErrorMatches, "unable to setup network: container address allocation not supported")
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -294,7 +294,7 @@ func (s *hostPreparerSuite) TestPrepareHostNoBridger(c *gc.C) {
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, "unable to find python interpreter")
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -321,7 +321,7 @@ func (s *hostPreparerSuite) TestPrepareHostNoLock(c *gc.C) {
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, `failed to acquire machine lock for bridging: timeout acquiring mutex`)
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		},
@@ -343,7 +343,7 @@ func (s *hostPreparerSuite) TestPrepareHostBridgeFailure(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, `failed to bridge devices: script invocation error: IOError`)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -381,7 +381,7 @@ func (s *hostPreparerSuite) TestPrepareHostObserveFailure(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, `cannot discover observed network config: cannot get network interfaces: enoent`)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -418,7 +418,7 @@ func (s *hostPreparerSuite) TestPrepareHostObservedFailure(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, `failure`)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLock",
 		}, {
@@ -467,7 +467,7 @@ func (s *hostPreparerSuite) TestPrepareHostCancel(c *gc.C) {
 	containerTag := names.NewMachineTag("1/lxd/0")
 	err := preparer.Prepare(containerTag)
 	c.Check(err, gc.ErrorMatches, `failed to acquire machine lock for bridging: AcquireLock cancelled`)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{
 			FuncName: "AcquireLockFunc",
 		},

--- a/container/broker/kvm-broker_test.go
+++ b/container/broker/kvm-broker_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -107,7 +107,7 @@ func (s *kvmBrokerSuite) TestStartInstanceWithoutNetworkChanges(c *gc.C) {
 	machineId := "1/kvm/0"
 	result, err := s.startInstance(c, broker, machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+	s.api.CheckCalls(c, []jujutesting.StubCall{{
 		FuncName: "ContainerConfig",
 	}, {
 		FuncName: "PrepareHost",
@@ -130,7 +130,7 @@ func (s *kvmBrokerSuite) TestMaintainInstanceAddress(c *gc.C) {
 
 	s.api.ResetCalls()
 
-	s.api.CheckCalls(c, []gitjujutesting.StubCall{})
+	s.api.CheckCalls(c, []jujutesting.StubCall{})
 	c.Assert(result.Instance.Id(), gc.Equals, instance.Id("juju-06f00d-1-kvm-0"))
 	s.assertResults(c, broker, result)
 }

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
@@ -82,7 +82,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithoutHostNetworkChanges(c *gc.C) {
 	machineId := "1/lxd/0"
 	containerTag := names.NewMachineTag("1-lxd-0")
 	s.startInstance(c, broker, machineId)
-	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+	s.api.CheckCalls(c, []jujutesting.StubCall{{
 		FuncName: "ContainerConfig",
 	}, {
 		FuncName: "PrepareHost",

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -19,7 +19,7 @@ import (
 
 type DownloadSuite struct {
 	testing.BaseSuite
-	gitjujutesting.HTTPSuite
+	jujutesting.HTTPSuite
 }
 
 func (s *DownloadSuite) SetUpSuite(c *gc.C) {
@@ -53,7 +53,7 @@ func (s *DownloadSuite) URL(c *gc.C, path string) *url.URL {
 
 func (s *DownloadSuite) testDownload(c *gc.C, hostnameVerification bool) {
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	d := downloader.StartDownload(
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
@@ -78,7 +78,7 @@ func (s *DownloadSuite) TestDownloadWithDisablingSSLHostnameVerification(c *gc.C
 }
 
 func (s *DownloadSuite) TestDownloadError(c *gc.C) {
-	gitjujutesting.Server.Response(404, nil, nil)
+	jujutesting.Server.Response(404, nil, nil)
 	tmp := c.MkDir()
 	d := downloader.StartDownload(
 		downloader.Request{
@@ -94,9 +94,9 @@ func (s *DownloadSuite) TestDownloadError(c *gc.C) {
 }
 
 func (s *DownloadSuite) TestVerifyValid(c *gc.C) {
-	stub := &gitjujutesting.Stub{}
+	stub := &jujutesting.Stub{}
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	dl := downloader.StartDownload(
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
@@ -115,9 +115,9 @@ func (s *DownloadSuite) TestVerifyValid(c *gc.C) {
 }
 
 func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
-	stub := &gitjujutesting.Stub{}
+	stub := &jujutesting.Stub{}
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	invalid := errors.NotValidf("oops")
 	dl := downloader.StartDownload(
 		downloader.Request{
@@ -139,7 +139,7 @@ func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
 
 func (s *DownloadSuite) TestAbort(c *gc.C) {
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	abort := make(chan struct{})
 	close(abort)
 	dl := downloader.StartDownload(

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,7 +18,7 @@ import (
 
 type DownloaderSuite struct {
 	testing.BaseSuite
-	gitjujutesting.HTTPSuite
+	jujutesting.HTTPSuite
 }
 
 func (s *DownloaderSuite) SetUpSuite(c *gc.C) {
@@ -52,7 +52,7 @@ func (s *DownloaderSuite) URL(c *gc.C, path string) *url.URL {
 
 func (s *DownloaderSuite) testStart(c *gc.C, hostnameVerification bool) {
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	dlr := downloader.New(downloader.NewArgs{
 		HostnameVerification: hostnameVerification,
 	})
@@ -77,7 +77,7 @@ func (s *DownloaderSuite) TestDownloadWithDisablingSSLHostnameVerification(c *gc
 
 func (s *DownloaderSuite) TestDownload(c *gc.C) {
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(200, nil, []byte("archive"))
+	jujutesting.Server.Response(200, nil, []byte("archive"))
 	dlr := downloader.New(downloader.NewArgs{})
 	filename, err := dlr.Download(downloader.Request{
 		URL:       s.URL(c, "/archive.tgz"),
@@ -91,7 +91,7 @@ func (s *DownloaderSuite) TestDownload(c *gc.C) {
 
 func (s *DownloaderSuite) TestDownloadHandles409Responses(c *gc.C) {
 	tmp := c.MkDir()
-	gitjujutesting.Server.Response(409, nil, []byte("archive"))
+	jujutesting.Server.Response(409, nil, []byte("archive"))
 	dlr := downloader.New(downloader.NewArgs{})
 	_, err := dlr.Download(downloader.Request{
 		URL:       s.URL(c, "/archive.tgz"),

--- a/environs/bootstrap/config_test.go
+++ b/environs/bootstrap/config_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -69,7 +69,7 @@ func (*ConfigSuite) TestConfigValuesSpecified(c *gc.C) {
 	}
 }
 
-func (s *ConfigSuite) addFiles(c *gc.C, files ...gitjujutesting.TestFile) {
+func (s *ConfigSuite) addFiles(c *gc.C, files ...jujutesting.TestFile) {
 	for _, f := range files {
 		err := os.WriteFile(osenv.JujuXDGDataHomePath(f.Name), []byte(f.Data), 0666)
 		c.Assert(err, gc.IsNil)
@@ -77,7 +77,7 @@ func (s *ConfigSuite) addFiles(c *gc.C, files ...gitjujutesting.TestFile) {
 }
 
 func (s *ConfigSuite) TestDefaultConfigReadsDefaultCACertKeyFiles(c *gc.C) {
-	s.addFiles(c, []gitjujutesting.TestFile{
+	s.addFiles(c, []jujutesting.TestFile{
 		{"ca-cert.pem", testing.CACert},
 		{"ca-private-key.pem", testing.CAKey},
 	}...)
@@ -90,7 +90,7 @@ func (s *ConfigSuite) TestDefaultConfigReadsDefaultCACertKeyFiles(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestConfigReadsCACertKeyFilesFromPaths(c *gc.C) {
-	s.addFiles(c, []gitjujutesting.TestFile{
+	s.addFiles(c, []jujutesting.TestFile{
 		{"ca-cert-2.pem", testing.OtherCACert},
 		{"ca-private-key-2.pem", testing.OtherCAKey},
 	}...)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -65,7 +65,7 @@ const (
 // (e.g. Amazon EC2).  The Environ is opened once only for all the tests
 // in the suite, stored in Env, and Destroyed after the suite has completed.
 type LiveTests struct {
-	gitjujutesting.CleanupSuite
+	jtesting.CleanupSuite
 
 	envtesting.ToolsFixture
 	sstesting.TestDataSuite

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -7,38 +7,80 @@ package sshprovisioner_test
 import (
 	"fmt"
 	"os"
+	"path"
+	"time"
 
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3/shell"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	apiclient "github.com/juju/juju/api/client/machinemanager"
-	"github.com/juju/juju/apiserver/facades/client/machinemanager"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
-	envtesting "github.com/juju/juju/environs/testing"
-	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/testing"
+	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
 
 type provisionerSuite struct {
-	testing.JujuConnSuite
+	jujutesting.LoggingCleanupSuite
 }
 
 var _ = gc.Suite(&provisionerSuite{})
 
+type mockMachineManager struct {
+	manual.ProvisioningClientAPI
+}
+
+func (m *mockMachineManager) ProvisioningScript(params.ProvisioningScriptParams) (script string, err error) {
+	return "echo hello", nil
+}
+
+func (m *mockMachineManager) AddMachines(args []params.AddMachineParams) ([]params.AddMachinesResult, error) {
+	if len(args) != 1 {
+		return nil, errors.Errorf("unexpected args: %+v", args)
+	}
+	a := args[0]
+	b := jujuversion.DefaultSupportedLTSBase()
+	if a.Base == nil || a.Base.Name != b.OS || a.Base.Channel != b.Channel.String() {
+		return nil, errors.Errorf("unexpected base: %v", a.Base)
+	}
+	if a.Nonce == "" {
+		return nil, errors.Errorf("unexpected empty nonce")
+	}
+	if len(a.Jobs) != 1 && a.Jobs[0] != model.JobHostUnits {
+		return nil, errors.Errorf("unexpected jobs: %v", a.Jobs)
+	}
+	return []params.AddMachinesResult{{
+		Machine: "2",
+	}}, nil
+}
+
+func (m *mockMachineManager) DestroyMachinesWithParams(force, keep, dryRun bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
+	if len(machines) == 0 || machines[0] != "2" {
+		return nil, errors.Errorf("unexpected machines: %v", machines)
+	}
+	return []params.DestroyMachineResult{{
+		Info: &params.DestroyMachineInfo{MachineId: machines[0]},
+	}}, nil
+}
+
 func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 	hostname, err := os.Hostname()
 	c.Assert(err, jc.ErrorIsNil)
-	client := apiclient.NewClient(s.APIState)
-	s.AddCleanup(func(*gc.C) { client.Close() })
+	client := &mockMachineManager{}
 	return manual.ProvisionMachineArgs{
 		Host:           hostname,
 		Client:         client,
@@ -48,48 +90,28 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	var series = jujuversion.DefaultSupportedLTS()
-	const arch = "amd64"
 
 	args := s.getArgs(c)
 	hostname := args.Host
 	args.Host = hostname
 	args.User = "ubuntu"
 
-	defaultToolsURL := envtools.DefaultBaseURL
-	envtools.DefaultBaseURL = ""
-
 	defer fakeSSH{
 		Series:             series,
-		Arch:               arch,
+		Arch:               arch.AMD64,
 		InitUbuntuUser:     true,
 		SkipProvisionAgent: true,
 	}.install(c).Restore()
-
-	// Attempt to provision a machine with no tools available, expect it to fail.
-	machineId, err := sshprovisioner.ProvisionMachine(args)
-	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
-	c.Assert(machineId, gc.Equals, "")
-
-	cfg := s.Environ.Config()
-	number, ok := cfg.AgentVersion()
-	c.Assert(ok, jc.IsTrue)
-	binVersion := version.Binary{
-		Number:  number,
-		Release: "ubuntu",
-		Arch:    arch,
-	}
-	envtesting.AssertUploadFakeToolsVersions(c, s.DefaultToolsStorage, "released", "released", binVersion)
-	envtools.DefaultBaseURL = defaultToolsURL
 
 	for i, errorCode := range []int{255, 0} {
 		c.Logf("test %d: code %d", i, errorCode)
 		defer fakeSSH{
 			Series:                 series,
-			Arch:                   arch,
+			Arch:                   arch.AMD64,
 			InitUbuntuUser:         true,
 			ProvisionAgentExitCode: errorCode,
 		}.install(c).Restore()
-		machineId, err = sshprovisioner.ProvisionMachine(args)
+		machineId, err := sshprovisioner.ProvisionMachine(args)
 		if errorCode != 0 {
 			c.Assert(err, gc.ErrorMatches, fmt.Sprintf("subprocess encountered error code %d", errorCode))
 			c.Assert(machineId, gc.Equals, "")
@@ -99,11 +121,6 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 			// machine ID will be incremented. Even though we failed and the
 			// machine is removed, the ID is not reused.
 			c.Assert(machineId, gc.Equals, fmt.Sprint(i+1))
-			m, err := s.State.Machine(machineId)
-			c.Assert(err, jc.ErrorIsNil)
-			instanceId, err := m.InstanceId()
-			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(instanceId, gc.Equals, instance.Id("manual:"+hostname))
 		}
 	}
 
@@ -115,7 +132,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 		SkipDetection:      true,
 		SkipProvisionAgent: true,
 	}.install(c).Restore()
-	_, err = sshprovisioner.ProvisionMachine(args)
+	_, err := sshprovisioner.ProvisionMachine(args)
 	c.Assert(err, gc.Equals, manual.ErrProvisioned)
 	defer fakeSSH{
 		Provisioned:              true,
@@ -128,51 +145,40 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "error checking if provisioned: subprocess encountered error code 255")
 }
 
-func (s *provisionerSuite) TestFinishInstanceConfig(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
-	const arch = "amd64"
-	defer fakeSSH{
-		Series:         series,
-		Arch:           arch,
-		InitUbuntuUser: true,
-	}.install(c).Restore()
-
-	machineId, err := sshprovisioner.ProvisionMachine(s.getArgs(c))
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Now check what we would've configured it with.
-	systemState, err := s.StatePool.SystemState()
-	c.Assert(err, jc.ErrorIsNil)
-	icfg, err := machinemanager.InstanceConfig(systemState, machinemanager.StateBackend(s.State), machineId, agent.BootstrapNonce, "/var/lib/juju")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(icfg, gc.NotNil)
-	c.Check(icfg.APIInfo, gc.NotNil)
-
-	apiInfo := s.APIInfo(c)
-	c.Check(icfg.APIInfo.Addrs, gc.DeepEquals, apiInfo.Addrs)
-}
-
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
-	const arch = "amd64"
 	defer fakeSSH{
-		Series:         series,
-		Arch:           arch,
+		Series:         jujuversion.DefaultSupportedLTS(),
+		Arch:           arch.AMD64,
 		InitUbuntuUser: true,
 	}.install(c).Restore()
 
-	machineId, err := sshprovisioner.ProvisionMachine(s.getArgs(c))
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.Model.UpdateModelConfig(
-		map[string]interface{}{
-			"enable-os-upgrade": false,
-		}, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	systemState, err := s.StatePool.SystemState()
-	c.Assert(err, jc.ErrorIsNil)
-	icfg, err := machinemanager.InstanceConfig(systemState, machinemanager.StateBackend(s.State), machineId, agent.BootstrapNonce, "/var/lib/juju")
+	logDir := "/var/log"
+	icfg := &instancecfg.InstanceConfig{
+		ControllerTag: testing.ControllerTag,
+		MachineId:     "10",
+		MachineNonce:  "5432",
+		Base:          series.MustParseBaseFromString("ubuntu@22.04"),
+		APIInfo: &api.Info{
+			Addrs:    []string{"127.0.0.1:1234"},
+			Password: "pw2",
+			CACert:   "CA CERT\n" + testing.CACert,
+			Tag:      names.NewMachineTag("10"),
+			ModelTag: testing.ModelTag,
+		},
+		DataDir:                 c.MkDir(),
+		LogDir:                  path.Join(logDir, "juju"),
+		MetricsSpoolDir:         c.MkDir(),
+		Jobs:                    []model.MachineJob{model.JobManageModel, model.JobHostUnits},
+		CloudInitOutputLog:      path.Join(logDir, "cloud-init-output.log"),
+		AgentEnvironment:        map[string]string{agent.ProviderType: "dummy"},
+		AuthorizedKeys:          "wheredidileavemykeys",
+		MachineAgentServiceName: "jujud-machine-10",
+	}
+	tools := []*coretools.Tools{{
+		Version: version.MustParseBinary("6.6.6-ubuntu-amd64"),
+		URL:     "https://example.org",
+	}}
+	err := icfg.SetTools(tools)
 	c.Assert(err, jc.ErrorIsNil)
 
 	script, err := sshprovisioner.ProvisioningScript(icfg)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -7,7 +7,7 @@ import (
 	stdcontext "context"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
@@ -191,7 +191,7 @@ func (*OpenSuite) TestDestroyNotFound(c *gc.C) {
 
 type destroyControllerEnv struct {
 	environs.Environ
-	gitjujutesting.Stub
+	jujutesting.Stub
 }
 
 func (e *destroyControllerEnv) DestroyController(ctx context.ProviderCallContext, uuid string) error {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -563,7 +563,7 @@ func assertRequestBody(c *gc.C, req *http.Request, expect interface{}) {
 }
 
 type mockClock struct {
-	gitjujutesting.Stub
+	jtesting.Stub
 	*testclock.Clock
 }
 
@@ -826,9 +826,9 @@ func (s *environSuite) TestStartInstanceCommonDeploymentRetryTimeout(c *gc.C) {
 			`waiting for common resources to be created: `+
 			`max duration exceeded: deployment incomplete`)
 
-	var expectedCalls []gitjujutesting.StubCall
+	var expectedCalls []jtesting.StubCall
 	for i := 0; i < failures; i++ {
-		expectedCalls = append(expectedCalls, gitjujutesting.StubCall{
+		expectedCalls = append(expectedCalls, jtesting.StubCall{
 			"After", []interface{}{5 * time.Second},
 		})
 	}

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -169,7 +169,7 @@ func (s *DestroySuite) TestDestroyEnvScopedVolumes(c *gc.C) {
 
 	// common.Destroy will ignore machine-scoped storage providers.
 	storageProvider.CheckCallNames(c, "Dynamic", "Scope", "Supports", "VolumeSource")
-	volumeSource.CheckCalls(c, []gitjujutesting.StubCall{
+	volumeSource.CheckCalls(c, []jujutesting.StubCall{
 		{"ListVolumes", []interface{}{s.callCtx}},
 		{"DestroyVolumes", []interface{}{s.callCtx, []string{"vol-0", "vol-1", "vol-2"}}},
 	})

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -27,7 +27,7 @@ import (
 	"github.com/juju/pubsub/v2"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v3"
@@ -125,7 +125,7 @@ func SampleConfig() testing.Attrs {
 // and the instance's state will eventually go to error, while the
 // received string will appear in the info field of the machine's status
 func PatchTransientErrorInjectionChannel(c chan error) func() {
-	return gitjujutesting.PatchValue(&transientErrorInjection, c)
+	return jujutesting.PatchValue(&transientErrorInjection, c)
 }
 
 // mongoInfo returns a mongo.MongoInfo which allows clients to connect to the

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"google.golang.org/api/compute/v1"
@@ -111,7 +111,7 @@ func MakeTestCredential() cloud.Credential {
 }
 
 type BaseSuiteUnpatched struct {
-	gitjujutesting.IsolationSuite
+	jujutesting.IsolationSuite
 
 	ControllerUUID string
 	Config         *config.Config

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -5,7 +5,7 @@ package lxd_test
 
 import (
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -45,7 +45,7 @@ func (s *environInstSuite) TestInstancesAPI(c *gc.C) {
 	ids := []instance.Id{"spam", "eggs", "ham"}
 	s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{{
 		FuncName: "AliveContainers",
 		Args: []interface{}{
 			s.Prefix(),

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -118,7 +118,7 @@ func (s *environSuite) TestBootstrapAPI(c *gc.C) {
 	_, err := s.Env.Bootstrap(ctx, s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{{
 		FuncName: "Bootstrap",
 		Args: []interface{}{
 			ctx,
@@ -150,7 +150,7 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 	err := s.Env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Destroy", []interface{}{s.callCtx}},
 		{"StorageSupported", nil},
 		{"GetStoragePools", nil},
@@ -186,7 +186,7 @@ func (s *environSuite) TestDestroyInvalidCredentialsDestroyingFileSystems(c *gc.
 	err := s.Env.Destroy(s.callCtx)
 	c.Assert(err, gc.ErrorMatches, ".* not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Destroy", []interface{}{s.callCtx}},
 		{"StorageSupported", nil},
 		{"GetStoragePools", nil},
@@ -240,7 +240,7 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	err := s.Env.DestroyController(s.callCtx, s.Config.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Destroy", []interface{}{s.callCtx}},
 		{"StorageSupported", nil},
 		{"GetStoragePools", nil},
@@ -287,7 +287,7 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *gc
 	err := s.Env.DestroyController(s.callCtx, s.Config.UUID())
 	c.Assert(err, gc.ErrorMatches, "not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Destroy", []interface{}{s.callCtx}},
 		{"StorageSupported", nil},
 		{"GetStoragePools", nil},
@@ -337,7 +337,7 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsDestroyFilesystem(
 	err := s.Env.DestroyController(s.callCtx, s.Config.UUID())
 	c.Assert(err, gc.ErrorMatches, ".*not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"Destroy", []interface{}{s.callCtx}},
 		{"StorageSupported", nil},
 		{"GetStoragePools", nil},
@@ -359,7 +359,7 @@ func (s *environSuite) TestAvailabilityZonesInvalidCredentials(c *gc.C) {
 	_, err := s.Env.AvailabilityZones(s.callCtx)
 	c.Assert(err, gc.ErrorMatches, ".*not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"IsClustered", nil},
 		{"GetClusterMembers", nil},
 	})
@@ -374,7 +374,7 @@ func (s *environSuite) TestInstanceAvailabilityZoneNamesInvalidCredentials(c *gc
 	_, err := s.Env.InstanceAvailabilityZoneNames(s.callCtx, []instance.Id{"not-valid"})
 	c.Assert(err, gc.ErrorMatches, ".*not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{
+	s.Stub.CheckCalls(c, []jujutesting.StubCall{
 		{"AliveContainers", []interface{}{s.Prefix()}},
 	})
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"go.uber.org/mock/gomock"
@@ -616,7 +616,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
 }
 
 type mockContext struct {
-	gitjujutesting.Stub
+	jtesting.Stub
 }
 
 func (c *mockContext) Verbosef(f string, args ...interface{}) {

--- a/provider/oci/common_test.go
+++ b/provider/oci/common_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	gitjujutesting "github.com/juju/testing"
+	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	ociCore "github.com/oracle/oci-go-sdk/v65/core"
 	ociIdentity "github.com/oracle/oci-go-sdk/v65/identity"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
@@ -245,7 +245,7 @@ func listShapesResponse() []ociCore.Shape {
 }
 
 type commonSuite struct {
-	gitjujutesting.IsolationSuite
+	jtesting.IsolationSuite
 
 	testInstanceID  string
 	testCompartment string

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-goose/goose/v5/nova"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"go.uber.org/mock/gomock"
@@ -510,7 +510,7 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumes(c *gc.C) {
 	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 		{"DeleteVolume", []interface{}{mockVolId}},
 	})
@@ -526,7 +526,7 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesNotFound(c *gc.C) {
 	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 	})
 }
@@ -552,7 +552,7 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesAttached(c *gc.C) {
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], jc.ErrorIsNil)
 	c.Assert(statuses, gc.HasLen, 0)
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{{
 		"GetVolume", []interface{}{mockVolId},
 	}, {
 		"GetVolume", []interface{}{mockVolId},
@@ -590,7 +590,7 @@ func (s *cinderVolumeSourceSuite) TestReleaseVolumes(c *gc.C) {
 		"juju-controller-uuid": "",
 		"juju-model-uuid":      "",
 	}
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 		{"SetVolumeMetadata", []interface{}{mockVolId, metadata}},
 	})
@@ -611,7 +611,7 @@ func (s *cinderVolumeSourceSuite) TestReleaseVolumesAttached(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], gc.ErrorMatches, `cannot release volume "0": volume still in-use`)
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{{
 		"GetVolume", []interface{}{mockVolId},
 	}})
 }
@@ -628,7 +628,7 @@ func (s *cinderVolumeSourceSuite) TestReleaseVolumesInvalidCredential(c *gc.C) {
 	_, err := volSource.ReleaseVolumes(s.callCtx, []string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.invalidCredential, jc.IsTrue)
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{{
 		"GetVolume", []interface{}{mockVolId},
 	}})
 }
@@ -691,7 +691,7 @@ func (s *cinderVolumeSourceSuite) TestDetachVolumes(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil, nil})
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"DetachVolume", []interface{}{mockServerId, mockVolId}},
 		{"DetachVolume", []interface{}{mockServerId2, "42"}},
 	})
@@ -800,7 +800,7 @@ func (s *cinderVolumeSourceSuite) TestImportVolume(c *gc.C) {
 		Size:       mockVolSize,
 		Persistent: true,
 	})
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 		{"SetVolumeMetadata", []interface{}{mockVolId, tags}},
 	})
@@ -818,7 +818,7 @@ func (s *cinderVolumeSourceSuite) TestImportVolumeInUse(c *gc.C) {
 	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
 	_, err := volSource.(storage.VolumeImporter).ImportVolume(s.callCtx, mockVolId, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot import volume "0" with status "in-use"`)
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 	})
 }
@@ -833,14 +833,14 @@ func (s *cinderVolumeSourceSuite) TestImportVolumeInvalidCredential(c *gc.C) {
 	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
 	_, err := volSource.(storage.VolumeImporter).ImportVolume(s.callCtx, mockVolId, nil)
 	c.Assert(err, gc.ErrorMatches, `getting volume: invalid auth`)
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+	mockAdapter.CheckCalls(c, []jujutesting.StubCall{
 		{"GetVolume", []interface{}{mockVolId}},
 	})
 	c.Assert(s.invalidCredential, jc.IsTrue)
 }
 
 type mockAdapter struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	getVolume             func(string) (*cinder.Volume, error)
 	getVolumesDetail      func() ([]cinder.Volume, error)
 	deleteVolume          func(string) error

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/ssh"
@@ -241,7 +241,7 @@ func makeMockAdapter() *mockAdapter {
 	}
 }
 
-func overrideCinderProvider(s *gitjujutesting.CleanupSuite, adapter *mockAdapter) {
+func overrideCinderProvider(s *jujutesting.CleanupSuite, adapter *mockAdapter) {
 	s.PatchValue(openstack.NewOpenstackStorage, func(*openstack.Environ) (openstack.OpenstackStorage, error) {
 		return adapter, nil
 	})

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-goose/goose/v5/identity"
 	"github.com/go-goose/goose/v5/neutron"
 	"github.com/go-goose/goose/v5/nova"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"go.uber.org/mock/gomock"
@@ -29,7 +29,7 @@ import (
 
 // localTests contains tests which do not require a live service or test double to run.
 type localTests struct {
-	gitjujutesting.IsolationSuite
+	jujutesting.IsolationSuite
 }
 
 var _ = gc.Suite(&localTests{})
@@ -630,7 +630,7 @@ var handlerFunc = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) 
 })
 
 type providerUnitTests struct {
-	gitjujutesting.IsolationSuite
+	jujutesting.IsolationSuite
 }
 
 var _ = gc.Suite(&providerUnitTests{})

--- a/state/bakerystorage/storage_test.go
+++ b/state/bakerystorage/storage_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/mgo/v3"
 	mgotesting "github.com/juju/mgo/v3/testing"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
@@ -23,7 +23,7 @@ import (
 
 type StorageSuite struct {
 	testing.BaseSuite
-	gitjujutesting.Stub
+	jujutesting.Stub
 	collection      mockCollection
 	memStorage      bakery.RootKeyStore
 	closeCollection func()
@@ -99,7 +99,7 @@ func (s *StorageSuite) TestGet(c *gc.C) {
 	item, err := store.Get(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(item, jc.DeepEquals, rootKey)
-	s.CheckCalls(c, []gitjujutesting.StubCall{
+	s.CheckCalls(c, []jujutesting.StubCall{
 		{"GetCollection", nil},
 		{"GetStorage", []interface{}{&s.collection, time.Duration(0)}},
 		{"Close", nil},
@@ -129,7 +129,7 @@ func (s *StorageSuite) TestGetLegacyFallback(c *gc.C) {
 	item, err := store.Get(context.Background(), []byte("oldkey"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(item, jc.DeepEquals, rk.RootKey)
-	s.CheckCalls(c, []gitjujutesting.StubCall{
+	s.CheckCalls(c, []jujutesting.StubCall{
 		{"GetCollection", nil},
 		{"GetStorage", []interface{}{&s.collection, time.Duration(0)}},
 		{"GetCollection", nil},
@@ -146,7 +146,7 @@ func (s *StorageSuite) TestGetLegacyFallback(c *gc.C) {
 
 type mockCollection struct {
 	mongo.WriteCollection
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 
 	one func(q *mockQuery, result *interface{}) error
 }
@@ -165,7 +165,7 @@ func (c *mockCollection) Writeable() mongo.WriteCollection {
 
 type mockQuery struct {
 	mongo.Query
-	*gitjujutesting.Stub
+	*jujutesting.Stub
 	id  interface{}
 	one func(q *mockQuery, result *interface{}) error
 }
@@ -184,7 +184,7 @@ var _ = gc.Suite(&BakeryStorageSuite{})
 
 type BakeryStorageSuite struct {
 	mgotesting.MgoSuite
-	gitjujutesting.LoggingSuite
+	jujutesting.LoggingSuite
 
 	store  ExpirableStorage
 	bakery *bakery.Bakery

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -212,7 +212,13 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cred, jc.DeepEquals, stateCred)
+	stateCredential := cloud.NewNamedCredential(
+		stateCred.Name,
+		cloud.AuthType(stateCred.AuthType),
+		stateCred.Attributes,
+		stateCred.Revoked,
+	)
+	c.Assert(cred, jc.DeepEquals, stateCredential)
 	cloudCredentials, err := s.State.CloudCredentials(model.Owner(), "dummy")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudCredentials, jc.DeepEquals, map[string]state.Credential{

--- a/state/model.go
+++ b/state/model.go
@@ -655,13 +655,17 @@ func (m *Model) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 
 // CloudCredential returns the cloud credential used for managing the
 // model's cloud resources, and a boolean indicating whether a credential is set.
-func (m *Model) CloudCredential() (Credential, bool, error) {
+func (m *Model) CloudCredential() (jujucloud.Credential, bool, error) {
 	tag, ok := m.CloudCredentialTag()
 	if !ok {
-		return Credential{}, false, nil
+		return jujucloud.Credential{}, false, nil
 	}
 	cred, err := m.st.CloudCredential(tag)
-	return cred, true, err
+	if err != nil {
+		return jujucloud.Credential{}, false, errors.Trace(err)
+	}
+	result := jujucloud.NewNamedCredential(cred.Name, jujucloud.AuthType(cred.AuthType), cred.Attributes, cred.Revoked)
+	return result, true, nil
 }
 
 // MigrationMode returns whether the model is active or being migrated.

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -132,7 +132,13 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialNoUpdate(c *gc.C) {
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cred, jc.DeepEquals, stateCred)
+	stateCredential := cloud.NewNamedCredential(
+		stateCred.Name,
+		cloud.AuthType(stateCred.AuthType),
+		stateCred.Attributes,
+		stateCred.Revoked,
+	)
+	c.Assert(cred, jc.DeepEquals, stateCredential)
 }
 
 func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c *gc.C) {
@@ -250,7 +256,13 @@ func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.Cloud
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cred, jc.DeepEquals, stateCred)
+	stateCredential := cloud.NewNamedCredential(
+		stateCred.Name,
+		cloud.AuthType(stateCred.AuthType),
+		stateCred.Attributes,
+		stateCred.Revoked,
+	)
+	c.Assert(cred, jc.DeepEquals, stateCredential)
 	return m
 }
 

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -20,7 +20,7 @@ import (
 type baseModel interface {
 	Cloud() (cloud.Cloud, error)
 	CloudRegion() string
-	CloudCredential() (state.Credential, bool, error)
+	CloudCredential() (cloud.Credential, bool, error)
 }
 
 // Model exposes the methods needed for an EnvironConfigGetter.
@@ -79,7 +79,7 @@ func (g EnvironConfigGetter) CloudSpec() (environscloudspec.CloudSpec, error) {
 
 // CloudSpecForModel returns a CloudSpec for the specified model.
 func CloudSpecForModel(m baseModel) (environscloudspec.CloudSpec, error) {
-	cloud, err := m.Cloud()
+	cld, err := m.Cloud()
 	if err != nil {
 		return environscloudspec.CloudSpec{}, errors.Trace(err)
 	}
@@ -88,31 +88,11 @@ func CloudSpecForModel(m baseModel) (environscloudspec.CloudSpec, error) {
 	if err != nil {
 		return environscloudspec.CloudSpec{}, errors.Trace(err)
 	}
-	var credential *state.Credential
+	var credential *cloud.Credential
 	if ok {
 		credential = &credentialValue
 	}
-	return CloudSpec(cloud, regionName, credential)
-}
-
-// CloudSpec returns an environscloudspec.CloudSpec from a *state.State,
-// given the cloud, region and credential names.
-func CloudSpec(
-	modelCloud cloud.Cloud,
-	regionName string,
-	credential *state.Credential,
-) (environscloudspec.CloudSpec, error) {
-	var cloudCredential *cloud.Credential
-	if credential != nil {
-		cloudCredentialValue := cloud.NewNamedCredential(credential.Name,
-			cloud.AuthType(credential.AuthType),
-			credential.Attributes,
-			credential.Revoked,
-		)
-		cloudCredential = &cloudCredentialValue
-	}
-
-	return environscloudspec.MakeCloudSpec(modelCloud, regionName, cloudCredential)
+	return environscloudspec.MakeCloudSpec(cld, regionName, credential)
 }
 
 // NewEnvironFunc aliases a function that, given a Model,

--- a/worker/machiner/mock_test.go
+++ b/worker/machiner/mock_test.go
@@ -5,7 +5,7 @@ package machiner_test
 
 import (
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
@@ -31,7 +31,7 @@ func (w *mockWatcher) Wait() error {
 
 type mockMachine struct {
 	machiner.Machine
-	gitjujutesting.Stub
+	jujutesting.Stub
 	watcher mockWatcher
 	life    life.Value
 }
@@ -75,7 +75,7 @@ func (m *mockMachine) Watch() (watcher.NotifyWatcher, error) {
 }
 
 type mockMachineAccessor struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	machine mockMachine
 }
 

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
-	gitjujutesting "github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -856,7 +856,7 @@ func newMockMachineAccessor(c *gc.C) *mockMachineAccessor {
 }
 
 type mockClock struct {
-	gitjujutesting.Stub
+	jujutesting.Stub
 	now         time.Time
 	onNow       func() time.Time
 	onAfter     func(time.Duration) <-chan time.Time


### PR DESCRIPTION
Remove JujuConnSuite from the environs package. Not all tests are ported - one tested server side code so was removed.

As part of this, the state model.CloudCredential() return type was state.Credential, whereas the Cloud() return type was cloud.Cloud. So fix this by making the credential return type also cloud.Credential. This cleans things up a bit and makes one less state import in stateenvirons.

After this PR, JujuConnSuite is only used in apiserver tests plus a jujud agent tests suite.

Drive by: juju 1.x introduced a dumb import alias `gitjujutesting`. Remove this.

## QA steps

go test

