### PR TITLE
Output controller and model logs to archive

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -137,7 +137,7 @@ bootstrap() {
 			exit 1
 		fi
 
-		add_model "${model}" "${cloud}" "${bootstrapped_name}" "${output}"
+		juju_add_model "${model}" "${cloud}" "${bootstrapped_name}" "${output}"
 		name="${bootstrapped_name}"
 		BOOTSTRAPPED_CLOUD=$(juju show-model controller | yq -j | jq -r '.[] | .cloud')
 		export BOOTSTRAPPED_CLOUD
@@ -163,9 +163,9 @@ bootstrap() {
 	export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }
 
-# add_model is used to add a model for tracking. This is for internal use only
-# and shouldn't be used by any of the tests directly.
-add_model() {
+# juju_add_model is used to add a model for tracking. This is for internal use
+# only and shouldn't be used by any of the tests directly.
+juju_add_model() {
 	local model cloud controller
 
 	model=${1}
@@ -175,14 +175,23 @@ add_model() {
 
 	OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${cloud}" || true)
 	if [[ -n ${OUT} ]]; then
-		juju add-model -c "${controller}" "${model}" 2>&1 | OUTPUT "${output}"
+		juju add-model --show-log -c "${controller}" "${model}" 2>&1 | OUTPUT "${output}"
 	else
-		juju add-model -c "${controller}" "${model}" "${cloud}" 2>&1 | OUTPUT "${output}"
+		juju add-model --show-log -c "${controller}" "${model}" "${cloud}" 2>&1 | OUTPUT "${output}"
 	fi
 
-	post_add_model
+	post_add_model "${controller}" "${model}"
 
 	echo "${model}" >>"${TEST_DIR}/models"
+}
+
+add_model() {
+	local model
+
+	model=${1}
+
+	juju add-model --show-log "${model}" 2>&1
+	post_add_model "" "${model}"
 }
 
 # add_images_for_vsphere is used to add-image with known vSphere template paths for LTS series
@@ -248,7 +257,7 @@ juju_bootstrap() {
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
 
-	post_bootstrap
+	post_bootstrap "${name}" "${model}"
 }
 
 # pre_bootstrap contains setup required before bootstrap specific to providers
@@ -300,17 +309,46 @@ pre_bootstrap() {
 # and shouldn't be used by any of the tests directly.  Calls post_add_model
 # models are added during bootstrap.
 post_bootstrap() {
+	local name model
+
+	name=${1}
+	model=${2}
+
+	# Setup up log tailing on the controller.
+	# shellcheck disable=SC2069
+	juju debug-log -m "${name}:controller" --replay --tail 2>&1 >"${TEST_DIR}/controller-debug.log" &
+	CMD_PID=$!
+	echo "${CMD_PID}" >>"${TEST_DIR}/pids"
+
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"vsphere")
 		rm -r "${TEST_DIR}"/image-streams
 		;;
 	esac
-	post_add_model
+	post_add_model "${name}" "${model}"
 }
 
 # post_add_model does provider specific config required after a new model is added
 # and shouldn't be used by any of the tests directly.
 post_add_model() {
+	local controller model
+
+	controller=${1}
+	model=${2}
+
+	ctrl_arg="${controller}:${model}"
+	log_file="${controller}-${model}.log"
+	if [[ -z ${controller} ]]; then
+		ctrl_arg="${model}"
+		log_file="${model}.log"
+	fi
+
+	# Setup up log tailing on the controller.
+	# shellcheck disable=SC2069
+	juju debug-log -m "${ctrl_arg}" --replay --tail 2>&1 >"${TEST_DIR}/${log_file}" &
+	CMD_PID=$!
+	echo "${CMD_PID}" >>"${TEST_DIR}/pids"
+
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"vsphere")
 		add_images_for_vsphere

--- a/tests/includes/pids.sh
+++ b/tests/includes/pids.sh
@@ -1,0 +1,14 @@
+cleanup_pids() {
+	if [[ -f "${TEST_DIR}/pids" ]]; then
+		echo "====> Cleaning up pids"
+
+		while read -r pid; do
+			if ps -p "${pid}" >/dev/null; then
+				kill -9 "${pid}" || true
+			fi
+		done <"${TEST_DIR}/pids"
+		rm -f "${TEST_DIR}/pids" || true
+
+	fi
+	echo "====> Completed cleaning up pids"
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -278,6 +278,7 @@ cleanup() {
 
 	archive_logs "partial"
 
+	cleanup_pids
 	cleanup_jujus
 	cleanup_funcs
 

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -107,7 +107,7 @@ run_deploy_caas_workload() {
 	controller_name=$(juju controllers --format json | jq -r '.controllers | keys[0]')
 	juju add-k8s "${k8s_cloud_name}" --storage "${storage}" --controller "${controller_name}" 2>&1 | OUTPUT "${file}"
 
-	add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
+	juju_add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
 
 	juju deploy snappass-test
 

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -2,12 +2,12 @@ run_secrets_cmr() {
 	echo
 
 	echo "First set up a cross model relation"
-	juju --show-log add-model "model-secrets-offer"
+	add_model "model-secrets-offer"
 	juju --show-log deploy juju-qa-dummy-source
 	juju --show-log offer dummy-source:sink
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
-	juju --show-log add-model "model-secrets-consume"
+	add_model "model-secrets-consume"
 	juju --show-log deploy juju-qa-dummy-sink
 	juju --show-log integrate dummy-sink model-secrets-offer.dummy-source
 

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -69,7 +69,7 @@ check_secrets() {
 run_secrets_juju() {
 	echo
 
-	juju --show-log add-model "model-secrets-juju"
+	add_model "model-secrets-juju"
 	check_secrets
 	destroy_model "model-secrets-juju"
 }

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -5,7 +5,7 @@ run_secrets_vault() {
 
 	model_name='model-secrets-vault'
 	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
-	juju --show-log add-model "$model_name" --config secret-backend=myvault
+	add_model "$model_name" --config secret-backend=myvault
 
 	check_secrets
 
@@ -19,7 +19,7 @@ run_secret_drain() {
 	prepare_vault
 
 	model_name='model-secrets-drain'
-	juju --show-log add-model "$model_name"
+	add_model "$model_name"
 
 	vault_backend_name='myvault'
 	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
@@ -68,7 +68,7 @@ run_secret_drain() {
 }
 
 prepare_vault() {
-	juju add-model "model-vault-provider"
+	add_model "model-vault-provider"
 
 	if ! which "vault" >/dev/null 2>&1; then
 		sudo snap install vault


### PR DESCRIPTION
The following will tail the log files for the controller and any model that uses the add_model function. This should make it easier to see if there is a problem with the controller/model whilst a test is running.

This does its best to ensure we clean the pids up, but it's not 100% accurate. Also if the pid has been replaced with the same id, then you're SOL'd.

For most if not all CI jobs this will be fine.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

There should be some controller debug logs in the tests dir once it's bootstrapped.

```sh
$ cd tests && ./main.sh -v secrets_iaas
```

