### PR TITLE
Sort controller names on error

### DIFF
--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
@@ -417,6 +418,7 @@ func translateControllerError(store jujuclient.ClientStore, err error) error {
 	for name := range controllers {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return errors.Wrap(err, NewNoCurrentController(names))
 }
 


### PR DESCRIPTION
The controller names aren't stable, so when we report the user to switch to a controller the order is not always the same for repeated calls.

This just sorts the names on creating the error.

## QA steps

```sh
$ juju bootstrap lxd test1 --build-agent
$ juju bootstrap lxd test2 --build-agent
$ juju bootstrap lxd test3 --build-agent
$ watch juju status
```

In another shell kill test3 controller.

```sh
$ juju kill-controller test3
``` 

The error names should be sorted.
