### PR TITLE
[JUJU-4351] Mark default-series as deprecated in help text

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2122,6 +2122,11 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
+	DefaultSeriesKey: {
+		Description: "DEPRECATED in favour of default-base. Will be removed in 4.0. The default series to use for deploying charms, will act like --series when deploying charms",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
 	// TODO (jack-w-shaw) integrate this into mode
 	"development": {
 		Description: "Whether the model is in development mode",


### PR DESCRIPTION
default-series config attribute relies on our series construct, which is being deprecated in favour of base. default-series in model-config is one of the few remaining outward-facing instances of series

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju model-config --help
...
default-series:
  type: string
  description: DEPRECATED in favour of default-base. Will be removed in 4.0. The default
    series to use for deploying charms, will act like --series when deploying charms
...
```

## Documentation changes

Changes will be auto-applied on release