### PR TITLE
Skip schema facade generation when builing image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,7 @@ image-check: $(image_check_prereq)
 
 .PHONY: image-check-build
 image-check-build:
-	CLIENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" AGENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" make build
+	CLIENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" AGENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" make go-build
 
 .PHONY: image-check-build-skip
 image-check-build-skip:


### PR DESCRIPTION
We don't need to build the schema facade when building an image, because the schema facade generator will have been run previously. We don't need to boil the ocean.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Ensure that we can still make the operator image.

```sh
$ make operator-image
```
