### PR TITLE
[JUJU-4353] Export bundle default series properly

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/series"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -334,12 +335,25 @@ func bundleOutputFromBundleData(bd *charm.BundleData) *bundleOutput {
 }
 
 func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults bool, backend Backend) (*charm.BundleData, error) {
-	cfg := model.Config()
-	value, ok := cfg["default-series"]
-	if !ok {
-		value = version.DefaultSupportedLTS()
+	cfg, err := config.New(config.NoDefaults, model.Config())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	defaultSeries := fmt.Sprintf("%v", value)
+	var base series.Base
+	value, ok := cfg.DefaultBase()
+	if ok {
+		var err error
+		base, err = series.ParseBaseFromString(value)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		base = version.DefaultSupportedLTSBase()
+	}
+	defaultSeries, err := series.GetSeriesFromBase(base)
+	if err != nil {
+		return nil, err
+	}
 
 	data := &charm.BundleData{}
 

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -696,10 +696,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleEndpointBindingsSuccess(c *gc.C
 
 func (s *bundleSuite) TestExportBundleFailNoApplication(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
@@ -772,10 +769,7 @@ func minimalStatusArgs() description.StatusArgs {
 
 func (s *bundleSuite) TestExportBundleWithApplication(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	app := s.st.model.AddApplication(s.minimalApplicationArgs(description.IAAS))
@@ -811,10 +805,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithApplicationResources(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	app := s.st.model.AddApplication(s.minimalApplicationArgs(description.IAAS))
@@ -865,10 +856,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	args := s.minimalApplicationArgs(description.IAAS)
@@ -924,10 +912,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	appArgs := s.minimalApplicationArgs(description.IAAS)
@@ -969,10 +954,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	app := s.st.model.AddApplication(s.minimalApplicationArgs(description.IAAS))
@@ -1057,10 +1039,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithApplicationCharmConfig(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	app := s.st.model.AddApplication(s.minimalApplicationArgsWithCharmConfig(description.IAAS, map[string]interface{}{
@@ -1269,10 +1248,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	app := s.st.model.AddApplication(s.minimalApplicationArgs(description.IAAS))
@@ -1364,12 +1340,9 @@ func (s *bundleSuite) setEndpointSettings(ep description.Endpoint, units ...stri
 
 func (s *bundleSuite) newModel(modelType string, app1 string, app2 string) description.Model {
 	s.st.model = description.NewModel(description.ModelArgs{
-		Type:  modelType,
-		Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Type:        modelType,
+		Owner:       names.NewUserTag("magic"),
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	appName1 := s.addApplicationToModel(s.st.model, app1, 2)
@@ -1557,10 +1530,7 @@ relations:
 
 func (s *bundleSuite) TestExportBundleSubordinateApplication(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	s.st.Spaces[network.AlphaSpaceId] = network.AlphaSpaceName
@@ -1617,10 +1587,7 @@ applications:
 
 func (s *bundleSuite) setupExportBundleEndpointBindingsPrinted(all, oneOff string) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	args := s.minimalApplicationArgs(description.IAAS)
@@ -1702,10 +1669,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleSubordinateApplicationAndMachine(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	application := s.st.model.AddApplication(description.ApplicationArgs{
@@ -1867,10 +1831,7 @@ relations:
 
 func (s *bundleSuite) TestExportBundleWithContainers(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name": "awesome",
-			"uuid": "some-uuid",
-		},
+		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
 
 	application0 := s.st.model.AddApplication(description.ApplicationArgs{
@@ -1948,75 +1909,9 @@ machines:
 
 func (s *bundleSuite) TestMixedSeries(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name":           "awesome",
-			"uuid":           "some-uuid",
-			"default-series": "bionic",
-		},
-		CloudRegion: "some-region"})
-
-	application := s.st.model.AddApplication(description.ApplicationArgs{
-		Tag:      names.NewApplicationTag("magic"),
-		CharmURL: "ch:magic",
-	})
-	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/18.04/stable"})
-	application.AddUnit(description.UnitArgs{
-		Tag:     names.NewUnitTag("magic/0"),
-		Machine: names.NewMachineTag("0"),
-	})
-	s.st.model.AddMachine(description.MachineArgs{
-		Id:   names.NewMachineTag("0"),
-		Base: "ubuntu@18.04",
-	})
-
-	application = s.st.model.AddApplication(description.ApplicationArgs{
-		Tag:      names.NewApplicationTag("mojo"),
-		CharmURL: "ch:mojo",
-	})
-	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/22.04/stable"})
-	application.AddUnit(description.UnitArgs{
-		Tag:     names.NewUnitTag("mojo/0"),
-		Machine: names.NewMachineTag("1"),
-	})
-	s.st.model.AddMachine(description.MachineArgs{
-		Id:   names.NewMachineTag("1"),
-		Base: "ubuntu@22.04",
-	})
-
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	expectedResult := params.StringResult{Result: `
-series: bionic
-applications:
-  magic:
-    charm: magic
-    num_units: 1
-    to:
-    - "0"
-  mojo:
-    charm: mojo
-    series: jammy
-    num_units: 1
-    to:
-    - "1"
-machines:
-  "0": {}
-  "1":
-    series: jammy
-`[1:]}
-
-	c.Assert(result, gc.Equals, expectedResult)
-	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
-}
-
-func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
-	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config: map[string]interface{}{
-			"name":           "awesome",
-			"uuid":           "some-uuid",
-			"default-series": "bionic",
-		},
+		Config: coretesting.FakeConfig().Merge(map[string]interface{}{
+			"default-base": "ubuntu@20.04",
+		}),
 		CloudRegion: "some-region"})
 
 	application := s.st.model.AddApplication(description.ApplicationArgs{
@@ -2051,10 +1946,10 @@ func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
+series: focal
 applications:
   magic:
     charm: magic
-    series: focal
     num_units: 1
     to:
     - "0"
@@ -2065,10 +1960,69 @@ applications:
     to:
     - "1"
 machines:
-  "0":
-    series: focal
+  "0": {}
   "1":
     series: jammy
+`[1:]}
+
+	c.Assert(result, gc.Equals, expectedResult)
+	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
+}
+
+func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
+	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
+		Config:      coretesting.FakeConfig(),
+		CloudRegion: "some-region"})
+
+	application := s.st.model.AddApplication(description.ApplicationArgs{
+		Tag:      names.NewApplicationTag("magic"),
+		CharmURL: "ch:magic",
+	})
+	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/20.04/stable"})
+	application.AddUnit(description.UnitArgs{
+		Tag:     names.NewUnitTag("magic/0"),
+		Machine: names.NewMachineTag("0"),
+	})
+	s.st.model.AddMachine(description.MachineArgs{
+		Id:   names.NewMachineTag("0"),
+		Base: "ubuntu@20.04",
+	})
+
+	application = s.st.model.AddApplication(description.ApplicationArgs{
+		Tag:      names.NewApplicationTag("mojo"),
+		CharmURL: "ch:mojo",
+	})
+	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/22.04/stable"})
+	application.AddUnit(description.UnitArgs{
+		Tag:     names.NewUnitTag("mojo/0"),
+		Machine: names.NewMachineTag("1"),
+	})
+	s.st.model.AddMachine(description.MachineArgs{
+		Id:   names.NewMachineTag("1"),
+		Base: "ubuntu@22.04",
+	})
+
+	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedResult := params.StringResult{Result: `
+series: jammy
+applications:
+  magic:
+    charm: magic
+    series: focal
+    num_units: 1
+    to:
+    - "0"
+  mojo:
+    charm: mojo
+    num_units: 1
+    to:
+    - "1"
+machines:
+  "0":
+    series: focal
+  "1": {}
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
@@ -2291,10 +2245,7 @@ applications:
 		c.Logf("%d. %s", i, spec.descr)
 
 		s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-			Config: map[string]interface{}{
-				"name": "awesome",
-				"uuid": "some-uuid",
-			},
+			Config:      coretesting.FakeConfig(),
 			CloudRegion: "some-region"},
 		)
 		s.st.Spaces[network.AlphaSpaceId] = network.AlphaSpaceName


### PR DESCRIPTION
'default-series' no longer exists in configs. We parse it from default-base. This meant that we were ignoring the default base/series when exporting bundles. Fix this bug

Really we should be using a config method to query config items. Parse the config, and load it's default base.

This the needs to be converted to a series to maintain compatibility

This meant small changes to tests, since our fake configs now need to parse correctly.

There was one test (TestMixedSeriesNoDefaultSeries) which appeared to be incorrect. Fix this

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju add-model m
$ juju deploy ubuntu
$ juju deploy kafka
$ juju export-bundle
series: jammy
applications:
  kafka:
    charm: kafka
    channel: 3/stable
    revision: 123
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      data: rootfs,1,10240M
  ubuntu:
    charm: ubuntu
    channel: stable
    revision: 24
    series: focal
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
    series: focal
  "2":
    constraints: arch=amd64
```

Set default-base model config to ubuntu 22.04
```
$ juju model-config default-base=ubuntu@22.04
series: jammy
applications:
  kafka:
    charm: kafka
    channel: 3/stable
    revision: 123
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      data: rootfs,1,10240M
  ubuntu:
    charm: ubuntu
    channel: stable
    revision: 24
    series: focal
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
    series: focal
  "2":
    constraints: arch=amd64
```

Set default-base model config to ubuntu 20.04
```
$ juju model-config default-base=ubuntu@20.04
$ juju export-bundle 
series: focal
applications:
  kafka:
    charm: kafka
    channel: 3/stable
    revision: 123
    series: jammy
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      data: rootfs,1,10240M
  ubuntu:
    charm: ubuntu
    channel: stable
    revision: 24
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
  "2":
    constraints: arch=amd64
    series: jammy
```