### PR TITLE
Output controller and model logs to archive

### DIFF
--- a/tests/includes/pids.sh
+++ b/tests/includes/pids.sh
@@ -1,0 +1,14 @@
+cleanup_pids() {
+	if [[ -f "${TEST_DIR}/pids" ]]; then
+		echo "====> Cleaning up pids"
+
+		while read -r pid; do
+			if ps -p "${pid}" >/dev/null; then
+				kill -9 "${pid}" || true
+			fi
+		done <"${TEST_DIR}/pids"
+		rm -f "${TEST_DIR}/pids" || true
+
+	fi
+	echo "====> Completed cleaning up pids"
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -278,6 +278,7 @@ cleanup() {
 
 	archive_logs "partial"
 
+	cleanup_pids
 	cleanup_jujus
 	cleanup_funcs
 

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -107,7 +107,7 @@ run_deploy_caas_workload() {
 	controller_name=$(juju controllers --format json | jq -r '.controllers | keys[0]')
 	juju add-k8s "${k8s_cloud_name}" --storage "${storage}" --controller "${controller_name}" 2>&1 | OUTPUT "${file}"
 
-	add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
+	juju_add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
 
 	juju deploy snappass-test
 

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -2,12 +2,12 @@ run_secrets_cmr() {
 	echo
 
 	echo "First set up a cross model relation"
-	juju --show-log add-model "model-secrets-offer"
+	add_model "model-secrets-offer"
 	juju --show-log deploy juju-qa-dummy-source
 	juju --show-log offer dummy-source:sink
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
-	juju --show-log add-model "model-secrets-consume"
+	add_model "model-secrets-consume"
 	juju --show-log deploy juju-qa-dummy-sink
 	juju --show-log integrate dummy-sink model-secrets-offer.dummy-source
 

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -69,7 +69,7 @@ check_secrets() {
 run_secrets_juju() {
 	echo
 
-	juju --show-log add-model "model-secrets-juju"
+	add_model "model-secrets-juju"
 	check_secrets
 	destroy_model "model-secrets-juju"
 }

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -5,7 +5,7 @@ run_secrets_vault() {
 
 	model_name='model-secrets-vault'
 	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
-	juju --show-log add-model "$model_name" --config secret-backend=myvault
+	add_model "$model_name" --config secret-backend=myvault
 
 	check_secrets
 
@@ -19,7 +19,7 @@ run_secret_drain() {
 	prepare_vault
 
 	model_name='model-secrets-drain'
-	juju --show-log add-model "$model_name"
+	add_model "$model_name"
 
 	vault_backend_name='myvault'
 	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
@@ -68,7 +68,7 @@ run_secret_drain() {
 }
 
 prepare_vault() {
-	juju add-model "model-vault-provider"
+	add_model "model-vault-provider"
 
 	if ! which "vault" >/dev/null 2>&1; then
 		sudo snap install vault


### PR DESCRIPTION
This is a backport of https://github.com/juju/juju/pull/16003

----

The following will tail the log files for the controller and any model that uses the add_model function. This should make it easier to see if there is a problem with the controller/model whilst a test is running.

This does its best to ensure we clean the pids up, but it's not 100% accurate. Also if the pid has been replaced with the same id, then you're SOL'd.

For most if not all CI jobs this will be fine.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
$ cd tests && ./main.sh -v secrets_iaas
```