### PR TITLE
Remove unnecessary dummy provider imports

### DIFF
--- a/cmd/juju/application/show_test.go
+++ b/cmd/juju/application/show_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/jujuclient"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	jujutesting "github.com/juju/juju/testing"

--- a/cmd/juju/application/showunit_test.go
+++ b/cmd/juju/application/showunit_test.go
@@ -16,7 +16,6 @@ import (
 	apiapplication "github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	jujutesting "github.com/juju/juju/testing"
 )

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
-	_ "github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
 )

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -15,7 +15,6 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/storage/import_test.go
+++ b/cmd/juju/storage/import_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 	jujustorage "github.com/juju/juju/storage"
 )
 

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/status"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/model"
-	_ "github.com/juju/juju/provider/dummy"
 )
 
 type PoolCreateSuite struct {

--- a/cmd/juju/storage/pooldelete_test.go
+++ b/cmd/juju/storage/pooldelete_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -15,7 +15,6 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/juju/storage/poolupdate_test.go
+++ b/cmd/juju/storage/poolupdate_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 )
 
 type PoolUpdateSuite struct {

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/storage"
-	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
-	_ "github.com/juju/juju/provider/dummy"
 )
 
 func init() {

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -16,11 +16,6 @@ import (
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
-	_ "github.com/juju/juju/provider/azure"
-	_ "github.com/juju/juju/provider/dummy"
-	_ "github.com/juju/juju/provider/ec2"
-	_ "github.com/juju/juju/provider/maas"
-	_ "github.com/juju/juju/provider/openstack"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )


### PR DESCRIPTION
A small cleanup PR.
Various tests were unnecessarily importing the dummy provider, so remove that.
Also remove an obsolete test for an old facade version.

## QA steps

go test