### PR TITLE
[JUJU-4353] Fix a test that was broken in a previous commit

### DIFF
--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -1971,21 +1971,27 @@ machines:
 
 func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
-		Config:      coretesting.FakeConfig(),
+		Config: coretesting.FakeConfig().Merge(map[string]interface{}{
+			"default-base": "ubuntu@20.04",
+		}),
 		CloudRegion: "some-region"})
 
 	application := s.st.model.AddApplication(description.ApplicationArgs{
 		Tag:      names.NewApplicationTag("magic"),
 		CharmURL: "ch:magic",
 	})
-	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/20.04/stable"})
+
+	// TODO(jack-w-shaw) this test is somewhat contrived since ubuntu@21.04 is not a supported base.
+	// However, since this test requires at least 3 different bases, we need to do this until 24.04
+	// is supported
+	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/21.04/stable"})
 	application.AddUnit(description.UnitArgs{
 		Tag:     names.NewUnitTag("magic/0"),
 		Machine: names.NewMachineTag("0"),
 	})
 	s.st.model.AddMachine(description.MachineArgs{
 		Id:   names.NewMachineTag("0"),
-		Base: "ubuntu@20.04",
+		Base: "ubuntu@21.04",
 	})
 
 	application = s.st.model.AddApplication(description.ApplicationArgs{
@@ -2006,23 +2012,24 @@ func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: jammy
 applications:
   magic:
     charm: magic
-    series: focal
+    series: hirsute
     num_units: 1
     to:
     - "0"
   mojo:
     charm: mojo
+    series: jammy
     num_units: 1
     to:
     - "1"
 machines:
   "0":
-    series: focal
-  "1": {}
+    series: hirsute
+  "1":
+    series: jammy
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)


### PR DESCRIPTION
It was broken here:
https://github.com/juju/juju/pull/16013

This test asserts that if there are multiple bases/series specified by charms, none of which being the the default series, then no default series is inserted into the bundle

This was difficult to see since (as of writing) juju only supports two series. Fix this by forcing one our our application to deploy with an unsupported series

See original here:
https://github.com/juju/juju/blob/092d567548698c3bb1ebcb50f0f693c777010f24/apiserver/facades/client/bundle/bundle_test.go#L2013-L2076

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/client/bundle
```