### PR TITLE
[JUJU-4352] Export bundles with bases not series

### DIFF
--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -159,7 +159,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
                     charm: haproxy
                     revision: 42
                     channel: stable
-                    series: jammy
+                    base: ubuntu@22.04/stable
             relations:
                 - - django:web
                   - haproxy:web
@@ -489,7 +489,7 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
                     charm: ch:haproxy
                     revision: 42
                     channel: stable
-                    series: jammy
+                    base: ubuntu@22.04/stable
             relations:
                 - - django:web
                   - haproxy:web
@@ -792,7 +792,7 @@ func (s *bundleSuite) TestExportBundleWithApplication(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -841,7 +841,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationResources(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -895,7 +895,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -940,7 +940,7 @@ func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -1003,7 +1003,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   foo:
     charm: ubuntu
@@ -1150,7 +1150,7 @@ UGNmDMvj8tUYI7+SvffHrTBwBPvcGeXa7XP4Au+GoJUN0jHspCeik/04KwanRCmu
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   foo:
     charm: ubuntu
@@ -1277,7 +1277,7 @@ func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 saas:
   awesome:
     url: test:admin/default.awesome
@@ -1388,7 +1388,7 @@ func (s *bundleSuite) TestExportBundleModelWithSettingsRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1431,7 +1431,7 @@ func (s *bundleSuite) TestExportBundleModelWithCharmDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mariadb:
     charm: mariadb
@@ -1507,7 +1507,7 @@ func (s *bundleSuite) TestExportBundleModelRelationsWithSubordinates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1576,7 +1576,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplication(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: bionic
+default-base: ubuntu@18.04/stable
 applications:
   magic:
     charm: magic
@@ -1635,12 +1635,12 @@ applications:
   magic:
     charm: magic
     channel: stable
-    series: bionic
+    base: ubuntu@18.04/stable
     expose: true
   ubuntu:
     charm: ubuntu
     channel: stable
-    series: focal
+    base: ubuntu@20.04/stable
     options:
       key: value
 `[1:]}
@@ -1657,7 +1657,7 @@ applications:
   magic:
     charm: magic
     channel: stable
-    series: bionic
+    base: ubuntu@18.04/stable
     expose: true
     bindings:
       another: vlan2
@@ -1665,7 +1665,7 @@ applications:
   ubuntu:
     charm: ubuntu
     channel: stable
-    series: focal
+    base: ubuntu@20.04/stable
     options:
       key: value
     bindings:
@@ -1699,7 +1699,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplicationAndMachine(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: zesty
+default-base: ubuntu@17.04/stable
 applications:
   magic:
     charm: magic
@@ -1750,7 +1750,7 @@ func (s *bundleSuite) TestExportBundleModelWithConstraints(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mediawiki:
     charm: mediawiki
@@ -1806,7 +1806,7 @@ func (s *bundleSuite) TestExportBundleModelWithAnnotations(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1892,7 +1892,7 @@ func (s *bundleSuite) TestExportBundleWithContainers(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1915,7 +1915,7 @@ machines:
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
-func (s *bundleSuite) TestMixedSeries(c *gc.C) {
+func (s *bundleSuite) TestMixedBases(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config: coretesting.FakeConfig().Merge(map[string]interface{}{
 			"default-base": "ubuntu@20.04",
@@ -1954,7 +1954,7 @@ func (s *bundleSuite) TestMixedSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -1963,21 +1963,21 @@ applications:
     - "0"
   mojo:
     charm: mojo
-    series: jammy
+    base: ubuntu@22.04/stable
     num_units: 1
     to:
     - "1"
 machines:
   "0": {}
   "1":
-    series: jammy
+    base: ubuntu@22.04/stable
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
-func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
+func (s *bundleSuite) TestMixedBasesNoDefaultBases(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config:      coretesting.FakeConfig(),
 		CloudRegion: "some-region"})
@@ -2014,11 +2014,11 @@ func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: jammy
+default-base: ubuntu@22.04/stable
 applications:
   magic:
     charm: magic
-    series: focal
+    base: ubuntu@20.04/stable
     num_units: 1
     to:
     - "0"
@@ -2029,7 +2029,7 @@ applications:
     - "1"
 machines:
   "0":
-    series: focal
+    base: ubuntu@20.04/stable
   "1": {}
 `[1:]}
 
@@ -2071,7 +2071,7 @@ func (s *bundleSuite) TestExportCharmhubBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -2107,7 +2107,7 @@ func (s *bundleSuite) TestExportLocalBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: local:mysql
@@ -2133,7 +2133,7 @@ relations:
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
-func (s *bundleSuite) TestExportLocalBundleWithSeries(c *gc.C) {
+func (s *bundleSuite) TestExportLocalBundleWithBases(c *gc.C) {
 	model := s.newModel("iaas", "local:focal/wordpress", "local:mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
@@ -2141,7 +2141,7 @@ func (s *bundleSuite) TestExportLocalBundleWithSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: local:mysql
@@ -2178,7 +2178,7 @@ func (s *bundleSuite) TestExportBundleWithExposedEndpointSettings(c *gc.C) {
 			descr:   "exposed application without exposed endpoint settings (upgraded 2.8 controller)",
 			exposed: true,
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -2199,7 +2199,7 @@ applications:
 				},
 			},
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -2224,7 +2224,7 @@ applications:
 			},
 			// The exposed:true will be omitted and only the exposed-endpoints section (in the overlay) will be present
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic


### PR DESCRIPTION
This is a step towards removing series from all outward facing aspects of Juju.

This will also conveniently work to inform users that bundles not support bases

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju add-model m
$ juju deploy ubuntu --base ubuntu@20.04
$ juju deploy kafka
$ juju export-bundle
default-base: ubuntu@22.04/stable
applications:
  kafka:
    charm: kafka
    channel: 3/stable
    revision: 123
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      data: rootfs,1,10240M
  ubuntu:
    charm: ubuntu
    channel: stable
    revision: 24
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
  "2":
    constraints: arch=amd64
    base: ubuntu@20.04/stable

```
