### PR TITLE
[cmr test] wait_for relation to disappear before removing offer

### DIFF
--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -62,6 +62,7 @@ run_offer_consume() {
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "model-offer"
+	wait_for null '.offers."dummy-offer"."total-connected-count"'
 	juju remove-offer "admin/model-offer.dummy-offer" -y
 
 	echo "Clean up"
@@ -122,6 +123,7 @@ run_offer_consume_cross_controller() {
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "${offer_controller}:model-offer"
+	wait_for null '.offers."dummy-offer"."total-connected-count"'
 	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" -y
 
 	echo "Clean up"


### PR DESCRIPTION
The CMR tests (`test-cmr-test-offer-consume-*`) are failing intermittently with the error
```
ERROR cannot delete application offer "dummy-offer": offer has 1 relation
```

Before we remove the offer, `wait_for` to ensure the relation has disappeared.

### QA steps

```
cd tests
./main.sh -v cmr
```