### PR TITLE
[JUJU-4368] Prevent raising error prematurely in ModifyModelAccess

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1049,11 +1049,8 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 			result.Results[i].Error = apiservererrors.ServerError(errors.Annotate(err, "could not modify model access"))
 			continue
 		}
-		err = m.authorizer.HasPermission(permission.AdminAccess, modelTag)
-		if err != nil {
-			return result, errors.Trace(err)
-		}
-		canModify := err == nil || canModifyController
+
+		canModify := m.authorizer.HasPermission(permission.AdminAccess, modelTag) == nil || canModifyController
 
 		if !canModify {
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/juju/juju/commit/f30e2a0886df0d87e625d7c37fa27308920b30a2, which changes the signature of `HasPermission()` from returning a `(bool, error)` to returning just the `error` (that indicates the entity doesn't have the permission for the given operation). It did, however, kept the old error check to raise if there's an error coming from the HasPermission itself, which is no longer valid, and causes the ModifyModelAccess to prematurely raises an error if the user doesn't have AdminAccess on the model, even if it has a SuperuserAcess on the controller.

Fix LP [2028939](https://bugs.launchpad.net/juju/+bug/2028939).

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
 $ juju bootstrap localhost juju-3-2-remove-me && juju add-model tst32
```

```sh
 $ juju revoke admin admin tst32
```

```sh
 $ juju show-model tst32
tst32:
  name: admin/tst32
  short-name: tst32
  model-uuid: 715b6de3-0d10-4d7c-87f9-73fd75f73dbb
  model-type: iaas
  controller-uuid: 71fbd0f3-4422-432c-8eda-e4ae27ff982b
  controller-name: lxd32
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 3 minutes ago
  users:
    admin:
      display-name: admin
      access: write   <------------------------------------------------ Notice that the admin user only has write access
      last-connection: 2 minutes ago
  sla: unsupported
  agent-version: 3.2.2.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 3.2.2.1
```

The following errors without this change:
```sh
 $ juju revoke admin write test
ERROR permission denied (unauthorized access)
```

With this change, it should succeed, and you should see that the admin user has only the `read` access:

```sh
 $ juju revoke admin write tst32
 $ juju show-model tst32
tst32:
  name: admin/tst32
  short-name: tst32
  model-uuid: 715b6de3-0d10-4d7c-87f9-73fd75f73dbb
  model-type: iaas
  controller-uuid: 71fbd0f3-4422-432c-8eda-e4ae27ff982b
  controller-name: lxd32
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 37 minutes ago
  users:
    admin:
      display-name: admin
      access: read  <-------------------------------------------------- admin user has only the read access
      last-connection: 37 minutes ago
  sla: unsupported
  agent-version: 3.2.2.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 3.2.2.1
```

## Bug reference

Fix LP [2028939](https://bugs.launchpad.net/juju/+bug/2028939).
