### PR TITLE
Improve debug-{code,hooks} cli help msg

### DIFF
--- a/cmd/juju/ssh/debugcode.go
+++ b/cmd/juju/ssh/debugcode.go
@@ -14,10 +14,24 @@ import (
 )
 
 const usageDebugCodeExamples = `
+Debug all hooks and actions of unit '0':
+
     juju debug-code mysql/0
+
+Debug all hooks and actions of the leader:
+
     juju debug-code mysql/leader
+
+Debug the 'config-changed' hook of unit '1':
+
     juju debug-code mysql/1 config-changed
+
+Debug the 'pull-site' action and 'update-status' hook:
+
     juju debug-code hello-kubecon/0 pull-site update-status
+
+Debug the 'leader-elected' hook and set 'JUJU_DEBUG_AT' variable to 'hook':
+
     juju debug-code --at=hook mysql/0 leader-elected
 `
 

--- a/cmd/juju/ssh/debugcode.go
+++ b/cmd/juju/ssh/debugcode.go
@@ -37,16 +37,14 @@ type debugCodeCommand struct {
 }
 
 const debugCodeDoc = `
-The command launches a tmux session that will intercept matching events and/or 
-actions. It is similar to 'juju debug-hooks' but instead of dropping you into a
-shell prompt, it automatically executes the hooks and/or actions and sets the
-JUJU_DEBUG_AT environment variable. Charms implementing support for this
+The command launches a tmux session that will intercept matching hooks and/or 
+actions. 
+
+Initially, the tmux session will take you to '/var/lib/juju' or '/home/ubuntu'.
+As soon as a matching hook or action is fired, the hook or action is executed
+and the JUJU_DEBUG_AT variable is set. Charms implementing support for this
 should set debug breakpoints based on the environment variable. Charms written
 with the Charmed Operator Framework Ops automatically provide support for this.
-
-Initially, the tmux session will take you to '/var/lib/juju'. As soon as a
-matching event or action is fired, the hook or action is executed and the
-JUJU_DEBUG_AT variable is set.
 
 For more details on debugging charm code, see the charm SDK documentation.
 
@@ -54,7 +52,7 @@ Valid unit identifiers are:
   a standard unit ID, such as mysql/0 or;
   leader syntax of the form <application>/leader, such as mysql/leader.
 
-If no event or action is specified, all events and actions will be intercepted.
+If no hook or action is specified, all hooks and actions will be intercepted.
 
 See the "juju help ssh" for information about SSH related options
 accepted by the debug-code command.
@@ -63,7 +61,7 @@ accepted by the debug-code command.
 func (c *debugCodeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "debug-code",
-		Args:     "<unit name> [event or action names]",
+		Args:     "<unit name> [hook or action names]",
 		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
 		Doc:      debugCodeDoc,
 		Examples: usageDebugCodeExamples,

--- a/cmd/juju/ssh/debugcode.go
+++ b/cmd/juju/ssh/debugcode.go
@@ -13,6 +13,14 @@ import (
 	"github.com/juju/juju/network/ssh"
 )
 
+const usageDebugCodeExamples = `
+    juju debug-code mysql/0
+    juju debug-code mysql/leader
+    juju debug-code mysql/1 config-changed
+    juju debug-code hello-kubecon/0 pull-site update-status
+    juju debug-code --at=hook mysql/0 leader-elected
+`
+
 func NewDebugCodeCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugCodeCommand)
 	c.hostChecker = hostChecker
@@ -29,27 +37,36 @@ type debugCodeCommand struct {
 }
 
 const debugCodeDoc = `
-Interactively debug hooks and actions on a unit.
+The command launches a tmux session that will intercept matching events and/or 
+actions. It is similar to 'juju debug-hooks' but instead of dropping you into a
+shell prompt, it automatically executes the hooks and/or actions and sets the
+JUJU_DEBUG_AT environment variable. Charms implementing support for this
+should set debug breakpoints based on the environment variable. Charms written
+with the Charmed Operator Framework Ops automatically provide support for this.
+
+Initially, the tmux session will take you to '/var/lib/juju'. As soon as a
+matching event or action is fired, the hook or action is executed and the
+JUJU_DEBUG_AT variable is set.
+
+For more details on debugging charm code, see the charm SDK documentation.
 
 Valid unit identifiers are:
   a standard unit ID, such as mysql/0 or;
   leader syntax of the form <application>/leader, such as mysql/leader.
 
-Similar to 'juju debug-hooks' but rather than dropping you into a shell prompt, 
-it runs the hooks and sets the JUJU_DEBUG_AT environment variable. 
-Charms that implement support for this should use it to set breakpoints based on the environment
-variable.
+If no event or action is specified, all events and actions will be intercepted.
 
 See the "juju help ssh" for information about SSH related options
-accepted by the debug-hooks command.
+accepted by the debug-code command.
 `
 
 func (c *debugCodeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "debug-code",
-		Args:    "<unit name> [hook or action names]",
-		Purpose: "Launch a tmux session to debug hooks and/or actions.",
-		Doc:     debugCodeDoc,
+		Name:     "debug-code",
+		Args:     "<unit name> [event or action names]",
+		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
+		Doc:      debugCodeDoc,
+		Examples: usageDebugCodeExamples,
 	})
 }
 
@@ -60,7 +77,8 @@ func (c *debugCodeCommand) Init(args []string) error {
 func (c *debugCodeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.debugHooksCommand.SetFlags(f)
 	f.StringVar(&c.debugAt, "at", "all",
-		"interpreted by the charm for where you want to stop, defaults to 'all'")
+		"will set the JUJU_DEBUG_AT environment variable to this value, which will\n"+
+			"then be interpreted by the charm for where you want to stop, defaults to 'all'")
 }
 
 // Run ensures c.Target is a unit, and resolves its address,

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -28,9 +28,20 @@ import (
 )
 
 const usageDebugHooksExamples = `
+Debug all hooks and actions of unit '0':
+
     juju debug-hooks mysql/0
+
+Debug all hooks and actions of the leader:
+
     juju debug-hooks mysql/leader
+
+Debug the 'config-changed' hook of unit '1':
+
     juju debug-hooks mysql/1 config-changed
+
+Debug the 'pull-site' action and 'update-status' hook of unit '0':
+
     juju debug-hooks hello-kubecon/0 pull-site update-status
 `
 

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -27,6 +27,13 @@ import (
 	unitdebug "github.com/juju/juju/worker/uniter/runner/debug"
 )
 
+const usageDebugHooksExamples = `
+    juju debug-hooks mysql/0
+    juju debug-hooks mysql/leader
+    juju debug-hooks mysql/1 config-changed
+    juju debug-hooks hello-kubecon/0 pull-site update-status
+`
+
 func NewDebugHooksCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugHooksCommand)
 	c.hostChecker = hostChecker
@@ -45,11 +52,23 @@ type debugHooksCommand struct {
 }
 
 const debugHooksDoc = `
-Interactively debug hooks or actions remotely on an application unit.
+The command launches a tmux session that will intercept matching events and/or 
+actions. Unlike the 'juju debug-code' command, the hooks and/or actions are not
+executed directly; instead, the user needs to manually run the dispatch script
+inside the charm's directory.
+
+Initially, the tmux session will take you to '/var/lib/juju'. As soon as a 
+matching event or action is fired, the tmux session will automatically navigate
+you to '/var/lib/juju/agents/<unit-id>/charm' with a properly configured 
+environment.
+
+For more details on debugging charm code, see the charm SDK documentation.
 
 Valid unit identifiers are:
   a standard unit ID, such as mysql/0 or;
   leader syntax of the form <application>/leader, such as mysql/leader.
+
+If no event or action is specified, all events and actions will be intercepted.
 
 See the "juju help ssh" for information about SSH related options
 accepted by the debug-hooks command.
@@ -57,11 +76,12 @@ accepted by the debug-hooks command.
 
 func (c *debugHooksCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "debug-hooks",
-		Args:    "<unit name> [hook or action names]",
-		Purpose: "Launch a tmux session to debug hooks and/or actions.",
-		Doc:     debugHooksDoc,
-		Aliases: []string{"debug-hook"},
+		Name:     "debug-hooks",
+		Args:     "<unit name> [event or action names]",
+		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
+		Doc:      debugHooksDoc,
+		Examples: usageDebugHooksExamples,
+		Aliases:  []string{"debug-hook"},
 	})
 }
 

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -70,8 +70,8 @@ Initially, the tmux session will take you to '/var/lib/juju' or '/home/ubuntu'.
 As soon as a matching hook or action is fired, the tmux session will 
 automatically navigate you to '/var/lib/juju/agents/<unit-id>/charm' with a 
 properly configured environment. Unlike the 'juju debug-code' command, 
-the hooks and/or actions are not executed directly; instead, the user needs to
-manually run the dispatch script inside the charm's directory.
+the fired hooks and/or actions are not executed directly; instead, the user 
+needs to manually run the dispatch script inside the charm's directory.
 
 For more details on debugging charm code, see the charm SDK documentation.
 

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -52,15 +52,15 @@ type debugHooksCommand struct {
 }
 
 const debugHooksDoc = `
-The command launches a tmux session that will intercept matching events and/or 
-actions. Unlike the 'juju debug-code' command, the hooks and/or actions are not
-executed directly; instead, the user needs to manually run the dispatch script
-inside the charm's directory.
+The command launches a tmux session that will intercept matching hooks and/or 
+actions. 
 
-Initially, the tmux session will take you to '/var/lib/juju'. As soon as a 
-matching event or action is fired, the tmux session will automatically navigate
-you to '/var/lib/juju/agents/<unit-id>/charm' with a properly configured 
-environment.
+Initially, the tmux session will take you to '/var/lib/juju' or '/home/ubuntu'.
+As soon as a matching hook or action is fired, the tmux session will 
+automatically navigate you to '/var/lib/juju/agents/<unit-id>/charm' with a 
+properly configured environment. Unlike the 'juju debug-code' command, 
+the hooks and/or actions are not executed directly; instead, the user needs to
+manually run the dispatch script inside the charm's directory.
 
 For more details on debugging charm code, see the charm SDK documentation.
 
@@ -68,7 +68,7 @@ Valid unit identifiers are:
   a standard unit ID, such as mysql/0 or;
   leader syntax of the form <application>/leader, such as mysql/leader.
 
-If no event or action is specified, all events and actions will be intercepted.
+If no hook or action is specified, all hooks and actions will be intercepted.
 
 See the "juju help ssh" for information about SSH related options
 accepted by the debug-hooks command.
@@ -77,7 +77,7 @@ accepted by the debug-hooks command.
 func (c *debugHooksCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "debug-hooks",
-		Args:     "<unit name> [event or action names]",
+		Args:     "<unit name> [hook or action names]",
 		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
 		Doc:      debugHooksDoc,
 		Examples: usageDebugHooksExamples,


### PR DESCRIPTION
The PR adds more details and examples to the `debug-code` and `debug-hook` command line help message.
To fully understand these commands, the Charm SDK may be the place to look, but you should still be able to get a glimpse of what is happening by using the command line help message.

Furthermore, it is clarified that the hooks/actions are not executed immediately, but that he user is first located at `/var/lib/juju` and then redirected to the charm's directory or into the application code.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
juju debug-code -h
juju debug-hooks -h
```

## Documentation changes

The help messages of both commands have been extended. Beyond that, the optional positional argument name `[hooks or action names]` has been renamed to `[events or action names]`, because technically `events` and not `hooks` have to be specified.
