### PR TITLE
[JUJU-4368] Inspect error in modelmanager for deciding to raise

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1050,7 +1050,7 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 			continue
 		}
 		err = m.authorizer.HasPermission(permission.AdminAccess, modelTag)
-		if err != nil {
+		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 			return result, errors.Trace(err)
 		}
 		canModify := err == nil || canModifyController

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1049,8 +1049,11 @@ func (m *ModelManagerAPI) ModifyModelAccess(args params.ModifyModelAccessRequest
 			result.Results[i].Error = apiservererrors.ServerError(errors.Annotate(err, "could not modify model access"))
 			continue
 		}
-
-		canModify := m.authorizer.HasPermission(permission.AdminAccess, modelTag) == nil || canModifyController
+		err = m.authorizer.HasPermission(permission.AdminAccess, modelTag)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		canModify := err == nil || canModifyController
 
 		if !canModify {
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)


### PR DESCRIPTION
This is a fix/follow-up on https://github.com/juju/juju/pull/16024#discussion_r1280024609. It solves the issue from [LP#2028939](https://bugs.launchpad.net/juju/+bug/2028939) (described in e081275446ae248d040bae45e9c1d11552cd5bc2) in a way that doesn't throw away but raises the error if it's not related to permissions. If it is indeed an `ErrorEntityMissingPermission`, then we defer the decision to raise until we check the `SuperuserAccess`.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Same QA steps in #16024 should be followed for this one as well.

```sh
 $ juju bootstrap localhost juju-3-2-remove-me && juju add-model tst32
```

```sh
 $ juju revoke admin admin tst32
```

```sh
 $ juju show-model tst32
tst32:
  name: admin/tst32
  short-name: tst32
  model-uuid: 715b6de3-0d10-4d7c-87f9-73fd75f73dbb
  model-type: iaas
  controller-uuid: 71fbd0f3-4422-432c-8eda-e4ae27ff982b
  controller-name: lxd32
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 3 minutes ago
  users:
    admin:
      display-name: admin
      access: write   <------------------------------------------------ Notice that the admin user only has write access
      last-connection: 2 minutes ago
  sla: unsupported
  agent-version: 3.2.2.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 3.2.2.1
```

The following errors without this change:
```sh
 $ juju revoke admin write test
ERROR permission denied (unauthorized access)
```

With this change, it should succeed, and you should see that the admin user has only the `read` access:

```sh
 $ juju revoke admin write tst32
 $ juju show-model tst32
tst32:
  name: admin/tst32
  short-name: tst32
  model-uuid: 715b6de3-0d10-4d7c-87f9-73fd75f73dbb
  model-type: iaas
  controller-uuid: 71fbd0f3-4422-432c-8eda-e4ae27ff982b
  controller-name: lxd32
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 37 minutes ago
  users:
    admin:
      display-name: admin
      access: read  <-------------------------------------------------- admin user has only the read access
      last-connection: 37 minutes ago
  sla: unsupported
  agent-version: 3.2.2.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 3.2.2.1
```

## Bug reference

Fix LP [2028939](https://bugs.launchpad.net/juju/+bug/2028939).
