### PR TITLE
[JUJU-4367] Fix incorrect changes from previous commit

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -273,7 +273,7 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 
 	for i, arg := range args.Applications {
 		// If either the charm origin ID or Hash is set before a charm is
-		// downloaded, charm download will fail for charms with a forced corebase.
+		// downloaded, charm download will fail for charms with a forced series.
 		// The logic (refreshConfig) in sending the correct request to charmhub
 		// will break.
 		if arg.CharmOrigin != nil &&

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -127,7 +127,7 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 			continue
 		}
 
-		// TODO (stickupkid): Remove this when we remove corebase.
+		// TODO (stickupkid): Remove this when we remove series.
 		// This essentially, always ensures that we report back a default-series
 		// if we have a default-base.
 		if attr == config.DefaultBaseKey && val.Value != "" {
@@ -159,7 +159,7 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 	}
 
 	// TODO (stickupkid): For backwards compatibility we need to ensure that
-	// we always report back a default-corebase.
+	// we always report back a default-series.
 	if _, ok := result.Config[config.DefaultSeriesKey]; !ok {
 		result.Config[config.DefaultSeriesKey] = params.ConfigValue{
 			Value:  "",
@@ -252,7 +252,7 @@ func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {
 			}
 		}
 
-		// Always remove the default-corebase.
+		// Always remove the default-series.
 		delete(updateAttrs, config.DefaultSeriesKey)
 		return nil
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -257,7 +257,7 @@ type DeployCommand struct {
 	Base string
 
 	// Force is used to allow a charm/bundle to be deployed onto a machine
-	// running an unsupported corebase.
+	// running an unsupported series.
 	Force bool
 
 	// DryRun is used to specify that the bundle shouldn't actually be

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1505,7 +1505,7 @@ func (s *DeploySuite) setupNonESMBase(c *gc.C) (corebase.Base, string) {
 	}
 	defer func() { _ = file.Close() }()
 
-	// Overwrite the metadata.yaml to contain a non EMS corebase.
+	// Overwrite the metadata.yaml to contain a non EMS series.
 	newMetadata := strings.Join([]string{`name: logging`, `summary: ""`, `description: ""`, `series: `, `  - ` + nonEMSSeries, `  - artful`}, "\n")
 	if _, err := file.WriteString(newMetadata); err != nil {
 		c.Fatal("cannot write to metadata.yaml")

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -398,7 +398,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	if charm.IsUnsupportedSeriesError(err) {
 		msg := fmt.Sprintf("%v. Use --force to deploy the charm anyway.", err)
 		if usingDefaultSeries {
-			msg += " Used the default-corebase."
+			msg += " Used the default-series."
 		}
 		return errors.Errorf(msg)
 	} else if err != nil {
@@ -443,7 +443,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	if charm.IsUnsupportedSeriesError(err) {
 		msg := fmt.Sprintf("%v. Use --force to deploy the charm anyway.", err)
 		if usingDefaultSeries {
-			msg += " Used the default-corebase."
+			msg += " Used the default-series."
 		}
 		return errors.Errorf(msg)
 	}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -320,10 +320,10 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	// cannot easily be factored out).
 
 	// NOTE: Reading the charm here is only meant to aid in inferring the
-	// correct series, if this fails we fall back to the argument corebase. If
+	// correct series, if this fails we fall back to the argument series. If
 	// reading the charm fails here it will also fail below (the charm is read
 	// again below) where it is handled properly. This is just an expedient to
-	// get the correct corebase. A proper refactoring of the charmrepo package is
+	// get the correct series. A proper refactoring of the charmrepo package is
 	// needed for a more elegant fix.
 	charmOrBundle := d.charmOrBundle
 	if isLocalSchema(charmOrBundle) {

--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -35,7 +35,7 @@ type modelConfig interface {
 // really only valid if the seriesFlag is specified. There is code and tests
 // that allow the force flag when series isn't specified, but they should
 // really be cleaned up. The `deploy` CLI command has tests to ensure that
-// --force is only valid with --corebase.
+// --force is only valid with --series.
 type seriesSelector struct {
 	// seriesFlag is the series passed to the --series flag on the command line.
 	seriesFlag string
@@ -49,7 +49,7 @@ type seriesSelector struct {
 	// supportedJujuSeries is the list of series that juju supports.
 	supportedJujuSeries set.Strings
 	// force indicates the user explicitly wants to deploy to a requested
-	// series, regardless of whether the charm says it supports that corebase.
+	// series, regardless of whether the charm says it supports that series.
 	force bool
 	// from bundle specifies the deploy request comes from a bundle spec.
 	fromBundle bool
@@ -65,7 +65,7 @@ type seriesSelector struct {
 func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	// TODO(sidecar): handle systems
 
-	// User has requested a series with --corebase.
+	// User has requested a series with --series.
 	if s.seriesFlag != "" {
 		return s.userRequested(s.seriesFlag)
 	}

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -25,7 +25,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		err            string
 	}{
 		{
-			// Simple selectors first, no supported corebase.
+			// Simple selectors first, no supported series.
 
 			title: "juju deploy simple   # no default series, no supported series",
 			seriesSelector: seriesSelector{
@@ -110,7 +110,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			expectedSeries: "jammy",
 		},
 
-		// Now charms with supported corebase.
+		// Now charms with supported series.
 
 		{
 			title: "juju deploy multiseries   # use charm default, nothing specified, no default series",

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -158,7 +158,7 @@ func (c *diffBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 
 	f.StringVar(&c.arch, "arch", "", fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
-	f.StringVar(&c.series, "series", "", "specify a corebase. DEPRECATED: use --base")
+	f.StringVar(&c.series, "series", "", "specify a series. DEPRECATED: use --base")
 	f.StringVar(&c.base, "base", "", "specify a base")
 	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the bundle from Charmhub")
 	f.Var(cmd.NewAppendStringsValue(&c.bundleOverlays), "overlay", "Bundles to overlay on the primary bundle, applied in order")

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -811,7 +811,7 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.DeepEquals, make([]error, len(units)))
 
-	// Overwrite the metadata.yaml to change the supported corebase.
+	// Overwrite the metadata.yaml to change the supported series.
 	metadataPath := filepath.Join(repoPath, "metadata.yaml")
 	file, err := os.OpenFile(metadataPath, os.O_TRUNC|os.O_RDWR, 0666)
 	if err != nil {
@@ -822,7 +822,7 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	metadata := strings.Join(
 		[]string{
 			`name: multi-series`,
-			`summary: "That's a dummy charm with multi-corebase."`,
+			`summary: "That's a dummy charm with series."`,
 			`description: |`,
 			`    This is a longer description which`,
 			`    potentially contains multiple lines.`,
@@ -885,7 +885,7 @@ func (s *RefreshSuccessStateSuite) TestForcedLXDProfileUpgrade(c *gc.C) {
 	err = unit.AssignToMachine(container)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Overwrite the lxd-profile.yaml to change the supported corebase.
+	// Overwrite the lxd-profile.yaml to change the supported series.
 	lxdProfilePath := filepath.Join(repoPath, "lxd-profile.yaml")
 	file, err := os.OpenFile(lxdProfilePath, os.O_TRUNC|os.O_RDWR, 0666)
 	if err != nil {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -304,7 +304,7 @@ func (c *downloadCommand) refresh(
 			if res.Error.Code == transport.ErrorCodeRevisionNotFound {
 				possibleBases, err := c.suggested(cmdContext, base, normChannel.String(), res.Error.Extra.Releases)
 				// The following will attempt to refresh the charm with the
-				// suggested corebase. If it can't do that, it will give up after
+				// suggested series. If it can't do that, it will give up after
 				// the second attempt.
 				if retrySuggested && errors.Is(err, errors.NotSupported) && len(possibleBases) > 0 {
 					cmdContext.Infof("Base %q is not supported for charm %q, trying base %q", base.DisplayString(), c.charmOrBundle, possibleBases[0].DisplayString())

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -77,7 +77,7 @@ func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.arch, "arch", ArchAll, fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
-	f.StringVar(&c.series, "series", SeriesAll, "specify a corebase. DEPRECATED use --base")
+	f.StringVar(&c.series, "series", SeriesAll, "specify a series. DEPRECATED use --base")
 	f.StringVar(&c.base, "base", "", "specify a base")
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
 	f.BoolVar(&c.config, "config", false, "display config for this charm")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -253,7 +253,7 @@ type bootstrapCommand struct {
 	ControllerCharmChannelStr string
 	ControllerCharmChannel    charm.Channel
 
-	// Force is used to allow a bootstrap to be run on unsupported corebase.
+	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 }
 
@@ -809,7 +809,7 @@ to create a new model to deploy %sworkloads.
 		}
 	}
 
-	// Get the supported bootstrap corebase.
+	// Get the supported bootstrap series.
 	var imageStream string
 	if cfg, ok := bootstrapCfg.bootstrapModel["image-stream"]; ok {
 		imageStream = cfg.(string)

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -157,7 +157,7 @@ type addCommand struct {
 	modelConfigAPI    ModelConfigAPI
 	machineManagerAPI MachineManagerAPI
 	// Series defines the series the machine should use instead of the
-	// default-corebase. DEPRECATED use --base
+	// default-series. DEPRECATED use --base
 	Series string
 	// Base defines the series the machine should use instead of the
 	// default-base.

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -75,7 +75,7 @@ func (c *addImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.cloudImageMetadataCommandBase.SetFlags(f)
 
 	f.StringVar(&c.Region, "region", "", "image cloud region")
-	f.StringVar(&c.Series, "series", "", "image corebase. DEPRECATED, use --base")
+	f.StringVar(&c.Series, "series", "", "image series. DEPRECATED, use --base")
 	f.StringVar(&c.Base, "base", "", "image base")
 	f.StringVar(&c.Arch, "arch", "amd64", "image architecture")
 	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -106,7 +106,7 @@ func (c *imageMetadataCommand) Info() *cmd.Info {
 }
 
 func (c *imageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.Series, "s", "", "the charm corebase. DEPRECATED use --base")
+	f.StringVar(&c.Series, "s", "", "the charm series. DEPRECATED use --base")
 	f.StringVar(&c.Base, "base", "", "the charm base")
 	f.StringVar(&c.Arch, "a", arch.AMD64, "the image architecture")
 	f.StringVar(&c.Dir, "d", "", "the destination directory in which to place the metadata files")

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -84,7 +84,7 @@ func (c *listImagesCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Stream, "stream", "", "image metadata stream")
 	f.StringVar(&c.Region, "region", "", "image metadata cloud region")
 
-	f.Var(cmd.NewAppendStringsValue(&c.Series), "series", "only show cloud image metadata for these corebase. DEPRECATED use --bases")
+	f.Var(cmd.NewAppendStringsValue(&c.Series), "series", "only show cloud image metadata for these series. DEPRECATED use --bases")
 	f.Var(cmd.NewAppendStringsValue(&c.Bases), "bases", "only show cloud image metadata for these bases")
 	f.Var(cmd.NewAppendStringsValue(&c.Arches), "arch", "only show cloud image metadata for these architectures")
 

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -174,7 +174,7 @@ func (s *Server) CopyRemoteImage(
 }
 
 // baseLocalAlias returns the alias to assign to images for the
-// specified corebase. The alias is juju-specific, to support the
+// specified series. The alias is juju-specific, to support the
 // user supplying a customised image (e.g. CentOS with cloud-init).
 func baseLocalAlias(base, arch string, virtType instance.VirtType) string {
 	// We use a different alias for VMs, so that we can distinguish between

--- a/core/base/supportedseries.go
+++ b/core/base/supportedseries.go
@@ -281,7 +281,7 @@ func getOSFromSeries(series SeriesName) (coreos.OSType, error) {
 }
 
 var (
-	logger = loggo.GetLogger("juju.juju.series")
+	logger = loggo.GetLogger("juju.juju.base")
 
 	seriesVersionsMutex sync.Mutex
 )

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -411,7 +411,7 @@ func (ch *AddMachineChange) Description() []string {
 
 // AddMachineOptions holds GUI options for adding a machine or container.
 type AddMachineOptions struct {
-	// Series holds the machine OS corebase.
+	// Series holds the machine OS series.
 	Series string `json:"series,omitempty"`
 	// Constraints holds the machine constraints.
 	Constraints string `json:"constraints,omitempty"`
@@ -423,7 +423,7 @@ type AddMachineOptions struct {
 
 // AddMachineParams holds parameters for adding a machine or container.
 type AddMachineParams struct {
-	// Series holds the optional machine OS corebase.
+	// Series holds the optional machine OS series.
 	Series string `json:"series,omitempty"`
 	// Constraints holds the optional machine constraints.
 	Constraints string `json:"constraints,omitempty"`

--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -3584,7 +3584,7 @@ func (s *changesSuite) TestLocalCharmWithSeriesFromCharm(c *gc.C) {
     `, charmDir)
 	charmMeta := `
 name: multi-series
-summary: That's a dummy charm with multi-corebase.
+summary: That's a dummy charm with multi-series.
 description: A dummy charm.
 series:
     - jammy
@@ -3607,7 +3607,7 @@ func (s *changesSuite) TestLocalCharmWithSeriesFromBundle(c *gc.C) {
     `, charmDir)
 	charmMeta := `
 name: multi-series
-summary: That's a dummy charm with multi-corebase.
+summary: That's a dummy charm with multi-series.
 description: A dummy charm.
 series:
     - jammy

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -1253,7 +1253,7 @@ func applicationKey(charm, arch, series, channel string, revision int) string {
 }
 
 // getSeries retrieves the series of a application from the ApplicationSpec or from the
-// charm path or URL if provided, otherwise falling back on a default corebase.
+// charm path or URL if provided, otherwise falling back on a default series.
 //
 // DEPRECATED: This should be all about bases.
 func getSeries(application *charm.ApplicationSpec, defaultSeries string) (string, error) {
@@ -1265,7 +1265,7 @@ func getSeries(application *charm.ApplicationSpec, defaultSeries string) (string
 	if charm.IsValidLocalCharmOrBundlePath(application.Charm) {
 		_, charmURL, err := corecharm.NewCharmAtPath(application.Charm, defaultSeries)
 		if corecharm.IsMissingSeriesError(err) {
-			// local charm path is valid but the charm doesn't declare a default corebase.
+			// local charm path is valid but the charm doesn't declare a default series.
 			return defaultSeries, nil
 		} else if corecharm.IsUnsupportedSeriesError(err) {
 			// The bundle's default series is not supported by the charm, but we'll

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -54,7 +54,7 @@ type BootstrapParams struct {
 	BootstrapSeries string
 
 	// SupportedBootstrapSeries is a supported set of series to use for
-	// validating against the bootstrap corebase.
+	// validating against the bootstrap series.
 	SupportedBootstrapSeries set.Strings
 
 	// Placement, if non-empty, holds an environment-specific placement
@@ -73,7 +73,7 @@ type BootstrapParams struct {
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
 
-	// Force is used to allow a bootstrap to be run on unsupported corebase.
+	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 }
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -161,7 +161,7 @@ type BootstrapParams struct {
 	// in the controller model.
 	StoragePools map[string]corestorage.Attrs
 
-	// Force is used to allow a bootstrap to be run on unsupported corebase.
+	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 
 	// ControllerCharmPath is a local controller charm archive.
@@ -972,7 +972,7 @@ func bootstrapImageMetadata(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// This constraint will search image metadata for all supported architectures and corebase.
+	// This constraint will search image metadata for all supported architectures and series.
 	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: region,
 		Stream:    environ.Config().ImageStream(),

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -1001,7 +1001,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 
 	st := t.Env.(jujutesting.GetStater).GetStateInAPIServer()
 	// Wait for machine agent to come up on the bootstrap
-	// machine and ensure it deployed the proper corebase.
+	// machine and ensure it deployed the proper series.
 	m0, err := st.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
 	mw0 := newMachineToolWaiter(m0)

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -39,7 +39,7 @@ const (
 // Azure Resource Manager.
 //
 // For Ubuntu, we query the SKUs to determine the most recent point release
-// for a corebase.
+// for a series.
 func SeriesImage(
 	ctx context.ProviderCallContext,
 	base jujubase.Base, stream, location string,
@@ -91,7 +91,7 @@ func offerForUbuntuSeries(series string) (string, string, error) {
 }
 
 // ubuntuSKU returns the best SKU for the Canonical:UbuntuServer offering,
-// matching the given corebase.
+// matching the given series.
 func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
 	offer, seriesVersion, err := offerForUbuntuSeries(series)
 	if err != nil {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -128,7 +128,7 @@ func BootstrapInstance(
 		return nil, nil, nil, err
 	}
 
-	// Filter image metadata to the selected corebase.
+	// Filter image metadata to the selected series.
 	var imageMetadata []*imagemetadata.ImageMetadata
 	seriesVersion, err := corebase.BaseSeriesVersion(requestedBootstrapBase)
 	if err != nil {

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -354,7 +354,7 @@ func findInstanceSpec(
 
 	logger.Debugf("received %d image(s): %v", len(allImageMetadata), allImageMetadata)
 	filtered := []*imagemetadata.ImageMetadata{}
-	// Filter by corebase. imgCache.supportedShapes() and
+	// Filter by series. imgCache.supportedShapes() and
 	// imgCache.imageMetadata() will return filtered values
 	// by series already. This additional filtering is done
 	// in case someone wants to use this function with values

--- a/state/application.go
+++ b/state/application.go
@@ -1612,7 +1612,7 @@ type SetCharmConfig struct {
 	ForceUnits bool
 
 	// ForceBase forces the use of the charm even if it is not one of
-	// the charm's supported corebase.
+	// the charm's supported series.
 	ForceBase bool
 
 	// Force forces the overriding of the lxd profile validation even if the
@@ -1668,7 +1668,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		}
 	}
 
-	// If it's a v1 or v2 machine charm (no containers), check corebase.
+	// If it's a v1 or v2 machine charm (no containers), check series.
 	if charm.MetaFormat(cfg.Charm) == charm.FormatV1 || !corecharm.IsKubernetes(cfg.Charm) {
 		err := checkSeriesForSetCharm(a.CharmOrigin().Platform, cfg.Charm, cfg.ForceBase)
 		if err != nil {
@@ -1793,7 +1793,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		if cfg.CharmOrigin != nil {
 			origin := a.doc.CharmOrigin
 			// If either the charm origin ID or Hash is set before a charm is
-			// downloaded, charm download will fail for charms with a forced corebase.
+			// downloaded, charm download will fail for charms with a forced series.
 			// The logic (refreshConfig) in sending the correct request to charmhub
 			// will break.
 			if (origin.ID != "" && origin.Hash == "") || (origin.ID == "" && origin.Hash != "") {

--- a/state/state.go
+++ b/state/state.go
@@ -1169,7 +1169,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	}
 
 	// If either the charm origin ID or Hash is set before a charm is
-	// downloaded, charm download will fail for charms with a forced corebase.
+	// downloaded, charm download will fail for charms with a forced series.
 	// The logic (refreshConfig) in sending the correct request to charmhub
 	// will break.
 	if (args.CharmOrigin.ID != "" && args.CharmOrigin.Hash == "") ||
@@ -1458,13 +1458,13 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 }
 
 func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) (Base, error) {
-	// User has specified corebase. Overriding supported series is
+	// User has specified series. Overriding supported series is
 	// handled by the client, so args.Release is not necessarily
-	// one of the charm's supported corebase. We require that the
+	// one of the charm's supported series. We require that the
 	// specified series is of the same operating system as one of
-	// the supported corebase. For old-style charms with the series
+	// the supported series. For old-style charms with the series
 	// in the URL, that series is the one and only supported
-	// corebase.
+	// series.
 	appBase, err := corebase.ParseBase(args.CharmOrigin.Platform.OS, args.CharmOrigin.Platform.Channel)
 	if err != nil {
 		return Base{}, errors.Trace(err)
@@ -1474,7 +1474,7 @@ func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) (Ba
 	if cSeries := args.Charm.URL().Series; cSeries != "" {
 		supportedSeries = []string{cSeries}
 		// If a charm has a url, but is a kubernetes charm then we need to
-		// add this to the list of supported corebase.
+		// add this to the list of supported series.
 		if cSeries != corebase.Kubernetes.String() &&
 			(set.NewStrings(args.Charm.Meta().Series...).Contains(corebase.Kubernetes.String()) ||
 				len(args.Charm.Meta().Containers) > 0) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1898,7 +1898,7 @@ resources:
 `
 	ch := state.AddCustomCharmWithManifest(c, st, "cockroach", "metadata.yaml", charmDef, "focal", 1)
 	// A charm with supported series can only be force-deployed to series
-	// of the same operating systems as the supported corebase.
+	// of the same operating systems as the supported series.
 	cockroach, err := st.AddApplication(state.AddApplicationArgs{
 		Name: "mysql", Charm: ch, NumUnits: 1,
 		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
@@ -1935,7 +1935,7 @@ resources:
 `
 	ch := state.AddCustomCharmWithManifest(c, st, "cockroach", "metadata.yaml", charmDef, "focal", 1)
 	// A charm with supported series can only be force-deployed to series
-	// of the same operating systems as the supported corebase.
+	// of the same operating systems as the supported series.
 	cockroach, err := st.AddApplication(state.AddApplicationArgs{
 		Name: "cockroach", Charm: ch, NumUnits: 1,
 		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
@@ -2333,7 +2333,7 @@ func (s *StateSuite) TestAddApplicationCompatibleOSWithNoExplicitSupportedSeries
 func (s *StateSuite) TestAddApplicationOSIncompatibleWithSupportedSeries(c *gc.C) {
 	charm := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
 	// A charm with supported series can only be force-deployed to series
-	// of the same operating systems as the supported corebase.
+	// of the same operating systems as the supported series.
 	_, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name: "wordpress", Charm: charm,
 		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -31,7 +31,7 @@ func PreUpgradeSteps(_ *state.StatePool, agentConf agent.Config, isController, i
 	}
 	if isController {
 		// Update distro info in case the new Juju controller version
-		// is aware of new supported corebase. We'll keep going if this
+		// is aware of new supported series. We'll keep going if this
 		// fails, and the user can manually update it if they need to.
 		logger.Infof("updating distro-info")
 		err := updateDistroInfo()


### PR DESCRIPTION
My script to replace series with corebase was a little too liberal and as a result changed a number of occurences of the string "series" where it shouldn't have.

This happened in comments and strings.

Change these back to 'series'

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
make install
make static-analysis
```

`grep -r "corebase"` and verify it doesn't appear in any comments or strings 
