### PR TITLE
[JUJU-4367] Fix incorrect word

### DIFF
--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -822,7 +822,7 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	metadata := strings.Join(
 		[]string{
 			`name: multi-series`,
-			`summary: "That's a dummy charm with series."`,
+			`summary: "That's a dummy charm with multi-series."`,
 			`description: |`,
 			`    This is a longer description which`,
 			`    potentially contains multiple lines.`,


### PR DESCRIPTION
This was mistakenly changed in a previous commit

Revert the change

https://github.com/juju/juju/pull/16030#discussion_r1280867979