### PR TITLE
Make `--no-prompt` an alias for `-y` in `destroy-controller`, `kill-controller`, `destroy-model`, `unregister`

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -568,9 +568,7 @@ func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
-	// This unused var is declared to pass a valid ptr into BoolVar
-	var noPromptHolder bool
-	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
+	f.BoolVar(&c.assumeYes, "no-prompt", false, "")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -62,9 +62,7 @@ func (c *unregisterCommand) Info() *cmd.Info {
 func (c *unregisterCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
-	// This unused var is declared to pass a valid ptr into BoolVar
-	var noPromptHolder bool
-	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
+	f.BoolVar(&c.assumeYes, "no-prompt", false, "")
 }
 
 // SetClientStore implements Command.SetClientStore.

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -157,9 +157,7 @@ func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
-	// This unused var is declared to pass a valid ptr into BoolVar
-	var noPromptHolder bool
-	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
+	f.BoolVar(&c.assumeYes, "no-prompt", false, "")
 	f.DurationVar(&c.timeout, "t", unsetTimeout, "Timeout for each step of force model destruction")
 	f.DurationVar(&c.timeout, "timeout", unsetTimeout, "")
 	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances in the model")


### PR DESCRIPTION
In Juju 3+, a `--no-prompt` flag has been added to several removal commands. A series of PRs added this flag to 2.9 as well, for forward compatibility.

For commands which didn't previously have a "no prompt" option, it makes sense for the new `--no-prompt` flag to do nothing. However, for commands which already had the `-y` option, we should make `--no-prompt` an alias of `-y`.

```
juju help destroy-controller
...
Command Options:
...
-y, --yes, --no-prompt  (= false)
    Do not ask for confirmation
```