### PR TITLE
Add `go-client-build` Make target to 2.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,9 @@ build: rebuild-schema go-build
 ## build builds all the targets specified by BUILD_AGENT_TARGETS and
 ## BUILD_CLIENT_TARGETS while also rebuilding a new schema.
 
+.PHONY: go-client-build
+go-client-build: $(BUILD_CLIENT_TARGETS)
+
 .PHONY: go-build
 go-build: $(BUILD_AGENT_TARGETS) $(BUILD_CLIENT_TARGETS)
 ## build builds all the targets specified by BUILD_AGENT_TARGETS and


### PR DESCRIPTION
This is really damn useful for when you just want to test out client side changes, and don't want to build all of Juju.

This target exists in 3.2 onwards, so this is effectively a "backport".