### PR TITLE
Merge 2.9 into 3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,9 @@ build: rebuild-schema go-build
 ## build builds all the targets specified by BUILD_AGENT_TARGETS and
 ## BUILD_CLIENT_TARGETS while also rebuilding a new schema.
 
+.PHONY: go-client-build
+go-client-build: $(BUILD_CLIENT_TARGETS)
+
 .PHONY: go-build
 go-build: $(BUILD_AGENT_TARGETS) $(BUILD_CLIENT_TARGETS)
 ## build builds all the targets specified by BUILD_AGENT_TARGETS and


### PR DESCRIPTION
Merges the following patches:
- #16043
- #16042

### Conflicts
- cmd/juju/controller/destroy.go
- cmd/juju/controller/unregister.go
- cmd/juju/model/destroy.go

All resolved in favour of 3.1.