### PR TITLE
[JUJU-4242] Parse platform instead of constructing it

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -833,14 +833,9 @@ func (c *CharmHubRepository) selectNextBases(bases []transport.Base, origin core
 	// Serialize all the platforms into core entities.
 	results := make([]corecharm.Platform, len(compatible))
 	for k, base := range compatible {
-		track, err := corecharm.ChannelTrack(base.Channel)
+		platform, err := corecharm.ParsePlatform(fmt.Sprintf("%s/%s/%s", base.Architecture, base.Name, base.Channel))
 		if err != nil {
 			return nil, errors.Annotate(err, "base")
-		}
-		platform := corecharm.Platform{
-			Architecture: base.Architecture,
-			OS:           base.Name,
-			Channel:      track,
 		}
 		results[k] = platform
 	}
@@ -1034,6 +1029,7 @@ func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, or
 func selectReleaseByArchAndChannel(releases []transport.Release, origin corecharm.Origin) ([]corecharm.Platform, error) {
 	var (
 		empty   = origin.Channel == nil
+		arch    = origin.Platform.Architecture
 		channel charm.Channel
 	)
 	if !empty {
@@ -1043,17 +1039,11 @@ func selectReleaseByArchAndChannel(releases []transport.Release, origin corechar
 	for _, release := range releases {
 		base := release.Base
 
-		arch, os := base.Architecture, base.Name
-		track, err := corecharm.ChannelTrack(base.Channel)
+		platform, err := corecharm.ParsePlatform(fmt.Sprintf("%s/%s/%s", arch, base.Name, base.Channel))
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotate(err, "base")
 		}
-		platform := corecharm.Platform{
-			Architecture: origin.Platform.Architecture,
-			OS:           os,
-			Channel:      track,
-		}
-		if (empty || channel.String() == release.Channel) && (arch == "all" || arch == origin.Platform.Architecture) {
+		if (empty || channel.String() == release.Channel) && (base.Architecture == "all" || base.Architecture == arch) {
 			results = append(results, platform)
 		}
 	}

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/charm/v11"
 	charmresource "github.com/juju/charm/v11/resource"
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3/hash"
@@ -1143,9 +1144,23 @@ func (*selectNextBaseSuite) TestSelectNextBaseWithInvalidBaseChannel(c *gc.C) {
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
 			Architecture: "amd64",
+			OS:           "ubuntu",
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `base: empty channel not valid`)
+	c.Assert(errors.IsNotValid(err), jc.IsTrue)
+}
+
+func (*selectNextBaseSuite) TestSelectNextBaseWithInvalidOS(c *gc.C) {
+	repo := new(CharmHubRepository)
+	_, err := repo.selectNextBases([]transport.Base{{
+		Architecture: "amd64",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+		},
+	})
+	c.Assert(errors.IsNotValid(err), jc.IsTrue)
 }
 
 func (*selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
@@ -1154,6 +1169,27 @@ func (*selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
 		Architecture: "amd64",
 		Name:         "ubuntu",
 		Channel:      "20.04",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "20.04",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(platform, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Channel:      "20.04",
+	}})
+}
+
+func (*selectNextBaseSuite) TestSelectNextBaseWithValidBasesWithSeries(c *gc.C) {
+	repo := new(CharmHubRepository)
+	platform, err := repo.selectNextBases([]transport.Base{{
+		Architecture: "amd64",
+		Name:         "ubuntu",
+		Channel:      "focal",
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
 			Architecture: "amd64",
@@ -1428,6 +1464,30 @@ func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
 	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
 		Architecture: "arch",
 		OS:           "os",
+		Channel:      "20.04",
+	}})
+}
+
+func (selectReleaseByChannelSuite) TestSelectionSeriesInRelease(c *gc.C) {
+	release, err := selectReleaseByArchAndChannel([]transport.Release{{
+		Base: transport.Base{
+			Name:         "ubuntu",
+			Channel:      "focal",
+			Architecture: "arch",
+		},
+		Channel: "stable",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "arch",
+		},
+		Channel: &charm.Channel{
+			Risk: "stable",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "arch",
+		OS:           "ubuntu",
 		Channel:      "20.04",
 	}})
 }


### PR DESCRIPTION
This means we can be more robust in the face of unusual data from charmhub. Such as charmhub providing bases/releases with series such as 'jammy' instead of '22.04' in a charm's channel

This will also fix failing netowkr CI tests, since `juju-qa-network-test` is one of these unusual charms.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -p ec2 network
```