### PR TITLE
[JUJU-4242] Ensure juju only includes the channel track when refreshing a charm

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -953,6 +953,15 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 		method = MethodID
 	}
 
+	var track string
+	if origin.Platform.Channel != "" {
+		var err error
+		track, err = corecharm.ChannelTrack(origin.Platform.Channel)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
 	var (
 		cfg charmhub.RefreshConfig
 		err error
@@ -960,7 +969,7 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 		base = charmhub.RefreshBase{
 			Architecture: origin.Platform.Architecture,
 			Name:         origin.Platform.OS,
-			Channel:      origin.Platform.Channel,
+			Channel:      track,
 		}
 	)
 	switch method {

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -760,7 +760,7 @@ func (s *charmHubRepositorySuite) expectedRefreshRevisionNotFoundError(c *gc.C) 
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBase(c *gc.C) {
 	cfg, err := charmhub.InstallOneFromChannel("wordpress", "latest/stable", charmhub.RefreshBase{
-		Architecture: arch.DefaultArchitecture, Name: "ubuntu", Channel: "20.04",
+		Architecture: arch.DefaultArchitecture, Name: "ubuntu", Channel: "20.04/stable",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmRefreshFullWithResources(c, cfg)
@@ -1008,7 +1008,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 
 func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 	curl := charm.MustParseURL("ch:wordpress")
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/latest")
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/stable")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
 		Platform: platform,
@@ -1031,7 +1031,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
-				Channel:      "20.10/latest",
+				Channel:      "20.10",
 				Architecture: "amd64",
 			},
 		}},


### PR DESCRIPTION
This ensures data is normalised. Charmhub doesn't model the concepts of risks in bases

This also fixes our network test CI

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -p ec2 network
```

```sh
juju model-config -m controller logging-config="#charmhub=TRACE"`
juju deploy ubuntu --base ubuntu@20.04
juju debug-log -m controller
```
And ensure that each charmhub refresh base channel only includes the track