### PR TITLE
 [JUJU-4242] Parse platform instead of constructing it

### DIFF
--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -812,6 +812,10 @@ func (*selectNextBaseSuite) TestSelectNextBaseWithValidBasesWithSeries(c *gc.C) 
 		Architecture: "amd64",
 		Name:         "ubuntu",
 		Channel:      "focal",
+	}, {
+		Architecture: "amd64",
+		Name:         "ubuntu",
+		Channel:      "20.04",
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
 			Architecture: "amd64",
@@ -1095,6 +1099,13 @@ func (selectReleaseByChannelSuite) TestSelectionSeriesInRelease(c *gc.C) {
 		Base: transport.Base{
 			Name:         "ubuntu",
 			Channel:      "focal",
+			Architecture: "arch",
+		},
+		Channel: "stable",
+	}, {
+		Base: transport.Base{
+			Name:         "ubuntu",
+			Channel:      "20.04",
 			Architecture: "arch",
 		},
 		Channel: "stable",


### PR DESCRIPTION
This means we can be more robust in the face of unusual data from charmhub. Such as charmhub providing bases/releases with series such as 'jammy' instead of '22.04' in a charm's channel

This will also fix failing networl CI tests, since `juju-qa-network-test` is one of these unusual charms.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -c aws -p ec2 network
```