### PR TITLE
Remove duplicate `go-client-build` Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,9 +378,6 @@ go-agent-build-no-cgo: $(BUILD_AGENT_TARGETS)
 .PHONY: go-client-build
 go-client-build: $(BUILD_CLIENT_TARGETS)
 
-.PHONY: go-client-build
-go-client-build: $(BUILD_CLIENT_TARGETS)
-
 .PHONY: go-build
 go-build: go-agent-build go-client-build
 ## build: builds all the targets withouth rebuilding a new schema.


### PR DESCRIPTION
This was accidentally duplicated when merging through #16043 from 2.9.