### PR TITLE
[JUJU-4351] Remove shims around default-series in model-config

### DIFF
--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -14,7 +14,6 @@ import (
 	commonsecrets "github.com/juju/juju/apiserver/common/secrets"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
@@ -115,26 +114,6 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 			continue
 		}
 
-		// TODO (stickupkid): Remove this when we remove series.
-		// This essentially, always ensures that we report back a default-series
-		// if we have a default-base.
-		if attr == config.DefaultBaseKey && val.Value != "" {
-			base, err := corebase.ParseBaseFromString(val.Value.(string))
-			if err != nil {
-				return result, errors.Trace(err)
-			}
-
-			s, err := corebase.GetSeriesFromBase(base)
-			if err != nil {
-				return result, errors.Trace(err)
-			}
-
-			result.Config[config.DefaultSeriesKey] = params.ConfigValue{
-				Source: val.Source,
-				Value:  s,
-			}
-		}
-
 		// Only admins get to see attributes marked as secret.
 		if attr, ok := defaultSchema[attr]; ok && attr.Secret && !isAdmin {
 			continue
@@ -143,15 +122,6 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 		result.Config[attr] = params.ConfigValue{
 			Value:  val.Value,
 			Source: val.Source,
-		}
-	}
-
-	// TODO (stickupkid): For backwards compatibility we need to ensure that
-	// we always report back a default-series.
-	if _, ok := result.Config[config.DefaultSeriesKey]; !ok {
-		result.Config[config.DefaultSeriesKey] = params.ConfigValue{
-			Value:  "",
-			Source: "default",
 		}
 	}
 
@@ -183,9 +153,6 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 		}
 	}
 
-	// Series to base translations.
-	checkUpdateDefaultBase := c.checkUpdateDefaultBase()
-
 	// Make sure we don't allow changing agent-version.
 	checkAgentVersion := c.checkAgentVersion()
 
@@ -210,40 +177,7 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 		checkDefaultSpace,
 		checkCharmhubURL,
 		checkSecretBackend,
-		checkUpdateDefaultBase,
 	)
-}
-
-func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {
-	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
-		cfgSeries, defaultSeriesOK := updateAttrs[config.DefaultSeriesKey]
-		_, defaultBaseOK := updateAttrs[config.DefaultBaseKey]
-
-		if defaultSeriesOK && defaultBaseOK {
-			if cfgSeries != "" {
-				// If the default-series is set (and non-empty) and the default-base is set, error
-				// out, as you can't change both.
-				return errors.New("cannot set both default-series and default-base")
-			}
-		} else if defaultSeriesOK {
-			// If the default-series is set, but empty, then we need to patch the
-			// base.
-			if cfgSeries == "" {
-				updateAttrs[config.DefaultBaseKey] = ""
-			} else {
-				// Ensure that the new default-series updates the default-base.
-				base, err := corebase.GetBaseFromSeries(cfgSeries.(string))
-				if err != nil {
-					return errors.Trace(err)
-				}
-				updateAttrs[config.DefaultBaseKey] = base.String()
-			}
-		}
-
-		// Always remove the default-series.
-		delete(updateAttrs, config.DefaultSeriesKey)
-		return nil
-	}
 }
 
 func (c *ModelConfigAPI) checkLogTrace() state.ValidateConfigFunc {
@@ -363,15 +297,6 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 	}
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
-	}
-
-	// If we're attempting to remove the default-series, then we need to
-	// swap that out for the default-base.
-	for i, key := range args.Keys {
-		if key == config.DefaultSeriesKey {
-			args.Keys[i] = config.DefaultBaseKey
-			break
-		}
 	}
 
 	return c.backend.UpdateModelConfig(nil, args.Keys)

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -69,11 +69,10 @@ func (s *modelconfigSuite) TestAdminModelGet(c *gc.C) {
 	result, err := s.api.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Config, jc.DeepEquals, map[string]params.ConfigValue{
-		"type":           {Value: "dummy", Source: "model"},
-		"ftp-proxy":      {Value: "http://proxy", Source: "model"},
-		"agent-version":  {Value: "1.2.3.4", Source: "model"},
-		"charmhub-url":   {Value: "http://meshuggah.rocks", Source: "model"},
-		"default-series": {Value: "", Source: "default"},
+		"type":          {Value: "dummy", Source: "model"},
+		"ftp-proxy":     {Value: "http://proxy", Source: "model"},
+		"agent-version": {Value: "1.2.3.4", Source: "model"},
+		"charmhub-url":  {Value: "http://meshuggah.rocks", Source: "model"},
 	})
 }
 
@@ -86,11 +85,10 @@ func (s *modelconfigSuite) TestUserModelGet(c *gc.C) {
 	result, err := s.api.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Config, jc.DeepEquals, map[string]params.ConfigValue{
-		"type":           {Value: "dummy", Source: "model"},
-		"ftp-proxy":      {Value: "http://proxy", Source: "model"},
-		"agent-version":  {Value: "1.2.3.4", Source: "model"},
-		"charmhub-url":   {Value: "http://meshuggah.rocks", Source: "model"},
-		"default-series": {Value: "", Source: "default"},
+		"type":          {Value: "dummy", Source: "model"},
+		"ftp-proxy":     {Value: "http://proxy", Source: "model"},
+		"agent-version": {Value: "1.2.3.4", Source: "model"},
+		"charmhub-url":  {Value: "http://meshuggah.rocks", Source: "model"},
 	})
 }
 
@@ -182,66 +180,6 @@ func (s *modelconfigSuite) TestModelSetCannotChangeCharmHubURL(c *gc.C) {
 	args.Config["charmhub-url"] = result.Config["charmhub-url"].Value
 	err = s.api.ModelSet(args)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *modelconfigSuite) TestModelSetCannotChangeBothDefaultSeriesAndDefaultBaseWithSeries(c *gc.C) {
-	old, err := config.New(config.UseDefaults, coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"default-series": "jammy",
-	}))
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.backend.old = old
-	args := params.ModelSet{
-		Config: map[string]interface{}{
-			"default-series": "jammy",
-			"default-base":   "ubuntu@22.04",
-		},
-	}
-	err = s.api.ModelSet(args)
-	c.Assert(err, gc.ErrorMatches, "cannot set both default-series and default-base")
-
-	err = s.api.ModelSet(params.ModelSet{
-		Config: map[string]interface{}{
-			"default-series": "jammy",
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.api.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config["default-series"], gc.NotNil)
-	c.Assert(result.Config["default-series"].Value, gc.Equals, "jammy")
-	c.Assert(result.Config["default-base"].Value, gc.Equals, "ubuntu@22.04/stable")
-}
-
-func (s *modelconfigSuite) TestModelSetCannotChangeBothDefaultSeriesAndDefaultBaseWithBase(c *gc.C) {
-	old, err := config.New(config.UseDefaults, coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"default-base": "ubuntu@22.04",
-	}))
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.backend.old = old
-	args := params.ModelSet{
-		Config: map[string]interface{}{
-			"default-series": "jammy",
-			"default-base":   "ubuntu@22.04",
-		},
-	}
-	err = s.api.ModelSet(args)
-	c.Assert(err, gc.ErrorMatches, "cannot set both default-series and default-base")
-
-	err = s.api.ModelSet(params.ModelSet{
-		Config: map[string]interface{}{
-			"default-series": "jammy",
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.api.ModelGet()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config["default-series"], gc.NotNil)
-	c.Assert(result.Config["default-series"].Value, gc.Equals, "jammy")
-	c.Assert(result.Config["default-base"].Value, gc.Equals, "ubuntu@22.04/stable")
 }
 
 func (s *modelconfigSuite) TestAdminCanSetLogTrace(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/caas"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/permission"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
@@ -329,25 +328,6 @@ func (m *ModelManagerAPI) CreateModel(ctx stdcontext.Context, args params.ModelC
 			credentialValue.Revoked,
 		)
 		credential = &cloudCredential
-	}
-
-	// Swap out the config default-series for default-base if it's set.
-	// TODO(stickupkid): This can be removed once we've fully migrated to bases.
-	if s, ok := args.Config[config.DefaultSeriesKey]; ok {
-		if _, ok := args.Config[config.DefaultBaseKey]; ok {
-			return result, errors.New("default-base and default-series cannot both be set")
-		}
-		if s == "" {
-			args.Config[config.DefaultBaseKey] = ""
-		} else {
-			base, err := corebase.GetBaseFromSeries(s.(string))
-			if err != nil {
-				return result, errors.Trace(err)
-			}
-			args.Config[config.DefaultBaseKey] = base.String()
-		}
-
-		delete(args.Config, config.DefaultSeriesKey)
 	}
 
 	cloudSpec, err := environscloudspec.MakeCloudSpec(cloud, cloudRegionName, credential)

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -96,9 +96,6 @@ the same cloud/region as the controller model. If a region is specified
 without a cloud qualifier, then it is assumed to be in the same cloud
 as the controller model.
 
-When adding --config, the default-series key is deprecated in favour of
-default-base, e.g. ubuntu@22.04.
-
 `
 
 const addModelHelpExamples = `
@@ -637,11 +634,6 @@ func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interfac
 	if err := common.FinalizeAuthorizedKeys(ctx, attrs); err != nil {
 		if errors.Cause(err) != common.ErrNoAuthorizedKeys {
 			return nil, errors.Trace(err)
-		}
-	}
-	if _, ok := attrs[config.DefaultSeriesKey]; ok {
-		if _, ok := attrs[config.DefaultBaseKey]; ok {
-			return nil, errors.Errorf("cannot specify both default-series and default-base")
 		}
 	}
 	return attrs, nil

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -303,10 +303,6 @@ const (
 	// logging.
 	LoggingOutputKey = "logging-output"
 
-	// DefaultSeriesKey is a key for determining the series a model should
-	// explicitly use for charms unless otherwise provided.
-	DefaultSeriesKey = "default-series"
-
 	// DefaultBaseKey is a key for determining the base a model should
 	// explicitly use for charms unless otherwise provided.
 	DefaultBaseKey = "default-base"

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -11,8 +11,6 @@ import (
 	cookiejar "github.com/juju/persistent-cookiejar"
 
 	"github.com/juju/juju/cloud"
-	corebase "github.com/juju/juju/core/base"
-	"github.com/juju/juju/environs/config"
 )
 
 // MemStore is an in-memory implementation of ClientStore.
@@ -470,24 +468,6 @@ func (c *MemStore) BootstrapConfigForController(controllerName string) (*Bootstr
 	defer c.mu.Unlock()
 
 	if cfg, ok := c.BootstrapConfig[controllerName]; ok {
-		// TODO(stickupkid): This can be removed once series has been removed.
-		// This is here to keep us honest with the tests, although not required.
-		if key, ok := cfg.Config[config.DefaultBaseKey]; ok {
-			if key == nil || key == "" {
-				cfg.Config[config.DefaultSeriesKey] = ""
-			} else {
-				base, err := corebase.ParseBaseFromString(key.(string))
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-
-				s, err := corebase.GetSeriesFromBase(base)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				cfg.Config[config.DefaultSeriesKey] = s
-			}
-		}
 		return &cfg, nil
 	}
 	return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -250,6 +250,8 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 	return dbModel, newSt, nil
 }
 
+var defaultSeriesKey = "default-series"
+
 // modelConfig creates a config for the model being imported.
 func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 	// If the tools version is before 2.9.35, the default-series
@@ -270,10 +272,10 @@ func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 	newer := version.MustParse("2.9.35")
 	if comp := toolsVersion.Compare(newer); comp < 0 {
 		attrs[config.DefaultBaseKey] = ""
-		delete(attrs, config.DefaultSeriesKey)
+		delete(attrs, defaultSeriesKey)
 	}
 
-	if v, ok := attrs[config.DefaultSeriesKey]; ok {
+	if v, ok := attrs[defaultSeriesKey]; ok {
 		if v == "" {
 			attrs[config.DefaultBaseKey] = ""
 		} else {
@@ -283,7 +285,7 @@ func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 			}
 			attrs[config.DefaultBaseKey] = s.String()
 		}
-		delete(attrs, config.DefaultSeriesKey)
+		delete(attrs, defaultSeriesKey)
 	}
 
 	// Ensure the expected default secret-backend value is set.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4345,7 +4345,7 @@ func (s *StateSuite) TestSetModelAgentVersionRetriesOnConfigChange(c *gc.C) {
 	// other than the version, and make sure it retries
 	// and passes.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		s.changeEnviron(c, modelConfig, "default-series", "focal")
+		s.changeEnviron(c, modelConfig, "default-base", "ubuntu@20.04")
 	}).Check()
 
 	// Change the agent-version and ensure it has changed.
@@ -4425,9 +4425,9 @@ func (s *StateSuite) TestSetModelAgentVersionExcessiveContention(c *gc.C) {
 	// Set a hook to change the config 3 times
 	// to test we return ErrExcessiveContention.
 	hooks := []jujutxn.TestHook{
-		{Before: func() { s.changeEnviron(c, modelConfig, "default-series", "focal") }},
-		{Before: func() { s.changeEnviron(c, modelConfig, "default-series", "jammy") }},
-		{Before: func() { s.changeEnviron(c, modelConfig, "default-series", "focal") }},
+		{Before: func() { s.changeEnviron(c, modelConfig, "default-base", "ubuntu@20.04") }},
+		{Before: func() { s.changeEnviron(c, modelConfig, "default-base", "ubuntu@22.04") }},
+		{Before: func() { s.changeEnviron(c, modelConfig, "default-base", "ubuntu@20.04") }},
 	}
 
 	state.SetMaxTxnAttempts(c, s.State, 3)

--- a/tests/suites/deploy/deploy_default_base.sh
+++ b/tests/suites/deploy/deploy_default_base.sh
@@ -1,12 +1,12 @@
 run_deploy_default_series() {
 	echo
 
-	model_name="test-deploy-default-series"
+	model_name="test-deploy-default-base"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
 
-	juju model-config default-series=focal
+	juju model-config default-base=ubuntu@20.04
 	juju deploy ubuntu --storage "files=tmpfs"
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
@@ -21,12 +21,12 @@ run_deploy_default_series() {
 run_deploy_not_default_series() {
 	echo
 
-	model_name="test-deploy-not-default-series"
+	model_name="test-deploy-not-default-base"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
 
-	juju model-config default-series=focal
+	juju model-config default-base=ubuntu@20.04
 	juju deploy ubuntu --storage "files=tmpfs" --base ubuntu@22.04
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 


### PR DESCRIPTION
Remove shims around default-series in model-config

We can drop support for default-series now that we have gone up a major version

Default-base should be used instead

This is a step towards removing series from out codebase entirely

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ juju add-model m
$ juju model-config | grep default-series
(prints nothing)
$ juju model-config default-series
ERROR "default-series" is not a key of the currently targeted model: "admin/m2"
$ juju model-config default-series="jammy"
WARNING key "default-series" is not defined in the current model configuration: possible misspelling
$ juju model-config | grep "default-"
default-base                       default  ""
default-series                     model    jammy
...
```

We currently don't support migrating 3.x models to 4.0. But once we do. we'll have to check default-base is correctly migrated

## Documentation changes

`default-series` should be removed from our model-config docs