### PR TITLE
[JUJU-4242] Ensure risk is dropped when resolving charms

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -421,8 +421,14 @@ func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepo
 		}
 	}
 	if argBase != nil {
-		platform.OS = argBase.Name
-		platform.Channel = argBase.Channel
+		base, err := corebase.ParseBase(argBase.Name, argBase.Channel)
+		if err != nil {
+			return corecharm.Platform{}, usedModelDefaultBase, err
+		}
+		platform.OS = base.OS
+		// platform channels don't model the concept of a risk
+		// so ensure that only the track is included
+		platform.Channel = base.Channel.Track
 	}
 
 	// Initial validation of platform from known data.
@@ -455,7 +461,9 @@ func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepo
 				return corecharm.Platform{}, usedModelDefaultBase, err
 			}
 			platform.OS = defaultBase.OS
-			platform.Channel = defaultBase.Channel.String()
+			// platform channels don't model the concept of a risk
+			// so ensure that only the track is included
+			platform.Channel = defaultBase.Channel.Track
 			usedModelDefaultBase = true
 		}
 	}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -462,6 +462,28 @@ func (s *validatorSuite) TestDeducePlatformSimple(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
 }
 
+func (s *validatorSuite) TestDeducePlatformRiskInChannel(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	//model constraint default
+	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testme",
+		Base: &params.Base{
+			Name:    "ubuntu",
+			Channel: "22.10/stable",
+		},
+	}
+	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
+	c.Assert(err, gc.IsNil)
+	c.Assert(usedModelDefaultBase, jc.IsFalse)
+	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Channel:      "22.10",
+	})
+}
+
 func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -504,7 +526,7 @@ func (s *validatorSuite) TestDeducePlatformModelDefaultBase(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "amd64",
 		OS:           "ubuntu",
-		Channel:      "22.04/stable",
+		Channel:      "22.04",
 	})
 }
 


### PR DESCRIPTION
Deduce platform should ensure the platform it returns doesn't include a risk. This is because charmhub doesn't really recognise the risk construct

This function `deducePlatform` is used to create a platform which is later passed into repo.ResovleAndDeploy

This will bring our application facade in line with what is done here:
https://github.com/juju/juju/blob/3.3/apiserver/facades/client/charms/conversions.go#L80

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju model-config -m controller logging-config="#charmhub=TRACE"`
juju deploy ubuntu --base ubuntu@20.04
juju debug-log -m controller
```

```sh
$ juju deploy juju-qa-network-health --base ubuntu@20.04
Located charm "juju-qa-network-health" in charm-hub, revision 19
Deploying "juju-qa-network-health" from charm-hub charm "juju-qa-network-health", revision 19 in channel stable on ubuntu@20.04/stable
```

And ensure that each charmhub refresh base channel only includes the track