### PR TITLE
[JUJU-4402] Enable `sync-agent-binary` for old Juju versions

### DIFF
--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -113,11 +113,6 @@ func SyncTools(syncContext *SyncContext) error {
 	}
 
 	logger.Infof("found %d agent binaries", len(sourceTools))
-	if !syncContext.AllVersions {
-		var latest version.Number
-		latest, sourceTools = sourceTools.Newest()
-		logger.Infof("found %d recent agent binaries (version %s)", len(sourceTools), latest)
-	}
 	for _, tool := range sourceTools {
 		logger.Debugf("found source agent binary: %v", tool)
 	}

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -182,6 +182,25 @@ func (s *syncSuite) TestSyncing(c *gc.C) {
 	}
 }
 
+// regression test for https://pad.lv/2029881
+func (s *syncSuite) TestSyncToolsOldPatchVersion(c *gc.C) {
+	s.setUpTest(c)
+	defer s.tearDownTest(c)
+
+	// Add some extra tools for the newer patch versions
+	toolstesting.MakeTools(c, s.localStorage, "released", []string{"1.8.3-ubuntu-amd64"})
+
+	err := sync.SyncTools(&sync.SyncContext{
+		Source: s.localStorage,
+		// Request an older patch version of the current series (1.8.x)
+		ChosenVersion: version.MustParse("1.8.0"),
+		TargetToolsUploader: &fakeToolsUploader{
+			uploaded: make(map[version.Binary]bool),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type fakeToolsUploader struct {
 	uploaded map[version.Binary]bool
 }


### PR DESCRIPTION
In `environs/sync/SyncTools`, after we retrieve the agent binaries, we were throwing away all but the newest version:
https://github.com/juju/juju/blob/7163ac3259fe922094c8ed812003c57c75fb2966/environs/sync/sync.go#L118

This meant we were unable to use `sync-agent-binary` for older Juju versions, e.g. 2.9.22. There is no reason to do this, considering we later filter the obtained binaries for those matching the requested version:
https://github.com/juju/juju/blob/8d607a4884acf081a895ddf0e4c33896577a4b35/environs/sync/sync.go#L122

Remove the extraneous filtering step, and add a regression test to ensure we can sync tools for an old patch version.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap lxd c
juju sync-agent-binary --agent-version 2.9.22
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2029881