### PR TITLE
[JUJU-4238] Update resource command docs

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -464,12 +464,40 @@ media wiki' value. The same applies to single value options. For example,
 
 the value of 'my wiki' will be used.
 
-Use the '--resource' option to upload resources needed by the charm. This
-option may be repeated if multiple resources are needed:
+Use the '--resource' option to specify the resources you want to use for your charm.
+The format is
+
+    --resource <resource name>=<resource>
+
+where the resource name is the name from the metadata.yaml file of the charm
+and where, depending on the type of the resource, the resource can be specified
+as follows: 
+
+(1) If the resource is type 'file', you can specify it by providing
+(a) the charm revision number or
+(b) a path to a local file.
+
+(2) If the resource is type 'oci-image', you can specify it by providing
+(a) the charm revision number,
+(b) a path to a local file = private OCI image,
+(c) a link to a public OCI image.
+
+
+Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
+You will not be able to go back to using a resource from Charmhub.
+
+Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+controller to be streamed to the charm when "resource-get" is called by a hook.
+
+Note: If you choose (2b): You will need to specify:
+(i) the local path to the private OCI image as well as
+(ii) the username/password required to access the private OCI image.
+
+Note: If multiple resources are needed, repeat the option.
+
+For example:
 
   juju deploy foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
-
-Where 'bar' and 'baz' are named in the metadata file for charm 'foo'.
 
 Use the '--to' option to deploy to an existing machine or container by
 specifying a "placement directive". The ` + "`status`" + ` command should be used for

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -495,9 +495,6 @@ Note: If you choose (2b): You will need to specify:
 
 Note: If multiple resources are needed, repeat the option.
 
-For example:
-
-  juju deploy foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
 
 Use the '--to' option to deploy to an existing machine or container by
 specifying a "placement directive". The ` + "`status`" + ` command should be used for
@@ -596,6 +593,10 @@ attribute of 'gpu=nvidia-tesla-p100':
 
     juju deploy mycharm --device \
        twingpu=2,nvidia.com/gpu,gpu=nvidia-tesla-p100
+
+Deploy with specific resources:
+
+    juju deploy foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
 `
 
 func (c *DeployCommand) Info() *cmd.Info {
@@ -614,6 +615,7 @@ func (c *DeployCommand) Info() *cmd.Info {
 			"refresh",
 			"set-constraints",
 			"spaces",
+			"charm-resources",
 		},
 	})
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -474,11 +474,11 @@ and where, depending on the type of the resource, the resource can be specified
 as follows: 
 
 (1) If the resource is type 'file', you can specify it by providing
-(a) the charm revision number or
+(a) the resource revision number or
 (b) a path to a local file.
 
 (2) If the resource is type 'oci-image', you can specify it by providing
-(a) the charm revision number,
+(a) the resource revision number,
 (b) a path to a local file = private OCI image,
 (c) a link to a public OCI image.
 

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -117,6 +117,10 @@ func (c *baseCharmResourcesCommand) baseInfo() *cmd.Info {
 		Purpose:  "Display the resources for a charm in a repository.",
 		Doc:      charmResourcesDoc,
 		Examples: charmResourcesExamples,
+		SeeAlso: []string{
+			"resources",
+			"attach-resource",
+		},
 	})
 }
 
@@ -202,12 +206,6 @@ func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
 const charmResourcesDoc = `
 This command will report the resources and the current revision of each
 resource for a charm in a repository.
-
-<charm> can be a charm URL, or an unambiguously condensed form of it,
-just like the deploy command.
-
-Release is implied from the <charm> supplied. If not provided, the default
-series for the model is used.
 
 Channel can be specified with --channel.  If not provided, stable is used.
 

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/charm/v11"
 	charmresource "github.com/juju/charm/v11/resource"
-	jujucmd "github.com/juju/cmd/v3"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -38,38 +37,14 @@ func (s *CharmResourcesSuite) TestInfo(c *gc.C) {
 	var command resourcecmd.CharmResourcesCommand
 	info := command.Info()
 
-	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "charm-resources",
-		Args:    "<charm>",
-		Purpose: "Display the resources for a charm in a repository.",
-		Aliases: []string{"list-charm-resources"},
-		Doc: `
-This command will report the resources and the current revision of each
-resource for a charm in a repository.
-
-<charm> can be a charm URL, or an unambiguously condensed form of it,
-just like the deploy command.
-
-Release is implied from the <charm> supplied. If not provided, the default
-series for the model is used.
-
-Channel can be specified with --channel.  If not provided, stable is used.
-
-Where a channel is not supplied, stable is used.
-`,
-		Examples: `
-Display charm resources for the postgresql charm:
-
-    juju charm-resources postgresql
-
-Display charm resources for mycharm in the 2.0/edge channel:
-
-    juju charm-resources mycharm --channel 2.0/edge
-
-`,
-		FlagKnownAs:    "option",
-		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
-	})
+	// Verify that Info is wired up. Without verifying exact text.
+	c.Check(info.Name, gc.Equals, "charm-resources")
+	c.Check(info.Aliases, gc.Not(gc.Equals), "")
+	c.Check(info.Purpose, gc.Not(gc.Equals), "")
+	c.Check(info.Doc, gc.Not(gc.Equals), "")
+	c.Check(info.Examples, gc.Not(gc.Equals), "")
+	c.Check(info.FlagKnownAs, gc.Not(gc.Equals), "")
+	c.Check(len(info.ShowSuperFlags), jc.GreaterThan, 2)
 }
 
 func (s *CharmResourcesSuite) TestOkay(c *gc.C) {

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -57,6 +57,10 @@ func (c *ListCommand) Info() *cmd.Info {
 		Aliases: []string{"list-resources"},
 		Args:    "<application or unit>",
 		Purpose: "Show the resources for an application or unit.",
+		SeeAlso: []string{
+			"attach-resource",
+			"charm-resources",
+		},
 		Doc: `
 This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	charmresource "github.com/juju/charm/v11/resource"
-	jujucmd "github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -61,19 +60,13 @@ func (s *ShowApplicationSuite) TestInfo(c *gc.C) {
 	var command resourcecmd.ListCommand
 	info := command.Info()
 
-	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "resources",
-		Aliases: []string{"list-resources"},
-		Args:    "<application or unit>",
-		Purpose: "Show the resources for an application or unit.",
-		Doc: `
-This command shows the resources required by and those in use by an existing
-application or unit in your model.  When run for an application, it will also show any
-updates available for resources from a store.
-`,
-		FlagKnownAs:    "option",
-		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
-	})
+	// Verify that Info is wired up. Without verifying exact text.
+	c.Check(info.Name, gc.Equals, "resources")
+	c.Check(info.Args, gc.Not(gc.Equals), "")
+	c.Check(info.Purpose, gc.Not(gc.Equals), "")
+	c.Check(info.Doc, gc.Not(gc.Equals), "")
+	c.Check(info.FlagKnownAs, gc.Not(gc.Equals), "")
+	c.Check(len(info.ShowSuperFlags), jc.GreaterThan, 2)
 }
 
 func (s *ShowApplicationSuite) TestRunNoResourcesForApplication(c *gc.C) {

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -67,11 +67,11 @@ and where, depending on the type of the resource, the resource can be specified
 as follows: 
 
 (1) If the resource is type 'file', you can specify it by providing
-(a) the charm revision number or
+(a) the resource revision number or
 (b) a path to a local file.
 
 (2) If the resource is type 'oci-image', you can specify it by providing
-(a) the charm revision number,
+(a) the resource revision number,
 (b) a path to a local file = private OCI image,
 (c) a link to a public OCI image.
 

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -93,7 +93,7 @@ Note: If you choose (2b): You will need to specify:
 func (c *UploadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "attach-resource",
-		Args:    "application name=file|OCI image",
+		Args:    "application <resource name>=<resource>",
 		Purpose: "Update a resource for an application.",
 		Doc:     attachDoc,
 		SeeAlso: []string{

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -58,12 +58,34 @@ const (
 	attachDoc = `
 This command updates a resource for an application.
 
-For file resources, it uploads a file from your local disk to the juju controller to be
-streamed to the charm when "resource-get" is called by a hook.
+The format is
 
-For OCI image resources used by k8s applications, an OCI image or file path is specified.
-A file is specified when a private OCI image is needed and the username/password used to
-access the image is needed along with the image path.
+    <resource name>=<resource>
+
+where the resource name is the name from the metadata.yaml file of the charm
+and where, depending on the type of the resource, the resource can be specified
+as follows: 
+
+(1) If the resource is type 'file', you can specify it by providing
+(a) the charm revision number or
+(b) a path to a local file.
+
+(2) If the resource is type 'oci-image', you can specify it by providing
+(a) the charm revision number,
+(b) a path to a local file = private OCI image,
+(c) a link to a public OCI image.
+
+
+Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
+You will not be able to go back to using a resource from Charmhub.
+
+Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+controller to be streamed to the charm when "resource-get" is called by a hook.
+
+Note: If you choose (2b): You will need to specify:
+(i) the local path to the private OCI image as well as
+(ii) the username/password required to access the private OCI image.
+
 `
 )
 
@@ -74,6 +96,10 @@ func (c *UploadCommand) Info() *cmd.Info {
 		Args:    "application name=file|OCI image",
 		Purpose: "Update a resource for an application.",
 		Doc:     attachDoc,
+		SeeAlso: []string{
+			"resources",
+			"charm-resources",
+		},
 	})
 }
 

--- a/cmd/juju/resource/upload_test.go
+++ b/cmd/juju/resource/upload_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 
 	charmresource "github.com/juju/charm/v11/resource"
-	jujucmd "github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -95,23 +94,12 @@ func (s *UploadSuite) TestInfo(c *gc.C) {
 	var command resourcecmd.UploadCommand
 	info := command.Info()
 
-	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "attach-resource",
-		Args:    "application name=file|OCI image",
-		Purpose: "Update a resource for an application.",
-		Doc: `
-This command updates a resource for an application.
-
-For file resources, it uploads a file from your local disk to the juju controller to be
-streamed to the charm when "resource-get" is called by a hook.
-
-For OCI image resources used by k8s applications, an OCI image or file path is specified.
-A file is specified when a private OCI image is needed and the username/password used to
-access the image is needed along with the image path.
-`,
-		FlagKnownAs:    "option",
-		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},
-	})
+	// Verify that Info is wired up. Without verifying exact text.
+	c.Check(info.Name, gc.Equals, "attach-resource")
+	c.Check(info.Purpose, gc.Not(gc.Equals), "")
+	c.Check(info.Doc, gc.Not(gc.Equals), "")
+	c.Check(info.FlagKnownAs, gc.Not(gc.Equals), "")
+	c.Check(len(info.ShowSuperFlags), jc.GreaterThan, 2)
 }
 
 func (s *UploadSuite) TestUploadFileResource(c *gc.C) {


### PR DESCRIPTION
For `juju deploy ... --resources`, `juju attach-resource`: Clarified all the ways to specify a resource (i.e., charm revision, path to local file, link to OCI image; + how each correlates with resource type; and the consequences of choosing a non-Charmhub resource). 

For `juju charm-resources`: Removed second (on <charm> being a charm URL) and third (on implied release) paragraph because they are no longer applicable.

For `juju attach-resource`, `juju charm-resources`, and `juju resources` -- added SeeAlso. 

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

 Run `juju documentation --split --out=tmp` 

## Documentation changes

This is a documentation PR.
