### PR TITLE
Fix show cloud yaml support

### DIFF
--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -58,7 +58,6 @@ func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 
 func (s *showSuite) TestShowLocal(c *gc.C) {
 	s.assertShowLocal(c, `
-
 Client cloud "aws-china":
 
 defined: public
@@ -76,7 +75,6 @@ regions:
 func (s *showSuite) TestShowLocalWithDefaultCloud(c *gc.C) {
 	s.store.Credentials["aws-china"] = jujucloud.CloudCredential{DefaultRegion: "cn-north-1"}
 	s.assertShowLocal(c, `
-
 Client cloud "aws-china":
 
 defined: public
@@ -221,6 +219,7 @@ regions:
     endpoint: https://ec2.cn-north-1.amazonaws.com.cn
   cn-northwest-1:
     endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
+
 `[1:])
 }
 
@@ -245,7 +244,6 @@ clouds:
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
-
 Client cloud "homestack":
 
 defined: local
@@ -308,7 +306,6 @@ clouds:
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, strings.Join([]string{`
-
 Client cloud "homestack":
 
 defined: local
@@ -360,7 +357,6 @@ clouds:
 `[1:]
 
 var resultWithCert = `
-
 Client cloud "homestack":
 
 defined: local


### PR DESCRIPTION
The yaml support was broken in subtle ways. To preserve the old display we add a new formatter that uses it. The yaml and json formatters work correctly by outputting the right format to the stdout.

In addition, we no longer write to standard out for yaml output. This was breaking yaml in some decoders. For the json output, we make the output an array of documents. For yaml output, these are multi-yaml documents. This is more inline with what I'd expect for a yaml output.

I think this is a much better approach rather than the janky yaml display formatted.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This should be backward compatible with the old yaml formatting (minus a few new lines at the top). The only addition is that `--format=yaml` should actually output yaml with the correct block indention.

#### Cloud not found

```sh
$ juju show-cloud fart --include-config
ERROR cloud fart not found, possible alternative clouds:

  - aws
  - aws-china
  - aws-gov
  - azure
  - azure-china
  - equinix
  - google
  - localhost
  - lxd
  - oracle
```

#### Cloud output

```sh
$ juju show-cloud localhost
Client cloud "localhost":

defined: built-in
type: lxd
description: LXD Container Hypervisor
auth-types: [certificate]
credential-count: 1
regions:
  localhost: {}
```

```sh
$ juju show-cloud localhost --format=yaml
name: localhost
summary: Client cloud "localhost"
defined: built-in
type: lxd
description: LXD Container Hypervisor
auth-types: [certificate]
credential-count: 1
regions:
  localhost: {}
```

```sh
juju show-cloud localhost --format=json | jq
[
  {
    "name": "localhost",
    "summary": "Client cloud \"localhost\"",
    "defined": "built-in",
    "type": "lxd",
    "description": "LXD Container Hypervisor",
    "auth-types": [
      "certificate"
    ],
    "credential-count": 1,
    "regions": {
      "localhost": {}
    }
  }
]
```

#### Included config

```sh
$ juju show-cloud aws-china --include-config
Client cloud "aws-china":

defined: public
type: ec2
description: Amazon China
auth-types: [access-key]
regions:
  cn-north-1:
    endpoint: https://ec2.cn-north-1.amazonaws.com.cn
  cn-northwest-1:
    endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn

The available config options specific to ec2 clouds are:
vpc-id:
  type: string
  description: Use a specific AWS VPC ID (optional). When not specified, Juju requires
    a default VPC or EC2-Classic features to be available for the account/region.
vpc-id-force:
  type: bool
  description: Force Juju to use the AWS VPC ID specified with vpc-id, when it fails
    the minimum validation criteria. Not accepted without vpc-id
```
