### PR TITLE
[JUJU-4415] Ensure juju db snap running

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -4,6 +4,7 @@
 package unit
 
 import (
+	stdcontext "context"
 	"os"
 	"time"
 
@@ -245,7 +246,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			APICallerName:        apiCallerName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			// Realistically,  operators should not open state for any reason.
-			OpenStateForUpgrade: func() (*state.StatePool, error) {
+			OpenStateForUpgrade: func(stdcontext.Context) (*state.StatePool, error) {
 				return nil, errors.New("operator cannot open state")
 			},
 			PreUpgradeSteps: config.PreUpgradeSteps,

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -146,7 +146,7 @@ var (
 )
 
 // Run initializes state for an environment.
-func (c *BootstrapCommand) Run(_ *cmd.Context) error {
+func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	bootstrapParamsData, err := os.ReadFile(c.BootstrapParamsFile)
 	if err != nil {
 		return errors.Annotate(err, "reading bootstrap params file")
@@ -182,8 +182,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		Cloud:          cloudSpec,
 		Config:         args.ControllerModelConfig,
 	}
-
-	ctx := stdcontext.TODO()
 
 	var env environs.BootstrapEnviron
 	if isCAAS {
@@ -291,7 +289,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := c.startMongo(isCAAS, addrs, agentConfig); err != nil {
+	if err := c.startMongo(ctx, isCAAS, addrs, agentConfig); err != nil {
 		return errors.Annotate(err, "failed to start mongo")
 	}
 
@@ -440,7 +438,7 @@ func ensureKeys(
 	return nil
 }
 
-func (c *BootstrapCommand) startMongo(isCAAS bool, addrs network.ProviderAddresses, agentConfig agent.Config) error {
+func (c *BootstrapCommand) startMongo(ctx stdcontext.Context, isCAAS bool, addrs network.ProviderAddresses, agentConfig agent.Config) error {
 	logger.Debugf("starting mongo")
 
 	info, ok := agentConfig.MongoInfo()
@@ -478,7 +476,7 @@ func (c *BootstrapCommand) startMongo(isCAAS bool, addrs network.ProviderAddress
 		if err := cmdutil.EnsureMongoServerInstalled(ensureServerParams); err != nil {
 			return err
 		}
-		if err := cmdutil.EnsureMongoServerStarted(ensureServerParams.JujuDBSnapChannel); err != nil {
+		if err := cmdutil.EnsureMongoServerStarted(ctx, ensureServerParams.JujuDBSnapChannel); err != nil {
 			return err
 		}
 	}

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -4,6 +4,7 @@
 package caasoperator
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/clock"
@@ -185,7 +186,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:        apiCallerName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			// Realistically,  operators should not open state for any reason.
-			OpenStateForUpgrade: func() (*state.StatePool, error) {
+			OpenStateForUpgrade: func(stdcontext.Context) (*state.StatePool, error) {
 				return nil, errors.New("operator cannot open state")
 			},
 			PreUpgradeSteps: config.PreUpgradeSteps,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -829,10 +830,10 @@ func (a *MachineAgent) Restart() error {
 //
 // TODO(mjs)- review the need for this once the dependency engine is
 // in use. Why can't upgradesteps depend on the main state connection?
-func (a *MachineAgent) openStateForUpgrade() (*state.StatePool, error) {
+func (a *MachineAgent) openStateForUpgrade(ctx context.Context) (*state.StatePool, error) {
 	agentConfig := a.CurrentConfig()
 	if !a.isCaasAgent {
-		if err := cmdutil.EnsureMongoServerStarted(agentConfig.JujuDBSnapChannel()); err != nil {
+		if err := cmdutil.EnsureMongoServerStarted(ctx, agentConfig.JujuDBSnapChannel()); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"context"
 	"net/http"
 	"runtime"
 	"time"
@@ -156,7 +157,7 @@ type ManifoldsConfig struct {
 
 	// OpenStateForUpgrade is a function the upgradesteps worker can
 	// use to establish a connection to state.
-	OpenStateForUpgrade func() (*state.StatePool, error)
+	OpenStateForUpgrade func(context.Context) (*state.StatePool, error)
 
 	// MachineStartup is passed to the machine manifold. It does
 	// machine setup work which relies on an API connection.

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -4,6 +4,7 @@
 package mongo_test
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -192,7 +193,7 @@ func (s *MongoSuite) TestEnsureServerStarted(c *gc.C) {
 
 	testing.PatchExecutableAsEchoArgs(c, s, "snap")
 
-	err := mongo.EnsureServerStartedForTest(dataDir, "stable")
+	err := mongo.EnsureServerStartedForTest(context.Background(), dataDir, "stable")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/worker/upgradedatabase/manifold.go
+++ b/worker/upgradedatabase/manifold.go
@@ -4,6 +4,7 @@
 package upgradedatabase
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/errors"
@@ -23,7 +24,7 @@ type ManifoldConfig struct {
 	AgentName         string
 	UpgradeDBGateName string
 	Logger            Logger
-	OpenState         func() (*state.StatePool, error)
+	OpenState         func(stdcontext.Context) (*state.StatePool, error)
 	Clock             Clock
 }
 
@@ -68,11 +69,11 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 
 			// Wrap the state pool factory to return our implementation.
 			openState := func() (Pool, error) {
-				p, err := cfg.OpenState()
+				p, err := cfg.OpenState(stdcontext.Background())
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
-				return &pool{p}, nil
+				return &pool{StatePool: p}, nil
 			}
 
 			// Wrap the upgrade steps execution so that we can generate a context lazily.

--- a/worker/upgradedatabase/manifold_test.go
+++ b/worker/upgradedatabase/manifold_test.go
@@ -4,6 +4,8 @@
 package upgradedatabase_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -48,7 +50,7 @@ func (s *manifoldSuite) getConfig() upgradedatabase.ManifoldConfig {
 		AgentName:         "agent-name",
 		UpgradeDBGateName: "upgrade-database-lock",
 		Logger:            s.logger,
-		OpenState:         func() (*state.StatePool, error) { return nil, nil },
+		OpenState:         func(context.Context) (*state.StatePool, error) { return nil, nil },
 		Clock:             clock.WallClock,
 	}
 }

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -4,6 +4,7 @@
 package upgradesteps
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/clock"
@@ -27,7 +28,7 @@ type ManifoldConfig struct {
 	AgentName            string
 	APICallerName        string
 	UpgradeStepsGateName string
-	OpenStateForUpgrade  func() (*state.StatePool, error)
+	OpenStateForUpgrade  func(stdcontext.Context) (*state.StatePool, error)
 	PreUpgradeSteps      upgrades.PreUpgradeStepsFunc
 	NewAgentStatusSetter func(apiConn api.Connection) (StatusSetter, error)
 }


### PR DESCRIPTION
The following ensures that the running of the mongo snap is done.
This failure can happen if we try to start a snap that's already
doing some pending work. As we're using the CLI directly we don't
have a way to check the error message nicely (unlike an API). This
means we have to just keep retrying until it works, or alternatively
we fail and bounce and try again.

Additionally, we not make the opening of state via the upgradedatabase
async, so we need to fully grok what that actually means in terms of 
impact on start-up of an agent.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```
