### PR TITLE
[JUJU-4421] Fix issue getting secret watchers from facade context

### DIFF
--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -533,10 +533,10 @@ func (w *remoteRelationCompatWatcher) expandChange(change params.RelationUnitsCh
 	}
 
 	expanded := params.RemoteRelationChangeEvent{
-		RelationToken:    w.relationToken,
-		ApplicationToken: w.appToken,
-		ChangedUnits:     changedUnits,
-		DepartedUnits:    departedUnits,
+		RelationToken:           w.relationToken,
+		ApplicationOrOfferToken: w.appToken,
+		ChangedUnits:            changedUnits,
+		DepartedUnits:           departedUnits,
 	}
 	// No need to handle AppChanged here - the v1 API can't tell us
 	// app settings.

--- a/apiserver/common/crossmodel/crossmodel_test.go
+++ b/apiserver/common/crossmodel/crossmodel_test.go
@@ -39,9 +39,9 @@ func (s *crossmodelSuite) TestExpandChangeWhenRelationHasGone(c *gc.C) {
 		&mockBackend{}, "some-relation", "some-app", change)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RemoteRelationChangeEvent{
-		RelationToken:    "some-relation",
-		ApplicationToken: "some-app",
-		DepartedUnits:    []int{2, 3},
+		RelationToken:           "some-relation",
+		ApplicationOrOfferToken: "some-app",
+		DepartedUnits:           []int{2, 3},
 	})
 }
 

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -69,9 +69,6 @@ type Backend interface {
 	// specified cross-model relation key.
 	OfferNameForRelation(string) (string, error)
 
-	// AppNameForOffer returns the application for an offer.
-	AppNameForOffer(offerName string) (string, error)
-
 	// GetRemoteEntity returns the tag of the entity associated with the given token.
 	GetRemoteEntity(string) (names.Tag, error)
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -138,15 +138,6 @@ func (st stateShim) OfferNameForRelation(key string) (string, error) {
 	return offer.OfferName, nil
 }
 
-func (st stateShim) AppNameForOffer(offerName string) (string, error) {
-	offers := state.NewApplicationOffers(st.State)
-	offer, err := offers.ApplicationOffer(offerName)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return offer.ApplicationName, nil
-}
-
 func (st stateShim) GetRemoteEntity(token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
 	return r.GetRemoteEntity(token)

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -178,18 +178,6 @@ func (st *mockState) OfferNameForRelation(key string) (string, error) {
 	return st.offerNames[key], nil
 }
 
-func (st *mockState) AppNameForOffer(offerName string) (string, error) {
-	st.MethodCall(st, "AppNameForOffer", offerName)
-	if err := st.NextErr(); err != nil {
-		return "", err
-	}
-	offer, ok := st.offers[offerName]
-	if !ok {
-		return "", errors.NotFoundf("offer %q", offerName)
-	}
-	return offer.ApplicationName, nil
-}
-
 func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {
 	st.MethodCall(st, "ImportRemoteEntity", entity, token)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
+++ b/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
@@ -92,21 +92,6 @@ func (mr *MockRemoteRelationsStateMockRecorder) AllModelUUIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelUUIDs", reflect.TypeOf((*MockRemoteRelationsState)(nil).AllModelUUIDs))
 }
 
-// AppNameForOffer mocks base method.
-func (m *MockRemoteRelationsState) AppNameForOffer(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppNameForOffer", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AppNameForOffer indicates an expected call of AppNameForOffer.
-func (mr *MockRemoteRelationsStateMockRecorder) AppNameForOffer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNameForOffer", reflect.TypeOf((*MockRemoteRelationsState)(nil).AppNameForOffer), arg0)
-}
-
 // Application mocks base method.
 func (m *MockRemoteRelationsState) Application(arg0 string) (crossmodel.Application, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/remoterelations/register.go
+++ b/apiserver/facades/controller/remoterelations/register.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -32,5 +33,6 @@ func newAPI(ctx facade.Context) (*API, error) {
 		service,
 		common.NewControllerConfigAPI(systemState, service),
 		ctx.Resources(), ctx.Auth(),
+		ctx.Logger().ChildWithLabels("remoterelations", corelogger.CMR),
 	)
 }

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -734,7 +734,7 @@ func (w *srvRemoteRelationWatcher) Next() (params.RemoteRelationWatchResult, err
 	expanded, err := crossmodel.ExpandChange(
 		w.backend,
 		w.watcher.RelationToken,
-		w.watcher.ApplicationToken,
+		w.watcher.ApplicationOrOfferToken,
 		changes,
 	)
 	if err != nil {
@@ -1257,7 +1257,7 @@ func newSecretsTriggerWatcher(context facade.Context) (facade.Facade, error) {
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
 	}
-	w, err := context.WatcherRegistry().Get(context.ID())
+	w, err := GetWatcherByID(context.WatcherRegistry(), context.Resources(), context.ID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1311,7 +1311,7 @@ func newSecretBackendsRotateWatcher(context facade.Context) (facade.Facade, erro
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
 	}
-	w, err := context.WatcherRegistry().Get(context.ID())
+	w, err := GetWatcherByID(context.WatcherRegistry(), context.Resources(), context.ID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1368,7 +1368,7 @@ func newSecretsRevisionWatcher(context facade.Context) (facade.Facade, error) {
 	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
 	}
-	w, err := context.WatcherRegistry().Get(context.ID())
+	w, err := GetWatcherByID(context.WatcherRegistry(), context.Resources(), context.ID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -365,8 +365,9 @@ type RemoteRelationChangeEvent struct {
 	// RelationToken is the token of the relation.
 	RelationToken string `json:"relation-token"`
 
-	// ApplicationToken is the token of the application.
-	ApplicationToken string `json:"application-token"`
+	// ApplicationOrOfferToken is the token of the application or offer.
+	// Note we can't easily change the json tag for compatibility reasons.
+	ApplicationOrOfferToken string `json:"application-token"`
 
 	// Life is the current lifecycle state of the relation.
 	Life life.Value `json:"life"`

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -706,11 +706,11 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             life.Dying,
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
-				Macaroons:        macaroon.Slice{apiMac},
-				BakeryVersion:    bakery.LatestVersion,
+				Life:                    life.Dying,
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
+				Macaroons:               macaroon.Slice{apiMac},
+				BakeryVersion:           bakery.LatestVersion,
 			},
 		}},
 	}
@@ -729,8 +729,8 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 
 	unitsWatcher, _ := s.relationsFacade.remoteRelationWatcher("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		RelationToken:    "token-db2:db django:db",
-		ApplicationToken: "token-django",
+		RelationToken:           "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
 			Settings: map[string]interface{}{"foo": "bar"},
@@ -746,8 +746,8 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
 					Settings: map[string]interface{}{"foo": "bar"},
@@ -766,21 +766,21 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 
 	unitsWatcher, _ = s.relationsFacade.removeRelation("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		RelationToken:    "token-db2:db django:db",
-		ApplicationToken: "token-django",
-		DepartedUnits:    []int{1},
-		UnitCount:        intPtr(1),
+		RelationToken:           "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
+		DepartedUnits:           []int{1},
+		UnitCount:               intPtr(1),
 	}
 
 	expected = []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
-				DepartedUnits:    []int{1},
-				UnitCount:        intPtr(1),
-				Macaroons:        macaroon.Slice{mac},
-				BakeryVersion:    bakery.LatestVersion,
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
+				DepartedUnits:           []int{1},
+				UnitCount:               intPtr(1),
+				Macaroons:               macaroon.Slice{mac},
+				BakeryVersion:           bakery.LatestVersion,
 			},
 		}},
 	}
@@ -790,21 +790,21 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 	// Remove relation before we receive the final unit change event.
 	unitsWatcher, _ = s.relationsFacade.removeRelation("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		RelationToken:    "token-db2:db django:db",
-		ApplicationToken: "token-django",
-		DepartedUnits:    []int{2},
-		UnitCount:        intPtr(0),
+		RelationToken:           "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
+		DepartedUnits:           []int{2},
+		UnitCount:               intPtr(0),
 	}
 
 	expected = []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
-				DepartedUnits:    []int{2},
-				UnitCount:        intPtr(0),
-				Macaroons:        macaroon.Slice{mac},
-				BakeryVersion:    bakery.LatestVersion,
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
+				DepartedUnits:           []int{2},
+				UnitCount:               intPtr(0),
+				Macaroons:               macaroon.Slice{mac},
+				BakeryVersion:           bakery.LatestVersion,
 			},
 		}},
 	}
@@ -820,9 +820,9 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 		}
 	}
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		RelationToken:    "token-db2:db django:db",
-		ApplicationToken: "token-django",
-		DepartedUnits:    []int{2},
+		RelationToken:           "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
+		DepartedUnits:           []int{2},
 	}
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected = []jujutesting.StubCall{
@@ -838,8 +838,8 @@ func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {
 
 	unitsWatcher, _ := s.relationsFacade.remoteRelationWatcher("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		RelationToken:    "token-db2:db django:db",
-		ApplicationToken: "token-django",
+		RelationToken:           "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
 			Settings: map[string]interface{}{"foo": "bar"},
@@ -852,8 +852,8 @@ func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
 					Settings: map[string]interface{}{"foo": "bar"},
@@ -876,8 +876,8 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnPublish(c *gc.C) {
 
 	unitsWatcher, _ := s.relationsFacade.remoteRelationWatcher("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		ApplicationToken: "token-django",
-		RelationToken:    "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-django",
+		RelationToken:           "token-db2:db django:db",
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
 			Settings: map[string]interface{}{"foo": "bar"},
@@ -890,8 +890,8 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnPublish(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
 					Settings: map[string]interface{}{"foo": "bar"},
@@ -912,8 +912,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedConsumes(c *gc.C) {
 
 	unitsWatcher, _ := s.remoteRelationsFacade.remoteRelationWatcher("token-db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		ApplicationToken: "token-offer-db2-uuid",
-		RelationToken:    "token-db2:db django:db",
+		ApplicationOrOfferToken: "token-offer-db2-uuid",
+		RelationToken:           "token-db2:db django:db",
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
 			Settings: map[string]interface{}{"foo": "bar"},
@@ -926,8 +926,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedConsumes(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-offer-db2-uuid",
-				RelationToken:    "token-db2:db django:db",
+				ApplicationOrOfferToken: "token-offer-db2-uuid",
+				RelationToken:           "token-db2:db django:db",
 				ChangedUnits: []params.RemoteRelationUnitChange{{
 					UnitId:   1,
 					Settings: map[string]interface{}{"foo": "bar"},
@@ -955,10 +955,10 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             life.Dying,
-				ApplicationToken: "token-offer-db2-uuid",
-				RelationToken:    "token-db2:db django:db",
-				Suspended:        &suspended,
+				Life:                    life.Dying,
+				ApplicationOrOfferToken: "token-offer-db2-uuid",
+				RelationToken:           "token-db2:db django:db",
+				Suspended:               &suspended,
 			},
 		}},
 	}
@@ -981,9 +981,9 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 	s.stub.SetErrors(errors.New("failed"))
 	unitsWatcher, _ := s.relationsFacade.remoteRelationWatcher("db2:db django:db")
 	unitsWatcher.changes <- params.RemoteRelationChangeEvent{
-		ApplicationToken: "token-django",
-		RelationToken:    "token-db2:db django:db",
-		DepartedUnits:    []int{1},
+		ApplicationOrOfferToken: "token-django",
+		RelationToken:           "token-db2:db django:db",
+		DepartedUnits:           []int{1},
 	}
 
 	// The error causes relation change publication to fail.
@@ -992,11 +992,11 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 	expected := []jujutesting.StubCall{
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				ApplicationToken: "token-django",
-				RelationToken:    "token-db2:db django:db",
-				DepartedUnits:    []int{1},
-				Macaroons:        macaroon.Slice{apiMac},
-				BakeryVersion:    bakery.LatestVersion,
+				ApplicationOrOfferToken: "token-django",
+				RelationToken:           "token-db2:db django:db",
+				DepartedUnits:           []int{1},
+				Macaroons:               macaroon.Slice{apiMac},
+				BakeryVersion:           bakery.LatestVersion,
 			},
 		}},
 		{"Close", nil},
@@ -1061,12 +1061,12 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 			FuncName: "PublishRelationChange",
 			Args: []interface{}{
 				params.RemoteRelationChangeEvent{
-					ApplicationToken: "token-django",
-					RelationToken:    "token-db2:db django:db",
-					Life:             life.Dying,
-					Macaroons:        macaroon.Slice{apiMac},
-					BakeryVersion:    bakery.LatestVersion,
-					ForceCleanup:     &forceCleanup,
+					ApplicationOrOfferToken: "token-django",
+					RelationToken:           "token-db2:db django:db",
+					Life:                    life.Dying,
+					Macaroons:               macaroon.Slice{apiMac},
+					BakeryVersion:           bakery.LatestVersion,
+					ForceCleanup:            &forceCleanup,
 				},
 			}},
 		)


### PR DESCRIPTION
Fix secret watcher breakage introduced by https://github.com/juju/juju/pull/15817

Plus a few drive by fixes described below.

The core issue is that in the Next() facade calls, we were fetching the secret watchers like this

`context.WatcherRegistry().Get(context.ID())`

instead of

`GetWatcherByID(context.WatcherRegistry(), context.Resources(), context.ID())`

The result was that Next() would error out with a not found error and workers which used secret watchers would break.

`GetWatcherByID` is deprecated, but for now is has been used to fix this issue since all the other watchers use it too and they can be updated together later.

The offer status watcher is also tweaked to use `EnsureErr()` when needed, rather than copying and pasting the EnsureErr code. EnsureErr is used all over - if we want to change that, we should do it in one go to avoid ad hoc code duplication everywhere.

The watcher issue affected cross model relations. As part of investigating the issue, a few small cleanups were done. The `RemoteRelationChangeEvent` strict gets `ApplicationToken` renamed to `ApplicationOrOfferToken` because it now can be either.
The `AppNameForOffer()` method is removed as we always process a remote app, not an offer.

And the event publish code in the remoteRelationsWorker is tweaked to match that in the remoteUnitsWorker for consistency.


## QA steps

deploy juju-qa-dummy-source
set the token
make an offer
make a new model
deploy juju-qa-dummy-sink
relate to the offer
ensure everything goes active
