### PR TITLE
Ensure leadership determination failure is not fatal for `juju status`

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2960,7 +2960,7 @@ func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
 	}
 	leaders, err := api.leadershipReader.Leaders()
 	if err != nil {
-		return result, errors.Annotate(err, "could not fetch leaders")
+		return result, errors.Annotate(err, "querying leaders")
 	}
 	var ok bool
 	result.Result, ok = leaders[application.Name]

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -289,7 +289,12 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {
 		if context.leaders, err = c.api.leadershipReader.Leaders(); err != nil {
-			return noStatus, errors.Annotate(err, "could not fetch leaders")
+			// Leader information is additive for status.
+			// Given that it comes from Dqlite, which may be subject to
+			// reconfiguration when mutating the control plane, we would
+			// rather return as much status as possible over an error.
+			logger.Warningf("could not determine application leaders: %v", err)
+			context.leaders = make(map[string]string)
 		}
 	}
 	if context.controllerTimestamp, err = c.api.stateAccessor.ControllerTimestamp(); err != nil {


### PR DESCRIPTION
We have integration tests that verify entry into, and exit from a HA control plane.

On versions 3.2+, where leadership is backed by Dqlite, going from HA-n down to 1 means there is a period of unavailability during which the cluster gets reconfigured to be a single node.

Since we are polling status during this time, we fail tests now and then, because querying for leaders can return an error.

The solution is to log a warning instead of returning an error (as we do for Mongo primary determination) and simply omit leadership decoration from the status return.

This ensures that status remains operational, and HA integration tests are stable consistently.

## QA steps

`cd tests && ./main.sh controller`
