### PR TITLE
Merge 3.1 into 3.2

### DIFF
--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -56,7 +56,6 @@ func InstallFakeEnsureMongo(suite patchingSuite, dataDir string) *FakeEnsureMong
 	f := &FakeEnsureMongo{}
 	suite.PatchValue(&mongo.CurrentReplicasetConfig, f.CurrentConfig)
 	suite.PatchValue(&cmdutil.EnsureMongoServerInstalled, f.EnsureMongo)
-	suite.PatchValue(&cmdutil.EnsureMongoServerStarted, f.EnsureMongoStarted)
 	ensureParams := cmdutil.NewEnsureMongoParams
 	suite.PatchValue(&cmdutil.NewEnsureMongoParams, func(agentConfig agent.Config) (mongo.EnsureServerParams, error) {
 		params, err := ensureParams(agentConfig)
@@ -88,7 +87,7 @@ func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error
 	}, nil
 }
 
-func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
+func (f *FakeEnsureMongo) EnsureMongo(ctx context.Context, args mongo.EnsureServerParams) error {
 	f.EnsureCount++
 	f.DataDir, f.OplogSize = args.DataDir, args.OplogSize
 	f.Info = controller.StateServingInfo{
@@ -100,10 +99,6 @@ func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
 		SharedSecret:   args.SharedSecret,
 		SystemIdentity: args.SystemIdentity,
 	}
-	return f.Err
-}
-
-func (f *FakeEnsureMongo) EnsureMongoStarted(snapChannel string) error {
 	return f.Err
 }
 

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -146,7 +146,7 @@ var (
 )
 
 // Run initializes state for an environment.
-func (c *BootstrapCommand) Run(_ *cmd.Context) error {
+func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	bootstrapParamsData, err := os.ReadFile(c.BootstrapParamsFile)
 	if err != nil {
 		return errors.Annotate(err, "reading bootstrap params file")
@@ -182,8 +182,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		Cloud:          cloudSpec,
 		Config:         args.ControllerModelConfig,
 	}
-
-	ctx := stdcontext.TODO()
 
 	var env environs.BootstrapEnviron
 	if isCAAS {
@@ -243,7 +241,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 	}
 
-	callCtx := context.NewCloudCallContext(stdcontext.Background())
+	callCtx := context.NewCloudCallContext(ctx)
 	// At this stage, cloud credential has not yet been stored server-side
 	// as there is no server-side. If these cloud calls will fail with
 	// invalid credential, just log it.
@@ -293,7 +291,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := c.startMongo(isCAAS, addrs, agentConfig); err != nil {
+	if err := c.startMongo(ctx, isCAAS, addrs, agentConfig); err != nil {
 		return errors.Annotate(err, "failed to start mongo")
 	}
 
@@ -442,7 +440,7 @@ func ensureKeys(
 	return nil
 }
 
-func (c *BootstrapCommand) startMongo(isCAAS bool, addrs network.ProviderAddresses, agentConfig agent.Config) error {
+func (c *BootstrapCommand) startMongo(ctx stdcontext.Context, isCAAS bool, addrs network.ProviderAddresses, agentConfig agent.Config) error {
 	logger.Debugf("starting mongo")
 
 	info, ok := agentConfig.MongoInfo()
@@ -477,10 +475,7 @@ func (c *BootstrapCommand) startMongo(isCAAS bool, addrs network.ProviderAddress
 		if err != nil {
 			return err
 		}
-		if err := cmdutil.EnsureMongoServerInstalled(ensureServerParams); err != nil {
-			return err
-		}
-		if err := cmdutil.EnsureMongoServerStarted(ensureServerParams.JujuDBSnapChannel); err != nil {
+		if err := cmdutil.EnsureMongoServerInstalled(ctx, ensureServerParams); err != nil {
 			return err
 		}
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	stdcontext "context"
 	"fmt"
 	"io"
 	"net/http"
@@ -824,11 +825,6 @@ func (a *MachineAgent) Restart() error {
 // in use. Why can't upgradesteps depend on the main state connection?
 func (a *MachineAgent) openStateForUpgrade() (*state.StatePool, error) {
 	agentConfig := a.CurrentConfig()
-	if !a.isCaasAgent {
-		if err := cmdutil.EnsureMongoServerStarted(agentConfig.JujuDBSnapChannel()); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
 	info, ok := agentConfig.MongoInfo()
 	if !ok {
 		return nil, errors.New("no state info available")
@@ -952,9 +948,9 @@ func mongoDialOptions(
 	return dialOpts, nil
 }
 
-func (a *MachineAgent) initState(agentConfig agent.Config) (*state.StatePool, error) {
+func (a *MachineAgent) initState(ctx stdcontext.Context, agentConfig agent.Config) (*state.StatePool, error) {
 	// Start MongoDB server and dial.
-	if err := a.ensureMongoServer(agentConfig); err != nil {
+	if err := a.ensureMongoServer(ctx, agentConfig); err != nil {
 		return nil, err
 	}
 
@@ -1139,7 +1135,7 @@ var stateWorkerDialOpts mongo.DialOpts
 
 // ensureMongoServer ensures that mongo is installed and running,
 // and ready for opening a state connection.
-func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
+func (a *MachineAgent) ensureMongoServer(ctx stdcontext.Context, agentConfig agent.Config) (err error) {
 	a.mongoInitMutex.Lock()
 	defer a.mongoInitMutex.Unlock()
 	if a.mongoInitialized {
@@ -1160,7 +1156,7 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := cmdutil.EnsureMongoServerInstalled(ensureServerParams); err != nil {
+	if err := cmdutil.EnsureMongoServerInstalled(ctx, ensureServerParams); err != nil {
 		return err
 	}
 	logger.Debugf("mongodb service is installed")

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	stdcontext "context"
 	"net/http"
 	"runtime"
 	"time"
@@ -141,7 +142,7 @@ type ManifoldsConfig struct {
 
 	// OpenStatePool is function used by the state manifold to create a
 	// *state.StatePool.
-	OpenStatePool func(coreagent.Config) (*state.StatePool, error)
+	OpenStatePool func(stdcontext.Context, coreagent.Config) (*state.StatePool, error)
 
 	// OpenStateForUpgrade is a function the upgradesteps worker can
 	// use to establish a connection to state.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1420,7 +1420,7 @@ func (s *MachineSuite) TestReplicasetInitForNewController(c *gc.C) {
 
 	agentConfig := a.CurrentConfig()
 
-	err := a.ensureMongoServer(agentConfig)
+	err := a.ensureMongoServer(stdcontext.Background(), agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -16,11 +16,8 @@ import (
 	jworker "github.com/juju/juju/worker"
 )
 
-var (
-	// EnsureMongoServerInstalled is patched for testing.
-	EnsureMongoServerInstalled = mongo.EnsureServerInstalled
-	EnsureMongoServerStarted   = mongo.EnsureServerStarted
-)
+// EnsureMongoServerInstalled is patched for testing.
+var EnsureMongoServerInstalled = mongo.EnsureServerInstalled
 
 // AgentDone processes the error returned by an exiting agent.
 func AgentDone(logger loggo.Logger, err error) error {

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
 	github.com/canonical/go-dqlite v1.20.0
 	github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0
-	github.com/canonical/pebble v0.0.0-20230711093550-00bcd1f7dda5
+	github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0 h1:1JfA4hOWjPoF18ebpKFWafOWFplCh0jvHhAethmLQFo=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0/go.mod h1:BAaklWDYuotKE0eQnwO6NArKc6rEwnTheuOPrtlLBYA=
-github.com/canonical/pebble v0.0.0-20230711093550-00bcd1f7dda5 h1:DnoB6HlU+gZv5nmu+rM+lp/VPr28qSjjeVF9C60XRmM=
-github.com/canonical/pebble v0.0.0-20230711093550-00bcd1f7dda5/go.mod h1:hitlSwXdnqhfPQnIgfRqY7MdI/jkF9GjEWytC5Zb55o=
+github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35 h1:9g6zJXqo0JktO+51qS6K971sAKyNGXK+vFO7RDEbw+Q=
+github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35/go.mod h1:Ore8BG+F6AknKKT6EmtI6EUXISstdcKSwjO5NuXjV6Q=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -1519,7 +1519,6 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
@@ -1657,7 +1656,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -4,6 +4,8 @@
 package mongo
 
 import (
+	"context"
+
 	"go.uber.org/mock/gomock"
 )
 
@@ -21,12 +23,11 @@ var (
 	DefaultOplogSize = defaultOplogSize
 	FsAvailSpace     = fsAvailSpace
 
-	EnsureServerStartedForTest = ensureServerStarted
-	NewSnapService             = &newSnapService
+	NewSnapService = &newSnapService
 )
 
-func SysctlEditableEnsureServer(args EnsureServerParams, sysctlFiles map[string]string) error {
-	return ensureServer(args, sysctlFiles)
+func SysctlEditableEnsureServer(ctx context.Context, args EnsureServerParams, sysctlFiles map[string]string) error {
+	return ensureServer(ctx, args, sysctlFiles)
 }
 
 func NewMongodFinderWithMockSearch(ctrl *gomock.Controller) (*MongodFinder, *MockSearchTools) {

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/errors"
@@ -22,7 +23,7 @@ var logger = loggo.GetLogger("juju.worker.state")
 type ManifoldConfig struct {
 	AgentName              string
 	StateConfigWatcherName string
-	OpenStatePool          func(coreagent.Config) (*state.StatePool, error)
+	OpenStatePool          func(stdcontext.Context, coreagent.Config) (*state.StatePool, error)
 	PingInterval           time.Duration
 
 	// SetStatePool is called with the state pool when it is created,
@@ -82,7 +83,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Annotate(dependency.ErrMissing, "no StateServingInfo in config")
 			}
 
-			pool, err := config.OpenStatePool(agent.CurrentConfig())
+			pool, err := config.OpenStatePool(stdcontext.Background(), agent.CurrentConfig())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -57,7 +58,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *ManifoldSuite) fakeOpenState(coreagent.Config) (*state.StatePool, error) {
+func (s *ManifoldSuite) fakeOpenState(context.Context, coreagent.Config) (*state.StatePool, error) {
 	s.openStateCalled = true
 	if s.openStateErr != nil {
 		return nil, s.openStateErr


### PR DESCRIPTION
Trivial merge 3.1 into 3.2

Conflicts were in go.sum file, which required a `go mod tidy`.
