### PR TITLE
[JUJU-4423] Pass controller config into API address state methods 

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -529,12 +529,16 @@ func initControllerCloudService(
 
 // initAPIHostPorts sets the initial API host/port addresses in state.
 func initAPIHostPorts(st *state.State, pAddrs corenetwork.ProviderAddresses, apiPort int) error {
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	addrs, err := pAddrs.ToSpaceAddresses(st)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	hostPorts := corenetwork.SpaceAddressesWithPort(addrs, apiPort)
-	return st.SetAPIHostPorts([]corenetwork.SpaceHostPorts{hostPorts})
+	return st.SetAPIHostPorts(controllerConfig, []corenetwork.SpaceHostPorts{hostPorts})
 }
 
 // machineJobFromParams returns the job corresponding to model.MachineJob.

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -288,7 +288,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(*gotHW, gc.DeepEquals, expectHW)
 
 	// Check that the API host ports are initialised correctly.
-	apiHostPorts, err := st.APIHostPortsForClients()
+	apiHostPorts, err := st.APIHostPortsForClients(controllerCfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
 		corenetwork.SpaceAddressesWithPort(filteredAddrs, 1234),

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -110,11 +110,17 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 	if err != nil {
 		return fail, errors.Trace(err)
 	}
+
+	controllerConfig, err := ctrlSt.ControllerConfig()
+	if err != nil {
+		return fail, errors.Trace(err)
+	}
+
 	getHostPorts := ctrlSt.APIHostPortsForAgents
 	if k, _ := names.TagKind(req.AuthTag); k == names.UserTagKind {
 		getHostPorts = ctrlSt.APIHostPortsForClients
 	}
-	hostPorts, err := getHostPorts()
+	hostPorts, err := getHostPorts(controllerConfig)
 	if err != nil {
 		return fail, errors.Trace(err)
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -270,7 +270,12 @@ func (s *loginSuite) loginHostPorts(
 }
 
 func (s *loginSuite) assertAgentLogin(c *gc.C, info *api.Info, mgmtSpace *state.Space) {
-	err := s.ControllerModel(c).State().SetAPIHostPorts(nil)
+	st := s.ControllerModel(c).State()
+
+	cfg, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Initially just the address we connect with is returned by the helper
@@ -299,7 +304,7 @@ func (s *loginSuite) assertAgentLogin(c *gc.C, info *api.Info, mgmtSpace *state.
 		network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 	}
 
-	err = s.ControllerModel(c).State().SetAPIHostPorts([]network.SpaceHostPorts{
+	err = st.SetAPIHostPorts(cfg, []network.SpaceHostPorts{
 		network.SpaceAddressesWithPort(server1Addresses, 123),
 		network.SpaceAddressesWithPort(server2Addresses, 456),
 	})
@@ -334,11 +339,15 @@ func (s *loginSuite) TestLoginAddressesForClients(c *gc.C) {
 		network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 	}
 
+	st := s.ControllerModel(c).State()
+	cfg, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	newAPIHostPorts := []network.SpaceHostPorts{
 		network.SpaceAddressesWithPort(server1Addresses, 123),
 		network.SpaceAddressesWithPort(server2Addresses, 456),
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(newAPIHostPorts)
+	err = st.SetAPIHostPorts(cfg, newAPIHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := []network.MachineHostPorts{

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -14,7 +15,7 @@ import (
 // APIAddressAccessor describes methods that allow agents to maintain
 // up-to-date information on how to connect to the Juju API server.
 type APIAddressAccessor interface {
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
 }
 
@@ -37,8 +38,8 @@ func NewAPIAddresser(getter APIAddressAccessor, resources facade.Resources) *API
 }
 
 // APIHostPorts returns the API server addresses.
-func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
-	sSvrs, err := a.getter.APIHostPortsForAgents()
+func (a *APIAddresser) APIHostPorts(controllerConfig controller.Config) (params.APIHostPortsResult, error) {
+	sSvrs, err := a.getter.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return params.APIHostPortsResult{}, err
 	}
@@ -66,8 +67,8 @@ func (a *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
-	addrs, err := apiAddresses(a.getter)
+func (a *APIAddresser) APIAddresses(controllerConfig controller.Config) (params.StringsResult, error) {
+	addrs, err := apiAddresses(controllerConfig, a.getter)
 	if err != nil {
 		return params.StringsResult{}, err
 	}
@@ -76,8 +77,8 @@ func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
 	}, nil
 }
 
-func apiAddresses(getter APIHostPortsForAgentsGetter) ([]string, error) {
-	apiHostPorts, err := getter.APIHostPortsForAgents()
+func apiAddresses(controllerConfig controller.Config, getter APIHostPortsForAgentsGetter) ([]string, error) {
+	apiHostPorts, err := getter.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -35,7 +35,7 @@ func (s *apiAddresserSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *apiAddresserSuite) TestAPIAddresses(c *gc.C) {
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(coretesting.FakeControllerConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Result, gc.DeepEquals, []string{"apiaddresses:1", "apiaddresses:2"})
 }
@@ -59,7 +59,7 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 		}
 	}
 
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(coretesting.FakeControllerConfig())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Result, gc.DeepEquals, []string{
@@ -82,7 +82,7 @@ func (fakeAddresses) ControllerConfig() (controller.Config, error) {
 	return coretesting.FakeControllerConfig(), nil
 }
 
-func (f fakeAddresses) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (f fakeAddresses) APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error) {
 	return f.hostPorts, nil
 }
 

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -137,11 +137,12 @@ func (s *ControllerConfigAPI) getModelControllerInfo(ctx context.Context, model 
 
 // StateControllerInfo returns the local controller details for the given State.
 func StateControllerInfo(st controllerInfoState) (addrs []string, caCert string, _ error) {
-	addr, err := apiAddresses(st)
+	controllerConfig, err := st.ControllerConfig()
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	controllerConfig, err := st.ControllerConfig()
+
+	addr, err := apiAddresses(controllerConfig, st)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -77,7 +78,7 @@ func (s *controllerConfigSuite) TestControllerConfigFetchError(c *gc.C) {
 }
 
 func (s *controllerConfigSuite) expectStateControllerInfo(c *gc.C) {
-	s.st.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{
+	s.st.EXPECT().APIHostPortsForAgents(gomock.Any()).Return([]network.SpaceHostPorts{
 		network.NewSpaceHostPorts(17070, "192.168.1.1"),
 	}, nil)
 	s.st.EXPECT().ControllerConfig().Return(map[string]interface{}{
@@ -136,7 +137,7 @@ func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	systemState := s.ControllerModel(c).State()
-	apiAddr, err := systemState.APIHostPortsForClients()
+	apiAddr, err := systemState.APIHostPortsForClients(coretesting.FakeControllerConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Addresses, gc.HasLen, 1)
 	c.Assert(results.Results[0].Addresses[0], gc.Equals, apiAddr[0][0].String())

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -137,11 +137,11 @@ type ControllerConfigState interface {
 	ControllerConfig() (controller.Config, error)
 
 	ModelExists(string) (bool, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	CompletedMigrationForModel(string) (state.ModelMigration, error)
 }
 
 type controllerInfoState interface {
 	ControllerConfig() (controller.Config, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }

--- a/apiserver/common/mocks/controllerconfig_mock.go
+++ b/apiserver/common/mocks/controllerconfig_mock.go
@@ -39,18 +39,18 @@ func (m *MockControllerConfigState) EXPECT() *MockControllerConfigStateMockRecor
 }
 
 // APIHostPortsForAgents mocks base method.
-func (m *MockControllerConfigState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (m *MockControllerConfigState) APIHostPortsForAgents(arg0 controller.Config) ([]network.SpaceHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPortsForAgents")
+	ret := m.ctrl.Call(m, "APIHostPortsForAgents", arg0)
 	ret0, _ := ret[0].([]network.SpaceHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPortsForAgents indicates an expected call of APIHostPortsForAgents.
-func (mr *MockControllerConfigStateMockRecorder) APIHostPortsForAgents() *gomock.Call {
+func (mr *MockControllerConfigStateMockRecorder) APIHostPortsForAgents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockControllerConfigState)(nil).APIHostPortsForAgents))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockControllerConfigState)(nil).APIHostPortsForAgents), arg0)
 }
 
 // CompletedMigrationForModel mocks base method.

--- a/apiserver/common/mocks/tools_mock.go
+++ b/apiserver/common/mocks/tools_mock.go
@@ -118,18 +118,18 @@ func (m *MockToolsURLGetter) EXPECT() *MockToolsURLGetterMockRecorder {
 }
 
 // ToolsURLs mocks base method.
-func (m *MockToolsURLGetter) ToolsURLs(arg0 version.Binary) ([]string, error) {
+func (m *MockToolsURLGetter) ToolsURLs(arg0 controller.Config, arg1 version.Binary) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ToolsURLs", arg0)
+	ret := m.ctrl.Call(m, "ToolsURLs", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ToolsURLs indicates an expected call of ToolsURLs.
-func (mr *MockToolsURLGetterMockRecorder) ToolsURLs(arg0 interface{}) *gomock.Call {
+func (mr *MockToolsURLGetterMockRecorder) ToolsURLs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToolsURLs", reflect.TypeOf((*MockToolsURLGetter)(nil).ToolsURLs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToolsURLs", reflect.TypeOf((*MockToolsURLGetter)(nil).ToolsURLs), arg0, arg1)
 }
 
 // MockAPIHostPortsForAgentsGetter is a mock of APIHostPortsForAgentsGetter interface.

--- a/apiserver/common/mocks/tools_mock.go
+++ b/apiserver/common/mocks/tools_mock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	common "github.com/juju/juju/apiserver/common"
+	controller "github.com/juju/juju/controller"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
 	binarystorage "github.com/juju/juju/state/binarystorage"
@@ -155,18 +156,18 @@ func (m *MockAPIHostPortsForAgentsGetter) EXPECT() *MockAPIHostPortsForAgentsGet
 }
 
 // APIHostPortsForAgents mocks base method.
-func (m *MockAPIHostPortsForAgentsGetter) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (m *MockAPIHostPortsForAgentsGetter) APIHostPortsForAgents(arg0 controller.Config) ([]network.SpaceHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPortsForAgents")
+	ret := m.ctrl.Call(m, "APIHostPortsForAgents", arg0)
 	ret0, _ := ret[0].([]network.SpaceHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPortsForAgents indicates an expected call of APIHostPortsForAgents.
-func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) APIHostPortsForAgents() *gomock.Call {
+func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) APIHostPortsForAgents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).APIHostPortsForAgents))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).APIHostPortsForAgents), arg0)
 }
 
 // MockToolsStorageGetter is a mock of ToolsStorageGetter interface.

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -554,9 +554,9 @@ func (s *getUrlSuite) setup(c *gc.C) *gomock.Controller {
 func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, nil)
+	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents(gomock.Any()).Return(nil, nil)
 
-	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
+	g := common.NewToolsURLGetter("my-uuid", coretesting.FakeControllerConfig(), s.apiHostPortsGetter)
 	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from")
 }
@@ -564,9 +564,9 @@ func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 func (s *getUrlSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, errors.New("oh noes"))
+	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents(gomock.Any()).Return(nil, errors.New("oh noes"))
 
-	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
+	g := common.NewToolsURLGetter("my-uuid", coretesting.FakeControllerConfig(), s.apiHostPortsGetter)
 	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "oh noes")
 }
@@ -574,11 +574,11 @@ func (s *getUrlSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {
 func (s *getUrlSuite) TestToolsURLGetter(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{
+	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents(gomock.Any()).Return([]network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "0.1.2.3"),
 	}, nil)
 
-	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
+	g := common.NewToolsURLGetter("my-uuid", coretesting.FakeControllerConfig(), s.apiHostPortsGetter)
 	current := coretesting.CurrentVersion()
 	urls, err := g.ToolsURLs(current)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -162,7 +162,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 	if err != nil {
 		return errResp(err)
 	}
-	apiHostPorts, err := f.ctrlSt.APIHostPortsForAgents()
+	apiHostPorts, err := f.ctrlSt.APIHostPortsForAgents(controllerConfig)
 	if err != nil {
 		return errResp(err)
 	}

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
 	"github.com/juju/juju/caas"
 	_ "github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/controller"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -82,7 +83,7 @@ func (st *mockState) ControllerConfig() (jujucontroller.Config, error) {
 	return st.controllerConfig, nil
 }
 
-func (st *mockState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (st *mockState) APIHostPortsForAgents(_ controller.Config) ([]network.SpaceHostPorts, error) {
 	st.MethodCall(st, "APIHostPortsForAgents")
 	addrs := network.NewSpaceAddresses("52.7.1.1", "10.0.2.1")
 	ctlr1 := network.SpaceAddressesWithPort(addrs, 17070)

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/controller"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -26,7 +27,7 @@ type State interface {
 // required by the CAAS application facade.
 type ControllerState interface {
 	ControllerConfig() (jujucontroller.Config, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }
 
 // Model provides the subset of CAAS model state required

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -86,12 +86,7 @@ func NewDeployerAPI(ctx facade.Context) (*DeployerAPI, error) {
 // ConnectionInfo returns all the address information that the
 // deployer task needs in one call.
 func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	controllerConfig, err := d.st.ControllerConfig()
-	if err != nil {
-		return result, errors.Trace(err)
-	}
-
-	apiAddrs, err := d.APIAddresses(controllerConfig)
+	apiAddrs, err := d.APIAddresses()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -112,6 +107,26 @@ func (d *DeployerAPI) SetStatus(args params.SetStatus) (params.ErrorResults, err
 // It should be blanked when this facade version is next incremented.
 func (d *DeployerAPI) ModelUUID() params.StringResult {
 	return params.StringResult{Result: d.st.ModelUUID()}
+}
+
+// APIHostPorts returns the API server addresses.
+func (d *DeployerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	controllerConfig, err := d.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return d.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (d *DeployerAPI) APIAddresses() (result params.StringsResult, err error) {
+	controllerConfig, err := d.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return d.APIAddresser.APIAddresses(controllerConfig)
 }
 
 // getAllUnits returns a list of all principal and subordinate units

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -190,10 +190,10 @@ func (s *deployerSuite) TestSetPasswords(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{nil},
-			{apiservertesting.ErrUnauthorized},
-			{nil},
-			{apiservertesting.ErrUnauthorized},
+			{Error: nil},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: nil},
+			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})
 	err = s.principal0.Refresh()
@@ -289,10 +289,10 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{&params.Error{Message: `cannot remove entity "unit-mysql-0": still alive`}},
-			{apiservertesting.ErrUnauthorized},
-			{&params.Error{Message: `cannot remove entity "unit-logging-0": still alive`}},
-			{apiservertesting.ErrUnauthorized},
+			{Error: &params.Error{Message: `cannot remove entity "unit-mysql-0": still alive`}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: &params.Error{Message: `cannot remove entity "unit-logging-0": still alive`}},
+			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})
 	c.Assert(s.revoker.revoked.IsEmpty(), jc.IsTrue)
@@ -317,7 +317,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	result, err = s.deployer.Remove(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{{nil}},
+		Results: []params.ErrorResult{{Error: nil}},
 	})
 	c.Assert(s.revoker.revoked.Contains("logging/0"), jc.IsTrue)
 
@@ -328,7 +328,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	result, err = s.deployer.Remove(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{{apiservertesting.ErrUnauthorized}},
+		Results: []params.ErrorResult{{Error: apiservertesting.ErrUnauthorized}},
 	})
 }
 
@@ -342,7 +342,9 @@ func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
 	hostPorts[1].Scope = network.ScopeCloudLocal
 
 	st := s.ControllerModel(c).State()
-	err = st.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts})
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.SetAPIHostPorts(controllerConfig, []network.SpaceHostPorts{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.DeployerConnectionValues{
@@ -366,9 +368,9 @@ func (s *deployerSuite) TestSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{nil},
-			{apiservertesting.ErrUnauthorized},
-			{apiservertesting.ErrUnauthorized},
+			{Error: nil},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})
 	sInfo, err := s.principal0.Status()

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -174,3 +174,23 @@ func (api *MachinerAPI) RecordAgentStartInformation(args params.RecordAgentStart
 	}
 	return results, nil
 }
+
+// APIHostPorts returns the API server addresses.
+func (api *MachinerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	controllerConfig, err := api.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return api.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (api *MachinerAPI) APIAddresses() (result params.StringsResult, err error) {
+	controllerConfig, err := api.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return api.APIAddresser.APIAddresses(controllerConfig)
+}

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -137,11 +137,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	controllerConfig, err := systemState.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), controllerConfig, systemState)
+	urlGetter := common.NewToolsURLGetter(model.UUID(), systemState)
 	callCtx := context.CallContext(st)
 	resources := ctx.Resources()
 	api := &ProvisionerAPI{
@@ -179,7 +175,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		return environs.GetEnviron(configGetter, environs.New)
 	}
 	api.InstanceIdGetter = common.NewInstanceIdGetter(st, getAuthFunc)
-	api.toolsFinder = common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	api.toolsFinder = common.NewToolsFinder(st, configGetter, st, urlGetter, newEnviron)
 	api.ToolsGetter = common.NewToolsGetter(st, configGetter, st, urlGetter, api.toolsFinder, getAuthOwner)
 	return api, nil
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -137,7 +137,11 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), systemState)
+	controllerConfig, err := systemState.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	urlGetter := common.NewToolsURLGetter(model.UUID(), controllerConfig, systemState)
 	callCtx := context.CallContext(st)
 	resources := ctx.Resources()
 	api := &ProvisionerAPI{

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1337,3 +1337,23 @@ func (api *ProvisionerAPI) setOneMachineCharmProfiles(machineTag string, profile
 func (api *ProvisionerAPI) ModelUUID() params.StringResult {
 	return params.StringResult{Result: api.st.ModelUUID()}
 }
+
+// APIHostPorts returns the API server addresses.
+func (api *ProvisionerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	controllerConfig, err := api.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return api.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (api *ProvisionerAPI) APIAddresses() (result params.StringsResult, err error) {
+	controllerConfig, err := api.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return api.APIAddresser.APIAddresses(controllerConfig)
+}

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1812,10 +1812,13 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 	hostPorts := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "0.1.2.3"),
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(hostPorts)
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.APIAddresses()
+	result, err := s.provisioner.APIAddresses(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1818,7 +1818,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.APIAddresses(controllerConfig)
+	result, err := s.provisioner.APIAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/agent/proxyupdater"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
@@ -281,7 +282,11 @@ func (sb *stubBackend) ModelConfig() (*config.Config, error) {
 	return coretesting.CustomModelConfig(sb.c, sb.configAttrs), nil
 }
 
-func (sb *stubBackend) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (sb *stubBackend) ControllerConfig() (controller.Config, error) {
+	return coretesting.FakeControllerConfig(), nil
+}
+
+func (sb *stubBackend) APIHostPortsForAgents(_ controller.Config) ([]network.SpaceHostPorts, error) {
 	sb.MethodCall(sb, "APIHostPortsForAgents")
 	if err := sb.NextErr(); err != nil {
 		return nil, err

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -50,6 +50,7 @@ type UniterAPI struct {
 	*leadershipapiserver.LeadershipSettingsAccessor
 	*secretsmanager.SecretsManagerAPI
 	meterstatus.MeterStatus
+
 	lxdProfileAPI       *LXDProfileAPIv2
 	m                   *state.Model
 	st                  *state.State
@@ -2708,4 +2709,24 @@ func (u *UniterAPI) LXDProfileRequired(args params.CharmURLs) (params.BoolResult
 // CanApplyLXDProfile is a shim to call the LXDProfileAPIv2 version of this method.
 func (u *UniterAPI) CanApplyLXDProfile(args params.Entities) (params.BoolResults, error) {
 	return u.lxdProfileAPI.CanApplyLXDProfile(args)
+}
+
+// APIHostPorts returns the API server addresses.
+func (u *UniterAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	controllerConfig, err := u.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return u.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (u *UniterAPI) APIAddresses() (result params.StringsResult, err error) {
+	controllerConfig, err := u.st.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return u.APIAddresser.APIAddresses(controllerConfig)
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2977,7 +2977,7 @@ func (s *uniterSuite) TestAPIAddresses(c *gc.C) {
 	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.uniter.APIAddresses(controllerConfig)
+	result, err := s.uniter.APIAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2971,10 +2971,13 @@ func (s *uniterSuite) TestAPIAddresses(c *gc.C) {
 	hostPorts := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "0.1.2.3"),
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(hostPorts)
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.uniter.APIAddresses()
+	result, err := s.uniter.APIAddresses(controllerConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -57,7 +57,11 @@ func NewUpgraderAPI(
 	if err != nil {
 		return nil, err
 	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), ctrlSt)
+	controllerConfig, err := ctrlSt.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	urlGetter := common.NewToolsURLGetter(model.UUID(), controllerConfig, ctrlSt)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := common.EnvironFuncForModel(model, configGetter)
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -57,14 +57,10 @@ func NewUpgraderAPI(
 	if err != nil {
 		return nil, err
 	}
-	controllerConfig, err := ctrlSt.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), controllerConfig, ctrlSt)
+	urlGetter := common.NewToolsURLGetter(model.UUID(), ctrlSt)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := common.EnvironFuncForModel(model, configGetter)
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	toolsFinder := common.NewToolsFinder(st, configGetter, st, urlGetter, newEnviron)
 	return &UpgraderAPI{
 		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, toolsFinder, getCanReadWrite),
 		ToolsSetter: common.NewToolsSetter(st, getCanReadWrite),

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -45,7 +45,7 @@ type Backend interface {
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
-	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
+	APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error)
 	Application(string) (Application, error)
 	Charm(*charm.URL) (*state.Charm, error)
 	ControllerConfig() (controller.Config, error)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -125,13 +125,8 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 		return nil, errors.Trace(err)
 	}
 
-	controllerConfig, err := systemState.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+	toolsFinder := common.NewToolsFinder(st, configGetter, st, urlGetter, newEnviron)
 	blockChecker := common.NewBlockChecker(st)
 	leadershipReader, err := ctx.LeadershipReader(modelUUID)
 	if err != nil {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -124,7 +124,13 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+
+	controllerConfig, err := systemState.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	blockChecker := common.NewBlockChecker(st)
 	leadershipReader, err := ctx.LeadershipReader(modelUUID)
@@ -133,8 +139,8 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	}
 
 	return NewClient(
-		&stateShim{st, model, nil},
-		&poolShim{ctx.StatePool()},
+		&stateShim{State: st, model: model, session: nil},
+		&poolShim{pool: ctx.StatePool()},
 		resources,
 		authorizer,
 		presence,

--- a/apiserver/facades/client/client/mocks/client_mock.go
+++ b/apiserver/facades/client/client/mocks/client_mock.go
@@ -48,18 +48,18 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 }
 
 // APIHostPortsForClients mocks base method.
-func (m *MockBackend) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (m *MockBackend) APIHostPortsForClients(arg0 controller.Config) ([]network.SpaceHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPortsForClients")
+	ret := m.ctrl.Call(m, "APIHostPortsForClients", arg0)
 	ret0, _ := ret[0].([]network.SpaceHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPortsForClients indicates an expected call of APIHostPortsForClients.
-func (mr *MockBackendMockRecorder) APIHostPortsForClients() *gomock.Call {
+func (mr *MockBackendMockRecorder) APIHostPortsForClients(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForClients", reflect.TypeOf((*MockBackend)(nil).APIHostPortsForClients))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForClients", reflect.TypeOf((*MockBackend)(nil).APIHostPortsForClients), arg0)
 }
 
 // AbortCurrentUpgrade mocks base method.

--- a/apiserver/facades/client/machinemanager/instanceconfig.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig.go
@@ -64,12 +64,12 @@ func InstanceConfig(ctrlSt ControllerBackend, st InstanceConfigBackend, machineI
 	if !ok {
 		return nil, errors.New("no agent version set in model configuration")
 	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), controllerConfig, ctrlSt)
+	urlGetter := common.NewToolsURLGetter(model.UUID(), ctrlSt)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := func() (environs.BootstrapEnviron, error) {
 		return environs.GetEnviron(configGetter, environs.New)
 	}
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	toolsFinder := common.NewToolsFinder(ctrlSt, configGetter, st, urlGetter, newEnviron)
 	toolsList, err := toolsFinder.FindAgents(common.FindAgentsParams{
 		Number: agentVersion,
 		OSType: machine.Base().OS,

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -71,7 +71,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 		SpaceAddress: network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}, nil).MinTimes(1)
-	s.ctrlSt.EXPECT().ControllerConfig().Return(coretesting.FakeControllerConfig(), nil)
+	s.ctrlSt.EXPECT().ControllerConfig().Return(coretesting.FakeControllerConfig(), nil).MinTimes(1)
 	s.ctrlSt.EXPECT().ControllerTag().Return(coretesting.ControllerTag).AnyTimes()
 
 	icfg, err := machinemanager.InstanceConfig(s.ctrlSt, s.st, "0", "nonce", "")

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -67,7 +67,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	storageCloser.EXPECT().Close().Return(nil)
 	s.st.EXPECT().ToolsStorage().Return(storageCloser, nil)
 
-	s.ctrlSt.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{{{
+	s.ctrlSt.EXPECT().APIHostPortsForAgents(gomock.Any()).Return([]network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}, nil).MinTimes(1)

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -777,7 +777,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScript(c *gc.C) {
 	storageCloser := s.expectProvisioningStorageCloser(ctrl)
 	s.st.EXPECT().ToolsStorage().Return(storageCloser, nil)
 
-	s.ctrlSt.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{{{
+	s.ctrlSt.EXPECT().APIHostPortsForAgents(gomock.Any()).Return([]network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}, nil).Times(2)
@@ -834,7 +834,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptDisablePackageCo
 	storageCloser := s.expectProvisioningStorageCloser(ctrl)
 	s.st.EXPECT().ToolsStorage().Return(storageCloser, nil)
 
-	s.ctrlSt.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{{{
+	s.ctrlSt.EXPECT().APIHostPortsForAgents(gomock.Any()).Return([]network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}, nil).Times(2)

--- a/apiserver/facades/client/machinemanager/mocks/instance_config_mock.go
+++ b/apiserver/facades/client/machinemanager/mocks/instance_config_mock.go
@@ -39,18 +39,18 @@ func (m *MockControllerBackend) EXPECT() *MockControllerBackendMockRecorder {
 }
 
 // APIHostPortsForAgents mocks base method.
-func (m *MockControllerBackend) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (m *MockControllerBackend) APIHostPortsForAgents(arg0 controller.Config) ([]network.SpaceHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPortsForAgents")
+	ret := m.ctrl.Call(m, "APIHostPortsForAgents", arg0)
 	ret0, _ := ret[0].([]network.SpaceHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPortsForAgents indicates an expected call of APIHostPortsForAgents.
-func (mr *MockControllerBackendMockRecorder) APIHostPortsForAgents() *gomock.Call {
+func (mr *MockControllerBackendMockRecorder) APIHostPortsForAgents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockControllerBackend)(nil).APIHostPortsForAgents))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForAgents", reflect.TypeOf((*MockControllerBackend)(nil).APIHostPortsForAgents), arg0)
 }
 
 // ControllerConfig mocks base method.

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -54,7 +54,7 @@ type BackendState interface {
 type ControllerBackend interface {
 	ControllerTag() names.ControllerTag
 	ControllerConfig() (controller.Config, error)
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }
 
 type Pool interface {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -888,14 +888,12 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	st := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 	ctlrSt := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 
-	controllerConfig, err := s.ControllerModel(c).State().ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), controllerConfig, ctlrSt)
+	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), ctlrSt)
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: s.ControllerModel(c)}
 	newEnviron := common.EnvironFuncForModel(model, configGetter)
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	toolsFinder := common.NewToolsFinder(st, configGetter, st, urlGetter, newEnviron)
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		st, nil, ctlrSt,
 		&mockModelManagerService{},

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -887,7 +887,10 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
 	st := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 	ctlrSt := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
-	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), ctlrSt)
+
+	controllerConfig, err := s.ControllerModel(c).State().ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), controllerConfig, ctlrSt)
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: s.ControllerModel(c)}

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -61,12 +61,8 @@ func newFacadeV10(ctx facade.Context) (*ModelManagerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	controllerConfig, err := systemState.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+	toolsFinder := common.NewToolsFinder(systemState, configGetter, st, urlGetter, newEnviron)
 
 	apiUser, _ := auth.GetAuthTag().(names.UserTag)
 	backend := common.NewUserAwareModelManagerBackend(model, pool, apiUser)

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -61,7 +61,11 @@ func newFacadeV10(ctx facade.Context) (*ModelManagerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+	controllerConfig, err := systemState.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 
 	apiUser, _ := auth.GetAuthTag().(names.UserTag)

--- a/apiserver/facades/client/modelupgrader/register.go
+++ b/apiserver/facades/client/modelupgrader/register.go
@@ -45,13 +45,8 @@ func newFacadeV1(ctx facade.Context) (*ModelUpgraderAPI, error) {
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := common.EnvironFuncForModel(model, configGetter)
 
-	controllerConfig, err := systemState.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+	toolsFinder := common.NewToolsFinder(systemState, configGetter, st, urlGetter, newEnviron)
 	environscloudspecGetter := cloudspec.MakeCloudSpecGetter(pool)
 
 	// Since we know this is a user tag (because AuthClient is true),

--- a/apiserver/facades/client/modelupgrader/register.go
+++ b/apiserver/facades/client/modelupgrader/register.go
@@ -45,7 +45,12 @@ func newFacadeV1(ctx facade.Context) (*ModelUpgraderAPI, error) {
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := common.EnvironFuncForModel(model, configGetter)
 
-	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
+	controllerConfig, err := systemState.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	urlGetter := common.NewToolsURLGetter(modelUUID, controllerConfig, systemState)
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	environscloudspecGetter := cloudspec.MakeCloudSpecGetter(pool)
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -80,8 +80,8 @@ func (st *mockState) ControllerConfig() (controller.Config, error) {
 	return cfg, nil
 }
 
-func (st *mockState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
-	st.MethodCall(st, "APIHostPortsForAgents")
+func (st *mockState) APIHostPortsForAgents(controllerConfig controller.Config) ([]network.SpaceHostPorts, error) {
+	st.MethodCall(st, "APIHostPortsForAgents", controllerConfig)
 	return []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1, "10.0.0.1"),
 	}, nil

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -335,7 +335,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
-	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents()
+	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents(cfg)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting api addresses")
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -38,7 +38,7 @@ type CAASApplicationProvisionerState interface {
 type CAASApplicationControllerState interface {
 	ControllerConfig() (controller.Config, error)
 	ModelUUID() string
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
+	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
 	WatchControllerConfig() state.NotifyWatcher
 }

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -33,7 +33,7 @@ func newMockState() *mockState {
 	}
 }
 
-func (st *mockState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
+func (st *mockState) APIHostPortsForAgents(controllerConf controller.Config) ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1, "10.0.0.1"),
 	}, nil

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -79,7 +79,7 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 				modelConfig.Name()))
 	}
 
-	apiAddresses, err := a.APIAddresses()
+	apiAddresses, err := a.APIAddresses(controllerConf)
 	if err != nil && apiAddresses.Error != nil {
 		err = apiAddresses.Error
 	}

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -79,7 +79,7 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 				modelConfig.Name()))
 	}
 
-	apiAddresses, err := a.APIAddresses(controllerConf)
+	apiAddresses, err := a.APIAddresses()
 	if err != nil && apiAddresses.Error != nil {
 		err = apiAddresses.Error
 	}
@@ -108,4 +108,24 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 // It should be blanked when this facade version is next incremented.
 func (a *API) ModelUUID() params.StringResult {
 	return params.StringResult{Result: a.state.ModelUUID()}
+}
+
+// APIHostPorts returns the API server addresses.
+func (u *API) APIHostPorts() (result params.APIHostPortsResult, err error) {
+	controllerConfig, err := u.ctrlState.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return u.APIAddresser.APIHostPorts(controllerConfig)
+}
+
+// APIAddresses returns the list of addresses used to connect to the API.
+func (u *API) APIAddresses() (result params.StringsResult, err error) {
+	controllerConfig, err := u.ctrlState.ControllerConfig()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return u.APIAddresser.APIAddresses(controllerConfig)
 }

--- a/apiserver/facades/controller/migrationmaster/backend.go
+++ b/apiserver/facades/controller/migrationmaster/backend.go
@@ -31,5 +31,5 @@ type Backend interface {
 
 // ControllerState defines the state functionality for controller model.
 type ControllerState interface {
-	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
+	APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error)
 }

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -175,7 +175,7 @@ func (api *API) SourceControllerInfo() (params.MigrationSourceInfo, error) {
 	}
 	cacert, _ := cfg.CACert()
 
-	hostports, err := api.controllerState.APIHostPortsForClients()
+	hostports, err := api.controllerState.APIHostPortsForClients(cfg)
 	if err != nil {
 		return empty, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -185,20 +185,22 @@ func (s *Suite) TestModelInfo(c *gc.C) {
 func (s *Suite) TestSourceControllerInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	exp := s.backend.EXPECT()
-	exp.AllLocalRelatedModels().Return([]string{"related-model-uuid"}, nil)
-	s.backend.EXPECT().ControllerConfig().Return(controller.Config{
+	cfg := controller.Config{
 		controller.ControllerUUIDKey: coretesting.ControllerTag.Id(),
 		controller.ControllerName:    "mycontroller",
 		controller.CACertKey:         "cacert",
-	}, nil)
+	}
+
+	exp := s.backend.EXPECT()
+	exp.AllLocalRelatedModels().Return([]string{"related-model-uuid"}, nil)
+	s.backend.EXPECT().ControllerConfig().Return(cfg, nil)
 	apiAddr := []network.SpaceHostPorts{{{
 		SpaceAddress: network.SpaceAddress{
 			MachineAddress: network.MachineAddress{Value: "10.0.0.1"},
 		},
 		NetPort: 666,
 	}}}
-	s.controllerBackend.EXPECT().APIHostPortsForClients().Return(apiAddr, nil)
+	s.controllerBackend.EXPECT().APIHostPortsForClients(cfg).Return(apiAddr, nil)
 
 	info, err := s.mustMakeAPI(c).SourceControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -226,18 +226,18 @@ func (m *MockControllerState) EXPECT() *MockControllerStateMockRecorder {
 }
 
 // APIHostPortsForClients mocks base method.
-func (m *MockControllerState) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (m *MockControllerState) APIHostPortsForClients(arg0 controller.Config) ([]network.SpaceHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPortsForClients")
+	ret := m.ctrl.Call(m, "APIHostPortsForClients", arg0)
 	ret0, _ := ret[0].([]network.SpaceHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPortsForClients indicates an expected call of APIHostPortsForClients.
-func (mr *MockControllerStateMockRecorder) APIHostPortsForClients() *gomock.Call {
+func (mr *MockControllerStateMockRecorder) APIHostPortsForClients(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForClients", reflect.TypeOf((*MockControllerState)(nil).APIHostPortsForClients))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPortsForClients", reflect.TypeOf((*MockControllerState)(nil).APIHostPortsForClients), arg0)
 }
 
 // MockModelExporter is a mock of ModelExporter interface.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -89,7 +89,11 @@ func (s *serverSuite) TestStop(c *gc.C) {
 }
 
 func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
-	err := s.ControllerModel(c).State().SetAPIHostPorts(nil)
+	st := s.ControllerModel(c).State()
+	cfg, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -197,7 +197,7 @@ func (b *fakeMigrationBackend) LatestMigration() (state.ModelMigration, error) {
 	return new(fakeModelMigration), nil
 }
 
-func (b *fakeMigrationBackend) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (b *fakeMigrationBackend) APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{
 		{
 			network.SpaceHostPort{SpaceAddress: network.NewSpaceAddress("1.2.3.4"), NetPort: 5},

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -56,7 +56,10 @@ func (s *AgentSuite) SetUpTest(c *gc.C) {
 	hostPorts := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "0.1.2.3"),
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(hostPorts)
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&proxyupdater.NewWorker, func(proxyupdater.Config) (worker.Worker, error) {
 		return newDummyWorker(), nil

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -316,7 +316,11 @@ func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
 	hostPorts := network.SpaceHostPorts{
 		{SpaceAddress: network.SpaceAddress{MachineAddress: mHP.MachineAddress}, NetPort: mHP.NetPort}}
 
-	err = s.ControllerModel(c).State().SetAPIHostPorts([]network.SpaceHostPorts{hostPorts})
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(controllerConfig, []network.SpaceHostPorts{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Logf("api host ports primed %#v", hostPorts)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -985,7 +985,11 @@ func (s *MachineSuite) TestMachineAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 	updatedServers := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "localhost"),
 	}
-	err := s.ControllerModel(c).State().SetAPIHostPorts(updatedServers)
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.SetAPIHostPorts(controllerConfig, updatedServers)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for config to be updated.

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -277,7 +277,7 @@ func (s *ApiServerSuite) setupControllerModel(c *gc.C, controllerCfg controller.
 	}}
 	st, err := ctrl.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.SetAPIHostPorts(sHsPs)
+	err = st.SetAPIHostPorts(controllerCfg, sHsPs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.controllerModelUUID = st.ControllerModelUUID()

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -130,8 +130,10 @@ func AddControllerMachine(c *gc.C, st *state.State) *state.Machine {
 	err = machine.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 	hostPorts := []network.SpaceHostPorts{network.NewSpaceHostPorts(1234, "0.1.2.3")}
-	err = st.SetAPIHostPorts(hostPorts)
+	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return machine

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -212,13 +212,13 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
-	cfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.SetJujuManagementSpace(c, "mgmt01")
+
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -343,9 +343,6 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
-	cfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -369,6 +366,9 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		},
 		NetPort: 2,
 	}
+
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.SetAPIHostPorts(cfg, []network.SpaceHostPorts{{mgmtHP}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -193,7 +193,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
 
-	addrs, err := s.State.APIHostPortsForClients()
+	addrs, err := s.State.APIHostPortsForClients(controllerCfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4747,13 +4747,13 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 }
 
 func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
-	cfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.SetJujuManagementSpace(c, "mgmt01")
+
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4603,7 +4603,10 @@ func (s *StateSuite) TestStateServingInfo(c *gc.C) {
 }
 
 func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -4617,16 +4620,16 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 		SpaceAddress: network.NewSpaceAddress("0.6.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}}}
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(cfg, newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForClients()
+	gotHostPorts, err := ctrlSt.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
@@ -4634,19 +4637,22 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      13,
 	}}}
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(cfg, newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForClients()
+	gotHostPorts, err = ctrlSt.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
 func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	hostPorts := []network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
@@ -4663,7 +4669,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 	var prevRevno int64
 	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.SetAPIHostPorts(hostPorts)
+		err := s.State.SetAPIHostPorts(cfg, hostPorts)
 		c.Assert(err, jc.ErrorIsNil)
 		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
@@ -4673,7 +4679,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 		prevAgentsRevno = revno
 	}).Check()
 
-	err := s.State.SetAPIHostPorts(hostPorts)
+	err = s.State.SetAPIHostPorts(cfg, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
 
@@ -4687,6 +4693,9 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 }
 
 func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	hostPorts0 := network.SpaceHostPorts{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
@@ -4704,7 +4713,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 	var prevRevno int64
 	var prevAgentsRevno int64
 	defer state.SetBeforeHooks(c, s.State, func() {
-		err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts0})
+		err := s.State.SetAPIHostPorts(cfg, []network.SpaceHostPorts{hostPorts0})
 		c.Assert(err, jc.ErrorIsNil)
 		revno, err := state.TxnRevno(s.State, ctrC, "apiHostPorts")
 		c.Assert(err, jc.ErrorIsNil)
@@ -4714,7 +4723,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 		prevAgentsRevno = revno
 	}).Check()
 
-	err := s.State.SetAPIHostPorts([]network.SpaceHostPorts{hostPorts1})
+	err = s.State.SetAPIHostPorts(cfg, []network.SpaceHostPorts{hostPorts1})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
 
@@ -4728,22 +4737,25 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	hostPorts, err := ctrlSt.APIHostPortsForClients()
+	hostPorts, err := ctrlSt.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostPorts, gc.DeepEquals, []network.SpaceHostPorts{hostPorts1})
 
-	hostPorts, err = ctrlSt.APIHostPortsForAgents()
+	hostPorts, err = ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostPorts, gc.DeepEquals, []network.SpaceHostPorts{hostPorts1})
 }
 
 func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.SetJujuManagementSpace(c, "mgmt01")
 
-	addrs, err := s.State.APIHostPortsForClients()
+	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -4768,16 +4780,16 @@ func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	}
 	newHostPorts := []network.SpaceHostPorts{{hostPort1, hostPort2}, {hostPort3}}
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(cfg, newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForClients()
+	gotHostPorts, err := ctrlSt.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
-	gotHostPorts, err = ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err = ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	// First slice filtered down to the address in the management space.
 	// Second filtered to zero elements, so retains the supplied slice.
@@ -4785,7 +4797,10 @@ func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 }
 
 func (s *StateSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -4801,18 +4816,21 @@ func (s *StateSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(col.FindId(key).One(&bson.D{}), gc.Equals, mgo.ErrNotFound)
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(cfg, newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err := ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
 func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	addrs, err := s.State.APIHostPortsForClients()
+	cfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.HasLen, 0)
 
@@ -4821,7 +4839,7 @@ func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 		NetPort:      1,
 	}}}
 
-	err = s.State.SetAPIHostPorts(newHostPorts)
+	err = s.State.SetAPIHostPorts(cfg, newHostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Delete the addresses for agents document after setting.
@@ -4833,7 +4851,7 @@ func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 
 	ctrlSt, err := s.StatePool.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	gotHostPorts, err := ctrlSt.APIHostPortsForAgents()
+	gotHostPorts, err := ctrlSt.APIHostPortsForAgents(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
-	jujucontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/pki"
@@ -26,7 +26,7 @@ func TestPackage(t *stdtesting.T) {
 
 type CertUpdaterSuite struct {
 	coretesting.BaseSuite
-	stateServingInfo jujucontroller.StateServingInfo
+	stateServingInfo controller.StateServingInfo
 }
 
 var _ = gc.Suite(&CertUpdaterSuite{})
@@ -34,7 +34,7 @@ var _ = gc.Suite(&CertUpdaterSuite{})
 func (s *CertUpdaterSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.stateServingInfo = jujucontroller.StateServingInfo{
+	s.stateServingInfo = controller.StateServingInfo{
 		Cert:         coretesting.ServerCert,
 		PrivateKey:   coretesting.ServerKey,
 		CAPrivateKey: coretesting.CAKey,
@@ -81,13 +81,17 @@ func (m *mockMachine) Addresses() (addresses network.SpaceAddresses) {
 	return network.NewSpaceAddresses("0.1.2.3")
 }
 
-func (s *CertUpdaterSuite) StateServingInfo() (jujucontroller.StateServingInfo, bool) {
+func (s *CertUpdaterSuite) StateServingInfo() (controller.StateServingInfo, bool) {
 	return s.stateServingInfo, true
 }
 
 type mockAPIHostGetter struct{}
 
-func (g *mockAPIHostGetter) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
+func (g *mockAPIHostGetter) ControllerConfig() (controller.Config, error) {
+	return coretesting.FakeControllerConfig(), nil
+}
+
+func (g *mockAPIHostGetter) APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{{
 		{SpaceAddress: network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeCloudLocal)), NetPort: 17070},
 		{SpaceAddress: network.NewSpaceAddress("10.1.1.1", network.WithScope(network.ScopeMachineLocal)), NetPort: 17070},

--- a/worker/peergrouper/publish.go
+++ b/worker/peergrouper/publish.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 )
 
@@ -23,7 +24,7 @@ type CachingAPIHostPortsSetter struct {
 	last []network.SpaceHostPorts
 }
 
-func (s *CachingAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHostPorts) error {
+func (s *CachingAPIHostPortsSetter) SetAPIHostPorts(controllerConfig controller.Config, apiServers []network.SpaceHostPorts) error {
 	if len(apiServers) == 0 {
 		return errors.Errorf("no API servers specified")
 	}
@@ -41,7 +42,7 @@ func (s *CachingAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHo
 		return nil
 	}
 
-	if err := s.APIHostPortsSetter.SetAPIHostPorts(sorted); err != nil {
+	if err := s.APIHostPortsSetter.SetAPIHostPorts(controllerConfig, sorted); err != nil {
 		return errors.Annotate(err, "setting API host ports")
 	}
 	s.last = sorted

--- a/worker/peergrouper/publish_test.go
+++ b/worker/peergrouper/publish_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/testing"
 )
@@ -22,7 +23,7 @@ type mockAPIHostPortsSetter struct {
 	apiHostPorts []network.SpaceHostPorts
 }
 
-func (s *mockAPIHostPortsSetter) SetAPIHostPorts(apiHostPorts []network.SpaceHostPorts) error {
+func (s *mockAPIHostPortsSetter) SetAPIHostPorts(_ controller.Config, apiHostPorts []network.SpaceHostPorts) error {
 	s.calls++
 	s.apiHostPorts = apiHostPorts
 	return nil
@@ -38,7 +39,7 @@ func (s *publishSuite) TestPublisherSetsAPIHostPortsOnce(c *gc.C) {
 	// statePublish.SetAPIHostPorts should not update state a second time.
 	apiServers := []network.SpaceHostPorts{hostPorts1}
 	for i := 0; i < 2; i++ {
-		err := statePublish.SetAPIHostPorts(apiServers)
+		err := statePublish.SetAPIHostPorts(testing.FakeControllerConfig(), apiServers)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -47,7 +48,7 @@ func (s *publishSuite) TestPublisherSetsAPIHostPortsOnce(c *gc.C) {
 
 	apiServers = append(apiServers, hostPorts2)
 	for i := 0; i < 2; i++ {
-		err := statePublish.SetAPIHostPorts(apiServers)
+		err := statePublish.SetAPIHostPorts(testing.FakeControllerConfig(), apiServers)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	c.Assert(mock.calls, gc.Equals, 2)
@@ -62,7 +63,7 @@ func (s *publishSuite) TestPublisherSortsHostPorts(c *gc.C) {
 		var mock mockAPIHostPortsSetter
 		statePublish := &CachingAPIHostPortsSetter{APIHostPortsSetter: &mock}
 		for i := 0; i < 2; i++ {
-			err := statePublish.SetAPIHostPorts([]network.SpaceHostPorts{publish})
+			err := statePublish.SetAPIHostPorts(testing.FakeControllerConfig(), []network.SpaceHostPorts{publish})
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		c.Assert(mock.calls, gc.Equals, 1)
@@ -76,6 +77,6 @@ func (s *publishSuite) TestPublisherSortsHostPorts(c *gc.C) {
 func (s *publishSuite) TestPublisherRejectsNoServers(c *gc.C) {
 	var mock mockAPIHostPortsSetter
 	statePublish := &CachingAPIHostPortsSetter{APIHostPortsSetter: &mock}
-	err := statePublish.SetAPIHostPorts(nil)
+	err := statePublish.SetAPIHostPorts(testing.FakeControllerConfig(), nil)
 	c.Assert(err, gc.ErrorMatches, "no API servers specified")
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -75,7 +75,7 @@ type MongoSession interface {
 }
 
 type APIHostPortsSetter interface {
-	SetAPIHostPorts([]network.SpaceHostPorts) error
+	SetAPIHostPorts(controller.Config, []network.SpaceHostPorts) error
 }
 
 var (
@@ -333,7 +333,12 @@ func (w *pgWorker) loop() error {
 		}
 
 		var failed bool
-		if err := w.config.APIHostPortsSetter.SetAPIHostPorts(apiHostPorts); err != nil {
+		cfg, err := w.config.State.ControllerConfig()
+		if err != nil {
+			logger.Errorf("cannot read controller config: %v", err)
+			failed = true
+		}
+		if err := w.config.APIHostPortsSetter.SetAPIHostPorts(cfg, apiHostPorts); err != nil {
 			logger.Errorf("cannot write API server addresses: %v", err)
 			failed = true
 		}

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/pubsub/apiserver"
@@ -487,7 +488,7 @@ func (s *workerSuite) TestSetMembersErrorIsNotFatal(c *gc.C) {
 
 type SetAPIHostPortsFunc func(apiServers []network.SpaceHostPorts) error
 
-func (f SetAPIHostPortsFunc) SetAPIHostPorts(apiServers []network.SpaceHostPorts) error {
+func (f SetAPIHostPortsFunc) SetAPIHostPorts(_ controller.Config, apiServers []network.SpaceHostPorts) error {
 	return f(apiServers)
 }
 
@@ -1150,7 +1151,7 @@ func mustNextStatus(c *gc.C, w *voyeur.Watcher, context string) *replicaset.Stat
 
 type nopAPIHostPortsSetter struct{}
 
-func (nopAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHostPorts) error {
+func (nopAPIHostPortsSetter) SetAPIHostPorts(controller.Config, []network.SpaceHostPorts) error {
 	return nil
 }
 


### PR DESCRIPTION
The following moves the controller config from inside the state 
methods to dependencies of the methods. The following methods
that are impacted are:

 - APIHostPortsForClients
 - APIHostPortsForAgents
 - SetAPIHostPorts

The consequences of this change means that the facades now have to
pass in the controller config at the request time. The downside to this
is that we now have to ensure that common apiserver composable types
are now correctly wrapped. This is to ensure that we're not breaking
API compatibility for no reason.

Note: there should be no changes in the schema after this change.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```

