### PR TITLE
[JUJU-4353] Delegate defaulting series of local charms to deploy

### DIFF
--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -3573,30 +3573,6 @@ func (s *changesSuite) TestLocalCharmWithExplicitSeries(c *gc.C) {
 	s.assertLocalBundleChangesWithDevices(c, charmDir, bundleContent, "xenial")
 }
 
-func (s *changesSuite) TestLocalCharmWithSeriesFromCharm(c *gc.C) {
-	charmDir := filepath.Join(c.MkDir(), "multiseries")
-	err := os.Mkdir(charmDir, 0700)
-	c.Assert(err, jc.ErrorIsNil)
-	bundleContent := fmt.Sprintf(`
-        applications:
-            django:
-                charm: %s
-    `, charmDir)
-	charmMeta := `
-name: multi-series
-summary: That's a dummy charm with multi-series.
-description: A dummy charm.
-series:
-    - jammy
-    - focal
-    - bionic
-`[1:]
-	err = os.WriteFile(filepath.Join(charmDir, "metadata.yaml"), []byte(charmMeta), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertLocalBundleChanges(c, charmDir, bundleContent, "jammy")
-	s.assertLocalBundleChangesWithDevices(c, charmDir, bundleContent, "jammy")
-}
-
 func (s *changesSuite) TestLocalCharmWithSeriesFromBundle(c *gc.C) {
 	charmDir := c.MkDir()
 	bundleContent := fmt.Sprintf(`

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/naturalsort"
 
 	corebase "github.com/juju/juju/core/base"
-	corecharm "github.com/juju/juju/core/charm"
 )
 
 type resolver struct {
@@ -1263,20 +1262,7 @@ func getSeries(application *charm.ApplicationSpec, defaultSeries string) (string
 
 	// Handle local charm paths.
 	if charm.IsValidLocalCharmOrBundlePath(application.Charm) {
-		_, charmURL, err := corecharm.NewCharmAtPath(application.Charm, defaultSeries)
-		if corecharm.IsMissingSeriesError(err) {
-			// local charm path is valid but the charm doesn't declare a default series.
-			return defaultSeries, nil
-		} else if corecharm.IsUnsupportedSeriesError(err) {
-			// The bundle's default series is not supported by the charm, but we'll
-			// use it anyway. This is no different to the case above where application.Series
-			// is used without checking for potential charm incompatibility.
-			return defaultSeries, nil
-		} else if err != nil {
-			return "", errors.Trace(err)
-		}
-		// Return the default series from the local charm.
-		return charmURL.Series, nil
+		return defaultSeries, nil
 	}
 
 	// The following is safe because the bundle data is assumed to be already


### PR DESCRIPTION
This does not really belong in bundle client-side code, but should live in the controller/deployment side of things

No behaviour has actually changed. Note that if the charm does not support the default series provided, we return it anyway. This means charmURL.Series will always be the provided default series

The only exception to this is if no default series is inputted. In that case, in the original code, the default series of the charm will be returned. This defaulting, however, should be handled outside of the client bundle code, but on deploy of the charm itself.  The QA steps verify no change in behaviour

The test which is removed can be removed represents this change in behaviour. It can be removed since what it would be testing if fixed is already covered by other tests. However, happy to restore it + fix if other would prefer. All it would require is:
```
s.assertLocalBundleChanges(c, charmDir, bundleContent, "")
s.assertLocalBundleChangesWithDevices(c, charmDir, bundleContent, "")
```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Verify unit tests pass

Verify that `./main.sh -v deploy test_deploy_bundles` pass

Create a local charm e.g.
```sh
mkdir ubuntu
cd ubuntu
juju download ubuntu
unzip ubuntu_r24.charm
cd ..
```

Create a test bundle as follows:
```
$ cat bundle.yaml
applications:
  ubu:
    charm: ./ubuntu
    num_units: 1
```

Edit the charm manifest.yaml accordinging:
```
bases:
- channel: '20.04'
  name: ubuntu
- channel: '22.04'
  name: ubuntu
```

Notice that `juju deploy ./ubuntu` deploys ubuntu with base ubuntu@20.04

Verify that `juju deploy ./bundle.yaml` also deploys ubuntu with base ubuntu@20.04 

Edit the charm manifest.yaml as follows:
```
bases:
- channel: '22.04'
  name: ubuntu
```

Notice that `juju deploy ./ubuntu` deploys ubuntu with base ubuntu@22.04

Verify that `juju deploy ./bundle.yaml` also deploys ubuntu with base ubuntu@22.04 
