### PR TITLE
[JUJU-4315] Inject ctrl config peergrouper

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -620,6 +620,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:            agentName,
 			ClockName:            clockName,
 			StateName:            stateName,
+			ServiceFactoryName:   serviceFactoryName,
 			Hub:                  config.CentralHub,
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            peergrouper.New,

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -807,7 +807,13 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"peer-grouper": {
 		"agent",
+		"change-stream",
 		"clock",
+		"db-accessor",
+		"file-notify-watcher",
+		"is-controller-flag",
+		"query-logger",
+		"service-factory",
 		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",
@@ -1234,7 +1240,13 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"peer-grouper": {
 		"agent",
+		"change-stream",
 		"clock",
+		"db-accessor",
+		"file-notify-watcher",
+		"is-controller-flag",
+		"query-logger",
+		"service-factory",
 		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",


### PR DESCRIPTION
The following passes the controller config from the service worker factory via the dependency engine.

This allows us to directly inject the controller config nicely into any worker without creating a service. This will be the standard practice for how a controller config or for that matter any service will be used in a worker.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```
