### PR TITLE
[JUJU-4452] Add context.Context in agent/agent facade

### DIFF
--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -7,6 +7,8 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -35,7 +37,7 @@ type AgentAPI struct {
 	resources facade.Resources
 }
 
-func (api *AgentAPI) GetEntities(args params.Entities) params.AgentGetEntitiesResults {
+func (api *AgentAPI) GetEntities(ctx context.Context, args params.Entities) params.AgentGetEntitiesResults {
 	results := params.AgentGetEntitiesResults{
 		Entities: make([]params.AgentGetEntitiesResult, len(args.Entities)),
 	}
@@ -77,7 +79,7 @@ func (api *AgentAPI) getEntity(tag names.Tag) (result params.AgentGetEntitiesRes
 	return
 }
 
-func (api *AgentAPI) StateServingInfo() (result params.StateServingInfo, err error) {
+func (api *AgentAPI) StateServingInfo(ctx context.Context) (result params.StateServingInfo, err error) {
 	if !api.auth.AuthController() {
 		err = apiservererrors.ErrPerm
 		return
@@ -111,7 +113,7 @@ func (api *AgentAPI) StateServingInfo() (result params.StateServingInfo, err err
 // be overridden by tests.
 var MongoIsMaster = mongo.IsMaster
 
-func (api *AgentAPI) IsMaster() (params.IsMasterResult, error) {
+func (api *AgentAPI) IsMaster(ctx context.Context) (params.IsMasterResult, error) {
 	if !api.auth.AuthController() {
 		return params.IsMasterResult{}, apiservererrors.ErrPerm
 	}
@@ -140,7 +142,7 @@ func stateJobsToAPIParamsJobs(jobs []state.MachineJob) []model.MachineJob {
 }
 
 // WatchCredentials watches for changes to the specified credentials.
-func (api *AgentAPI) WatchCredentials(args params.Entities) (params.NotifyWatchResults, error) {
+func (api *AgentAPI) WatchCredentials(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	if !api.auth.AuthController() {
 		return params.NotifyWatchResults{}, apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -4,6 +4,8 @@
 package agent_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -108,7 +110,7 @@ func (s *agentSuite) TestGetEntities(c *gc.C) {
 		ServiceFactory_: servicefactorytesting.NewTestingServiceFactory(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results := api.GetEntities(args)
+	results := api.GetEntities(context.Background(), args)
 	c.Assert(results, gc.DeepEquals, params.AgentGetEntitiesResults{
 		Entities: []params.AgentGetEntitiesResult{
 			{
@@ -143,7 +145,7 @@ func (s *agentSuite) TestGetEntitiesContainer(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results := api.GetEntities(args)
+	results := api.GetEntities(context.Background(), args)
 	c.Assert(results, gc.DeepEquals, params.AgentGetEntitiesResults{
 		Entities: []params.AgentGetEntitiesResult{
 			{Error: apiservertesting.ErrUnauthorized},
@@ -181,7 +183,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 		ServiceFactory_: servicefactorytesting.NewTestingServiceFactory(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results := api.GetEntities(params.Entities{
+	results := api.GetEntities(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-1"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -292,7 +294,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	tag := names.NewCloudCredentialTag("dummy/fred/default")
-	result, err := api.WatchCredentials(params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})
+	result, err := api.WatchCredentials(context.Background(), params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.NotifyWatchResults{Results: []params.NotifyWatchResult{{NotifyWatcherId: "1", Error: nil}}})
 	c.Assert(s.resources.Count(), gc.Equals, 1)
@@ -321,7 +323,7 @@ func (s *agentSuite) TestWatchAuthError(c *gc.C) {
 		ServiceFactory_: servicefactorytesting.NewTestingServiceFactory(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = api.WatchCredentials(params.Entities{})
+	_, err = api.WatchCredentials(context.Background(), params.Entities{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 }


### PR DESCRIPTION
This PR adds context.Context parameter to agent/agent facade calls and fixes the unit tests.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
go test github.com/juju/juju/apiserver/facades/agent/agent/... -gocheck.v

make build && make install && juju version
juju bootstrap lxd lxd
```
