### PR TITLE
[JUJU-4453] Add context.Context in agent/caas* facades

### DIFF
--- a/apiserver/facades/agent/caasadmission/caasadmission.go
+++ b/apiserver/facades/agent/caasadmission/caasadmission.go
@@ -5,10 +5,8 @@ package caasadmission
 
 import (
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/facade"
 )
 
 type Facade struct {
-	auth facade.Authorizer
 	*common.ControllerConfigAPI
 }

--- a/apiserver/facades/agent/caasadmission/register.go
+++ b/apiserver/facades/agent/caasadmission/register.go
@@ -25,7 +25,6 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 	}
 
 	return &Facade{
-		auth: authorizer,
 		ControllerConfigAPI: common.NewControllerConfigAPI(
 			ctx.State(),
 			ctx.ServiceFactory().ExternalController(),

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -6,13 +6,10 @@ package caasagent
 import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
-	"github.com/juju/juju/apiserver/facade"
 )
 
 // FacadeV2 is the V2 facade of the caas agent
 type FacadeV2 struct {
-	auth      facade.Authorizer
-	resources facade.Resources
 	cloudspec.CloudSpecer
 	*common.ModelWatcher
 	*common.ControllerConfigAPI

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -49,7 +49,5 @@ func newStateFacadeV2(ctx facade.Context) (*FacadeV2, error) {
 			ctx.State(),
 			ctx.ServiceFactory().ExternalController(),
 		),
-		auth:      authorizer,
-		resources: resources,
 	}, nil
 }

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -4,6 +4,7 @@
 package caasapplication
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -65,7 +66,7 @@ func NewFacade(
 }
 
 // UnitIntroduction sets the status of each given entity.
-func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.CAASUnitIntroductionResult, error) {
+func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntroductionArgs) (params.CAASUnitIntroductionResult, error) {
 	tag, ok := f.auth.GetAuthTag().(names.ApplicationTag)
 	if !ok {
 		return params.CAASUnitIntroductionResult{}, apiservererrors.ErrPerm
@@ -215,7 +216,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 // UnitTerminating should be called by the CAASUnitTerminationWorker when
 // the agent receives a signal to exit. UnitTerminating will return how
 // the agent should shutdown.
-func (f *Facade) UnitTerminating(args params.Entity) (params.CAASUnitTerminationResult, error) {
+func (f *Facade) UnitTerminating(ctx context.Context, args params.Entity) (params.CAASUnitTerminationResult, error) {
 	tag, ok := f.auth.GetAuthTag().(names.UnitTag)
 	if !ok {
 		return params.CAASUnitTerminationResult{}, apiservererrors.ErrPerm

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -4,6 +4,7 @@
 package caasapplication_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -85,7 +86,7 @@ func (s *CAASApplicationSuite) TestAddUnit(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -127,7 +128,7 @@ func (s *CAASApplicationSuite) TestAddUnitNotNeeded(c *gc.C) {
 	}
 	s.st.app.SetErrors(errors.NotAssignedf("unrequired unit"))
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, "unrequired unit not assigned")
 
@@ -158,7 +159,7 @@ func (s *CAASApplicationSuite) TestReuseUnitByName(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -198,7 +199,7 @@ func (s *CAASApplicationSuite) TestDontReuseDeadUnitByName(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `dead unit "gitlab/0" already exists`)
 
@@ -220,7 +221,7 @@ func (s *CAASApplicationSuite) TestFindByProviderID(c *gc.C) {
 	}
 	s.st.app.unit.SetErrors(errors.NotFoundf("cloud container"))
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -258,7 +259,7 @@ func (s *CAASApplicationSuite) TestAgentConf(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -301,7 +302,7 @@ func (s *CAASApplicationSuite) TestDyingApplication(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `application not provisioned`)
 }
@@ -313,7 +314,7 @@ func (s *CAASApplicationSuite) TestMissingArgUUID(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `pod-uuid not valid`)
 }
@@ -325,7 +326,7 @@ func (s *CAASApplicationSuite) TestMissingArgName(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `pod-name not valid`)
 }
@@ -355,7 +356,7 @@ func (s *CAASApplicationSuite) TestUnitTerminatingAgentWillRestart(c *gc.C) {
 	args := params.Entity{
 		Tag: "unit-gitlab-0",
 	}
-	results, err := s.facade.UnitTerminating(args)
+	results, err := s.facade.UnitTerminating(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.WillRestart, jc.IsTrue)
@@ -386,7 +387,7 @@ func (s *CAASApplicationSuite) TestUnitTerminatingAgentDying(c *gc.C) {
 	args := params.Entity{
 		Tag: "unit-gitlab-0",
 	}
-	results, err := s.facade.UnitTerminating(args)
+	results, err := s.facade.UnitTerminating(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.WillRestart, jc.IsFalse)


### PR DESCRIPTION
This PR adds context.Context parameter to agent/caasadmission agent/caasagent, agent/caasapplication facade calls and fixes the unit tests.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/caasagent/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/caasapplication/... -gocheck.v 
make go-build
```