### PR TITLE
[JUJU-4455] Inject ctrl config certupdater

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -772,8 +772,10 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:                agentName,
 			AuthorityName:            certificateWatcherName,
 			StateName:                stateName,
+			ServiceFactoryName:       serviceFactoryName,
 			NewWorker:                certupdater.NewCertificateUpdater,
 			NewMachineAddressWatcher: certupdater.NewMachineAddressWatcher,
+			Logger:                   loggo.GetLogger("juju.worker.certupdater"),
 		})),
 
 		// The machiner Worker will wait for the identified machine to become

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -485,7 +485,12 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 	"certificate-updater": {
 		"agent",
 		"certificate-watcher",
+		"change-stream",
+		"db-accessor",
+		"file-notify-watcher",
 		"is-controller-flag",
+		"query-logger",
+		"service-factory",
 		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",

--- a/core/watcher/notify_test.go
+++ b/core/watcher/notify_test.go
@@ -4,6 +4,7 @@
 package watcher_test
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -63,7 +64,7 @@ type notifyHandler struct {
 	setupDone     chan struct{}
 }
 
-func (nh *notifyHandler) SetUp() (watcher.NotifyWatcher, error) {
+func (nh *notifyHandler) SetUp(context.Context) (watcher.NotifyWatcher, error) {
 	defer func() { nh.setupDone <- struct{}{} }()
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
@@ -84,7 +85,7 @@ func (nh *notifyHandler) TearDown() error {
 	return nh.teardownError
 }
 
-func (nh *notifyHandler) Handle(_ <-chan struct{}) error {
+func (nh *notifyHandler) Handle(context.Context) error {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
 	nh.actions = append(nh.actions, "handler")

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -4,6 +4,7 @@
 package apiaddressupdater
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -79,12 +80,12 @@ func NewAPIAddressUpdater(config Config) (worker.Worker, error) {
 }
 
 // SetUp is part of the watcher.NotifyHandler interface.
-func (c *APIAddressUpdater) SetUp() (watcher.NotifyWatcher, error) {
+func (c *APIAddressUpdater) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	return c.config.Addresser.WatchAPIHostPorts()
 }
 
 // Handle is part of the watcher.NotifyHandler interface.
-func (c *APIAddressUpdater) Handle(_ <-chan struct{}) error {
+func (c *APIAddressUpdater) Handle(_ context.Context) error {
 	hps, err := c.getAddresses()
 	if err != nil {
 		return err

--- a/worker/authenticationworker/worker.go
+++ b/worker/authenticationworker/worker.go
@@ -4,6 +4,7 @@
 package authenticationworker
 
 import (
+	"context"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -60,7 +61,7 @@ func NewWorker(client Client, agentConfig agent.Config) (worker.Worker, error) {
 }
 
 // SetUp is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) SetUp() (watcher.NotifyWatcher, error) {
+func (kw *keyupdaterWorker) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	// Record the keys Juju knows about.
 	jujuKeys, err := kw.client.AuthorisedKeys(kw.tag)
 	if err != nil {
@@ -115,7 +116,7 @@ func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string) error {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) Handle(_ <-chan struct{}) error {
+func (kw *keyupdaterWorker) Handle(_ context.Context) error {
 	// Read the keys that Juju has.
 	newKeys, err := kw.client.AuthorisedKeys(kw.tag)
 	if err != nil {

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -4,6 +4,8 @@
 package logger
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -116,7 +118,7 @@ func (l *loggerWorker) setLogging() {
 // SetUp is called by the NotifyWorker when the worker starts, and it is
 // required to return a notify watcher that is used as the event source
 // for the Handle method.
-func (l *loggerWorker) SetUp() (watcher.NotifyWatcher, error) {
+func (l *loggerWorker) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	l.config.Logger.Infof("logger worker started")
 	// We need to set this up initially as the NotifyWorker sucks up the first
 	// event.
@@ -125,7 +127,7 @@ func (l *loggerWorker) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is called by the NotifyWorker whenever the notify event is fired.
-func (l *loggerWorker) Handle(_ <-chan struct{}) error {
+func (l *loggerWorker) Handle(_ context.Context) error {
 	l.setLogging()
 	return nil
 }

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -4,6 +4,7 @@
 package machiner
 
 import (
+	"context"
 	"net"
 
 	"github.com/juju/errors"
@@ -77,7 +78,7 @@ var NewMachiner = func(cfg Config) (worker.Worker, error) {
 // GetObservedNetworkConfig is patched for testing.
 var GetObservedNetworkConfig = common.GetObservedNetworkConfig
 
-func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
+func (mr *Machiner) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	// Find which machine we're responsible for.
 	m, err := mr.config.MachineAccessor.Machine(mr.config.Tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
@@ -176,7 +177,7 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 	return m.SetMachineAddresses(machineAddresses)
 }
 
-func (mr *Machiner) Handle(_ <-chan struct{}) error {
+func (mr *Machiner) Handle(_ context.Context) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
 		// so we could call NotifyMachineDead here in case the agent failed to

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -356,7 +356,7 @@ func (s *MachinerSuite) TestSetDead(c *gc.C) {
 	s.accessor.machine.watcher.changes <- struct{}{}
 
 	err := stopWorker(mr)
-	c.Assert(err, gc.Equals, jworker.ErrTerminateAgent)
+	c.Assert(err, jc.Satisfies, func(e any) bool { return errors.Is(e.(error), jworker.ErrTerminateAgent) })
 }
 
 func (s *MachinerSuite) TestSetMachineAddresses(c *gc.C) {

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -68,14 +68,14 @@ func NewWorker(api Facade, env environs.Environ, credentialAPI common.Credential
 
 // SetUp (part of watcher.NotifyHandler) starts watching for machine
 // removals.
-func (u *Undertaker) SetUp() (watcher.NotifyWatcher, error) {
+func (u *Undertaker) SetUp(_ stdcontext.Context) (watcher.NotifyWatcher, error) {
 	u.Logger.Infof("setting up machine undertaker")
 	return u.API.WatchMachineRemovals()
 }
 
 // Handle (part of watcher.NotifyHandler) cleans up provider resources
 // and removes machines that have been marked for removal.
-func (u *Undertaker) Handle(<-chan struct{}) error {
+func (u *Undertaker) Handle(_ stdcontext.Context) error {
 	removals, err := u.API.AllMachineRemovals()
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/meterstatus/connected_test.go
+++ b/worker/meterstatus/connected_test.go
@@ -4,6 +4,7 @@
 package meterstatus_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -104,12 +105,12 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerDoesNotRerunNoChange(c *gc.C) {
 	handler, err := meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus", "RunHook", "MeterStatus")
@@ -139,12 +140,12 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerRunsHookOnChanges(c *gc.C) {
 	handler, err := meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	handler.Handle(nil)
+	handler.Handle(context.Background())
 	s.msClient.SetStatus("RED")
-	handler.Handle(nil)
+	handler.Handle(context.Background())
 
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus", "RunHook", "MeterStatus", "RunHook")
@@ -170,10 +171,10 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerHandlesHookMissingError(c *gc.C)
 	handler, err := meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus", "RunHook")
 }
@@ -198,10 +199,10 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerHandlesRandomHookError(c *gc.C) 
 	handler, err := meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus", "RunHook")
@@ -232,10 +233,10 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerDoesNotRerunAfterRestart(c *gc.C
 	handler, err := meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus", "RunHook")
@@ -245,10 +246,10 @@ func (s *ConnectedWorkerSuite) TestStatusHandlerDoesNotRerunAfterRestart(c *gc.C
 	handler, err = meterstatus.NewConnectedStatusHandler(config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler, gc.NotNil)
-	_, err = handler.SetUp()
+	_, err = handler.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = handler.Handle(nil)
+	err = handler.Handle(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "WatchMeterStatus", "MeterStatus")

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -4,6 +4,7 @@
 package proxyupdater
 
 import (
+	"context"
 	"io"
 	stdos "os"
 	stdexec "os/exec"
@@ -313,7 +314,7 @@ func (w *proxyWorker) onChange() error {
 }
 
 // SetUp is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) SetUp() (watcher.NotifyWatcher, error) {
+func (w *proxyWorker) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	// We need to set this up initially as the NotifyWorker sucks up the first
 	// event.
 	err := w.onChange()
@@ -325,7 +326,7 @@ func (w *proxyWorker) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) Handle(_ <-chan struct{}) error {
+func (w *proxyWorker) Handle(_ context.Context) error {
 	return w.onChange()
 }
 

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -4,6 +4,8 @@
 package reboot
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -45,12 +47,12 @@ func NewReboot(client reboot.Client, agentTag names.Tag, machineLock machinelock
 	return w, errors.Trace(err)
 }
 
-func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
+func (r *Reboot) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	watcher, err := r.client.WatchForRebootEvent()
 	return watcher, errors.Trace(err)
 }
 
-func (r *Reboot) Handle(_ <-chan struct{}) error {
+func (r *Reboot) Handle(_ context.Context) error {
 	rAction, err := r.client.GetRebootAction()
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -4,6 +4,8 @@
 package reboot_test
 
 import (
+	"errors"
+
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -67,7 +69,7 @@ func (s *rebootSuite) TestWorkerReboot(c *gc.C) {
 	w, err := reboot.NewReboot(client, names.NewMachineTag("666"), lock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
-	c.Assert(err, gc.Equals, worker.ErrRebootMachine)
+	c.Assert(err, jc.Satisfies, func(e any) bool { return errors.Is(e.(error), worker.ErrRebootMachine) })
 }
 
 func (s *rebootSuite) TestContainerShutdown(c *gc.C) {
@@ -93,5 +95,5 @@ func (s *rebootSuite) TestContainerShutdown(c *gc.C) {
 	w, err := reboot.NewReboot(client, names.NewMachineTag("666/lxd/0"), lock)
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, w)
-	c.Assert(err, gc.Equals, worker.ErrShutdownMachine)
+	c.Assert(err, jc.Satisfies, func(e any) bool { return errors.Is(e.(error), worker.ErrShutdownMachine) })
 }

--- a/worker/stateconverter/converter.go
+++ b/worker/stateconverter/converter.go
@@ -4,6 +4,7 @@
 package stateconverter
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -58,7 +59,7 @@ func (w wrapper) Machine(tag names.MachineTag) (Machine, error) {
 
 // SetUp implements NotifyWatchHandler's SetUp method. It returns a watcher that
 // checks for changes to the current machine.
-func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
+func (c *converter) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
 	c.logger.Tracef("Calling SetUp for %s", c.machineTag)
 	m, err := c.machiner.Machine(c.machineTag)
 	if err != nil {
@@ -71,7 +72,7 @@ func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
 // Handle implements NotifyWatchHandler's Handle method.  If the change means
 // that the machine is now expected to manage the environment,
 // we throw a fatal error to instigate agent restart.
-func (c *converter) Handle(_ <-chan struct{}) error {
+func (c *converter) Handle(_ context.Context) error {
 	c.logger.Tracef("Calling Handle for %s", c.machineTag)
 	results, err := c.machine.Jobs()
 	if err != nil {

--- a/worker/stateconverter/converter_test.go
+++ b/worker/stateconverter/converter_test.go
@@ -4,6 +4,8 @@
 package stateconverter_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -29,7 +31,7 @@ func (s *converterSuite) TestSetUp(c *gc.C) {
 	s.machine.EXPECT().Watch().Return(nil, nil)
 
 	conv := s.newConverter()
-	_, err := conv.SetUp()
+	_, err := conv.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -39,7 +41,7 @@ func (s *converterSuite) TestSetupMachinerErr(c *gc.C) {
 	s.machiner.EXPECT().Machine(gomock.Any()).Return(nil, expectedError)
 
 	conv := s.newConverter()
-	w, err := conv.SetUp()
+	w, err := conv.SetUp(context.Background())
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 	c.Assert(w, gc.IsNil)
 }
@@ -51,7 +53,7 @@ func (s *converterSuite) TestSetupWatchErr(c *gc.C) {
 	s.machine.EXPECT().Watch().Return(nil, expectedError)
 
 	conv := s.newConverter()
-	w, err := conv.SetUp()
+	w, err := conv.SetUp(context.Background())
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 	c.Assert(w, gc.IsNil)
 }
@@ -64,7 +66,7 @@ func (s *converterSuite) TestHandle(c *gc.C) {
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
 
 	conv := s.newConverter()
-	_, err := conv.SetUp()
+	_, err := conv.SetUp(context.Background())
 	c.Assert(err, gc.IsNil)
 	err = conv.Handle(nil)
 	// Since machine has model.JobManageModel, we expect an error
@@ -80,7 +82,7 @@ func (s *converterSuite) TestHandleNotController(c *gc.C) {
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
 
 	conv := s.newConverter()
-	_, err := conv.SetUp()
+	_, err := conv.SetUp(context.Background())
 	c.Assert(err, gc.IsNil)
 	err = conv.Handle(nil)
 	c.Assert(err, gc.IsNil)
@@ -96,13 +98,13 @@ func (s *converterSuite) TestHandleJobsError(c *gc.C) {
 	s.machine.EXPECT().Jobs().Return(nil, expectedError)
 
 	conv := s.newConverter()
-	_, err := conv.SetUp()
+	_, err := conv.SetUp(context.Background())
 	c.Assert(err, gc.IsNil)
 	err = conv.Handle(nil)
 	// Since machine has model.JobManageModel, we expect an error
 	// which will get machineTag to restart.
 	c.Assert(err.Error(), gc.Equals, "bounce agent to pick up new jobs")
-	_, err = conv.SetUp()
+	_, err = conv.SetUp(context.Background())
 	c.Assert(err, gc.IsNil)
 	err = conv.Handle(nil)
 	c.Assert(errors.Cause(err), gc.Equals, expectedError)


### PR DESCRIPTION
The following changes inject the controller config into the `certupdater`. 

Whilst making the changes for the `certupdater` the `NotifyWorker` type now 
uses a `context.Context` directly. This is fully tied to the lifetime of the underlying
catacomb. This means we can drop the ad-hoc abort chan struct for a fully
featured `context.Context`. The interface for the notify worker becomes
a lot more symmetrical for `setup` and `handle`.

The consequence of these changes impacts quite a few additional workers, which
required some test changes to make sure they're updated.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju enable-ha
$ juju deploy ubuntu -n 3
```

