### PR TITLE
[JUJU-4454] Add context.Context in agent/credentialvalidator facade

### DIFF
--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -4,6 +4,8 @@
 package credentialcommon
 
 import (
+	"context"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -23,7 +25,7 @@ func NewCredentialManagerAPI(backend StateBackend) *CredentialManagerAPI {
 }
 
 // InvalidateModelCredential marks the cloud credential for this model as invalid.
-func (api *CredentialManagerAPI) InvalidateModelCredential(args params.InvalidateCredentialArg) (params.ErrorResult, error) {
+func (api *CredentialManagerAPI) InvalidateModelCredential(ctx context.Context, args params.InvalidateCredentialArg) (params.ErrorResult, error) {
 	err := api.backend.InvalidateModelCredential(args.Reason)
 	if err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -4,6 +4,8 @@
 package credentialcommon_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -31,7 +33,7 @@ func (s *CredentialSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -42,7 +44,7 @@ func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -4,6 +4,8 @@
 package credentialvalidator
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common/credentialcommon"
@@ -16,18 +18,18 @@ import (
 // CredentialValidatorV2 defines the methods on version 2 facade for the
 // credentialvalidator API endpoint.
 type CredentialValidatorV2 interface {
-	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
-	ModelCredential() (params.ModelCredential, error)
-	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
-	WatchModelCredential() (params.NotifyWatchResult, error)
+	InvalidateModelCredential(context.Context, params.InvalidateCredentialArg) (params.ErrorResult, error)
+	ModelCredential(context.Context) (params.ModelCredential, error)
+	WatchCredential(context.Context, params.Entity) (params.NotifyWatchResult, error)
+	WatchModelCredential(context.Context) (params.NotifyWatchResult, error)
 }
 
 // CredentialValidatorV1 defines the methods on version 1 facade
 // for the credentialvalidator API endpoint.
 type CredentialValidatorV1 interface {
-	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
-	ModelCredential() (params.ModelCredential, error)
-	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
+	InvalidateModelCredential(context.Context, params.InvalidateCredentialArg) (params.ErrorResult, error)
+	ModelCredential(context.Context) (params.ModelCredential, error)
+	WatchCredential(context.Context, params.Entity) (params.NotifyWatchResult, error)
 }
 
 type CredentialValidatorAPI struct {
@@ -55,7 +57,7 @@ func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resourc
 
 // WatchCredential returns a NotifyWatcher that observes
 // changes to a given cloud credential.
-func (api *CredentialValidatorAPI) WatchCredential(tag params.Entity) (params.NotifyWatchResult, error) {
+func (api *CredentialValidatorAPI) WatchCredential(ctx context.Context, tag params.Entity) (params.NotifyWatchResult, error) {
 	fail := func(failure error) (params.NotifyWatchResult, error) {
 		return params.NotifyWatchResult{}, apiservererrors.ServerError(failure)
 	}
@@ -88,7 +90,7 @@ func (api *CredentialValidatorAPI) WatchCredential(tag params.Entity) (params.No
 }
 
 // ModelCredential returns cloud credential information for a  model.
-func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, error) {
+func (api *CredentialValidatorAPI) ModelCredential(ctx context.Context) (params.ModelCredential, error) {
 	c, err := api.backend.ModelCredential()
 	if err != nil {
 		return params.ModelCredential{}, apiservererrors.ServerError(err)
@@ -103,7 +105,7 @@ func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, er
 }
 
 // WatchModelCredential returns a NotifyWatcher that watches what cloud credential a model uses.
-func (api *CredentialValidatorAPI) WatchModelCredential() (params.NotifyWatchResult, error) {
+func (api *CredentialValidatorAPI) WatchModelCredential(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	watch, err := api.backend.WatchModelCredential()
 	if err != nil {

--- a/apiserver/facades/client/credentialmanager/client.go
+++ b/apiserver/facades/client/credentialmanager/client.go
@@ -4,6 +4,8 @@
 package credentialmanager
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/common/credentialcommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -12,7 +14,7 @@ import (
 
 // CredentialManager defines the methods on credentialmanager API endpoint.
 type CredentialManager interface {
-	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
+	InvalidateModelCredential(context.Context, params.InvalidateCredentialArg) (params.ErrorResult, error)
 }
 
 type CredentialManagerAPI struct {

--- a/apiserver/facades/client/credentialmanager/client_test.go
+++ b/apiserver/facades/client/credentialmanager/client_test.go
@@ -4,6 +4,8 @@
 package credentialmanager_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -55,7 +57,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredentialUnauthorized(c *gc
 }
 
 func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -66,7 +68,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialManagerSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{


### PR DESCRIPTION
This PR adds context.Context parameter to agent/credentialvalidator facade calls and fixes the unit tests.


## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/credentialvalidator/... -gocheck.v 
go test github.com/juju/juju/apiserver/common/credentialcommon/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/credentialmanager/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```