### PR TITLE
[JUJU-4456] Add context.Context in agent/(d-l)* facades

### DIFF
--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -4,6 +4,8 @@
 package deployer
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -85,8 +87,8 @@ func NewDeployerAPI(ctx facade.Context) (*DeployerAPI, error) {
 
 // ConnectionInfo returns all the address information that the
 // deployer task needs in one call.
-func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	apiAddrs, err := d.APIAddresses()
+func (d *DeployerAPI) ConnectionInfo(ctx context.Context) (result params.DeployerConnectionValues, err error) {
+	apiAddrs, err := d.APIAddresses(ctx)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -97,7 +99,7 @@ func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, 
 }
 
 // SetStatus sets the status of the specified entities.
-func (d *DeployerAPI) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (d *DeployerAPI) SetStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	return d.StatusSetter.SetStatus(args)
 }
 
@@ -110,7 +112,7 @@ func (d *DeployerAPI) ModelUUID() params.StringResult {
 }
 
 // APIHostPorts returns the API server addresses.
-func (d *DeployerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+func (d *DeployerAPI) APIHostPorts(ctx context.Context) (result params.APIHostPortsResult, err error) {
 	controllerConfig, err := d.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -120,7 +122,7 @@ func (d *DeployerAPI) APIHostPorts() (result params.APIHostPortsResult, err erro
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (d *DeployerAPI) APIAddresses() (result params.StringsResult, err error) {
+func (d *DeployerAPI) APIAddresses(ctx context.Context) (result params.StringsResult, err error) {
 	controllerConfig, err := d.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -4,6 +4,7 @@
 package deployer_test
 
 import (
+	"context"
 	"sort"
 	stdtesting "testing"
 
@@ -351,7 +352,7 @@ func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
 		APIAddresses: []string{"1.2.3.4:1234", "0.1.2.3:1234"},
 	}
 
-	result, err := s.deployer.ConnectionInfo()
+	result, err := s.deployer.ConnectionInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expected)
 }
@@ -364,7 +365,7 @@ func (s *deployerSuite) TestSetStatus(c *gc.C) {
 			{Tag: "unit-fake-42", Status: "blocked", Info: "waiting", Data: map[string]interface{}{"foo": "bar"}},
 		},
 	}
-	results, err := s.deployer.SetStatus(args)
+	results, err := s.deployer.SetStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{

--- a/apiserver/facades/agent/diskmanager/diskmanager.go
+++ b/apiserver/facades/agent/diskmanager/diskmanager.go
@@ -4,6 +4,8 @@
 package diskmanager
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -25,7 +27,7 @@ var getState = func(st *state.State) stateInterface {
 	return stateShim{st}
 }
 
-func (d *DiskManagerAPI) SetMachineBlockDevices(args params.SetMachineBlockDevices) (params.ErrorResults, error) {
+func (d *DiskManagerAPI) SetMachineBlockDevices(ctx context.Context, args params.SetMachineBlockDevices) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.MachineBlockDevices)),
 	}

--- a/apiserver/facades/agent/diskmanager/diskmanager_test.go
+++ b/apiserver/facades/agent/diskmanager/diskmanager_test.go
@@ -4,6 +4,7 @@
 package diskmanager_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v4"
@@ -47,7 +48,7 @@ func (s *DiskManagerSuite) SetUpTest(c *gc.C) {
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevices(c *gc.C) {
 	devices := []storage.BlockDevice{{DeviceName: "sda"}, {DeviceName: "sdb"}}
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.Background(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine:      "machine-0",
 			BlockDevices: devices,
@@ -60,7 +61,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevices(c *gc.C) {
 }
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesEmptyArgs(c *gc.C) {
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{})
+	results, err := s.api.SetMachineBlockDevices(context.Background(), params.SetMachineBlockDevices{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -75,7 +76,7 @@ func (s *DiskManagerSuite) TestNewDiskManagerAPINonMachine(c *gc.C) {
 }
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesInvalidTags(c *gc.C) {
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.Background(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine: "machine-0",
 		}, {
@@ -99,7 +100,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesInvalidTags(c *gc.C) {
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesStateError(c *gc.C) {
 	s.st.err = errors.New("boom")
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.Background(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine: "machine-0",
 		}},

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
@@ -4,6 +4,8 @@
 package fanconfigurer
 
 import (
+	"context"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/rpc/params"
@@ -13,8 +15,8 @@ import (
 
 // FanConfigurer defines the methods on fanconfigurer API endpoint.
 type FanConfigurer interface {
-	WatchForFanConfigChanges() (params.NotifyWatchResult, error)
-	FanConfig() (params.FanConfigResult, error)
+	WatchForFanConfigChanges(ctx context.Context) (params.NotifyWatchResult, error)
+	FanConfig(ctx context.Context) (params.FanConfigResult, error)
 }
 
 type FanConfigurerAPI struct {
@@ -40,7 +42,7 @@ func NewFanConfigurerAPIForModel(model state.ModelAccessor, resources facade.Res
 // changes to the FAN configuration.
 // so we use the regular error return.
 // TODO(wpk) 2017-09-21 We should use Model directly, and watch only for FanConfig changes.
-func (m *FanConfigurerAPI) WatchForFanConfigChanges() (params.NotifyWatchResult, error) {
+func (m *FanConfigurerAPI) WatchForFanConfigChanges(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	watch := m.model.WatchForModelConfigChanges()
 	// Consume the initial event. Technically, API
@@ -56,7 +58,7 @@ func (m *FanConfigurerAPI) WatchForFanConfigChanges() (params.NotifyWatchResult,
 }
 
 // FanConfig returns current FAN configuration.
-func (m *FanConfigurerAPI) FanConfig() (params.FanConfigResult, error) {
+func (m *FanConfigurerAPI) FanConfig(ctx context.Context) (params.FanConfigResult, error) {
 	result := params.FanConfigResult{}
 	config, err := m.model.ModelConfig()
 	if err != nil {

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
@@ -59,7 +59,7 @@ func (s *fanconfigurerSuite) TestWatchSuccess(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := e.WatchForFanConfigChanges()
+	result, err := e.WatchForFanConfigChanges(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
 	c.Assert(resources.Count(), gc.Equals, 1)
@@ -95,7 +95,7 @@ func (s *fanconfigurerSuite) TestFanConfigSuccess(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := e.FanConfig()
+	result, err := e.FanConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Fans, gc.HasLen, 2)
 	c.Check(result.Fans[0].Underlay, gc.Equals, "10.100.0.0/16")
@@ -119,7 +119,7 @@ func (s *fanconfigurerSuite) TestFanConfigFetchError(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = e.FanConfig()
+	_, err = e.FanConfig(context.Background())
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 

--- a/apiserver/facades/agent/hostkeyreporter/facade.go
+++ b/apiserver/facades/agent/hostkeyreporter/facade.go
@@ -4,6 +4,8 @@
 package hostkeyreporter
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -35,7 +37,7 @@ func New(backend Backend, _ facade.Resources, authorizer facade.Authorizer) (*Fa
 }
 
 // ReportKeys sets the SSH host keys for one or more entities.
-func (facade *Facade) ReportKeys(args params.SSHHostKeySet) (params.ErrorResults, error) {
+func (facade *Facade) ReportKeys(ctx context.Context, args params.SSHHostKeySet) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.EntityKeys)),
 	}

--- a/apiserver/facades/agent/hostkeyreporter/facade_test.go
+++ b/apiserver/facades/agent/hostkeyreporter/facade_test.go
@@ -4,6 +4,8 @@
 package hostkeyreporter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -47,7 +49,7 @@ func (s *facadeSuite) TestReportKeys(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.facade.ReportKeys(args)
+	result, err := s.facade.ReportKeys(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -4,6 +4,7 @@
 package instancemutater_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -264,7 +265,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfo(c *gc
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.InstanceId, gc.Equals, instance.Id("0"))
@@ -307,7 +308,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithNo
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.InstanceId, gc.Equals, instance.Id("0"))
@@ -348,7 +349,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithIn
 	s.expectFindMachineError(s.machineTag, errors.New("not found"))
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.ErrorMatches, "not found")
 }
@@ -362,7 +363,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithMa
 	s.expectInstanceIdNotProvisioned()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.ErrorMatches, "machine-0: attempting to get instanceId: ")
 	c.Assert(results.InstanceId, gc.Equals, instance.Id(""))
@@ -471,7 +472,7 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfiles(c *gc.C) 
 	s.expectSetProfiles(profiles, nil)
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.SetCharmProfiles(params.SetProfileArgs{
+	results, err := facade.SetCharmProfiles(context.Background(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{
 			{
 				Entity:   params.Entity{Tag: "machine-0"},
@@ -497,7 +498,7 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfilesWithError(
 	s.expectSetProfiles(profiles, errors.New("Failure"))
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.SetCharmProfiles(params.SetProfileArgs{
+	results, err := facade.SetCharmProfiles(context.Background(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{
 			{
 				Entity:   params.Entity{Tag: "machine-0"},
@@ -550,7 +551,7 @@ func (s *InstanceMutaterAPISetModificationStatusSuite) TestSetModificationStatus
 	s.expectSetModificationStatus(status.Applied, "applied", nil)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.SetModificationStatus(params.SetStatus{
+	result, err := facade.SetModificationStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-0", Status: "applied", Info: "applied", Data: nil},
 		},
@@ -572,7 +573,7 @@ func (s *InstanceMutaterAPISetModificationStatusSuite) TestSetModificationStatus
 	s.expectSetModificationStatus(status.Applied, "applied", errors.New("failed"))
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.SetModificationStatus(params.SetStatus{
+	result, err := facade.SetModificationStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-0", Status: "applied", Info: "applied", Data: nil},
 		},
@@ -626,7 +627,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachines(c *gc.C) {
 	s.expectWatchModelMachinesWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchModelMachines()
+	result, err := facade.WatchModelMachines(context.Background())
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -643,7 +644,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachinesWithClosedC
 	s.expectWatchModelMachinesWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	_, err := facade.WatchModelMachines()
+	_, err := facade.WatchModelMachines(context.Background())
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
 }
 
@@ -655,7 +656,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachines(c *gc.C) {
 	s.expectWatchMachinesWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchMachines()
+	result, err := facade.WatchMachines(context.Background())
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -672,7 +673,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachinesWithClosedChanne
 	s.expectWatchMachinesWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	_, err := facade.WatchMachines()
+	_, err := facade.WatchMachines(context.Background())
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
 }
 
@@ -752,7 +753,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -771,7 +772,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectLife(s.machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewUserTag("bob@local").String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -790,7 +791,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -809,7 +810,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithManualMachine()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -828,7 +829,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededError()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -907,7 +908,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainers(c *gc.C) {
 	s.expectWatchContainersWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: s.machineTag.String()})
+	result, err := facade.WatchContainers(context.Background(), params.Entity{Tag: s.machineTag.String()})
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -923,7 +924,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainersWithInvalidT
 	s.expectLife(s.machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: names.NewUserTag("bob@local").String()})
+	result, err := facade.WatchContainers(context.Background(), params.Entity{Tag: names.NewUserTag("bob@local").String()})
 	c.Logf("%#v", err)
 	c.Assert(err, gc.ErrorMatches, "\"user-bob\" is not a valid machine tag")
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
@@ -937,7 +938,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainersWithClosedCh
 	s.expectWatchContainersWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: s.machineTag.String()})
+	result, err := facade.WatchContainers(context.Background(), params.Entity{Tag: s.machineTag.String()})
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial machine containers")
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
 }

--- a/apiserver/facades/agent/keyupdater/authorisedkeys.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys.go
@@ -4,6 +4,8 @@
 package keyupdater
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3/ssh"
@@ -18,8 +20,8 @@ import (
 
 // KeyUpdater defines the methods on the keyupdater API end point.
 type KeyUpdater interface {
-	AuthorisedKeys(args params.Entities) (params.StringsResults, error)
-	WatchAuthorisedKeys(args params.Entities) (params.NotifyWatchResults, error)
+	AuthorisedKeys(ctx context.Context, args params.Entities) (params.StringsResults, error)
+	WatchAuthorisedKeys(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error)
 }
 
 // KeyUpdaterAPI implements the KeyUpdater interface and is the concrete
@@ -38,7 +40,7 @@ var _ KeyUpdater = (*KeyUpdaterAPI)(nil)
 // for the specified machines.
 // The current implementation relies on global authorised keys being stored in the model config.
 // This will change as new user management and authorisation functionality is added.
-func (api *KeyUpdaterAPI) WatchAuthorisedKeys(arg params.Entities) (params.NotifyWatchResults, error) {
+func (api *KeyUpdaterAPI) WatchAuthorisedKeys(ctx context.Context, arg params.Entities) (params.NotifyWatchResults, error) {
 	results := make([]params.NotifyWatchResult, len(arg.Entities))
 
 	canRead, err := api.getCanRead()
@@ -81,7 +83,7 @@ func (api *KeyUpdaterAPI) WatchAuthorisedKeys(arg params.Entities) (params.Notif
 // AuthorisedKeys reports the authorised ssh keys for the specified machines.
 // The current implementation relies on global authorised keys being stored in the model config.
 // This will change as new user management and authorisation functionality is added.
-func (api *KeyUpdaterAPI) AuthorisedKeys(arg params.Entities) (params.StringsResults, error) {
+func (api *KeyUpdaterAPI) AuthorisedKeys(ctx context.Context, arg params.Entities) (params.StringsResults, error) {
 	if len(arg.Entities) == 0 {
 		return params.StringsResults{}, nil
 	}

--- a/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
@@ -4,6 +4,8 @@
 package keyupdater_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -82,7 +84,7 @@ func (s *authorisedKeysSuite) TestNewKeyUpdaterAPIRefusesNonMachineAgent(c *gc.C
 
 func (s *authorisedKeysSuite) TestWatchAuthorisedKeysNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.keyupdater.WatchAuthorisedKeys(params.Entities{})
+	results, err := s.keyupdater.WatchAuthorisedKeys(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -103,7 +105,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeys(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results, err := s.keyupdater.WatchAuthorisedKeys(args)
+	results, err := s.keyupdater.WatchAuthorisedKeys(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -130,7 +132,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeys(c *gc.C) {
 
 func (s *authorisedKeysSuite) TestAuthorisedKeysForNoone(c *gc.C) {
 	// Not an error to request nothing, dumb, but not an error.
-	results, err := s.keyupdater.AuthorisedKeys(params.Entities{})
+	results, err := s.keyupdater.AuthorisedKeys(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -145,7 +147,7 @@ func (s *authorisedKeysSuite) TestAuthorisedKeys(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results, err := s.keyupdater.AuthorisedKeys(args)
+	results, err := s.keyupdater.AuthorisedKeys(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{

--- a/apiserver/facades/agent/leadership/interface.go
+++ b/apiserver/facades/agent/leadership/interface.go
@@ -16,7 +16,7 @@ import (
 type LeadershipService interface {
 
 	// ClaimLeadership makes a leadership claim with the given parameters.
-	ClaimLeadership(params params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error)
+	ClaimLeadership(ctx context.Context, params params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error)
 
 	// BlockUntilLeadershipReleased blocks the caller until leadership is
 	// released for the given service.

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -49,7 +49,7 @@ type leadershipService struct {
 }
 
 // ClaimLeadership is part of the LeadershipService interface.
-func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error) {
+func (m *leadershipService) ClaimLeadership(ctx context.Context, args params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error) {
 
 	results := make([]params.ErrorResult, len(args.Params))
 	for pIdx, p := range args.Params {

--- a/apiserver/facades/agent/leadership/leadership_test.go
+++ b/apiserver/facades/agent/leadership/leadership_test.go
@@ -107,7 +107,7 @@ func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, claimer, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -137,7 +137,7 @@ func (s *leadershipSuite) TestClaimLeadershipApplicationAgent(c *gc.C) {
 		tag: names.NewApplicationTag(StubAppNm),
 	}
 	ldrSvc := newLeadershipService(c, claimer, authorizer)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -164,7 +164,7 @@ func (s *leadershipSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, claimer, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -182,7 +182,7 @@ func (s *leadershipSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipBadService(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  "application-bad/0",
@@ -199,7 +199,7 @@ func (s *leadershipSuite) TestClaimLeadershipBadService(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipBadUnit(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -216,7 +216,7 @@ func (s *leadershipSuite) TestClaimLeadershipBadUnit(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipDurationTooShort(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -233,7 +233,7 @@ func (s *leadershipSuite) TestClaimLeadershipDurationTooShort(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipDurationTooLong(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -292,7 +292,7 @@ func (s *leadershipSuite) TestClaimLeadershipFailBadUnit(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, nil, authorizer)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -310,7 +310,7 @@ func (s *leadershipSuite) TestClaimLeadershipFailBadUnit(c *gc.C) {
 
 func (s *leadershipSuite) TestClaimLeadershipFailBadService(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.Background(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag("lol-different").String(),

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -4,6 +4,8 @@
 package logger
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -18,8 +20,8 @@ import (
 // endpoint because our rpc mechanism panics.  However, I still feel that this
 // provides a useful documentation purpose.
 type Logger interface {
-	WatchLoggingConfig(args params.Entities) params.NotifyWatchResults
-	LoggingConfig(args params.Entities) params.StringResults
+	WatchLoggingConfig(ctx context.Context, args params.Entities) params.NotifyWatchResults
+	LoggingConfig(ctx context.Context, args params.Entities) params.StringResults
 }
 
 // LoggerAPI implements the Logger interface and is the concrete
@@ -36,7 +38,7 @@ var _ Logger = (*LoggerAPI)(nil)
 // for the agents specified..  Unfortunately the current infrastructure makes
 // watching parts of the config non-trivial, so currently any change to the
 // config will cause the watcher to notify the client.
-func (api *LoggerAPI) WatchLoggingConfig(arg params.Entities) params.NotifyWatchResults {
+func (api *LoggerAPI) WatchLoggingConfig(ctx context.Context, arg params.Entities) params.NotifyWatchResults {
 	result := make([]params.NotifyWatchResult, len(arg.Entities))
 	for i, entity := range arg.Entities {
 		tag, err := names.ParseTag(entity.Tag)
@@ -64,7 +66,7 @@ func (api *LoggerAPI) WatchLoggingConfig(arg params.Entities) params.NotifyWatch
 }
 
 // LoggingConfig reports the logging configuration for the agents specified.
-func (api *LoggerAPI) LoggingConfig(arg params.Entities) params.StringResults {
+func (api *LoggerAPI) LoggingConfig(ctx context.Context, arg params.Entities) params.StringResults {
 	if len(arg.Entities) == 0 {
 		return params.StringResults{}
 	}

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -4,6 +4,8 @@
 package logger_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -87,7 +89,7 @@ func (s *loggerSuite) TestNewLoggerAPIAcceptsApplicationAgent(c *gc.C) {
 
 func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results := s.logger.WatchLoggingConfig(params.Entities{})
+	results := s.logger.WatchLoggingConfig(context.Background(), params.Entities{})
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
@@ -103,7 +105,7 @@ func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results := s.logger.WatchLoggingConfig(args)
+	results := s.logger.WatchLoggingConfig(context.Background(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -120,7 +122,7 @@ func (s *loggerSuite) TestWatchLoggingConfigRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-12354"}},
 	}
-	results := s.logger.WatchLoggingConfig(args)
+	results := s.logger.WatchLoggingConfig(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].NotifyWatcherId, gc.Equals, "")
@@ -129,7 +131,7 @@ func (s *loggerSuite) TestWatchLoggingConfigRefusesWrongAgent(c *gc.C) {
 
 func (s *loggerSuite) TestLoggingConfigForNoone(c *gc.C) {
 	// Not an error to request nothing, dumb, but not an error.
-	results := s.logger.LoggingConfig(params.Entities{})
+	results := s.logger.LoggingConfig(context.Background(), params.Entities{})
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
@@ -137,7 +139,7 @@ func (s *loggerSuite) TestLoggingConfigRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-12354"}},
 	}
-	results := s.logger.LoggingConfig(args)
+	results := s.logger.LoggingConfig(context.Background(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
@@ -150,7 +152,7 @@ func (s *loggerSuite) TestLoggingConfigForAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results := s.logger.LoggingConfig(args)
+	results := s.logger.LoggingConfig(context.Background(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Error, gc.IsNil)


### PR DESCRIPTION
This PR adds context.Context parameter to:
- agent/deployer
- agent/deskmanager
- agent/fanconfigurer
- agent/hostkeyreporter
- agent/instancemutater
- agent/keyupdater
- agent/leadership
- agent/logger 

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/deployer/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/diskmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/fanconfigurer/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/hostkeyreporter/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/instancemutater/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/keyupdater/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/leadership/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/logger/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```
