### PR TITLE
[JUJU-4457] Add context.Context in agent/(m-p)* facades

### DIFF
--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -4,6 +4,8 @@
 package machine
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -75,7 +77,7 @@ func (api *MachinerAPI) getMachine(tag string, authChecker common.AuthFunc) (*st
 	return entity.(*state.Machine), nil
 }
 
-func (api *MachinerAPI) SetMachineAddresses(args params.SetMachinesAddresses) (params.ErrorResults, error) {
+func (api *MachinerAPI) SetMachineAddresses(ctx context.Context, args params.SetMachinesAddresses) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.MachineAddresses)),
 	}
@@ -102,7 +104,7 @@ func (api *MachinerAPI) SetMachineAddresses(args params.SetMachinesAddresses) (p
 }
 
 // Jobs returns the jobs assigned to the given entities.
-func (api *MachinerAPI) Jobs(args params.Entities) (params.JobsResults, error) {
+func (api *MachinerAPI) Jobs(ctx context.Context, args params.Entities) (params.JobsResults, error) {
 	result := params.JobsResults{
 		Results: make([]params.JobsResult, len(args.Entities)),
 	}
@@ -129,7 +131,7 @@ func (api *MachinerAPI) Jobs(args params.Entities) (params.JobsResults, error) {
 }
 
 // RecordAgentStartTime updates the agent start time field in the machine doc.
-func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.ErrorResults, error) {
+func (api *MachinerAPI) RecordAgentStartTime(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -153,7 +155,7 @@ func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.Error
 
 // RecordAgentStartInformation syncs the machine model with information
 // reported by a machine agent when it starts.
-func (api *MachinerAPI) RecordAgentStartInformation(args params.RecordAgentStartInformationArgs) (params.ErrorResults, error) {
+func (api *MachinerAPI) RecordAgentStartInformation(ctx context.Context, args params.RecordAgentStartInformationArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -176,7 +178,7 @@ func (api *MachinerAPI) RecordAgentStartInformation(args params.RecordAgentStart
 }
 
 // APIHostPorts returns the API server addresses.
-func (api *MachinerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+func (api *MachinerAPI) APIHostPorts(ctx context.Context) (result params.APIHostPortsResult, err error) {
 	controllerConfig, err := api.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -186,7 +188,7 @@ func (api *MachinerAPI) APIHostPorts() (result params.APIHostPortsResult, err er
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (api *MachinerAPI) APIAddresses() (result params.StringsResult, err error) {
+func (api *MachinerAPI) APIAddresses(ctx context.Context) (result params.StringsResult, err error) {
 	controllerConfig, err := api.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -4,6 +4,7 @@
 package machine_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/loggo"
@@ -188,7 +189,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 		{Tag: "machine-42", Addresses: params.FromMachineAddresses(addresses...)},
 	}}
 
-	result, err := s.machiner.SetMachineAddresses(args)
+	result, err := s.machiner.SetMachineAddresses(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -217,7 +218,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
 		{Tag: "machine-1", Addresses: params.FromMachineAddresses(addresses...)},
 	}}
-	result, err := s.machiner.SetMachineAddresses(args)
+	result, err := s.machiner.SetMachineAddresses(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -229,7 +230,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 2)
 
 	args.MachineAddresses[0].Addresses = nil
-	result, err = s.machiner.SetMachineAddresses(args)
+	result, err = s.machiner.SetMachineAddresses(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -249,7 +250,7 @@ func (s *machinerSuite) TestJobs(c *gc.C) {
 		{Tag: "machine-42"},
 	}}
 
-	result, err := s.machiner.Jobs(args)
+	result, err := s.machiner.Jobs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.JobsResults{
 		Results: []params.JobsResult{
@@ -300,7 +301,7 @@ func (s *machinerSuite) TestRecordAgentStartInformation(c *gc.C) {
 		{Tag: "machine-42", Hostname: "missing-gem"},
 	}}
 
-	result, err := s.machiner.RecordAgentStartInformation(args)
+	result, err := s.machiner.RecordAgentStartInformation(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{

--- a/apiserver/facades/agent/machineactions/machineactions.go
+++ b/apiserver/facades/agent/machineactions/machineactions.go
@@ -5,6 +5,8 @@
 package machineactions
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -47,26 +49,26 @@ func NewFacade(
 
 // Actions returns the Actions by Tags passed and ensures that the machine asking
 // for them is the machine that has the actions
-func (f *Facade) Actions(args params.Entities) params.ActionResults {
+func (f *Facade) Actions(ctx context.Context, args params.Entities) params.ActionResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.Actions(args, actionFn)
 }
 
 // BeginActions marks the actions represented by the passed in Tags as running.
-func (f *Facade) BeginActions(args params.Entities) params.ErrorResults {
+func (f *Facade) BeginActions(ctx context.Context, args params.Entities) params.ErrorResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.BeginActions(args, actionFn)
 }
 
 // FinishActions saves the result of a completed Action
-func (f *Facade) FinishActions(args params.ActionExecutionResults) params.ErrorResults {
+func (f *Facade) FinishActions(ctx context.Context, args params.ActionExecutionResults) params.ErrorResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.FinishActions(args, actionFn)
 }
 
 // WatchActionNotifications returns a StringsWatcher for observing
 // incoming action calls to a machine.
-func (f *Facade) WatchActionNotifications(args params.Entities) params.StringsWatchResults {
+func (f *Facade) WatchActionNotifications(ctx context.Context, args params.Entities) params.StringsWatchResults {
 	tagToActionReceiver := f.backend.TagToActionReceiverFn(f.backend.FindEntity)
 	watchOne := common.WatchPendingActionsForReceiver(tagToActionReceiver, f.resources.Register)
 	return common.WatchActionNotifications(args, f.accessMachine, watchOne)
@@ -75,7 +77,7 @@ func (f *Facade) WatchActionNotifications(args params.Entities) params.StringsWa
 // RunningActions lists the actions running for the entities passed in.
 // If we end up needing more than ListRunning at some point we could follow/abstract
 // what's done in the client actions package.
-func (f *Facade) RunningActions(args params.Entities) params.ActionsByReceivers {
+func (f *Facade) RunningActions(ctx context.Context, args params.Entities) params.ActionsByReceivers {
 	canAccess := f.accessMachine
 	tagToActionReceiver := f.backend.TagToActionReceiverFn(f.backend.FindEntity)
 

--- a/apiserver/facades/agent/machineactions/machineactions_test.go
+++ b/apiserver/facades/agent/machineactions/machineactions_test.go
@@ -5,6 +5,7 @@
 package machineactions_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v4"
@@ -51,7 +52,7 @@ func (*FacadeSuite) TestRunningActions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	stub.SetErrors(errors.New("boom"))
-	results := facade.RunningActions(entities(
+	results := facade.RunningActions(context.Background(), entities(
 		"valid", // we will cause this one to err out
 		"valid",
 		"invalid",

--- a/apiserver/facades/agent/meterstatus/meterstatus.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus.go
@@ -4,6 +4,8 @@
 package meterstatus
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -19,8 +21,8 @@ import (
 
 // MeterStatus defines the methods exported by the meter status API facade.
 type MeterStatus interface {
-	GetMeterStatus(args params.Entities) (params.MeterStatusResults, error)
-	WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error)
+	GetMeterStatus(ctx context.Context, args params.Entities) (params.MeterStatusResults, error)
+	WatchMeterStatus(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error)
 }
 
 // MeterStatusState represents the state of an model required by the MeterStatus.
@@ -77,7 +79,7 @@ func NewMeterStatusAPI(
 
 // WatchMeterStatus returns a NotifyWatcher for observing changes
 // to each unit's meter status.
-func (m *MeterStatusAPI) WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error) {
+func (m *MeterStatusAPI) WatchMeterStatus(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -115,7 +117,7 @@ func (m *MeterStatusAPI) watchOneUnitMeterStatus(tag names.UnitTag) (string, err
 }
 
 // GetMeterStatus returns meter status information for each unit.
-func (m *MeterStatusAPI) GetMeterStatus(args params.Entities) (params.MeterStatusResults, error) {
+func (m *MeterStatusAPI) GetMeterStatus(ctx context.Context, args params.Entities) (params.MeterStatusResults, error) {
 	result := params.MeterStatusResults{
 		Results: make([]params.MeterStatusResult, len(args.Entities)),
 	}

--- a/apiserver/facades/agent/meterstatus/meterstatus_test.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus_test.go
@@ -4,6 +4,8 @@
 package meterstatus_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -66,7 +68,7 @@ func (s *meterStatusSuite) TestGetMeterStatusUnauthenticated(c *gc.C) {
 	defer release()
 	otherunit := f.MakeUnit(c, &jujufactory.UnitParams{Application: application})
 	args := params.Entities{Entities: []params.Entity{{otherunit.Tag().String()}}}
-	result, err := s.status.GetMeterStatus(args)
+	result, err := s.status.GetMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -86,7 +88,7 @@ func (s *meterStatusSuite) TestGetMeterStatusBadTag(c *gc.C) {
 	for i, tag := range tags {
 		args.Entities[i] = params.Entity{Tag: tag}
 	}
-	result, err := s.status.GetMeterStatus(args)
+	result, err := s.status.GetMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(tags))
 	for i, result := range result.Results {
@@ -122,7 +124,7 @@ func (s *meterStatusSuite) TestWatchMeterStatus(c *gc.C) {
 		{Tag: s.unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -150,7 +152,7 @@ func (s *meterStatusSuite) TestWatchMeterStatusWithStateChange(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: s.unit.UnitTag().String()},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -187,7 +189,7 @@ func (s *meterStatusSuite) TestWatchMeterStatusWithApplicationTag(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: unit.UnitTag().String()},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/meterstatus/testing/tests.go
+++ b/apiserver/facades/agent/meterstatus/testing/tests.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -19,7 +21,7 @@ import (
 // TestGetMeterStatus tests unit meter status retrieval.
 func TestGetMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate.Unit) {
 	args := params.Entities{Entities: []params.Entity{{Tag: unit.Tag().String()}}}
-	result, err := status.GetMeterStatus(args)
+	result, err := status.GetMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -32,7 +34,7 @@ func TestGetMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate
 	err = unit.SetMeterStatus(newCode, newInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err = status.GetMeterStatus(args)
+	result, err = status.GetMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -48,7 +50,7 @@ func TestWatchMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujusta
 		{Tag: unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/metricsadder/metricsadder.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder.go
@@ -4,6 +4,8 @@
 package metricsadder
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -14,7 +16,7 @@ import (
 // MetricsAdder defines methods that are used to store metric batches in the state.
 type MetricsAdder interface {
 	// AddMetricBatches stores the specified metric batches in the state.
-	AddMetricBatches(batches params.MetricBatchParams) (params.ErrorResults, error)
+	AddMetricBatches(ctx context.Context, batches params.MetricBatchParams) (params.ErrorResults, error)
 }
 
 // MetricsAdderAPI implements the metrics adder interface and is the concrete
@@ -26,7 +28,7 @@ type MetricsAdderAPI struct {
 var _ MetricsAdder = (*MetricsAdderAPI)(nil)
 
 // AddMetricBatches implements the MetricsAdder interface.
-func (api *MetricsAdderAPI) AddMetricBatches(args params.MetricBatchParams) (params.ErrorResults, error) {
+func (api *MetricsAdderAPI) AddMetricBatches(ctx context.Context, args params.MetricBatchParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Batches)),
 	}

--- a/apiserver/facades/agent/metricsadder/metricsadder_test.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder_test.go
@@ -4,6 +4,7 @@
 package metricsadder_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -108,7 +109,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 	}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.adder.AddMetricBatches(context.Background(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -144,7 +145,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.adder.AddMetricBatches(context.Background(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -195,7 +196,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 
 	for i, test := range tests {
 		c.Logf("test %d: %s -> %s", i, test.about, test.tag)
-		result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+		result, err := s.adder.AddMetricBatches(context.Background(), params.MetricBatchParams{
 			Batches: []params.MetricBatchParam{{
 				Tag: test.tag,
 				Batch: params.MetricBatch{

--- a/apiserver/facades/agent/metricsender/metricsender.go
+++ b/apiserver/facades/agent/metricsender/metricsender.go
@@ -4,6 +4,8 @@
 package metricsender
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -17,7 +19,7 @@ var logger = loggo.GetLogger("juju.apiserver.metricsender")
 // MetricSender defines the interface used to send metrics
 // to a collection service.
 type MetricSender interface {
-	Send([]*wireformat.MetricBatch) (*wireformat.Response, error)
+	Send(context.Context, []*wireformat.MetricBatch) (*wireformat.Response, error)
 }
 
 type SenderFactory func(url string) MetricSender
@@ -109,7 +111,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 				wireData = append(wireData, ToWire(m, modelName))
 			}
 		}
-		response, err := sender.Send(wireData)
+		response, err := sender.Send(context.Background(), wireData)
 		if err != nil {
 			logger.Errorf("%+v", err)
 			if incErr := metricsManager.IncrementConsecutiveErrors(); incErr != nil {

--- a/apiserver/facades/agent/metricsender/nopsender.go
+++ b/apiserver/facades/agent/metricsender/nopsender.go
@@ -4,6 +4,8 @@
 package metricsender
 
 import (
+	"context"
+
 	wireformat "github.com/juju/romulus/wireformat/metrics"
 	"github.com/juju/utils/v3"
 )
@@ -14,7 +16,7 @@ type NopSender struct {
 }
 
 // Implement the send interface, act like everything is fine.
-func (n NopSender) Send(batches []*wireformat.MetricBatch) (*wireformat.Response, error) {
+func (n NopSender) Send(ctx context.Context, batches []*wireformat.MetricBatch) (*wireformat.Response, error) {
 	var resp = make(wireformat.EnvironmentResponses)
 	for _, batch := range batches {
 		resp.Ack(batch.ModelUUID, batch.UUID)

--- a/apiserver/facades/agent/metricsender/sender.go
+++ b/apiserver/facades/agent/metricsender/sender.go
@@ -5,6 +5,7 @@ package metricsender
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -19,7 +20,7 @@ type HTTPSender struct {
 }
 
 // Send sends the given metrics to the collector service.
-func (s *HTTPSender) Send(metrics []*wireformat.MetricBatch) (*wireformat.Response, error) {
+func (s *HTTPSender) Send(ctx context.Context, metrics []*wireformat.MetricBatch) (*wireformat.Response, error) {
 	b, err := json.Marshal(metrics)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/agent/metricsender/testing/mocksender.go
+++ b/apiserver/facades/agent/metricsender/testing/mocksender.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 
 	wireformat "github.com/juju/romulus/wireformat/metrics"
@@ -20,7 +21,7 @@ type MockSender struct {
 }
 
 // Send implements the Send interface.
-func (m *MockSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, error) {
+func (m *MockSender) Send(ctx context.Context, d []*wireformat.MetricBatch) (*wireformat.Response, error) {
 	m.Data = append(m.Data, d)
 	respUUID, err := utils.NewUUID()
 	if err != nil {
@@ -60,6 +61,6 @@ type ErrorSender struct {
 }
 
 // Send implements the Send interface returning errors specified in the ErrorSender.
-func (e *ErrorSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, error) {
+func (e *ErrorSender) Send(ctx context.Context, d []*wireformat.MetricBatch) (*wireformat.Response, error) {
 	return &wireformat.Response{}, e.Err
 }

--- a/apiserver/facades/agent/migrationflag/facade.go
+++ b/apiserver/facades/agent/migrationflag/facade.go
@@ -4,6 +4,8 @@
 package migrationflag
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -56,7 +58,7 @@ func (facade *Facade) auth(tagString string) error {
 
 // Phase returns the current migration phase or an error for every
 // supplied entity.
-func (facade *Facade) Phase(entities params.Entities) params.PhaseResults {
+func (facade *Facade) Phase(ctx context.Context, entities params.Entities) params.PhaseResults {
 	count := len(entities.Entities)
 	results := params.PhaseResults{
 		Results: make([]params.PhaseResult, count),
@@ -83,7 +85,7 @@ func (facade *Facade) onePhase(tagString string) (string, error) {
 
 // Watch returns an id for use with the NotifyWatcher facade, or an
 // error, for every supplied entity.
-func (facade *Facade) Watch(entities params.Entities) params.NotifyWatchResults {
+func (facade *Facade) Watch(ctx context.Context, entities params.Entities) params.NotifyWatchResults {
 	count := len(entities.Entities)
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, count),

--- a/apiserver/facades/agent/migrationflag/facade_test.go
+++ b/apiserver/facades/agent/migrationflag/facade_test.go
@@ -4,6 +4,8 @@
 package migrationflag_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -52,7 +54,7 @@ func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
 	facade, err := migrationflag.New(backend, nil, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results := facade.Phase(entities(
+	results := facade.Phase(context.Background(), entities(
 		coretesting.ModelTag.String(),
 		coretesting.ModelTag.String(),
 	))
@@ -73,7 +75,7 @@ func (*FacadeSuite) TestPhaseErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 3 entities: unparseable, unauthorized, call error.
-	results := facade.Phase(entities(
+	results := facade.Phase(context.Background(), entities(
 		"urgle",
 		unknownModel,
 		coretesting.ModelTag.String(),
@@ -102,7 +104,7 @@ func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
 	facade, err := migrationflag.New(backend, resources, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results := facade.Watch(entities(
+	results := facade.Watch(context.Background(), entities(
 		coretesting.ModelTag.String(),
 		coretesting.ModelTag.String(),
 	))
@@ -130,7 +132,7 @@ func (*FacadeSuite) TestWatchErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 3 entities: unparseable, unauthorized, closed channel.
-	results := facade.Watch(entities(
+	results := facade.Watch(context.Background(), entities(
 		"urgle",
 		unknownModel,
 		coretesting.ModelTag.String(),

--- a/apiserver/facades/agent/migrationminion/migrationminion.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion.go
@@ -4,6 +4,8 @@
 package migrationminion
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -44,7 +46,7 @@ func NewAPI(
 //
 // The MigrationStatusWatcher facade must be used to receive events
 // from the watcher.
-func (api *API) Watch() (params.NotifyWatchResult, error) {
+func (api *API) Watch(ctx context.Context) (params.NotifyWatchResult, error) {
 	w := api.backend.WatchMigrationStatus()
 	return params.NotifyWatchResult{
 		NotifyWatcherId: api.resources.Register(w),
@@ -53,7 +55,7 @@ func (api *API) Watch() (params.NotifyWatchResult, error) {
 
 // Report allows a migration minion to submit whether it succeeded or
 // failed for a specific migration phase.
-func (api *API) Report(info params.MinionReport) error {
+func (api *API) Report(ctx context.Context, info params.MinionReport) error {
 	phase, ok := migration.ParsePhase(info.Phase)
 	if !ok {
 		return errors.New("unable to parse phase")

--- a/apiserver/facades/agent/migrationminion/migrationminion_test.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion_test.go
@@ -4,6 +4,8 @@
 package migrationminion_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -71,14 +73,14 @@ func (s *Suite) TestAuthNotAgent(c *gc.C) {
 
 func (s *Suite) TestWatch(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	result, err := api.Watch()
+	result, err := api.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.resources.Get(result.NotifyWatcherId), gc.NotNil)
 }
 
 func (s *Suite) TestReport(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.Background(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "IMPORT",
 		Success:     true,
@@ -92,7 +94,7 @@ func (s *Suite) TestReport(c *gc.C) {
 
 func (s *Suite) TestReportInvalidPhase(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.Background(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "WTF",
 		Success:     true,
@@ -104,7 +106,7 @@ func (s *Suite) TestReportNoSuchMigration(c *gc.C) {
 	failure := errors.NotFoundf("model")
 	s.backend.modelLookupErr = failure
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.Background(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "QUIESCE",
 		Success:     false,

--- a/apiserver/facades/agent/payloadshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/payloadshookcontext/unitfacade.go
@@ -4,6 +4,8 @@
 package payloadshookcontext
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -55,7 +57,7 @@ func NewUnitFacade(backend UnitPayloadBackend, logger loggo.Logger) *UnitFacade 
 }
 
 // Track stores a payload to be tracked in state.
-func (uf UnitFacade) Track(args params.TrackPayloadArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) Track(ctx context.Context, args params.TrackPayloadArgs) (params.PayloadResults, error) {
 	uf.logger.Debugf("tracking %d payloads from API", len(args.Payloads))
 
 	var r params.PayloadResults
@@ -87,7 +89,7 @@ func (uf UnitFacade) track(pl payloads.Payload) (string, error) {
 // List builds the list of payload being tracked for
 // the given unit and IDs. If no IDs are provided then all tracked
 // payloads for the unit are returned.
-func (uf UnitFacade) List(args params.Entities) (params.PayloadResults, error) {
+func (uf UnitFacade) List(ctx context.Context, args params.Entities) (params.PayloadResults, error) {
 	if len(args.Entities) == 0 {
 		return uf.listAll()
 	}
@@ -139,7 +141,7 @@ func (uf UnitFacade) listAll() (params.PayloadResults, error) {
 }
 
 // LookUp identifies the payload with the provided name and raw ID.
-func (uf UnitFacade) LookUp(args params.LookUpPayloadArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) LookUp(ctx context.Context, args params.LookUpPayloadArgs) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, arg := range args.Args {
 		id, err := uf.backend.LookUp(arg.Name, arg.ID)
@@ -150,7 +152,7 @@ func (uf UnitFacade) LookUp(args params.LookUpPayloadArgs) (params.PayloadResult
 }
 
 // SetStatus sets the raw status of a payload.
-func (uf UnitFacade) SetStatus(args params.SetPayloadStatusArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) SetStatus(ctx context.Context, args params.SetPayloadStatusArgs) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, arg := range args.Args {
 		id, err := api.API2ID(arg.Tag)
@@ -166,7 +168,7 @@ func (uf UnitFacade) SetStatus(args params.SetPayloadStatusArgs) (params.Payload
 }
 
 // Untrack marks the identified payload as no longer being tracked.
-func (uf UnitFacade) Untrack(args params.Entities) (params.PayloadResults, error) {
+func (uf UnitFacade) Untrack(ctx context.Context, args params.Entities) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, entity := range args.Entities {
 		id, err := api.API2ID(entity.Tag)

--- a/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
@@ -4,6 +4,8 @@
 package payloadshookcontext_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -49,7 +51,7 @@ func (s *suite) TestTrack(c *gc.C) {
 		}},
 	}
 
-	res, err := a.Track(args)
+	res, err := a.Track(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, params.PayloadResults{
@@ -99,7 +101,7 @@ func (s *suite) TestListOne(c *gc.C) {
 			Tag: names.NewPayloadTag(id).String(),
 		}},
 	}
-	results, err := a.List(args)
+	results, err := a.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.Payload{
@@ -146,7 +148,7 @@ func (s *suite) TestListAll(c *gc.C) {
 
 	a := unitfacade.NewUnitFacade(s.state, loggo.GetLogger("juju.apiserver.payloadshookcontext"))
 	args := params.Entities{}
-	results, err := a.List(args)
+	results, err := a.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.Payload{
@@ -181,7 +183,7 @@ func (s *suite) TestLookUpOkay(c *gc.C) {
 			ID:   "bar",
 		}},
 	}
-	res, err := a.LookUp(args)
+	res, err := a.LookUp(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCalls(c, []testing.StubCall{{
@@ -222,7 +224,7 @@ func (s *suite) TestLookUpMixed(c *gc.C) {
 			ID:   "eggs",
 		}},
 	}
-	res, err := a.LookUp(args)
+	res, err := a.LookUp(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "LookUp", "LookUp", "LookUp")
@@ -263,7 +265,7 @@ func (s *suite) TestSetStatus(c *gc.C) {
 			Status: payloads.StateRunning,
 		}},
 	}
-	res, err := a.SetStatus(args)
+	res, err := a.SetStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.state.id, gc.Equals, id)
@@ -290,7 +292,7 @@ func (s *suite) TestUntrack(c *gc.C) {
 			Tag: names.NewPayloadTag(id).String(),
 		}},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, id)
@@ -313,7 +315,7 @@ func (s *suite) TestUntrackEmptyID(c *gc.C) {
 			Tag: "",
 		}},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, "")
@@ -337,7 +339,7 @@ func (s *suite) TestUntrackNoIDs(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, id)

--- a/apiserver/facades/agent/provisioner/container_test.go
+++ b/apiserver/facades/agent/provisioner/container_test.go
@@ -4,6 +4,8 @@
 package provisioner_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -71,7 +73,7 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 			Tag: "unit-mysql-0", // not a valid machine tag
 		}}}
 	// Only machine 0 can have its containers updated.
-	results, err := aProvisioner.PrepareContainerInterfaceInfo(args)
+	results, err := aProvisioner.PrepareContainerInterfaceInfo(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "dummy provider network config not supported")
 	c.Skip("dummy provider needs networking https://pad.lv/1651974")
 	// Overall request is ok
@@ -126,7 +128,7 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 			Tag: "unit-mysql-0", // not a valid machine tag
 		}}}
 	// Only machine 0 can have it's containers updated.
-	results, err := aProvisioner.HostChangesForContainers(args)
+	results, err := aProvisioner.HostChangesForContainers(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "dummy provider network config not supported")
 	c.Skip("dummy provider needs networking https://pad.lv/1651974")
 	// Overall request is ok

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	stdcontext "context"
 	"sync"
 
 	"github.com/juju/collections/set"
@@ -234,7 +235,7 @@ func (api *ProvisionerAPI) watchOneMachineContainers(arg params.WatchContainer) 
 
 // WatchContainers starts a StringsWatcher to watch containers deployed to
 // any machine passed in args.
-func (api *ProvisionerAPI) WatchContainers(args params.WatchContainers) (params.StringsWatchResults, error) {
+func (api *ProvisionerAPI) WatchContainers(ctx stdcontext.Context, args params.WatchContainers) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Params)),
 	}
@@ -248,12 +249,12 @@ func (api *ProvisionerAPI) WatchContainers(args params.WatchContainers) (params.
 
 // WatchAllContainers starts a StringsWatcher to watch all containers deployed to
 // any machine passed in args.
-func (api *ProvisionerAPI) WatchAllContainers(args params.WatchContainers) (params.StringsWatchResults, error) {
-	return api.WatchContainers(args)
+func (api *ProvisionerAPI) WatchAllContainers(ctx stdcontext.Context, args params.WatchContainers) (params.StringsWatchResults, error) {
+	return api.WatchContainers(ctx, args)
 }
 
 // SetSupportedContainers updates the list of containers supported by the machines passed in args.
-func (api *ProvisionerAPI) SetSupportedContainers(args params.MachineContainersParams) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) SetSupportedContainers(ctx stdcontext.Context, args params.MachineContainersParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Params)),
 	}
@@ -287,7 +288,7 @@ func (api *ProvisionerAPI) SetSupportedContainers(args params.MachineContainersP
 }
 
 // SupportedContainers returns the list of containers supported by the machines passed in args.
-func (api *ProvisionerAPI) SupportedContainers(args params.Entities) (params.MachineContainerResults, error) {
+func (api *ProvisionerAPI) SupportedContainers(ctx stdcontext.Context, args params.Entities) (params.MachineContainerResults, error) {
 	result := params.MachineContainerResults{
 		Results: make([]params.MachineContainerResult, len(args.Entities)),
 	}
@@ -317,7 +318,7 @@ func (api *ProvisionerAPI) SupportedContainers(args params.Entities) (params.Mac
 
 // ContainerManagerConfig returns information from the model config that is
 // needed for configuring the container manager.
-func (api *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
+func (api *ProvisionerAPI) ContainerManagerConfig(ctx stdcontext.Context, args params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
 	var result params.ContainerManagerConfig
 	cfg := make(map[string]string)
 	cfg[container.ConfigModelUUID] = api.st.ModelUUID()
@@ -345,7 +346,7 @@ func (api *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerCo
 
 // ContainerConfig returns information from the model config that is
 // needed for container cloud-init.
-func (api *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
+func (api *ProvisionerAPI) ContainerConfig(ctx stdcontext.Context) (params.ContainerConfig, error) {
 	result := params.ContainerConfig{}
 	cfg, err := api.m.ModelConfig()
 	if err != nil {
@@ -374,7 +375,7 @@ func (api *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 
 // MachinesWithTransientErrors returns status data for machines with provisioning
 // errors which are transient.
-func (api *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, error) {
+func (api *ProvisionerAPI) MachinesWithTransientErrors(ctx stdcontext.Context) (params.StatusResults, error) {
 	var results params.StatusResults
 	canAccessFunc, err := api.getAuthFunc()
 	if err != nil {
@@ -417,7 +418,7 @@ func (api *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, 
 }
 
 // AvailabilityZone returns a provider-specific availability zone for each given machine entity
-func (api *ProvisionerAPI) AvailabilityZone(args params.Entities) (params.StringResults, error) {
+func (api *ProvisionerAPI) AvailabilityZone(ctx stdcontext.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -449,7 +450,7 @@ func (api *ProvisionerAPI) AvailabilityZone(args params.Entities) (params.String
 }
 
 // KeepInstance returns the keep-instance value for each given machine entity.
-func (api *ProvisionerAPI) KeepInstance(args params.Entities) (params.BoolResults, error) {
+func (api *ProvisionerAPI) KeepInstance(ctx stdcontext.Context, args params.Entities) (params.BoolResults, error) {
 	result := params.BoolResults{
 
 		Results: make([]params.BoolResult, len(args.Entities)),
@@ -479,7 +480,7 @@ func (api *ProvisionerAPI) KeepInstance(args params.Entities) (params.BoolResult
 // a slice of instance.Ids that belong to the same distribution
 // group as that machine. This information may be used to
 // distribute instances for high availability.
-func (api *ProvisionerAPI) DistributionGroup(args params.Entities) (params.DistributionGroupResults, error) {
+func (api *ProvisionerAPI) DistributionGroup(ctx stdcontext.Context, args params.Entities) (params.DistributionGroupResults, error) {
 	result := params.DistributionGroupResults{
 		Results: make([]params.DistributionGroupResult, len(args.Entities)),
 	}
@@ -564,7 +565,7 @@ func commonServiceInstances(st *state.State, m *state.Machine) ([]instance.Id, e
 // a slice of machine.Ids that belong to the same distribution
 // group as that machine. This information may be used to
 // distribute instances for high availability.
-func (api *ProvisionerAPI) DistributionGroupByMachineId(args params.Entities) (params.StringsResults, error) {
+func (api *ProvisionerAPI) DistributionGroupByMachineId(ctx stdcontext.Context, args params.Entities) (params.StringsResults, error) {
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.Entities)),
 	}
@@ -623,7 +624,7 @@ func commonApplicationMachineId(st *state.State, m *state.Machine) ([]string, er
 }
 
 // Constraints returns the constraints for each given machine entity.
-func (api *ProvisionerAPI) Constraints(args params.Entities) (params.ConstraintsResults, error) {
+func (api *ProvisionerAPI) Constraints(ctx stdcontext.Context, args params.Entities) (params.ConstraintsResults, error) {
 	result := params.ConstraintsResults{
 		Results: make([]params.ConstraintsResult, len(args.Entities)),
 	}
@@ -651,7 +652,7 @@ func (api *ProvisionerAPI) Constraints(args params.Entities) (params.Constraints
 }
 
 // FindTools returns a List containing all tools matching the given parameters.
-func (api *ProvisionerAPI) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+func (api *ProvisionerAPI) FindTools(ctx stdcontext.Context, args params.FindToolsParams) (params.FindToolsResult, error) {
 	list, err := api.toolsFinder.FindAgents(common.FindAgentsParams{
 		Number:      args.Number,
 		Arch:        args.Arch,
@@ -667,7 +668,7 @@ func (api *ProvisionerAPI) FindTools(args params.FindToolsParams) (params.FindTo
 // SetInstanceInfo sets the provider specific machine id, nonce,
 // metadata and network info for each given machine. Once set, the
 // instance id cannot be changed.
-func (api *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) SetInstanceInfo(ctx stdcontext.Context, args params.InstancesInfo) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Machines)),
 	}
@@ -715,7 +716,7 @@ func (api *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Er
 
 // WatchMachineErrorRetry returns a NotifyWatcher that notifies when
 // the provisioner should retry provisioning machines with transient errors.
-func (api *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, error) {
+func (api *ProvisionerAPI) WatchMachineErrorRetry(ctx stdcontext.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	if !api.authorizer.AuthController() {
 		return result, apiservererrors.ErrPerm
@@ -733,7 +734,7 @@ func (api *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, e
 // ReleaseContainerAddresses finds addresses allocated to a container and marks
 // them as Dead, to be released and removed. It accepts container tags as
 // arguments.
-func (api *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) ReleaseContainerAddresses(ctx stdcontext.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -781,7 +782,7 @@ func (api *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (para
 
 // PrepareContainerInterfaceInfo allocates an address and returns information to
 // configure networking for a container. It accepts container tags as arguments.
-func (api *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
+func (api *ProvisionerAPI) PrepareContainerInterfaceInfo(ctx stdcontext.Context, args params.Entities) (
 	params.MachineNetworkConfigResults,
 	error,
 ) {
@@ -794,7 +795,7 @@ func (api *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 
 // GetContainerInterfaceInfo returns information to configure networking for a
 // container. It accepts container tags as arguments.
-func (api *ProvisionerAPI) GetContainerInterfaceInfo(args params.Entities) (
+func (api *ProvisionerAPI) GetContainerInterfaceInfo(ctx stdcontext.Context, args params.Entities) (
 	params.MachineNetworkConfigResults,
 	error,
 ) {
@@ -1039,7 +1040,7 @@ func (ctx *hostChangesContext) ConfigType() string {
 // HostChangesForContainers returns the set of changes that need to be done
 // to the host machine to prepare it for the containers to be created.
 // Pass in a list of the containers that you want the changes for.
-func (api *ProvisionerAPI) HostChangesForContainers(args params.Entities) (params.HostNetworkChangeResults, error) {
+func (api *ProvisionerAPI) HostChangesForContainers(stdcontext stdcontext.Context, args params.Entities) (params.HostNetworkChangeResults, error) {
 	ctx := &hostChangesContext{
 		result: params.HostNetworkChangeResults{
 			Results: make([]params.HostNetworkChange, len(args.Entities)),
@@ -1110,7 +1111,7 @@ func (ctx *containerProfileContext) ConfigType() string {
 // container based on the charms deployed to the container. It accepts container
 // tags as arguments. Unlike machineLXDProfileNames which has the environ
 // write the lxd profiles and returns the names of profiles already written.
-func (api *ProvisionerAPI) GetContainerProfileInfo(args params.Entities) (params.ContainerProfileResults, error) {
+func (api *ProvisionerAPI) GetContainerProfileInfo(stdcontext stdcontext.Context, args params.Entities) (params.ContainerProfileResults, error) {
 	ctx := &containerProfileContext{
 		result: params.ContainerProfileResults{
 			Results: make([]params.ContainerProfileResult, len(args.Entities)),
@@ -1125,7 +1126,7 @@ func (api *ProvisionerAPI) GetContainerProfileInfo(args params.Entities) (params
 
 // InstanceStatus returns the instance status for each given entity.
 // Only machine tags are accepted.
-func (api *ProvisionerAPI) InstanceStatus(args params.Entities) (params.StatusResults, error) {
+func (api *ProvisionerAPI) InstanceStatus(ctx stdcontext.Context, args params.Entities) (params.StatusResults, error) {
 	result := params.StatusResults{
 		Results: make([]params.StatusResult, len(args.Entities)),
 	}
@@ -1196,7 +1197,7 @@ func (api *ProvisionerAPI) setOneInstanceStatus(canAccess common.AuthFunc, arg p
 
 // SetInstanceStatus updates the instance status for each given
 // entity. Only machine tags are accepted.
-func (api *ProvisionerAPI) SetInstanceStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) SetInstanceStatus(ctx stdcontext.Context, args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -1219,7 +1220,7 @@ func (api *ProvisionerAPI) SetInstanceStatus(args params.SetStatus) (params.Erro
 // the instance to be placed into a error state. This modification status
 // serves the purpose of highlighting that to the operator.
 // Only machine tags are accepted.
-func (api *ProvisionerAPI) SetModificationStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) SetModificationStatus(ctx stdcontext.Context, args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -1268,7 +1269,7 @@ func (api *ProvisionerAPI) setOneModificationStatus(canAccess common.AuthFunc, a
 // MarkMachinesForRemoval indicates that the specified machines are
 // ready to have any provider-level resources cleaned up and then be
 // removed.
-func (api *ProvisionerAPI) MarkMachinesForRemoval(machines params.Entities) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) MarkMachinesForRemoval(ctx stdcontext.Context, machines params.Entities) (params.ErrorResults, error) {
 	results := make([]params.ErrorResult, len(machines.Entities))
 	canAccess, err := api.getAuthFunc()
 	if err != nil {
@@ -1293,7 +1294,7 @@ func (api *ProvisionerAPI) markOneMachineForRemoval(machineTag string, canAccess
 	return machine.MarkForRemoval()
 }
 
-func (api *ProvisionerAPI) SetHostMachineNetworkConfig(args params.SetMachineNetworkConfig) error {
+func (api *ProvisionerAPI) SetHostMachineNetworkConfig(ctx stdcontext.Context, args params.SetMachineNetworkConfig) error {
 	return api.SetObservedNetworkConfig(args)
 }
 
@@ -1308,7 +1309,7 @@ func (api *ProvisionerAPI) CACert() (params.BytesResult, error) {
 }
 
 // SetCharmProfiles records the given slice of charm profile names.
-func (api *ProvisionerAPI) SetCharmProfiles(args params.SetProfileArgs) (params.ErrorResults, error) {
+func (api *ProvisionerAPI) SetCharmProfiles(ctx stdcontext.Context, args params.SetProfileArgs) (params.ErrorResults, error) {
 	results := make([]params.ErrorResult, len(args.Args))
 	canAccess, err := api.getAuthFunc()
 	if err != nil {
@@ -1334,12 +1335,12 @@ func (api *ProvisionerAPI) setOneMachineCharmProfiles(machineTag string, profile
 }
 
 // ModelUUID returns the model UUID that the current connection is for.
-func (api *ProvisionerAPI) ModelUUID() params.StringResult {
+func (api *ProvisionerAPI) ModelUUID(ctx stdcontext.Context) params.StringResult {
 	return params.StringResult{Result: api.st.ModelUUID()}
 }
 
 // APIHostPorts returns the API server addresses.
-func (api *ProvisionerAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+func (api *ProvisionerAPI) APIHostPorts(ctx stdcontext.Context) (result params.APIHostPortsResult, err error) {
 	controllerConfig, err := api.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -1349,7 +1350,7 @@ func (api *ProvisionerAPI) APIHostPorts() (result params.APIHostPortsResult, err
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (api *ProvisionerAPI) APIAddresses() (result params.StringsResult, err error) {
+func (api *ProvisionerAPI) APIAddresses(ctx stdcontext.Context) (result params.StringsResult, err error) {
 	controllerConfig, err := api.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"context"
 	"fmt"
 	stdtesting "testing"
 	"time"
@@ -449,7 +450,7 @@ func (s *withoutControllerSuite) TestSetInstanceStatus(c *gc.C) {
 			{Tag: "unit-foo-0", Status: status.Error.String(), Info: "foobar"},
 			{Tag: "application-bar", Status: status.ProvisioningError.String(), Info: "foobar"},
 		}}
-	result, err := s.provisioner.SetInstanceStatus(args)
+	result, err := s.provisioner.SetInstanceStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -504,7 +505,7 @@ func (s *withoutControllerSuite) TestSetModificationStatus(c *gc.C) {
 			{Tag: "unit-foo-0", Status: status.Error.String(), Info: "foobar"},
 			{Tag: "application-bar", Status: status.Error.String(), Info: "foobar"},
 		}}
-	result, err := s.provisioner.SetModificationStatus(args)
+	result, err := s.provisioner.SetModificationStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -568,7 +569,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	err = s.machines[4].SetProvisioned("i-am", "", "fake_nonce", &hwChars)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.MachinesWithTransientErrors()
+	result, err := s.provisioner.MachinesWithTransientErrors(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
@@ -624,7 +625,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	err = s.machines[3].SetInstanceStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := aProvisioner.MachinesWithTransientErrors()
+	result, err := aProvisioner.MachinesWithTransientErrors(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{{
@@ -716,7 +717,7 @@ func (s *withoutControllerSuite) TestWatchContainers(c *gc.C) {
 		{MachineTag: "unit-foo-0", ContainerType: ""},
 		{MachineTag: "application-bar", ContainerType: ""},
 	}}
-	result, err := s.provisioner.WatchContainers(args)
+	result, err := s.provisioner.WatchContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -753,7 +754,7 @@ func (s *withoutControllerSuite) TestWatchAllContainers(c *gc.C) {
 		{MachineTag: "unit-foo-0"},
 		{MachineTag: "application-bar"},
 	}}
-	result, err := s.provisioner.WatchAllContainers(args)
+	result, err := s.provisioner.WatchAllContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -886,7 +887,7 @@ func (s *withoutControllerSuite) TestInstanceStatus(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.InstanceStatus(args)
+	result, err := s.provisioner.InstanceStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	// Zero out the updated timestamps so we can easily check the results.
 	for i, statusResult := range result.Results {
@@ -936,7 +937,7 @@ func (s *withoutControllerSuite) TestAvailabilityZone(c *gc.C) {
 		{Tag: emptyAzMachine.Tag().String()},
 		{Tag: nilAzMachine.Tag().String()},
 	}}
-	result, err := s.provisioner.AvailabilityZone(args)
+	result, err := s.provisioner.AvailabilityZone(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -964,7 +965,7 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.KeepInstance(args)
+	result, err := s.provisioner.KeepInstance(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -1046,7 +1047,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 		{Tag: s.machines[3].Tag().String()},
 		{Tag: "machine-5"},
 	}}
-	result, err := s.provisioner.DistributionGroup(args)
+	result, err := s.provisioner.DistributionGroup(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1067,7 +1068,7 @@ func (s *withoutControllerSuite) TestDistributionGroupControllerAuth(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.DistributionGroup(args)
+	result, err := s.provisioner.DistributionGroup(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1104,7 +1105,7 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 		{Tag: "machine-1-lxd-99"},
 		{Tag: "machine-1-lxd-99-lxd-100"},
 	}}
-	result, err := provisioner.DistributionGroup(args)
+	result, err := provisioner.DistributionGroup(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1172,7 +1173,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 		{Tag: s.machines[3].Tag().String()},
 		{Tag: "machine-5"},
 	}}
-	result, err := s.provisioner.DistributionGroupByMachineId(args)
+	result, err := s.provisioner.DistributionGroupByMachineId(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1193,7 +1194,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineIdControllerAuth(
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.DistributionGroupByMachineId(args)
+	result, err := s.provisioner.DistributionGroupByMachineId(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1230,7 +1231,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineIdMachineAgentAut
 		{Tag: "machine-1-lxd-99"},
 		{Tag: "machine-1-lxd-99-lxd-100"},
 	}}
-	result, err := provisioner.DistributionGroupByMachineId(args)
+	result, err := provisioner.DistributionGroupByMachineId(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1267,7 +1268,7 @@ func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.Constraints(args)
+	result, err := s.provisioner.Constraints(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ConstraintsResults{
 		Results: []params.ConstraintsResult{
@@ -1342,7 +1343,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.SetInstanceInfo(args)
+	result, err := s.provisioner.SetInstanceInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1469,7 +1470,7 @@ func (s *withoutControllerSuite) TestWatchModelMachines(c *gc.C) {
 
 func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType) map[string]string {
 	args := params.ContainerManagerConfigParams{Type: typ}
-	results, err := s.provisioner.ContainerManagerConfig(args)
+	results, err := s.provisioner.ContainerManagerConfig(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	return results.ManagerConfig
 }
@@ -1487,7 +1488,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	s.PatchValue(&provisioner.ErrorRetryWaitDelay, 2*coretesting.ShortWait)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 
-	_, err := s.provisioner.WatchMachineErrorRetry()
+	_, err := s.provisioner.WatchMachineErrorRetry(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify the resources were registered and stop them when done.
@@ -1516,7 +1517,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := aProvisioner.WatchMachineErrorRetry()
+	result, err := aProvisioner.WatchMachineErrorRetry(context.Background())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{})
 }
@@ -1527,7 +1528,7 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	err = s.machines[2].EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
-	res, err := s.provisioner.MarkMachinesForRemoval(params.Entities{
+	res, err := s.provisioner.MarkMachinesForRemoval(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "machine-2"},         // ok
 			{Tag: "machine-100"},       // not found
@@ -1587,7 +1588,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 
 	cfg, err := s.ControllerModel(c).ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.provisioner.ContainerConfig()
+	results, err := s.provisioner.ContainerConfig(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(results.UpdateBehavior, gc.Not(gc.IsNil))
 	c.Check(results.ProviderType, gc.Equals, "dummy")
@@ -1632,7 +1633,7 @@ func (s *withoutControllerSuite) TestContainerConfigLegacy(c *gc.C) {
 
 	cfg, err := s.ControllerModel(c).ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.provisioner.ContainerConfig()
+	results, err := s.provisioner.ContainerConfig(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(results.UpdateBehavior, gc.Not(gc.IsNil))
 	c.Check(results.ProviderType, gc.Equals, "dummy")
@@ -1658,7 +1659,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainers(c *gc.C) {
 		MachineTag:     "machine-1",
 		ContainerTypes: []instance.ContainerType{instance.LXD, instance.KVM},
 	}}}
-	results, err := s.provisioner.SetSupportedContainers(args)
+	results, err := s.provisioner.SetSupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1706,7 +1707,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainersPermissions(c *gc.C) 
 		},
 	}
 	// Only machine 0 can have it's containers updated.
-	results, err := aProvisioner.SetSupportedContainers(args)
+	results, err := aProvisioner.SetSupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1725,7 +1726,7 @@ func (s *withoutControllerSuite) TestSupportedContainers(c *gc.C) {
 		MachineTag:     "machine-1",
 		ContainerTypes: []instance.ContainerType{instance.LXD, instance.KVM},
 	}}}
-	_, err := s.provisioner.SetSupportedContainers(setArgs)
+	_, err := s.provisioner.SetSupportedContainers(context.Background(), setArgs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{{
@@ -1733,7 +1734,7 @@ func (s *withoutControllerSuite) TestSupportedContainers(c *gc.C) {
 	}, {
 		Tag: "machine-1",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1758,7 +1759,7 @@ func (s *withoutControllerSuite) TestSupportedContainersWithoutBeingSet(c *gc.C)
 	}, {
 		Tag: "machine-1",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1771,7 +1772,7 @@ func (s *withoutControllerSuite) TestSupportedContainersWithInvalidTag(c *gc.C) 
 	args := params.Entities{Entities: []params.Entity{{
 		Tag: "user-0",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	for _, result := range results.Results {
@@ -1787,7 +1788,7 @@ func (s *withoutControllerSuite) TestSupportsNoContainers(c *gc.C) {
 			},
 		},
 	}
-	results, err := s.provisioner.SetSupportedContainers(args)
+	results, err := s.provisioner.SetSupportedContainers(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -1818,7 +1819,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.APIAddresses()
+	result, err := s.provisioner.APIAddresses(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -4,6 +4,7 @@
 package proxyupdater_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v4"
@@ -64,7 +65,7 @@ func (s *ProxyUpdaterSuite) SetUpTest(c *gc.C) {
 func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C) {
 	// WatchForProxyConfigAndAPIHostPortChanges combines WatchForModelConfigChanges
 	// and WatchAPIHostPorts. Check that they are both called and we get the
-	result := s.facade.WatchForProxyConfigAndAPIHostPortChanges(s.oneEntity())
+	result := s.facade.WatchForProxyConfigAndAPIHostPortChanges(context.Background(), s.oneEntity())
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
 
@@ -100,7 +101,7 @@ func (s *ProxyUpdaterSuite) TestMirrorConfig(c *gc.C) {
 		"apt-mirror": "http://mirror",
 	})
 	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -113,7 +114,7 @@ func (s *ProxyUpdaterSuite) TestMirrorConfig(c *gc.C) {
 
 func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -142,7 +143,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigJujuProxy(c *gc.C) {
 		"apt-https-proxy":  "apt https proxy",
 	})
 
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -175,7 +176,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigExtendsExisting(c *gc.C) {
 		"apt-https-proxy": "apt https proxy",
 		"no-proxy":        "9.9.9.9",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",
@@ -201,7 +202,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigNoDuplicates(c *gc.C) {
 		"apt-https-proxy": "apt https proxy",
 		"no-proxy":        "0.1.2.3",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",
@@ -225,7 +226,7 @@ func (s *ProxyUpdaterSuite) TestSnapProxyConfig(c *gc.C) {
 		"snap-store-proxy":      "store proxy",
 		"snap-store-assertions": "trust us",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.Background(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3067,7 +3067,7 @@ func (s *uniterSuite) TestWatchCAASUnitAddressesHash(c *gc.C) {
 
 func (s *uniterSuite) TestGetMeterStatusUnauthenticated(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{{s.mysqlUnit.Tag().String()}}}
-	result, err := s.uniter.GetMeterStatus(args)
+	result, err := s.uniter.GetMeterStatus(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -3087,7 +3087,7 @@ func (s *uniterSuite) TestGetMeterStatusBadTag(c *gc.C) {
 	for i, tag := range tags {
 		args.Entities[i] = params.Entity{Tag: tag}
 	}
-	result, err := s.uniter.GetMeterStatus(args)
+	result, err := s.uniter.GetMeterStatus(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(tags))
 	for i, result := range result.Results {


### PR DESCRIPTION
This PR adds context.Context parameter to:
- agent/machine
- agent/machineactions
- agent/meterstatus
- agent/meteradder
- agent/metersender
- agent/migrationflag
- agent/migrationminion
- agent/playloadhookcontext
- agent/provisioner
- agent/proxyupdater 
facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/machine/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/machineactions/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/meterstatus/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/metricsadder/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/metricssender/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/metricsender/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/migrationflag/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/migrationminion/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/payloadshookcontext/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/provisioner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/proxyupdater/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```