### PR TITLE
[JUJU-4471] Add context.Context in agent/(r-u)* facades

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -94,7 +95,7 @@ func NewToolsGetter(
 }
 
 // Tools finds the tools necessary for the given agents.
-func (t *ToolsGetter) Tools(args params.Entities) (params.ToolsResults, error) {
+func (t *ToolsGetter) Tools(ctx context.Context, args params.Entities) (params.ToolsResults, error) {
 	result := params.ToolsResults{
 		Results: make([]params.ToolsResult, len(args.Entities)),
 	}
@@ -179,7 +180,7 @@ func NewToolsSetter(st ToolsFindEntity, getCanWrite GetAuthFunc) *ToolsSetter {
 }
 
 // SetTools updates the recorded tools version for the agents.
-func (t *ToolsSetter) SetTools(args params.EntitiesVersion) (params.ErrorResults, error) {
+func (t *ToolsSetter) SetTools(ctx context.Context, args params.EntitiesVersion) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.AgentTools)),
 	}

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -100,7 +101,7 @@ func (s *getToolsSuite) TestTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("42")).Return(nil, apiservertesting.NotFoundError("machine 42"))
 
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
@@ -156,7 +157,7 @@ func (s *getToolsSuite) TestOSTools(c *gc.C) {
 		Entities: []params.Entity{
 			{Tag: "machine-0"},
 		}}
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -182,7 +183,7 @@ func (s *getToolsSuite) TestToolsError(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-42"}},
 	}
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "splat")
 	c.Assert(result.Results, gc.HasLen, 1)
 }
@@ -241,7 +242,7 @@ func (s *setToolsSuite) TestSetTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("42")).Return(nil, apiservertesting.NotFoundError("machine 42"))
 
-	result, err := ts.SetTools(args)
+	result, err := ts.SetTools(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -264,7 +265,7 @@ func (s *setToolsSuite) TestToolsSetError(c *gc.C) {
 			},
 		}},
 	}
-	result, err := ts.SetTools(args)
+	result, err := ts.SetTools(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "splat")
 	c.Assert(result.Results, gc.HasLen, 1)
 }

--- a/apiserver/facades/agent/reboot/reboot.go
+++ b/apiserver/facades/agent/reboot/reboot.go
@@ -5,6 +5,8 @@
 package reboot
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -63,7 +65,7 @@ func NewRebootAPI(ctx facade.Context) (*RebootAPI, error) {
 
 // WatchForRebootEvent starts a watcher to track if there is a new
 // reboot request on the machines ID or any of its parents (in case we are a container).
-func (r *RebootAPI) WatchForRebootEvent() (params.NotifyWatchResult, error) {
+func (r *RebootAPI) WatchForRebootEvent(ctx context.Context) (params.NotifyWatchResult, error) {
 	var err error = apiservererrors.ErrPerm
 	var watch state.NotifyWatcher
 	var result params.NotifyWatchResult

--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -5,6 +5,8 @@
 package reboot_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -61,7 +63,7 @@ func (s *rebootSuite) setUpMachine(c *gc.C, machine *state.Machine) *machines {
 		{Tag: machine.Tag().String()},
 	}}
 
-	resultMachine, err := rebootAPI.WatchForRebootEvent()
+	resultMachine, err := rebootAPI.WatchForRebootEvent(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(resultMachine.NotifyWatcherId, gc.Not(gc.Equals), "")
 	c.Check(resultMachine.Error, gc.IsNil)

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade.go
@@ -4,6 +4,8 @@
 package resourceshookcontext
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/client/resources"
@@ -48,7 +50,7 @@ type UnitFacade struct {
 // GetResourceInfo returns the resource info for each of the given
 // resource names (for the implicit application). If any one is missing then
 // the corresponding result is set with errors.NotFound.
-func (uf UnitFacade) GetResourceInfo(args params.ListUnitResourcesArgs) (params.UnitResourcesResult, error) {
+func (uf UnitFacade) GetResourceInfo(ctx context.Context, args params.ListUnitResourcesArgs) (params.UnitResourcesResult, error) {
 	var r params.UnitResourcesResult
 	r.Resources = make([]params.UnitResourceResult, len(args.ResourceNames))
 

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -4,6 +4,8 @@
 package resourceshookcontext_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +53,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoOkay(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.Background(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{"spam", "eggs"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -74,7 +76,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoEmpty(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.Background(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -93,7 +95,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoNotFound(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.Background(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{"eggs"},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/retrystrategy/retrystrategy.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy.go
@@ -5,6 +5,7 @@
 package retrystrategy
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -29,8 +30,8 @@ const (
 
 // RetryStrategy defines the methods exported by the RetryStrategy API facade.
 type RetryStrategy interface {
-	RetryStrategy(params.Entities) (params.RetryStrategyResults, error)
-	WatchRetryStrategy(params.Entities) (params.NotifyWatchResults, error)
+	RetryStrategy(context.Context, params.Entities) (params.RetryStrategyResults, error)
+	WatchRetryStrategy(context.Context, params.Entities) (params.NotifyWatchResults, error)
 }
 
 // RetryStrategyAPI implements RetryStrategy
@@ -45,7 +46,7 @@ var _ RetryStrategy = (*RetryStrategyAPI)(nil)
 
 // RetryStrategy returns RetryStrategyResults that can be used by any code that uses
 // to configure the retry timer that's currently in juju utils.
-func (h *RetryStrategyAPI) RetryStrategy(args params.Entities) (params.RetryStrategyResults, error) {
+func (h *RetryStrategyAPI) RetryStrategy(ctx context.Context, args params.Entities) (params.RetryStrategyResults, error) {
 	results := params.RetryStrategyResults{
 		Results: make([]params.RetryStrategyResult, len(args.Entities)),
 	}
@@ -84,7 +85,7 @@ func (h *RetryStrategyAPI) RetryStrategy(args params.Entities) (params.RetryStra
 
 // WatchRetryStrategy watches for changes to the model. Currently we only allow
 // changes to the boolean that determines whether retries should be attempted or not.
-func (h *RetryStrategyAPI) WatchRetryStrategy(args params.Entities) (params.NotifyWatchResults, error) {
+func (h *RetryStrategyAPI) WatchRetryStrategy(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}

--- a/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
@@ -5,6 +5,8 @@
 package retrystrategy_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -79,7 +81,7 @@ func (s *retryStrategySuite) TestRetryStrategyUnauthenticated(c *gc.C) {
 	otherUnit := f.MakeUnit(c, &jujufactory.UnitParams{Application: app})
 	args := params.Entities{Entities: []params.Entity{{otherUnit.Tag().String()}}}
 
-	res, err := s.strategy.RetryStrategy(args)
+	res, err := s.strategy.RetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -91,7 +93,7 @@ func (s *retryStrategySuite) TestRetryStrategyBadTag(c *gc.C) {
 	for i, t := range tagsTests {
 		args.Entities[i] = params.Entity{Tag: t.tag}
 	}
-	res, err := s.strategy.RetryStrategy(args)
+	res, err := s.strategy.RetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, len(tagsTests))
 	for i, r := range res.Results {
@@ -134,7 +136,7 @@ func (s *retryStrategySuite) assertRetryStrategy(c *gc.C, tag string) {
 		RetryTimeFactor: retrystrategy.RetryTimeFactor,
 	}
 	args := params.Entities{Entities: []params.Entity{{Tag: tag}}}
-	r, err := s.strategy.RetryStrategy(args)
+	r, err := s.strategy.RetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Results, gc.HasLen, 1)
 	c.Assert(r.Results[0].Error, gc.IsNil)
@@ -143,7 +145,7 @@ func (s *retryStrategySuite) assertRetryStrategy(c *gc.C, tag string) {
 	s.setRetryStrategy(c, false)
 	expected.ShouldRetry = false
 
-	r, err = s.strategy.RetryStrategy(args)
+	r, err = s.strategy.RetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Results, gc.HasLen, 1)
 	c.Assert(r.Results[0].Error, gc.IsNil)
@@ -167,7 +169,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyUnauthenticated(c *gc.C) {
 	otherUnit := f.MakeUnit(c, &jujufactory.UnitParams{Application: app})
 	args := params.Entities{Entities: []params.Entity{{otherUnit.Tag().String()}}}
 
-	res, err := s.strategy.WatchRetryStrategy(args)
+	res, err := s.strategy.WatchRetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -179,7 +181,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyBadTag(c *gc.C) {
 	for i, t := range tagsTests {
 		args.Entities[i] = params.Entity{Tag: t.tag}
 	}
-	res, err := s.strategy.WatchRetryStrategy(args)
+	res, err := s.strategy.WatchRetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, len(tagsTests))
 	for i, r := range res.Results {
@@ -196,7 +198,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategy(c *gc.C) {
 		{Tag: s.unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	r, err := s.strategy.WatchRetryStrategy(args)
+	r, err := s.strategy.WatchRetryStrategy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/secretsdrain/secrets.go
+++ b/apiserver/facades/agent/secretsdrain/secrets.go
@@ -4,6 +4,8 @@
 package secretsdrain
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -37,7 +39,7 @@ type SecretsDrainAPI struct {
 }
 
 // GetSecretsToDrain returns metadata for the secrets that need to be drained.
-func (s *SecretsDrainAPI) GetSecretsToDrain() (params.ListSecretResults, error) {
+func (s *SecretsDrainAPI) GetSecretsToDrain(ctx context.Context) (params.ListSecretResults, error) {
 	modelConfig, err := s.model.ModelConfig()
 	if err != nil {
 		return params.ListSecretResults{}, errors.Trace(err)
@@ -72,7 +74,7 @@ func (s *SecretsDrainAPI) GetSecretsToDrain() (params.ListSecretResults, error) 
 }
 
 // ChangeSecretBackend updates the backend for the specified secret after migration done.
-func (s *SecretsDrainAPI) ChangeSecretBackend(args params.ChangeSecretBackendArgs) (params.ErrorResults, error) {
+func (s *SecretsDrainAPI) ChangeSecretBackend(ctx context.Context, args params.ChangeSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -112,7 +114,7 @@ func toChangeSecretBackendParams(token leadership.Token, uri *coresecrets.URI, a
 }
 
 // WatchSecretBackendChanged sets up a watcher to notify of changes to the secret backend.
-func (s *SecretsDrainAPI) WatchSecretBackendChanged() (params.NotifyWatchResult, error) {
+func (s *SecretsDrainAPI) WatchSecretBackendChanged(ctx context.Context) (params.NotifyWatchResult, error) {
 	stateWatcher := s.model.WatchForModelConfigChanges()
 	w, err := newSecretBackendModelConfigWatcher(s.model, stateWatcher, s.logger)
 	if err != nil {

--- a/apiserver/facades/agent/secretsdrain/secrets_test.go
+++ b/apiserver/facades/agent/secretsdrain/secrets_test.go
@@ -4,6 +4,7 @@
 package secretsdrain_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -155,7 +156,7 @@ func (s *SecretsDrainSuite) assertGetSecretsToDrain(
 		},
 	}, nil)
 
-	results, err := s.facade.GetSecretsToDrain()
+	results, err := s.facade.GetSecretsToDrain(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
@@ -292,7 +293,7 @@ func (s *SecretsDrainSuite) TestChangeSecretBackend(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
 	s.token.EXPECT().Check().Return(nil).Times(2)
 
-	result, err := s.facade.ChangeSecretBackend(params.ChangeSecretBackendArgs{
+	result, err := s.facade.ChangeSecretBackend(context.Background(), params.ChangeSecretBackendArgs{
 		Args: []params.ChangeSecretBackendArg{
 			{
 				URI:      uri1.String(),
@@ -346,7 +347,7 @@ func (s *SecretsDrainSuite) TestWatchSecretBackendChanged(c *gc.C) {
 
 	s.watcherRegistry.EXPECT().Register(gomock.Any()).Return("11", nil)
 
-	result, err := s.facade.WatchSecretBackendChanged()
+	result, err := s.facade.WatchSecretBackendChanged(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.NotifyWatchResult{
 		NotifyWatcherId: "11",

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -4,6 +4,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -179,7 +180,7 @@ func ptr[T any](v T) *T {
 func (s *SecretsManagerSuite) TestGetSecretBackendConfigs(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.facade.GetSecretBackendConfigs(params.SecretBackendArgs{
+	result, err := s.facade.GetSecretBackendConfigs(context.Background(), params.SecretBackendArgs{
 		BackendIDs: []string{"backend-id"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -203,7 +204,7 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfigs(c *gc.C) {
 func (s *SecretsManagerSuite) TestGetSecretBackendConfigsForDrain(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.facade.GetSecretBackendConfigs(params.SecretBackendArgs{
+	result, err := s.facade.GetSecretBackendConfigs(context.Background(), params.SecretBackendArgs{
 		ForDrain:   true,
 		BackendIDs: []string{"backend-id"},
 	})
@@ -228,7 +229,7 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfigsForDrain(c *gc.C) {
 func (s *SecretsManagerSuite) TestCreateSecretURIs(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	results, err := s.facade.CreateSecretURIs(params.CreateSecretURIsArg{
+	results, err := s.facade.CreateSecretURIs(context.Background(), params.CreateSecretURIsArg{
 		Count: 2,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -277,7 +278,7 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 		},
 	)
 
-	results, err := s.facade.CreateSecrets(params.CreateSecretArgs{
+	results, err := s.facade.CreateSecrets(context.Background(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{{
 			OwnerTag: "application-mariadb",
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -329,7 +330,7 @@ func (s *SecretsManagerSuite) TestCreateSecretDuplicateLabel(c *gc.C) {
 		nil, fmt.Errorf("dup label %w", state.LabelExists),
 	)
 
-	results, err := s.facade.CreateSecrets(params.CreateSecretArgs{
+	results, err := s.facade.CreateSecrets(context.Background(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{{
 			OwnerTag: "application-mariadb",
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -391,7 +392,7 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{}, nil).Times(2)
 	s.expectSecretAccessQuery(4)
 
-	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
+	results, err := s.facade.UpdateSecrets(context.Background(), params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
 			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -445,7 +446,7 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{}, nil)
 	s.expectSecretAccessQuery(2)
 
-	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
+	results, err := s.facade.UpdateSecrets(context.Background(), params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
 			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -488,7 +489,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 
-	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := s.facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -511,7 +512,7 @@ func (s *SecretsManagerSuite) TestRemoveSecretRevision(c *gc.C) {
 	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(2)
 
-	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := s.facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -530,7 +531,7 @@ func (s *SecretsManagerSuite) TestRemoveSecretNotFound(c *gc.C) {
 	expectURI := *uri
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, errors.NotFoundf("not found"))
 
-	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := s.facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -551,7 +552,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingConsumerLa
 			Label:          "label",
 		}, nil)
 
-	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
+	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
 		URIs:        []string{uri.String()},
 	})
@@ -574,7 +575,7 @@ func (s *SecretsManagerSuite) TestGetConsumerRemoteSecretsRevisionInfo(c *gc.C) 
 			Label:          "label",
 		}, nil)
 
-	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
+	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
 		URIs:        []string{uri.String()},
 	})
@@ -601,7 +602,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingNoConsumer
 			OwnerTags: []names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")},
 		}).Return(nil, nil)
 
-	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
+	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
 		URIs:        []string{uri.String()},
 	})
@@ -631,7 +632,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoForPeerUnitsAcce
 		Label:    "owner-label",
 	}}, nil)
 
-	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
+	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
 		URIs:        []string{uri.String()},
 	})
@@ -675,7 +676,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 		Revision: 667,
 	}}, nil)
 
-	results, err := s.facade.GetSecretMetadata()
+	results, err := s.facade.GetSecretMetadata(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
@@ -703,7 +704,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 func (s *SecretsManagerSuite) TestGetSecretContentInvalidArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -732,7 +733,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretURIArg(c *gc.C) 
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -768,7 +769,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *gc.C
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "foo"},
 		},
@@ -811,7 +812,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForUnitOwnedSecretUpdateLabel(
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "foo"},
 		},
@@ -859,7 +860,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretUpdateLabel(c *gc.
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "foo"},
 		},
@@ -901,7 +902,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForUnitAccessApplicationOwnedS
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "foo"},
 		},
@@ -945,7 +946,7 @@ func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, isUnitAgen
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -984,7 +985,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "label"},
 		},
@@ -1030,7 +1031,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "label"},
 		},
@@ -1071,7 +1072,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateLabel(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "new-label"},
 		},
@@ -1090,7 +1091,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTimeUsingLabelFai
 	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetURIByConsumerLabel("label-1", names.NewUnitTag("mariadb/0")).Return(nil, errors.NotFoundf("secret"))
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "label-1"},
 		},
@@ -1124,7 +1125,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "label", Refresh: true},
 		},
@@ -1155,7 +1156,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerPeekArg(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Peek: true},
 		},
@@ -1206,7 +1207,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 			},
 		}, 666, true, nil)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -1277,7 +1278,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 		CurrentRevision: 665,
 	})
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "foo"},
 		},
@@ -1348,7 +1349,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 		CurrentRevision: 666,
 	})
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Refresh: true},
 		},
@@ -1417,7 +1418,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 		CurrentRevision: 666,
 	})
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Refresh: true},
 		},
@@ -1458,7 +1459,7 @@ func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	watchChan <- []string{uri.String()}
 	s.secretsWatcher.EXPECT().Changes().Return(watchChan)
 
-	result, err := s.facade.WatchConsumedSecretsChanges(params.Entities{
+	result, err := s.facade.WatchConsumedSecretsChanges(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1488,7 +1489,7 @@ func (s *SecretsManagerSuite) TestGetSecretRevisionContentInfo(c *gc.C) {
 		}, nil,
 	)
 
-	results, err := s.facade.GetSecretRevisionContentInfo(params.SecretRevisionArg{
+	results, err := s.facade.GetSecretRevisionContentInfo(context.Background(), params.SecretRevisionArg{
 		URI:       uri.String(),
 		Revisions: []int{666},
 	})
@@ -1531,7 +1532,7 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
 	watchChan <- []string{uri.String()}
 	s.secretsWatcher.EXPECT().Changes().Return(watchChan)
 
-	result, err := s.facade.WatchObsolete(params.Entities{
+	result, err := s.facade.WatchObsolete(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1565,7 +1566,7 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	}}
 	s.secretsTriggerWatcher.EXPECT().Changes().Return(rotateChan)
 
-	result, err := s.facade.WatchSecretsRotationChanges(params.Entities{
+	result, err := s.facade.WatchSecretsRotationChanges(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1594,7 +1595,7 @@ func (s *SecretsManagerSuite) TestSecretsRotated(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.Background(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.ID,
 			OriginalRevision: 666,
@@ -1627,7 +1628,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *gc.C) {
 		LatestRevision: 666,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.Background(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.ID,
 			OriginalRevision: 666,
@@ -1656,7 +1657,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedForce(c *gc.C) {
 		LatestRevision:   667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.Background(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.ID,
 			OriginalRevision: 666,
@@ -1682,7 +1683,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.Background(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.ID,
 			OriginalRevision: 666,
@@ -1715,7 +1716,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	}}
 	s.secretsTriggerWatcher.EXPECT().Changes().Return(expiryChan)
 
-	result, err := s.facade.WatchSecretRevisionsExpiryChanges(params.Entities{
+	result, err := s.facade.WatchSecretRevisionsExpiryChanges(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1752,7 +1753,7 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 
-	result, err := s.facade.SecretsGrant(params.GrantRevokeSecretArgs{
+	result, err := s.facade.SecretsGrant(context.Background(), params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
 			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),
@@ -1796,7 +1797,7 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 
-	result, err := s.facade.SecretsRevoke(params.GrantRevokeSecretArgs{
+	result, err := s.facade.SecretsRevoke(context.Background(), params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
 			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -4,6 +4,8 @@
 package storageprovisioner
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -223,7 +225,7 @@ func NewStorageProvisionerAPIv4(
 
 // WatchApplications starts a StringsWatcher to watch CAAS applications
 // deployed to this model.
-func (s *StorageProvisionerAPIv4) WatchApplications() (params.StringsWatchResult, error) {
+func (s *StorageProvisionerAPIv4) WatchApplications(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := s.st.WatchApplications()
 	if changes, ok := <-watch.Changes(); ok {
 		return params.StringsWatchResult{
@@ -235,7 +237,7 @@ func (s *StorageProvisionerAPIv4) WatchApplications() (params.StringsWatchResult
 }
 
 // WatchBlockDevices watches for changes to the specified machines' block devices.
-func (s *StorageProvisionerAPIv4) WatchBlockDevices(args params.Entities) (params.NotifyWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchBlockDevices(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	canAccess, err := s.getBlockDevicesAuthFunc()
 	if err != nil {
 		return params.NotifyWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -271,7 +273,7 @@ func (s *StorageProvisionerAPIv4) WatchBlockDevices(args params.Entities) (param
 }
 
 // WatchMachines watches for changes to the specified machines.
-func (s *StorageProvisionerAPIv4) WatchMachines(args params.Entities) (params.NotifyWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchMachines(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.NotifyWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -311,13 +313,13 @@ func (s *StorageProvisionerAPIv4) WatchMachines(args params.Entities) (params.No
 
 // WatchVolumes watches for changes to volumes scoped to the
 // entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchVolumes(args params.Entities) (params.StringsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumes(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	return s.watchStorageEntities(args, s.sb.WatchModelVolumes, s.sb.WatchMachineVolumes, nil)
 }
 
 // WatchFilesystems watches for changes to filesystems scoped
 // to the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchFilesystems(args params.Entities) (params.StringsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchFilesystems(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	w := filesystemwatcher.Watchers{s.sb}
 	return s.watchStorageEntities(args,
 		w.WatchModelManagedFilesystems,
@@ -376,7 +378,7 @@ func (s *StorageProvisionerAPIv4) watchStorageEntities(
 
 // WatchVolumeAttachments watches for changes to volume attachments scoped to
 // the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	return s.watchAttachments(
 		args,
 		s.sb.WatchModelVolumeAttachments,
@@ -388,7 +390,7 @@ func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(args params.Entities) (
 
 // WatchFilesystemAttachments watches for changes to filesystem attachments
 // scoped to the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	w := filesystemwatcher.Watchers{s.sb}
 	return s.watchAttachments(
 		args,
@@ -401,7 +403,7 @@ func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(args params.Entitie
 
 // WatchVolumeAttachmentPlans watches for changes to volume attachments for a machine for the purpose of allowing
 // that machine to run any initialization needed, for that volume to actually appear as a block device (ie: iSCSI)
-func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.MachineStorageIdsWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -444,7 +446,7 @@ func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(args params.Entitie
 	return results, nil
 }
 
-func (s *StorageProvisionerAPIv4) RemoveVolumeAttachmentPlan(args params.MachineStorageIds) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveVolumeAttachmentPlan(ctx context.Context, args params.MachineStorageIds) (params.ErrorResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -529,7 +531,7 @@ func (s *StorageProvisionerAPIv4) watchAttachments(
 }
 
 // Volumes returns details of volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) Volumes(args params.Entities) (params.VolumeResults, error) {
+func (s *StorageProvisionerAPIv4) Volumes(ctx context.Context, args params.Entities) (params.VolumeResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.VolumeResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -564,7 +566,7 @@ func (s *StorageProvisionerAPIv4) Volumes(args params.Entities) (params.VolumeRe
 }
 
 // Filesystems returns details of filesystems with the specified tags.
-func (s *StorageProvisionerAPIv4) Filesystems(args params.Entities) (params.FilesystemResults, error) {
+func (s *StorageProvisionerAPIv4) Filesystems(ctx context.Context, args params.Entities) (params.FilesystemResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.FilesystemResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -599,7 +601,7 @@ func (s *StorageProvisionerAPIv4) Filesystems(args params.Entities) (params.File
 }
 
 // VolumeAttachmentPlans returns details of volume attachment plans with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(args params.MachineStorageIds) (params.VolumeAttachmentPlanResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(ctx context.Context, args params.MachineStorageIds) (params.VolumeAttachmentPlanResults, error) {
 	// NOTE(gsamfira): Containers will probably not be a concern for this at the moment
 	// revisit this if containers should be treated
 	canAccess, err := s.getMachineAuthFunc()
@@ -630,7 +632,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(args params.MachineStora
 }
 
 // VolumeAttachments returns details of volume attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeAttachments(args params.MachineStorageIds) (params.VolumeAttachmentResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeAttachments(ctx context.Context, args params.MachineStorageIds) (params.VolumeAttachmentResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.VolumeAttachmentResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -660,7 +662,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachments(args params.MachineStorageId
 
 // VolumeBlockDevices returns details of the block devices corresponding to the
 // volume attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeBlockDevices(args params.MachineStorageIds) (params.BlockDeviceResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeBlockDevices(ctx context.Context, args params.MachineStorageIds) (params.BlockDeviceResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.BlockDeviceResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -689,7 +691,7 @@ func (s *StorageProvisionerAPIv4) VolumeBlockDevices(args params.MachineStorageI
 }
 
 // FilesystemAttachments returns details of filesystem attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) FilesystemAttachments(args params.MachineStorageIds) (params.FilesystemAttachmentResults, error) {
+func (s *StorageProvisionerAPIv4) FilesystemAttachments(ctx context.Context, args params.MachineStorageIds) (params.FilesystemAttachmentResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.FilesystemAttachmentResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -719,7 +721,7 @@ func (s *StorageProvisionerAPIv4) FilesystemAttachments(args params.MachineStora
 
 // VolumeParams returns the parameters for creating or destroying
 // the volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) VolumeParams(args params.Entities) (params.VolumeParamsResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeParams(ctx context.Context, args params.Entities) (params.VolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.VolumeParamsResults{}, err
@@ -815,7 +817,7 @@ func (s *StorageProvisionerAPIv4) VolumeParams(args params.Entities) (params.Vol
 
 // RemoveVolumeParams returns the parameters for destroying
 // or releasing the volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) RemoveVolumeParams(args params.Entities) (params.RemoveVolumeParamsResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveVolumeParams(ctx context.Context, args params.Entities) (params.RemoveVolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.RemoveVolumeParamsResults{}, err
@@ -871,7 +873,7 @@ func (s *StorageProvisionerAPIv4) RemoveVolumeParams(args params.Entities) (para
 
 // FilesystemParams returns the parameters for creating the filesystems
 // with the specified tags.
-func (s *StorageProvisionerAPIv4) FilesystemParams(args params.Entities) (params.FilesystemParamsResults, error) {
+func (s *StorageProvisionerAPIv4) FilesystemParams(ctx context.Context, args params.Entities) (params.FilesystemParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.FilesystemParamsResults{}, err
@@ -929,7 +931,7 @@ func (s *StorageProvisionerAPIv4) FilesystemParams(args params.Entities) (params
 
 // RemoveFilesystemParams returns the parameters for destroying or
 // releasing the filesystems with the specified tags.
-func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(args params.Entities) (params.RemoveFilesystemParamsResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(ctx context.Context, args params.Entities) (params.RemoveFilesystemParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.RemoveFilesystemParamsResults{}, err
@@ -986,6 +988,7 @@ func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(args params.Entities) (
 // VolumeAttachmentParams returns the parameters for creating the volume
 // attachments with the specified IDs.
 func (s *StorageProvisionerAPIv4) VolumeAttachmentParams(
+	ctx context.Context,
 	args params.MachineStorageIds,
 ) (params.VolumeAttachmentParamsResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
@@ -1069,6 +1072,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachmentParams(
 // FilesystemAttachmentParams returns the parameters for creating the filesystem
 // attachments with the specified IDs.
 func (s *StorageProvisionerAPIv4) FilesystemAttachmentParams(
+	ctx context.Context,
 	args params.MachineStorageIds,
 ) (params.FilesystemAttachmentParamsResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
@@ -1326,7 +1330,7 @@ func (s *StorageProvisionerAPIv4) SetVolumeInfo(args params.Volumes) (params.Err
 }
 
 // SetFilesystemInfo records the details of newly provisioned filesystems.
-func (s *StorageProvisionerAPIv4) SetFilesystemInfo(args params.Filesystems) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) SetFilesystemInfo(ctx context.Context, args params.Filesystems) (params.ErrorResults, error) {
 	canAccessFilesystem, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, err
@@ -1354,7 +1358,7 @@ func (s *StorageProvisionerAPIv4) SetFilesystemInfo(args params.Filesystems) (pa
 	return results, nil
 }
 
-func (s *StorageProvisionerAPIv4) CreateVolumeAttachmentPlans(args params.VolumeAttachmentPlans) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) CreateVolumeAttachmentPlans(ctx context.Context, args params.VolumeAttachmentPlans) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -1383,7 +1387,7 @@ func (s *StorageProvisionerAPIv4) CreateVolumeAttachmentPlans(args params.Volume
 	return results, nil
 }
 
-func (s *StorageProvisionerAPIv4) SetVolumeAttachmentPlanBlockInfo(args params.VolumeAttachmentPlans) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) SetVolumeAttachmentPlanBlockInfo(ctx context.Context, args params.VolumeAttachmentPlans) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -1415,6 +1419,7 @@ func (s *StorageProvisionerAPIv4) SetVolumeAttachmentPlanBlockInfo(args params.V
 // SetVolumeAttachmentInfo records the details of newly provisioned volume
 // attachments.
 func (s *StorageProvisionerAPIv4) SetVolumeAttachmentInfo(
+	ctx context.Context,
 	args params.VolumeAttachments,
 ) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
@@ -1448,6 +1453,7 @@ func (s *StorageProvisionerAPIv4) SetVolumeAttachmentInfo(
 // SetFilesystemAttachmentInfo records the details of newly provisioned filesystem
 // attachments.
 func (s *StorageProvisionerAPIv4) SetFilesystemAttachmentInfo(
+	ctx context.Context,
 	args params.FilesystemAttachments,
 ) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
@@ -1480,7 +1486,7 @@ func (s *StorageProvisionerAPIv4) SetFilesystemAttachmentInfo(
 
 // AttachmentLife returns the lifecycle state of each specified machine
 // storage attachment.
-func (s *StorageProvisionerAPIv4) AttachmentLife(args params.MachineStorageIds) (params.LifeResults, error) {
+func (s *StorageProvisionerAPIv4) AttachmentLife(ctx context.Context, args params.MachineStorageIds) (params.LifeResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.LifeResults{}, err
@@ -1527,7 +1533,7 @@ func (s *StorageProvisionerAPIv4) AttachmentLife(args params.MachineStorageIds) 
 }
 
 // Remove removes volumes and filesystems from state.
-func (s *StorageProvisionerAPIv4) Remove(args params.Entities) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) Remove(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, err
@@ -1563,7 +1569,7 @@ func (s *StorageProvisionerAPIv4) Remove(args params.Entities) (params.ErrorResu
 
 // RemoveAttachment removes the specified machine storage attachments
 // from state.
-func (s *StorageProvisionerAPIv4) RemoveAttachment(args params.MachineStorageIds) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveAttachment(ctx context.Context, args params.MachineStorageIds) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, err

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -293,7 +294,7 @@ func (s *iaasProvisionerSuite) TestHostedVolumes(c *gc.C) {
 	s.setupVolumes(c)
 	s.authorizer.Controller = false
 
-	results, err := s.api.Volumes(params.Entities{
+	results, err := s.api.Volumes(context.Background(), params.Entities{
 		Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -320,7 +321,7 @@ func (s *iaasProvisionerSuite) TestVolumesModel(c *gc.C) {
 	s.setupVolumes(c)
 	s.authorizer.Tag = names.NewMachineTag("2") // neither 0 nor 1
 
-	results, err := s.api.Volumes(params.Entities{
+	results, err := s.api.Volumes(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{"volume-1"},
@@ -348,7 +349,7 @@ func (s *iaasProvisionerSuite) TestVolumesModel(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestVolumesEmptyArgs(c *gc.C) {
-	results, err := s.api.Volumes(params.Entities{})
+	results, err := s.api.Volumes(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -357,7 +358,7 @@ func (s *iaasProvisionerSuite) TestFilesystems(c *gc.C) {
 	s.setupFilesystems(c)
 	s.authorizer.Tag = names.NewMachineTag("2") // neither 0 nor 1
 
-	results, err := s.api.Filesystems(params.Entities{
+	results, err := s.api.Filesystems(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{"filesystem-0-0"},
 			{"filesystem-1"},
@@ -395,7 +396,7 @@ func (s *iaasProvisionerSuite) TestVolumeAttachments(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.VolumeAttachments(params.MachineStorageIds{
+	results, err := s.api.VolumeAttachments(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -440,7 +441,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachments(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.FilesystemAttachments(params.MachineStorageIds{
+	results, err := s.api.FilesystemAttachments(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "filesystem-0-0",
@@ -475,7 +476,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachments(c *gc.C) {
 func (s *iaasProvisionerSuite) TestVolumeParams(c *gc.C) {
 	// Only IAAS models support block storage right now.
 	s.setupVolumes(c)
-	results, err := s.api.VolumeParams(params.Entities{
+	results, err := s.api.VolumeParams(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{"volume-1"},
@@ -538,7 +539,7 @@ func (s *iaasProvisionerSuite) TestVolumeParams(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
-	results, err := s.api.VolumeParams(params.Entities{})
+	results, err := s.api.VolumeParams(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -611,7 +612,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	err = s.storageBackend.RemoveVolumeAttachment(unitMachineTag, storageVolume.VolumeTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveVolumeParams(params.Entities{
+	results, err := s.api.RemoveVolumeParams(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{storageVolume.Tag().String()},
@@ -646,7 +647,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 
 func (s *iaasProvisionerSuite) TestFilesystemParams(c *gc.C) {
 	s.setupFilesystems(c)
-	results, err := s.api.FilesystemParams(params.Entities{
+	results, err := s.api.FilesystemParams(context.Background(), params.Entities{
 		Entities: []params.Entity{{"filesystem-0-0"}, {"filesystem-1"}, {"filesystem-42"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -737,7 +738,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	err = s.storageBackend.RemoveFilesystemAttachment(unitMachineTag, storageFilesystem.FilesystemTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveFilesystemParams(params.Entities{
+	results, err := s.api.RemoveFilesystemParams(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{"filesystem-0-0"},
 			{storageFilesystem.Tag().String()},
@@ -791,7 +792,7 @@ func (s *iaasProvisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.VolumeAttachmentParams(params.MachineStorageIds{
+	results, err := s.api.VolumeAttachmentParams(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -861,7 +862,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.FilesystemAttachmentParams(params.MachineStorageIds{
+	results, err := s.api.FilesystemAttachmentParams(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "filesystem-0-0",
@@ -916,7 +917,7 @@ func (s *iaasProvisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.SetVolumeAttachmentInfo(params.VolumeAttachments{
+	results, err := s.api.SetVolumeAttachmentInfo(context.Background(), params.VolumeAttachments{
 		VolumeAttachments: []params.VolumeAttachment{{
 			MachineTag: "machine-0",
 			VolumeTag:  "volume-0-0",
@@ -964,7 +965,7 @@ func (s *iaasProvisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.SetFilesystemAttachmentInfo(params.FilesystemAttachments{
+	results, err := s.api.SetFilesystemAttachmentInfo(context.Background(), params.FilesystemAttachments{
 		FilesystemAttachments: []params.FilesystemAttachment{{
 			MachineTag:    "machine-0",
 			FilesystemTag: "filesystem-0-0",
@@ -1019,7 +1020,7 @@ func (s *caasProvisionerSuite) TestWatchApplications(c *gc.C) {
 		},
 	})
 
-	result, err := s.api.WatchApplications()
+	result, err := s.api.WatchApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.StringsWatcherId, gc.Equals, "1")
 	c.Assert(result.Changes, jc.DeepEquals, []string{"mariadb"})
@@ -1053,7 +1054,7 @@ func (s *iaasProvisionerSuite) TestWatchVolumes(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchVolumes(args)
+	result, err := s.api.WatchVolumes(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(result.Results[1].Changes)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
@@ -1098,7 +1099,7 @@ func (s *iaasProvisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchVolumeAttachments(args)
+	result, err := s.api.WatchVolumeAttachments(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Sort(byMachineAndEntity(result.Results[0].Changes))
 	sort.Sort(byMachineAndEntity(result.Results[1].Changes))
@@ -1159,7 +1160,7 @@ func (s *iaasProvisionerSuite) TestWatchFilesystems(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchFilesystems(args)
+	result, err := s.api.WatchFilesystems(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(result.Results[1].Changes)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
@@ -1204,7 +1205,7 @@ func (s *iaasProvisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchFilesystemAttachments(args)
+	result, err := s.api.WatchFilesystemAttachments(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Sort(byMachineAndEntity(result.Results[0].Changes))
 	sort.Sort(byMachineAndEntity(result.Results[1].Changes))
@@ -1264,7 +1265,7 @@ func (s *iaasProvisionerSuite) TestWatchBlockDevices(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	results, err := s.api.WatchBlockDevices(args)
+	results, err := s.api.WatchBlockDevices(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -1326,7 +1327,7 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 		{MachineTag: "machine-42", AttachmentTag: "volume-42"},
 		{MachineTag: "application-mysql", AttachmentTag: "volume-1"},
 	}}
-	results, err := s.api.VolumeBlockDevices(args)
+	results, err := s.api.VolumeBlockDevices(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.BlockDeviceResults{
 		Results: []params.BlockDeviceResult{
@@ -1399,7 +1400,7 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevicesPlanBlockInfoSet(c *gc.C) {
 	args := params.MachineStorageIds{Ids: []params.MachineStorageId{
 		{MachineTag: "machine-0", AttachmentTag: "volume-0-0"},
 	}}
-	results, err := s.api.VolumeBlockDevices(args)
+	results, err := s.api.VolumeBlockDevices(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.BlockDeviceResults{
 		Results: []params.BlockDeviceResult{
@@ -1434,7 +1435,7 @@ func (s *iaasProvisionerSuite) TestAttachmentLife(c *gc.C) {
 	// TODO(axw) test filesystem attachment life
 	// TODO(axw) test Dying
 
-	results, err := s.api.AttachmentLife(params.MachineStorageIds{
+	results, err := s.api.AttachmentLife(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -1491,7 +1492,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumesController(c *gc.C) {
 	err = s.storageBackend.DestroyVolume(names.NewVolumeTag("1"), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.api.Remove(args)
+	result, err := s.api.Remove(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1519,7 +1520,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemsController(c *gc.C) {
 	err = s.storageBackend.DestroyFilesystem(names.NewFilesystemTag("1"), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.api.Remove(args)
+	result, err := s.api.Remove(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1549,7 +1550,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumesMachineAgent(c *gc.C) {
 	err = s.storageBackend.DestroyVolume(names.NewVolumeTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.api.Remove(args)
+	result, err := s.api.Remove(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1575,7 +1576,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 	err = s.storageBackend.RemoveFilesystemAttachment(names.NewMachineTag("0"), names.NewFilesystemTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.api.Remove(args)
+	result, err := s.api.Remove(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1596,7 +1597,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
 	err := s.storageBackend.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("1"), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveAttachment(params.MachineStorageIds{
+	results, err := s.api.RemoveAttachment(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -1629,7 +1630,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
 	err := s.storageBackend.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveAttachment(params.MachineStorageIds{
+	results, err := s.api.RemoveAttachment(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "filesystem-0-0",
@@ -1682,7 +1683,7 @@ func (s *caasProvisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 		{"environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{"unit-mysql-0"}},
 	}
-	result, err := s.api.WatchFilesystemAttachments(args)
+	result, err := s.api.WatchFilesystemAttachments(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Sort(byMachineAndEntity(result.Results[0].Changes))
 	sort.Sort(byMachineAndEntity(result.Results[1].Changes))
@@ -1730,7 +1731,7 @@ func (s *caasProvisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
 	err := s.storageBackend.DetachFilesystem(names.NewUnitTag("mariadb/0"), names.NewFilesystemTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveAttachment(params.MachineStorageIds{
+	results, err := s.api.RemoveAttachment(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "unit-mariadb-0",
 			AttachmentTag: "filesystem-0",
@@ -1769,7 +1770,7 @@ func (s *caasProvisionerSuite) TestRemoveFilesystemsApplicationAgent(c *gc.C) {
 	err = s.storageBackend.RemoveFilesystemAttachment(names.NewUnitTag("mariadb/0"), names.NewFilesystemTag("0"), false)
 	c.Assert(err, gc.ErrorMatches, "removing attachment of filesystem 0 from unit mariadb/0: filesystem attachment is not dying")
 
-	result, err := s.api.Remove(args)
+	result, err := s.api.Remove(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1800,7 +1801,7 @@ func (s *caasProvisionerSuite) TestFilesystemLife(c *gc.C) {
 func (s caasProvisionerSuite) TestFilesystemAttachmentLife(c *gc.C) {
 	s.setupFilesystems(c)
 
-	results, err := s.api.AttachmentLife(params.MachineStorageIds{
+	results, err := s.api.AttachmentLife(context.Background(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "unit-mariadb-0",
 			AttachmentTag: "filesystem-0",

--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -4,6 +4,8 @@
 package unitassigner
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -34,7 +36,7 @@ type API struct {
 
 // AssignUnits assigns the units with the given ids to the correct machine. The
 // error results are returned in the same order as the given entities.
-func (a *API) AssignUnits(args params.Entities) (params.ErrorResults, error) {
+func (a *API) AssignUnits(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
 	// state uses ids, but the API uses Tags, so we have to convert back and
@@ -77,7 +79,7 @@ func (a *API) AssignUnits(args params.Entities) (params.ErrorResults, error) {
 
 // WatchUnitAssignments returns a strings watcher that is notified when new unit
 // assignments are added to the db.
-func (a *API) WatchUnitAssignments() (params.StringsWatchResult, error) {
+func (a *API) WatchUnitAssignments(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := a.st.WatchForUnitAssignment()
 	if changes, ok := <-watch.Changes(); ok {
 		return params.StringsWatchResult{
@@ -90,6 +92,6 @@ func (a *API) WatchUnitAssignments() (params.StringsWatchResult, error) {
 
 // SetAgentStatus will set status for agents of Units passed in args, if one
 // of the args is not an Unit it will fail.
-func (a *API) SetAgentStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (a *API) SetAgentStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	return a.statusSetter.SetStatus(args)
 }

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -4,6 +4,8 @@
 package unitassigner
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,7 +23,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	f.results = []state.UnitAssignmentResult{{Unit: "foo/0"}}
 	api := API{st: f, res: common.NewResources()}
 	args := params.Entities{Entities: []params.Entity{{Tag: "unit-foo-0"}, {Tag: "unit-bar-1"}}}
-	res, err := api.AssignUnits(args)
+	res, err := api.AssignUnits(context.Background(), args)
 	c.Assert(f.ids, gc.DeepEquals, []string{"foo/0", "bar/1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 2)
@@ -34,7 +36,7 @@ func (testsuite) TestWatchUnitAssignment(c *gc.C) {
 	f := &fakeState{}
 	api := API{st: f, res: common.NewResources()}
 	f.ids = []string{"boo", "far"}
-	res, err := api.WatchUnitAssignments()
+	res, err := api.WatchUnitAssignments(context.Background())
 	c.Assert(f.watchCalled, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Changes, gc.DeepEquals, f.ids)
@@ -49,7 +51,7 @@ func (testsuite) TestSetStatus(c *gc.C) {
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{{Tag: "foo/0"}},
 	}
-	res, err := api.SetAgentStatus(args)
+	res, err := api.SetAgentStatus(context.Background(), args)
 	c.Assert(args, jc.DeepEquals, f.args)
 	c.Assert(res, jc.DeepEquals, f.res)
 	c.Assert(err, gc.Equals, f.err)

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/charm/v11"
@@ -475,7 +476,7 @@ func (s *uniterGoalStateSuite) assertInScope(c *gc.C, relUnit *state.RelationUni
 // goalStates call uniter.GoalStates API and compares the output with the
 // expected result.
 func testGoalStates(c *gc.C, thisUniter *uniter.UniterAPI, args params.Entities, expected params.GoalStateResults) {
-	result, err := thisUniter.GoalStates(args)
+	result, err := thisUniter.GoalStates(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	for i := range result.Results {
 		if result.Results[i].Error != nil {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -4,6 +4,7 @@
 package uniter
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -76,7 +77,7 @@ type UniterAPI struct {
 
 // OpenedMachinePortRangesByEndpoint returns the port ranges opened by each
 // unit on the provided machines grouped by application endpoint.
-func (u *UniterAPI) OpenedMachinePortRangesByEndpoint(args params.Entities) (params.OpenPortRangesByEndpointResults, error) {
+func (u *UniterAPI) OpenedMachinePortRangesByEndpoint(ctx context.Context, args params.Entities) (params.OpenPortRangesByEndpointResults, error) {
 	result := params.OpenPortRangesByEndpointResults{
 		Results: make([]params.OpenPortRangesByEndpointResult, len(args.Entities)),
 	}
@@ -129,7 +130,7 @@ func (u *UniterAPI) getOneMachineOpenedPortRanges(canAccess common.AuthFunc, mac
 }
 
 // OpenedPortRangesByEndpoint returns the port ranges opened by the unit.
-func (u *UniterAPI) OpenedPortRangesByEndpoint() (params.OpenPortRangesByEndpointResults, error) {
+func (u *UniterAPI) OpenedPortRangesByEndpoint(ctx context.Context) (params.OpenPortRangesByEndpointResults, error) {
 	result := params.OpenPortRangesByEndpointResults{
 		Results: make([]params.OpenPortRangesByEndpointResult, 1),
 	}
@@ -172,7 +173,7 @@ func (u *UniterAPI) OpenedPortRangesByEndpoint() (params.OpenPortRangesByEndpoin
 }
 
 // OpenedApplicationPortRangesByEndpoint returns the port ranges opened by each application.
-func (u *UniterAPI) OpenedApplicationPortRangesByEndpoint(entity params.Entity) (params.ApplicationOpenedPortsResults, error) {
+func (u *UniterAPI) OpenedApplicationPortRangesByEndpoint(ctx context.Context, entity params.Entity) (params.ApplicationOpenedPortsResults, error) {
 	result := params.ApplicationOpenedPortsResults{
 		Results: make([]params.ApplicationOpenedPortsResult, 1),
 	}
@@ -220,7 +221,7 @@ func (u *UniterAPI) applicationOpenedPortsForEndpoint(endpointName string, pgs [
 // AssignedMachine returns the machine tag for each given unit tag, or
 // an error satisfying params.IsCodeNotAssigned when a unit has no
 // assigned machine.
-func (u *UniterAPI) AssignedMachine(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) AssignedMachine(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -258,7 +259,7 @@ func (u *UniterAPI) getMachine(tag names.MachineTag) (*state.Machine, error) {
 }
 
 // PublicAddress returns the public address for each given unit, if set.
-func (u *UniterAPI) PublicAddress(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) PublicAddress(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -292,7 +293,7 @@ func (u *UniterAPI) PublicAddress(args params.Entities) (params.StringResults, e
 }
 
 // PrivateAddress returns the private address for each given unit, if set.
-func (u *UniterAPI) PrivateAddress(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) PrivateAddress(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -337,7 +338,7 @@ var getZone = func(st *state.State, tag names.Tag) (string, error) {
 }
 
 // AvailabilityZone returns the availability zone for each given unit, if applicable.
-func (u *UniterAPI) AvailabilityZone(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) AvailabilityZone(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	var results params.StringResults
 
 	canAccess, err := u.accessUnit()
@@ -374,7 +375,7 @@ func (u *UniterAPI) AvailabilityZone(args params.Entities) (params.StringResults
 }
 
 // Resolved returns the current resolved setting for each given unit.
-func (u *UniterAPI) Resolved(args params.Entities) (params.ResolvedModeResults, error) {
+func (u *UniterAPI) Resolved(ctx context.Context, args params.Entities) (params.ResolvedModeResults, error) {
 	result := params.ResolvedModeResults{
 		Results: make([]params.ResolvedModeResult, len(args.Entities)),
 	}
@@ -402,7 +403,7 @@ func (u *UniterAPI) Resolved(args params.Entities) (params.ResolvedModeResults, 
 }
 
 // ClearResolved removes any resolved setting from each given unit.
-func (u *UniterAPI) ClearResolved(args params.Entities) (params.ErrorResults, error) {
+func (u *UniterAPI) ClearResolved(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -431,7 +432,7 @@ func (u *UniterAPI) ClearResolved(args params.Entities) (params.ErrorResults, er
 
 // GetPrincipal returns the result of calling PrincipalName() and
 // converting it to a tag, on each given unit.
-func (u *UniterAPI) GetPrincipal(args params.Entities) (params.StringBoolResults, error) {
+func (u *UniterAPI) GetPrincipal(ctx context.Context, args params.Entities) (params.StringBoolResults, error) {
 	result := params.StringBoolResults{
 		Results: make([]params.StringBoolResult, len(args.Entities)),
 	}
@@ -464,7 +465,7 @@ func (u *UniterAPI) GetPrincipal(args params.Entities) (params.StringBoolResults
 
 // Destroy advances all given Alive units' lifecycles as far as
 // possible. See state/Unit.Destroy().
-func (u *UniterAPI) Destroy(args params.Entities) (params.ErrorResults, error) {
+func (u *UniterAPI) Destroy(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -492,7 +493,7 @@ func (u *UniterAPI) Destroy(args params.Entities) (params.ErrorResults, error) {
 }
 
 // DestroyAllSubordinates destroys all subordinates of each given unit.
-func (u *UniterAPI) DestroyAllSubordinates(args params.Entities) (params.ErrorResults, error) {
+func (u *UniterAPI) DestroyAllSubordinates(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -520,7 +521,7 @@ func (u *UniterAPI) DestroyAllSubordinates(args params.Entities) (params.ErrorRe
 }
 
 // HasSubordinates returns the whether each given unit has any subordinates.
-func (u *UniterAPI) HasSubordinates(args params.Entities) (params.BoolResults, error) {
+func (u *UniterAPI) HasSubordinates(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	result := params.BoolResults{
 		Results: make([]params.BoolResult, len(args.Entities)),
 	}
@@ -550,7 +551,7 @@ func (u *UniterAPI) HasSubordinates(args params.Entities) (params.BoolResults, e
 
 // CharmModifiedVersion returns the most CharmModifiedVersion for all given
 // units or applications.
-func (u *UniterAPI) CharmModifiedVersion(args params.Entities) (params.IntResults, error) {
+func (u *UniterAPI) CharmModifiedVersion(ctx context.Context, args params.Entities) (params.IntResults, error) {
 	results := params.IntResults{
 		Results: make([]params.IntResult, len(args.Entities)),
 	}
@@ -599,7 +600,7 @@ func (u *UniterAPI) charmModifiedVersion(tagStr string, canAccess func(names.Tag
 }
 
 // CharmURL returns the charm URL for all given units or applications.
-func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, error) {
+func (u *UniterAPI) CharmURL(ctx context.Context, args params.Entities) (params.StringBoolResults, error) {
 	result := params.StringBoolResults{
 		Results: make([]params.StringBoolResult, len(args.Entities)),
 	}
@@ -646,7 +647,7 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 
 // SetCharmURL sets the charm URL for each given unit. An error will
 // be returned if a unit is dead, or the charm URL is not known.
-func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResults, error) {
+func (u *UniterAPI) SetCharmURL(ctx context.Context, args params.EntitiesCharmURL) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -680,7 +681,7 @@ func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResul
 }
 
 // WorkloadVersion returns the workload version for all given units or applications.
-func (u *UniterAPI) WorkloadVersion(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) WorkloadVersion(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -716,7 +717,7 @@ func (u *UniterAPI) WorkloadVersion(args params.Entities) (params.StringResults,
 
 // SetWorkloadVersion sets the workload version for each given unit. An error will
 // be returned if a unit is dead.
-func (u *UniterAPI) SetWorkloadVersion(args params.EntityWorkloadVersions) (params.ErrorResults, error) {
+func (u *UniterAPI) SetWorkloadVersion(ctx context.Context, args params.EntityWorkloadVersions) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -752,7 +753,7 @@ func (u *UniterAPI) SetWorkloadVersion(args params.EntityWorkloadVersions) (para
 // It is implemented here directly as a result of removing it from
 // embedded APIAddresser *without* bumping the facade version.
 // It should be blanked when this facade version is next incremented.
-func (u *UniterAPI) ModelUUID() params.StringResult {
+func (u *UniterAPI) ModelUUID(ctx context.Context) params.StringResult {
 	return params.StringResult{Result: u.m.UUID()}
 }
 
@@ -760,7 +761,7 @@ func (u *UniterAPI) ModelUUID() params.StringResult {
 // incoming action calls to a unit. See also state/watcher.go
 // Unit.WatchActionNotifications(). This method is called from
 // api/uniter/uniter.go WatchActionNotifications().
-func (u *UniterAPI) WatchActionNotifications(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UniterAPI) WatchActionNotifications(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	tagToActionReceiver := common.TagToActionReceiverFn(u.st.FindEntity)
 	watchOne := common.WatchOneActionReceiverNotifications(tagToActionReceiver, u.resources.Register)
 	canAccess, err := u.accessUnit()
@@ -772,7 +773,7 @@ func (u *UniterAPI) WatchActionNotifications(args params.Entities) (params.Strin
 
 // ConfigSettings returns the complete set of application charm config
 // settings available to each given unit.
-func (u *UniterAPI) ConfigSettings(args params.Entities) (params.ConfigSettingsResults, error) {
+func (u *UniterAPI) ConfigSettings(ctx context.Context, args params.Entities) (params.ConfigSettingsResults, error) {
 	result := params.ConfigSettingsResults{
 		Results: make([]params.ConfigSettingsResult, len(args.Entities)),
 	}
@@ -814,7 +815,7 @@ func (u *UniterAPI) ConfigSettings(args params.Entities) (params.ConfigSettingsR
 
 // CharmArchiveSha256 returns the SHA256 digest of the charm archive
 // (bundle) data for each charm url in the given parameters.
-func (u *UniterAPI) CharmArchiveSha256(args params.CharmURLs) (params.StringResults, error) {
+func (u *UniterAPI) CharmArchiveSha256(ctx context.Context, args params.CharmURLs) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.URLs)),
 	}
@@ -839,7 +840,7 @@ func (u *UniterAPI) CharmArchiveSha256(args params.CharmURLs) (params.StringResu
 
 // Relation returns information about all given relation/unit pairs,
 // including their id, key and the local endpoint.
-func (u *UniterAPI) Relation(args params.RelationUnits) (params.RelationResults, error) {
+func (u *UniterAPI) Relation(ctx context.Context, args params.RelationUnits) (params.RelationResults, error) {
 	result := params.RelationResults{
 		Results: make([]params.RelationResult, len(args.RelationUnits)),
 	}
@@ -858,7 +859,7 @@ func (u *UniterAPI) Relation(args params.RelationUnits) (params.RelationResults,
 }
 
 // ActionStatus returns the status of Actions by Tags passed in.
-func (u *UniterAPI) ActionStatus(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) ActionStatus(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.StringResults{}, err
@@ -888,7 +889,7 @@ func (u *UniterAPI) ActionStatus(args params.Entities) (params.StringResults, er
 
 // Actions returns the Actions by Tags passed and ensures that the Unit asking
 // for them is the same Unit that has the Actions.
-func (u *UniterAPI) Actions(args params.Entities) (params.ActionResults, error) {
+func (u *UniterAPI) Actions(ctx context.Context, args params.Entities) (params.ActionResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.ActionResults{}, err
@@ -904,7 +905,7 @@ func (u *UniterAPI) Actions(args params.Entities) (params.ActionResults, error) 
 }
 
 // BeginActions marks the actions represented by the passed in Tags as running.
-func (u *UniterAPI) BeginActions(args params.Entities) (params.ErrorResults, error) {
+func (u *UniterAPI) BeginActions(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, err
@@ -920,7 +921,7 @@ func (u *UniterAPI) BeginActions(args params.Entities) (params.ErrorResults, err
 }
 
 // FinishActions saves the result of a completed Action
-func (u *UniterAPI) FinishActions(args params.ActionExecutionResults) (params.ErrorResults, error) {
+func (u *UniterAPI) FinishActions(ctx context.Context, args params.ActionExecutionResults) (params.ErrorResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, err
@@ -936,7 +937,7 @@ func (u *UniterAPI) FinishActions(args params.ActionExecutionResults) (params.Er
 }
 
 // LogActionsMessages records the log messages against the specified actions.
-func (u *UniterAPI) LogActionsMessages(args params.ActionMessageParams) (params.ErrorResults, error) {
+func (u *UniterAPI) LogActionsMessages(ctx context.Context, args params.ActionMessageParams) (params.ErrorResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, err
@@ -968,7 +969,7 @@ func (u *UniterAPI) LogActionsMessages(args params.ActionMessageParams) (params.
 // RelationById returns information about all given relations,
 // specified by their ids, including their key and the local
 // endpoint.
-func (u *UniterAPI) RelationById(args params.RelationIds) (params.RelationResults, error) {
+func (u *UniterAPI) RelationById(ctx context.Context, args params.RelationIds) (params.RelationResults, error) {
 	result := params.RelationResults{
 		Results: make([]params.RelationResult, len(args.RelationIds)),
 	}
@@ -983,7 +984,7 @@ func (u *UniterAPI) RelationById(args params.RelationIds) (params.RelationResult
 }
 
 // RelationsStatus returns for each unit the corresponding relation and status information.
-func (u *UniterAPI) RelationsStatus(args params.Entities) (params.RelationUnitStatusResults, error) {
+func (u *UniterAPI) RelationsStatus(ctx context.Context, args params.Entities) (params.RelationUnitStatusResults, error) {
 	result := params.RelationUnitStatusResults{
 		Results: make([]params.RelationUnitStatusResult, len(args.Entities)),
 	}
@@ -1052,7 +1053,7 @@ func (u *UniterAPI) RelationsStatus(args params.Entities) (params.RelationUnitSt
 }
 
 // Refresh retrieves the latest values for attributes on this unit.
-func (u *UniterAPI) Refresh(args params.Entities) (params.UnitRefreshResults, error) {
+func (u *UniterAPI) Refresh(ctx context.Context, args params.Entities) (params.UnitRefreshResults, error) {
 	result := params.UnitRefreshResults{
 		Results: make([]params.UnitRefreshResult, len(args.Entities)),
 	}
@@ -1098,7 +1099,7 @@ func (u *UniterAPI) getProviderID(unit *state.Unit) (string, error) {
 }
 
 // CurrentModel returns the name and UUID for the current juju model.
-func (u *UniterAPI) CurrentModel() (params.ModelResult, error) {
+func (u *UniterAPI) CurrentModel(ctx context.Context) (params.ModelResult, error) {
 	result := params.ModelResult{}
 	model, err := u.st.Model()
 	if err == nil {
@@ -1115,7 +1116,7 @@ func (u *UniterAPI) CurrentModel() (params.ModelResult, error) {
 // TODO(dimitern): Refactor the uniter to call this instead of calling
 // ModelConfig() just to get the provider type. Once we have machine
 // addresses, this might be completely unnecessary though.
-func (u *UniterAPI) ProviderType() (params.StringResult, error) {
+func (u *UniterAPI) ProviderType(ctx context.Context) (params.StringResult, error) {
 	result := params.StringResult{}
 	cfg, err := u.m.ModelConfig()
 	if err == nil {
@@ -1127,7 +1128,7 @@ func (u *UniterAPI) ProviderType() (params.StringResult, error) {
 // EnterScope ensures each unit has entered its scope in the relation,
 // for all of the given relation/unit pairs. See also
 // state.RelationUnit.EnterScope().
-func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, error) {
+func (u *UniterAPI) EnterScope(ctx context.Context, args params.RelationUnits) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.RelationUnits)),
 	}
@@ -1203,7 +1204,7 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 // LeaveScope signals each unit has left its scope in the relation,
 // for all of the given relation/unit pairs. See also
 // state.RelationUnit.LeaveScope().
-func (u *UniterAPI) LeaveScope(args params.RelationUnits) (params.ErrorResults, error) {
+func (u *UniterAPI) LeaveScope(ctx context.Context, args params.RelationUnits) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.RelationUnits)),
 	}
@@ -1232,7 +1233,7 @@ func (u *UniterAPI) LeaveScope(args params.RelationUnits) (params.ErrorResults, 
 // NOTE(achilleasa): Using this call to read application data is deprecated
 // and will not work for k8s charms (see LP1876097). Instead, clients should
 // use ReadLocalApplicationSettings.
-func (u *UniterAPI) ReadSettings(args params.RelationUnits) (params.SettingsResults, error) {
+func (u *UniterAPI) ReadSettings(ctx context.Context, args params.RelationUnits) (params.SettingsResults, error) {
 	result := params.SettingsResults{
 		Results: make([]params.SettingsResult, len(args.RelationUnits)),
 	}
@@ -1292,7 +1293,7 @@ func (u *UniterAPI) ReadSettings(args params.RelationUnits) (params.SettingsResu
 
 // ReadLocalApplicationSettings returns the local application settings for a
 // particular relation when invoked by the leader unit.
-func (u *UniterAPI) ReadLocalApplicationSettings(arg params.RelationUnit) (params.SettingsResult, error) {
+func (u *UniterAPI) ReadLocalApplicationSettings(ctx context.Context, arg params.RelationUnit) (params.SettingsResult, error) {
 	var res params.SettingsResult
 
 	unitTag, err := names.ParseUnitTag(arg.Unit)
@@ -1373,7 +1374,7 @@ func (u *UniterAPI) readLocalApplicationSettings(relTag string, appTag names.App
 
 // ReadRemoteSettings returns the remote settings of each given set of
 // relation/local unit/remote unit.
-func (u *UniterAPI) ReadRemoteSettings(args params.RelationUnitPairs) (params.SettingsResults, error) {
+func (u *UniterAPI) ReadRemoteSettings(ctx context.Context, args params.RelationUnitPairs) (params.SettingsResults, error) {
 	result := params.SettingsResults{
 		Results: make([]params.SettingsResult, len(args.RelationUnitPairs)),
 	}
@@ -1485,7 +1486,7 @@ func (u *UniterAPI) updateApplicationSettingsOp(rel *state.Relation, unit *state
 // WatchRelationUnits returns a RelationUnitsWatcher for observing
 // changes to every unit in the supplied relation that is visible to
 // the supplied unit. See also state/watcher.go:RelationUnit.Watch().
-func (u *UniterAPI) WatchRelationUnits(args params.RelationUnits) (params.RelationUnitsWatchResults, error) {
+func (u *UniterAPI) WatchRelationUnits(ctx context.Context, args params.RelationUnits) (params.RelationUnitsWatchResults, error) {
 	result := params.RelationUnitsWatchResults{
 		Results: make([]params.RelationUnitsWatchResult, len(args.RelationUnits)),
 	}
@@ -1509,7 +1510,7 @@ func (u *UniterAPI) WatchRelationUnits(args params.RelationUnits) (params.Relati
 }
 
 // SetRelationStatus updates the status of the specified relations.
-func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.ErrorResults, error) {
+func (u *UniterAPI) SetRelationStatus(ctx context.Context, args params.RelationStatusArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 
 	unitCache := make(map[string]*state.Unit)
@@ -1892,7 +1893,7 @@ func leadershipSettingsAccessorFactory(
 }
 
 // AddMetricBatches adds the metrics for the specified unit.
-func (u *UniterAPI) AddMetricBatches(args params.MetricBatchParams) (params.ErrorResults, error) {
+func (u *UniterAPI) AddMetricBatches(ctx context.Context, args params.MetricBatchParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Batches)),
 	}
@@ -1938,7 +1939,7 @@ func (u *UniterAPI) AddMetricBatches(args params.MetricBatchParams) (params.Erro
 // WatchUnitRelations methods.
 
 // SLALevel returns the model's SLA level.
-func (u *UniterAPI) SLALevel() (params.StringResult, error) {
+func (u *UniterAPI) SLALevel(ctx context.Context) (params.StringResult, error) {
 	result := params.StringResult{}
 	sla, err := u.st.SLALevel()
 	if err == nil {
@@ -1948,7 +1949,7 @@ func (u *UniterAPI) SLALevel() (params.StringResult, error) {
 }
 
 // NetworkInfo returns network interfaces/addresses for specified bindings.
-func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
+func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.NetworkInfoResults{}, err
@@ -1980,7 +1981,7 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 // relevant to that unit. For principal units, this will be all of the
 // relations for the application. For subordinate units, only
 // relations with the principal unit's application will be monitored.
-func (u *UniterAPI) WatchUnitRelations(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UniterAPI) WatchUnitRelations(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -2060,7 +2061,7 @@ func makeAppAuthChecker(authTag names.Tag) common.AuthFunc {
 // authenticated unit or application resides.
 // A check is made beforehand to ensure that the request is made by an entity
 // that has been granted the appropriate trust.
-func (u *UniterAPI) CloudSpec() (params.CloudSpecResult, error) {
+func (u *UniterAPI) CloudSpec(ctx context.Context) (params.CloudSpecResult, error) {
 	canAccess, err := u.accessCloudSpec()
 	if err != nil {
 		return params.CloudSpecResult{}, err
@@ -2073,7 +2074,7 @@ func (u *UniterAPI) CloudSpec() (params.CloudSpecResult, error) {
 }
 
 // GoalStates returns information of charm units and relations.
-func (u *UniterAPI) GoalStates(args params.Entities) (params.GoalStateResults, error) {
+func (u *UniterAPI) GoalStates(ctx context.Context, args params.Entities) (params.GoalStateResults, error) {
 	result := params.GoalStateResults{
 		Results: make([]params.GoalStateResult, len(args.Entities)),
 	}
@@ -2263,7 +2264,7 @@ func (u *UniterAPI) goalStateUnits(app *state.Application, principalName string)
 // save this hash and use it to decide whether the config-changed hook
 // needs to be run (or whether this was just an agent restart with no
 // substantive config change).
-func (u *UniterAPI) WatchConfigSettingsHash(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UniterAPI) WatchConfigSettingsHash(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	getWatcher := func(unit *state.Unit) (state.StringsWatcher, error) {
 		return unit.WatchConfigSettingsHash()
 	}
@@ -2278,7 +2279,7 @@ func (u *UniterAPI) WatchConfigSettingsHash(args params.Entities) (params.String
 // hash of the application config values whenever they change. The
 // uniter can use the hash to determine whether the actual values have
 // changed since it last saw the config.
-func (u *UniterAPI) WatchTrustConfigSettingsHash(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UniterAPI) WatchTrustConfigSettingsHash(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	getWatcher := func(unit *state.Unit) (state.StringsWatcher, error) {
 		return unit.WatchApplicationConfigSettingsHash()
 	}
@@ -2293,7 +2294,7 @@ func (u *UniterAPI) WatchTrustConfigSettingsHash(args params.Entities) (params.S
 // hashes of the addresses for the unit whenever the addresses
 // change. The uniter can use the hash to determine whether the actual
 // address values have changed since it last saw the config.
-func (u *UniterAPI) WatchUnitAddressesHash(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UniterAPI) WatchUnitAddressesHash(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	getWatcher := func(unit *state.Unit) (state.StringsWatcher, error) {
 		if !unit.ShouldBeAssigned() {
 			app, err := unit.Application()
@@ -2355,7 +2356,7 @@ func (u *UniterAPI) watchOneUnitHashes(tag names.UnitTag, getWatcher func(u *sta
 }
 
 // CloudAPIVersion returns the cloud API version, if available.
-func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
+func (u *UniterAPI) CloudAPIVersion(ctx context.Context) (params.StringResult, error) {
 	result := params.StringResult{}
 
 	configGetter := stateenvirons.EnvironConfigGetter{Model: u.m, NewContainerBroker: u.containerBrokerFunc}
@@ -2373,7 +2374,7 @@ func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
 
 // UpdateNetworkInfo refreshes the network settings for a unit's bound
 // endpoints.
-func (u *UniterAPI) UpdateNetworkInfo(args params.Entities) (params.ErrorResults, error) {
+func (u *UniterAPI) UpdateNetworkInfo(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -2465,7 +2466,7 @@ func (u *UniterAPI) updateUnitNetworkInfoOperation(unitTag names.UnitTag, unit *
 // CommitHookChanges batches together all required API calls for applying
 // a set of changes after a hook successfully completes and executes them in a
 // single transaction.
-func (u *UniterAPI) CommitHookChanges(args params.CommitHookChangesArgs) (params.ErrorResults, error) {
+func (u *UniterAPI) CommitHookChanges(ctx context.Context, args params.CommitHookChangesArgs) (params.ErrorResults, error) {
 	canAccessUnit, err := u.accessUnit()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -2634,7 +2635,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 
 	// TODO - do in txn once we have support for that
 	if len(changes.SecretDeletes) > 0 {
-		result, err := u.SecretsManagerAPI.RemoveSecrets(params.DeleteSecretArgs{Args: changes.SecretDeletes})
+		result, err := u.SecretsManagerAPI.RemoveSecrets(context.Background(), params.DeleteSecretArgs{Args: changes.SecretDeletes})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2643,7 +2644,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 	}
 	if len(changes.SecretCreates) > 0 {
-		result, err := u.SecretsManagerAPI.CreateSecrets(params.CreateSecretArgs{Args: changes.SecretCreates})
+		result, err := u.SecretsManagerAPI.CreateSecrets(context.Background(), params.CreateSecretArgs{Args: changes.SecretCreates})
 		if err == nil {
 			var errorStrings []string
 			for _, r := range result.Results {
@@ -2660,7 +2661,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 	}
 	if len(changes.SecretUpdates) > 0 {
-		result, err := u.SecretsManagerAPI.UpdateSecrets(params.UpdateSecretArgs{Args: changes.SecretUpdates})
+		result, err := u.SecretsManagerAPI.UpdateSecrets(context.Background(), params.UpdateSecretArgs{Args: changes.SecretUpdates})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2669,7 +2670,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 	}
 	if len(changes.SecretGrants) > 0 {
-		result, err := u.SecretsManagerAPI.SecretsGrant(params.GrantRevokeSecretArgs{Args: changes.SecretGrants})
+		result, err := u.SecretsManagerAPI.SecretsGrant(context.Background(), params.GrantRevokeSecretArgs{Args: changes.SecretGrants})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2678,7 +2679,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 	}
 	if len(changes.SecretRevokes) > 0 {
-		result, err := u.SecretsManagerAPI.SecretsRevoke(params.GrantRevokeSecretArgs{Args: changes.SecretRevokes})
+		result, err := u.SecretsManagerAPI.SecretsRevoke(context.Background(), params.GrantRevokeSecretArgs{Args: changes.SecretRevokes})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2692,27 +2693,27 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 }
 
 // WatchInstanceData is a shim to call the LXDProfileAPIv2 version of this method.
-func (u *UniterAPI) WatchInstanceData(args params.Entities) (params.NotifyWatchResults, error) {
+func (u *UniterAPI) WatchInstanceData(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	return u.lxdProfileAPI.WatchInstanceData(args)
 }
 
 // LXDProfileName is a shim to call the LXDProfileAPIv2 version of this method.
-func (u *UniterAPI) LXDProfileName(args params.Entities) (params.StringResults, error) {
+func (u *UniterAPI) LXDProfileName(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	return u.lxdProfileAPI.LXDProfileName(args)
 }
 
 // LXDProfileRequired is a shim to call the LXDProfileAPIv2 version of this method.
-func (u *UniterAPI) LXDProfileRequired(args params.CharmURLs) (params.BoolResults, error) {
+func (u *UniterAPI) LXDProfileRequired(ctx context.Context, args params.CharmURLs) (params.BoolResults, error) {
 	return u.lxdProfileAPI.LXDProfileRequired(args)
 }
 
 // CanApplyLXDProfile is a shim to call the LXDProfileAPIv2 version of this method.
-func (u *UniterAPI) CanApplyLXDProfile(args params.Entities) (params.BoolResults, error) {
+func (u *UniterAPI) CanApplyLXDProfile(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	return u.lxdProfileAPI.CanApplyLXDProfile(args)
 }
 
 // APIHostPorts returns the API server addresses.
-func (u *UniterAPI) APIHostPorts() (result params.APIHostPortsResult, err error) {
+func (u *UniterAPI) APIHostPorts(ctx context.Context) (result params.APIHostPortsResult, err error) {
 	controllerConfig, err := u.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -2722,7 +2723,7 @@ func (u *UniterAPI) APIHostPorts() (result params.APIHostPortsResult, err error)
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (u *UniterAPI) APIAddresses() (result params.StringsResult, err error) {
+func (u *UniterAPI) APIAddresses(ctx context.Context) (result params.StringsResult, err error) {
 	controllerConfig, err := u.st.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -556,7 +556,7 @@ func (s *uniterSuite) TestPublicAddress(c *gc.C) {
 		Code:    params.CodeNoAddressSet,
 		Message: `"unit-wordpress-0" has no public address set`,
 	}
-	result, err := s.uniter.PublicAddress(args)
+	result, err := s.uniter.PublicAddress(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -575,7 +575,7 @@ func (s *uniterSuite) TestPublicAddress(c *gc.C) {
 	c.Assert(address.Value, gc.Equals, "1.2.3.4")
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err = s.uniter.PublicAddress(args)
+	result, err = s.uniter.PublicAddress(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -596,7 +596,7 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 		Code:    params.CodeNoAddressSet,
 		Message: `"unit-wordpress-0" has no private address set`,
 	}
-	result, err := s.uniter.PrivateAddress(args)
+	result, err := s.uniter.PrivateAddress(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -615,7 +615,7 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 	c.Assert(address.Value, gc.Equals, "1.2.3.4")
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err = s.uniter.PrivateAddress(args)
+	result, err = s.uniter.PrivateAddress(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -657,7 +657,7 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 		IngressAddresses: []string{privateAddress.Value},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -675,7 +675,7 @@ func (s *uniterSuite) TestAvailabilityZone(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-wordpress-0"},
 	}}
-	result, err := s.uniter.AvailabilityZone(args)
+	result, err := s.uniter.AvailabilityZone(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result, gc.DeepEquals, params.StringResults{
@@ -696,7 +696,7 @@ func (s *uniterSuite) TestResolvedAPIV6(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.Resolved(args)
+	result, err := s.uniter.Resolved(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ResolvedModeResults{
 		Results: []params.ResolvedModeResult{
@@ -718,7 +718,7 @@ func (s *uniterSuite) TestClearResolved(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.ClearResolved(args)
+	result, err := s.uniter.ClearResolved(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -750,7 +750,7 @@ func (s *uniterSuite) TestGetPrincipal(c *gc.C) {
 		{Tag: subordinate.Tag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.GetPrincipal(args)
+	result, err := s.uniter.GetPrincipal(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
@@ -766,7 +766,7 @@ func (s *uniterSuite) TestGetPrincipal(c *gc.C) {
 	subAuthorizer.Tag = subordinate.Tag()
 	subUniter := s.newUniterAPI(c, s.ControllerModel(c).State(), subAuthorizer)
 
-	result, err = subUniter.GetPrincipal(args)
+	result, err = subUniter.GetPrincipal(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
@@ -786,7 +786,7 @@ func (s *uniterSuite) TestHasSubordinates(c *gc.C) {
 		{Tag: "unit-logging-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.HasSubordinates(args)
+	result, err := s.uniter.HasSubordinates(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -801,7 +801,7 @@ func (s *uniterSuite) TestHasSubordinates(c *gc.C) {
 	s.addRelatedApplication(c, "wordpress", "logging", s.wordpressUnit)
 	s.addRelatedApplication(c, "wordpress", "monitoring", s.wordpressUnit)
 
-	result, err = s.uniter.HasSubordinates(args)
+	result, err = s.uniter.HasSubordinates(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -821,7 +821,7 @@ func (s *uniterSuite) TestDestroy(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.Destroy(args)
+	result, err := s.uniter.Destroy(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -853,7 +853,7 @@ func (s *uniterSuite) TestDestroyAllSubordinates(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.DestroyAllSubordinates(args)
+	result, err := s.uniter.DestroyAllSubordinates(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -897,7 +897,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 		// tags, not strings, which is coming soon.
 		// {Tag: "just-foo"},
 	}}
-	result, err := s.uniter.CharmURL(args)
+	result, err := s.uniter.CharmURL(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
@@ -922,7 +922,7 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 		{Tag: "unit-wordpress-0", CharmURL: s.wpCharm.String()},
 		{Tag: "unit-foo-42", CharmURL: "ch:amd64/quantal/foo-321"},
 	}}
-	result, err := s.uniter.SetCharmURL(args)
+	result, err := s.uniter.SetCharmURL(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -957,7 +957,7 @@ func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {
 		{Tag: "just-foo"},
 	}}
 
-	result, err := s.uniter.WorkloadVersion(args)
+	result, err := s.uniter.WorkloadVersion(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -980,7 +980,7 @@ func (s *uniterSuite) TestSetWorkloadVersion(c *gc.C) {
 		{Tag: "unit-wordpress-0", WorkloadVersion: "shiro"},
 		{Tag: "unit-foo-42", WorkloadVersion: "pidge"},
 	}}
-	result, err := s.uniter.SetWorkloadVersion(args)
+	result, err := s.uniter.SetWorkloadVersion(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1005,7 +1005,7 @@ func (s *uniterSuite) TestCharmModifiedVersion(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "application-foo"},
 	}}
-	result, err := s.uniter.CharmModifiedVersion(args)
+	result, err := s.uniter.CharmModifiedVersion(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.IntResults{
 		Results: []params.IntResult{
@@ -1029,7 +1029,7 @@ func (s *uniterSuite) TestWatchConfigSettingsHash(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.WatchConfigSettingsHash(args)
+	result, err := s.uniter.WatchConfigSettingsHash(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -1069,7 +1069,7 @@ func (s *uniterSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.WatchTrustConfigSettingsHash(args)
+	result, err := s.uniter.WatchTrustConfigSettingsHash(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -1110,7 +1110,7 @@ func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 		{Tag: wrongAction.Tag().String(), Value: "world"},
 		{Tag: "foo-42", Value: "mars"},
 	}}
-	result, err := s.uniter.LogActionsMessages(args)
+	result, err := s.uniter.LogActionsMessages(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1142,7 +1142,7 @@ func (s *uniterSuite) TestLogActionMessageAborting(c *gc.C) {
 	args := params.ActionMessageParams{Messages: []params.EntityString{
 		{Tag: anAction.Tag().String(), Value: "hello"},
 	}}
-	result, err := s.uniter.LogActionsMessages(args)
+	result, err := s.uniter.LogActionsMessages(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1168,7 +1168,7 @@ func (s *uniterSuite) TestWatchActionNotifications(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.WatchActionNotifications(args)
+	result, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -1222,7 +1222,7 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 	}}
 
-	results, err := s.uniter.WatchActionNotifications(args)
+	results, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkUnorderedActionIdsEqual(c, []string{action1.Id(), action2.Id()}, results)
@@ -1247,7 +1247,7 @@ func (s *uniterSuite) TestWatchActionNotificationsMalformedTag(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "ewenit-mysql-0"},
 	}}
-	results, err := s.uniter.WatchActionNotifications(args)
+	results, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.NotNil)
 	c.Assert(len(results.Results), gc.Equals, 1)
@@ -1260,7 +1260,7 @@ func (s *uniterSuite) TestWatchActionNotificationsMalformedUnitName(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-mysql-01"},
 	}}
-	results, err := s.uniter.WatchActionNotifications(args)
+	results, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.NotNil)
 	c.Assert(len(results.Results), gc.Equals, 1)
@@ -1277,7 +1277,7 @@ func (s *uniterSuite) TestWatchActionNotificationsNotUnit(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: action.Tag().String()},
 	}}
-	results, err := s.uniter.WatchActionNotifications(args)
+	results, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.NotNil)
 	c.Assert(len(results.Results), gc.Equals, 1)
@@ -1290,7 +1290,7 @@ func (s *uniterSuite) TestWatchActionNotificationsPermissionDenied(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-nonexistentgarbage-0"},
 	}}
-	results, err := s.uniter.WatchActionNotifications(args)
+	results, err := s.uniter.WatchActionNotifications(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.NotNil)
 	c.Assert(len(results.Results), gc.Equals, 1)
@@ -1300,7 +1300,7 @@ func (s *uniterSuite) TestWatchActionNotificationsPermissionDenied(c *gc.C) {
 }
 
 func (s *uniterSuite) TestConfigSettings(c *gc.C) {
-	res, err := s.uniter.SetCharmURL(params.EntitiesCharmURL{
+	res, err := s.uniter.SetCharmURL(stdcontext.Background(), params.EntitiesCharmURL{
 		Entities: []params.EntityCharmURL{
 			{
 				Tag:      s.wordpressUnit.Tag().String(),
@@ -1321,7 +1321,7 @@ func (s *uniterSuite) TestConfigSettings(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := s.uniter.ConfigSettings(args)
+	result, err := s.uniter.ConfigSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ConfigSettingsResults{
 		Results: []params.ConfigSettingsResult{
@@ -1340,7 +1340,7 @@ func (s *uniterSuite) TestWatchUnitRelations(c *gc.C) {
 		{Tag: "unit-wordpress-0"},
 		{Tag: "unit-foo-0"},
 	}}
-	result, err := s.uniter.WatchUnitRelations(args)
+	result, err := s.uniter.WatchUnitRelations(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
@@ -1382,7 +1382,7 @@ func (s *uniterSuite) TestWatchSubordinateUnitRelations(c *gc.C) {
 	subAuthorizer.Tag = mysqlLogUnit.Tag()
 	uniterAPI := s.newUniterAPI(c, s.ControllerModel(c).State(), subAuthorizer)
 
-	result, err := uniterAPI.WatchUnitRelations(params.Entities{
+	result, err := uniterAPI.WatchUnitRelations(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: mysqlLogUnit.Tag().String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1450,7 +1450,7 @@ func (s *uniterSuite) TestWatchUnitRelationsSubordinateWithGlobalEndpoint(c *gc.
 	subAuthorizer.Tag = mysqlLogUnit.Tag()
 	uniterAPI := s.newUniterAPI(c, s.ControllerModel(c).State(), subAuthorizer)
 
-	result, err := uniterAPI.WatchUnitRelations(params.Entities{
+	result, err := uniterAPI.WatchUnitRelations(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: mysqlLogUnit.Tag().String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1512,7 +1512,7 @@ func (s *uniterSuite) TestWatchUnitRelationsWithSubSubRelation(c *gc.C) {
 	subAuthorizer.Tag = monUnit.Tag()
 	uniterAPI := s.newUniterAPI(c, s.ControllerModel(c).State(), subAuthorizer)
 
-	result, err := uniterAPI.WatchUnitRelations(params.Entities{
+	result, err := uniterAPI.WatchUnitRelations(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: monUnit.Tag().String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1601,7 +1601,7 @@ func (s *uniterSuite) TestCharmArchiveSha256(c *gc.C) {
 		{URL: s.wpCharm.String()},
 		{URL: dummyCharm.String()},
 	}}
-	result, err := s.uniter.CharmArchiveSha256(args)
+	result, err := s.uniter.CharmArchiveSha256(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -1614,7 +1614,7 @@ func (s *uniterSuite) TestCharmArchiveSha256(c *gc.C) {
 
 func (s *uniterSuite) TestCurrentModel(c *gc.C) {
 	model := s.ControllerModel(c)
-	result, err := s.uniter.CurrentModel()
+	result, err := s.uniter.CurrentModel(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	expected := params.ModelResult{
 		Name: model.Name(),
@@ -1679,7 +1679,7 @@ func (s *uniterSuite) TestActions(c *gc.C) {
 				Tag: actionTag.String(),
 			}},
 		}
-		results, err := s.uniter.Actions(args)
+		results, err := s.uniter.Actions(stdcontext.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(results.Results, gc.HasLen, 1)
 
@@ -1697,7 +1697,7 @@ func (s *uniterSuite) TestActionsNotPresent(c *gc.C) {
 			Tag: names.NewActionTag(uuid.String()).String(),
 		}},
 	}
-	results, err := s.uniter.Actions(args)
+	results, err := s.uniter.Actions(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -1722,7 +1722,7 @@ func (s *uniterSuite) TestActionsWrongUnit(c *gc.C) {
 			Tag: action.Tag().String(),
 		}},
 	}
-	actions, err := mysqlUnitFacade.Actions(args)
+	actions, err := mysqlUnitFacade.Actions(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(actions.Results), gc.Equals, 1)
 	c.Assert(actions.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
@@ -1738,7 +1738,7 @@ func (s *uniterSuite) TestActionsPermissionDenied(c *gc.C) {
 			Tag: action.Tag().String(),
 		}},
 	}
-	actions, err := s.uniter.Actions(args)
+	actions, err := s.uniter.Actions(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(actions.Results), gc.Equals, 1)
 	c.Assert(actions.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
@@ -1764,7 +1764,7 @@ func (s *uniterSuite) TestFinishActionsSuccess(c *gc.C) {
 			Results:   testOutput,
 		}},
 	}
-	res, err := s.uniter.FinishActions(actionResults)
+	res, err := s.uniter.FinishActions(stdcontext.Background(), actionResults)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 
@@ -1799,7 +1799,7 @@ func (s *uniterSuite) TestFinishActionsFailure(c *gc.C) {
 			Message:   testError,
 		}},
 	}
-	res, err := s.uniter.FinishActions(actionResults)
+	res, err := s.uniter.FinishActions(stdcontext.Background(), actionResults)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 
@@ -1841,7 +1841,7 @@ func (s *uniterSuite) TestFinishActionsAuthAccess(c *gc.C) {
 	}
 
 	// Invoke FinishActions
-	res, err := s.uniter.FinishActions(actionResults)
+	res, err := s.uniter.FinishActions(stdcontext.Background(), actionResults)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify permissions errors for actions queued on different unit
@@ -1868,7 +1868,7 @@ func (s *uniterSuite) TestBeginActions(c *gc.C) {
 	c.Assert(len(running), gc.Equals, 0, gc.Commentf("expected no running actions, got %d", len(running)))
 
 	args := params.Entities{Entities: []params.Entity{{Tag: good.ActionTag().String()}}}
-	res, err := s.uniter.BeginActions(args)
+	res, err := s.uniter.BeginActions(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(res.Results), gc.Equals, 1)
 	c.Assert(res.Results[0].Error, gc.IsNil)
@@ -1898,7 +1898,7 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 		{Relation: "foo", Unit: "bar"},
 		{Relation: "unit-wordpress-0", Unit: rel.Tag().String()},
 	}}
-	result, err := s.uniter.Relation(args)
+	result, err := s.uniter.Relation(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
@@ -1937,7 +1937,7 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 	args := params.RelationIds{
 		RelationIds: []int{-1, rel.Id(), otherRel.Id(), 42, 234},
 	}
-	result, err := s.uniter.RelationById(args)
+	result, err := s.uniter.RelationById(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResults{
 		Results: []params.RelationResult{
@@ -1964,7 +1964,7 @@ func (s *uniterSuite) TestProviderType(c *gc.C) {
 	cfg, err := s.ControllerModel(c).ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.uniter.ProviderType()
+	result, err := s.uniter.ProviderType(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResult{Result: cfg.Type()})
 }
@@ -1994,7 +1994,7 @@ func (s *uniterSuite) TestEnterScope(c *gc.C) {
 		{Relation: rel.Tag().String(), Unit: "application-mysql"},
 		{Relation: rel.Tag().String(), Unit: "user-foo"},
 	}}
-	result, err := s.uniter.EnterScope(args)
+	result, err := s.uniter.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -2083,7 +2083,7 @@ func (s *uniterSuite) TestEnterScopeIgnoredForInvalidPrincipals(c *gc.C) {
 		Relation: mysqlRel.Tag().String(),
 		Unit:     wpLoggingU.Tag().String(),
 	}}}
-	result, err := uniterAPI.EnterScope(args)
+	result, err := uniterAPI.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
@@ -2126,7 +2126,7 @@ func (s *uniterSuite) TestLeaveScope(c *gc.C) {
 		{Relation: rel.Tag().String(), Unit: "application-mysql"},
 		{Relation: rel.Tag().String(), Unit: "user-foo"},
 	}}
-	result, err := s.uniter.LeaveScope(args)
+	result, err := s.uniter.LeaveScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -2200,7 +2200,7 @@ func (s *uniterSuite) TestRelationsSuspended(c *gc.C) {
 		},
 	}
 	check := func() {
-		result, err := s.uniter.RelationsStatus(args)
+		result, err := s.uniter.RelationsStatus(stdcontext.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result, gc.DeepEquals, expect)
 	}
@@ -2223,7 +2223,7 @@ func (s *uniterSuite) TestSetRelationsStatusNotLeader(c *gc.C) {
 			{s.wordpressUnit.Tag().String(), rel.Id(), params.Suspended, "message"},
 		},
 	}
-	result, err := s.uniter.SetRelationStatus(args)
+	result, err := s.uniter.SetRelationStatus(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), gc.ErrorMatches, `"wordpress/0" is not leader of "wordpress"`)
 }
@@ -2285,7 +2285,7 @@ func (s *uniterSuite) TestSetRelationsStatusLeader(c *gc.C) {
 
 	s.leadershipChecker.isLeader = true
 
-	result, err := s.uniter.SetRelationStatus(args)
+	result, err := s.uniter.SetRelationStatus(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expect)
 	check(rel, status.Suspended, "message")
@@ -2323,7 +2323,7 @@ func (s *uniterSuite) TestReadSettings(c *gc.C) {
 		{Relation: rel.Tag().String(), Unit: "application-mysql"},
 		{Relation: rel.Tag().String(), Unit: "user-foo"},
 	}}
-	result, err := s.uniter.ReadSettings(args)
+	result, err := s.uniter.ReadSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2367,7 +2367,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationWhenNotLeader(c *gc.C) {
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: rel.Tag().String(), Unit: "application-wordpress"},
 	}}
-	result, err := s.uniter.ReadSettings(args)
+	result, err := s.uniter.ReadSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2412,7 +2412,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationInPeerRelation(c *gc.C) {
 		Relation: rel.Tag().String(),
 		Unit:     "application-riak",
 	}}}
-	result, err := uniter.ReadSettings(args)
+	result, err := uniter.ReadSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2444,7 +2444,7 @@ func (s *uniterSuite) TestReadLocalApplicationSettingsWhenNotLeader(c *gc.C) {
 		Relation: rel.Tag().String(),
 		Unit:     "unit-wordpress-1",
 	}
-	_, err = s.uniter.ReadLocalApplicationSettings(arg)
+	_, err = s.uniter.ReadLocalApplicationSettings(stdcontext.Background(), arg)
 	c.Assert(errors.Cause(err), gc.Equals, apiservererrors.ErrPerm)
 }
 
@@ -2471,7 +2471,7 @@ func (s *uniterSuite) TestReadLocalApplicationSettingsForAnotherApplicationAsAnO
 		Relation: rel.Tag().String(),
 		Unit:     "unit-wordpress-0",
 	}
-	_, err = uniter.ReadLocalApplicationSettings(arg)
+	_, err = uniter.ReadLocalApplicationSettings(stdcontext.Background(), arg)
 	c.Assert(errors.Cause(err), gc.Equals, apiservererrors.ErrPerm, gc.Commentf("expected ErrPerm due to mismatch in logged in app and inferred app from provided unit name"))
 }
 
@@ -2511,7 +2511,7 @@ func (s *uniterSuite) TestReadLocalApplicationSettingsInPeerRelation(c *gc.C) {
 		Relation: rel.Tag().String(),
 		Unit:     "unit-riak-0",
 	}
-	result, err := uniter.ReadLocalApplicationSettings(arg)
+	result, err := uniter.ReadLocalApplicationSettings(stdcontext.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResult{
 		Settings: params.Settings{
@@ -2557,7 +2557,7 @@ func (s *uniterSuite) TestReadLocalApplicationSettingsInPeerRelationAsAnOperator
 		Relation: rel.Tag().String(),
 		Unit:     "unit-riak-0",
 	}
-	result, err := uniter.ReadLocalApplicationSettings(arg)
+	result, err := uniter.ReadLocalApplicationSettings(stdcontext.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResult{
 		Settings: params.Settings{
@@ -2582,7 +2582,7 @@ func (s *uniterSuite) TestReadSettingsWithNonStringValuesFails(c *gc.C) {
 		{Relation: rel.Tag().String(), Unit: "unit-wordpress-0"},
 	}}
 	expectErr := `unexpected relation setting "invalid-bool": expected string, got bool`
-	result, err := s.uniter.ReadSettings(args)
+	result, err := s.uniter.ReadSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2618,7 +2618,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 		{Relation: rel.Tag().String(), LocalUnit: "application-mysql", RemoteUnit: "foo"},
 		{Relation: rel.Tag().String(), LocalUnit: "user-foo", RemoteUnit: "unit-wordpress-0"},
 	}}
-	result, err := s.uniter.ReadRemoteSettings(args)
+	result, err := s.uniter.ReadRemoteSettings(stdcontext.Background(), args)
 
 	// We don't set the remote unit settings on purpose
 	// to test the error.
@@ -2671,7 +2671,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 			}},
 		},
 	}
-	result, err = s.uniter.ReadRemoteSettings(args)
+	result, err = s.uniter.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expect)
 
@@ -2682,7 +2682,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysqlUnit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	result, err = s.uniter.ReadRemoteSettings(args)
+	result, err = s.uniter.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expect)
 }
@@ -2734,7 +2734,7 @@ func (s *uniterSuite) TestReadRemoteSettingsForApplication(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 		},
 	}
-	result, err := s.uniter.ReadRemoteSettings(args)
+	result, err := s.uniter.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expect)
 }
@@ -2757,7 +2757,7 @@ func (s *uniterSuite) TestReadRemoteSettingsWithNonStringValuesFails(c *gc.C) {
 		RemoteUnit: "unit-mysql-0",
 	}}}
 	expectErr := `unexpected relation setting "invalid-bool": expected string, got bool`
-	result, err := s.uniter.ReadRemoteSettings(args)
+	result, err := s.uniter.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2803,7 +2803,7 @@ func (s *uniterSuite) TestReadRemoteApplicationSettingsForPeerRelation(c *gc.C) 
 		LocalUnit:  "unit-riak-0",
 		RemoteUnit: "application-riak",
 	}}}
-	result, err := uniter.ReadRemoteSettings(args)
+	result, err := uniter.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2839,7 +2839,7 @@ func (s *uniterSuite) TestReadRemoteSettingsForCAASApplicationInPeerRelationSide
 		LocalUnit:  unit.Tag().String(),
 		RemoteUnit: unit2.Tag().String(),
 	}}}
-	result, err := uniterAPI.ReadRemoteSettings(args)
+	result, err := uniterAPI.ReadRemoteSettings(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
@@ -2875,7 +2875,7 @@ func (s *uniterSuite) TestWatchRelationUnits(c *gc.C) {
 		{Relation: rel.Tag().String(), Unit: "application-mysql"},
 		{Relation: rel.Tag().String(), Unit: "user-foo"},
 	}}
-	result, err := s.uniter.WatchRelationUnits(args)
+	result, err := s.uniter.WatchRelationUnits(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	// UnitSettings versions are volatile, so we don't check them.
 	// We just make sure the keys of the Changed field are as
@@ -2977,7 +2977,7 @@ func (s *uniterSuite) TestAPIAddresses(c *gc.C) {
 	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.uniter.APIAddresses()
+	result, err := s.uniter.APIAddresses(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},
@@ -2994,7 +2994,7 @@ func (s *uniterSuite) TestWatchUnitAddressesHash(c *gc.C) {
 		{Tag: "machine-0"},
 		{Tag: "application-wordpress"},
 	}}
-	result, err := s.uniter.WatchUnitAddressesHash(args)
+	result, err := s.uniter.WatchUnitAddressesHash(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -3038,7 +3038,7 @@ func (s *uniterSuite) TestWatchCAASUnitAddressesHash(c *gc.C) {
 
 	uniterAPI := s.newUniterAPI(c, cm.State(), s.authorizer)
 
-	result, err := uniterAPI.WatchUnitAddressesHash(args)
+	result, err := uniterAPI.WatchUnitAddressesHash(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -3281,7 +3281,7 @@ func (s *uniterSuite) TestAssignedMachine(c *gc.C) {
 		{Tag: "application-foo"},
 		{Tag: "relation-svc1.rel1#svc2.rel2"},
 	}}
-	result, err := s.uniter.AssignedMachine(args)
+	result, err := s.uniter.AssignedMachine(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -3348,7 +3348,7 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.uniter.OpenedMachinePortRangesByEndpoint(args)
+	result, err := s.uniter.OpenedMachinePortRangesByEndpoint(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.OpenPortRangesByEndpointResults{
 		Results: []params.OpenPortRangesByEndpointResult{
@@ -3368,7 +3368,7 @@ func (s *uniterSuite) TestSLALevel(c *gc.C) {
 	err := s.ControllerModel(c).State().SetSLA("essential", "bob", []byte("creds"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.uniter.SLALevel()
+	result, err := s.uniter.SLALevel(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringResult{Result: "essential"})
 }
@@ -3402,7 +3402,7 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelation(c *gc.C) {
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
-	result, err := thisUniter.EnterScope(args)
+	result, err := thisUniter.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
@@ -3432,7 +3432,7 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
-	result, err := thisUniter.EnterScope(args)
+	result, err := thisUniter.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
@@ -3465,7 +3465,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
 
-	result, err := thisUniter.EnterScope(args)
+	result, err := thisUniter.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
@@ -3492,7 +3492,7 @@ func (s *uniterSuite) TestModelEgressSubnets(c *gc.C) {
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
-	result, err := thisUniter.EnterScope(args)
+	result, err := thisUniter.EnterScope(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
@@ -3551,13 +3551,13 @@ func (s *uniterSuite) TestRefresh(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 		},
 	}
-	results, err := s.uniter.Refresh(args)
+	results, err := s.uniter.Refresh(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, expect)
 }
 
 func (s *uniterSuite) TestRefreshNoArgs(c *gc.C) {
-	results, err := s.uniter.Refresh(params.Entities{Entities: []params.Entity{}})
+	results, err := s.uniter.Refresh(stdcontext.Background(), params.Entities{Entities: []params.Entity{}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UnitRefreshResults{Results: []params.UnitRefreshResult{}})
 }
@@ -3594,7 +3594,7 @@ func (s *uniterSuite) TestOpenedApplicationPortRangesByEndpoint(c *gc.C) {
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)
 
-	result, err := uniterAPI.OpenedApplicationPortRangesByEndpoint(arg)
+	result, err := uniterAPI.OpenedApplicationPortRangesByEndpoint(stdcontext.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ApplicationOpenedPortsResults{
 		Results: []params.ApplicationOpenedPortsResult{
@@ -3634,7 +3634,7 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)
 
-	result, err := uniterAPI.OpenedPortRangesByEndpoint()
+	result, err := uniterAPI.OpenedPortRangesByEndpoint(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.OpenPortRangesByEndpointResults{
 		Results: []params.OpenPortRangesByEndpointResult{
@@ -3694,7 +3694,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatch(c *gc.C) {
 	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.uniter.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.uniter.AddMetricBatches(stdcontext.Background(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -3725,7 +3725,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.uniter.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.uniter.AddMetricBatches(stdcontext.Background(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -3780,7 +3780,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.about)
-		result, err := s.uniter.AddMetricBatches(params.MetricBatchParams{
+		result, err := s.uniter.AddMetricBatches(stdcontext.Background(), params.MetricBatchParams{
 			Batches: []params.MetricBatchParam{{
 				Tag: test.tag,
 				Batch: params.MetricBatch{
@@ -4056,7 +4056,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 
 	for _, test := range tests {
 		c.Logf("Testing %s", test.Name)
-		result, err := s.uniter.NetworkInfo(test.Arg)
+		result, err := s.uniter.NetworkInfo(stdcontext.Background(), test.Arg)
 		if test.Error != "" {
 			c.Check(err, gc.ErrorMatches, test.Error)
 		} else {
@@ -4145,7 +4145,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 		IngressAddresses: []string{"100.64.0.10"},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4174,7 +4174,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoL2Binding(c *gc.C) {
 		},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4214,7 +4214,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 		IngressAddresses: []string{"192.168.1.20"},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4250,7 +4250,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForJujuInfoDefaultSpace(c *gc.C)
 		IngressAddresses: []string{"192.168.1.20"},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4305,7 +4305,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 		IngressAddresses: []string{"192.168.1.20"},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4379,7 +4379,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 		IngressAddresses: []string{expectedIngressAddress.Value},
 	}
 
-	result, err := s.uniter.NetworkInfo(args)
+	result, err := s.uniter.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
@@ -4415,7 +4415,7 @@ func (s *uniterNetworkInfoSuite) TestUpdateNetworkInfo(c *gc.C) {
 		},
 	}
 
-	res, err := s.uniter.UpdateNetworkInfo(args)
+	res, err := s.uniter.UpdateNetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.OneError(), gc.IsNil)
 
@@ -4474,7 +4474,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 	api, err := uniter.NewUniterAPI(s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := api.CommitHookChanges(req)
+	result, err := api.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4534,7 +4534,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesWhenNotLeader(c *gc.C) {
 	api, err := uniter.NewUniterAPI(s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := api.CommitHookChanges(req)
+	result, err := api.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4618,7 +4618,7 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 	}})
 	req, _ := b.Build()
 
-	result, err := s.uniter.CommitHookChanges(req)
+	result, err := s.uniter.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4686,7 +4686,7 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	api, err := uniter.NewUniterAPI(s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := api.CommitHookChanges(req)
+	result, err := api.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4732,7 +4732,7 @@ func (s *uniterSuite) TestCommitHookChangesWithPortsSidecarApplication(c *gc.C) 
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := uniterAPI.CommitHookChanges(req)
+	result, err := uniterAPI.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4767,7 +4767,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAAS(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{Tag: unit.Tag()}
 	uniterAPI := s.newUniterAPI(c, s.st, s.authorizer)
 
-	result, err := uniterAPI.CommitHookChanges(req)
+	result, err := uniterAPI.CommitHookChanges(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -4835,7 +4835,7 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 	}
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)
-	result, err := uniterAPI.NetworkInfo(args)
+	result, err := uniterAPI.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Results["db"], jc.DeepEquals, expectedResult)
 }
@@ -4885,13 +4885,13 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	}
 
 	uniterAPI := s.newUniterAPI(c, cm.State(), s.authorizer)
-	result, err := uniterAPI.NetworkInfo(args)
+	result, err := uniterAPI.NetworkInfo(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Results["db"], jc.DeepEquals, expectedResult)
 }
 
 func (s *uniterSuite) TestGetCloudSpecDeniesAccessWhenNotTrusted(c *gc.C) {
-	result, err := s.uniter.CloudSpec()
+	result, err := s.uniter.CloudSpec(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.CloudSpecResult{Error: apiservertesting.ErrUnauthorized})
 }
@@ -4915,7 +4915,7 @@ func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
-	result, err := s.uniter.CloudSpec()
+	result, err := s.uniter.CloudSpec(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result.Name, gc.Equals, "dummy")
@@ -4943,7 +4943,7 @@ func (s *cloudSpecUniterSuite) TestCloudAPIVersion(c *gc.C) {
 		return &fakeBroker{}, nil
 	})
 
-	result, err := uniterAPI.CloudAPIVersion()
+	result, err := uniterAPI.CloudAPIVersion(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResult{
 		Result: "6.66",

--- a/apiserver/facades/agent/upgrader/unitupgrader.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader.go
@@ -4,6 +4,8 @@
 package upgrader
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
 
@@ -64,7 +66,7 @@ func (u *UnitUpgraderAPI) watchAssignedMachine(unitTag names.Tag) (string, error
 // WatchAPIVersion starts a watcher to track if there is a new version
 // of the API that we want to upgrade to. The watcher tracks changes to
 // the unit's assigned machine since that's where the required agent version is stored.
-func (u *UnitUpgraderAPI) WatchAPIVersion(args params.Entities) (params.NotifyWatchResults, error) {
+func (u *UnitUpgraderAPI) WatchAPIVersion(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -89,7 +91,7 @@ func (u *UnitUpgraderAPI) WatchAPIVersion(args params.Entities) (params.NotifyWa
 
 // DesiredVersion reports the Agent Version that we want that unit to be running.
 // The desired version is what the unit's assigned machine is running.
-func (u *UnitUpgraderAPI) DesiredVersion(args params.Entities) (params.VersionResults, error) {
+func (u *UnitUpgraderAPI) DesiredVersion(ctx context.Context, args params.Entities) (params.VersionResults, error) {
 	result := make([]params.VersionResult, len(args.Entities))
 	for i, entity := range args.Entities {
 		tag, err := names.ParseTag(entity.Tag)
@@ -107,7 +109,7 @@ func (u *UnitUpgraderAPI) DesiredVersion(args params.Entities) (params.VersionRe
 }
 
 // Tools finds the tools necessary for the given agents.
-func (u *UnitUpgraderAPI) Tools(args params.Entities) (params.ToolsResults, error) {
+func (u *UnitUpgraderAPI) Tools(ctx context.Context, args params.Entities) (params.ToolsResults, error) {
 	result := params.ToolsResults{
 		Results: make([]params.ToolsResult, len(args.Entities)),
 	}

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -4,6 +4,8 @@
 package upgrader_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -91,7 +93,7 @@ func (s *unitUpgraderSuite) TearDownTest(c *gc.C) {
 
 func (s *unitUpgraderSuite) TestWatchAPIVersionNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.WatchAPIVersion(params.Entities{})
+	results, err := s.upgrader.WatchAPIVersion(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -100,7 +102,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}},
 	}
-	results, err := s.upgrader.WatchAPIVersion(args)
+	results, err := s.upgrader.WatchAPIVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
@@ -145,7 +147,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}},
 	}
-	results, err := anUpgrader.WatchAPIVersion(args)
+	results, err := anUpgrader.WatchAPIVersion(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
@@ -155,7 +157,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 
 func (s *unitUpgraderSuite) TestToolsNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.Tools(params.Entities{})
+	results, err := s.upgrader.Tools(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -172,7 +174,7 @@ func (s *unitUpgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}},
 	}
-	results, err := anUpgrader.Tools(args)
+	results, err := anUpgrader.Tools(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -191,7 +193,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{agent}}
-	results, err := s.upgrader.Tools(args)
+	results, err := s.upgrader.Tools(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	assertTools := func() {
 		c.Check(results.Results, gc.HasLen, 1)
@@ -205,7 +207,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 
 func (s *unitUpgraderSuite) TestSetToolsNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.SetTools(params.EntitiesVersion{})
+	results, err := s.upgrader.SetTools(context.Background(), params.EntitiesVersion{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -228,7 +230,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		}},
 	}
 
-	results, err := anUpgrader.SetTools(args)
+	results, err := anUpgrader.SetTools(context.Background(), args)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
@@ -246,7 +248,7 @@ func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
 			}},
 		},
 	}
-	results, err := s.upgrader.SetTools(args)
+	results, err := s.upgrader.SetTools(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -267,7 +269,7 @@ func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
 
 func (s *unitUpgraderSuite) TestDesiredVersionNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.DesiredVersion(params.Entities{})
+	results, err := s.upgrader.DesiredVersion(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -284,7 +286,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}},
 	}
-	results, err := anUpgrader.DesiredVersion(args)
+	results, err := anUpgrader.DesiredVersion(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
@@ -300,7 +302,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 		{Tag: s.rawUnit.Tag().String()},
 		{Tag: "unit-wordpress-12345"},
 	}}
-	results, err := s.upgrader.DesiredVersion(args)
+	results, err := s.upgrader.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 2)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -318,7 +320,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}}}
-	results, err := s.upgrader.DesiredVersion(args)
+	results, err := s.upgrader.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -4,6 +4,8 @@
 package upgrader
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -21,10 +23,10 @@ import (
 )
 
 type Upgrader interface {
-	WatchAPIVersion(args params.Entities) (params.NotifyWatchResults, error)
-	DesiredVersion(args params.Entities) (params.VersionResults, error)
-	Tools(args params.Entities) (params.ToolsResults, error)
-	SetTools(args params.EntitiesVersion) (params.ErrorResults, error)
+	WatchAPIVersion(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error)
+	DesiredVersion(ctx context.Context, args params.Entities) (params.VersionResults, error)
+	Tools(ctx context.Context, args params.Entities) (params.ToolsResults, error)
+	SetTools(ctx context.Context, args params.EntitiesVersion) (params.ErrorResults, error)
 }
 
 // UpgraderAPI provides access to the Upgrader API facade.
@@ -74,7 +76,7 @@ func NewUpgraderAPI(
 
 // WatchAPIVersion starts a watcher to track if there is a new version
 // of the API that we want to upgrade to
-func (u *UpgraderAPI) WatchAPIVersion(args params.Entities) (params.NotifyWatchResults, error) {
+func (u *UpgraderAPI) WatchAPIVersion(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -132,7 +134,7 @@ func (u *UpgraderAPI) entityIsManager(tag names.Tag) bool {
 }
 
 // DesiredVersion reports the Agent Version that we want that agent to be running
-func (u *UpgraderAPI) DesiredVersion(args params.Entities) (params.VersionResults, error) {
+func (u *UpgraderAPI) DesiredVersion(ctx context.Context, args params.Entities) (params.VersionResults, error) {
 	results := make([]params.VersionResult, len(args.Entities))
 	if len(args.Entities) == 0 {
 		return params.VersionResults{}, nil

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -4,6 +4,7 @@
 package upgrader_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -84,7 +85,7 @@ func (s *upgraderSuite) TearDownTest(c *gc.C) {
 
 func (s *upgraderSuite) TestWatchAPIVersionNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.WatchAPIVersion(params.Entities{})
+	results, err := s.upgrader.WatchAPIVersion(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -93,7 +94,7 @@ func (s *upgraderSuite) TestWatchAPIVersion(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results, err := s.upgrader.WatchAPIVersion(args)
+	results, err := s.upgrader.WatchAPIVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
@@ -127,7 +128,7 @@ func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: app.Tag().String()}},
 	}
-	results, err := upgrader.WatchAPIVersion(args)
+	results, err := upgrader.WatchAPIVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
@@ -164,7 +165,7 @@ func (s *upgraderSuite) TestWatchAPIVersionUnit(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unit.Tag().String()}},
 	}
-	results, err := upgrader.WatchAPIVersion(args)
+	results, err := upgrader.WatchAPIVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
@@ -197,7 +198,7 @@ func (s *upgraderSuite) TestWatchAPIVersionControllerAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: node.Tag().String()}},
 	}
-	results, err := upgrader.WatchAPIVersion(args)
+	results, err := upgrader.WatchAPIVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Check(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
@@ -227,7 +228,7 @@ func (s *upgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results, err := anUpgrader.WatchAPIVersion(args)
+	results, err := anUpgrader.WatchAPIVersion(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
@@ -237,7 +238,7 @@ func (s *upgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 
 func (s *upgraderSuite) TestToolsNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.Tools(params.Entities{})
+	results, err := s.upgrader.Tools(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -252,7 +253,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results, err := anUpgrader.Tools(args)
+	results, err := anUpgrader.Tools(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
@@ -291,7 +292,7 @@ func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{agent}}
-	results, err := s.upgrader.Tools(args)
+	results, err := s.upgrader.Tools(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	assertTools := func() {
 		c.Check(results.Results, gc.HasLen, 1)
@@ -307,7 +308,7 @@ func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
 
 func (s *upgraderSuite) TestSetToolsNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.SetTools(params.EntitiesVersion{})
+	results, err := s.upgrader.SetTools(context.Background(), params.EntitiesVersion{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -328,7 +329,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		}},
 	}
 
-	results, err := anUpgrader.SetTools(args)
+	results, err := anUpgrader.SetTools(context.Background(), args)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
@@ -346,7 +347,7 @@ func (s *upgraderSuite) TestSetTools(c *gc.C) {
 			}},
 		},
 	}
-	results, err := s.upgrader.SetTools(args)
+	results, err := s.upgrader.SetTools(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -362,7 +363,7 @@ func (s *upgraderSuite) TestSetTools(c *gc.C) {
 
 func (s *upgraderSuite) TestDesiredVersionNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.upgrader.DesiredVersion(params.Entities{})
+	results, err := s.upgrader.DesiredVersion(context.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 0)
 }
@@ -377,7 +378,7 @@ func (s *upgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results, err := anUpgrader.DesiredVersion(args)
+	results, err := anUpgrader.DesiredVersion(context.Background(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
@@ -390,7 +391,7 @@ func (s *upgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 		{Tag: s.rawMachine.Tag().String()},
 		{Tag: "machine-12345"},
 	}}
-	results, err := s.upgrader.DesiredVersion(args)
+	results, err := s.upgrader.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 2)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -405,7 +406,7 @@ func (s *upgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 
 func (s *upgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	results, err := s.upgrader.DesiredVersion(args)
+	results, err := s.upgrader.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -447,7 +448,7 @@ func (s *upgraderSuite) TestDesiredVersionUnrestrictedForAPIAgents(c *gc.C) {
 	upgraderAPI, err := upgrader.NewUpgraderAPI(systemState, s.hosted, s.resources, authorizer, loggo.GetLogger("juju.apiserver.upgrader"))
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.apiMachine.Tag().String()}}}
-	results, err := upgraderAPI.DesiredVersion(args)
+	results, err := upgraderAPI.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -460,7 +461,7 @@ func (s *upgraderSuite) TestDesiredVersionRestrictedForNonAPIAgents(c *gc.C) {
 	newVersion := s.bumpDesiredAgentVersion(c)
 	c.Assert(newVersion, gc.Not(gc.Equals), jujuversion.Current)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}}}
-	results, err := s.upgrader.DesiredVersion(args)
+	results, err := s.upgrader.DesiredVersion(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -4,6 +4,8 @@
 package upgradeseries
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -63,7 +65,7 @@ func NewUpgradeSeriesAPI(
 }
 
 // MachineStatus gets the current upgrade-machine status of a machine.
-func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusResults, error) {
+func (a *API) MachineStatus(ctx context.Context, args params.Entities) (params.UpgradeSeriesStatusResults, error) {
 	result := params.UpgradeSeriesStatusResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -91,7 +93,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 }
 
 // SetMachineStatus sets the current upgrade-machine status of a machine.
-func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
+func (a *API) SetMachineStatus(ctx context.Context, args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -120,7 +122,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 // Note that a machine could have been upgraded out-of-band by running
 // do-release-upgrade outside of the upgrade-machine workflow,
 // making this value incorrect.
-func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) {
+func (a *API) CurrentSeries(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -149,7 +151,7 @@ func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) 
 
 // TargetSeries returns the series that a machine has been locked
 // for upgrading to.
-func (a *API) TargetSeries(args params.Entities) (params.StringResults, error) {
+func (a *API) TargetSeries(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -177,7 +179,7 @@ func (a *API) TargetSeries(args params.Entities) (params.StringResults, error) {
 
 // StartUnitCompletion starts the upgrade series completion phase for all subordinate
 // units of a given machine.
-func (a *API) StartUnitCompletion(args params.UpgradeSeriesStartUnitCompletionParam) (params.ErrorResults, error) {
+func (a *API) StartUnitCompletion(ctx context.Context, args params.UpgradeSeriesStartUnitCompletionParam) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -204,7 +206,7 @@ func (a *API) StartUnitCompletion(args params.UpgradeSeriesStartUnitCompletionPa
 // called after all machine and unit statuses are "completed".
 // It updates the machine series to reflect the completed upgrade, then
 // removes the upgrade-machine lock.
-func (a *API) FinishUpgradeSeries(args params.UpdateChannelArgs) (params.ErrorResults, error) {
+func (a *API) FinishUpgradeSeries(ctx context.Context, args params.UpdateChannelArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -250,14 +252,14 @@ func (a *API) FinishUpgradeSeries(args params.UpdateChannelArgs) (params.ErrorRe
 // UnitsPrepared returns the units running on this machine that have completed
 // their upgrade-machine preparation, and are ready to be stopped and have their
 // unit agent services converted for the target series.
-func (a *API) UnitsPrepared(args params.Entities) (params.EntitiesResults, error) {
+func (a *API) UnitsPrepared(ctx context.Context, args params.Entities) (params.EntitiesResults, error) {
 	result, err := a.unitsInState(args, model.UpgradeSeriesPrepareCompleted)
 	return result, errors.Trace(err)
 }
 
 // UnitsCompleted returns the units running on this machine that have completed
 // the upgrade-machine workflow and are in their normal running state.
-func (a *API) UnitsCompleted(args params.Entities) (params.EntitiesResults, error) {
+func (a *API) UnitsCompleted(ctx context.Context, args params.Entities) (params.EntitiesResults, error) {
 	result, err := a.unitsInState(args, model.UpgradeSeriesCompleted)
 	return result, errors.Trace(err)
 }
@@ -310,24 +312,24 @@ func (a *API) authAndGetMachine(entityTag string, canAccess common.AuthFunc) (co
 
 // PinnedLeadership returns all pinned applications and the entities that
 // require their pinned behaviour, for leadership in the current model.
-func (a *API) PinnedLeadership() (params.PinnedLeadershipResult, error) {
+func (a *API) PinnedLeadership(ctx context.Context) (params.PinnedLeadershipResult, error) {
 	return a.leadership.PinnedLeadership()
 }
 
 // PinMachineApplications pins leadership for applications represented by units
 // running on the auth'd machine.
-func (a *API) PinMachineApplications() (params.PinApplicationsResults, error) {
+func (a *API) PinMachineApplications(ctx context.Context) (params.PinApplicationsResults, error) {
 	return a.leadership.PinApplicationLeaders()
 }
 
 // UnpinMachineApplications unpins leadership for applications represented by
 // units running on the auth'd machine.
-func (a *API) UnpinMachineApplications() (params.PinApplicationsResults, error) {
+func (a *API) UnpinMachineApplications(ctx context.Context) (params.PinApplicationsResults, error) {
 	return a.leadership.UnpinApplicationLeaders()
 }
 
 // SetInstanceStatus sets the status of the machine.
-func (a *API) SetInstanceStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (a *API) SetInstanceStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
 	canAccess, err := a.AccessMachine()

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -4,6 +4,8 @@
 package upgradeseries_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -63,7 +65,7 @@ func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 
 	s.machine.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
 
-	results, err := s.api.MachineStatus(s.entityArgs)
+	results, err := s.api.MachineStatus(context.Background(), s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{{Status: model.UpgradeSeriesPrepareCompleted}},
@@ -80,7 +82,7 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 		Params: []params.UpgradeSeriesStatusParam{{Entity: entity, Status: model.UpgradeSeriesPrepareCompleted}},
 	}
 
-	results, err := s.api.SetMachineStatus(args)
+	results, err := s.api.SetMachineStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},
@@ -92,7 +94,7 @@ func (s *upgradeSeriesSuite) TestCurrentSeries(c *gc.C) {
 
 	s.machine.EXPECT().Base().Return(state.UbuntuBase("16.04")).AnyTimes()
 
-	results, err := s.api.CurrentSeries(s.entityArgs)
+	results, err := s.api.CurrentSeries(context.Background(), s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{{Result: "xenial"}},
@@ -104,7 +106,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesTarget(c *gc.C) {
 
 	s.machine.EXPECT().UpgradeSeriesTarget().Return("bionic", nil)
 
-	results, err := s.api.TargetSeries(s.entityArgs)
+	results, err := s.api.TargetSeries(context.Background(), s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{{Result: "bionic"}},
@@ -116,7 +118,7 @@ func (s *upgradeSeriesSuite) TestStartUnitCompletion(c *gc.C) {
 
 	s.machine.EXPECT().StartUpgradeSeriesUnitCompletion(gomock.Any()).Return(nil)
 
-	results, err := s.api.StartUnitCompletion(s.upgradeSeriesStartUnitCompletionArgs)
+	results, err := s.api.StartUnitCompletion(context.Background(), s.upgradeSeriesStartUnitCompletionArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},
@@ -131,7 +133,7 @@ func (s *upgradeSeriesSuite) TestUnitsPrepared(c *gc.C) {
 		"redis/1": {Status: model.UpgradeSeriesPrepareStarted},
 	}, nil)
 
-	results, err := s.api.UnitsPrepared(s.entityArgs)
+	results, err := s.api.UnitsPrepared(context.Background(), s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.EntitiesResults{
 		Results: []params.EntitiesResult{{Entities: []params.Entity{{Tag: s.unitTag.String()}}}},
@@ -146,7 +148,7 @@ func (s *upgradeSeriesSuite) TestUnitsCompleted(c *gc.C) {
 		"redis/1": {Status: model.UpgradeSeriesCompleteStarted},
 	}, nil)
 
-	results, err := s.api.UnitsCompleted(s.entityArgs)
+	results, err := s.api.UnitsCompleted(context.Background(), s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.EntitiesResults{
 		Results: []params.EntitiesResult{{Entities: []params.Entity{{Tag: s.unitTag.String()}}}},
@@ -166,7 +168,7 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesUpgraded(c *gc.C) {
 		Args: []params.UpdateChannelArg{{Entity: entity, Channel: "20.04"}},
 	}
 
-	results, err := s.api.FinishUpgradeSeries(args)
+	results, err := s.api.FinishUpgradeSeries(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},
@@ -185,7 +187,7 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesNotUpgraded(c *gc.C) {
 		Args: []params.UpdateChannelArg{{Entity: entity, Channel: "22.04"}},
 	}
 
-	results, err := s.api.FinishUpgradeSeries(args)
+	results, err := s.api.FinishUpgradeSeries(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},
@@ -203,7 +205,7 @@ func (s *upgradeSeriesSuite) TestSetStatus(c *gc.C) {
 		Message: msg,
 	}).Return(nil)
 
-	results, err := s.api.SetInstanceStatus(params.SetStatus{
+	results, err := s.api.SetInstanceStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{
 				Tag:    s.machineTag.String(),

--- a/apiserver/facades/agent/upgradesteps/upgradesteps.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps.go
@@ -4,6 +4,8 @@
 package upgradesteps
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -24,13 +26,13 @@ import (
 // upgrade steps API endpoint.
 type UpgradeStepsV2 interface {
 	UpgradeStepsV1
-	WriteAgentState(params.SetUnitStateArgs) (params.ErrorResults, error)
+	WriteAgentState(context.Context, params.SetUnitStateArgs) (params.ErrorResults, error)
 }
 
 // UpgradeStepsV1 defines the methods on the version 2 facade for the
 // upgrade steps API endpoint.
 type UpgradeStepsV1 interface {
-	ResetKVMMachineModificationStatusIdle(params.Entity) (params.ErrorResult, error)
+	ResetKVMMachineModificationStatusIdle(context.Context, params.Entity) (params.ErrorResult, error)
 }
 
 // UpgradeStepsAPI implements version 2 of the Upgrade Steps API,
@@ -75,7 +77,7 @@ func NewUpgradeStepsAPI(st UpgradeStepsState,
 // ResetKVMMachineModificationStatusIdle sets the modification status
 // of a kvm machine to idle if it is in an error state before upgrade.
 // Related to lp:1829393.
-func (api *UpgradeStepsAPI) ResetKVMMachineModificationStatusIdle(arg params.Entity) (params.ErrorResult, error) {
+func (api *UpgradeStepsAPI) ResetKVMMachineModificationStatusIdle(ctx context.Context, arg params.Entity) (params.ErrorResult, error) {
 	var result params.ErrorResult
 	canAccess, err := api.getMachineAuthFunc()
 	if err != nil {
@@ -112,7 +114,7 @@ func (api *UpgradeStepsAPI) ResetKVMMachineModificationStatusIdle(arg params.Ent
 
 // WriteAgentState writes the agent state for the set of units provided. This
 // call presently deals with the state for the unit agent.
-func (api *UpgradeStepsAPI) WriteAgentState(args params.SetUnitStateArgs) (params.ErrorResults, error) {
+func (api *UpgradeStepsAPI) WriteAgentState(ctx context.Context, args params.SetUnitStateArgs) (params.ErrorResults, error) {
 	ctrlCfg, err := api.st.ControllerConfig()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -4,6 +4,8 @@
 package upgradesteps_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/txn"
@@ -58,7 +60,7 @@ func (s *machineUpgradeStepsSuite) TestResetKVMMachineModificationStatusIdle(c *
 
 	s.setupFacadeAPI(c)
 
-	result, err := s.api.ResetKVMMachineModificationStatusIdle(s.arg)
+	result, err := s.api.ResetKVMMachineModificationStatusIdle(context.Background(), s.arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 }
@@ -72,7 +74,7 @@ func (s *machineUpgradeStepsSuite) TestResetKVMMachineModificationStatusIdleSetE
 
 	s.setupFacadeAPI(c)
 
-	result, err := s.api.ResetKVMMachineModificationStatusIdle(s.arg)
+	result, err := s.api.ResetKVMMachineModificationStatusIdle(context.Background(), s.arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{
 		Error: &params.Error{
@@ -90,7 +92,7 @@ func (s *machineUpgradeStepsSuite) TestResetKVMMachineModificationStatusIdleKVMI
 
 	s.setupFacadeAPI(c)
 
-	_, err := s.api.ResetKVMMachineModificationStatusIdle(s.arg)
+	_, err := s.api.ResetKVMMachineModificationStatusIdle(context.Background(), s.arg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -101,7 +103,7 @@ func (s *machineUpgradeStepsSuite) TestResetKVMMachineModificationStatusIdleLXD(
 
 	s.setupFacadeAPI(c)
 
-	_, err := s.api.ResetKVMMachineModificationStatusIdle(s.arg)
+	_, err := s.api.ResetKVMMachineModificationStatusIdle(context.Background(), s.arg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -136,7 +138,7 @@ func (s *unitUpgradeStepsSuite) TestWriteAgentState(c *gc.C) {
 		},
 	}
 
-	results, err := s.api.WriteAgentState(args)
+	results, err := s.api.WriteAgentState(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{}, {}}})
 }
@@ -156,7 +158,7 @@ func (s *unitUpgradeStepsSuite) TestWriteAgentStateError(c *gc.C) {
 		},
 	}
 
-	results, err := s.api.WriteAgentState(args)
+	results, err := s.api.WriteAgentState(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{
 		{},


### PR DESCRIPTION
This PR adds context.Context parameter to:
- agent/reboot
- agent/resourceshookcontext
- agent/retrystrategy
- agent/sercretsdrain
- agent/secretsmanager
- agent/storageprovisioner
- agent/unitassigner
- agent/uniter
- agent/upgrader
- agent/upgradeseries
- agent/upgradesteps
facade calls and fixes the unit tests.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/reboot/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/resourceshookcontext/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/retrystrategy/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/secretsdrain/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/secretsmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/storageprovisioner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/unitassigner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/uniter/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/upgrader/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/upgradeseries/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/agent/upgradesteps/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```