### PR TITLE
[JUJU-4478] Add context.Context in client/(a-h)* facades

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -81,7 +83,7 @@ func (a *ActionAPI) checkCanAdmin() error {
 
 // Actions takes a list of ActionTags, and returns the full Action for
 // each ID.
-func (a *ActionAPI) Actions(arg params.Entities) (params.ActionResults, error) {
+func (a *ActionAPI) Actions(ctx context.Context, arg params.Entities) (params.ActionResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
@@ -119,7 +121,7 @@ func (a *ActionAPI) Actions(arg params.Entities) (params.ActionResults, error) {
 }
 
 // Cancel attempts to cancel enqueued Actions from running.
-func (a *ActionAPI) Cancel(arg params.Entities) (params.ActionResults, error) {
+func (a *ActionAPI) Cancel(ctx context.Context, arg params.Entities) (params.ActionResults, error) {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
@@ -168,7 +170,7 @@ func (a *ActionAPI) Cancel(arg params.Entities) (params.ActionResults, error) {
 
 // ApplicationsCharmsActions returns a slice of charm Actions for a slice of
 // services.
-func (a *ActionAPI) ApplicationsCharmsActions(args params.Entities) (params.ApplicationsCharmActionsResults, error) {
+func (a *ActionAPI) ApplicationsCharmsActions(ctx context.Context, args params.Entities) (params.ApplicationsCharmActionsResults, error) {
 	result := params.ApplicationsCharmActionsResults{Results: make([]params.ApplicationCharmActionsResult, len(args.Entities))}
 	if err := a.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -207,7 +209,7 @@ func (a *ActionAPI) ApplicationsCharmsActions(args params.Entities) (params.Appl
 }
 
 // WatchActionsProgress creates a watcher that reports on action log messages.
-func (api *ActionAPI) WatchActionsProgress(actions params.Entities) (params.StringsWatchResults, error) {
+func (api *ActionAPI) WatchActionsProgress(ctx context.Context, actions params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(actions.Entities)),
 	}

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -4,6 +4,7 @@
 package action_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -191,7 +192,7 @@ func (s *actionSuite) TestCancel(c *gc.C) {
 			// "my-one"
 			{Tag: results.Actions[2].Action.Tag},
 		}}
-	cancelled, err := s.action.Cancel(arg)
+	cancelled, err := s.action.Cancel(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cancelled.Results, gc.HasLen, 2)
 
@@ -252,7 +253,7 @@ func (s *actionSuite) TestAbort(c *gc.C) {
 			// "wp-one"
 			{Tag: results.Actions[0].Action.Tag},
 		}}
-	cancelled, err := s.action.Cancel(arg)
+	cancelled, err := s.action.Cancel(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cancelled.Results, gc.HasLen, 1)
 	c.Assert(cancelled.Results[0].Action.Name, gc.Equals, "fakeaction")
@@ -352,7 +353,7 @@ func (s *actionSuite) TestApplicationsCharmsActions(c *gc.C) {
 			svcTags.Entities[j] = params.Entity{Tag: svcTag.String()}
 		}
 
-		results, err := s.action.ApplicationsCharmsActions(svcTags)
+		results, err := s.action.ApplicationsCharmsActions(context.Background(), svcTags)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(results.Results, jc.DeepEquals, t.expectedResults.Results)
 	}
@@ -391,6 +392,7 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := s.action.WatchActionsProgress(
+		context.Background(),
 		params.Entities{Entities: []params.Entity{{Tag: "action-2"}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/annotations/client.go
+++ b/apiserver/facades/client/annotations/client.go
@@ -4,6 +4,8 @@
 package annotations
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -20,8 +22,8 @@ var getState = func(st *state.State, m *state.Model) annotationAccess {
 
 // Annotations defines the methods on the service API end point.
 type Annotations interface {
-	Get(args params.Entities) params.AnnotationsGetResults
-	Set(args params.AnnotationsSet) params.ErrorResults
+	Get(ctx context.Context, args params.Entities) params.AnnotationsGetResults
+	Set(ctx context.Context, args params.AnnotationsSet) params.ErrorResults
 }
 
 // API implements the service interface and is the concrete
@@ -42,7 +44,7 @@ func (api *API) checkCanWrite() error {
 // Get returns annotations for given entities.
 // If annotations cannot be retrieved for a given entity, an error is returned.
 // Each entity is treated independently and, hence, will fail or succeed independently.
-func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
+func (api *API) Get(ctx context.Context, args params.Entities) params.AnnotationsGetResults {
 	if err := api.checkCanRead(); err != nil {
 		result := make([]params.AnnotationsGetResult, len(args.Entities))
 		for i := range result {
@@ -65,7 +67,7 @@ func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 }
 
 // Set stores annotations for given entities
-func (api *API) Set(args params.AnnotationsSet) params.ErrorResults {
+func (api *API) Set(ctx context.Context, args params.AnnotationsSet) params.ErrorResults {
 	if err := api.checkCanWrite(); err != nil {
 		errorResults := make([]params.ErrorResult, len(args.Annotations))
 		for i := range errorResults {

--- a/apiserver/facades/client/annotations/client_test.go
+++ b/apiserver/facades/client/annotations/client_test.go
@@ -4,6 +4,7 @@
 package annotations_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -87,7 +88,7 @@ func (s *annotationSuite) TestApplicationAnnotations(c *gc.C) {
 func (s *annotationSuite) assertAnnotationsRemoval(c *gc.C, tag names.Tag) {
 	entity := tag.String()
 	entities := params.Entities{[]params.Entity{{entity}}}
-	ann := s.annotationsAPI.Get(entities)
+	ann := s.annotationsAPI.Get(context.Background(), entities)
 	c.Assert(ann.Results, gc.HasLen, 1)
 
 	aResult := ann.Results[0]
@@ -101,10 +102,11 @@ func (s *annotationSuite) TestInvalidEntityAnnotations(c *gc.C) {
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsAPI.Set(
+		context.Background(),
 		params.AnnotationsSet{Annotations: constructSetParameters([]string{entity}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*permission denied.*")
 
-	got := s.annotationsAPI.Get(entities)
+	got := s.annotationsAPI.Get(context.Background(), entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -174,10 +176,11 @@ func (s *annotationSuite) TestRelationAnnotations(c *gc.C) {
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsAPI.Set(
+		context.Background(),
 		params.AnnotationsSet{Annotations: constructSetParameters([]string{tag}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*does not support annotations.*")
 
-	got := s.annotationsAPI.Get(entities)
+	got := s.annotationsAPI.Get(context.Background(), entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -214,6 +217,7 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsAPI.Set(
+		context.Background(),
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
 	c.Assert(setResult.Results, gc.HasLen, 1)
 
@@ -222,7 +226,7 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	c.Assert(oneError, gc.Matches, fmt.Sprintf(".*%q.*", rTag))
 	c.Assert(oneError, gc.Matches, ".*does not support annotations.*")
 
-	got := s.annotationsAPI.Get(params.Entities{[]params.Entity{
+	got := s.annotationsAPI.Get(context.Background(), params.Entities{[]params.Entity{
 		{rEntity},
 		{sEntity}}})
 	c.Assert(got.Results, gc.HasLen, 2)
@@ -264,6 +268,7 @@ func (s *annotationSuite) setupEntity(
 	initialAnnotations map[string]string) {
 	if initialAnnotations != nil {
 		initialResult := s.annotationsAPI.Set(
+			context.Background(),
 			params.AnnotationsSet{
 				Annotations: constructSetParameters(entities, initialAnnotations)})
 		c.Assert(initialResult.Combine(), jc.ErrorIsNil)
@@ -275,6 +280,7 @@ func (s *annotationSuite) assertSetEntityAnnotations(c *gc.C,
 	annotations map[string]string,
 	expectedError string) {
 	setResult := s.annotationsAPI.Set(
+		context.Background(),
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
 	if expectedError != "" {
 		c.Assert(setResult.OneError().Error(), gc.Matches, expectedError)
@@ -287,7 +293,7 @@ func (s *annotationSuite) assertGetEntityAnnotations(c *gc.C,
 	entities params.Entities,
 	entity string,
 	expected map[string]string) params.AnnotationsGetResult {
-	got := s.annotationsAPI.Get(entities)
+	got := s.annotationsAPI.Get(context.Background(), entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
@@ -304,6 +310,7 @@ func (s *annotationSuite) cleanupEntityAnnotations(c *gc.C,
 		cleanup[key] = ""
 	}
 	cleanupResult := s.annotationsAPI.Set(
+		context.Background(),
 		params.AnnotationsSet{Annotations: constructSetParameters(entities, cleanup)})
 	c.Assert(cleanupResult.Combine(), jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -241,7 +241,7 @@ func (api *APIBase) checkCanWrite() error {
 // SetMetricCredentials sets credentials on the application.
 // TODO (cderici) only used for metered charms in cmd MeteredDeployAPI,
 // kept for client compatibility, remove in juju 4.0
-func (api *APIBase) SetMetricCredentials(args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
+func (api *APIBase) SetMetricCredentials(ctx context.Context, args params.ApplicationMetricCredentials) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -267,7 +267,7 @@ func (api *APIBase) SetMetricCredentials(args params.ApplicationMetricCredential
 
 // Deploy fetches the charms from the charm store and deploys them
 // using the specified placement directives.
-func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults, error) {
+func (api *APIBase) Deploy(ctx context.Context, args params.ApplicationsDeploy) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -886,7 +886,7 @@ func (api *APIBase) setConfig(app Application, generation, settingsYAML string, 
 
 // UpdateApplicationBase updates the application base.
 // Base for subordinates is updated too.
-func (api *APIBase) UpdateApplicationBase(args params.UpdateChannelArgs) (params.ErrorResults, error) {
+func (api *APIBase) UpdateApplicationBase(ctx context.Context, args params.UpdateChannelArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -924,7 +924,7 @@ func (api *APIBase) updateOneApplicationBase(arg params.UpdateChannelArg) error 
 }
 
 // SetCharm sets the charm for a given for the application.
-func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
+func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetCharm) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1178,7 +1178,7 @@ func charmConfigFromConfigValues(yamlContents map[string]interface{}) (charm.Set
 
 // GetCharmURLOrigin returns the charm URL and charm origin the given
 // application is running at present.
-func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmURLOriginResult, error) {
+func (api *APIBase) GetCharmURLOrigin(ctx context.Context, args params.ApplicationGet) (params.CharmURLOriginResult, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.CharmURLOriginResult{}, errors.Trace(err)
 	}
@@ -1227,7 +1227,7 @@ func makeParamsCharmOrigin(origin *state.CharmOrigin) (params.CharmOrigin, error
 }
 
 // CharmRelations implements the server side of Application.CharmRelations.
-func (api *APIBase) CharmRelations(p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
+func (api *APIBase) CharmRelations(ctx context.Context, p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
 	var results params.ApplicationCharmRelationsResults
 	if err := api.checkCanRead(); err != nil {
 		return results, errors.Trace(err)
@@ -1250,7 +1250,7 @@ func (api *APIBase) CharmRelations(p params.ApplicationCharmRelations) (params.A
 
 // Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
-func (api *APIBase) Expose(args params.ApplicationExpose) error {
+func (api *APIBase) Expose(ctx context.Context, args params.ApplicationExpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return errors.Trace(err)
 	}
@@ -1329,7 +1329,7 @@ func (api *APIBase) mapExposedEndpointParams(params map[string]params.ExposedEnd
 
 // Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
-func (api *APIBase) Unexpose(args params.ApplicationUnexpose) error {
+func (api *APIBase) Unexpose(ctx context.Context, args params.ApplicationUnexpose) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1351,7 +1351,7 @@ func (api *APIBase) Unexpose(args params.ApplicationUnexpose) error {
 }
 
 // AddUnits adds a given number of units to an application.
-func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
+func (api *APIBase) AddUnits(ctx context.Context, args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
 	if api.model.Type() == state.ModelTypeCAAS {
 		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("adding units to a container-based model")
 	}
@@ -1440,7 +1440,7 @@ func addApplicationUnits(backend Backend, modelType state.ModelType, args params
 }
 
 // DestroyUnit removes a given set of application units.
-func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
+func (api *APIBase) DestroyUnit(ctx context.Context, args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if api.model.Type() == state.ModelTypeCAAS {
 		return params.DestroyUnitResults{}, errors.NotSupportedf("removing units on a non-container model")
 	}
@@ -1541,7 +1541,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 }
 
 // DestroyApplication removes a given set of applications.
-func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
+func (api *APIBase) DestroyApplication(ctx context.Context, args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DestroyApplicationResults{}, err
 	}
@@ -1647,7 +1647,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 }
 
 // DestroyConsumedApplications removes a given set of consumed (remote) applications.
-func (api *APIBase) DestroyConsumedApplications(args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
+func (api *APIBase) DestroyConsumedApplications(ctx context.Context, args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -1689,7 +1689,7 @@ func (api *APIBase) DestroyConsumedApplications(args params.DestroyConsumedAppli
 }
 
 // ScaleApplications scales the specified application to the requested number of units.
-func (api *APIBase) ScaleApplications(args params.ScaleApplicationsParams) (params.ScaleApplicationResults, error) {
+func (api *APIBase) ScaleApplications(ctx context.Context, args params.ScaleApplicationsParams) (params.ScaleApplicationResults, error) {
 	if api.model.Type() != state.ModelTypeCAAS {
 		return params.ScaleApplicationResults{}, errors.NotSupportedf("scaling applications on a non-container model")
 	}
@@ -1760,7 +1760,7 @@ func (api *APIBase) ScaleApplications(args params.ScaleApplicationsParams) (para
 }
 
 // GetConstraints returns the constraints for a given application.
-func (api *APIBase) GetConstraints(args params.Entities) (params.ApplicationGetConstraintsResults, error) {
+func (api *APIBase) GetConstraints(ctx context.Context, args params.Entities) (params.ApplicationGetConstraintsResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConstraintsResults{}, errors.Trace(err)
 	}
@@ -1793,7 +1793,7 @@ func (api *APIBase) getConstraints(entity string) (constraints.Value, error) {
 }
 
 // SetConstraints sets the constraints for a given application.
-func (api *APIBase) SetConstraints(args params.SetConstraints) error {
+func (api *APIBase) SetConstraints(ctx context.Context, args params.SetConstraints) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1882,7 +1882,7 @@ func (api *APIBase) AddRelation(args params.AddRelation) (_ params.AddRelationRe
 
 // DestroyRelation removes the relation between the
 // specified endpoints or an id.
-func (api *APIBase) DestroyRelation(args params.DestroyRelation) (err error) {
+func (api *APIBase) DestroyRelation(ctx context.Context, args params.DestroyRelation) (err error) {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -1907,7 +1907,7 @@ func (api *APIBase) DestroyRelation(args params.DestroyRelation) (err error) {
 }
 
 // SetRelationsSuspended sets the suspended status of the specified relations.
-func (api *APIBase) SetRelationsSuspended(args params.RelationSuspendedArgs) (params.ErrorResults, error) {
+func (api *APIBase) SetRelationsSuspended(ctx context.Context, args params.RelationSuspendedArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return statusResults, errors.Trace(err)
@@ -2171,7 +2171,7 @@ func (api *APIBase) maybeUpdateExistingApplicationEndpoints(
 
 // CharmConfig returns charm config for the input list of applications and
 // model generations.
-func (api *APIBase) CharmConfig(args params.ApplicationGetArgs) (params.ApplicationGetConfigResults, error) {
+func (api *APIBase) CharmConfig(ctx context.Context, args params.ApplicationGetArgs) (params.ApplicationGetConfigResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
@@ -2187,7 +2187,7 @@ func (api *APIBase) CharmConfig(args params.ApplicationGetArgs) (params.Applicat
 }
 
 // GetConfig returns the charm config for each of the input applications.
-func (api *APIBase) GetConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+func (api *APIBase) GetConfig(ctx context.Context, args params.Entities) (params.ApplicationGetConfigResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
@@ -2233,7 +2233,7 @@ func (api *APIBase) getCharmConfig(gen string, appName string) (map[string]inter
 // SetConfigs implements the server side of Application.SetConfig.  Both
 // application and charm config are set. It does not unset values in
 // Config map that are set to an empty string. Unset should be used for that.
-func (api *APIBase) SetConfigs(args params.ConfigSetArgs) (params.ErrorResults, error) {
+func (api *APIBase) SetConfigs(ctx context.Context, args params.ConfigSetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -2264,7 +2264,7 @@ func (api *APIBase) addAppToBranch(branchName string, appName string) error {
 }
 
 // UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig.
-func (api *APIBase) UnsetApplicationsConfig(args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
+func (api *APIBase) UnsetApplicationsConfig(ctx context.Context, args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -2323,7 +2323,7 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 }
 
 // ResolveUnitErrors marks errors on the specified units as resolved.
-func (api *APIBase) ResolveUnitErrors(p params.UnitsResolved) (params.ErrorResults, error) {
+func (api *APIBase) ResolveUnitErrors(ctx context.Context, p params.UnitsResolved) (params.ErrorResults, error) {
 	if p.All {
 		unitsWithErrors, err := api.backend.UnitsInError()
 		if err != nil {
@@ -2363,7 +2363,7 @@ func (api *APIBase) ResolveUnitErrors(p params.UnitsResolved) (params.ErrorResul
 }
 
 // ApplicationsInfo returns applications information.
-func (api *APIBase) ApplicationsInfo(in params.Entities) (params.ApplicationInfoResults, error) {
+func (api *APIBase) ApplicationsInfo(ctx context.Context, in params.Entities) (params.ApplicationInfoResults, error) {
 	// Get all the space infos before iterating over the application infos.
 	allSpaceInfosLookup, err := api.backend.AllSpaceInfos()
 	if err != nil {
@@ -2479,7 +2479,7 @@ func (api *APIBase) mapExposedEndpointsFromState(exposedEndpoints map[string]sta
 
 // MergeBindings merges operator-defined bindings with the current bindings for
 // one or more applications.
-func (api *APIBase) MergeBindings(in params.ApplicationMergeBindingsArgs) (params.ErrorResults, error) {
+func (api *APIBase) MergeBindings(ctx context.Context, in params.ApplicationMergeBindingsArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -2606,7 +2606,7 @@ func validateAgentVersions(application Application, versioner AgentVersioner) er
 
 // UnitsInfo returns unit information for the given entities (units or
 // applications).
-func (api *APIBase) UnitsInfo(in params.Entities) (params.UnitInfoResults, error) {
+func (api *APIBase) UnitsInfo(ctx context.Context, in params.Entities) (params.UnitInfoResults, error) {
 	var results []params.UnitInfoResult
 	leaders, err := api.leadershipReader.Leaders()
 	if err != nil {
@@ -2873,7 +2873,7 @@ func checkCAASMinVersion(ch CharmMeta, caasVersion *version.Number) (err error) 
 }
 
 // Leader returns the unit name of the leader for the given application.
-func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
+func (api *APIBase) Leader(ctx context.Context, entity params.Entity) (params.StringResult, error) {
 	result := params.StringResult{}
 	application, err := names.ParseApplicationTag(entity.Tag)
 	if err != nil {
@@ -2896,7 +2896,7 @@ func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
 // fails, a list of all errors found in validation will be returned. If a
 // local resource is provided, details required for uploading the validated
 // resource will be returned.
-func (api *APIBase) DeployFromRepository(args params.DeployFromRepositoryArgs) (params.DeployFromRepositoryResults, error) {
+func (api *APIBase) DeployFromRepository(ctx context.Context, args params.DeployFromRepositoryArgs) (params.DeployFromRepositoryResults, error) {
 	if err := api.checkCanWrite(); err != nil {
 		return params.DeployFromRepositoryResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -105,7 +105,7 @@ func (s *applicationSuite) setupApplicationDeploy(c *gc.C, args string) (*charm.
 }
 
 func (s *applicationSuite) assertApplicationDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -120,7 +120,7 @@ func (s *applicationSuite) assertApplicationDeployPrincipal(c *gc.C, curl *charm
 }
 
 func (s *applicationSuite) assertApplicationDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
-	_, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	_, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -151,7 +151,7 @@ func (s *applicationSuite) TestBlockChangesApplicationDeployPrincipal(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationDeploySubordinate(c *gc.C) {
 	curl, ch := s.addCharmToState(c, "ch:utopic/logging-47", "logging")
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -185,7 +185,7 @@ func (s *applicationSuite) combinedSettings(ch *state.Charm, inSettings charm.Se
 
 func (s *applicationSuite) TestApplicationDeployConfig(c *gc.C) {
 	curl, _ := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -210,7 +210,7 @@ func (s *applicationSuite) TestApplicationDeployConfigError(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
 	curl, _ := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -240,7 +240,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -289,7 +289,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -344,7 +344,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
 			CharmOrigin:     createCharmOriginFromURL(curl),
@@ -385,7 +385,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 }
 
 func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
-	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+	results, err := s.applicationAPI.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        "ch:jammy/application-name-1",
 			CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}},
@@ -464,7 +464,7 @@ func (s *applicationSuite) TestClientAddApplicationUnits(c *gc.C) {
 		if t.to != "" {
 			args.Placement = []*instance.Placement{instance.MustParsePlacement(t.to)}
 		}
-		result, err := s.applicationAPI.AddUnits(args)
+		result, err := s.applicationAPI.AddUnits(context.Background(), args)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 			continue
@@ -490,7 +490,7 @@ func (s *applicationSuite) TestAddApplicationUnitsToNewContainer(c *gc.C) {
 	machine, err := s.ControllerModel(c).State().AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.applicationAPI.AddUnits(params.AddApplicationUnits{
+	_, err = s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        1,
 		Placement:       []*instance.Placement{instance.MustParsePlacement("lxd:" + machine.Id())},
@@ -547,7 +547,7 @@ func (s *applicationSuite) TestAddApplicationUnits(c *gc.C) {
 		if applicationName == "" {
 			applicationName = "dummy"
 		}
-		result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
+		result, err := s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
 			ApplicationName: applicationName,
 			NumUnits:        len(t.expected),
 			Placement:       t.placement,
@@ -569,7 +569,7 @@ func (s *applicationSuite) TestAddApplicationUnits(c *gc.C) {
 }
 
 func (s *applicationSuite) assertAddApplicationUnits(c *gc.C) {
-	result, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
+	result, err := s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 	})
@@ -602,10 +602,10 @@ func (s *applicationSuite) TestApplicationCharmRelations(c *gc.C) {
 	_, err = st.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.applicationAPI.CharmRelations(params.ApplicationCharmRelations{ApplicationName: "blah"})
+	_, err = s.applicationAPI.CharmRelations(context.Background(), params.ApplicationCharmRelations{ApplicationName: "blah"})
 	c.Assert(err, gc.ErrorMatches, `application "blah" not found`)
 
-	result, err := s.applicationAPI.CharmRelations(params.ApplicationCharmRelations{ApplicationName: "wordpress"})
+	result, err := s.applicationAPI.CharmRelations(context.Background(), params.ApplicationCharmRelations{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.CharmRelations, gc.DeepEquals, []string{
 		"cache", "db", "juju-info", "logging-dir", "monitoring-port", "url",
@@ -613,7 +613,7 @@ func (s *applicationSuite) TestApplicationCharmRelations(c *gc.C) {
 }
 
 func (s *applicationSuite) assertAddApplicationUnitsBlocked(c *gc.C, msg string) {
-	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
+	_, err := s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 	})
@@ -660,7 +660,7 @@ func (s *applicationSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
 	})
-	_, err := s.applicationAPI.AddUnits(params.AddApplicationUnits{
+	_, err := s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "dummy",
 		NumUnits:        3,
 		Placement:       []*instance.Placement{instance.MustParsePlacement("42")},
@@ -698,7 +698,7 @@ func (s *applicationSuite) TestApplicationExposeEndpoints(c *gc.C) {
 	})
 	c.Assert(app.IsExposed(), jc.IsFalse)
 
-	err := s.applicationAPI.Expose(params.ApplicationExpose{
+	err := s.applicationAPI.Expose(context.Background(), params.ApplicationExpose{
 		ApplicationName: app.Name(),
 		ExposedEndpoints: map[string]params.ExposedEndpoint{
 			// Exposing an endpoint with no expose options implies
@@ -727,7 +727,7 @@ func (s *applicationSuite) TestApplicationExposeEndpointsWithPre29Client(c *gc.C
 	})
 	c.Assert(app.IsExposed(), jc.IsFalse)
 
-	err := s.applicationAPI.Expose(params.ApplicationExpose{
+	err := s.applicationAPI.Expose(context.Background(), params.ApplicationExpose{
 		ApplicationName: app.Name(),
 		// If no endpoint-specific expose params are provided, the call
 		// will emulate the behavior of a pre 2.9 controller where all
@@ -838,7 +838,7 @@ var applicationExposeTests = []struct {
 func (s *applicationSuite) assertApplicationExpose(c *gc.C) {
 	for i, t := range applicationExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationAPI.Expose(params.ApplicationExpose{
+		err := s.applicationAPI.Expose(context.Background(), params.ApplicationExpose{
 			ApplicationName:  t.application,
 			ExposedEndpoints: t.exposedEndpointParams,
 		})
@@ -857,7 +857,7 @@ func (s *applicationSuite) assertApplicationExpose(c *gc.C) {
 func (s *applicationSuite) assertApplicationExposeBlocked(c *gc.C, msg string) {
 	for i, t := range applicationExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.applicationAPI.Expose(params.ApplicationExpose{
+		err := s.applicationAPI.Expose(context.Background(), params.ApplicationExpose{
 			ApplicationName:  t.application,
 			ExposedEndpoints: t.exposedEndpointParams,
 		})
@@ -954,7 +954,7 @@ func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		c.Assert(app.IsExposed(), gc.Equals, len(t.initial) != 0)
-		err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{
+		err := s.applicationAPI.Unexpose(context.Background(), params.ApplicationUnexpose{
 			ApplicationName:  t.application,
 			ExposedEndpoints: t.unexposeEndpoints,
 		})
@@ -985,7 +985,7 @@ func (s *applicationSuite) setupApplicationUnexpose(c *gc.C) *state.Application 
 }
 
 func (s *applicationSuite) assertApplicationUnexpose(c *gc.C, app *state.Application) {
-	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{ApplicationName: "dummy-application"})
+	err := s.applicationAPI.Unexpose(context.Background(), params.ApplicationUnexpose{ApplicationName: "dummy-application"})
 	c.Assert(err, jc.ErrorIsNil)
 	app.Refresh()
 	c.Assert(app.IsExposed(), gc.Equals, false)
@@ -994,7 +994,7 @@ func (s *applicationSuite) assertApplicationUnexpose(c *gc.C, app *state.Applica
 }
 
 func (s *applicationSuite) assertApplicationUnexposeBlocked(c *gc.C, app *state.Application, msg string) {
-	err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{ApplicationName: "dummy-application"})
+	err := s.applicationAPI.Unexpose(context.Background(), params.ApplicationUnexpose{ApplicationName: "dummy-application"})
 	s.AssertBlocked(c, err, msg)
 	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1029,7 +1029,7 @@ func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
 	// Update constraints for the application.
 	cons, err := constraints.Parse("mem=4096", "cores=2")
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err = s.applicationAPI.SetConstraints(context.Background(), params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
@@ -1052,7 +1052,7 @@ func (s *applicationSuite) setupSetApplicationConstraints(c *gc.C) (*state.Appli
 }
 
 func (s *applicationSuite) assertSetApplicationConstraints(c *gc.C, application *state.Application, cons constraints.Value) {
-	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err := s.applicationAPI.SetConstraints(context.Background(), params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the constraints have been correctly updated.
 	obtained, err := application.Constraints()
@@ -1061,7 +1061,7 @@ func (s *applicationSuite) assertSetApplicationConstraints(c *gc.C, application 
 }
 
 func (s *applicationSuite) assertSetApplicationConstraintsBlocked(c *gc.C, msg string, application *state.Application, cons constraints.Value) {
-	err := s.applicationAPI.SetConstraints(params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
+	err := s.applicationAPI.SetConstraints(context.Background(), params.SetConstraints{ApplicationName: "dummy", Constraints: cons})
 	s.AssertBlocked(c, err, msg)
 }
 
@@ -1097,7 +1097,7 @@ func (s *applicationSuite) TestClientGetApplicationConstraints(c *gc.C) {
 		Constraints: barConstraints,
 	})
 
-	results, err := s.applicationAPI.GetConstraints(params.Entities{
+	results, err := s.applicationAPI.GetConstraints(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "wat"}, {Tag: "machine-0"}, {Tag: "user-foo"},
 			{Tag: "application-foo"}, {Tag: "application-bar"}, {Tag: "application-wat"},

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -301,7 +301,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	app.EXPECT().SetCharm(setCharmConfigMatcher{c: c, expected: cfg})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -329,7 +329,7 @@ func (s *ApplicationSuite) TestSetCharmEverything(c *gc.C) {
 	app.EXPECT().UpdateApplicationConfig(coreconfig.ConfigAttributes{"trust": true}, nil, schemaFields, defaults)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err = s.api.SetCharm(params.ApplicationSetCharm{
+	err = s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName:    "postgresql",
 		CharmURL:           curl.String(),
 		CharmOrigin:        createCharmOriginFromURL(curl),
@@ -348,7 +348,7 @@ func (s *ApplicationSuite) TestSetCharmWithBlockChange(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:something-else",
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
@@ -360,7 +360,7 @@ func (s *ApplicationSuite) TestSetCharmRejectCharmStore(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "cs:something-else",
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
@@ -385,7 +385,7 @@ func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
 	app.EXPECT().SetCharm(setCharmConfigMatcher{c: c, expected: cfg})
 
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		ForceUnits:      true,
@@ -405,7 +405,7 @@ func (s *ApplicationSuite) TestSetCharmInvalidApplication(c *gc.C) {
 
 	s.backend.EXPECT().Application("badapplication").Return(nil, errors.NotFoundf(`application "badapplication"`))
 	curl := charm.MustParseURL("ch:something-else")
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "badapplication",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -440,7 +440,7 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	toUint64Ptr := func(v uint64) *uint64 {
 		return &v
 	}
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		StorageConstraints: map[string]params.StorageConstraints{
@@ -466,7 +466,7 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	app := s.expectDefaultApplication(ctrl)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -511,7 +511,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -532,7 +532,7 @@ func (s *ApplicationSuite) TestSetCharmDisallowDowngradeFormat(c *gc.C) {
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "postgresql")
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -555,7 +555,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -594,7 +594,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 
 	s.model.EXPECT().AgentVersion().Return(version.Number{Major: 2, Minor: 6, Patch: 0}, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -618,7 +618,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 
 	s.model.EXPECT().AgentVersion().Return(version.Number{Major: 2, Minor: 5, Patch: 0}, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -647,7 +647,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 
 	s.model.EXPECT().AgentVersion().Return(version.Number{Major: 2, Minor: 6, Patch: 0}, nil)
 
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        curl.String(),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -688,7 +688,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	// Try to upgrade the charm
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -730,7 +730,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	// Try to upgrade the charm
-	err := s.api.SetCharm(params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -748,7 +748,7 @@ func (s *ApplicationSuite) TestDestroyRelation(c *gc.C) {
 	relation.EXPECT().DestroyWithForce(false, gomock.Any())
 	s.backend.EXPECT().InferActiveRelation("a", "b").Return(relation, nil)
 
-	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a", "b"}})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{Endpoints: []string{"a", "b"}})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -757,7 +757,7 @@ func (s *ApplicationSuite) TestDestroyRelationNoRelationsFound(c *gc.C) {
 
 	s.backend.EXPECT().InferActiveRelation("a", "b").Return(nil, errors.New("no relations found"))
 
-	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a", "b"}})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{Endpoints: []string{"a", "b"}})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
@@ -766,7 +766,7 @@ func (s *ApplicationSuite) TestDestroyRelationRelationNotFound(c *gc.C) {
 
 	s.backend.EXPECT().InferActiveRelation("a:b", "c:d").Return(nil, errors.NotFoundf(`relation "a:b c:d"`))
 
-	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a:b", "c:d"}})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{Endpoints: []string{"a:b", "c:d"}})
 	c.Assert(err, gc.ErrorMatches, `relation "a:b c:d" not found`)
 }
 
@@ -774,7 +774,7 @@ func (s *ApplicationSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	s.removeAllowed = errors.New("remove blocked")
 	defer s.setup(c).Finish()
 
-	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a", "b"}})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{Endpoints: []string{"a", "b"}})
 	c.Assert(err, gc.ErrorMatches, "remove blocked")
 }
 
@@ -786,7 +786,7 @@ func (s *ApplicationSuite) TestDestroyRelationId(c *gc.C) {
 	relation.EXPECT().DestroyWithForce(false, gomock.Any())
 	s.backend.EXPECT().Relation(123).Return(relation, nil)
 
-	err := s.api.DestroyRelation(params.DestroyRelation{RelationId: 123})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{RelationId: 123})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -795,7 +795,7 @@ func (s *ApplicationSuite) TestDestroyRelationIdRelationNotFound(c *gc.C) {
 
 	s.backend.EXPECT().Relation(123).Return(nil, errors.NotFoundf(`relation "123"`))
 
-	err := s.api.DestroyRelation(params.DestroyRelation{RelationId: 123})
+	err := s.api.DestroyRelation(context.Background(), params.DestroyRelation{RelationId: 123})
 	c.Assert(err, gc.ErrorMatches, `relation "123" not found`)
 }
 
@@ -870,7 +870,7 @@ func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
 
 	s.backend.EXPECT().ApplyOperation(&state.DestroyApplicationOperation{}).Return(nil)
 
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	results, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 		}},
@@ -887,7 +887,7 @@ func (s *ApplicationSuite) TestDestroyApplicationWithBlockRemove(c *gc.C) {
 	s.removeAllowed = errors.New("remove blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	_, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 		}},
@@ -916,7 +916,7 @@ func (s *ApplicationSuite) TestForceDestroyApplication(c *gc.C) {
 		MaxWait: common.MaxWait(&zero),
 	}}).Return(nil)
 
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	results, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Force:          true,
@@ -944,7 +944,7 @@ func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
 		DestroyStorage: true,
 	}).Return(nil)
 
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	results, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			DestroyStorage: true,
@@ -978,7 +978,7 @@ func (s *ApplicationSuite) TestDestroyApplicationDryRun(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	s.expectDefaultStorageAttachments(ctrl)
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	results, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			DryRun:         true,
@@ -992,7 +992,7 @@ func (s *ApplicationSuite) TestDestroyApplicationNotFound(c *gc.C) {
 
 	s.backend.EXPECT().Application("postgresql").Return(nil, errors.NotFoundf(`application "postgresql"`))
 
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+	results, err := s.api.DestroyApplication(context.Background(), params.DestroyApplicationsParams{
 		Applications: []params.DestroyApplicationParams{{
 			ApplicationTag: "application-postgresql",
 		}},
@@ -1024,7 +1024,7 @@ func (s *ApplicationSuite) TestDestroyConsumedApplication(c *gc.C) {
 	s.backend.EXPECT().RemoteApplication("hosted-db2").Return(remApp, nil)
 	s.backend.EXPECT().ApplyOperation(&state.DestroyRemoteApplicationOperation{}).Return(nil)
 
-	results, err := s.api.DestroyConsumedApplications(params.DestroyConsumedApplicationsParams{
+	results, err := s.api.DestroyConsumedApplications(context.Background(), params.DestroyConsumedApplicationsParams{
 		Applications: []params.DestroyConsumedApplicationParams{{ApplicationTag: "application-hosted-db2"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1046,7 +1046,7 @@ func (s *ApplicationSuite) TestForceDestroyConsumedApplication(c *gc.C) {
 		MaxWait: zero,
 	}}).Return(nil)
 
-	results, err := s.api.DestroyConsumedApplications(params.DestroyConsumedApplicationsParams{
+	results, err := s.api.DestroyConsumedApplications(context.Background(), params.DestroyConsumedApplicationsParams{
 		Applications: []params.DestroyConsumedApplicationParams{{
 			ApplicationTag: "application-hosted-db2",
 			Force:          &force,
@@ -1063,7 +1063,7 @@ func (s *ApplicationSuite) TestDestroyConsumedApplicationNotFound(c *gc.C) {
 
 	s.backend.EXPECT().RemoteApplication("hosted-db2").Return(nil, errors.NotFoundf(`saas application "hosted-db2"`))
 
-	results, err := s.api.DestroyConsumedApplications(params.DestroyConsumedApplicationsParams{
+	results, err := s.api.DestroyConsumedApplications(context.Background(), params.DestroyConsumedApplicationsParams{
 		Applications: []params.DestroyConsumedApplicationParams{{ApplicationTag: "application-hosted-db2"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1099,7 +1099,7 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 
 	s.expectDefaultStorageAttachments(ctrl)
 
-	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	results, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
 			{
 				UnitTag: "unit-postgresql-0",
@@ -1134,7 +1134,7 @@ func (s *ApplicationSuite) TestDestroyUnitWithRemoveBlock(c *gc.C) {
 	s.removeAllowed = errors.New("remove blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	_, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{{
 			UnitTag: "unit-postgresql-1",
 		}},
@@ -1170,7 +1170,7 @@ func (s *ApplicationSuite) TestForceDestroyUnit(c *gc.C) {
 
 	s.expectDefaultStorageAttachments(ctrl)
 
-	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	results, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
 			{
 				UnitTag: "unit-postgresql-0",
@@ -1206,7 +1206,7 @@ func (s *ApplicationSuite) TestDestroySubordinateUnits(c *gc.C) {
 	unit0.EXPECT().IsPrincipal().Return(false)
 	s.backend.EXPECT().Unit("subordinate/0").Return(unit0, nil)
 
-	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	results, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{{
 			UnitTag: "unit-subordinate-0",
 		}},
@@ -1233,7 +1233,7 @@ func (s *ApplicationSuite) TestDestroyUnitDryRun(c *gc.C) {
 
 	s.expectDefaultStorageAttachments(ctrl)
 
-	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	results, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
 			{
 				UnitTag: "unit-postgresql-0",
@@ -1289,7 +1289,7 @@ func (s *ApplicationSuite) TestDeployAttachStorage(c *gc.C) {
 			AttachStorage:   []string{"volume-baz-0"},
 		}},
 	}
-	results, err := s.api.Deploy(args)
+	results, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -1332,7 +1332,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 			NumUnits: 1,
 		}},
 	}
-	results, err := s.api.Deploy(args)
+	results, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -1386,7 +1386,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		NumUnits:        1,
 		Storage:         storageConstraints,
 	}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 
@@ -1413,7 +1413,7 @@ func (s *ApplicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 	}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 
@@ -1445,7 +1445,7 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 		NumUnits:        1,
 		Placement:       placement,
 	}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1488,7 +1488,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "#", Directive: "0/lxd/0"}},
 	}}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: args,
 	})
 
@@ -1510,7 +1510,7 @@ func (s *ApplicationSuite) TestApplicationDeployFailCharmOrigin(c *gc.C) {
 	}, {
 		CharmOrigin: originHash,
 	}}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: args,
 	})
 
@@ -1529,7 +1529,7 @@ func (s *ApplicationSuite) TestApplicationDeploymentRemovesPendingResourcesOnFai
 	resourcesManager.EXPECT().RemovePendingAppResources("my-app", resources).Return(nil)
 	s.backend.EXPECT().Resources().Return(resourcesManager)
 
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			// CharmURL is missing to ensure deployApplication fails
 			// so that we can assert pending app resources are removed
@@ -1560,7 +1560,7 @@ func (s *ApplicationSuite) TestApplicationDeploymentTrust(c *gc.C) {
 		NumUnits:        1,
 		Config:          withTrust,
 	}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args},
 	})
 
@@ -1599,7 +1599,7 @@ func (s *ApplicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 			"endpoint": "42",
 		},
 	}}
-	results, err := s.api.Deploy(params.ApplicationsDeploy{
+	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: args,
 	})
 
@@ -1655,7 +1655,7 @@ func (s *ApplicationSuite) TestDeployMinDeploymentVersionTooHigh(c *gc.C) {
 			Config:          map[string]string{"kubernetes-service-annotations": "a=b c="},
 		}},
 	}
-	results, err := s.api.Deploy(args)
+	results, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(
@@ -1705,7 +1705,7 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 			Placement:       []*instance.Placement{{}, {}},
 		}},
 	}
-	results, err := s.api.Deploy(args)
+	results, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -1731,7 +1731,7 @@ func (s *ApplicationSuite) TestDeployCAASBlockStorageRejected(c *gc.C) {
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.OneError(), gc.ErrorMatches, `block storage "block" is not supported for container charms`)
@@ -1758,7 +1758,7 @@ func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	msg := result.OneError().Error()
@@ -1790,7 +1790,7 @@ func (s *ApplicationSuite) TestDeployCAASModelCharmNeedsNoOperatorStorage(c *gc.
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -1817,7 +1817,7 @@ func (s *ApplicationSuite) TestDeployCAASModelSidecarCharmNeedsNoOperatorStorage
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -1843,7 +1843,7 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultOperatorStorageClass(c *gc.
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -1871,7 +1871,7 @@ func (s *ApplicationSuite) TestDeployCAASModelWrongOperatorStorageType(c *gc.C) 
 			NumUnits:        1,
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	msg := result.OneError().Error()
@@ -1904,7 +1904,7 @@ func (s *ApplicationSuite) TestDeployCAASModelInvalidStorage(c *gc.C) {
 			},
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	msg := result.OneError().Error()
 	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `storage class not found`)
@@ -1941,7 +1941,7 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultStorageClass(c *gc.C) {
 			},
 		}},
 	}
-	result, err := s.api.Deploy(args)
+	result, err := s.api.Deploy(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Error, gc.IsNil)
 }
@@ -1957,7 +1957,7 @@ func (s *ApplicationSuite) TestAddUnits(c *gc.C) {
 	app.EXPECT().AddUnit(state.AddUnitParams{AttachStorage: []names.StorageTag{}}).Return(newUnit, nil)
 	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
-	results, err := s.api.AddUnits(params.AddApplicationUnits{
+	results, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
 	})
@@ -1972,7 +1972,7 @@ func (s *ApplicationSuite) TestAddUnitsCAASModel(c *gc.C) {
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	_, err := s.api.AddUnits(params.AddApplicationUnits{
+	_, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
 	})
@@ -1992,7 +1992,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorage(c *gc.C) {
 	}).Return(newUnit, nil)
 	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
-	_, err := s.api.AddUnits(params.AddApplicationUnits{
+	_, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "postgresql",
 		NumUnits:        1,
 		AttachStorage:   []string{"storage-pgdata-0"},
@@ -2008,7 +2008,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorageMultipleUnits(c *gc.C) {
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "foo")
 	s.backend.EXPECT().Application("foo").AnyTimes().Return(app, nil)
 
-	_, err := s.api.AddUnits(params.AddApplicationUnits{
+	_, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "foo",
 		NumUnits:        2,
 		AttachStorage:   []string{"storage-foo-0"},
@@ -2024,7 +2024,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorageInvalidStorageTag(c *gc.C) {
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "foo")
 	s.backend.EXPECT().Application("foo").AnyTimes().Return(app, nil)
 
-	_, err := s.api.AddUnits(params.AddApplicationUnits{
+	_, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
 		ApplicationName: "foo",
 		NumUnits:        1,
 		AttachStorage:   []string{"volume-0"},
@@ -2036,7 +2036,7 @@ func (s *ApplicationSuite) TestDestroyUnitsCAASModel(c *gc.C) {
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	_, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+	_, err := s.api.DestroyUnit(context.Background(), params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
 			{UnitTag: "unit-postgresql-0"},
 			{
@@ -2057,7 +2057,7 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModel(c *gc.C) {
 	app.EXPECT().SetScale(5, int64(0), true).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	results, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	results, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Scale:          5,
@@ -2090,7 +2090,7 @@ func (s *ApplicationSuite) TestScaleApplicationsNotAllowedForOperator(c *gc.C) {
 			Scale:          5,
 		}},
 	}
-	result, err := s.api.ScaleApplications(args)
+	result, err := s.api.ScaleApplications(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.NotNil)
@@ -2117,7 +2117,7 @@ func (s *ApplicationSuite) TestScaleApplicationsNotAllowedForDaemonSet(c *gc.C) 
 			Scale:          5,
 		}},
 	}
-	result, err := s.api.ScaleApplications(args)
+	result, err := s.api.ScaleApplications(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.NotNil)
@@ -2130,7 +2130,7 @@ func (s *ApplicationSuite) TestScaleApplicationsBlocked(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	_, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Scale:          5,
@@ -2148,7 +2148,7 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleChange(c *gc.C) {
 	app.EXPECT().ChangeScale(5).Return(7, nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	results, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	results, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			ScaleChange:    5,
@@ -2166,7 +2166,7 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleArgCheckScaleAndSc
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	results, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	results, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Scale:          5,
@@ -2181,7 +2181,7 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleArgCheckInvalidSca
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	results, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	results, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Scale:          -1,
@@ -2194,7 +2194,7 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleArgCheckInvalidSca
 func (s *ApplicationSuite) TestScaleApplicationsIAASModel(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	_, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+	_, err := s.api.ScaleApplications(context.Background(), params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{
 			ApplicationTag: "application-postgresql",
 			Scale:          5,
@@ -2251,7 +2251,7 @@ func (s *ApplicationSuite) TestSetRelationSuspended(c *gc.C) {
 	s.backend.EXPECT().Relation(123).Return(rel, nil)
 	s.backend.EXPECT().OfferConnectionForRelation("wordpress:db mysql:db").Return(nil, nil)
 
-	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	results, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  true,
@@ -2269,7 +2269,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedNoOp(c *gc.C) {
 	rel := s.expectRelation(ctrl, "wordpress:db mysql:db", true)
 	s.backend.EXPECT().Relation(123).Return(rel, nil)
 
-	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	results, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  true,
@@ -2289,7 +2289,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedFalse(c *gc.C) {
 	s.backend.EXPECT().Relation(123).Return(rel, nil)
 	s.backend.EXPECT().OfferConnectionForRelation("wordpress:db mysql:db").Return(nil, nil)
 
-	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	results, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  false,
@@ -2312,7 +2312,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedPermission(c *gc.C) {
 	s.backend.EXPECT().OfferConnectionForRelation("wordpress:db mysql:db").Return(offerConn, nil)
 	s.backend.EXPECT().ApplicationOfferForUUID("offer-uuid").Return(&crossmodel.ApplicationOffer{OfferUUID: "mysql"}, nil)
 
-	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	results, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  false,
@@ -2330,7 +2330,7 @@ func (s *ApplicationSuite) TestSetNonOfferRelationStatus(c *gc.C) {
 	s.backend.EXPECT().Relation(123).Return(rel, nil)
 	s.backend.EXPECT().OfferConnectionForRelation("mediawiki:db mysql:db").Return(nil, errors.NotFoundf(""))
 
-	results, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	results, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  true,
@@ -2344,7 +2344,7 @@ func (s *ApplicationSuite) TestBlockSetRelationSuspended(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	_, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  true,
@@ -2359,7 +2359,7 @@ func (s *ApplicationSuite) TestSetRelationSuspendedPermissionDenied(c *gc.C) {
 	}
 	defer s.setup(c).Finish()
 
-	_, err := s.api.SetRelationsSuspended(params.RelationSuspendedArgs{
+	_, err := s.api.SetRelationsSuspended(context.Background(), params.RelationSuspendedArgs{
 		Args: []params.RelationSuspendedArg{{
 			RelationId: 123,
 			Suspended:  true,
@@ -2538,6 +2538,7 @@ func (s *ApplicationSuite) TestApplicationUpdateBaseNoParams(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	results, err := s.api.UpdateApplicationBase(
+		context.Background(),
 		params.UpdateChannelArgs{
 			Args: []params.UpdateChannelArg{},
 		},
@@ -2553,6 +2554,7 @@ func (s *ApplicationSuite) TestApplicationUpdateBasePermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	_, err := s.api.UpdateApplicationBase(
+		context.Background(),
 		params.UpdateChannelArgs{
 			Args: []params.UpdateChannelArg{{
 				Entity:  params.Entity{Tag: names.NewApplicationTag("postgresql").String()},
@@ -2618,7 +2620,7 @@ func (s *ApplicationSuite) TestSetConfigBranch(c *gc.C) {
 	gen.EXPECT().AssignApplication("postgresql")
 	s.backend.EXPECT().Branch("new-branch").Return(gen, nil)
 
-	result, err := s.api.SetConfigs(params.ConfigSetArgs{
+	result, err := s.api.SetConfigs(context.Background(), params.ConfigSetArgs{
 		Args: []params.ConfigSet{{
 			ApplicationName: "postgresql",
 			Config: map[string]string{
@@ -2641,7 +2643,7 @@ func (s *ApplicationSuite) TestSetEmptyConfigMasterBranch(c *gc.C) {
 	s.expectUpdateApplicationConfig(c, app)
 
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
-	result, err := s.api.SetConfigs(params.ConfigSetArgs{
+	result, err := s.api.SetConfigs(context.Background(), params.ConfigSetArgs{
 		Args: []params.ConfigSet{{
 			ApplicationName: "postgresql",
 			Config: map[string]string{
@@ -2667,7 +2669,7 @@ func (s *ApplicationSuite) TestUnsetApplicationConfig(c *gc.C) {
 	app.EXPECT().UpdateCharmConfig("new-branch", charm.Settings{"stringVal": nil})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	result, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{
+	result, err := s.api.UnsetApplicationsConfig(context.Background(), params.ApplicationConfigUnsetArgs{
 		Args: []params.ApplicationUnset{{
 			ApplicationName: "postgresql",
 			Options:         []string{"trust", "stringVal"},
@@ -2682,7 +2684,7 @@ func (s *ApplicationSuite) TestBlockUnsetApplicationConfig(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{})
+	_, err := s.api.UnsetApplicationsConfig(context.Background(), params.ApplicationConfigUnsetArgs{})
 	c.Assert(err, gc.ErrorMatches, "change blocked")
 }
 
@@ -2693,7 +2695,7 @@ func (s *ApplicationSuite) TestUnsetApplicationConfigPermissionDenied(c *gc.C) {
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	_, err := s.api.UnsetApplicationsConfig(params.ApplicationConfigUnsetArgs{
+	_, err := s.api.UnsetApplicationsConfig(context.Background(), params.ApplicationConfigUnsetArgs{
 		Args: []params.ApplicationUnset{{
 			ApplicationName: "postgresql",
 			Options:         []string{"option"},
@@ -2720,7 +2722,7 @@ func (s *ApplicationSuite) TestResolveUnitErrors(c *gc.C) {
 			Entities: entities,
 		},
 	}
-	result, err := s.api.ResolveUnitErrors(p)
+	result, err := s.api.ResolveUnitErrors(context.Background(), p)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{}, {}}})
 }
@@ -2737,7 +2739,7 @@ func (s *ApplicationSuite) TestResolveUnitErrorsAll(c *gc.C) {
 		All:   true,
 		Retry: true,
 	}
-	_, err := s.api.ResolveUnitErrors(p)
+	_, err := s.api.ResolveUnitErrors(context.Background(), p)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2745,7 +2747,7 @@ func (s *ApplicationSuite) TestBlockResolveUnitErrors(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	_, err := s.api.ResolveUnitErrors(params.UnitsResolved{})
+	_, err := s.api.ResolveUnitErrors(context.Background(), params.UnitsResolved{})
 	c.Assert(err, gc.ErrorMatches, "change blocked")
 }
 
@@ -2762,7 +2764,7 @@ func (s *ApplicationSuite) TestResolveUnitErrorsPermissionDenied(c *gc.C) {
 			Entities: entities,
 		},
 	}
-	_, err := s.api.ResolveUnitErrors(p)
+	_, err := s.api.ResolveUnitErrors(context.Background(), p)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -2785,7 +2787,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOne(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil).MinTimes(1)
 
 	entities := []params.Entity{{Tag: "application-postgresql"}}
-	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
+	result, err := s.api.ApplicationsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.ApplicationResult{
@@ -2826,7 +2828,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 	s.backend.EXPECT().Application("postgresql").Return(app, nil).MinTimes(1)
 
 	entities := []params.Entity{{Tag: "application-postgresql"}}
-	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
+	result, err := s.api.ApplicationsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.ApplicationResult{
@@ -2857,7 +2859,7 @@ func (s *ApplicationSuite) TestApplicationsInfoDetailsErr(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil).MinTimes(1)
 
 	entities := []params.Entity{{Tag: "application-postgresql"}}
-	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
+	result, err := s.api.ApplicationsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(*result.Results[0].Error, gc.ErrorMatches, "boom")
@@ -2874,7 +2876,7 @@ func (s *ApplicationSuite) TestApplicationsInfoBindingsErr(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil).MinTimes(1)
 
 	entities := []params.Entity{{Tag: "application-postgresql"}}
-	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
+	result, err := s.api.ApplicationsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(*result.Results[0].Error, gc.ErrorMatches, "boom")
@@ -2902,7 +2904,7 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	s.backend.EXPECT().Application("wordpress").Return(nil, errors.NotFoundf(`application "wordpress"`))
 
 	entities := []params.Entity{{Tag: "application-postgresql"}, {Tag: "application-wordpress"}, {Tag: "unit-postgresql-0"}}
-	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
+	result, err := s.api.ApplicationsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.ApplicationResult{
@@ -2935,7 +2937,7 @@ func (s *ApplicationSuite) TestApplicationMergeBindingsErr(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.api.MergeBindings(req)
+	result, err := s.api.MergeBindings(context.Background(), req)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(req.Args))
@@ -3005,7 +3007,7 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 	s.backend.EXPECT().Application("gitlab").Return(nil, errors.NotFoundf(`application "gitlab"`))
 
 	entities := []params.Entity{{Tag: "unit-postgresql-0"}, {Tag: "unit-mysql-0"}}
-	result, err := s.api.UnitsInfo(params.Entities{Entities: entities})
+	result, err := s.api.UnitsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -3067,7 +3069,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 	s.backend.EXPECT().Application("gitlab").Return(nil, errors.NotFoundf(`application "gitlab"`)).MinTimes(1)
 
 	entities := []params.Entity{{Tag: "application-postgresql"}}
-	result, err := s.api.UnitsInfo(params.Entities{Entities: entities})
+	result, err := s.api.UnitsInfo(context.Background(), params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 2)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -3126,7 +3128,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 func (s *ApplicationSuite) TestLeader(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.api.Leader(params.Entity{Tag: names.NewApplicationTag("postgresql").String()})
+	result, err := s.api.Leader(context.Background(), params.Entity{Tag: names.NewApplicationTag("postgresql").String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.Equals, "postgresql/0")
@@ -3166,7 +3168,7 @@ func (s *ApplicationSuite) TestCharmConfig(c *gc.C) {
 	s.setupConfigTest(ctrl)
 
 	branch := "test-branch"
-	results, err := s.api.CharmConfig(params.ApplicationGetArgs{
+	results, err := s.api.CharmConfig(context.Background(), params.ApplicationGetArgs{
 		Args: []params.ApplicationGet{
 			{ApplicationName: "foo", BranchName: branch},
 			{ApplicationName: "bar", BranchName: branch},
@@ -3183,7 +3185,7 @@ func (s *ApplicationSuite) TestGetConfig(c *gc.C) {
 
 	s.setupConfigTest(ctrl)
 
-	results, err := s.api.GetConfig(params.Entities{
+	results, err := s.api.GetConfig(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "wat"}, {Tag: "machine-0"}, {Tag: "user-foo"},
 			{Tag: "application-foo"}, {Tag: "application-bar"}, {Tag: "application-wat"},
@@ -3271,7 +3273,7 @@ func (s *ApplicationSuite) TestSetMetricCredentialsOneArg(c *gc.C) {
 	app.EXPECT().SetMetricCredentials([]byte("creds 1234")).Return(nil)
 	s.backend.EXPECT().Application("mysql").Return(app, nil)
 
-	results, err := s.api.SetMetricCredentials(params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
+	results, err := s.api.SetMetricCredentials(context.Background(), params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
 		ApplicationName:   "mysql",
 		MetricCredentials: []byte("creds 1234"),
 	}}})
@@ -3293,7 +3295,7 @@ func (s *ApplicationSuite) TestSetMetricCredentialsTwoArgsBothPass(c *gc.C) {
 	app1.EXPECT().SetMetricCredentials([]byte("creds 4567")).Return(nil)
 	s.backend.EXPECT().Application("wordpress").Return(app1, nil)
 
-	results, err := s.api.SetMetricCredentials(params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
+	results, err := s.api.SetMetricCredentials(context.Background(), params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
 		ApplicationName:   "mysql",
 		MetricCredentials: []byte("creds 1234"),
 	}, {
@@ -3315,7 +3317,7 @@ func (s *ApplicationSuite) TestSetMetricCredentialsTwoArgsSecondFails(c *gc.C) {
 	s.backend.EXPECT().Application("mysql").Return(app, nil)
 	s.backend.EXPECT().Application("not-an-application").Return(nil, errors.NotFoundf(`application "not-an-application"`))
 
-	results, err := s.api.SetMetricCredentials(params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
+	results, err := s.api.SetMetricCredentials(context.Background(), params.ApplicationMetricCredentials{Creds: []params.ApplicationMetricCredential{{
 		ApplicationName:   "mysql",
 		MetricCredentials: []byte("creds 1234"),
 	}, {
@@ -3372,7 +3374,7 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
+	result, err := s.api.GetCharmURLOrigin(context.Background(), params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.URL, gc.Equals, "ch:postgresql-42")

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -4,6 +4,7 @@
 package applicationoffers_test
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -63,7 +64,7 @@ func (s *offerAccessSuite) modifyAccess(
 			OfferURL: offerURL,
 		}}}
 
-	result, err := s.api.ModifyOfferAccess(args)
+	result, err := s.api.ModifyOfferAccess(context.Background(), args)
 	if err != nil {
 		return err
 	}
@@ -358,7 +359,7 @@ func (s *offerAccessSuite) TestGrantOfferInvalidUserTag(c *gc.C) {
 				OfferURL: "test.someoffer",
 			}}}
 
-		result, err := s.api.ModifyOfferAccess(args)
+		result, err := s.api.ModifyOfferAccess(context.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
 	}
@@ -369,7 +370,7 @@ func (s *offerAccessSuite) TestModifyOfferAccessEmptyArgs(c *gc.C) {
 	args := params.ModifyOfferAccessRequest{
 		Changes: []params.ModifyOfferAccess{{OfferURL: "test.someoffer"}}}
 
-	result, err := s.api.ModifyOfferAccess(args)
+	result, err := s.api.ModifyOfferAccess(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `could not modify offer access: "" offer access not valid`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
@@ -387,7 +388,7 @@ func (s *offerAccessSuite) TestModifyOfferAccessInvalidAction(c *gc.C) {
 			OfferURL: "test.someoffer",
 		}}}
 
-	result, err := s.api.ModifyOfferAccess(args)
+	result, err := s.api.ModifyOfferAccess(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `unknown action "dance"`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -67,7 +67,7 @@ func createOffersAPI(
 }
 
 // Offer makes application endpoints available for consumption at a specified URL.
-func (api *OffersAPI) Offer(all params.AddApplicationOffers) (params.ErrorResults, error) {
+func (api *OffersAPI) Offer(ctx context.Context, all params.AddApplicationOffers) (params.ErrorResults, error) {
 	result := make([]params.ErrorResult, len(all.Offers))
 
 	apiUser := api.Authorizer.GetAuthTag().(names.UserTag)
@@ -145,7 +145,7 @@ func (api *OffersAPI) makeAddOfferArgsFromParams(user names.UserTag, backend Bac
 
 // ListApplicationOffers gets deployed details about application offers that match given filter.
 // The results contain details about the deployed applications such as connection count.
-func (api *OffersAPI) ListApplicationOffers(filters params.OfferFilters) (params.QueryApplicationOffersResults, error) {
+func (api *OffersAPI) ListApplicationOffers(ctx context.Context, filters params.OfferFilters) (params.QueryApplicationOffersResults, error) {
 	var result params.QueryApplicationOffersResults
 	user := api.Authorizer.GetAuthTag().(names.UserTag)
 	offers, err := api.getApplicationOffersDetails(user, filters, permission.AdminAccess)
@@ -157,7 +157,7 @@ func (api *OffersAPI) ListApplicationOffers(filters params.OfferFilters) (params
 }
 
 // ModifyOfferAccess changes the application offer access granted to users.
-func (api *OffersAPI) ModifyOfferAccess(args params.ModifyOfferAccessRequest) (result params.ErrorResults, _ error) {
+func (api *OffersAPI) ModifyOfferAccess(ctx context.Context, args params.ModifyOfferAccessRequest) (result params.ErrorResults, _ error) {
 	result = params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Changes)),
 	}
@@ -313,7 +313,7 @@ func (api *OffersAPI) revokeOfferAccess(backend Backend, offerTag names.Applicat
 }
 
 // ApplicationOffers gets details about remote applications that match given URLs.
-func (api *OffersAPI) ApplicationOffers(urls params.OfferURLs) (params.ApplicationOffersResults, error) {
+func (api *OffersAPI) ApplicationOffers(ctx context.Context, urls params.OfferURLs) (params.ApplicationOffersResults, error) {
 	user := api.Authorizer.GetAuthTag().(names.UserTag)
 	return api.getApplicationOffers(user, urls)
 }
@@ -376,7 +376,7 @@ func (api *OffersAPI) getApplicationOffers(user names.UserTag, urls params.Offer
 }
 
 // FindApplicationOffers gets details about remote applications that match given filter.
-func (api *OffersAPI) FindApplicationOffers(filters params.OfferFilters) (params.QueryApplicationOffersResults, error) {
+func (api *OffersAPI) FindApplicationOffers(ctx context.Context, filters params.OfferFilters) (params.QueryApplicationOffersResults, error) {
 	var result params.QueryApplicationOffersResults
 	var filtersToUse params.OfferFilters
 
@@ -502,7 +502,7 @@ func (api *OffersAPI) getConsumeDetails(user names.UserTag, urls params.OfferURL
 
 // RemoteApplicationInfo returns information about the requested remote application.
 // This call currently has no client side API, only there for the Dashboard at this stage.
-func (api *OffersAPI) RemoteApplicationInfo(args params.OfferURLs) (params.RemoteApplicationInfoResults, error) {
+func (api *OffersAPI) RemoteApplicationInfo(ctx context.Context, args params.OfferURLs) (params.RemoteApplicationInfoResults, error) {
 	results := make([]params.RemoteApplicationInfoResult, len(args.OfferURLs))
 	user := api.Authorizer.GetAuthTag().(names.UserTag)
 	for i, url := range args.OfferURLs {
@@ -559,7 +559,7 @@ func (api *OffersAPI) oneRemoteApplicationInfo(user names.UserTag, urlStr string
 }
 
 // DestroyOffers removes the offers specified by the given URLs, forcing if necessary.
-func (api *OffersAPI) DestroyOffers(args params.DestroyApplicationOffers) (params.ErrorResults, error) {
+func (api *OffersAPI) DestroyOffers(ctx context.Context, args params.DestroyApplicationOffers) (params.ErrorResults, error) {
 	result := make([]params.ErrorResult, len(args.OfferURLs))
 
 	user := api.Authorizer.GetAuthTag().(names.UserTag)

--- a/apiserver/facades/client/block/client.go
+++ b/apiserver/facades/client/block/client.go
@@ -4,6 +4,8 @@
 package block
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -49,7 +51,7 @@ func (a *API) checkCanWrite() error {
 }
 
 // List implements Block.List().
-func (a *API) List() (params.BlockResults, error) {
+func (a *API) List(ctx context.Context) (params.BlockResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.BlockResults{}, err
 	}
@@ -82,7 +84,7 @@ func convertBlock(b state.Block) params.BlockResult {
 }
 
 // SwitchBlockOn implements Block.SwitchBlockOn().
-func (a *API) SwitchBlockOn(args params.BlockSwitchParams) params.ErrorResult {
+func (a *API) SwitchBlockOn(ctx context.Context, args params.BlockSwitchParams) params.ErrorResult {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}
 	}
@@ -92,7 +94,7 @@ func (a *API) SwitchBlockOn(args params.BlockSwitchParams) params.ErrorResult {
 }
 
 // SwitchBlockOff implements Block.SwitchBlockOff().
-func (a *API) SwitchBlockOff(args params.BlockSwitchParams) params.ErrorResult {
+func (a *API) SwitchBlockOff(ctx context.Context, args params.BlockSwitchParams) params.ErrorResult {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}
 	}

--- a/apiserver/facades/client/block/client_test.go
+++ b/apiserver/facades/client/block/client_test.go
@@ -4,6 +4,8 @@
 package block_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -45,7 +47,7 @@ func (s *blockSuite) TestListBlockNoneExistent(c *gc.C) {
 }
 
 func (s *blockSuite) assertBlockList(c *gc.C, length int) {
-	all, err := s.api.List()
+	all, err := s.api.List(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all.Results, gc.HasLen, length)
 }
@@ -59,7 +61,7 @@ func (s *blockSuite) assertSwitchBlockOn(c *gc.C, blockType, msg string) {
 		Type:    blockType,
 		Message: msg,
 	}
-	err := s.api.SwitchBlockOn(on)
+	err := s.api.SwitchBlockOn(context.Background(), on)
 	c.Assert(err.Error, gc.IsNil)
 	s.assertBlockList(c, 1)
 }
@@ -70,7 +72,7 @@ func (s *blockSuite) TestSwitchInvalidBlockOn(c *gc.C) {
 		Message: "for TestSwitchInvalidBlockOn",
 	}
 
-	c.Assert(func() { s.api.SwitchBlockOn(on) }, gc.PanicMatches, ".*unknown block type.*")
+	c.Assert(func() { s.api.SwitchBlockOn(context.Background(), on) }, gc.PanicMatches, ".*unknown block type.*")
 }
 
 func (s *blockSuite) TestSwitchBlockOff(c *gc.C) {
@@ -80,7 +82,7 @@ func (s *blockSuite) TestSwitchBlockOff(c *gc.C) {
 	off := params.BlockSwitchParams{
 		Type: valid.String(),
 	}
-	err := s.api.SwitchBlockOff(off)
+	err := s.api.SwitchBlockOff(context.Background(), off)
 	c.Assert(err.Error, gc.IsNil)
 	s.assertBlockList(c, 0)
 }

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -5,6 +5,7 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -128,7 +129,7 @@ func (b *BundleAPI) doGetBundleChanges(
 // bundle data. The changes are sorted by requirements, so that they can be
 // applied in order.
 // V4 GetChangesMapArgs is not supported on anything less than v4
-func (b *BundleAPI) GetChangesMapArgs(args params.BundleChangesParams) (params.BundleChangesMapArgsResults, error) {
+func (b *BundleAPI) GetChangesMapArgs(ctx context.Context, args params.BundleChangesParams) (params.BundleChangesMapArgsResults, error) {
 	vs := validators{
 		verifyConstraints: func(s string) error {
 			_, err := constraints.Parse(s)
@@ -185,7 +186,7 @@ func (b *BundleAPI) doGetBundleChangesMapArgs(
 }
 
 // ExportBundle exports the current model configuration as bundle.
-func (b *BundleAPI) ExportBundle(arg params.ExportBundleParams) (params.StringResult, error) {
+func (b *BundleAPI) ExportBundle(ctx context.Context, arg params.ExportBundleParams) (params.StringResult, error) {
 	fail := func(failErr error) (params.StringResult, error) {
 		return params.StringResult{}, apiservererrors.ServerError(failErr)
 	}

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -4,6 +4,7 @@
 package bundle_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -59,7 +60,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleContentError(c *gc.C) {
 	args := params.BundleChangesParams{
 		BundleDataYAML: ":",
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `cannot read bundle YAML: malformed bundle: bundle is empty not valid`)
 	c.Assert(r, gc.DeepEquals, params.BundleChangesMapArgsResults{})
 }
@@ -76,7 +77,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleVerificationErrors(c *gc.C) {
                     num_units: -1
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
@@ -97,7 +98,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleConstraintsError(c *gc.C) {
                     constraints: bad=wolf
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
@@ -116,7 +117,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleStorageError(c *gc.C) {
                         bad: 0,100M
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
@@ -135,7 +136,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleDevicesError(c *gc.C) {
                         bad-gpu: -1,nvidia.com/gpu
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
@@ -165,7 +166,7 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
                   - haproxy:web
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
 		Id:     "addCharm-0",
@@ -233,7 +234,7 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccessCharmHubRevision(c *gc.C) {
                     channel: candidate
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
 		Id:     "addCharm-0",
@@ -281,7 +282,7 @@ func (s *bundleSuite) TestGetChangesMapArgsKubernetes(c *gc.C) {
                   - haproxy:web
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
 		Id:     "addCharm-0",
@@ -349,7 +350,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleEndpointBindingsSuccess(c *gc.C
                         url: public
         `,
 	}
-	r, err := s.facade.GetChangesMapArgs(args)
+	r, err := s.facade.GetChangesMapArgs(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for _, change := range r.Changes {
@@ -376,7 +377,7 @@ func (s *bundleSuite) TestExportBundleFailNoApplication(c *gc.C) {
 		CloudRegion: "some-region"})
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, gc.NotNil)
 	c.Assert(result, gc.Equals, params.StringResult{})
 	c.Check(err, gc.ErrorMatches, "nothing to export as there are no applications")
@@ -457,7 +458,7 @@ func (s *bundleSuite) TestExportBundleWithApplication(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -506,7 +507,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationResources(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -560,7 +561,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -605,7 +606,7 @@ func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -668,7 +669,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -815,7 +816,7 @@ UGNmDMvj8tUYI7+SvffHrTBwBPvcGeXa7XP4Au+GoJUN0jHspCeik/04KwanRCmu
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -942,7 +943,7 @@ func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
 
 	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -1052,7 +1053,7 @@ func (s *bundleSuite) TestExportBundleModelWithSettingsRelations(c *gc.C) {
 	model := s.newModel("iaas", "wordpress", "mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1095,7 +1096,7 @@ func (s *bundleSuite) TestExportBundleModelWithCharmDefaults(c *gc.C) {
 	})
 	app.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/20.04/stable"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{IncludeCharmDefaults: true})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{IncludeCharmDefaults: true})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1171,7 +1172,7 @@ func (s *bundleSuite) TestExportBundleModelRelationsWithSubordinates(c *gc.C) {
 	s.setEndpointSettings(mysqlEndpoint, "mysql/0")
 	s.setEndpointSettings(loggingEndpoint, "logging/2")
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1239,7 +1240,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplication(c *gc.C) {
 	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/18.04/stable"})
 	application.SetStatus(minimalStatusArgs())
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1294,7 +1295,7 @@ func (s *bundleSuite) setupExportBundleEndpointBindingsPrinted(all, oneOff strin
 
 func (s *bundleSuite) TestExportBundleNoEndpointBindingsPrinted(c *gc.C) {
 	s.setupExportBundleEndpointBindingsPrinted("0", "0")
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1316,7 +1317,7 @@ applications:
 
 func (s *bundleSuite) TestExportBundleEndpointBindingsPrinted(c *gc.C) {
 	s.setupExportBundleEndpointBindingsPrinted("0", "1")
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1362,7 +1363,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplicationAndMachine(c *gc.C) 
 
 	s.addMinimalMachineWithConstraints(s.st.model, "0")
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1414,7 +1415,7 @@ func (s *bundleSuite) TestExportBundleModelWithConstraints(c *gc.C) {
 
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -1470,7 +1471,7 @@ func (s *bundleSuite) TestExportBundleModelWithAnnotations(c *gc.C) {
 
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -1556,7 +1557,7 @@ func (s *bundleSuite) TestExportBundleWithContainers(c *gc.C) {
 	})
 	ut.SetAgentStatus(minimalStatusArgs())
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
 series: focal
@@ -1617,7 +1618,7 @@ func (s *bundleSuite) TestMixedSeries(c *gc.C) {
 		Base: "ubuntu@22.04",
 	})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1683,7 +1684,7 @@ func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 		Base: "ubuntu@22.04",
 	})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
@@ -1715,7 +1716,7 @@ func (s *bundleSuite) TestExportKubernetesBundle(c *gc.C) {
 	model := s.newModel("caas", "wordpress", "mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1741,7 +1742,7 @@ func (s *bundleSuite) TestExportCharmhubBundle(c *gc.C) {
 	model := s.newModel("iaas", "ch:wordpress", "ch:mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1777,7 +1778,7 @@ func (s *bundleSuite) TestExportLocalBundle(c *gc.C) {
 	model := s.newModel("iaas", "local:wordpress", "local:mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1811,7 +1812,7 @@ func (s *bundleSuite) TestExportLocalBundleWithSeries(c *gc.C) {
 	model := s.newModel("iaas", "local:focal/wordpress", "local:mysql")
 	model.SetStatus(description.StatusArgs{Value: "available"})
 
-	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
@@ -1949,7 +1950,7 @@ applications:
 		application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/20.04/stable"})
 		application.SetStatus(minimalStatusArgs())
 
-		result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+		result, err := s.facade.ExportBundle(context.Background(), params.ExportBundleParams{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		exp := params.StringResult{Result: spec.expBundle}

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -4,6 +4,7 @@
 package charms
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"sync"
@@ -74,7 +75,7 @@ type API struct {
 }
 
 // CharmInfo returns information about the requested charm.
-func (a *API) CharmInfo(args params.CharmURL) (params.Charm, error) {
+func (a *API) CharmInfo(ctx context.Context, args params.CharmURL) (params.Charm, error) {
 	return a.charmInfoAPI.CharmInfo(args)
 }
 
@@ -124,7 +125,7 @@ func NewCharmsAPI(
 // List returns a list of charm URLs currently in the state.
 // If supplied parameter contains any names, the result will
 // be filtered to return only the charms with supplied names.
-func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
+func (a *API) List(ctx context.Context, args params.CharmsList) (params.CharmsListResult, error) {
 	a.logger.Tracef("List %+v", args)
 	if err := a.checkCanRead(); err != nil {
 		return params.CharmsListResult{}, errors.Trace(err)
@@ -152,7 +153,7 @@ func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
 
 // GetDownloadInfos attempts to get the bundle corresponding to the charm url
 // and origin.
-func (a *API) GetDownloadInfos(args params.CharmURLAndOrigins) (params.DownloadInfoResults, error) {
+func (a *API) GetDownloadInfos(ctx context.Context, args params.CharmURLAndOrigins) (params.DownloadInfoResults, error) {
 	a.logger.Tracef("GetDownloadInfos %+v", args)
 
 	results := params.DownloadInfoResults{
@@ -242,7 +243,7 @@ func normalizeCharmOrigin(origin params.CharmOrigin, fallbackArch string, logger
 // AddCharm adds the given charm URL (which must include revision) to the
 // environment, if it does not exist yet. Local charms are not supported,
 // only charm store and charm hub URLs. See also AddLocalCharm().
-func (a *API) AddCharm(args params.AddCharmWithOrigin) (params.CharmOriginResult, error) {
+func (a *API) AddCharm(ctx context.Context, args params.AddCharmWithOrigin) (params.CharmOriginResult, error) {
 	a.logger.Tracef("AddCharm %+v", args)
 	return a.addCharmWithAuthorization(params.AddCharmWithAuth{
 		URL:    args.URL,
@@ -257,7 +258,7 @@ func (a *API) AddCharm(args params.AddCharmWithOrigin) (params.CharmOriginResult
 //
 // Since the charm macaroons are no longer supported, this is the same as
 // AddCharm. We keep it for backwards compatibility in APIv5.
-func (a *APIv5) AddCharmWithAuthorization(args params.AddCharmWithAuth) (params.CharmOriginResult, error) {
+func (a *APIv5) AddCharmWithAuthorization(ctx context.Context, args params.AddCharmWithAuth) (params.CharmOriginResult, error) {
 	a.logger.Tracef("AddCharmWithAuthorization %+v", args)
 	return a.addCharmWithAuthorization(args)
 }
@@ -343,7 +344,7 @@ func (a *API) queueAsyncCharmDownload(args params.AddCharmWithAuth) (corecharm.O
 
 // ResolveCharms resolves the given charm URLs with an optionally specified
 // preferred channel.  Channel provided via CharmOrigin.
-func (a *API) ResolveCharms(args params.ResolveCharmsWithChannel) (params.ResolveCharmWithChannelResults, error) {
+func (a *API) ResolveCharms(ctx context.Context, args params.ResolveCharmsWithChannel) (params.ResolveCharmWithChannelResults, error) {
 	a.logger.Tracef("ResolveCharms %+v", args)
 	if err := a.checkCanRead(); err != nil {
 		return params.ResolveCharmWithChannelResults{}, errors.Trace(err)
@@ -435,8 +436,8 @@ func (a *API) resolveOneCharm(arg params.ResolveCharmWithChannel) params.Resolve
 // ResolveCharms resolves the given charm URLs with an optionally specified
 // preferred channel.  Channel provided via CharmOrigin.
 // We need to include SupportedSeries in facade version 6
-func (a *APIv6) ResolveCharms(args params.ResolveCharmsWithChannel) (params.ResolveCharmWithChannelResultsV6, error) {
-	res, err := a.API.ResolveCharms(args)
+func (a *APIv6) ResolveCharms(ctx context.Context, args params.ResolveCharmsWithChannel) (params.ResolveCharmWithChannelResultsV6, error) {
+	res, err := a.API.ResolveCharms(ctx, args)
 	if err != nil {
 		return params.ResolveCharmWithChannelResultsV6{}, errors.Trace(err)
 	}
@@ -514,7 +515,7 @@ func (a *API) getCharmRepository(src corecharm.Source) (corecharm.Repository, er
 // IsMetered returns whether or not the charm is metered.
 // TODO (cderici) only used for metered charms in cmd MeteredDeployAPI,
 // kept for client compatibility, remove in juju 4.0
-func (a *API) IsMetered(args params.CharmURL) (params.IsMeteredResult, error) {
+func (a *API) IsMetered(ctx context.Context, args params.CharmURL) (params.IsMeteredResult, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.IsMeteredResult{}, errors.Trace(err)
 	}
@@ -535,7 +536,7 @@ func (a *API) IsMetered(args params.CharmURL) (params.IsMeteredResult, error) {
 
 // CheckCharmPlacement checks if a charm is allowed to be placed with in a
 // given application.
-func (a *API) CheckCharmPlacement(args params.ApplicationCharmPlacements) (params.ErrorResults, error) {
+func (a *API) CheckCharmPlacement(ctx context.Context, args params.ApplicationCharmPlacements) (params.ErrorResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -675,7 +676,7 @@ func (a *API) getMachineArch(machine charmsinterfaces.Machine) (arch.Arch, error
 }
 
 // ListCharmResources returns a series of resources for a given charm.
-func (a *API) ListCharmResources(args params.CharmURLAndOrigins) (params.CharmResourcesResults, error) {
+func (a *API) ListCharmResources(ctx context.Context, args params.CharmURLAndOrigins) (params.CharmResourcesResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.CharmResourcesResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -4,6 +4,7 @@
 package charms_test
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -64,7 +65,7 @@ func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
 	defer release()
 	meteredCharm := f.MakeCharm(
 		c, &factory.CharmParams{Name: "metered", URL: "ch:amd64/xenial/metered"})
-	info, err := s.api.CharmInfo(params.CharmURL{
+	info, err := s.api.CharmInfo(context.Background(), params.CharmURL{
 		URL: meteredCharm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -105,7 +106,7 @@ func (s *charmsSuite) assertListCharms(c *gc.C, someCharms, args, expected []str
 			Name: aCharm, URL: fmt.Sprintf("local:quantal/%s-1", aCharm),
 		})
 	}
-	found, err := s.api.List(params.CharmsList{Names: args})
+	found, err := s.api.List(context.Background(), params.CharmsList{Names: args})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.CharmURLs, gc.HasLen, len(expected))
 	c.Check(found.CharmURLs, jc.DeepEquals, expected)
@@ -115,7 +116,7 @@ func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
 	charm := f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
-	metered, err := s.api.IsMetered(params.CharmURL{
+	metered, err := s.api.IsMetered(context.Background(), params.CharmURL{
 		URL: charm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +127,7 @@ func (s *charmsSuite) TestIsMeteredTrue(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
 	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:amd64/quantal/metered"})
-	metered, err := s.api.IsMetered(params.CharmURL{
+	metered, err := s.api.IsMetered(context.Background(), params.CharmURL{
 		URL: meteredCharm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -212,7 +213,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 			},
 		},
 	}
-	result, err := api.ResolveCharms(args)
+	result, err := api.ResolveCharms(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results, jc.DeepEquals, expected)
@@ -228,7 +229,7 @@ func (s *charmsMockSuite) TestResolveCharmsUnknownSchema(c *gc.C) {
 		Resolve: []params.ResolveCharmWithChannel{{Reference: curl.String()}},
 	}
 
-	result, err := api.ResolveCharms(args)
+	result, err := api.ResolveCharms(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, `unknown schema for charm URL "local:testme"`)
@@ -260,7 +261,7 @@ func (s *charmsMockSuite) TestResolveCharmNoDefinedSeries(c *gc.C) {
 		Origin:         edgeOrigin,
 		SupportedBases: []params.Base{{Name: "ubuntu", Channel: "20.04/stable"}},
 	}}
-	result, err := api.ResolveCharms(args)
+	result, err := api.ResolveCharms(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results, jc.DeepEquals, expected)
@@ -320,7 +321,7 @@ func (s *charmsMockSuite) TestResolveCharmV6(c *gc.C) {
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		},
 	}
-	result, err := apiv6.ResolveCharms(args)
+	result, err := apiv6.ResolveCharms(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results, jc.DeepEquals, expected)
@@ -339,7 +340,7 @@ func (s *charmsMockSuite) TestAddCharmWithLocalSource(c *gc.C) {
 		},
 		Force: false,
 	}
-	_, err = api.AddCharm(args)
+	_, err = api.AddCharm(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `unknown schema for charm URL "local:testme"`)
 }
 
@@ -411,7 +412,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 			Risk:   "edge",
 		},
 	}
-	obtained, err := api.AddCharm(args)
+	obtained, err := api.AddCharm(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, params.CharmOriginResult{
 		Origin: params.CharmOrigin{
@@ -456,7 +457,7 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 		},
 		Force: false,
 	}
-	obtained, err := api.AddCharm(args)
+	obtained, err := api.AddCharm(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, params.CharmOriginResult{
 		Origin: params.CharmOrigin{
@@ -485,7 +486,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithSubordinate(c *gc.C) {
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
@@ -510,7 +511,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
@@ -539,7 +540,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArch(c *gc.C) {
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
@@ -568,7 +569,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
@@ -597,7 +598,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchAndHardware
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
@@ -632,7 +633,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithHeterogeneous(c *gc.C) {
 		}},
 	}
 
-	result, err := api.CheckCharmPlacement(args)
+	result, err := api.CheckCharmPlacement(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), gc.ErrorMatches, "charm can not be placed in a heterogeneous environment")
 }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -4,6 +4,8 @@
 package client
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -187,7 +189,7 @@ func NewClient(
 }
 
 // WatchAll initiates a watcher for entities in the connected model.
-func (c *Client) WatchAll() (params.AllWatcherId, error) {
+func (c *Client) WatchAll(ctx stdcontext.Context) (params.AllWatcherId, error) {
 	if err := c.checkCanRead(); err != nil {
 		return params.AllWatcherId{}, err
 	}
@@ -233,7 +235,7 @@ func (s *stripApplicationOffers) Next() ([]multiwatcher.Delta, error) {
 
 // FindTools returns a List containing all tools matching the given parameters.
 // TODO(juju 3.1) - remove, used by 2.9 client only
-func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+func (c *Client) FindTools(ctx stdcontext.Context, args params.FindToolsParams) (params.FindToolsResult, error) {
 	if err := c.checkCanWrite(); err != nil {
 		return params.FindToolsResult{}, err
 	}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -4,6 +4,7 @@
 package client_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v11"
@@ -421,7 +422,7 @@ func (s *findToolsSuite) TestFindToolsIAAS(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := api.FindTools(params.FindToolsParams{MajorVersion: 2})
+	result, err := api.FindTools(context.Background(), params.FindToolsParams{MajorVersion: 2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.FindToolsResult{List: simpleStreams})
 }
@@ -507,7 +508,7 @@ func (s *findToolsSuite) TestFindToolsCAASReleased(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := api.FindTools(params.FindToolsParams{MajorVersion: 2})
+	result, err := api.FindTools(context.Background(), params.FindToolsParams{MajorVersion: 2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.FindToolsResult{
 		List: []*tools.Tools{
@@ -591,7 +592,7 @@ func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := api.FindTools(params.FindToolsParams{MajorVersion: 2, AgentStream: envtools.DevelStream})
+	result, err := api.FindTools(context.Background(), params.FindToolsParams{MajorVersion: 2, AgentStream: envtools.DevelStream})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.FindToolsResult{
 		List: []*tools.Tools{

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -136,7 +136,7 @@ func (c *ControllerAPI) checkIsSuperUser() error {
 //
 // NOTE: the implementation intentionally does not check for SuperuserAccess
 // as the Version is known even to users with login access.
-func (c *ControllerAPI) ControllerVersion() (params.ControllerVersionResults, error) {
+func (c *ControllerAPI) ControllerVersion(ctx context.Context) (params.ControllerVersionResults, error) {
 	result := params.ControllerVersionResults{
 		Version:   jujuversion.Current.String(),
 		GitCommit: jujuversion.GitCommit,
@@ -150,7 +150,7 @@ func (c *ControllerAPI) ControllerVersion() (params.ControllerVersionResults, er
 //
 // NOTE: the implementation intentionally does not check for SuperuserAccess
 // as the URL is known even to users with login access.
-func (c *ControllerAPI) IdentityProviderURL() (params.StringResult, error) {
+func (c *ControllerAPI) IdentityProviderURL(ctx context.Context) (params.StringResult, error) {
 	var result params.StringResult
 
 	cfgRes, err := c.ControllerConfig()
@@ -165,7 +165,7 @@ func (c *ControllerAPI) IdentityProviderURL() (params.StringResult, error) {
 }
 
 // MongoVersion allows the introspection of the mongo version per controller
-func (c *ControllerAPI) MongoVersion() (params.StringResult, error) {
+func (c *ControllerAPI) MongoVersion(ctx context.Context) (params.StringResult, error) {
 	result := params.StringResult{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)
@@ -264,7 +264,7 @@ func (c *ControllerAPI) dashboardConnectionInfoForIAAS(
 
 // DashboardConnectionInfo returns the connection information for a client to
 // connect to the Juju Dashboard including any proxying information.
-func (c *ControllerAPI) DashboardConnectionInfo() (params.DashboardConnectionInfo, error) {
+func (c *ControllerAPI) DashboardConnectionInfo(ctx context.Context) (params.DashboardConnectionInfo, error) {
 	getDashboardInfo := func() (params.DashboardConnectionInfo, error) {
 		rval := params.DashboardConnectionInfo{}
 		controllerApp, err := c.state.Application(bootstrap.ControllerApplicationName)
@@ -329,7 +329,7 @@ func (c *ControllerAPI) DashboardConnectionInfo() (params.DashboardConnectionInf
 
 // AllModels allows controller administrators to get the list of all the
 // models in the controller.
-func (c *ControllerAPI) AllModels() (params.UserModelList, error) {
+func (c *ControllerAPI) AllModels(ctx context.Context) (params.UserModelList, error) {
 	result := params.UserModelList{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)
@@ -383,7 +383,7 @@ func (c *ControllerAPI) AllModels() (params.UserModelList, error) {
 // which have a block in place.  The resulting slice is sorted by model
 // name, then owner. Callers must be controller administrators to retrieve the
 // list.
-func (c *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
+func (c *ControllerAPI) ListBlockedModels(ctx context.Context) (params.ModelBlockInfoList, error) {
 	results := params.ModelBlockInfoList{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return results, errors.Trace(err)
@@ -428,7 +428,7 @@ func (c *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 // ModelConfig returns the model config for the controller
 // model.  For information on the current model, use
 // client.ModelGet
-func (c *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
+func (c *ControllerAPI) ModelConfig(ctx context.Context) (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)
@@ -459,7 +459,7 @@ func (c *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
 // HostedModelConfigs returns all the information that the client needs in
 // order to connect directly with the host model's provider and destroy it
 // directly.
-func (c *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, error) {
+func (c *ControllerAPI) HostedModelConfigs(ctx context.Context) (params.HostedModelConfigsResults, error) {
 	result := params.HostedModelConfigsResults{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)
@@ -510,7 +510,7 @@ func (c *ControllerAPI) HostedModelConfigs() (params.HostedModelConfigsResults, 
 }
 
 // RemoveBlocks removes all the blocks in the controller.
-func (c *ControllerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
+func (c *ControllerAPI) RemoveBlocks(ctx context.Context, args params.RemoveBlocksArgs) error {
 	if err := c.checkIsSuperUser(); err != nil {
 		return errors.Trace(err)
 	}
@@ -524,7 +524,7 @@ func (c *ControllerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
 // WatchAllModels starts watching events for all models in the
 // controller. The returned AllWatcherId should be used with Next on the
 // AllModelWatcher endpoint to receive deltas.
-func (c *ControllerAPI) WatchAllModels() (params.AllWatcherId, error) {
+func (c *ControllerAPI) WatchAllModels(ctx context.Context) (params.AllWatcherId, error) {
 	if err := c.checkIsSuperUser(); err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}
@@ -537,7 +537,7 @@ func (c *ControllerAPI) WatchAllModels() (params.AllWatcherId, error) {
 // WatchAllModelSummaries starts watching the summary updates from the cache.
 // This method is superuser access only, and watches all models in the
 // controller.
-func (c *ControllerAPI) WatchAllModelSummaries() (params.SummaryWatcherID, error) {
+func (c *ControllerAPI) WatchAllModelSummaries(ctx context.Context) (params.SummaryWatcherID, error) {
 	if err := c.checkIsSuperUser(); err != nil {
 		return params.SummaryWatcherID{}, errors.Trace(err)
 	}
@@ -551,7 +551,7 @@ func (c *ControllerAPI) WatchAllModelSummaries() (params.SummaryWatcherID, error
 
 // WatchModelSummaries starts watching the summary updates from the cache.
 // Only models that the user has access to are returned.
-func (c *ControllerAPI) WatchModelSummaries() (params.SummaryWatcherID, error) {
+func (c *ControllerAPI) WatchModelSummaries(ctx context.Context) (params.SummaryWatcherID, error) {
 	// TODO(dqlite) - implement me
 	return params.SummaryWatcherID{}, errors.NotSupportedf("WatchModelSummaries")
 	//user := c.apiUser.Id()
@@ -563,7 +563,7 @@ func (c *ControllerAPI) WatchModelSummaries() (params.SummaryWatcherID, error) {
 
 // GetControllerAccess returns the level of access the specified users
 // have on the controller.
-func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAccessResults, error) {
+func (c *ControllerAPI) GetControllerAccess(ctx context.Context, req params.Entities) (params.UserAccessResults, error) {
 	results := params.UserAccessResults{}
 	err := c.authorizer.HasPermission(permission.SuperuserAccess, c.state.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
@@ -597,7 +597,7 @@ func (c *ControllerAPI) GetControllerAccess(req params.Entities) (params.UserAcc
 
 // InitiateMigration attempts to begin the migration of one or
 // more models to other controllers.
-func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) (
+func (c *ControllerAPI) InitiateMigration(ctx context.Context, reqArgs params.InitiateMigrationArgs) (
 	params.InitiateMigrationResults, error,
 ) {
 	out := params.InitiateMigrationResults{
@@ -690,7 +690,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 }
 
 // ModifyControllerAccess changes the model access granted to users.
-func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
+func (c *ControllerAPI) ModifyControllerAccess(ctx context.Context, args params.ModifyControllerAccessRequest) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Changes)),
 	}
@@ -731,7 +731,7 @@ func (c *ControllerAPI) ModifyControllerAccess(args params.ModifyControllerAcces
 // ConfigSet changes the value of specified controller configuration
 // settings. Only some settings can be changed after bootstrap.
 // Settings that aren't specified in the params are left unchanged.
-func (c *ControllerAPI) ConfigSet(args params.ControllerConfigSet) error {
+func (c *ControllerAPI) ConfigSet(ctx context.Context, args params.ControllerConfigSet) error {
 	if err := c.checkIsSuperUser(); err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -168,7 +168,7 @@ func (s *controllerSuite) TestAllModels(c *gc.C) {
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "no-access", Owner: remoteUserTag}).Close()
 
-	response, err := s.controller.AllModels()
+	response, err := s.controller.AllModels(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	// The results are sorted.
 	expected := []string{"controller", "no-access", "owned", "user"}
@@ -192,7 +192,7 @@ func (s *controllerSuite) TestHostedModelConfigs_OnlyHostedModelsReturned(c *gc.
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "second", Owner: remoteUserTag}).Close()
 
-	results, err := s.controller.HostedModelConfigs()
+	results, err := s.controller.HostedModelConfigs(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(results.Models), gc.Equals, 2)
 
@@ -236,7 +236,7 @@ func (s *controllerSuite) TestHostedModelConfigs_CanOpenEnviron(c *gc.C) {
 	s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "second", Owner: remoteUserTag}).Close()
 
-	results, err := s.controller.HostedModelConfigs()
+	results, err := s.controller.HostedModelConfigs(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(results.Models), gc.Equals, 2)
 
@@ -264,7 +264,7 @@ func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyModel")
 	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
 
-	list, err := s.controller.ListBlockedModels()
+	list, err := s.controller.ListBlockedModels(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(list.Models, jc.DeepEquals, []params.ModelBlockInfo{
@@ -291,13 +291,13 @@ func (s *controllerSuite) TestListBlockedModels(c *gc.C) {
 }
 
 func (s *controllerSuite) TestListBlockedModelsNoBlocks(c *gc.C) {
-	list, err := s.controller.ListBlockedModels()
+	list, err := s.controller.ListBlockedModels(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(list.Models, gc.HasLen, 0)
 }
 
 func (s *controllerSuite) TestModelConfig(c *gc.C) {
-	cfg, err := s.controller.ModelConfig()
+	cfg, err := s.controller.ModelConfig(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }
@@ -321,7 +321,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		})
 
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := controller.ModelConfig()
+	cfg, err := controller.ModelConfig(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }
@@ -369,7 +369,7 @@ func (s *controllerSuite) TestRemoveBlocks(c *gc.C) {
 	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyModel")
 	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
 
-	err := s.controller.RemoveBlocks(params.RemoveBlocksArgs{All: true})
+	err := s.controller.RemoveBlocks(stdcontext.Background(), params.RemoveBlocksArgs{All: true})
 	c.Assert(err, jc.ErrorIsNil)
 
 	blocks, err := s.State.AllBlocksForController()
@@ -378,12 +378,12 @@ func (s *controllerSuite) TestRemoveBlocks(c *gc.C) {
 }
 
 func (s *controllerSuite) TestRemoveBlocksNotAll(c *gc.C) {
-	err := s.controller.RemoveBlocks(params.RemoveBlocksArgs{})
+	err := s.controller.RemoveBlocks(stdcontext.Background(), params.RemoveBlocksArgs{})
 	c.Assert(err, gc.ErrorMatches, "not supported")
 }
 
 func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
-	watcherId, err := s.controller.WatchAllModels()
+	watcherId, err := s.controller.WatchAllModels(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var disposed bool
@@ -518,7 +518,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 			},
 		},
 	}
-	out, err := s.controller.InitiateMigration(args)
+	out, err := s.controller.InitiateMigration(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 2)
 
@@ -571,7 +571,7 @@ func (s *controllerSuite) TestInitiateMigrationSpecError(c *gc.C) {
 			// TargetInfo missing
 		}},
 	}
-	out, err := s.controller.InitiateMigration(args)
+	out, err := s.controller.InitiateMigration(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 1)
 	result := out.Results[0]
@@ -604,7 +604,7 @@ func (s *controllerSuite) TestInitiateMigrationPartialFailure(c *gc.C) {
 			},
 		},
 	}
-	out, err := s.controller.InitiateMigration(args)
+	out, err := s.controller.InitiateMigration(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 2)
 
@@ -636,7 +636,7 @@ func (s *controllerSuite) TestInitiateMigrationInvalidMacaroons(c *gc.C) {
 			},
 		},
 	}
-	out, err := s.controller.InitiateMigration(args)
+	out, err := s.controller.InitiateMigration(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 1)
 	result := out.Results[0]
@@ -665,7 +665,7 @@ func (s *controllerSuite) TestInitiateMigrationPrecheckFail(c *gc.C) {
 			},
 		}},
 	}
-	out, err := s.controller.InitiateMigration(args)
+	out, err := s.controller.InitiateMigration(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Results, gc.HasLen, 1)
 	c.Check(out.Results[0].Error, gc.ErrorMatches, "boom")
@@ -692,7 +692,7 @@ func (s *controllerSuite) modifyControllerAccess(c *gc.C, user names.UserTag, ac
 			Action:  action,
 			Access:  access,
 		}}}
-	result, err := s.controller.ModifyControllerAccess(args)
+	result, err := s.controller.ModifyControllerAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	return result.OneError()
 }
@@ -836,7 +836,7 @@ func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *gc.C) {
 				Access:  string(permission.SuperuserAccess),
 			}}}
 
-		result, err := s.controller.ModifyControllerAccess(args)
+		result, err := s.controller.ModifyControllerAccess(stdcontext.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
 	}
@@ -845,7 +845,7 @@ func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *gc.C) {
 func (s *controllerSuite) TestModifyControllerAccessEmptyArgs(c *gc.C) {
 	args := params.ModifyControllerAccessRequest{Changes: []params.ModifyControllerAccess{{}}}
 
-	result, err := s.controller.ModifyControllerAccess(args)
+	result, err := s.controller.ModifyControllerAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `"" controller access not valid`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
@@ -860,7 +860,7 @@ func (s *controllerSuite) TestModifyControllerAccessInvalidAction(c *gc.C) {
 			Access:  string(permission.LoginAccess),
 		}}}
 
-	result, err := s.controller.ModifyControllerAccess(args)
+	result, err := s.controller.ModifyControllerAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `unknown action "dance"`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
@@ -875,7 +875,7 @@ func (s *controllerSuite) TestGetControllerAccess(c *gc.C) {
 	req := params.Entities{
 		Entities: []params.Entity{{Tag: user.Tag().String()}, {Tag: user2.Tag().String()}},
 	}
-	results, err := s.controller.GetControllerAccess(req)
+	results, err := s.controller.GetControllerAccess(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.DeepEquals, []params.UserAccessResult{{
 		Result: &params.UserAccess{
@@ -907,7 +907,7 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 			Action:  params.GrantControllerAccess,
 			Access:  "superuser",
 		}}}
-	result, err := s.controller.ModifyControllerAccess(args)
+	result, err := s.controller.ModifyControllerAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 
@@ -916,7 +916,7 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	req := params.Entities{
 		Entities: []params.Entity{{Tag: user.Tag().String()}, {Tag: differentUser.Tag().String()}},
 	}
-	results, err := endpoint.GetControllerAccess(req)
+	results, err := endpoint.GetControllerAccess(stdcontext.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	c.Assert(*results.Results[0].Result, jc.DeepEquals, params.UserAccess{
@@ -963,7 +963,7 @@ func (s *controllerSuite) TestConfigSet(c *gc.C) {
 	// Sanity check.
 	c.Assert(config.AuditingEnabled(), gc.Equals, false)
 
-	err = s.controller.ConfigSet(params.ControllerConfigSet{Config: map[string]interface{}{
+	err = s.controller.ConfigSet(stdcontext.Background(), params.ControllerConfigSet{Config: map[string]interface{}{
 		"auditing-enabled": true,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -988,7 +988,7 @@ func (s *controllerSuite) TestConfigSetRequiresSuperUser(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = endpoint.ConfigSet(params.ControllerConfigSet{Config: map[string]interface{}{
+	err = endpoint.ConfigSet(stdcontext.Background(), params.ControllerConfigSet{Config: map[string]interface{}{
 		"something": 23,
 	}})
 
@@ -1004,7 +1004,7 @@ func (s *controllerSuite) TestConfigSetPublishesEvent(c *gc.C) {
 		close(done)
 	})
 
-	err := s.controller.ConfigSet(params.ControllerConfigSet{Config: map[string]interface{}{
+	err := s.controller.ConfigSet(stdcontext.Background(), params.ControllerConfigSet{Config: map[string]interface{}{
 		"features": "foo,bar",
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1019,7 +1019,7 @@ func (s *controllerSuite) TestConfigSetPublishesEvent(c *gc.C) {
 }
 
 func (s *controllerSuite) TestMongoVersion(c *gc.C) {
-	result, err := s.controller.MongoVersion()
+	result, err := s.controller.MongoVersion(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var resErr *params.Error
@@ -1037,7 +1037,7 @@ func (s *controllerSuite) TestIdentityProviderURL(c *gc.C) {
 	}(s.ControllerConfig)
 
 	// Our default test configuration does not specify an IdentityURL
-	urlRes, err := s.controller.IdentityProviderURL()
+	urlRes, err := s.controller.IdentityProviderURL(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(urlRes.Result, gc.Equals, "")
 
@@ -1050,7 +1050,7 @@ func (s *controllerSuite) TestIdentityProviderURL(c *gc.C) {
 	}
 	s.SetUpTest(c)
 
-	urlRes, err = s.controller.IdentityProviderURL()
+	urlRes, err = s.controller.IdentityProviderURL(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(urlRes.Result, gc.Equals, expURL)
 }
@@ -1067,7 +1067,7 @@ func (s *controllerSuite) TestWatchAllModelSummariesByAdmin(c *gc.C) {
 	// TODO(dqlite) - implement me
 	c.Skip("watch model summaries to be implemented")
 	// Default authorizer is an admin.
-	result, err := s.controller.WatchAllModelSummaries()
+	result, err := s.controller.WatchAllModelSummaries(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	watcherAPI := s.newSummaryWatcherFacade(c, result.WatcherID)
@@ -1111,7 +1111,7 @@ func (s *controllerSuite) TestWatchAllModelSummariesByNonAdmin(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = endPoint.WatchAllModelSummaries()
+	_, err = endPoint.WatchAllModelSummaries(stdcontext.Background())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -1136,7 +1136,7 @@ func (s *controllerSuite) TestWatchModelSummariesByNonAdmin(c *gc.C) {
 
 	// Default authorizer is an admin. As a user, admin can't see
 	// Bob's model.
-	result, err := s.controller.WatchModelSummaries()
+	result, err := s.controller.WatchModelSummaries(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	watcherAPI := s.newSummaryWatcherFacade(c, result.WatcherID)


### PR DESCRIPTION
This commit adds context.Context parameter to:
- client/action
- client/annotations
- client/application
- client/applicationoffers
- client/block
- client/bundles
- client/charms
- client/client
- client/cloud
- client/controller 

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/client/action/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/annotations/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/application/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/applicationoffers/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/block/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/bundle/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/charms/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/client/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/cloud/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/controller/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```