### PR TITLE
[JUJU-4479] Add context.Context in client/(i-p)* facades

### DIFF
--- a/apiserver/facades/client/imagemetadatamanager/metadata.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata.go
@@ -4,6 +4,7 @@
 package imagemetadatamanager
 
 import (
+	"context"
 	"sort"
 
 	"github.com/juju/errors"
@@ -48,7 +49,7 @@ func createAPI(
 // List returns all found cloud image metadata that satisfy
 // given filter.
 // Returned list contains metadata ordered by priority.
-func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMetadataResult, error) {
+func (api *API) List(ctx context.Context, filter params.ImageMetadataFilter) (params.ListCloudImageMetadataResult, error) {
 	found, err := api.metadata.FindMetadata(cloudimagemetadata.MetadataFilter{
 		Region:          filter.Region,
 		Versions:        filter.Versions,
@@ -78,7 +79,7 @@ func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMe
 
 // Save stores given cloud image metadata.
 // It supports bulk calls.
-func (api *API) Save(metadata params.MetadataSaveParams) (params.ErrorResults, error) {
+func (api *API) Save(ctx context.Context, metadata params.MetadataSaveParams) (params.ErrorResults, error) {
 	model, err := api.metadata.Model()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -100,7 +101,7 @@ func (api *API) Save(metadata params.MetadataSaveParams) (params.ErrorResults, e
 
 // Delete deletes cloud image metadata for given image ids.
 // It supports bulk calls.
-func (api *API) Delete(images params.MetadataImageIds) (params.ErrorResults, error) {
+func (api *API) Delete(ctx context.Context, images params.MetadataImageIds) (params.ErrorResults, error) {
 	all := make([]params.ErrorResult, len(images.Ids))
 	for i, imageId := range images.Ids {
 		err := api.metadata.DeleteMetadata(imageId)

--- a/apiserver/facades/client/imagemetadatamanager/metadata_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata_test.go
@@ -4,6 +4,8 @@
 package imagemetadatamanager_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -19,7 +21,7 @@ type metadataSuite struct {
 var _ = gc.Suite(&metadataSuite{})
 
 func (s *metadataSuite) TestFindNil(c *gc.C) {
-	found, err := s.api.List(params.ImageMetadataFilter{})
+	found, err := s.api.List(context.Background(), params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag, findMetadata)
@@ -30,7 +32,7 @@ func (s *metadataSuite) TestFindEmpty(c *gc.C) {
 		return map[string][]cloudimagemetadata.Metadata{}, nil
 	}
 
-	found, err := s.api.List(params.ImageMetadataFilter{})
+	found, err := s.api.List(context.Background(), params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag, findMetadata)
@@ -44,7 +46,7 @@ func (s *metadataSuite) TestFindEmptyGroups(c *gc.C) {
 		}, nil
 	}
 
-	found, err := s.api.List(params.ImageMetadataFilter{})
+	found, err := s.api.List(context.Background(), params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag, findMetadata)
@@ -56,7 +58,7 @@ func (s *metadataSuite) TestFindError(c *gc.C) {
 		return nil, errors.New(msg)
 	}
 
-	found, err := s.api.List(params.ImageMetadataFilter{})
+	found, err := s.api.List(context.Background(), params.ImageMetadataFilter{})
 	c.Assert(err, gc.ErrorMatches, msg)
 	c.Assert(found.Result, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag, findMetadata)
@@ -82,7 +84,7 @@ func (s *metadataSuite) TestFindOrder(c *gc.C) {
 			nil
 	}
 
-	found, err := s.api.List(params.ImageMetadataFilter{})
+	found, err := s.api.List(context.Background(), params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 4)
 
@@ -96,7 +98,7 @@ func (s *metadataSuite) TestFindOrder(c *gc.C) {
 }
 
 func (s *metadataSuite) TestSaveEmpty(c *gc.C) {
-	errs, err := s.api.Save(params.MetadataSaveParams{})
+	errs, err := s.api.Save(context.Background(), params.MetadataSaveParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag, model)
@@ -130,7 +132,7 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 		return errors.New(msg)
 	}
 
-	errs, err := s.api.Save(params.MetadataSaveParams{
+	errs, err := s.api.Save(context.Background(), params.MetadataSaveParams{
 		Metadata: []params.CloudImageMetadataList{{
 			Metadata: []params.CloudImageMetadata{m1},
 		}, {
@@ -148,7 +150,7 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 }
 
 func (s *metadataSuite) TestDeleteEmpty(c *gc.C) {
-	errs, err := s.api.Delete(params.MetadataImageIds{})
+	errs, err := s.api.Delete(context.Background(), params.MetadataImageIds{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 0)
 	s.assertCalls(c, controllerTag)
@@ -166,7 +168,7 @@ func (s *metadataSuite) TestDelete(c *gc.C) {
 		return nil
 	}
 
-	errs, err := s.api.Delete(params.MetadataImageIds{[]string{idOk, idFail}})
+	errs, err := s.api.Delete(context.Background(), params.MetadataImageIds{[]string{idOk, idFail}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)

--- a/apiserver/facades/client/keymanager/keymanager.go
+++ b/apiserver/facades/client/keymanager/keymanager.go
@@ -4,6 +4,7 @@
 package keymanager
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -76,7 +77,7 @@ func (api *KeyManagerAPI) checkCanWrite(sshUser string) error {
 }
 
 // ListKeys returns the authorised ssh keys for the specified users.
-func (api *KeyManagerAPI) ListKeys(arg params.ListSSHKeys) (params.StringsResults, error) {
+func (api *KeyManagerAPI) ListKeys(ctx context.Context, arg params.ListSSHKeys) (params.StringsResults, error) {
 	if len(arg.Entities.Entities) == 0 {
 		return params.StringsResults{}, nil
 	}
@@ -162,7 +163,7 @@ func (api *KeyManagerAPI) currentKeyDataForAdd() (keys []string, fingerprints se
 }
 
 // AddKeys adds new authorised ssh keys for the specified user.
-func (api *KeyManagerAPI) AddKeys(arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
+func (api *KeyManagerAPI) AddKeys(ctx context.Context, arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(arg.User); err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(err)
 	}
@@ -254,7 +255,7 @@ func runSSHKeyImport(keyIds []string) map[string][]importedSSHKey {
 }
 
 // ImportKeys imports new authorised ssh keys from the specified key ids for the specified user.
-func (api *KeyManagerAPI) ImportKeys(arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
+func (api *KeyManagerAPI) ImportKeys(ctx context.Context, arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(arg.User); err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(err)
 	}
@@ -334,7 +335,7 @@ func (api *KeyManagerAPI) currentKeyDataForDelete() (
 }
 
 // DeleteKeys deletes the authorised ssh keys for the specified user.
-func (api *KeyManagerAPI) DeleteKeys(arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
+func (api *KeyManagerAPI) DeleteKeys(ctx context.Context, arg params.ModifyUserSSHKeys) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(arg.User); err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -186,7 +186,7 @@ func NewMachineManagerAPI(
 
 // AddMachines adds new machines with the supplied parameters.
 // The args will contain Base info.
-func (mm *MachineManagerAPI) AddMachines(args params.AddMachines) (params.AddMachinesResults, error) {
+func (mm *MachineManagerAPI) AddMachines(ctx context.Context, args params.AddMachines) (params.AddMachinesResults, error) {
 	results := params.AddMachinesResults{
 		Machines: make([]params.AddMachinesResult, len(args.MachineParams)),
 	}
@@ -317,7 +317,7 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 // ProvisioningScript returns a shell script that, when run,
 // provisions a machine agent on the machine executing the script.
-func (mm *MachineManagerAPI) ProvisioningScript(args params.ProvisioningScriptParams) (params.ProvisioningScriptResult, error) {
+func (mm *MachineManagerAPI) ProvisioningScript(ctx context.Context, args params.ProvisioningScriptParams) (params.ProvisioningScriptResult, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.ProvisioningScriptResult{}, err
 	}
@@ -369,7 +369,7 @@ func (mm *MachineManagerAPI) ProvisioningScript(args params.ProvisioningScriptPa
 }
 
 // RetryProvisioning marks a provisioning error as transient on the machines.
-func (mm *MachineManagerAPI) RetryProvisioning(p params.RetryProvisioningArgs) (params.ErrorResults, error) {
+func (mm *MachineManagerAPI) RetryProvisioning(ctx context.Context, p params.RetryProvisioningArgs) (params.ErrorResults, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -435,7 +435,7 @@ func (mm *MachineManagerAPI) maybeUpdateInstanceStatus(all bool, m Machine, data
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.
-func (mm *MachineManagerAPI) DestroyMachineWithParams(args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
+func (mm *MachineManagerAPI) DestroyMachineWithParams(ctx context.Context, args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
 	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
@@ -444,7 +444,7 @@ func (mm *MachineManagerAPI) DestroyMachineWithParams(args params.DestroyMachine
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.
-func (mm *MachineManagerV9) DestroyMachineWithParams(args params.DestroyMachinesParamsV9) (params.DestroyMachineResults, error) {
+func (mm *MachineManagerV9) DestroyMachineWithParams(ctx context.Context, args params.DestroyMachinesParamsV9) (params.DestroyMachineResults, error) {
 	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
@@ -632,6 +632,7 @@ func (mm *MachineManagerAPI) classifyDetachedStorage(units []Unit) (destroyed, d
 // If they do, a list of the machine's current units is returned for use in
 // soliciting user confirmation of the command.
 func (mm *MachineManagerAPI) UpgradeSeriesValidate(
+	ctx context.Context,
 	args params.UpdateChannelArgs,
 ) (params.UpgradeSeriesUnitsResults, error) {
 	entities := make([]ValidationEntity, len(args.Args))
@@ -662,7 +663,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesValidate(
 }
 
 // UpgradeSeriesPrepare prepares a machine for a OS series upgrade.
-func (mm *MachineManagerAPI) UpgradeSeriesPrepare(arg params.UpdateChannelArg) (params.ErrorResult, error) {
+func (mm *MachineManagerAPI) UpgradeSeriesPrepare(ctx context.Context, arg params.UpdateChannelArg) (params.ErrorResult, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.ErrorResult{}, err
 	}
@@ -677,7 +678,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesPrepare(arg params.UpdateChannelArg) (
 
 // UpgradeSeriesComplete marks a machine as having completed a managed series
 // upgrade.
-func (mm *MachineManagerAPI) UpgradeSeriesComplete(arg params.UpdateChannelArg) (params.ErrorResult, error) {
+func (mm *MachineManagerAPI) UpgradeSeriesComplete(ctx context.Context, arg params.UpdateChannelArg) (params.ErrorResult, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.ErrorResult{}, err
 	}
@@ -694,7 +695,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesComplete(arg params.UpdateChannelArg) 
 
 // WatchUpgradeSeriesNotifications returns a watcher that fires on upgrade
 // series events.
-func (mm *MachineManagerAPI) WatchUpgradeSeriesNotifications(args params.Entities) (params.NotifyWatchResults, error) {
+func (mm *MachineManagerAPI) WatchUpgradeSeriesNotifications(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	err := mm.authorizer.CanRead()
 	if err != nil {
 		return params.NotifyWatchResults{}, err
@@ -728,7 +729,7 @@ func (mm *MachineManagerAPI) WatchUpgradeSeriesNotifications(args params.Entitie
 // GetUpgradeSeriesMessages returns all new messages associated with upgrade
 // series events. Messages that have already been retrieved once are not
 // returned by this method.
-func (mm *MachineManagerAPI) GetUpgradeSeriesMessages(args params.UpgradeSeriesNotificationParams) (params.StringsResults, error) {
+func (mm *MachineManagerAPI) GetUpgradeSeriesMessages(ctx context.Context, args params.UpgradeSeriesNotificationParams) (params.StringsResults, error) {
 	if err := mm.authorizer.CanRead(); err != nil {
 		return params.StringsResults{}, err
 	}

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -4,6 +4,7 @@
 package machinemanager_test
 
 import (
+	stdcontext "context"
 	"sort"
 	"strconv"
 	"strings"
@@ -163,7 +164,7 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *gc.C) {
 		},
 	}).Return(&state.Machine{}, nil)
 
-	machines, err := s.api.AddMachines(params.AddMachines{MachineParams: apiParams})
+	machines, err := s.api.AddMachines(stdcontext.Background(), params.AddMachines{MachineParams: apiParams})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines.Machines, gc.HasLen, 2)
 }
@@ -173,7 +174,7 @@ func (s *AddMachineManagerSuite) TestAddMachinesStateError(c *gc.C) {
 
 	s.st.EXPECT().AddOneMachine(gomock.Any()).Return(&state.Machine{}, errors.New("boom"))
 
-	results, err := s.api.AddMachines(params.AddMachines{
+	results, err := s.api.AddMachines(stdcontext.Background(), params.AddMachines{
 		MachineParams: []params.AddMachineParams{{
 			Base: &params.Base{Name: "ubuntu", Channel: "22.04"},
 		}},
@@ -316,7 +317,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedAllStorageRetrieval
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	noWait := 0 * time.Second
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		MachineTags: []string{"machine-0"},
 		MaxWait:     &noWait,
 	})
@@ -341,7 +342,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeUnitStorageRetr
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	noWait := 0 * time.Second
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		MachineTags: []string{"machine-0"},
 		MaxWait:     &noWait,
 	})
@@ -370,7 +371,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeStorageRetrieva
 	s.st.EXPECT().Machine("1").Return(machine1, nil)
 
 	noWait := 0 * time.Second
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		MachineTags: []string{"machine-0", "machine-1"},
 		MaxWait:     &noWait,
 	})
@@ -406,7 +407,7 @@ func (s *DestroyMachineManagerSuite) TestForceDestroyMachineFailedSomeStorageRet
 	s.st.EXPECT().Machine("1").Return(machine1, nil)
 
 	noWait := 0 * time.Second
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		Force:       true,
 		MachineTags: []string{"machine-0", "machine-1"},
 		MaxWait:     &noWait,
@@ -444,7 +445,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineDryRun(c *gc.C) {
 	machine0 := s.expectDestroyMachine(ctrl, nil, nil, false, false, false)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		MachineTags: []string{"machine-0"},
 		DryRun:      true,
 	})
@@ -479,7 +480,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersDryRun(c *g
 	container0 := s.expectDestroyMachine(ctrl, nil, nil, false, false, false)
 	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
 
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		MachineTags: []string{"machine-0"},
 		DryRun:      true,
 	})
@@ -530,7 +531,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNoWait(c *gc.C)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	noWait := 0 * time.Second
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		Keep:        true,
 		Force:       true,
 		MachineTags: []string{"machine-0"},
@@ -566,7 +567,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNilWait(c *gc.C
 	machine0 := s.expectDestroyMachine(ctrl, nil, nil, true, true, true)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		Keep:        true,
 		Force:       true,
 		MachineTags: []string{"machine-0"},
@@ -602,7 +603,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainers(c *gc.C) {
 	machine0 := s.expectDestroyMachine(ctrl, nil, []string{"0/lxd/0"}, true, false, false)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		Force:       false,
 		MachineTags: []string{"machine-0"},
 	})
@@ -627,7 +628,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersWithForce(c
 	container0 := s.expectDestroyMachine(ctrl, nil, nil, true, false, true)
 	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
 
-	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+	results, err := s.api.DestroyMachineWithParams(stdcontext.Background(), params.DestroyMachinesParams{
 		Force:       true,
 		MachineTags: []string{"machine-0"},
 	})
@@ -782,7 +783,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScript(c *gc.C) {
 		NetPort:      1,
 	}}}, nil).Times(2)
 
-	result, err := s.api.ProvisioningScript(params.ProvisioningScriptParams{
+	result, err := s.api.ProvisioningScript(stdcontext.Background(), params.ProvisioningScriptParams{
 		MachineId: "0",
 		Nonce:     "nonce",
 	})
@@ -810,7 +811,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptNoArch(c *gc.C) 
 
 	machine0 := s.expectProvisioningMachine(ctrl, nil)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
-	_, err := s.api.ProvisioningScript(params.ProvisioningScriptParams{
+	_, err := s.api.ProvisioningScript(stdcontext.Background(), params.ProvisioningScriptParams{
 		MachineId: "0",
 		Nonce:     "nonce",
 	})
@@ -839,7 +840,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptDisablePackageCo
 		NetPort:      1,
 	}}}, nil).Times(2)
 
-	result, err := s.api.ProvisioningScript(params.ProvisioningScriptParams{
+	result, err := s.api.ProvisioningScript(stdcontext.Background(), params.ProvisioningScriptParams{
 		MachineId: "0",
 		Nonce:     "nonce",
 	})
@@ -887,7 +888,7 @@ func (s *ProvisioningMachineManagerSuite) TestRetryProvisioning(c *gc.C) {
 	machine1.EXPECT().Id().Return("1")
 	s.st.EXPECT().AllMachines().Return([]machinemanager.Machine{machine0, machine1}, nil)
 
-	results, err := s.api.RetryProvisioning(params.RetryProvisioningArgs{
+	results, err := s.api.RetryProvisioning(stdcontext.Background(), params.RetryProvisioningArgs{
 		Machines: []string{"machine-0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -910,7 +911,7 @@ func (s *ProvisioningMachineManagerSuite) TestRetryProvisioningAll(c *gc.C) {
 	machine1.EXPECT().InstanceStatus().Return(status.StatusInfo{Status: "pending"}, nil)
 	s.st.EXPECT().AllMachines().Return([]machinemanager.Machine{machine0, machine1}, nil)
 
-	results, err := s.api.RetryProvisioning(params.RetryProvisioningArgs{
+	results, err := s.api.RetryProvisioning(stdcontext.Background(), params.RetryProvisioningArgs{
 		All: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1025,7 +1026,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateOK(c
 			Channel: "22.04",
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result := results.Results[0]
@@ -1045,7 +1046,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateIsCo
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
@@ -1064,7 +1065,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateIsLo
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
@@ -1083,7 +1084,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateNoCh
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, "channel missing from args")
@@ -1103,7 +1104,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateNotF
 		}},
 	}
 
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
 		"machine-0 is running centos and is not valid for Ubuntu series upgrade")
@@ -1123,7 +1124,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateAlre
 		}},
 	}
 
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, "machine-0 is already running base ubuntu@20.04")
 }
@@ -1142,7 +1143,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateOlde
 		}},
 	}
 
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
 		"machine machine-0 is running ubuntu@20.04 which is a newer base than ubuntu@18.04.")
@@ -1170,7 +1171,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateUnit
 			Channel: "22.04",
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
 		"unit unit-foo-0 is not ready to start a series upgrade; its agent status is: \"executing\" ")
@@ -1198,7 +1199,7 @@ func (s *UpgradeSeriesValidateMachineManagerSuite) TestUpgradeSeriesValidateUnit
 			Channel: "22.04",
 		}},
 	}
-	results, err := s.api.UpgradeSeriesValidate(args)
+	results, err := s.api.UpgradeSeriesValidate(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
 		"unit unit-foo-[0-2] is not ready to start a series upgrade; its status is: \"error\" ")
@@ -1287,6 +1288,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepare(c *gc
 
 	machineTag := names.NewMachineTag("0")
 	result, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{
 				Tag: machineTag.String()},
@@ -1304,6 +1306,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepareMachin
 
 	machineTag := names.NewMachineTag("76")
 	result, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{
 				Tag: machineTag.String()},
@@ -1317,6 +1320,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepareMachin
 func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepareNotMachineTag(c *gc.C) {
 	unitTag := names.NewUnitTag("mysql/0")
 	result, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{
 				Tag: unitTag.String()},
@@ -1350,6 +1354,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPreparePermis
 	s.setAPIUser(c, user)
 	machineTag := names.NewMachineTag("0")
 	_, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{
 				Tag: machineTag.String()},
@@ -1361,6 +1366,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPreparePermis
 
 func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepareNoSeries(c *gc.C) {
 	result, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		},
@@ -1382,6 +1388,7 @@ func (s *UpgradeSeriesPrepareMachineManagerSuite) TestUpgradeSeriesPrepareIncomp
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	result, err := s.api.UpgradeSeriesPrepare(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity:  params.Entity{Tag: names.NewMachineTag("0").String()},
 			Channel: "22.04",
@@ -1450,6 +1457,7 @@ func (s *UpgradeSeriesCompleteMachineManagerSuite) TestUpgradeSeriesComplete(c *
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	_, err := s.api.UpgradeSeriesComplete(
+		stdcontext.Background(),
 		params.UpdateChannelArg{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
 		},

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -4,6 +4,7 @@
 package metricsdebug
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -37,10 +38,10 @@ type metricsDebug interface {
 // MetricsDebug defines the methods on the metricsdebug API end point.
 type MetricsDebug interface {
 	// GetMetrics returns all metrics stored by the state server.
-	GetMetrics(arg params.Entities) (params.MetricResults, error)
+	GetMetrics(ctx context.Context, arg params.Entities) (params.MetricResults, error)
 
 	// SetMeterStatus will set the meter status on the given entity tag.
-	SetMeterStatus(params.MeterStatusParams) (params.ErrorResults, error)
+	SetMeterStatus(context.Context, params.MeterStatusParams) (params.ErrorResults, error)
 }
 
 // MetricsDebugAPI implements the metricsdebug interface and is the concrete
@@ -52,7 +53,7 @@ type MetricsDebugAPI struct {
 var _ MetricsDebug = (*MetricsDebugAPI)(nil)
 
 // GetMetrics returns all metrics stored by the state server.
-func (api *MetricsDebugAPI) GetMetrics(args params.Entities) (params.MetricResults, error) {
+func (api *MetricsDebugAPI) GetMetrics(ctx context.Context, args params.Entities) (params.MetricResults, error) {
 	results := params.MetricResults{
 		Results: make([]params.EntityMetrics, len(args.Entities)),
 	}
@@ -150,7 +151,7 @@ func (api *MetricsDebugAPI) filterLastValuePerKeyPerUnit(batches []state.MetricB
 }
 
 // SetMeterStatus sets meter statuses for entities.
-func (api *MetricsDebugAPI) SetMeterStatus(args params.MeterStatusParams) (params.ErrorResults, error) {
+func (api *MetricsDebugAPI) SetMeterStatus(ctx context.Context, args params.MeterStatusParams) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Statuses)),
 	}

--- a/apiserver/facades/client/metricsdebug/metricsdebug_test.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug_test.go
@@ -4,6 +4,7 @@
 package metricsdebug_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -165,7 +166,7 @@ func (s *metricsDebugSuite) TestSetMeterStatus(c *gc.C) {
 
 	for i, test := range tests {
 		c.Logf("running test %d: %v", i, test.about)
-		result, err := s.metricsdebug.SetMeterStatus(test.params)
+		result, err := s.metricsdebug.SetMeterStatus(context.Background(), test.params)
 		if test.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			test.assert(c, result)
@@ -191,7 +192,7 @@ func (s *metricsDebugSuite) TestGetMetrics(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{"unit-metered/0"},
 	}}
-	result, err := s.metricsdebug.GetMetrics(args)
+	result, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 1)
@@ -228,7 +229,7 @@ func (s *metricsDebugSuite) TestGetMetricsLabelOrdering(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{"unit-metered/0"},
 	}}
-	result, err := s.metricsdebug.GetMetrics(args)
+	result, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 4)
@@ -262,7 +263,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectly(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB, metricC}})
 	args := params.Entities{}
-	result, err := s.metricsdebug.GetMetrics(args)
+	result, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 4)
@@ -306,7 +307,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWhenNotAllMetricsInEac
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricA, metricB, metricC}})
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})
 	args := params.Entities{}
-	result, err := s.metricsdebug.GetMetrics(args)
+	result, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
@@ -346,7 +347,7 @@ func (s *metricsDebugSuite) TestGetMetricsFiltersCorrectlyWithMultipleBatchesPer
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit0, Metrics: []state.Metric{metricC}})
 	f.MakeMetric(c, &factory.MetricParams{Unit: unit1, Metrics: []state.Metric{metricA, metricB}})
 	args := params.Entities{}
-	result, err := s.metricsdebug.GetMetrics(args)
+	result, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Metrics, gc.HasLen, 3)
@@ -394,14 +395,14 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocks(c *gc.C) {
 		{"unit-metered/1"},
 	}}
 
-	metrics0, err := s.metricsdebug.GetMetrics(args0)
+	metrics0, err := s.metricsdebug.GetMetrics(context.Background(), args0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics0.Results, gc.HasLen, 1)
 	c.Assert(metrics0.Results[0].Metrics[0].Key, gc.Equals, metricUnit0.Metrics()[0].Key)
 	c.Assert(metrics0.Results[0].Metrics[0].Value, gc.Equals, metricUnit0.Metrics()[0].Value)
 	c.Assert(metrics0.Results[0].Metrics[0].Time, jc.TimeBetween(metricUnit0.Metrics()[0].Time, metricUnit0.Metrics()[0].Time))
 
-	metrics1, err := s.metricsdebug.GetMetrics(args1)
+	metrics1, err := s.metricsdebug.GetMetrics(context.Background(), args1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics1.Results, gc.HasLen, 1)
 	c.Assert(metrics1.Results[0].Metrics[0].Key, gc.Equals, metricUnit1.Metrics()[0].Key)
@@ -431,7 +432,7 @@ func (s *metricsDebugSuite) TestGetMultipleMetricsNoMocksWithApplication(c *gc.C
 		{"application-metered"},
 	}}
 
-	metrics, err := s.metricsdebug.GetMetrics(args)
+	metrics, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics.Results, gc.HasLen, 1)
 	c.Assert(metrics.Results[0].Metrics, gc.HasLen, 2)
@@ -463,7 +464,7 @@ func (s *metricsDebugSuite) TestGetModelNoMocks(c *gc.C) {
 	})
 
 	args := params.Entities{Entities: []params.Entity{}}
-	metrics, err := s.metricsdebug.GetMetrics(args)
+	metrics, err := s.metricsdebug.GetMetrics(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metrics.Results, gc.HasLen, 1)
 	metric0 := metrics.Results[0].Metrics[0]

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -4,6 +4,7 @@
 package modelconfig
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -84,7 +85,7 @@ func (c *ModelConfigAPI) isModelAdmin() (bool, error) {
 
 // ModelGet implements the server-side part of the
 // model-config CLI command.
-func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
+func (c *ModelConfigAPI) ModelGet(ctx context.Context) (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := c.canReadModel(); err != nil {
 		return result, errors.Trace(err)
@@ -130,7 +131,7 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 
 // ModelSet implements the server-side part of the
 // set-model-config CLI command.
-func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
+func (c *ModelConfigAPI) ModelSet(ctx context.Context, args params.ModelSet) error {
 	if err := c.checkCanWrite(); err != nil {
 		return err
 	}
@@ -291,7 +292,7 @@ func (c *ModelConfigAPI) checkSecretBackend() state.ValidateConfigFunc {
 
 // ModelUnset implements the server-side part of the
 // set-model-config CLI command.
-func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
+func (c *ModelConfigAPI) ModelUnset(ctx context.Context, args params.ModelUnset) error {
 	if err := c.checkCanWrite(); err != nil {
 		return err
 	}
@@ -303,7 +304,7 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 }
 
 // GetModelConstraints returns the constraints for the model.
-func (c *ModelConfigAPI) GetModelConstraints() (params.GetConstraintsResults, error) {
+func (c *ModelConfigAPI) GetModelConstraints(ctx context.Context) (params.GetConstraintsResults, error) {
 	if err := c.canReadModel(); err != nil {
 		return params.GetConstraintsResults{}, err
 	}
@@ -316,7 +317,7 @@ func (c *ModelConfigAPI) GetModelConstraints() (params.GetConstraintsResults, er
 }
 
 // SetModelConstraints sets the constraints for the model.
-func (c *ModelConfigAPI) SetModelConstraints(args params.SetConstraints) error {
+func (c *ModelConfigAPI) SetModelConstraints(ctx context.Context, args params.SetConstraints) error {
 	if err := c.checkCanWrite(); err != nil {
 		return err
 	}
@@ -328,7 +329,7 @@ func (c *ModelConfigAPI) SetModelConstraints(args params.SetConstraints) error {
 }
 
 // SetSLALevel sets the sla level on the model.
-func (c *ModelConfigAPI) SetSLALevel(args params.ModelSLA) error {
+func (c *ModelConfigAPI) SetSLALevel(ctx context.Context, args params.ModelSLA) error {
 	if err := c.checkCanWrite(); err != nil {
 		return err
 	}
@@ -337,7 +338,7 @@ func (c *ModelConfigAPI) SetSLALevel(args params.ModelSLA) error {
 }
 
 // SLALevel returns the current sla level for the model.
-func (c *ModelConfigAPI) SLALevel() (params.StringResult, error) {
+func (c *ModelConfigAPI) SLALevel(ctx context.Context) (params.StringResult, error) {
 	result := params.StringResult{}
 	level, err := c.backend.SLALevel()
 	if err != nil {
@@ -348,7 +349,7 @@ func (c *ModelConfigAPI) SLALevel() (params.StringResult, error) {
 }
 
 // Sequences returns the model's sequence names and next values.
-func (c *ModelConfigAPI) Sequences() (params.ModelSequencesResult, error) {
+func (c *ModelConfigAPI) Sequences(ctx context.Context) (params.ModelSequencesResult, error) {
 	result := params.ModelSequencesResult{}
 	if err := c.canReadModel(); err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -4,6 +4,7 @@
 package modelgeneration
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/collections/set"
@@ -47,7 +48,7 @@ func NewModelGenerationAPI(
 	}, nil
 }
 
-func (api *API) hasAdminAccess() error {
+func (api *API) hasAdminAccess(ctx context.Context) error {
 	// We used to cache the result on the api object if the user was a superuser.
 	// We don't do that anymore as permission caching could become invalid
 	// for long lived connections.
@@ -64,9 +65,9 @@ func (api *API) hasAdminAccess() error {
 }
 
 // AddBranch adds a new branch with the input name to the model.
-func (api *API) AddBranch(arg params.BranchArg) (params.ErrorResult, error) {
+func (api *API) AddBranch(ctx context.Context, arg params.BranchArg) (params.ErrorResult, error) {
 	result := params.ErrorResult{}
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -80,8 +81,8 @@ func (api *API) AddBranch(arg params.BranchArg) (params.ErrorResult, error) {
 
 // TrackBranch marks the input units and/or applications as tracking the input
 // branch, causing them to realise changes made under that branch.
-func (api *API) TrackBranch(arg params.BranchTrackArg) (params.ErrorResults, error) {
-	if err := api.hasAdminAccess(); err != nil {
+func (api *API) TrackBranch(ctx context.Context, arg params.BranchTrackArg) (params.ErrorResults, error) {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return params.ErrorResults{}, err
 	}
 
@@ -122,10 +123,10 @@ func (api *API) TrackBranch(arg params.BranchTrackArg) (params.ErrorResults, err
 
 // CommitBranch commits the input branch, making its changes applicable to
 // the whole model and marking it complete.
-func (api *API) CommitBranch(arg params.BranchArg) (params.IntResult, error) {
+func (api *API) CommitBranch(ctx context.Context, arg params.BranchArg) (params.IntResult, error) {
 	result := params.IntResult{}
 
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -145,10 +146,10 @@ func (api *API) CommitBranch(arg params.BranchArg) (params.IntResult, error) {
 // AbortBranch aborts the input branch, marking it complete.  However no
 // changes are made applicable to the whole model.  No units may be assigned
 // to the branch when aborting.
-func (api *API) AbortBranch(arg params.BranchArg) (params.ErrorResult, error) {
+func (api *API) AbortBranch(ctx context.Context, arg params.BranchArg) (params.ErrorResult, error) {
 	result := params.ErrorResult{}
 
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -169,10 +170,11 @@ func (api *API) AbortBranch(arg params.BranchArg) (params.ErrorResult, error) {
 // master generation.
 // An error is returned if no in-flight branch matching in input is found.
 func (api *API) BranchInfo(
+	ctx context.Context,
 	args params.BranchInfoArgs) (params.BranchResults, error) {
 	result := params.BranchResults{}
 
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -207,10 +209,10 @@ func (api *API) BranchInfo(
 // ShowCommit will return details a commit given by its generationId
 // An error is returned if either no branch can be found corresponding to the generation id.
 // Or the generation id given is below 1.
-func (api *API) ShowCommit(arg params.GenerationId) (params.GenerationResult, error) {
+func (api *API) ShowCommit(ctx context.Context, arg params.GenerationId) (params.GenerationResult, error) {
 	result := params.GenerationResult{}
 
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -236,10 +238,10 @@ func (api *API) ShowCommit(arg params.GenerationId) (params.GenerationResult, er
 }
 
 // ListCommits will return the commits, hence only branches with generation_id higher than 0
-func (api *API) ListCommits() (params.BranchResults, error) {
+func (api *API) ListCommits(ctx context.Context) (params.BranchResults, error) {
 	var result params.BranchResults
 
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 
@@ -330,9 +332,9 @@ func (api *API) getGenerationCommit(branch Generation) (params.Generation, error
 
 // HasActiveBranch returns a true result if the input model has an "in-flight"
 // branch matching the input name.
-func (api *API) HasActiveBranch(arg params.BranchArg) (params.BoolResult, error) {
+func (api *API) HasActiveBranch(ctx context.Context, arg params.BranchArg) (params.BoolResult, error) {
 	result := params.BoolResult{}
-	if err := api.hasAdminAccess(); err != nil {
+	if err := api.hasAdminAccess(ctx); err != nil {
 		return result, err
 	}
 

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -4,6 +4,8 @@
 package modelgeneration_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -49,7 +51,7 @@ func (s *modelGenerationSuite) TestAddBranchInvalidNameError(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
 
 	arg := params.BranchArg{BranchName: model.GenerationMaster}
-	result, err := s.api.AddBranch(arg)
+	result, err := s.api.AddBranch(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.NotNil)
 	c.Check(result.Error.Message, gc.Matches, ".* not valid")
@@ -59,7 +61,7 @@ func (s *modelGenerationSuite) TestAddBranchSuccess(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
 	s.expectAddBranch()
 
-	result, err := s.api.AddBranch(s.newBranchArg())
+	result, err := s.api.AddBranch(context.Background(), s.newBranchArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }
@@ -78,7 +80,7 @@ func (s *modelGenerationSuite) TestTrackBranchEntityTypeError(c *gc.C) {
 			{Tag: names.NewMachineTag("7").String()},
 		},
 	}
-	result, err := s.api.TrackBranch(arg)
+	result, err := s.api.TrackBranch(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Results, gc.DeepEquals, []params.ErrorResult{
 		{Error: nil},
@@ -100,7 +102,7 @@ func (s *modelGenerationSuite) TestTrackBranchSuccess(c *gc.C) {
 			{Tag: names.NewApplicationTag("ghost").String()},
 		},
 	}
-	result, err := s.api.TrackBranch(arg)
+	result, err := s.api.TrackBranch(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Results, gc.DeepEquals, []params.ErrorResult{
 		{Error: nil},
@@ -119,7 +121,7 @@ func (s *modelGenerationSuite) TestTrackBranchWithTooManyNumUnits(c *gc.C) {
 		},
 		NumUnits: 1,
 	}
-	result, err := s.api.TrackBranch(arg)
+	result, err := s.api.TrackBranch(context.Background(), arg)
 	c.Assert(err, gc.ErrorMatches, "number of units and unit IDs can not be specified at the same time")
 	c.Check(result.Results, gc.DeepEquals, []params.ErrorResult(nil))
 }
@@ -129,7 +131,7 @@ func (s *modelGenerationSuite) TestCommitBranchSuccess(c *gc.C) {
 	s.expectCommit()
 	s.expectBranch()
 
-	result, err := s.api.CommitBranch(s.newBranchArg())
+	result, err := s.api.CommitBranch(context.Background(), s.newBranchArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.IntResult{Result: 3, Error: nil})
 }
@@ -139,7 +141,7 @@ func (s *modelGenerationSuite) TestAbortBranchSuccess(c *gc.C) {
 	s.expectAbort()
 	s.expectBranch()
 
-	result, err := s.api.AbortBranch(s.newBranchArg())
+	result, err := s.api.AbortBranch(context.Background(), s.newBranchArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: nil})
 }
@@ -148,7 +150,7 @@ func (s *modelGenerationSuite) TestHasActiveBranchTrue(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
 	s.expectHasActiveBranch(nil)
 
-	result, err := s.api.HasActiveBranch(s.newBranchArg())
+	result, err := s.api.HasActiveBranch(context.Background(), s.newBranchArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Check(result.Result, jc.IsTrue)
@@ -158,7 +160,7 @@ func (s *modelGenerationSuite) TestHasActiveBranchFalse(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
 	s.expectHasActiveBranch(errors.NotFoundf(s.newBranchName))
 
-	result, err := s.api.HasActiveBranch(s.newBranchArg())
+	result, err := s.api.HasActiveBranch(context.Background(), s.newBranchArg())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Check(result.Result, jc.IsFalse)
@@ -194,7 +196,7 @@ func (s *modelGenerationSuite) testBranchInfo(c *gc.C, branchNames []string, det
 
 	s.setupMockApp(ctrl, units)
 
-	result, err := s.api.BranchInfo(params.BranchInfoArgs{
+	result, err := s.api.BranchInfo(context.Background(), params.BranchInfoArgs{
 		BranchNames: branchNames,
 		Detailed:    detailed,
 	})

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/errors"
@@ -94,7 +95,7 @@ func (s *ListModelsWithInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 // TODO (anastasiamac 2017-11-24) add test with migration and SLA
 
 func (s *ListModelsWithInfoSuite) TestListModelSummaries(c *gc.C) {
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ModelSummaryResults{
 		Results: []params.ModelSummaryResult{
@@ -123,7 +124,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesWithUserAccess(c *gc.C) 
 		summary.Access = permission.AdminAccess
 		return []state.ModelSummary{summary}, nil
 	}
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Result.UserAccess, jc.DeepEquals, params.ModelAdminAccess)
 }
@@ -135,7 +136,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesWithLastConnected(c *gc.
 		summary.UserLastConnection = &now
 		return []state.ModelSummary{summary}, nil
 	}
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Result.UserLastConnection, jc.DeepEquals, &now)
 }
@@ -146,7 +147,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesWithMachineCount(c *gc.C
 		summary.MachineCount = int64(64)
 		return []state.ModelSummary{summary}, nil
 	}
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Result.Counts[0], jc.DeepEquals, params.ModelEntityCount{params.Machines, 64})
 }
@@ -157,7 +158,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesWithCoreCount(c *gc.C) {
 		summary.CoreCount = int64(43)
 		return []state.ModelSummary{summary}, nil
 	}
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Result.Counts[0], jc.DeepEquals, params.ModelEntityCount{params.Cores, 43})
 }
@@ -172,7 +173,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesWithMachineAndUserDetail
 		summary.CoreCount = int64(42)
 		return []state.ModelSummary{summary}, nil
 	}
-	result, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	result, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ModelSummaryResults{
 		Results: []params.ModelSummaryResult{
@@ -204,19 +205,19 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesDenied(c *gc.C) {
 	user := names.NewUserTag("external@remote")
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("other@remote")
-	_, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: other.String()})
+	_, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: other.String()})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *ListModelsWithInfoSuite) TestListModelSummariesInvalidUser(c *gc.C) {
-	_, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: "invalid"})
+	_, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: "invalid"})
 	c.Assert(err, gc.ErrorMatches, `"invalid" is not a valid tag`)
 }
 
 func (s *ListModelsWithInfoSuite) TestListModelSummariesStateError(c *gc.C) {
 	errMsg := "captain error for ModelSummariesForUser"
 	s.st.Stub.SetErrors(errors.New(errMsg))
-	_, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	_, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, gc.ErrorMatches, errMsg)
 }
 
@@ -224,7 +225,7 @@ func (s *ListModelsWithInfoSuite) TestListModelSummariesNoModelsForUser(c *gc.C)
 	s.st.modelDetailsForUser = func() ([]state.ModelSummary, error) {
 		return []state.ModelSummary{}, nil
 	}
-	results, err := s.api.ListModelSummaries(params.ModelSummariesRequest{UserTag: s.adminUser.String()})
+	results, err := s.api.ListModelSummaries(stdcontext.Background(), params.ModelSummariesRequest{UserTag: s.adminUser.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -346,7 +346,7 @@ func (s *modelInfoSuite) TestModelInfoNonOwner(c *gc.C) {
 }
 
 func (s *modelInfoSuite) getModelInfo(c *gc.C, modelUUID string) params.ModelInfo {
-	results, err := s.modelmanager.ModelInfo(params.Entities{
+	results, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{
 			names.NewModelTag(modelUUID).String(),
 		}},
@@ -398,7 +398,7 @@ func (s *modelInfoSuite) TestRunningMigration(c *gc.C) {
 		start:  start,
 	}
 
-	results, err := s.modelmanager.ModelInfo(params.Entities{
+	results, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 
@@ -418,7 +418,7 @@ func (s *modelInfoSuite) TestFailedMigration(c *gc.C) {
 		end:    end,
 	}
 
-	results, err := s.modelmanager.ModelInfo(params.Entities{
+	results, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 
@@ -430,7 +430,7 @@ func (s *modelInfoSuite) TestFailedMigration(c *gc.C) {
 }
 
 func (s *modelInfoSuite) TestNoMigration(c *gc.C) {
-	results, err := s.modelmanager.ModelInfo(params.Entities{
+	results, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -592,7 +592,7 @@ func (s *modelInfoSuite) assertSuccess(c *gc.C, modelUUID string, desiredLife st
 }
 
 func (s *modelInfoSuite) testModelInfoError(c *gc.C, modelTag, expectedErr string) {
-	results, err := s.modelmanager.ModelInfo(params.Entities{
+	results, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{modelTag}},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -285,7 +285,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		CloudRegion:        "qux",
 		CloudCredentialTag: "cloudcred-some-cloud_admin_some-credential",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c,
 		"ControllerTag",
@@ -362,7 +362,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *gc.C) {
 		CloudRegion:        "qux",
 		CloudCredentialTag: "cloudcred-some-cloud_admin_some-credential",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModelArgs := s.getModelArgs(c)
@@ -376,7 +376,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloudNotFound(c *gc.C) {
 		OwnerTag: "user-admin",
 		CloudTag: "cloud-some-unknown-cloud",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `cloud "some-unknown-cloud" not found, expected one of \["some-cloud"\]`)
 }
 
@@ -385,7 +385,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *gc.C) {
 		Name:     "foo",
 		OwnerTag: "user-admin",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModelArgs := s.getModelArgs(c)
@@ -406,7 +406,7 @@ func (s *modelManagerSuite) testCreateModelDefaultCredentialAdmin(c *gc.C, owner
 		Name:     "foo",
 		OwnerTag: ownerTag,
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModelArgs := s.getModelArgs(c)
@@ -420,7 +420,7 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 		Name:     "foo",
 		OwnerTag: "user-bob",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModelArgs := s.getModelArgs(c)
@@ -433,7 +433,7 @@ func (s *modelManagerSuite) TestCreateModelNoDefaultCredentialNonAdmin(c *gc.C) 
 		Name:     "foo",
 		OwnerTag: "user-bob",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "no credential specified")
 }
 
@@ -444,7 +444,7 @@ func (s *modelManagerSuite) TestCreateModelUnknownCredential(c *gc.C) {
 		OwnerTag:           "user-admin",
 		CloudCredentialTag: "cloudcred-some-cloud_admin_bar",
 	}
-	_, err := s.api.CreateModel(stdcontext.TODO(), args)
+	_, err := s.api.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `getting credential: credential not found`)
 }
 
@@ -456,7 +456,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		CloudTag:           "cloud-k8s-cloud",
 		CloudCredentialTag: "cloudcred-k8s-cloud_admin_some-credential",
 	}
-	_, err := s.caasApi.CreateModel(stdcontext.TODO(), args)
+	_, err := s.caasApi.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	s.caasSt.CheckCallNames(c,
 		"ControllerTag",
@@ -529,13 +529,13 @@ func (s *modelManagerSuite) TestCreateCAASModelNamespaceClash(c *gc.C) {
 		CloudTag:           "cloud-k8s-cloud",
 		CloudCredentialTag: "cloudcred-k8s-cloud_admin_some-credential",
 	}
-	_, err := s.caasApi.CreateModel(stdcontext.TODO(), args)
+	_, err := s.caasApi.CreateModel(stdcontext.Background(), args)
 	s.caasBroker.CheckCallNames(c, "Create")
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
 
 func (s *modelManagerSuite) TestModelDefaults(c *gc.C) {
-	results, err := s.api.ModelDefaultsForClouds(params.Entities{
+	results, err := s.api.ModelDefaultsForClouds(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewCloudTag("dummy").String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -565,7 +565,7 @@ func (s *modelManagerSuite) TestSetModelDefaults(c *gc.C) {
 				"attr3": "val3",
 				"attr4": "val4"},
 		}}}
-	result, err := s.api.SetModelDefaults(params)
+	result, err := s.api.SetModelDefaults(stdcontext.Background(), params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 	c.Assert(s.ctlrSt.cfgDefaults, jc.DeepEquals, config.ModelDefaultAttributes{
@@ -601,7 +601,7 @@ func (s *modelManagerSuite) assertBlocked(c *gc.C, err error, msg string) {
 
 func (s *modelManagerSuite) TestBlockChangesSetModelDefaults(c *gc.C) {
 	s.blockAllChanges(c, "TestBlockChangesSetModelDefaults")
-	_, err := s.api.SetModelDefaults(params.SetModelDefaults{})
+	_, err := s.api.SetModelDefaults(stdcontext.Background(), params.SetModelDefaults{})
 	s.assertBlocked(c, err, "TestBlockChangesSetModelDefaults")
 }
 
@@ -610,7 +610,7 @@ func (s *modelManagerSuite) TestUnsetModelDefaults(c *gc.C) {
 		Keys: []params.ModelUnsetKeys{{
 			Keys: []string{"attr"},
 		}}}
-	result, err := s.api.UnsetModelDefaults(args)
+	result, err := s.api.UnsetModelDefaults(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 	want := config.ModelDefaultAttributes{
@@ -636,7 +636,7 @@ func (s *modelManagerSuite) TestBlockUnsetModelDefaults(c *gc.C) {
 		Keys: []params.ModelUnsetKeys{{
 			Keys: []string{"abc"},
 		}}}
-	_, err := s.api.UnsetModelDefaults(args)
+	_, err := s.api.UnsetModelDefaults(stdcontext.Background(), args)
 	s.assertBlocked(c, err, "TestBlockUnsetModelDefaults")
 }
 
@@ -646,14 +646,14 @@ func (s *modelManagerSuite) TestUnsetModelDefaultsMissing(c *gc.C) {
 		Keys: []params.ModelUnsetKeys{{
 			Keys: []string{"not there"},
 		}}}
-	result, err := s.api.UnsetModelDefaults(args)
+	result, err := s.api.UnsetModelDefaults(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 }
 
 func (s *modelManagerSuite) TestModelDefaultsAsNormalUser(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("charlie"))
-	got, err := s.api.ModelDefaultsForClouds(params.Entities{
+	got, err := s.api.ModelDefaultsForClouds(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewCloudTag("dummy").String()}},
 	})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
@@ -662,7 +662,7 @@ func (s *modelManagerSuite) TestModelDefaultsAsNormalUser(c *gc.C) {
 
 func (s *modelManagerSuite) TestSetModelDefaultsAsNormalUser(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("charlie"))
-	got, err := s.api.SetModelDefaults(params.SetModelDefaults{
+	got, err := s.api.SetModelDefaults(stdcontext.Background(), params.SetModelDefaults{
 		Config: []params.ModelDefaultValues{{
 			Config: map[string]interface{}{
 				"ftp-proxy": "http://charlie",
@@ -677,7 +677,7 @@ func (s *modelManagerSuite) TestSetModelDefaultsAsNormalUser(c *gc.C) {
 
 	// Make sure it didn't change.
 	s.setAPIUser(c, names.NewUserTag("admin"))
-	results, err := s.api.ModelDefaultsForClouds(params.Entities{
+	results, err := s.api.ModelDefaultsForClouds(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewCloudTag("dummy").String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -688,7 +688,7 @@ func (s *modelManagerSuite) TestSetModelDefaultsAsNormalUser(c *gc.C) {
 
 func (s *modelManagerSuite) TestUnsetModelDefaultsAsNormalUser(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("charlie"))
-	got, err := s.api.UnsetModelDefaults(params.UnsetModelDefaults{
+	got, err := s.api.UnsetModelDefaults(stdcontext.Background(), params.UnsetModelDefaults{
 		Keys: []params.ModelUnsetKeys{{
 			Keys: []string{"attr2"}}}})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
@@ -698,7 +698,7 @@ func (s *modelManagerSuite) TestUnsetModelDefaultsAsNormalUser(c *gc.C) {
 
 	// Make sure it didn't change.
 	s.setAPIUser(c, names.NewUserTag("admin"))
-	results, err := s.api.ModelDefaultsForClouds(params.Entities{
+	results, err := s.api.ModelDefaultsForClouds(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewCloudTag("dummy").String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -778,7 +778,7 @@ func (s *modelManagerSuite) TestDumpModelUsers(c *gc.C) {
 }
 
 func (s *modelManagerSuite) TestDumpModelsDB(c *gc.C) {
-	results := s.api.DumpModelsDB(params.Entities{Entities: []params.Entity{{
+	results := s.api.DumpModelsDB(stdcontext.Background(), params.Entities{Entities: []params.Entity{{
 		Tag: "bad-tag",
 	}, {
 		Tag: "application-foo",
@@ -804,7 +804,7 @@ func (s *modelManagerSuite) TestDumpModelsDBMissingModel(c *gc.C) {
 	s.st.SetErrors(errors.NotFoundf("boom"))
 	tag := names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f000")
 	models := params.Entities{Entities: []params.Entity{{Tag: tag.String()}}}
-	results := s.api.DumpModelsDB(models)
+	results := s.api.DumpModelsDB(stdcontext.Background(), models)
 
 	s.st.CheckCalls(c, []jtesting.StubCall{
 		{FuncName: "ControllerTag", Args: nil},
@@ -826,7 +826,7 @@ func (s *modelManagerSuite) TestDumpModelsDBUsers(c *gc.C) {
 		names.NewUserTag("unknown"),
 	} {
 		s.setAPIUser(c, user)
-		results := s.api.DumpModelsDB(models)
+		results := s.api.DumpModelsDB(stdcontext.Background(), models)
 		c.Assert(results.Results, gc.HasLen, 1)
 		result := results.Results[0]
 		c.Assert(result.Result, gc.IsNil)
@@ -839,7 +839,7 @@ func (s *modelManagerSuite) TestAddModelCanCreateModel(c *gc.C) {
 	addModelUser := names.NewUserTag("add-model")
 	s.ctlrSt.cloudUsers[addModelUser.Id()] = permission.AddModelAccess
 	s.setAPIUser(c, addModelUser)
-	_, err := s.api.CreateModel(stdcontext.TODO(), createArgs(addModelUser))
+	_, err := s.api.CreateModel(stdcontext.Background(), createArgs(addModelUser))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -848,7 +848,7 @@ func (s *modelManagerSuite) TestAddModelCantCreateModelForSomeoneElse(c *gc.C) {
 	s.ctlrSt.cloudUsers[addModelUser.Id()] = permission.AddModelAccess
 	s.setAPIUser(c, addModelUser)
 	nonAdminUser := names.NewUserTag("non-admin")
-	_, err := s.api.CreateModel(stdcontext.TODO(), createArgs(nonAdminUser))
+	_, err := s.api.CreateModel(stdcontext.Background(), createArgs(nonAdminUser))
 	c.Assert(err, gc.ErrorMatches, "\"add-model\" permission does not permit creation of models for different owners: permission denied")
 }
 
@@ -950,7 +950,7 @@ func (s *modelManagerStateSuite) createArgsForVersion(c *gc.C, owner names.UserT
 func (s *modelManagerStateSuite) TestUserCanCreateModel(c *gc.C) {
 	owner := names.NewUserTag("admin")
 	s.setAPIUser(c, owner)
-	model, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	model, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.OwnerTag, gc.Equals, owner.String())
 	c.Assert(model.Name, gc.Equals, "test-model")
@@ -961,7 +961,7 @@ func (s *modelManagerStateSuite) TestAdminCanCreateModelForSomeoneElse(c *gc.C) 
 	s.setAPIUser(c, jujutesting.AdminUser)
 	owner := names.NewUserTag("external@remote")
 
-	model, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	model, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(model.OwnerTag, gc.Equals, owner.String())
 	c.Assert(model.Name, gc.Equals, "test-model")
@@ -982,14 +982,14 @@ func (s *modelManagerStateSuite) TestAdminCanCreateModelForSomeoneElse(c *gc.C) 
 func (s *modelManagerStateSuite) TestNonAdminCannotCreateModelForSomeoneElse(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("non-admin@remote"))
 	owner := names.NewUserTag("external@remote")
-	_, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	_, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *modelManagerStateSuite) TestNonAdminCannotCreateModelForSelf(c *gc.C) {
 	owner := names.NewUserTag("non-admin@remote")
 	s.setAPIUser(c, owner)
-	_, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	_, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -998,7 +998,7 @@ func (s *modelManagerStateSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	s.setAPIUser(c, admin)
 	args := createArgs(admin)
 	args.Config["somebool"] = "maybe"
-	_, err := s.modelmanager.CreateModel(stdcontext.TODO(), args)
+	_, err := s.modelmanager.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches,
 		"failed to create config: provider config preparation failed: somebool: expected bool, got string\\(\"maybe\"\\)",
 	)
@@ -1021,7 +1021,7 @@ func (s *modelManagerStateSuite) TestCreateModelBadConfig(c *gc.C) {
 		c.Logf("%d: %s", i, test.key)
 		args := createArgs(owner)
 		args.Config[test.key] = test.value
-		_, err := s.modelmanager.CreateModel(stdcontext.TODO(), args)
+		_, err := s.modelmanager.CreateModel(stdcontext.Background(), args)
 		c.Assert(err, gc.ErrorMatches, test.errMatch)
 
 	}
@@ -1031,7 +1031,7 @@ func (s *modelManagerStateSuite) TestCreateModelSameAgentVersion(c *gc.C) {
 	admin := jujutesting.AdminUser
 	s.setAPIUser(c, admin)
 	args := s.createArgsForVersion(c, admin, jujuversion.Current.String())
-	_, err := s.modelmanager.CreateModel(stdcontext.TODO(), args)
+	_, err := s.modelmanager.CreateModel(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1068,7 +1068,7 @@ func (s *modelManagerStateSuite) TestCreateModelBadAgentVersion(c *gc.C) {
 	} {
 		c.Logf("test %d", i)
 		args := s.createArgsForVersion(c, admin, test.value)
-		_, err := s.modelmanager.CreateModel(stdcontext.TODO(), args)
+		_, err := s.modelmanager.CreateModel(stdcontext.Background(), args)
 		c.Check(err, gc.ErrorMatches, test.errMatch)
 	}
 }
@@ -1082,7 +1082,7 @@ func (s *modelManagerStateSuite) checkModelMatches(c *gc.C, model params.Model, 
 func (s *modelManagerStateSuite) TestListModelsAdminSelf(c *gc.C) {
 	user := jujutesting.AdminUser
 	s.setAPIUser(c, user)
-	result, err := s.modelmanager.ListModels(params.Entity{Tag: user.String()})
+	result, err := s.modelmanager.ListModels(stdcontext.Background(), params.Entity{Tag: user.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 1)
 	expected, err := s.ControllerModel(c).State().Model()
@@ -1094,7 +1094,7 @@ func (s *modelManagerStateSuite) TestListModelsAdminListsOther(c *gc.C) {
 	user := jujutesting.AdminUser
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("admin")
-	result, err := s.modelmanager.ListModels(params.Entity{Tag: other.String()})
+	result, err := s.modelmanager.ListModels(stdcontext.Background(), params.Entity{Tag: other.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 1)
 }
@@ -1103,7 +1103,7 @@ func (s *modelManagerStateSuite) TestListModelsDenied(c *gc.C) {
 	user := names.NewUserTag("external@remote")
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("other@remote")
-	_, err := s.modelmanager.ListModels(params.Entity{Tag: other.String()})
+	_, err := s.modelmanager.ListModels(stdcontext.Background(), params.Entity{Tag: other.String()})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -1125,7 +1125,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	// can create models are controller admins.
 	owner := names.NewUserTag("admin")
 	s.setAPIUser(c, owner)
-	m, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	m, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := s.StatePool().Get(m.UUID)
@@ -1147,7 +1147,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 
 	force := true
 	timeout := time.Minute
-	results, err := s.modelmanager.DestroyModels(stdcontext.TODO(), params.DestroyModelsParams{
+	results, err := s.modelmanager.DestroyModels(stdcontext.Background(), params.DestroyModelsParams{
 		Models: []params.DestroyModelParams{{
 			ModelTag: "model-" + m.UUID,
 			Force:    &force,
@@ -1173,7 +1173,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	// usefulness until proper controller permissions are in place.
 	owner := names.NewUserTag("admin")
 	s.setAPIUser(c, owner)
-	m, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	m, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := s.StatePool().Get(m.UUID)
@@ -1195,7 +1195,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.modelmanager.DestroyModels(stdcontext.TODO(), params.DestroyModelsParams{
+	results, err := s.modelmanager.DestroyModels(stdcontext.Background(), params.DestroyModelsParams{
 		Models: []params.DestroyModelParams{{
 			ModelTag: "model-" + m.UUID,
 		}},
@@ -1213,7 +1213,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	owner := names.NewUserTag("admin")
 	s.setAPIUser(c, owner)
-	m, err := s.modelmanager.CreateModel(stdcontext.TODO(), createArgs(owner))
+	m, err := s.modelmanager.CreateModel(stdcontext.Background(), createArgs(owner))
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := s.StatePool().Get(m.UUID)
@@ -1236,7 +1236,7 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	user := names.NewUserTag("other@remote")
 	s.setAPIUser(c, user)
 
-	results, err := s.modelmanager.DestroyModels(stdcontext.TODO(), params.DestroyModelsParams{
+	results, err := s.modelmanager.DestroyModels(stdcontext.Background(), params.DestroyModelsParams{
 		Models: []params.DestroyModelParams{
 			{ModelTag: "model-" + m.UUID},
 			{ModelTag: "model-9f484882-2f18-4fd2-967d-db9663db7bea"},
@@ -1276,7 +1276,7 @@ func (s *modelManagerStateSuite) modifyAccess(c *gc.C, user names.UserTag, actio
 			ModelTag: model.String(),
 		}}}
 
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	result, err := s.modelmanager.ModifyModelAccess(stdcontext.Background(), args)
 	if err != nil {
 		return err
 	}
@@ -1396,7 +1396,7 @@ func (s *modelManagerStateSuite) assertModelAccess(c *gc.C, st *state.State) {
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.modelmanager.ModelInfo(params.Entities{Entities: []params.Entity{{Tag: m.ModelTag().String()}}})
+	result, err := s.modelmanager.ModelInfo(stdcontext.Background(), params.Entities{Entities: []params.Entity{{Tag: m.ModelTag().String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -1627,7 +1627,7 @@ func (s *modelManagerStateSuite) TestGrantModelInvalidUserTag(c *gc.C) {
 				Access:   params.ModelReadAccess,
 			}}}
 
-		result, err := s.modelmanager.ModifyModelAccess(args)
+		result, err := s.modelmanager.ModifyModelAccess(stdcontext.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
 	}
@@ -1637,7 +1637,7 @@ func (s *modelManagerStateSuite) TestModifyModelAccessEmptyArgs(c *gc.C) {
 	s.setAPIUser(c, jujutesting.AdminUser)
 	args := params.ModifyModelAccessRequest{Changes: []params.ModifyModelAccess{{}}}
 
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	result, err := s.modelmanager.ModifyModelAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `could not modify model access: "" model access not valid`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
@@ -1654,7 +1654,7 @@ func (s *modelManagerStateSuite) TestModifyModelAccessInvalidAction(c *gc.C) {
 			ModelTag: s.ControllerModel(c).ModelTag().String(),
 		}}}
 
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	result, err := s.modelmanager.ModifyModelAccess(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `unknown action "dance"`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
@@ -1709,6 +1709,7 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 	c.Assert(endPoint, gc.NotNil)
 
 	res, err := endPoint.ModelInfo(
+		stdcontext.Background(),
 		params.Entities{
 			Entities: []params.Entity{
 				{Tag: model.ModelTag().String()},
@@ -1771,7 +1772,7 @@ func (s *modelManagerSuite) TestModelStatus(c *gc.C) {
 func (s *modelManagerSuite) TestChangeModelCredential(c *gc.C) {
 	s.st.model.setCloudCredentialF = func(tag names.CloudCredentialTag) (bool, error) { return true, nil }
 	credentialTag := names.NewCloudCredentialTag("foo/bob/bar").String()
-	results, err := s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err := s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: credentialTag},
 		},
@@ -1785,7 +1786,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialBulkUninterrupted(c *gc.C) 
 	s.st.model.setCloudCredentialF = func(tag names.CloudCredentialTag) (bool, error) { return true, nil }
 	credentialTag := names.NewCloudCredentialTag("foo/bob/bar").String()
 	// Check that we don't err out immediately if a model errs.
-	results, err := s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err := s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: "bad-model-tag"},
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: credentialTag},
@@ -1798,7 +1799,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialBulkUninterrupted(c *gc.C) 
 	c.Assert(results.Results[1].Error, gc.IsNil)
 
 	// Check that we don't err out if a model errs even if some firsts in collection pass.
-	results, err = s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err = s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: s.st.ModelTag().String()},
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: "bad-credential-tag"},
@@ -1814,7 +1815,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialUnauthorisedUser(c *gc.C) {
 	apiUser := names.NewUserTag("bob@remote")
 	s.setAPIUser(c, apiUser)
 
-	results, err := s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err := s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: credentialTag},
 		},
@@ -1828,7 +1829,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialGetModelFail(c *gc.C) {
 	s.st.SetErrors(errors.New("getting model"))
 	credentialTag := names.NewCloudCredentialTag("foo/bob/bar").String()
 
-	results, err := s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err := s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: credentialTag},
 		},
@@ -1842,7 +1843,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialGetModelFail(c *gc.C) {
 func (s *modelManagerSuite) TestChangeModelCredentialNotUpdated(c *gc.C) {
 	s.st.model.setCloudCredentialF = func(tag names.CloudCredentialTag) (bool, error) { return false, nil }
 	credentialTag := names.NewCloudCredentialTag("foo/bob/bar").String()
-	results, err := s.api.ChangeModelCredential(params.ChangeModelCredentialsParams{
+	results, err := s.api.ChangeModelCredential(stdcontext.Background(), params.ChangeModelCredentialsParams{
 		Models: []params.ChangeModelCredentialParams{
 			{ModelTag: s.st.ModelTag().String(), CloudCredentialTag: credentialTag},
 		},

--- a/apiserver/facades/client/modelupgrader/upgrader.go
+++ b/apiserver/facades/client/modelupgrader/upgrader.go
@@ -4,6 +4,7 @@
 package modelupgrader
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -103,7 +104,7 @@ type ConfigSource interface {
 
 // AbortModelUpgrade aborts and archives the model upgrade
 // synchronisation record, if any.
-func (m *ModelUpgraderAPI) AbortModelUpgrade(arg params.ModelParam) error {
+func (m *ModelUpgraderAPI) AbortModelUpgrade(ctx stdcontext.Context, arg params.ModelParam) error {
 	modelTag, err := names.ParseModelTag(arg.ModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -124,7 +125,7 @@ func (m *ModelUpgraderAPI) AbortModelUpgrade(arg params.ModelParam) error {
 }
 
 // UpgradeModel upgrades a model.
-func (m *ModelUpgraderAPI) UpgradeModel(arg params.UpgradeModelParams) (result params.UpgradeModelResult, err error) {
+func (m *ModelUpgraderAPI) UpgradeModel(ctx stdcontext.Context, arg params.UpgradeModelParams) (result params.UpgradeModelResult, err error) {
 	m.logger.Tracef("UpgradeModel arg %#v", arg)
 	targetVersion := arg.TargetVersion
 	defer func() {

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -4,6 +4,8 @@
 package modelupgrader_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -149,7 +151,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelWithInvalidModelTag(c *gc.C) {
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
-	_, err := api.UpgradeModel(params.UpgradeModelParams{ModelTag: "!!!"})
+	_, err := api.UpgradeModel(stdcontext.Background(), params.UpgradeModelParams{ModelTag: "!!!"})
 	c.Assert(err, gc.ErrorMatches, `"!!!" is not a valid tag`)
 }
 
@@ -161,6 +163,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelWithModelWithNoPermission(c *gc.C) {
 	defer ctrl.Finish()
 
 	_, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      coretesting.ModelTag.String(),
 			TargetVersion: version.MustParse("3.0.0"),
@@ -176,6 +179,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelWithChangeNotAllowed(c *gc.C) {
 	s.blockChecker.EXPECT().ChangeAllowed().Return(errors.Errorf("the operation has been blocked"))
 
 	_, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      coretesting.ModelTag.String(),
 			TargetVersion: version.MustParse("3.0.0"),
@@ -289,6 +293,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	}
 
 	result, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      ctrlModelTag.String(),
 			TargetVersion: version.MustParse("3.9.99"),
@@ -401,6 +406,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerDyingHostedModelJuju3(c
 	ctrlState.EXPECT().SetModelAgentVersion(version.MustParse("3.9.99"), nil, false).Return(nil)
 
 	result, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      ctrlModelTag.String(),
 			TargetVersion: version.MustParse("3.9.99"),
@@ -524,6 +530,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	model1.EXPECT().Name().Return("model-1")
 
 	result, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      ctrlModelTag.String(),
 			TargetVersion: version.MustParse("3.9.99"),
@@ -606,6 +613,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
 	}
 
 	result, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      coretesting.ModelTag.String(),
 			TargetVersion: version.MustParse("3.9.99"),
@@ -689,6 +697,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	model.EXPECT().Name().Return("model-1")
 
 	result, err := api.UpgradeModel(
+		stdcontext.Background(),
 		params.UpgradeModelParams{
 			ModelTag:      coretesting.ModelTag.String(),
 			TargetVersion: version.MustParse("3.9.99"),
@@ -717,7 +726,7 @@ func (s *modelUpgradeSuite) TestAbortCurrentUpgrade(c *gc.C) {
 		s.statePool.EXPECT().Get(modelUUID).Return(st, nil),
 		st.EXPECT().AbortCurrentUpgrade().Return(nil),
 	)
-	err := api.AbortModelUpgrade(params.ModelParam{ModelTag: coretesting.ModelTag.String()})
+	err := api.AbortModelUpgrade(stdcontext.Background(), params.ModelParam{ModelTag: coretesting.ModelTag.String()})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/payloads/facade.go
+++ b/apiserver/facades/client/payloads/facade.go
@@ -4,6 +4,8 @@
 package payloads
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	api "github.com/juju/juju/api/client/payloads"
@@ -31,7 +33,7 @@ func NewAPI(backend payloadBackend) *API {
 // List builds the list of payloads being tracked for
 // the given unit and IDs. If no IDs are provided then all tracked
 // payloads for the unit are returned.
-func (a API) List(args params.PayloadListArgs) (params.PayloadListResults, error) {
+func (a API) List(ctx context.Context, args params.PayloadListArgs) (params.PayloadListResults, error) {
 	var r params.PayloadListResults
 
 	payloadInfo, err := a.backend.ListAll()

--- a/apiserver/facades/client/payloads/facade_test.go
+++ b/apiserver/facades/client/payloads/facade_test.go
@@ -4,6 +4,8 @@
 package payloads_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -74,7 +76,7 @@ func (s *Suite) TestListNoPatterns(c *gc.C) {
 	args := params.PayloadListArgs{
 		Patterns: []string{},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, params.PayloadListResults{
@@ -96,7 +98,7 @@ func (s *Suite) TestListAllMatch(c *gc.C) {
 			"a-application/0",
 		},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, params.PayloadListResults{
@@ -118,7 +120,7 @@ func (s *Suite) TestListNoMatch(c *gc.C) {
 			"a-application/1",
 		},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results.Results, gc.HasLen, 0)
@@ -129,7 +131,7 @@ func (s *Suite) TestListNoPayloads(c *gc.C) {
 	args := params.PayloadListArgs{
 		Patterns: []string{},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results.Results, gc.HasLen, 0)
@@ -147,7 +149,7 @@ func (s *Suite) TestListMultiMatch(c *gc.C) {
 			"eggs",
 		},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, params.PayloadListResults{
@@ -169,7 +171,7 @@ func (s *Suite) TestListPartialMatch(c *gc.C) {
 			"spam",
 		},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, params.PayloadListResults{
@@ -192,7 +194,7 @@ func (s *Suite) TestListPartialMultiMatch(c *gc.C) {
 			"ham",
 		},
 	}
-	results, err := facade.List(args)
+	results, err := facade.List(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, params.PayloadListResults{
@@ -238,7 +240,7 @@ func (s *Suite) TestListAllFilters(c *gc.C) {
 				pattern,
 			},
 		}
-		results, err := facade.List(args)
+		results, err := facade.List(context.Background(), args)
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Check(results, jc.DeepEquals, params.PayloadListResults{

--- a/apiserver/facades/client/pinger/facade.go
+++ b/apiserver/facades/client/pinger/facade.go
@@ -4,6 +4,8 @@
 package pinger
 
 import (
+	"context"
+
 	"github.com/juju/worker/v3"
 )
 
@@ -26,12 +28,12 @@ func NewAPI(pinger Pinger) *API {
 }
 
 // Ping is used by the client heartbeat monitor and resets.
-func (a API) Ping() {
+func (a API) Ping(ctx context.Context) {
 	a.pinger.Ping()
 }
 
 // Stop stops the pinger.
-func (a API) Stop() error {
+func (a API) Stop(ctx context.Context) error {
 	a.pinger.Kill()
 	return a.pinger.Wait()
 }


### PR DESCRIPTION
This PR adds context.Context parameter to:
- client/imagemetadatamanager
- client/keymanager
- client/machinemanager
- client/metricsdebug
- client/modelconfig
- client/modelgeneration
- client/modelmanager
- client/modelupgrader
- client/payloads
- client/pinger 

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/client/imagemetadatamanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/keymanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/machinemanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/metricsdebug/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/modelconfig/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/modelgeneration/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/modelmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/modelupgrader/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/payloads/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/pinger/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```
