### PR TITLE
[JUJU-4480] Add context.Context in client/(r-u)* facades

### DIFF
--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	charmresource "github.com/juju/charm/v11/resource"
 	"github.com/juju/errors"
@@ -116,7 +118,7 @@ func NewResourcesAPI(backend Backend, factory func(*charm.URL) (NewCharmReposito
 }
 
 // ListResources returns the list of resources for the given application.
-func (a *API) ListResources(args params.ListResourcesArgs) (params.ResourcesResults, error) {
+func (a *API) ListResources(ctx context.Context, args params.ListResourcesArgs) (params.ResourcesResults, error) {
 	var r params.ResourcesResults
 	r.Results = make([]params.ResourcesResult, len(args.Entities))
 
@@ -146,7 +148,7 @@ func (a *API) ListResources(args params.ListResourcesArgs) (params.ResourcesResu
 // AddPendingResources adds the provided resources (info) to the Juju
 // model in a pending state, meaning they are not available until
 // resolved. Handles CharmHub and Local charms.
-func (a *API) AddPendingResources(args params.AddPendingResourcesArgsV2) (params.AddPendingResourcesResult, error) {
+func (a *API) AddPendingResources(ctx context.Context, args params.AddPendingResourcesArgsV2) (params.AddPendingResourcesResult, error) {
 	var result params.AddPendingResourcesResult
 
 	tag, apiErr := parseApplicationTag(args.Tag)

--- a/apiserver/facades/client/resources/server_addpending_test.go
+++ b/apiserver/facades/client/resources/server_addpending_test.go
@@ -4,6 +4,8 @@
 package resources_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	charmresource "github.com/juju/charm/v11/resource"
 	"github.com/juju/errors"
@@ -30,7 +32,7 @@ func (s *AddPendingResourcesSuite) TestNoURL(c *gc.C) {
 	s.backend.EXPECT().AddPendingResource(aTag.Id(), "", resourceMatcher{c: c}).Return(id1, nil)
 	facade := s.newFacade(c)
 
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -63,7 +65,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpToDate(c *gc.C) {
 	s.factory.EXPECT().ResolveResources(gomock.Any(), gomock.Any()).Return(res, nil)
 	facade := s.newFacade(c)
 
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -101,7 +103,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchComplete(c *gc.C) {
 	s.factory.EXPECT().ResolveResources(expected, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -152,7 +154,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchIncomplete(c *gc.C) {
 	s.factory.EXPECT().ResolveResources(res2, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -200,7 +202,7 @@ func (s *AddPendingResourcesSuite) TestWithURLNoRevision(c *gc.C) {
 	s.factory.EXPECT().ResolveResources(resNoRev, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -241,7 +243,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpload(c *gc.C) {
 	s.factory.EXPECT().ResolveResources([]charmresource.Resource{res1.Resource}, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -279,7 +281,7 @@ func (s *AddPendingResourcesSuite) TestUnknownResource(c *gc.C) {
 	s.factory.EXPECT().ResolveResources(expected, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: aTag.String(),
 		},
@@ -304,7 +306,7 @@ func (s *AddPendingResourcesSuite) TestDataStoreError(c *gc.C) {
 	s.backend.EXPECT().AddPendingResource(gomock.Any(), gomock.Any(), gomock.Any()).Return("", failure)
 
 	facade := s.newFacade(c)
-	result, err := facade.AddPendingResources(params.AddPendingResourcesArgsV2{
+	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
 		Entity: params.Entity{
 			Tag: "application-a-application",
 		},

--- a/apiserver/facades/client/resources/server_listresources_test.go
+++ b/apiserver/facades/client/resources/server_listresources_test.go
@@ -4,6 +4,8 @@
 package resources_test
 
 import (
+	"context"
+
 	charmresource "github.com/juju/charm/v11/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -62,7 +64,7 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 		},
 	}, nil)
 
-	results, err := s.newFacade(c).ListResources(params.ListResourcesArgs{
+	results, err := s.newFacade(c).ListResources(context.Background(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
 			Tag: appTag.String(),
 		}},
@@ -106,7 +108,7 @@ func (s *ListResourcesSuite) TestEmpty(c *gc.C) {
 	tag := names.NewApplicationTag("a-application")
 	s.backend.EXPECT().ListResources(tag.Id()).Return(coreresources.ApplicationResources{}, nil)
 
-	results, err := s.newFacade(c).ListResources(params.ListResourcesArgs{
+	results, err := s.newFacade(c).ListResources(context.Background(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
 			Tag: tag.String(),
 		}},
@@ -124,7 +126,7 @@ func (s *ListResourcesSuite) TestError(c *gc.C) {
 	tag := names.NewApplicationTag("a-application")
 	s.backend.EXPECT().ListResources(tag.Id()).Return(coreresources.ApplicationResources{}, failure)
 
-	results, err := s.newFacade(c).ListResources(params.ListResourcesArgs{
+	results, err := s.newFacade(c).ListResources(context.Background(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
 			Tag: tag.String(),
 		}},

--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -4,6 +4,7 @@
 package secretbackends
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -38,7 +39,7 @@ func (s *SecretBackendsAPI) checkCanAdmin() error {
 }
 
 // AddSecretBackends adds new secret backends.
-func (s *SecretBackendsAPI) AddSecretBackends(args params.AddSecretBackendArgs) (params.ErrorResults, error) {
+func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.AddSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -108,7 +109,7 @@ func (s *SecretBackendsAPI) createBackend(id string, arg params.SecretBackend) e
 }
 
 // UpdateSecretBackends updates secret backends.
-func (s *SecretBackendsAPI) UpdateSecretBackends(args params.UpdateSecretBackendArgs) (params.ErrorResults, error) {
+func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args params.UpdateSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -190,7 +191,7 @@ func (s *SecretBackendsAPI) updateBackend(arg params.UpdateSecretBackendArg) err
 }
 
 // ListSecretBackends lists available secret backends.
-func (s *SecretBackendsAPI) ListSecretBackends(arg params.ListSecretBackendsArgs) (params.ListSecretBackendsResults, error) {
+func (s *SecretBackendsAPI) ListSecretBackends(ctx context.Context, arg params.ListSecretBackendsArgs) (params.ListSecretBackendsResults, error) {
 	result := params.ListSecretBackendsResults{}
 	if arg.Reveal {
 		if err := s.checkCanAdmin(); err != nil {
@@ -208,7 +209,7 @@ func (s *SecretBackendsAPI) ListSecretBackends(arg params.ListSecretBackendsArgs
 }
 
 // RemoveSecretBackends removes secret backends.
-func (s *SecretBackendsAPI) RemoveSecretBackends(args params.RemoveSecretBackendArgs) (params.ErrorResults, error) {
+func (s *SecretBackendsAPI) RemoveSecretBackends(ctx context.Context, args params.RemoveSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -4,6 +4,7 @@
 package secretbackends_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -176,7 +177,7 @@ func (s *SecretsSuite) assertListSecretBackends(c *gc.C, modelType state.ModelTy
 	}, nil)
 	s.backendState.EXPECT().GetSecretBackendByID("backend-id-notfound").Return(nil, errors.NotFoundf(""))
 
-	results, err := facade.ListSecretBackends(params.ListSecretBackendsArgs{Names: names, Reveal: reveal})
+	results, err := facade.ListSecretBackends(context.Background(), params.ListSecretBackendsArgs{Names: names, Reveal: reveal})
 	c.Assert(err, jc.ErrorIsNil)
 	resultVaultCfg := map[string]interface{}{
 		"endpoint": "http://vault",
@@ -240,7 +241,7 @@ func (s *SecretsSuite) TestListSecretBackendsPermissionDeniedReveal(c *gc.C) {
 	facade, err := secretbackends.NewTestAPI(s.backendState, s.secretsState, s.statePool, s.authorizer, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.ListSecretBackends(params.ListSecretBackendsArgs{Reveal: true})
+	_, err = facade.ListSecretBackends(context.Background(), params.ListSecretBackendsArgs{Reveal: true})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -289,7 +290,7 @@ func (s *SecretsSuite) TestAddSecretBackends(c *gc.C) {
 		Config:      addedConfig,
 	}).Return("", errors.AlreadyExistsf(""))
 
-	results, err := facade.AddSecretBackends(params.AddSecretBackendArgs{
+	results, err := facade.AddSecretBackends(context.Background(), params.AddSecretBackendArgs{
 		Args: []params.AddSecretBackendArg{{
 			SecretBackend: params.SecretBackend{
 				Name:                "myvault",
@@ -333,7 +334,7 @@ func (s *SecretsSuite) TestAddSecretBackendsPermissionDenied(c *gc.C) {
 	facade, err := secretbackends.NewTestAPI(s.backendState, s.secretsState, s.statePool, s.authorizer, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.AddSecretBackends(params.AddSecretBackendArgs{})
+	_, err = facade.AddSecretBackends(context.Background(), params.AddSecretBackendArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -349,7 +350,7 @@ func (s *SecretsSuite) TestRemoveSecretBackends(c *gc.C) {
 	s.backendState.EXPECT().DeleteSecretBackend("myvault", true).Return(nil)
 	s.backendState.EXPECT().DeleteSecretBackend("myvault2", false).Return(errors.NotSupportedf("remove with revisions"))
 
-	results, err := facade.RemoveSecretBackends(params.RemoveSecretBackendArgs{
+	results, err := facade.RemoveSecretBackends(context.Background(), params.RemoveSecretBackendArgs{
 		Args: []params.RemoveSecretBackendArg{{
 			Name:  "myvault",
 			Force: true,
@@ -376,7 +377,7 @@ func (s *SecretsSuite) TestRemoveSecretBackendsPermissionDenied(c *gc.C) {
 	facade, err := secretbackends.NewTestAPI(s.backendState, s.secretsState, s.statePool, s.authorizer, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.RemoveSecretBackends(params.RemoveSecretBackendArgs{})
+	_, err = facade.RemoveSecretBackends(context.Background(), params.RemoveSecretBackendArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -424,7 +425,7 @@ func (s *SecretsSuite) TestUpdateSecretBackends(c *gc.C) {
 		Config:              updatedConfig,
 	}).Return(nil)
 
-	results, err := facade.UpdateSecretBackends(params.UpdateSecretBackendArgs{
+	results, err := facade.UpdateSecretBackends(context.Background(), params.UpdateSecretBackendArgs{
 		Args: []params.UpdateSecretBackendArg{{
 			Name:                "myvault",
 			NameChange:          ptr("new-name"),
@@ -454,6 +455,6 @@ func (s *SecretsSuite) TestUpdateSecretBackendsPermissionDenied(c *gc.C) {
 	facade, err := secretbackends.NewTestAPI(s.backendState, s.secretsState, s.statePool, s.authorizer, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.UpdateSecretBackends(params.UpdateSecretBackendArgs{})
+	_, err = facade.UpdateSecretBackends(context.Background(), params.UpdateSecretBackendArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -63,7 +63,7 @@ func (s *SecretsAPI) checkCanAdmin() error {
 }
 
 // ListSecrets lists available secrets.
-func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretResults, error) {
+func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs) (params.ListSecretResults, error) {
 	result := params.ListSecretResults{}
 	if arg.ShowSecrets {
 		if err := s.checkCanAdmin(); err != nil {
@@ -240,10 +240,10 @@ func (s *SecretsAPI) getBackend(id *string) (provider.SecretsBackend, error) {
 }
 
 // CreateSecrets isn't on the v1 API.
-func (s *SecretsAPIV1) CreateSecrets(_ struct{}) {}
+func (s *SecretsAPIV1) CreateSecrets(ctx context.Context, _ struct{}) {}
 
 // CreateSecrets creates new secrets.
-func (s *SecretsAPI) CreateSecrets(args params.CreateSecretArgs) (params.StringResults, error) {
+func (s *SecretsAPI) CreateSecrets(ctx context.Context, args params.CreateSecretArgs) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
@@ -344,10 +344,10 @@ func fromUpsertParams(p params.UpsertSecretArg) state.UpdateSecretParams {
 }
 
 // UpdateSecrets isn't on the v1 API.
-func (s *SecretsAPIV1) UpdateSecrets(_ struct{}) {}
+func (s *SecretsAPIV1) UpdateSecrets(ctx context.Context, _ struct{}) {}
 
 // UpdateSecrets creates new secrets.
-func (s *SecretsAPI) UpdateSecrets(args params.UpdateUserSecretArgs) (params.ErrorResults, error) {
+func (s *SecretsAPI) UpdateSecrets(ctx context.Context, args params.UpdateUserSecretArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -411,10 +411,10 @@ func (s *SecretsAPI) updateSecret(backend provider.SecretsBackend, arg params.Up
 }
 
 // RemoveSecrets isn't on the v1 API.
-func (s *SecretsAPIV1) RemoveSecrets(_ struct{}) {}
+func (s *SecretsAPIV1) RemoveSecrets(ctx context.Context, _ struct{}) {}
 
 // RemoveSecrets remove user secret.
-func (s *SecretsAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorResults, error) {
+func (s *SecretsAPI) RemoveSecrets(ctx context.Context, args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveSecretsForClient(
 		s.secretsState, s.backendConfigGetter,
 		s.authTag, args,
@@ -437,18 +437,18 @@ func (s *SecretsAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorRe
 }
 
 // GrantSecret isn't on the v1 API.
-func (s *SecretsAPIV1) GrantSecret(_ struct{}) {}
+func (s *SecretsAPIV1) GrantSecret(ctx context.Context, _ struct{}) {}
 
 // GrantSecret grants access to a user secret.
-func (s *SecretsAPI) GrantSecret(arg params.GrantRevokeUserSecretArg) (params.ErrorResults, error) {
+func (s *SecretsAPI) GrantSecret(ctx context.Context, arg params.GrantRevokeUserSecretArg) (params.ErrorResults, error) {
 	return s.secretsGrantRevoke(arg, s.secretsConsumer.GrantSecretAccess)
 }
 
 // RevokeSecret isn't on the v1 API.
-func (s *SecretsAPIV1) RevokeSecret(_ struct{}) {}
+func (s *SecretsAPIV1) RevokeSecret(ctx context.Context, _ struct{}) {}
 
 // RevokeSecret revokes access to a user secret.
-func (s *SecretsAPI) RevokeSecret(arg params.GrantRevokeUserSecretArg) (params.ErrorResults, error) {
+func (s *SecretsAPI) RevokeSecret(ctx context.Context, arg params.GrantRevokeUserSecretArg) (params.ErrorResults, error) {
 	return s.secretsGrantRevoke(arg, s.secretsConsumer.RevokeSecretAccess)
 }
 

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -4,6 +4,7 @@
 package secrets_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/collections/set"
@@ -179,7 +180,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 		}
 	}
 
-	results, err := facade.ListSecrets(params.ListSecretsArgs{ShowSecrets: reveal})
+	results, err := facade.ListSecrets(context.Background(), params.ListSecretsArgs{ShowSecrets: reveal})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
@@ -222,7 +223,7 @@ func (s *SecretsSuite) TestListSecretsPermissionDenied(c *gc.C) {
 	facade, err := apisecrets.NewTestAPI(s.secretsState, s.secretConsumer, nil, nil, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.ListSecrets(params.ListSecretsArgs{})
+	_, err = facade.ListSecrets(context.Background(), params.ListSecretsArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -238,7 +239,7 @@ func (s *SecretsSuite) TestListSecretsPermissionDeniedShow(c *gc.C) {
 	facade, err := apisecrets.NewTestAPI(s.secretsState, s.secretConsumer, nil, nil, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.ListSecrets(params.ListSecretsArgs{ShowSecrets: true})
+	_, err = facade.ListSecrets(context.Background(), params.ListSecretsArgs{ShowSecrets: true})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -254,7 +255,7 @@ func (s *SecretsSuite) TestCreateSecretsPermissionDenied(c *gc.C) {
 	facade, err := apisecrets.NewTestAPI(s.secretsState, s.secretConsumer, nil, nil, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.CreateSecrets(params.CreateSecretArgs{})
+	_, err = facade.CreateSecrets(context.Background(), params.CreateSecretArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -301,7 +302,7 @@ func (s *SecretsSuite) TestCreateSecretsEmptyData(c *gc.C) {
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := facade.CreateSecrets(params.CreateSecretArgs{
+	result, err := facade.CreateSecrets(context.Background(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{
 			{
 				OwnerTag: coretesting.ModelTag.Id(),
@@ -386,7 +387,7 @@ func (s *SecretsSuite) assertCreateSecrets(c *gc.C, isInternal bool, finalStepFa
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := facade.CreateSecrets(params.CreateSecretArgs{
+	result, err := facade.CreateSecrets(context.Background(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{
 			{
 				OwnerTag: coretesting.ModelTag.Id(),
@@ -495,7 +496,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, isInternal bool, finalStepFa
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := facade.UpdateSecrets(params.UpdateUserSecretArgs{
+	result, err := facade.UpdateSecrets(context.Background(), params.UpdateUserSecretArgs{
 		Args: []params.UpdateUserSecretArg{
 			{
 				AutoPrune: ptr(true),
@@ -592,7 +593,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 			return s.secretsBackend, nil
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -646,7 +647,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelAdmin(c *gc.C) {
 			return s.secretsBackend, nil
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -698,7 +699,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelOwned(c *gc.C) {
 			return s.secretsBackend, nil
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -751,7 +752,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 			return s.secretsBackend, nil
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -802,7 +803,7 @@ func (s *SecretsSuite) TestRemoveSecretNotFound(c *gc.C) {
 			return s.secretsBackend, nil
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := facade.RemoveSecrets(context.Background(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -870,7 +871,7 @@ func (s *SecretsSuite) TestGrantSecret(c *gc.C) {
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := facade.GrantSecret(params.GrantRevokeUserSecretArg{
+	result, err := facade.GrantSecret(context.Background(), params.GrantRevokeUserSecretArg{
 		URI: uri.String(),
 		Applications: []string{
 			"gitlab", "mysql",
@@ -891,7 +892,7 @@ func (s *SecretsSuite) TestGrantSecretPermissionDenied(c *gc.C) {
 	facade, err := apisecrets.NewTestAPI(s.secretsState, s.secretConsumer, nil, nil, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.GrantSecret(params.GrantRevokeUserSecretArg{})
+	_, err = facade.GrantSecret(context.Background(), params.GrantRevokeUserSecretArg{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -953,7 +954,7 @@ func (s *SecretsSuite) TestRevokeSecret(c *gc.C) {
 		}, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := facade.RevokeSecret(params.GrantRevokeUserSecretArg{
+	result, err := facade.RevokeSecret(context.Background(), params.GrantRevokeUserSecretArg{
 		URI: uri.String(),
 		Applications: []string{
 			"gitlab", "mysql",
@@ -974,6 +975,6 @@ func (s *SecretsSuite) TestRevokeSecretPermissionDenied(c *gc.C) {
 	facade, err := apisecrets.NewTestAPI(s.secretsState, s.secretConsumer, nil, nil, s.authorizer, s.authTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = facade.RevokeSecret(params.GrantRevokeUserSecretArg{})
+	_, err = facade.RevokeSecret(context.Background(), params.GrantRevokeUserSecretArg{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -4,6 +4,7 @@
 package spaces
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/collections/set"
@@ -68,7 +69,7 @@ func newAPIWithBacking(cfg apiConfig) (*API, error) {
 
 // CreateSpaces creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
-func (api *API) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
+func (api *API) CreateSpaces(ctx stdcontext.Context, args params.CreateSpacesParams) (results params.ErrorResults, err error) {
 	err = api.auth.HasPermission(permission.AdminAccess, api.backing.ModelTag())
 	if err != nil {
 		return results, err
@@ -123,7 +124,7 @@ func (api *API) createOneSpace(args params.CreateSpaceParams) error {
 }
 
 // ListSpaces lists all the available spaces and their associated subnets.
-func (api *API) ListSpaces() (results params.ListSpacesResults, err error) {
+func (api *API) ListSpaces(ctx stdcontext.Context) (results params.ListSpacesResults, err error) {
 	err = api.auth.HasPermission(permission.ReadAccess, api.backing.ModelTag())
 	if err != nil {
 		return results, err
@@ -164,7 +165,7 @@ func (api *API) ListSpaces() (results params.ListSpacesResults, err error) {
 }
 
 // ShowSpace shows the spaces for a set of given entities.
-func (api *API) ShowSpace(entities params.Entities) (params.ShowSpaceResults, error) {
+func (api *API) ShowSpace(ctx stdcontext.Context, entities params.Entities) (params.ShowSpaceResults, error) {
 	err := api.auth.HasPermission(permission.ReadAccess, api.backing.ModelTag())
 	if err != nil {
 		return params.ShowSpaceResults{}, err
@@ -226,7 +227,7 @@ func (api *API) ShowSpace(entities params.Entities) (params.ShowSpaceResults, er
 }
 
 // ReloadSpaces refreshes spaces from substrate
-func (api *API) ReloadSpaces() error {
+func (api *API) ReloadSpaces(ctx stdcontext.Context) error {
 	return api.reloadSpacesAPI.ReloadSpaces()
 }
 

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -4,6 +4,7 @@
 package spaces_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sort"
 
@@ -75,7 +76,7 @@ func (s *APISuite) TestShowSpaceDefault(c *gc.C) {
 		},
 	}}
 
-	res, err := s.API.ShowSpace(args)
+	res, err := s.API.ShowSpace(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, jc.DeepEquals, expected)
 }
@@ -89,7 +90,7 @@ func (s *APISuite) TestShowSpaceErrorGettingSpace(c *gc.C) {
 	s.expectDefaultSpace(ctrl, "default", bamErr, nil)
 	args := s.getShowSpaceArg("default")
 
-	res, err := s.API.ShowSpace(args)
+	res, err := s.API.ShowSpace(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := fmt.Sprintf("fetching space %q: %v", args.Entities[0].Tag, bamErr.Error())
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
@@ -104,7 +105,7 @@ func (s *APISuite) TestShowSpaceErrorGettingSubnets(c *gc.C) {
 	s.expectDefaultSpace(ctrl, "default", nil, bamErr)
 	args := s.getShowSpaceArg("default")
 
-	res, err := s.API.ShowSpace(args)
+	res, err := s.API.ShowSpace(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := fmt.Sprintf("fetching subnets: %v", bamErr.Error())
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
@@ -121,7 +122,7 @@ func (s *APISuite) TestShowSpaceErrorGettingApplications(c *gc.C) {
 
 	args := s.getShowSpaceArg("default")
 
-	res, err := s.API.ShowSpace(args)
+	res, err := s.API.ShowSpace(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := fmt.Sprintf("fetching applications: %v", expErr.Error())
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
@@ -138,7 +139,7 @@ func (s *APISuite) TestShowSpaceErrorGettingMachines(c *gc.C) {
 	s.expectMachines(ctrl, s.getDefaultSpaces(), bamErr, nil)
 
 	args := s.getShowSpaceArg("default")
-	res, err := s.API.ShowSpace(args)
+	res, err := s.API.ShowSpace(stdcontext.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := fmt.Sprintf("fetching machine count: %v", bamErr.Error())
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
@@ -746,7 +747,7 @@ func (s *LegacySuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 		Spaces: []params.CreateSpaceParams{arg},
 	}
 
-	results, err := s.facade.CreateSpaces(args)
+	results, err := s.facade.CreateSpaces(stdcontext.Background(), args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(results.Results), gc.Equals, 1)
 	if p.Error == "" {
@@ -902,7 +903,7 @@ func (s *LegacySuite) TestShowSpaceError(c *gc.C) {
 	)
 
 	entities := params.Entities{}
-	_, err := s.facade.ShowSpace(entities)
+	_, err := s.facade.ShowSpace(stdcontext.Background(), entities)
 	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: boom")
 }
 
@@ -912,7 +913,7 @@ func (s *LegacySuite) TestCreateSpacesModelConfigError(c *gc.C) {
 	)
 
 	args := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(args)
+	_, err := s.facade.CreateSpaces(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: boom")
 }
 
@@ -924,7 +925,7 @@ func (s *LegacySuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 	)
 
 	args := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(args)
+	_, err := s.facade.CreateSpaces(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches,
 		`getting environ: creating environ for model \"stub-zoned-networking-environ\" \(.*\): boom`)
 }
@@ -938,7 +939,7 @@ func (s *LegacySuite) TestCreateSpacesNotSupportedError(c *gc.C) {
 	)
 
 	args := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(args)
+	_, err := s.facade.CreateSpaces(stdcontext.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "spaces not supported")
 }
 
@@ -979,7 +980,7 @@ func (s *LegacySuite) TestListSpacesDefault(c *gc.C) {
 		}},
 	}}
 
-	result, err := s.facade.ListSpaces()
+	result, err := s.facade.ListSpaces(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, jc.DeepEquals, expected)
 }
@@ -987,7 +988,7 @@ func (s *LegacySuite) TestListSpacesDefault(c *gc.C) {
 func (s *LegacySuite) TestListSpacesAllSpacesError(c *gc.C) {
 	boom := errors.New("backing boom")
 	apiservertesting.BackingInstance.SetErrors(boom)
-	_, err := s.facade.ListSpaces()
+	_, err := s.facade.ListSpaces(stdcontext.Background())
 	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: backing boom")
 }
 
@@ -1003,7 +1004,7 @@ func (s *LegacySuite) TestListSpacesSubnetsError(c *gc.C) {
 		errors.New("space2 subnets failed"), // Space.Subnets()
 	)
 
-	results, err := s.facade.ListSpaces()
+	results, err := s.facade.ListSpaces(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	for i, space := range results.Results {
 		errmsg := fmt.Sprintf("fetching subnets: space%d subnets failed", i)
@@ -1023,7 +1024,7 @@ func (s *LegacySuite) TestListSpacesSubnetsSingleSubnetError(c *gc.C) {
 		boom, // Space.Subnets() (2nd with error)
 	)
 
-	results, err := s.facade.ListSpaces()
+	results, err := s.facade.ListSpaces(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	for i, space := range results.Results {
 		if i == 1 {
@@ -1042,13 +1043,13 @@ func (s *LegacySuite) TestListSpacesNotSupportedError(c *gc.C) {
 		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.supportsSpaces()
 	)
 
-	_, err := s.facade.ListSpaces()
+	_, err := s.facade.ListSpaces(stdcontext.Background())
 	c.Assert(err, gc.ErrorMatches, "spaces not supported")
 }
 
 func (s *LegacySuite) TestCreateSpacesBlocked(c *gc.C) {
 	s.blockChecker.SetErrors(apiservererrors.ServerError(apiservererrors.OperationBlockedError("test block")))
-	_, err := s.facade.CreateSpaces(params.CreateSpacesParams{})
+	_, err := s.facade.CreateSpaces(stdcontext.Background(), params.CreateSpacesParams{})
 	c.Assert(err, gc.ErrorMatches, "test block")
 	c.Assert(err, jc.Satisfies, params.IsCodeOperationBlocked)
 }

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -68,7 +68,7 @@ func (facade *Facade) checkIsModelAdmin() error {
 
 // PublicAddress reports the preferred public network address for one
 // or more entities. Machines and units are supported.
-func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResults, error) {
+func (facade *Facade) PublicAddress(ctx stdcontext.Context, args params.Entities) (params.SSHAddressResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)
 	}
@@ -79,7 +79,7 @@ func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResu
 
 // PrivateAddress reports the preferred private network address for one or
 // more entities. Machines and units are supported.
-func (facade *Facade) PrivateAddress(args params.Entities) (params.SSHAddressResults, error) {
+func (facade *Facade) PrivateAddress(ctx stdcontext.Context, args params.Entities) (params.SSHAddressResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)
 	}
@@ -91,7 +91,7 @@ func (facade *Facade) PrivateAddress(args params.Entities) (params.SSHAddressRes
 // AllAddresses reports all addresses that might have SSH listening for each
 // entity in args. The result is sorted with public addresses first.
 // Machines and units are supported as entity types.
-func (facade *Facade) AllAddresses(args params.Entities) (params.SSHAddressesResults, error) {
+func (facade *Facade) AllAddresses(ctx stdcontext.Context, args params.Entities) (params.SSHAddressesResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressesResults{}, errors.Trace(err)
 	}
@@ -180,7 +180,7 @@ func (facade *Facade) getAddressPerEntity(args params.Entities, addressGetter fu
 
 // PublicKeys returns the public SSH hosts for one or more
 // entities. Machines and units are supported.
-func (facade *Facade) PublicKeys(args params.Entities) (params.SSHPublicKeysResults, error) {
+func (facade *Facade) PublicKeys(ctx stdcontext.Context, args params.Entities) (params.SSHPublicKeysResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHPublicKeysResults{}, errors.Trace(err)
 	}
@@ -206,7 +206,7 @@ func (facade *Facade) PublicKeys(args params.Entities) (params.SSHPublicKeysResu
 
 // Proxy returns whether SSH connections should be proxied through the
 // controller hosts for the model associated with the API connection.
-func (facade *Facade) Proxy() (params.SSHProxyResult, error) {
+func (facade *Facade) Proxy(ctx stdcontext.Context) (params.SSHProxyResult, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHProxyResult{}, errors.Trace(err)
 	}
@@ -219,7 +219,7 @@ func (facade *Facade) Proxy() (params.SSHProxyResult, error) {
 
 // ModelCredentialForSSH returns a cloud spec for ssh purpose.
 // This facade call is only used for k8s model.
-func (facade *Facade) ModelCredentialForSSH() (params.CloudSpecResult, error) {
+func (facade *Facade) ModelCredentialForSSH(ctx stdcontext.Context) (params.CloudSpecResult, error) {
 	var result params.CloudSpecResult
 
 	if err := facade.checkIsModelAdmin(); err != nil {

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -89,7 +89,7 @@ func (s *facadeSuite) TestNonAuthUserDenied(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.m0}, {s.uFoo}, {s.uOther}},
 	}
-	results, err := s.facade.PublicAddress(args)
+	results, err := s.facade.PublicAddress(context.Background(), args)
 	// Check this was an error permission
 	c.Assert(err, gc.ErrorMatches, apiservererrors.ErrPerm.Error())
 	c.Assert(results, gc.DeepEquals, params.SSHAddressResults{})
@@ -108,7 +108,7 @@ func (s *facadeSuite) TestSuperUserAuth(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.m0}, {s.uFoo}, {s.uOther}},
 	}
-	results, err := s.facade.PublicAddress(args)
+	results, err := s.facade.PublicAddress(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, gc.DeepEquals, params.SSHAddressResults{
@@ -130,7 +130,7 @@ func (s *facadeSuite) TestPublicAddress(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.m0}, {s.uFoo}, {s.uOther}},
 	}
-	results, err := s.facade.PublicAddress(args)
+	results, err := s.facade.PublicAddress(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, gc.DeepEquals, params.SSHAddressResults{
@@ -151,7 +151,7 @@ func (s *facadeSuite) TestPrivateAddress(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.uOther}, {s.m0}, {s.uFoo}},
 	}
-	results, err := s.facade.PrivateAddress(args)
+	results, err := s.facade.PrivateAddress(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, gc.DeepEquals, params.SSHAddressResults{
@@ -172,7 +172,7 @@ func (s *facadeSuite) TestAllAddresses(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.uOther}, {s.m0}, {s.uFoo}},
 	}
-	results, err := s.facade.AllAddresses(args)
+	results, err := s.facade.AllAddresses(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, gc.DeepEquals, params.SSHAddressesResults{
@@ -206,7 +206,7 @@ func (s *facadeSuite) TestPublicKeys(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{s.m0}, {s.uOther}, {s.uFoo}},
 	}
-	results, err := s.facade.PublicKeys(args)
+	results, err := s.facade.PublicKeys(context.Background(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, gc.DeepEquals, params.SSHPublicKeysResults{
@@ -227,7 +227,7 @@ func (s *facadeSuite) TestPublicKeys(c *gc.C) {
 
 func (s *facadeSuite) TestProxyTrue(c *gc.C) {
 	s.backend.proxySSH = true
-	result, err := s.facade.Proxy()
+	result, err := s.facade.Proxy(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.UseProxy, jc.IsTrue)
 	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
@@ -237,7 +237,7 @@ func (s *facadeSuite) TestProxyTrue(c *gc.C) {
 
 func (s *facadeSuite) TestProxyFalse(c *gc.C) {
 	s.backend.proxySSH = false
-	result, err := s.facade.Proxy()
+	result, err := s.facade.Proxy(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.UseProxy, jc.IsFalse)
 	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
@@ -266,7 +266,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNotAuthorized(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := facade.ModelCredentialForSSH()
+	result, err := facade.ModelCredentialForSSH(context.Background())
 	c.Assert(err, gc.Equals, apiservererrors.ErrPerm)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.IsNil)
@@ -296,7 +296,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNonCAASModel(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := facade.ModelCredentialForSSH()
+	result, err := facade.ModelCredentialForSSH(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiservererrors.RestoreError(result.Error), gc.ErrorMatches, `facade ModelCredentialForSSH for non "caas" model not supported`)
 	c.Assert(result.Result, gc.IsNil)
@@ -338,7 +338,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedBadCredential(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := facade.ModelCredentialForSSH()
+	result, err := facade.ModelCredentialForSSH(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiservererrors.RestoreError(result.Error), gc.ErrorMatches, `cloud spec "name" has empty credential not valid`)
 	c.Assert(result.Result, gc.IsNil)
@@ -418,7 +418,7 @@ func (s *facadeSuite) assertModelCredentialForSSH(c *gc.C, f func(authorizer *mo
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := facade.ModelCredentialForSSH()
+	result, err := facade.ModelCredentialForSSH(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.DeepEquals, &params.CloudSpec{

--- a/apiserver/facades/client/storage/filesystemlist_test.go
+++ b/apiserver/facades/client/storage/filesystemlist_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -52,7 +54,7 @@ func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
 }
 
 func (s *filesystemSuite) TestListFilesystemsEmptyFilter(c *gc.C) {
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{
 		[]params.FilesystemFilter{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,7 +68,7 @@ func (s *filesystemSuite) TestListFilesystemsError(c *gc.C) {
 	s.storageAccessor.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, errors.New(msg)
 	}
-	results, err := s.api.ListFilesystems(params.FilesystemFilters{
+	results, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{
 		[]params.FilesystemFilter{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,7 +80,7 @@ func (s *filesystemSuite) TestListFilesystemsNoFilesystems(c *gc.C) {
 	s.storageAccessor.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, nil
 	}
-	results, err := s.api.ListFilesystems(params.FilesystemFilters{})
+	results, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -87,7 +89,7 @@ func (s *filesystemSuite) TestListFilesystemsFilter(c *gc.C) {
 	filters := []params.FilesystemFilter{{
 		Machines: []string{s.machineTag.String()},
 	}}
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{filters})
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
@@ -98,7 +100,7 @@ func (s *filesystemSuite) TestListFilesystemsFilterNonMatching(c *gc.C) {
 	filters := []params.FilesystemFilter{{
 		Machines: []string{"machine-42"},
 	}}
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{filters})
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Error, gc.IsNil)
@@ -111,7 +113,7 @@ func (s *filesystemSuite) TestListFilesystemsFilesystemInfo(c *gc.C) {
 	}
 	expected := s.expectedFilesystemDetails()
 	expected.Info.Size = 123
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{
 		[]params.FilesystemFilter{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -137,7 +139,7 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 	expectedStorageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	expectedStorageAttachmentDetails.Location = "/tmp"
 	expected.Storage.Attachments["unit-mysql-0"] = expectedStorageAttachmentDetails
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{
 		[]params.FilesystemFilter{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -150,7 +152,7 @@ func (s *filesystemSuite) TestListFilesystemsVolumeBacked(c *gc.C) {
 	s.filesystem.volume = &s.volumeTag
 	expected := s.expectedFilesystemDetails()
 	expected.VolumeTag = s.volumeTag.String()
-	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+	found, err := s.api.ListFilesystems(context.Background(), params.FilesystemFilters{
 		[]params.FilesystemFilter{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/storage/poolcreate_test.go
+++ b/apiserver/facades/client/storage/poolcreate_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -33,7 +35,7 @@ func (s *poolCreateSuite) TestCreatePool(c *gc.C) {
 			Attrs:    nil,
 		}},
 	}
-	results, err := s.api.CreatePool(args)
+	results, err := s.api.CreatePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -55,7 +57,7 @@ func (s *poolCreateSuite) TestCreatePoolError(c *gc.C) {
 			Name: "doesnt-matter",
 		}},
 	}
-	results, err := s.api.CreatePool(args)
+	results, err := s.api.CreatePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{

--- a/apiserver/facades/client/storage/poollist_test.go
+++ b/apiserver/facades/client/storage/poollist_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/collections/set"
@@ -44,7 +45,7 @@ func (s *poolSuite) TestEnsureStoragePoolFilter(c *gc.C) {
 
 func (s *poolSuite) TestList(c *gc.C) {
 	s.createPools(c, 1)
-	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	one := results.Results[0]
@@ -57,7 +58,7 @@ func (s *poolSuite) TestList(c *gc.C) {
 func (s *poolSuite) TestListManyResults(c *gc.C) {
 	s.registry.Providers["static"] = nil
 	s.createPools(c, 2)
-	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	assertPoolNames(c, results.Results[0].Result, "testpool0", "testpool1", "static")
 }
@@ -66,7 +67,7 @@ func (s *poolSuite) TestListByName(c *gc.C) {
 	s.createPools(c, 2)
 	tstName := fmt.Sprintf("%v%v", tstName, 1)
 
-	results, err := s.api.ListPools(params.StoragePoolFilters{
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{
 		[]params.StoragePoolFilter{{
 			Names: []string{tstName},
 		}},
@@ -87,7 +88,7 @@ func (s *poolSuite) TestListByType(c *gc.C) {
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.ListPools(params.StoragePoolFilters{
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{
 		[]params.StoragePoolFilter{{
 			Providers: []string{tstType},
 		}},
@@ -105,7 +106,7 @@ func (s *poolSuite) TestListByNameAndTypeAnd(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.ListPools(params.StoragePoolFilters{
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{
 		[]params.StoragePoolFilter{{
 			Providers: []string{tstType},
 			Names:     []string{poolName},
@@ -126,7 +127,7 @@ func (s *poolSuite) TestListByNamesOr(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.ListPools(params.StoragePoolFilters{
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{
 		[]params.StoragePoolFilter{{
 			Names: []string{
 				fmt.Sprintf("%v%v", tstName, 1),
@@ -155,7 +156,7 @@ func (s *poolSuite) TestListByTypesOr(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.ListPools(params.StoragePoolFilters{
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{
 		[]params.StoragePoolFilter{{
 			Providers: []string{tstType, string(provider.LoopProviderType)},
 		}},
@@ -166,7 +167,7 @@ func (s *poolSuite) TestListByTypesOr(c *gc.C) {
 
 func (s *poolSuite) TestListNoPools(c *gc.C) {
 	s.registry.Providers["static"] = nil
-	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
+	results, err := s.api.ListPools(context.Background(), params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	assertPoolNames(c, results.Results[0].Result, "static")

--- a/apiserver/facades/client/storage/poolremove_test.go
+++ b/apiserver/facades/client/storage/poolremove_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -39,7 +40,7 @@ func (s *poolRemoveSuite) TestRemovePool(c *gc.C) {
 			Name: poolName,
 		}},
 	}
-	results, err := s.api.RemovePool(args)
+	results, err := s.api.RemovePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -57,7 +58,7 @@ func (s *poolRemoveSuite) TestRemoveNotExists(c *gc.C) {
 			Name: poolName,
 		}},
 	}
-	results, err := s.api.RemovePool(args)
+	results, err := s.api.RemovePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -76,7 +77,7 @@ func (s *poolRemoveSuite) TestRemoveInUse(c *gc.C) {
 			Name: poolName,
 		}},
 	}
-	results, err := s.api.RemovePool(args)
+	results, err := s.api.RemovePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("storage pool %q in use", poolName))
@@ -98,7 +99,7 @@ func (s *poolRemoveSuite) TestRemoveSomeInUse(c *gc.C) {
 			Name: poolNameNotInUse,
 		}},
 	}
-	results, err := s.api.RemovePool(args)
+	results, err := s.api.RemovePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("storage pool %q in use", poolNameInUse))

--- a/apiserver/facades/client/storage/poolupdate_test.go
+++ b/apiserver/facades/client/storage/poolupdate_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -47,7 +48,7 @@ func (s *poolUpdateSuite) TestUpdatePool(c *gc.C) {
 			Attrs: newAttrs,
 		}},
 	}
-	results, err := s.api.UpdatePool(args)
+	results, err := s.api.UpdatePool(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -68,7 +69,7 @@ func (s *poolUpdateSuite) TestUpdatePoolError(c *gc.C) {
 			Name: poolName,
 		}},
 	}
-	results, err := s.api.UpdatePool(args)
+	results, err := s.api.UpdatePool(context.Background(), args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/collections/set"
@@ -76,7 +77,7 @@ func (a *StorageAPI) checkCanWrite() error {
 // StorageDetails retrieves and returns detailed information about desired
 // storage identified by supplied tags. If specified storage cannot be
 // retrieved, individual error is returned instead of storage information.
-func (a *StorageAPI) StorageDetails(entities params.Entities) (params.StorageDetailsResults, error) {
+func (a *StorageAPI) StorageDetails(ctx stdcontext.Context, entities params.Entities) (params.StorageDetailsResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.StorageDetailsResults{}, errors.Trace(err)
 	}
@@ -103,7 +104,7 @@ func (a *StorageAPI) StorageDetails(entities params.Entities) (params.StorageDet
 }
 
 // ListStorageDetails returns storage matching a filter.
-func (a *StorageAPI) ListStorageDetails(filters params.StorageFilters) (params.StorageDetailsListResults, error) {
+func (a *StorageAPI) ListStorageDetails(ctx stdcontext.Context, filters params.StorageFilters) (params.StorageDetailsListResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.StorageDetailsListResults{}, errors.Trace(err)
 	}
@@ -258,6 +259,7 @@ func storageAttachmentInfo(
 // This method lists union of pools and environment provider types.
 // If no filter is provided, all pools are returned.
 func (a *StorageAPI) ListPools(
+	ctx stdcontext.Context,
 	filters params.StoragePoolFilters,
 ) (params.StoragePoolsResults, error) {
 	if err := a.checkCanRead(); err != nil {
@@ -396,7 +398,7 @@ func (a *StorageAPI) validateProviderCriteria(registry storage.ProviderRegistry,
 }
 
 // CreatePool creates a new pool with specified parameters.
-func (a *StorageAPI) CreatePool(p params.StoragePoolArgs) (params.ErrorResults, error) {
+func (a *StorageAPI) CreatePool(ctx stdcontext.Context, p params.StoragePoolArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(p.Pools)),
 	}
@@ -417,7 +419,7 @@ func (a *StorageAPI) CreatePool(p params.StoragePoolArgs) (params.ErrorResults, 
 // ListVolumes lists volumes with the given filters. Each filter produces
 // an independent list of volumes, or an error if the filter is invalid
 // or the volumes could not be listed.
-func (a *StorageAPI) ListVolumes(filters params.VolumeFilters) (params.VolumeDetailsListResults, error) {
+func (a *StorageAPI) ListVolumes(ctx stdcontext.Context, filters params.VolumeFilters) (params.VolumeDetailsListResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.VolumeDetailsListResults{}, errors.Trace(err)
 	}
@@ -582,7 +584,7 @@ func createVolumeDetails(
 // ListFilesystems returns a list of filesystems in the environment matching
 // the provided filter. Each result describes a filesystem in detail, including
 // the filesystem's attachments.
-func (a *StorageAPI) ListFilesystems(filters params.FilesystemFilters) (params.FilesystemDetailsListResults, error) {
+func (a *StorageAPI) ListFilesystems(ctx stdcontext.Context, filters params.FilesystemFilters) (params.FilesystemDetailsListResults, error) {
 	results := params.FilesystemDetailsListResults{
 		Results: make([]params.FilesystemDetailsListResult, len(filters.Filters)),
 	}
@@ -747,7 +749,7 @@ func createFilesystemDetails(
 
 // AddToUnit validates and creates additional storage instances for units.
 // A "CHANGE" block can block this operation.
-func (a *StorageAPI) AddToUnit(args params.StoragesAddParams) (params.AddStorageResults, error) {
+func (a *StorageAPI) AddToUnit(ctx stdcontext.Context, args params.StoragesAddParams) (params.AddStorageResults, error) {
 	return a.addToUnit(args)
 }
 
@@ -803,7 +805,7 @@ func (a *StorageAPI) addToUnit(args params.StoragesAddParams) (params.AddStorage
 // from the model. If the arguments specify that the storage should be
 // destroyed, then the associated cloud storage will be destroyed first;
 // otherwise it will only be released from Juju's control.
-func (a *StorageAPI) Remove(args params.RemoveStorage) (params.ErrorResults, error) {
+func (a *StorageAPI) Remove(ctx stdcontext.Context, args params.RemoveStorage) (params.ErrorResults, error) {
 	return a.remove(args)
 }
 
@@ -837,7 +839,7 @@ func (a *StorageAPI) remove(args params.RemoveStorage) (params.ErrorResults, err
 // DetachStorage sets the specified storage attachments to Dying, unless they are
 // already Dying or Dead. Any associated, persistent storage will remain
 // alive. This call can be forced.
-func (a *StorageAPI) DetachStorage(args params.StorageDetachmentParams) (params.ErrorResults, error) {
+func (a *StorageAPI) DetachStorage(ctx stdcontext.Context, args params.StorageDetachmentParams) (params.ErrorResults, error) {
 	return a.internalDetach(args.StorageIds, args.Force, args.MaxWait)
 }
 
@@ -907,7 +909,7 @@ func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.Un
 
 // Attach attaches existing storage instances to units.
 // A "CHANGE" block can block this operation.
-func (a *StorageAPI) Attach(args params.StorageAttachmentIds) (params.ErrorResults, error) {
+func (a *StorageAPI) Attach(ctx stdcontext.Context, args params.StorageAttachmentIds) (params.ErrorResults, error) {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -938,7 +940,7 @@ func (a *StorageAPI) Attach(args params.StorageAttachmentIds) (params.ErrorResul
 
 // Import imports existing storage into the model.
 // A "CHANGE" block can block this operation.
-func (a *StorageAPI) Import(args params.BulkImportStorageParams) (params.ImportStorageResults, error) {
+func (a *StorageAPI) Import(ctx stdcontext.Context, args params.BulkImportStorageParams) (params.ImportStorageResults, error) {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ImportStorageResults{}, errors.Trace(err)
 	}
@@ -1063,7 +1065,7 @@ func (a *StorageAPI) importFilesystem(
 }
 
 // RemovePool deletes the named pool
-func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorResults, error) {
+func (a *StorageAPI) RemovePool(ctx stdcontext.Context, p params.StoragePoolDeleteArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(p.Pools)),
 	}
@@ -1080,7 +1082,7 @@ func (a *StorageAPI) RemovePool(p params.StoragePoolDeleteArgs) (params.ErrorRes
 }
 
 // UpdatePool deletes the named pool
-func (a *StorageAPI) UpdatePool(p params.StoragePoolArgs) (params.ErrorResults, error) {
+func (a *StorageAPI) UpdatePool(ctx stdcontext.Context, p params.StoragePoolArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(p.Pools)),
 	}

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -39,6 +40,7 @@ func (s *storageSuite) TestStorageListEmpty(c *gc.C) {
 	}
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -50,6 +52,7 @@ func (s *storageSuite) TestStorageListEmpty(c *gc.C) {
 
 func (s *storageSuite) TestStorageListFilesystem(c *gc.C) {
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -74,6 +77,7 @@ func (s *storageSuite) TestStorageListFilesystem(c *gc.C) {
 func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	s.storageInstance.kind = state.StorageKindBlock
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -104,6 +108,7 @@ func (s *storageSuite) TestStorageListError(c *gc.C) {
 	}
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,6 +128,7 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 	}
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -148,6 +154,7 @@ func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
 	}
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,6 +174,7 @@ func (s *storageSuite) TestStorageListMachineError(c *gc.C) {
 	msg := "list test error"
 	s.state.unitErr = msg
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -192,6 +200,7 @@ func (s *storageSuite) TestStorageListFilesystemError(c *gc.C) {
 	}
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -212,6 +221,7 @@ func (s *storageSuite) TestStorageListFilesystemAttachmentError(c *gc.C) {
 	s.state.unitErr = msg
 
 	found, err := s.api.ListStorageDetails(
+		stdcontext.Background(),
 		params.StorageFilters{[]params.StorageFilter{{}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -260,14 +270,14 @@ func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageD
 }
 
 func (s *storageSuite) TestShowStorageEmpty(c *gc.C) {
-	found, err := s.api.StorageDetails(params.Entities{})
+	found, err := s.api.StorageDetails(stdcontext.Background(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 0)
 }
 
 func (s *storageSuite) TestShowStorageInvalidTag(c *gc.C) {
 	// Only storage tags are permitted
-	found, err := s.api.StorageDetails(params.Entities{
+	found, err := s.api.StorageDetails(stdcontext.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-1"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -279,6 +289,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 	entity := params.Entity{Tag: s.storageTag.String()}
 
 	found, err := s.api.StorageDetails(
+		stdcontext.Background(),
 		params.Entities{Entities: []params.Entity{entity}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -312,14 +323,14 @@ func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
 	storageTag := "foo"
 	entity := params.Entity{Tag: storageTag}
 
-	found, err := s.api.StorageDetails(params.Entities{Entities: []params.Entity{entity}})
+	found, err := s.api.StorageDetails(stdcontext.Background(), params.Entities{Entities: []params.Entity{entity}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	s.assertInstanceInfoError(c, found.Results[0], params.StorageDetailsResult{}, `"foo" is not a valid tag`)
 }
 
 func (s *storageSuite) TestRemove(c *gc.C) {
-	results, err := s.api.Remove(params.RemoveStorage{[]params.RemoveStorageInstance{
+	results, err := s.api.Remove(stdcontext.Background(), params.RemoveStorage{[]params.RemoveStorageInstance{
 		{Tag: "storage-foo-0", DestroyStorage: true},
 		{Tag: "storage-foo-1", DestroyAttachments: true, DestroyStorage: true},
 		{Tag: "storage-foo-1", DestroyAttachments: true, DestroyStorage: false},
@@ -350,6 +361,7 @@ func (s *storageSuite) TestRemove(c *gc.C) {
 
 func (s *storageSuite) TestDetach(c *gc.C) {
 	results, err := s.api.DetachStorage(
+		stdcontext.Background(),
 		params.StorageDetachmentParams{
 			StorageIds: params.StorageAttachmentIds{[]params.StorageAttachmentId{
 				{StorageTag: "storage-data-0", UnitTag: "unit-mysql-0"},
@@ -385,6 +397,7 @@ func (s *storageSuite) TestDetach(c *gc.C) {
 
 func (s *storageSuite) TestDetachSpecifiedNotFound(c *gc.C) {
 	results, err := s.api.DetachStorage(
+		stdcontext.Background(),
 		params.StorageDetachmentParams{
 			StorageIds: params.StorageAttachmentIds{[]params.StorageAttachmentId{
 				{StorageTag: "storage-data-0", UnitTag: "unit-foo-42"},
@@ -426,6 +439,7 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 		)
 	}
 	results, err := s.api.DetachStorage(
+		stdcontext.Background(),
 		params.StorageDetachmentParams{
 			StorageIds: params.StorageAttachmentIds{[]params.StorageAttachmentId{
 				{StorageTag: "storage-data-0"},
@@ -447,6 +461,7 @@ func (s *storageSuite) TestDetachAttachmentNotFoundConcurrent(c *gc.C) {
 
 func (s *storageSuite) TestDetachNoAttachmentsStorageNotFound(c *gc.C) {
 	results, err := s.api.DetachStorage(
+		stdcontext.Background(),
 		params.StorageDetachmentParams{
 			StorageIds: params.StorageAttachmentIds{[]params.StorageAttachmentId{
 				{StorageTag: "storage-foo-42"},
@@ -467,7 +482,7 @@ func (s *storageSuite) TestDetachNoAttachmentsStorageNotFound(c *gc.C) {
 }
 
 func (s *storageSuite) TestAttach(c *gc.C) {
-	results, err := s.api.Attach(params.StorageAttachmentIds{[]params.StorageAttachmentId{
+	results, err := s.api.Attach(stdcontext.Background(), params.StorageAttachmentIds{[]params.StorageAttachmentId{
 		{StorageTag: "storage-data-0", UnitTag: "unit-mysql-0"},
 		{StorageTag: "storage-data-0", UnitTag: "machine-0"},
 		{StorageTag: "volume-0", UnitTag: "unit-mysql-0"},
@@ -497,7 +512,7 @@ func (s *storageSuite) TestImportFilesystem(c *gc.C) {
 	}
 	s.registry.Providers["radiance"] = dummyStorageProvider
 
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -547,7 +562,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBacked(c *gc.C) {
 	}
 	s.registry.Providers["radiance"] = dummyStorageProvider
 
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -598,7 +613,7 @@ func (s *storageSuite) TestImportFilesystemError(c *gc.C) {
 	s.registry.Providers["radiance"] = dummyStorageProvider
 
 	filesystemSource.SetErrors(errors.New("nope"))
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -623,7 +638,7 @@ func (s *storageSuite) TestImportFilesystemNotSupported(c *gc.C) {
 	}
 	s.registry.Providers["radiance"] = dummyStorageProvider
 
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -654,7 +669,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBackedNotSupported(c *gc.C) {
 	}
 	s.registry.Providers["radiance"] = dummyStorageProvider
 
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -672,7 +687,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBackedNotSupported(c *gc.C) {
 }
 
 func (s *storageSuite) TestImportValidationErrors(c *gc.C) {
-	results, err := s.api.Import(params.BulkImportStorageParams{[]params.ImportStorageParams{{
+	results, err := s.api.Import(stdcontext.Background(), params.BulkImportStorageParams{[]params.ImportStorageParams{{
 		Kind:        params.StorageKindBlock,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -706,7 +721,7 @@ func (s *storageSuite) TestListStorageAsAdminOnNotOwnedModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ListStorageDetails should not fail
-	_, err = s.api.ListStorageDetails(params.StorageFilters{})
+	_, err = s.api.ListStorageDetails(stdcontext.Background(), params.StorageFilters{})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -726,7 +741,7 @@ func (s *storageSuite) TestListStorageAsNonAdminOnNotOwnedModel(c *gc.C) {
 	c.Assert(errors.Is(err, authentication.ErrorEntityMissingPermission), jc.IsTrue)
 
 	// ListStorageDetails should fail with perm error
-	_, err = s.api.ListStorageDetails(params.StorageFilters{})
+	_, err = s.api.ListStorageDetails(stdcontext.Background(), params.StorageFilters{})
 	c.Assert(errors.Is(err, apiservererrors.ErrPerm), jc.IsTrue)
 }
 

--- a/apiserver/facades/client/storage/storageadd_test.go
+++ b/apiserver/facades/client/storage/storageadd_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -28,7 +29,7 @@ func (s *storageAddSuite) assertStorageAddedNoErrors(c *gc.C, args params.Storag
 }
 
 func (s *storageAddSuite) assertStoragesAddedNoErrors(c *gc.C, args params.StoragesAddParams) {
-	failures, err := s.api.AddToUnit(args)
+	failures, err := s.api.AddToUnit(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(failures.Results, gc.HasLen, len(args.Storages))
 	for _, one := range failures.Results {
@@ -57,7 +58,7 @@ func (s *storageAddSuite) TestStorageAddUnitBlocked(c *gc.C) {
 		UnitTag:     s.unitTag.String(),
 		StorageName: "data",
 	}
-	_, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	_, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{[]params.StorageAddParams{args}})
 	s.assertBlocked(c, err, "TestStorageAddUnitBlocked")
 }
 
@@ -78,7 +79,7 @@ func (s *storageAddSuite) TestStorageAddUnitInvalidName(c *gc.C) {
 		UnitTag:     "invalid-unit-name",
 		StorageName: "data",
 	}
-	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	failures, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{[]params.StorageAddParams{args}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(failures.Results, gc.HasLen, 1)
 	c.Assert(failures.Results[0].Error.Error(), gc.Matches, "\"invalid-unit-name\" is not a valid tag")
@@ -98,7 +99,7 @@ func (s *storageAddSuite) TestStorageAddUnitStateError(c *gc.C) {
 		UnitTag:     s.unitTag.String(),
 		StorageName: "data",
 	}
-	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	failures, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{[]params.StorageAddParams{args}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(failures.Results, gc.HasLen, 1)
 	c.Assert(failures.Results[0].Error.Error(), gc.Matches, fmt.Sprintf(".*%v.*", msg))
@@ -125,7 +126,7 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
 		}
 		return nil, nil
 	}
-	failures, err := s.api.AddToUnit(params.StoragesAddParams{
+	failures, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{
 		[]params.StorageAddParams{
 			wrong0,
 			right,
@@ -151,7 +152,7 @@ func (s *storageAddSuite) TestStorageAddUnitTags(c *gc.C) {
 		UnitTag:     s.unitTag.String(),
 		StorageName: "data",
 	}
-	results, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	results, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{[]params.StorageAddParams{args}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, jc.DeepEquals, []params.AddStorageResult{{
 		Result: &params.AddStorageDetails{
@@ -171,7 +172,7 @@ func (s *storageAddSuite) TestStorageAddUnitNotFoundErr(c *gc.C) {
 		UnitTag:     s.unitTag.String(),
 		StorageName: "data",
 	}
-	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	failures, err := s.api.AddToUnit(context.Background(), params.StoragesAddParams{[]params.StorageAddParams{args}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(failures.Results, gc.HasLen, 1)
 	c.Assert(failures.Results[0].Error.Error(), gc.Matches, "sanity not found")

--- a/apiserver/facades/client/storage/volumelist_test.go
+++ b/apiserver/facades/client/storage/volumelist_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -54,13 +56,13 @@ func (s *volumeSuite) expectedVolumeDetails() params.VolumeDetails {
 }
 
 func (s *volumeSuite) TestListVolumesNoFilters(c *gc.C) {
-	found, err := s.api.ListVolumes(params.VolumeFilters{})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 0)
 }
 
 func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
-	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Error, gc.IsNil)
@@ -73,7 +75,7 @@ func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 	s.storageAccessor.allVolumes = func() ([]state.Volume, error) {
 		return nil, errors.New(msg)
 	}
-	results, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	results, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, msg)
@@ -83,7 +85,7 @@ func (s *volumeSuite) TestListVolumesNoVolumes(c *gc.C) {
 	s.storageAccessor.allVolumes = func() ([]state.Volume, error) {
 		return nil, nil
 	}
-	results, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	results, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Result, gc.HasLen, 0)
@@ -94,7 +96,7 @@ func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
 	filters := []params.VolumeFilter{{
 		Machines: []string{s.machineTag.String()},
 	}}
-	found, err := s.api.ListVolumes(params.VolumeFilters{filters})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
@@ -106,7 +108,7 @@ func (s *volumeSuite) TestListVolumesFilterNonMatching(c *gc.C) {
 	filters := []params.VolumeFilter{{
 		Machines: []string{"machine-42"},
 	}}
-	found, err := s.api.ListVolumes(params.VolumeFilters{filters})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 0)
@@ -123,7 +125,7 @@ func (s *volumeSuite) TestListVolumesVolumeInfo(c *gc.C) {
 	expected.Info.Size = 123
 	expected.Info.HardwareId = "abc"
 	expected.Info.Persistent = true
-	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
@@ -144,7 +146,7 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 		},
 		Life: "alive",
 	}
-	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
@@ -166,7 +168,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 		},
 		Life: "alive",
 	}
-	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
@@ -199,7 +201,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 		},
 		Life: "alive",
 	}
-	found, err := s.api.ListVolumes(params.VolumeFilters{[]params.VolumeFilter{{}}})
+	found, err := s.api.ListVolumes(context.Background(), params.VolumeFilters{[]params.VolumeFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0].Result[0], jc.DeepEquals, expected)

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -4,6 +4,8 @@
 package subnets
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -79,7 +81,7 @@ func newAPIWithBacking(backing Backing, ctx context.ProviderCallContext, resourc
 // AllZones returns all availability zones known to Juju. If a
 // zone is unusable, unavailable, or deprecated the Available
 // field will be false.
-func (api *API) AllZones() (params.ZoneResults, error) {
+func (api *API) AllZones(ctx stdcontext.Context) (params.ZoneResults, error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ZoneResults{}, err
 	}
@@ -88,7 +90,7 @@ func (api *API) AllZones() (params.ZoneResults, error) {
 
 // ListSubnets returns the matching subnets after applying
 // optional filters.
-func (api *API) ListSubnets(args params.SubnetsFilters) (results params.ListSubnetsResults, err error) {
+func (api *API) ListSubnets(ctx stdcontext.Context, args params.SubnetsFilters) (results params.ListSubnetsResults, err error) {
 	if err := api.checkCanRead(); err != nil {
 		return params.ListSubnetsResults{}, err
 	}
@@ -131,7 +133,7 @@ func (api *API) ListSubnets(args params.SubnetsFilters) (results params.ListSubn
 }
 
 // SubnetsByCIDR returns the collection of subnets matching each CIDR in the input.
-func (api *API) SubnetsByCIDR(arg params.CIDRParams) (params.SubnetsResults, error) {
+func (api *API) SubnetsByCIDR(ctx stdcontext.Context, arg params.CIDRParams) (params.SubnetsResults, error) {
 	result := params.SubnetsResults{}
 
 	if err := api.checkCanRead(); err != nil {

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -4,6 +4,7 @@
 package usermanager
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -39,7 +40,7 @@ func (api *UserManagerAPI) hasControllerAdminAccess() (bool, error) {
 
 // AddUser adds a user with a username, and either a password or
 // a randomly generated secret key which will be returned.
-func (api *UserManagerAPI) AddUser(args params.AddUsers) (params.AddUserResults, error) {
+func (api *UserManagerAPI) AddUser(ctx context.Context, args params.AddUsers) (params.AddUserResults, error) {
 	var result params.AddUserResults
 
 	if err := api.check.ChangeAllowed(); err != nil {
@@ -85,7 +86,7 @@ func (api *UserManagerAPI) AddUser(args params.AddUsers) (params.AddUserResults,
 // information around for auditing purposes.
 // TODO(redir): Add information about getting deleted user information when we
 // add that capability.
-func (api *UserManagerAPI) RemoveUser(entities params.Entities) (params.ErrorResults, error) {
+func (api *UserManagerAPI) RemoveUser(ctx context.Context, entities params.Entities) (params.ErrorResults, error) {
 	var deletions params.ErrorResults
 
 	if err := api.check.ChangeAllowed(); err != nil {
@@ -150,7 +151,7 @@ func (api *UserManagerAPI) getUser(tag string) (*state.User, error) {
 
 // EnableUser enables one or more users.  If the user is already enabled,
 // the action is considered a success.
-func (api *UserManagerAPI) EnableUser(users params.Entities) (params.ErrorResults, error) {
+func (api *UserManagerAPI) EnableUser(ctx context.Context, users params.Entities) (params.ErrorResults, error) {
 	if _, err := api.hasControllerAdminAccess(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -163,7 +164,7 @@ func (api *UserManagerAPI) EnableUser(users params.Entities) (params.ErrorResult
 
 // DisableUser disables one or more users.  If the user is already disabled,
 // the action is considered a success.
-func (api *UserManagerAPI) DisableUser(users params.Entities) (params.ErrorResults, error) {
+func (api *UserManagerAPI) DisableUser(ctx context.Context, users params.Entities) (params.ErrorResults, error) {
 	if _, err := api.hasControllerAdminAccess(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -205,7 +206,7 @@ func (api *UserManagerAPI) enableUserImpl(args params.Entities, action string, m
 }
 
 // UserInfo returns information on a user.
-func (api *UserManagerAPI) UserInfo(request params.UserInfoRequest) (params.UserInfoResults, error) {
+func (api *UserManagerAPI) UserInfo(ctx context.Context, request params.UserInfoRequest) (params.UserInfoResults, error) {
 	var results params.UserInfoResults
 	isAdmin, err := api.hasControllerAdminAccess()
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
@@ -305,7 +306,7 @@ func (api *UserManagerAPI) checkCanRead(modelTag names.Tag) error {
 }
 
 // ModelUserInfo returns information on all users in the model.
-func (api *UserManagerAPI) ModelUserInfo(args params.Entities) (params.ModelUserInfoResults, error) {
+func (api *UserManagerAPI) ModelUserInfo(ctx context.Context, args params.Entities) (params.ModelUserInfoResults, error) {
 	var result params.ModelUserInfoResults
 	for _, entity := range args.Entities {
 		modelTag, err := names.ParseModelTag(entity.Tag)
@@ -352,7 +353,7 @@ func (api *UserManagerAPI) modelUserInfo(modelTag names.ModelTag) ([]params.Mode
 }
 
 // SetPassword changes the stored password for the specified users.
-func (api *UserManagerAPI) SetPassword(args params.EntityPasswords) (params.ErrorResults, error) {
+func (api *UserManagerAPI) SetPassword(ctx context.Context, args params.EntityPasswords) (params.ErrorResults, error) {
 	if err := api.check.ChangeAllowed(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -399,7 +400,7 @@ func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 // invalidating current passwords (if any) and generating
 // new random secret keys which will be returned.
 // Users cannot reset their own password.
-func (api *UserManagerAPI) ResetPassword(args params.Entities) (params.AddUserResults, error) {
+func (api *UserManagerAPI) ResetPassword(ctx context.Context, args params.Entities) (params.AddUserResults, error) {
 	var result params.AddUserResults
 
 	if err := api.check.ChangeAllowed(); err != nil {


### PR DESCRIPTION
This PR adds context.Context parameter to:
- client/resources
- client/secretbackends
- client/secrets
- client/spaces
- client/sshclient
- client/storage
- client/subnets
- client/usermanager 

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/client/resources/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/secretbackends/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/secrets/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/spaces/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/sshclient/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/storage/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/subnets/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/client/usermanager/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```
