### PR TITLE
[JUJU-4495] Ensure new Azure cred can access the Azure Vault Key app

### DIFF
--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -256,6 +256,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 	in := cloud.NewCredential("interactive", map[string]string{"subscription-id": fakeSubscriptionId})
 	ctx := cmdtesting.Context(c)
 	out, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		CloudName:             "azure",
 		Credential:            in,
 		CloudEndpoint:         "https://arm.invalid",
 		CloudStorageEndpoint:  "https://core.invalid",
@@ -274,6 +275,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 	s.servicePrincipalCreator.CheckCallNames(c, "InteractiveCreate")
 	args := s.servicePrincipalCreator.Calls()[0].Args
 	c.Assert(args[2], jc.DeepEquals, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: fakeSubscriptionId,
 		TenantId:       fakeTenantId,
 	})
@@ -285,6 +287,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractiveError(c *gc.C) {
 	s.servicePrincipalCreator.SetErrors(errors.New("blargh"))
 	ctx := cmdtesting.Context(c)
 	_, err := s.provider.FinalizeCredential(ctx, environs.FinalizeCredentialParams{
+		CloudName:             "azure",
 		Credential:            in,
 		CloudEndpoint:         "https://arm.invalid",
 		CloudIdentityEndpoint: "https://graph.invalid",

--- a/provider/azure/internal/azureauth/serviceprincipal_test.go
+++ b/provider/azure/internal/azureauth/serviceprincipal_test.go
@@ -143,6 +143,10 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 	mockAdaptor := &MockRequestAdaptor{NetHttpRequestAdapter: ra}
 	mockAdaptor.results = []requestResult{{
 		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
+		Params:      map[string]string{"appId": "cfa8b339-82a2-471a-a3c9-0fc0be7a4093"},
+		Result:      models.NewServicePrincipal(),
+	}, {
+		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
 		Params:      map[string]string{"appId": "60a04dc9-1857-425f-8076-5ba81ca53d66"},
 		Result:      sp,
 	}, {
@@ -167,6 +171,7 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 	sdkCtx := context.Background()
 
 	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: subscriptionId,
 		TenantId:       fakeTenantId,
 		Credential:     &azuretesting.FakeCredential{},
@@ -194,6 +199,10 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 	mockAdaptor := &MockRequestAdaptor{NetHttpRequestAdapter: ra}
 	mockAdaptor.results = []requestResult{{
 		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
+		Params:      map[string]string{"appId": "cfa8b339-82a2-471a-a3c9-0fc0be7a4093"},
+		Result:      models.NewServicePrincipal(),
+	}, {
+		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
 		Params:      map[string]string{"appId": "60a04dc9-1857-425f-8076-5ba81ca53d66"},
 		Result:      sp,
 	}, {
@@ -218,6 +227,7 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 	sdkCtx := context.Background()
 
 	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: subscriptionId,
 		TenantId:       fakeTenantId,
 		Credential:     &azuretesting.FakeCredential{},
@@ -255,6 +265,10 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFound(c *gc.C) {
 	mockAdaptor := &MockRequestAdaptor{NetHttpRequestAdapter: ra}
 	mockAdaptor.results = []requestResult{{
 		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
+		Params:      map[string]string{"appId": "cfa8b339-82a2-471a-a3c9-0fc0be7a4093"},
+		Result:      models.NewServicePrincipal(),
+	}, {
+		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
 		Params:      map[string]string{"appId": "60a04dc9-1857-425f-8076-5ba81ca53d66"},
 		Err:         dataError("Request_ResourceNotFound"),
 	}, {
@@ -282,6 +296,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFound(c *gc.C) {
 	sdkCtx := context.Background()
 
 	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: subscriptionId,
 		TenantId:       fakeTenantId,
 		Credential:     &azuretesting.FakeCredential{},
@@ -304,6 +319,10 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFoundRace(c *gc.C) 
 
 	mockAdaptor := &MockRequestAdaptor{NetHttpRequestAdapter: ra}
 	mockAdaptor.results = []requestResult{{
+		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
+		Params:      map[string]string{"appId": "cfa8b339-82a2-471a-a3c9-0fc0be7a4093"},
+		Result:      models.NewServicePrincipal(),
+	}, {
 		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
 		Params:      map[string]string{"appId": "60a04dc9-1857-425f-8076-5ba81ca53d66"},
 		Err:         dataError("Request_ResourceNotFound"),
@@ -335,6 +354,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFoundRace(c *gc.C) 
 	sdkCtx := context.Background()
 
 	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: subscriptionId,
 		TenantId:       fakeTenantId, Credential: &azuretesting.FakeCredential{},
 	})
@@ -356,6 +376,10 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 
 	mockAdaptor := &MockRequestAdaptor{NetHttpRequestAdapter: ra}
 	mockAdaptor.results = []requestResult{{
+		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
+		Params:      map[string]string{"appId": "cfa8b339-82a2-471a-a3c9-0fc0be7a4093"},
+		Result:      models.NewServicePrincipal(),
+	}, {
 		PathPattern: regexp.QuoteMeta("{+baseurl}/servicePrincipals(appId='{appId}')") + ".*",
 		Params:      map[string]string{"appId": "60a04dc9-1857-425f-8076-5ba81ca53d66"},
 		Result:      sp,
@@ -381,6 +405,7 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 	subscriptionId := "22222222-2222-2222-2222-222222222222"
 	sdkCtx := context.Background()
 	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+		CloudName:      "AzureCloud",
 		SubscriptionId: subscriptionId,
 		TenantId:       fakeTenantId, Credential: &azuretesting.FakeCredential{},
 	})


### PR DESCRIPTION
When doing the QA for https://github.com/juju/juju/pull/16090, a brand new Azure user was created. t turns out the user needs to have a service principal for the standard Azure Key Vault application. This was done manually

`az ad sp create --id cfa8b339-82a2-471a-a3c9-0fc0be7a4093`

but now this PR does it as part of the credential set up.

## QA steps

juju add-credential azure
...