### PR TITLE
Update PR template to include Jira card number

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,10 @@ QA steps here
 
 *How it affects user workflow (CLI or API). Delete section if not applicable.*
 
-## Bug reference
+## Links
 
-*Link to Launchpad bug. Delete section if not applicable.*
+**Launchpad bug:** https://pad.lv/<bug-number>
+
+**Jira card:** JUJU-[XXXX]
+
+*Insert other relevant links here.*


### PR DESCRIPTION
Per team discussion in Mattermost, we are going to start putting the Jira card number in the PR description, rather than the title. I've added a "Links" section to the PR template, which can include the Launchpad bug, Jira card number, and any other relevant links.