### PR TITLE
[JUJU-4483] Add context.Context in controller/(a-c)* facades

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -4,6 +4,7 @@
 package client_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -1108,7 +1109,7 @@ func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmhub(c *gc.C) {
 	c.Assert(appStatus.CanUpgradeTo, gc.Equals, "")
 
 	// Update to the latest available charm revision.
-	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
+	result, err := s.charmrevisionupdater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 

--- a/apiserver/facades/controller/actionpruner/pruner.go
+++ b/apiserver/facades/controller/actionpruner/pruner.go
@@ -4,6 +4,8 @@
 package actionpruner
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -30,7 +32,7 @@ var Prune = state.PruneOperations
 // Prune endpoint removes action entries until
 // only the ones newer than now - p.MaxHistoryTime remain and
 // the history is smaller than p.MaxHistoryMB.
-func (api *API) Prune(p params.ActionPruneArgs) error {
+func (api *API) Prune(ctx context.Context, p params.ActionPruneArgs) error {
 	if !api.authorizer.AuthController() {
 		return apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/controller/actionpruner/pruner_test.go
+++ b/apiserver/facades/controller/actionpruner/pruner_test.go
@@ -4,6 +4,7 @@
 package actionpruner_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -44,7 +45,7 @@ func (s *ActionPrunerSuite) TestPruneNonController(c *gc.C) {
 	s.context.Auth_ = testing.FakeAuthorizer{}
 	api, err := actionpruner.NewAPI(s.context)
 	c.Assert(err, jc.ErrorIsNil)
-	err = api.Prune(params.ActionPruneArgs{})
+	err = api.Prune(context.Background(), params.ActionPruneArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -56,7 +57,7 @@ func (s *ActionPrunerSuite) TestPrune(c *gc.C) {
 		called = true
 		return nil
 	})
-	err := s.api.Prune(params.ActionPruneArgs{
+	err := s.api.Prune(context.Background(), params.ActionPruneArgs{
 		MaxHistoryTime: time.Hour,
 		MaxHistoryMB:   666,
 	})

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -4,6 +4,8 @@
 package agenttools
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/version/v2"
@@ -127,7 +129,7 @@ func updateToolsAvailability(modelGetter ModelGetter, newEnviron newEnvironFunc,
 
 // UpdateToolsAvailable invokes a lookup and further update in environ
 // for new patches of the current tool versions.
-func (api *AgentToolsAPI) UpdateToolsAvailable() error {
+func (api *AgentToolsAPI) UpdateToolsAvailable(ctx context.Context) error {
 	if !api.authorizer.AuthController() {
 		return apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/controller/applicationscaler/facade.go
+++ b/apiserver/facades/controller/applicationscaler/facade.go
@@ -4,6 +4,8 @@
 package applicationscaler
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -45,7 +47,7 @@ func NewFacade(backend Backend, res facade.Resources, auth facade.Authorizer) (*
 
 // Watch returns a watcher that sends the names of services whose
 // unit count may be below their configured minimum.
-func (facade *Facade) Watch() (params.StringsWatchResult, error) {
+func (facade *Facade) Watch(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := facade.backend.WatchScaledServices()
 	if changes, ok := <-watch.Changes(); ok {
 		id := facade.resources.Register(watch)
@@ -59,7 +61,7 @@ func (facade *Facade) Watch() (params.StringsWatchResult, error) {
 
 // Rescale causes any supplied services to be scaled up to their
 // minimum size.
-func (facade *Facade) Rescale(args params.Entities) params.ErrorResults {
+func (facade *Facade) Rescale(ctx context.Context, args params.Entities) params.ErrorResults {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/facades/controller/applicationscaler/facade_test.go
+++ b/apiserver/facades/controller/applicationscaler/facade_test.go
@@ -4,6 +4,8 @@
 package applicationscaler_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -33,7 +35,7 @@ func (s *FacadeSuite) TestNotModelManager(c *gc.C) {
 
 func (s *FacadeSuite) TestWatchError(c *gc.C) {
 	fix := newWatchFixture(c, false)
-	result, err := fix.Facade.Watch()
+	result, err := fix.Facade.Watch(context.Background())
 	c.Check(err, gc.ErrorMatches, "blammo")
 	c.Check(result, gc.DeepEquals, params.StringsWatchResult{})
 	c.Check(fix.Resources.Count(), gc.Equals, 0)
@@ -41,7 +43,7 @@ func (s *FacadeSuite) TestWatchError(c *gc.C) {
 
 func (s *FacadeSuite) TestWatchSuccess(c *gc.C) {
 	fix := newWatchFixture(c, true)
-	result, err := fix.Facade.Watch()
+	result, err := fix.Facade.Watch(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(result.Changes, jc.DeepEquals, []string{"pow", "zap", "kerblooie"})
 	c.Check(fix.Resources.Count(), gc.Equals, 1)
@@ -51,7 +53,7 @@ func (s *FacadeSuite) TestWatchSuccess(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleNonsense(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("burble plink"))
+	result := fix.Facade.Rescale(context.Background(), entities("burble plink"))
 	c.Assert(result.Results, gc.HasLen, 1)
 	err := result.Results[0].Error
 	c.Check(err, gc.ErrorMatches, `"burble plink" is not a valid tag`)
@@ -59,7 +61,7 @@ func (s *FacadeSuite) TestRescaleNonsense(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleUnauthorized(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("unit-foo-27"))
+	result := fix.Facade.Rescale(context.Background(), entities("unit-foo-27"))
 	c.Assert(result.Results, gc.HasLen, 1)
 	err := result.Results[0].Error
 	c.Check(err, gc.ErrorMatches, "permission denied")
@@ -68,7 +70,7 @@ func (s *FacadeSuite) TestRescaleUnauthorized(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleNotFound(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("application-missing"))
+	result := fix.Facade.Rescale(context.Background(), entities("application-missing"))
 	c.Assert(result.Results, gc.HasLen, 1)
 	err := result.Results[0].Error
 	c.Check(err, gc.ErrorMatches, "application not found")
@@ -77,7 +79,7 @@ func (s *FacadeSuite) TestRescaleNotFound(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleError(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("application-error"))
+	result := fix.Facade.Rescale(context.Background(), entities("application-error"))
 	c.Assert(result.Results, gc.HasLen, 1)
 	err := result.Results[0].Error
 	c.Check(err, gc.ErrorMatches, "blammo")
@@ -85,7 +87,7 @@ func (s *FacadeSuite) TestRescaleError(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleSuccess(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("application-expected"))
+	result := fix.Facade.Rescale(context.Background(), entities("application-expected"))
 	c.Assert(result.Results, gc.HasLen, 1)
 	err := result.Results[0].Error
 	c.Check(err, gc.IsNil)
@@ -93,7 +95,7 @@ func (s *FacadeSuite) TestRescaleSuccess(c *gc.C) {
 
 func (s *FacadeSuite) TestRescaleMultiple(c *gc.C) {
 	fix := newRescaleFixture(c)
-	result := fix.Facade.Rescale(entities("application-error", "application-expected"))
+	result := fix.Facade.Rescale(context.Background(), entities("application-error", "application-expected"))
 	c.Assert(result.Results, gc.HasLen, 2)
 	err0 := result.Results[0].Error
 	c.Check(err0, gc.ErrorMatches, "blammo")

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -4,6 +4,7 @@
 package caasapplicationprovisioner
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -190,7 +191,7 @@ func NewCAASApplicationProvisionerAPI(
 
 // WatchApplications starts a StringsWatcher to watch applications
 // deployed to this model.
-func (a *API) WatchApplications() (params.StringsWatchResult, error) {
+func (a *API) WatchApplications(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := a.state.WatchApplications()
 	// Consume the initial event and forward it to the result.
 	if changes, ok := <-watch.Changes(); ok {
@@ -205,7 +206,7 @@ func (a *API) WatchApplications() (params.StringsWatchResult, error) {
 // WatchProvisioningInfo provides a watcher for changes that affect the
 // information returned by ProvisioningInfo. This is useful for ensuring the
 // latest application stated is ensured.
-func (a *API) WatchProvisioningInfo(args params.Entities) (params.NotifyWatchResults, error) {
+func (a *API) WatchProvisioningInfo(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	var result params.NotifyWatchResults
 	result.Results = make([]params.NotifyWatchResult, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -254,7 +255,7 @@ func (a *API) watchProvisioningInfo(appName names.ApplicationTag) (params.Notify
 }
 
 // ProvisioningInfo returns the info needed to provision a caas application.
-func (a *API) ProvisioningInfo(args params.Entities) (params.CAASApplicationProvisioningInfoResults, error) {
+func (a *API) ProvisioningInfo(ctx context.Context, args params.Entities) (params.CAASApplicationProvisioningInfoResults, error) {
 	var result params.CAASApplicationProvisioningInfoResults
 	result.Results = make([]params.CAASApplicationProvisioningInfo, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -372,7 +373,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 }
 
 // SetOperatorStatus sets the status of each given entity.
-func (a *API) SetOperatorStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (a *API) SetOperatorStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -401,7 +402,7 @@ func (a *API) setStatus(tag names.ApplicationTag, info status.StatusInfo) error 
 }
 
 // Units returns all the units for each application specified.
-func (a *API) Units(args params.Entities) (params.CAASUnitsResults, error) {
+func (a *API) Units(ctx context.Context, args params.Entities) (params.CAASUnitsResults, error) {
 	results := params.CAASUnitsResults{
 		Results: make([]params.CAASUnitsResult, len(args.Entities)),
 	}
@@ -633,7 +634,7 @@ func (a *API) devicesParams(app Application) ([]params.KubernetesDeviceParams, e
 }
 
 // ApplicationOCIResources returns the OCI image resources for an application.
-func (a *API) ApplicationOCIResources(args params.Entities) (params.CAASApplicationOCIResourceResults, error) {
+func (a *API) ApplicationOCIResources(ctx context.Context, args params.Entities) (params.CAASApplicationOCIResourceResults, error) {
 	res := params.CAASApplicationOCIResourceResults{
 		Results: make([]params.CAASApplicationOCIResourceResult, len(args.Entities)),
 	}
@@ -709,7 +710,7 @@ func readDockerImageResource(reader io.Reader) (params.DockerImageInfo, error) {
 
 // UpdateApplicationsUnits updates the Juju data model to reflect the given
 // units of the specified application.
-func (a *API) UpdateApplicationsUnits(args params.UpdateApplicationUnitArgs) (params.UpdateApplicationUnitResults, error) {
+func (a *API) UpdateApplicationsUnits(ctx context.Context, args params.UpdateApplicationUnitArgs) (params.UpdateApplicationUnitResults, error) {
 	result := params.UpdateApplicationUnitResults{
 		Results: make([]params.UpdateApplicationUnitResult, len(args.Args)),
 	}
@@ -1226,7 +1227,7 @@ func updateStatus(params params.ApplicationUnitParams) (
 
 // ClearApplicationsResources clears the flags which indicate
 // applications still have resources in the cluster.
-func (a *API) ClearApplicationsResources(args params.Entities) (params.ErrorResults, error) {
+func (a *API) ClearApplicationsResources(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -1255,7 +1256,7 @@ func (a *API) ClearApplicationsResources(args params.Entities) (params.ErrorResu
 // WatchUnits starts a StringsWatcher to watch changes to the
 // lifecycle states of units for the specified applications in
 // this model.
-func (a *API) WatchUnits(args params.Entities) (params.StringsWatchResults, error) {
+func (a *API) WatchUnits(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -1289,7 +1290,7 @@ func (a *API) watchUnits(tagString string) (string, []string, error) {
 
 // DestroyUnits is responsible for scaling down a set of units on the this
 // Application.
-func (a *API) DestroyUnits(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
+func (a *API) DestroyUnits(ctx context.Context, args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	results := make([]params.DestroyUnitResult, 0, len(args.Units))
 
 	for _, unit := range args.Units {
@@ -1335,7 +1336,7 @@ func (a *API) destroyUnit(args params.DestroyUnitParams) (params.DestroyUnitResu
 }
 
 // ProvisioningState returns the provisioning state for the application.
-func (a *API) ProvisioningState(args params.Entity) (params.CAASApplicationProvisioningStateResult, error) {
+func (a *API) ProvisioningState(ctx context.Context, args params.Entity) (params.CAASApplicationProvisioningStateResult, error) {
 	result := params.CAASApplicationProvisioningStateResult{}
 
 	appTag, err := names.ParseApplicationTag(args.Tag)
@@ -1363,7 +1364,7 @@ func (a *API) ProvisioningState(args params.Entity) (params.CAASApplicationProvi
 }
 
 // SetProvisioningState sets the provisioning state for the application.
-func (a *API) SetProvisioningState(args params.CAASApplicationProvisioningStateArg) (params.ErrorResult, error) {
+func (a *API) SetProvisioningState(ctx context.Context, args params.CAASApplicationProvisioningStateArg) (params.ErrorResult, error) {
 	result := params.ErrorResult{}
 
 	appTag, err := names.ParseApplicationTag(args.Application.Tag)
@@ -1395,7 +1396,7 @@ func (a *API) SetProvisioningState(args params.CAASApplicationProvisioningStateA
 }
 
 // ProvisionerConfig returns the provisioner's configuration.
-func (a *API) ProvisionerConfig() (params.CAASApplicationProvisionerConfigResult, error) {
+func (a *API) ProvisionerConfig(ctx context.Context) (params.CAASApplicationProvisionerConfigResult, error) {
 	result := params.CAASApplicationProvisionerConfigResult{
 		ProvisionerConfig: &params.CAASApplicationProvisionerConfig{},
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package caasapplicationprovisioner_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v11"
@@ -103,7 +104,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 			"trust": true,
 		},
 	}
-	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+	result, err := s.api.ProvisioningInfo(context.Background(), params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)
 
 	mc := jc.NewMultiChecker()
@@ -138,7 +139,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoPendingCharmError(
 			},
 		},
 	}
-	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+	result, err := s.api.ProvisioningInfo(context.Background(), params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, `charm "ch:gitlab" pending not provisioned`)
 }
@@ -155,7 +156,7 @@ func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.api.SetOperatorStatus(params.SetStatus{
+	result, err := s.api.SetOperatorStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
 			Tag:    "application-gitlab",
 			Status: "started",
@@ -200,7 +201,7 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.api.Units(params.Entities{
+	result, err := s.api.Units(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "application-gitlab",
 		}},
@@ -264,7 +265,7 @@ func (s *CAASApplicationProvisionerSuite) TestApplicationOCIResources(c *gc.C) {
 		},
 	}
 
-	result, err := s.api.ApplicationOCIResources(params.Entities{
+	result, err := s.api.ApplicationOCIResources(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "application-gitlab",
 		}},
@@ -378,7 +379,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage
 		},
 	}
 
-	results, err := s.api.UpdateApplicationsUnits(args)
+	results, err := s.api.UpdateApplicationsUnits(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0], gc.DeepEquals, params.UpdateApplicationUnitResult{
 		Info: &params.UpdateApplicationUnitsInfo{
@@ -542,7 +543,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 			{ApplicationTag: "application-gitlab", Units: units},
 		},
 	}
-	results, err := s.api.UpdateApplicationsUnits(args)
+	results, err := s.api.UpdateApplicationsUnits(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0], gc.DeepEquals, params.UpdateApplicationUnitResult{
 		Info: &params.UpdateApplicationUnitsInfo{
@@ -592,7 +593,7 @@ func (s *CAASApplicationProvisionerSuite) TestClearApplicationsResources(c *gc.C
 		},
 	}
 
-	result, err := s.api.ClearApplicationsResources(params.Entities{
+	result, err := s.api.ClearApplicationsResources(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "application-gitlab",
 		}},
@@ -620,7 +621,7 @@ func (s *CAASApplicationProvisionerSuite) TestWatchUnits(c *gc.C) {
 	}
 	unitsChanges <- []string{"gitlab/0", "gitlab/1"}
 
-	results, err := s.api.WatchUnits(params.Entities{
+	results, err := s.api.WatchUnits(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 		},
@@ -641,11 +642,11 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningState(c *gc.C) {
 		provisioningState: nil,
 	}
 
-	result, err := s.api.ProvisioningState(params.Entity{Tag: "application-gitlab"})
+	result, err := s.api.ProvisioningState(context.Background(), params.Entity{Tag: "application-gitlab"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.ProvisioningState, gc.IsNil)
 
-	setResult, err := s.api.SetProvisioningState(params.CAASApplicationProvisioningStateArg{
+	setResult, err := s.api.SetProvisioningState(context.Background(), params.CAASApplicationProvisioningStateArg{
 		Application: params.Entity{Tag: "application-gitlab"},
 		ProvisioningState: params.CAASApplicationProvisioningState{
 			Scaling:     true,
@@ -655,7 +656,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(setResult.Error, gc.IsNil)
 
-	result, err = s.api.ProvisioningState(params.Entity{Tag: "application-gitlab"})
+	result, err = s.api.ProvisioningState(context.Background(), params.Entity{Tag: "application-gitlab"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.ProvisioningState, jc.DeepEquals, &params.CAASApplicationProvisioningState{
 		Scaling:     true,
@@ -666,14 +667,14 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningState(c *gc.C) {
 }
 
 func (s *CAASApplicationProvisionerSuite) TestProvisionerConfig(c *gc.C) {
-	result, err := s.api.ProvisionerConfig()
+	result, err := s.api.ProvisionerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.ProvisionerConfig, gc.NotNil)
 	c.Assert(result.ProvisionerConfig.UnmanagedApplications.Entities, gc.HasLen, 0)
 
 	s.st.isController = true
-	result, err = s.api.ProvisionerConfig()
+	result, err = s.api.ProvisionerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.ProvisionerConfig, gc.NotNil)

--- a/apiserver/facades/controller/caasfirewaller/firewaller.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller.go
@@ -4,6 +4,7 @@
 package caasfirewaller
 
 import (
+	"context"
 	"sort"
 
 	"github.com/juju/errors"
@@ -29,17 +30,17 @@ type Facade struct {
 }
 
 // CharmInfo returns information about the requested charm.
-func (f *Facade) CharmInfo(args params.CharmURL) (params.Charm, error) {
+func (f *Facade) CharmInfo(ctx context.Context, args params.CharmURL) (params.Charm, error) {
 	return f.charmInfoAPI.CharmInfo(args)
 }
 
 // ApplicationCharmInfo returns information about an application's charm.
-func (f *Facade) ApplicationCharmInfo(args params.Entity) (params.Charm, error) {
+func (f *Facade) ApplicationCharmInfo(ctx context.Context, args params.Entity) (params.Charm, error) {
 	return f.appCharmInfoAPI.ApplicationCharmInfo(args)
 }
 
 // IsExposed returns whether the specified applications are exposed.
-func (f *Facade) IsExposed(args params.Entities) (params.BoolResults, error) {
+func (f *Facade) IsExposed(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	results := params.BoolResults{
 		Results: make([]params.BoolResult, len(args.Entities)),
 	}
@@ -67,7 +68,7 @@ func (f *Facade) isExposed(backend CAASFirewallerState, tagString string) (bool,
 }
 
 // ApplicationsConfig returns the config for the specified applications.
-func (f *Facade) ApplicationsConfig(args params.Entities) (params.ApplicationGetConfigResults, error) {
+func (f *Facade) ApplicationsConfig(ctx context.Context, args params.Entities) (params.ApplicationGetConfigResults, error) {
 	results := params.ApplicationGetConfigResults{
 		Results: make([]params.ConfigResult, len(args.Entities)),
 	}
@@ -93,7 +94,7 @@ func (f *Facade) getApplicationConfig(tagString string) (map[string]interface{},
 
 // WatchApplications starts a StringsWatcher to watch applications
 // deployed to this model.
-func (f *Facade) WatchApplications() (params.StringsWatchResult, error) {
+func (f *Facade) WatchApplications(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := f.state.WatchApplications()
 	// Consume the initial event and forward it to the result.
 	if changes, ok := <-watch.Changes(); ok {
@@ -139,7 +140,7 @@ func newFacade(
 
 // WatchOpenedPorts returns a new StringsWatcher for each given
 // model tag.
-func (f *Facade) WatchOpenedPorts(args params.Entities) (params.StringsWatchResults, error) {
+func (f *Facade) WatchOpenedPorts(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -183,7 +184,7 @@ func (f *Facade) watchOneModelOpenedPorts(tag names.Tag) (string, []string, erro
 }
 
 // GetOpenedPorts returns all the opened ports for each given application tag.
-func (f *Facade) GetOpenedPorts(arg params.Entity) (params.ApplicationOpenedPortsResults, error) {
+func (f *Facade) GetOpenedPorts(ctx context.Context, arg params.Entity) (params.ApplicationOpenedPortsResults, error) {
 	result := params.ApplicationOpenedPortsResults{
 		Results: make([]params.ApplicationOpenedPortsResult, 1),
 	}

--- a/apiserver/facades/controller/caasfirewaller/firewaller_test.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller_test.go
@@ -4,6 +4,8 @@
 package caasfirewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -115,7 +117,7 @@ func (s *firewallerSuite) TestWatchOpenedPorts(c *gc.C) {
 	openPortsChanges := []string{"port1", "port2"}
 	s.openPortsChanges <- openPortsChanges
 
-	results, err := s.facade.WatchOpenedPorts(params.Entities{
+	results, err := s.facade.WatchOpenedPorts(context.Background(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		}},
@@ -145,7 +147,7 @@ func (s *firewallerSuite) TestGetApplicationOpenedPorts(c *gc.C) {
 		},
 	}
 
-	results, err := s.facade.GetOpenedPorts(params.Entity{
+	results, err := s.facade.GetOpenedPorts(context.Background(), params.Entity{
 		Tag: "application-gitlab",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,14 +169,14 @@ func (s *firewallerSuite) TestGetApplicationOpenedPorts(c *gc.C) {
 }
 
 type facadeSidecar interface {
-	IsExposed(args params.Entities) (params.BoolResults, error)
-	ApplicationsConfig(args params.Entities) (params.ApplicationGetConfigResults, error)
-	WatchApplications() (params.StringsWatchResult, error)
+	IsExposed(ctx context.Context, args params.Entities) (params.BoolResults, error)
+	ApplicationsConfig(ctx context.Context, args params.Entities) (params.ApplicationGetConfigResults, error)
+	WatchApplications(ctx context.Context) (params.StringsWatchResult, error)
 	Life(args params.Entities) (params.LifeResults, error)
 	Watch(args params.Entities) (params.NotifyWatchResults, error)
-	ApplicationCharmInfo(args params.Entity) (params.Charm, error)
-	WatchOpenedPorts(args params.Entities) (params.StringsWatchResults, error)
-	GetOpenedPorts(arg params.Entity) (params.ApplicationOpenedPortsResults, error)
+	ApplicationCharmInfo(ctx context.Context, args params.Entity) (params.Charm, error)
+	WatchOpenedPorts(ctx context.Context, args params.Entities) (params.StringsWatchResults, error)
+	GetOpenedPorts(ctx context.Context, arg params.Entity) (params.ApplicationOpenedPortsResults, error)
 }
 
 func (s *firewallerSuite) TestPermission(c *gc.C) {
@@ -188,7 +190,7 @@ func (s *firewallerSuite) TestPermission(c *gc.C) {
 func (s *firewallerSuite) TestWatchApplications(c *gc.C) {
 	applicationNames := []string{"db2", "hadoop"}
 	s.applicationsChanges <- applicationNames
-	result, err := s.facade.WatchApplications()
+	result, err := s.facade.WatchApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.StringsWatcherId, gc.Equals, "1")
@@ -219,7 +221,7 @@ func (s *firewallerSuite) TestWatchApplication(c *gc.C) {
 
 func (s *firewallerSuite) TestIsExposed(c *gc.C) {
 	s.st.application.exposed = true
-	results, err := s.facade.IsExposed(params.Entities{
+	results, err := s.facade.IsExposed(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},
@@ -258,7 +260,7 @@ func (s *firewallerSuite) TestLife(c *gc.C) {
 }
 
 func (s *firewallerSuite) TestApplicationConfig(c *gc.C) {
-	results, err := s.facade.ApplicationsConfig(params.Entities{
+	results, err := s.facade.ApplicationsConfig(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},

--- a/apiserver/facades/controller/caasmodelconfigmanager/facade.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/facade.go
@@ -4,6 +4,8 @@
 package caasmodelconfigmanager
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/rpc/params"
@@ -15,6 +17,6 @@ type Facade struct {
 	controllerConfigAPI *common.ControllerConfigAPI
 }
 
-func (f *Facade) ControllerConfig() (params.ControllerConfigResult, error) {
+func (f *Facade) ControllerConfig(ctx context.Context) (params.ControllerConfigResult, error) {
 	return f.controllerConfigAPI.ControllerConfig()
 }

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -4,6 +4,7 @@
 package caasmodeloperator
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -56,7 +57,7 @@ func NewAPI(
 
 // ModelOperatorProvisioningInfo returns the information needed for provisioning
 // a new model operator into a caas cluster.
-func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) {
+func (a *API) ModelOperatorProvisioningInfo(ctx context.Context) (params.ModelOperatorInfo, error) {
 	var result params.ModelOperatorInfo
 	controllerConf, err := a.ctrlState.ControllerConfig()
 	if err != nil {
@@ -79,7 +80,7 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 				modelConfig.Name()))
 	}
 
-	apiAddresses, err := a.APIAddresses()
+	apiAddresses, err := a.APIAddresses(context.Background())
 	if err != nil && apiAddresses.Error != nil {
 		err = apiAddresses.Error
 	}
@@ -106,12 +107,12 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 // It is implemented here directly as a result of removing it from
 // embedded APIAddresser *without* bumping the facade version.
 // It should be blanked when this facade version is next incremented.
-func (a *API) ModelUUID() params.StringResult {
+func (a *API) ModelUUID(ctx context.Context) params.StringResult {
 	return params.StringResult{Result: a.state.ModelUUID()}
 }
 
 // APIHostPorts returns the API server addresses.
-func (u *API) APIHostPorts() (result params.APIHostPortsResult, err error) {
+func (u *API) APIHostPorts(ctx context.Context) (result params.APIHostPortsResult, err error) {
 	controllerConfig, err := u.ctrlState.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -121,7 +122,7 @@ func (u *API) APIHostPorts() (result params.APIHostPortsResult, err error) {
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (u *API) APIAddresses() (result params.StringsResult, err error) {
+func (u *API) APIAddresses(ctx context.Context) (result params.StringsResult, err error) {
 	controllerConfig, err := u.ctrlState.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -4,6 +4,8 @@
 package caasmodeloperator_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -54,7 +56,7 @@ func (m *ModelOperatorSuite) SetUpTest(c *gc.C) {
 }
 
 func (m *ModelOperatorSuite) TestProvisioningInfo(c *gc.C) {
-	info, err := m.api.ModelOperatorProvisioningInfo()
+	info, err := m.api.ModelOperatorProvisioningInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerConf, err := m.state.ControllerConfig()

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -4,6 +4,8 @@
 package caasoperatorupgrader
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -40,7 +42,7 @@ func NewCAASOperatorUpgraderAPI(
 }
 
 // UpgradeOperator upgrades the operator for the specified agents.
-func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorResult, error) {
+func (api *API) UpgradeOperator(ctx context.Context, arg params.KubernetesUpgradeArg) (params.ErrorResult, error) {
 	serverErr := func(err error) params.ErrorResult {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -4,6 +4,8 @@
 package caasoperatorupgrader_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -50,7 +52,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 
 func (s *CAASProvisionerSuite) TestUpgradeOperator(c *gc.C) {
 	vers := version.MustParse("6.6.6")
-	result, err := s.api.UpgradeOperator(params.KubernetesUpgradeArg{
+	result, err := s.api.UpgradeOperator(context.Background(), params.KubernetesUpgradeArg{
 		AgentTag: s.authorizer.Tag.String(),
 		Version:  vers,
 	})
@@ -69,7 +71,7 @@ func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	vers := version.MustParse("6.6.6")
-	result, err := api.UpgradeOperator(params.KubernetesUpgradeArg{
+	result, err := api.UpgradeOperator(context.Background(), params.KubernetesUpgradeArg{
 		AgentTag: s.authorizer.Tag.String(),
 		Version:  vers,
 	})

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -4,6 +4,8 @@
 package caasunitprovisioner
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -44,7 +46,7 @@ func NewFacade(
 
 // WatchApplicationsScale starts a NotifyWatcher to watch changes
 // to the applications' scale.
-func (f *Facade) WatchApplicationsScale(args params.Entities) (params.NotifyWatchResults, error) {
+func (f *Facade) WatchApplicationsScale(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -75,7 +77,7 @@ func (f *Facade) watchApplicationScale(tagString string) (string, error) {
 	return "", watcher.EnsureErr(w)
 }
 
-func (f *Facade) ApplicationsScale(args params.Entities) (params.IntResults, error) {
+func (f *Facade) ApplicationsScale(ctx context.Context, args params.Entities) (params.IntResults, error) {
 	results := params.IntResults{
 		Results: make([]params.IntResult, len(args.Entities)),
 	}
@@ -104,7 +106,7 @@ func (f *Facade) applicationScale(tagString string) (int, error) {
 }
 
 // ApplicationsTrust returns the trust status for specified applications in this model.
-func (f *Facade) ApplicationsTrust(args params.Entities) (params.BoolResults, error) {
+func (f *Facade) ApplicationsTrust(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	results := params.BoolResults{
 		Results: make([]params.BoolResult, len(args.Entities)),
 	}
@@ -138,7 +140,7 @@ func (f *Facade) applicationTrust(tagString string) (bool, error) {
 
 // WatchApplicationsTrustHash starts a StringsWatcher to watch changes
 // to the applications' trust status.
-func (f *Facade) WatchApplicationsTrustHash(args params.Entities) (params.StringsWatchResults, error) {
+func (f *Facade) WatchApplicationsTrustHash(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -175,7 +177,7 @@ func (f *Facade) watchApplicationTrustHash(tagString string) (string, error) {
 
 // UpdateApplicationsService updates the Juju data model to reflect the given
 // service details of the specified application.
-func (f *Facade) UpdateApplicationsService(args params.UpdateApplicationServiceArgs) (params.ErrorResults, error) {
+func (f *Facade) UpdateApplicationsService(ctx context.Context, args params.UpdateApplicationServiceArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package caasunitprovisioner_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -84,7 +85,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *gc.C) {
 func (s *CAASProvisionerSuite) TestWatchApplicationsScale(c *gc.C) {
 	s.scaleChanges <- struct{}{}
 
-	results, err := s.facade.WatchApplicationsScale(params.Entities{
+	results, err := s.facade.WatchApplicationsScale(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},
@@ -105,7 +106,7 @@ func (s *CAASProvisionerSuite) TestWatchApplicationsScale(c *gc.C) {
 func (s *CAASProvisionerSuite) TestWatchApplicationsConfigSetingsHash(c *gc.C) {
 	s.settingsChanges <- []string{"hash"}
 
-	results, err := s.facade.WatchApplicationsTrustHash(params.Entities{
+	results, err := s.facade.WatchApplicationsTrustHash(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},
@@ -124,7 +125,7 @@ func (s *CAASProvisionerSuite) TestWatchApplicationsConfigSetingsHash(c *gc.C) {
 }
 
 func (s *CAASProvisionerSuite) TestApplicationScale(c *gc.C) {
-	results, err := s.facade.ApplicationsScale(params.Entities{
+	results, err := s.facade.ApplicationsScale(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -4,6 +4,7 @@
 package charmdownloader
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/clock"
@@ -66,7 +67,7 @@ func newAPI(
 // WatchApplicationsWithPendingCharms registers and returns a watcher instance
 // that reports the ID of applications that reference a charm which has not yet
 // been downloaded.
-func (a *CharmDownloaderAPI) WatchApplicationsWithPendingCharms() (params.StringsWatchResult, error) {
+func (a *CharmDownloaderAPI) WatchApplicationsWithPendingCharms(ctx context.Context) (params.StringsWatchResult, error) {
 	if !a.authChecker.AuthController() {
 		return params.StringsWatchResult{}, apiservererrors.ErrPerm
 	}
@@ -85,7 +86,7 @@ func (a *CharmDownloaderAPI) WatchApplicationsWithPendingCharms() (params.String
 // DownloadApplicationCharms iterates the list of provided applications and
 // downloads any referenced charms that have not yet been persisted to the
 // blob store.
-func (a *CharmDownloaderAPI) DownloadApplicationCharms(args params.Entities) (params.ErrorResults, error) {
+func (a *CharmDownloaderAPI) DownloadApplicationCharms(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	if !a.authChecker.AuthController() {
 		return params.ErrorResults{}, apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -4,6 +4,7 @@
 package charmdownloader_test
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -42,7 +43,7 @@ func (s *charmDownloaderSuite) TestWatchApplicationsWithPendingCharmsAuthChecks(
 	defer s.setupMocks(c).Finish()
 	s.authChecker.EXPECT().AuthController().Return(false)
 
-	_, err := s.api.WatchApplicationsWithPendingCharms()
+	_, err := s.api.WatchApplicationsWithPendingCharms(context.Background())
 	c.Assert(err, gc.Equals, apiservererrors.ErrPerm, gc.Commentf("expected ErrPerm when not authenticating as the controller"))
 }
 
@@ -61,7 +62,7 @@ func (s *charmDownloaderSuite) TestWatchApplicationsWithPendingCharms(c *gc.C) {
 	})
 	s.resourcesBackend.EXPECT().Register(watcher).Return("42")
 
-	got, err := s.api.WatchApplicationsWithPendingCharms()
+	got, err := s.api.WatchApplicationsWithPendingCharms(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got.StringsWatcherId, gc.Equals, "42")
 	c.Assert(got.Changes, gc.DeepEquals, []string{"ufo", "cons", "piracy"})
@@ -71,7 +72,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsAuthChecks(c *gc.C) 
 	defer s.setupMocks(c).Finish()
 	s.authChecker.EXPECT().AuthController().Return(false)
 
-	_, err := s.api.DownloadApplicationCharms(params.Entities{})
+	_, err := s.api.DownloadApplicationCharms(context.Background(), params.Entities{})
 	c.Assert(err, gc.Equals, apiservererrors.ErrPerm, gc.Commentf("expected ErrPerm when not authenticating as the controller"))
 }
 
@@ -104,7 +105,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeploy(c *gc.C) {
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
 	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, false).Return(downloadedOrigin, nil)
 
-	got, err := s.api.DownloadApplicationCharms(params.Entities{
+	got, err := s.api.DownloadApplicationCharms(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{
 				Tag: names.NewApplicationTag("ufo").String(),
@@ -151,7 +152,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeployMultiAppOneCha
 	s.stateBackend.EXPECT().Application("another-ufo").Return(appTwo, nil)
 	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, false).Return(downloadedOrigin, nil).AnyTimes()
 
-	got, err := s.api.DownloadApplicationCharms(params.Entities{
+	got, err := s.api.DownloadApplicationCharms(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{
 				Tag: names.NewApplicationTag("ufo").String(),
@@ -194,7 +195,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsRefresh(c *gc.C) {
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
 	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, false).Return(downloadedOrigin, nil)
 
-	got, err := s.api.DownloadApplicationCharms(params.Entities{
+	got, err := s.api.DownloadApplicationCharms(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{
 				Tag: names.NewApplicationTag("ufo").String(),
@@ -229,7 +230,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsSetStatusIfDownloadF
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
 	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, false).Return(corecharm.Origin{}, errors.NotFoundf("charm"))
 
-	got, err := s.api.DownloadApplicationCharms(params.Entities{
+	got, err := s.api.DownloadApplicationCharms(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{
 				Tag: names.NewApplicationTag("ufo").String(),

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -27,7 +27,7 @@ import (
 
 // CharmRevisionUpdater defines the methods on the charmrevisionupdater API end point.
 type CharmRevisionUpdater interface {
-	UpdateLatestRevisions() (params.ErrorResult, error)
+	UpdateLatestRevisions(ctx context.Context) (params.ErrorResult, error)
 }
 
 // CharmRevisionUpdaterAPI implements the CharmRevisionUpdater interface and is the concrete
@@ -62,7 +62,7 @@ func NewCharmRevisionUpdaterAPIState(
 
 // UpdateLatestRevisions retrieves the latest revision information from the charm store for all deployed charms
 // and records this information in state.
-func (api *CharmRevisionUpdaterAPI) UpdateLatestRevisions() (params.ErrorResult, error) {
+func (api *CharmRevisionUpdaterAPI) UpdateLatestRevisions(ctx context.Context) (params.ErrorResult, error) {
 	if err := api.updateLatestRevisions(); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -4,6 +4,7 @@
 package charmrevisionupdater_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v11"
@@ -99,7 +100,7 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := updater.UpdateLatestRevisions()
+	result, err := updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }
@@ -176,7 +177,7 @@ func (s *updaterSuite) testCharmhubUpdateMetrics(c *gc.C, ctrl *gomock.Controlle
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := updater.UpdateLatestRevisions()
+	result, err := updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }
@@ -220,7 +221,7 @@ func (s *updaterSuite) TestEmptyModelMetrics(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = updater.UpdateLatestRevisions()
+	_, err = updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -242,7 +243,7 @@ func (s *updaterSuite) TestEmptyModelNoMetrics(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = updater.UpdateLatestRevisions()
+	_, err = updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -301,7 +302,7 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := updater.UpdateLatestRevisions()
+	result, err := updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }
@@ -331,7 +332,7 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(client), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := updater.UpdateLatestRevisions()
+	result, err := updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }
@@ -351,7 +352,7 @@ func (s *updaterSuite) TestCharmNotInStore(c *gc.C) {
 	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, s.clock, s.newCharmhubClient(charmhubClient), loggo.GetLogger("juju.apiserver.charmrevisionupdater"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := updater.UpdateLatestRevisions()
+	result, err := updater.UpdateLatestRevisions(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 }

--- a/apiserver/facades/controller/cleaner/cleaner.go
+++ b/apiserver/facades/controller/cleaner/cleaner.go
@@ -7,6 +7,8 @@
 package cleaner
 
 import (
+	"context"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/rpc/params"
@@ -20,12 +22,12 @@ type CleanerAPI struct {
 }
 
 // Cleanup triggers a state cleanup
-func (api *CleanerAPI) Cleanup() error {
+func (api *CleanerAPI) Cleanup(ctx context.Context) error {
 	return api.st.Cleanup()
 }
 
 // WatchCleanups watches for cleanups to be performed in state.
-func (api *CleanerAPI) WatchCleanups() (params.NotifyWatchResult, error) {
+func (api *CleanerAPI) WatchCleanups(ctx context.Context) (params.NotifyWatchResult, error) {
 	watch := api.st.WatchCleanups()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{

--- a/apiserver/facades/controller/cleaner/cleaner_test.go
+++ b/apiserver/facades/controller/cleaner/cleaner_test.go
@@ -4,6 +4,8 @@
 package cleaner_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -59,7 +61,7 @@ func (s *CleanerSuite) TestNewCleanerAPIRequiresController(c *gc.C) {
 }
 
 func (s *CleanerSuite) TestWatchCleanupsSuccess(c *gc.C) {
-	_, err := s.api.WatchCleanups()
+	_, err := s.api.WatchCleanups(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c, "WatchCleanups")
 }
@@ -68,21 +70,21 @@ func (s *CleanerSuite) TestWatchCleanupsFailure(c *gc.C) {
 	s.st.SetErrors(errors.New("boom!"))
 	s.st.watchCleanupsFails = true
 
-	result, err := s.api.WatchCleanups()
+	result, err := s.api.WatchCleanups(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error.Error(), gc.Equals, "boom!")
 	s.st.CheckCallNames(c, "WatchCleanups")
 }
 
 func (s *CleanerSuite) TestCleanupSuccess(c *gc.C) {
-	err := s.api.Cleanup()
+	err := s.api.Cleanup(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c, "Cleanup")
 }
 
 func (s *CleanerSuite) TestCleanupFailure(c *gc.C) {
 	s.st.SetErrors(errors.New("Boom!"))
-	err := s.api.Cleanup()
+	err := s.api.Cleanup(context.Background())
 	c.Assert(err, gc.ErrorMatches, "Boom!")
 	s.st.CheckCallNames(c, "Cleanup")
 }

--- a/apiserver/facades/controller/crosscontroller/crosscontroller.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller.go
@@ -4,6 +4,8 @@
 package crosscontroller
 
 import (
+	"context"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/rpc/params"
@@ -40,7 +42,7 @@ func NewCrossControllerAPI(
 
 // WatchControllerInfo creates a watcher that notifies when the API info
 // for the controller changes.
-func (api *CrossControllerAPI) WatchControllerInfo() (params.NotifyWatchResults, error) {
+func (api *CrossControllerAPI) WatchControllerInfo(ctx context.Context) (params.NotifyWatchResults, error) {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, 1),
 	}
@@ -54,7 +56,7 @@ func (api *CrossControllerAPI) WatchControllerInfo() (params.NotifyWatchResults,
 }
 
 // ControllerInfo returns the API info for the controller.
-func (api *CrossControllerAPI) ControllerInfo() (params.ControllerAPIInfoResults, error) {
+func (api *CrossControllerAPI) ControllerInfo(ctx context.Context) (params.ControllerAPIInfoResults, error) {
 	results := params.ControllerAPIInfoResults{
 		Results: make([]params.ControllerAPIInfoResult, 1),
 	}

--- a/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
@@ -4,6 +4,7 @@
 package crosscontroller_test
 
 import (
+	"context"
 	"errors"
 
 	jc "github.com/juju/testing/checkers"
@@ -53,7 +54,7 @@ func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CrossControllerSuite) TestControllerInfo(c *gc.C) {
-	results, err := s.api.ControllerInfo()
+	results, err := s.api.ControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{
 		[]params.ControllerAPIInfoResult{{
@@ -65,7 +66,7 @@ func (s *CrossControllerSuite) TestControllerInfo(c *gc.C) {
 
 func (s *CrossControllerSuite) TestControllerInfoWithDNSAddress(c *gc.C) {
 	s.publicDnsAddress = "publicDNSaddr"
-	results, err := s.api.ControllerInfo()
+	results, err := s.api.ControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{
 		[]params.ControllerAPIInfoResult{{
@@ -79,7 +80,7 @@ func (s *CrossControllerSuite) TestControllerInfoError(c *gc.C) {
 	s.localControllerInfo = func() ([]string, string, error) {
 		return nil, "", errors.New("nope")
 	}
-	results, err := s.api.ControllerInfo()
+	results, err := s.api.ControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{
 		[]params.ControllerAPIInfoResult{{
@@ -90,7 +91,7 @@ func (s *CrossControllerSuite) TestControllerInfoError(c *gc.C) {
 
 func (s *CrossControllerSuite) TestWatchControllerInfo(c *gc.C) {
 	s.watcher.changes <- struct{}{} // initial value
-	results, err := s.api.WatchControllerInfo()
+	results, err := s.api.WatchControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.NotifyWatchResults{
 		[]params.NotifyWatchResult{{
@@ -104,7 +105,7 @@ func (s *CrossControllerSuite) TestWatchControllerInfoError(c *gc.C) {
 	s.watcher.tomb.Kill(errors.New("nope"))
 	close(s.watcher.changes)
 
-	results, err := s.api.WatchControllerInfo()
+	results, err := s.api.WatchControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.NotifyWatchResults{
 		[]params.NotifyWatchResult{{

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -159,7 +159,7 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeVa
 
 	c.Assert(err, jc.ErrorIsNil)
 	suspended := true
-	results, err := s.api.PublishRelationChanges(params.RemoteRelationsChanges{
+	results, err := s.api.PublishRelationChanges(context.Background(), params.RemoteRelationsChanges{
 		Changes: []params.RemoteRelationChangeEvent{
 			{
 				Life:                    lifeValue,
@@ -280,7 +280,7 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 		}, bakery.Op{"offer-uuid", "consume"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.RegisterRemoteRelations(params.RegisterRemoteRelationArgs{
+	results, err := s.api.RegisterRemoteRelations(context.Background(), params.RegisterRemoteRelationArgs{
 		Relations: []params.RegisterRemoteRelationArg{{
 			ApplicationToken:  "app-token",
 			SourceModelTag:    coretesting.ModelTag.String(),
@@ -364,7 +364,7 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 		}, bakery.Op{"db2:db django:db", "relate"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.PublishIngressNetworkChanges(params.IngressNetworksChanges{
+	results, err := s.api.PublishIngressNetworkChanges(context.Background(), params.IngressNetworksChanges{
 		Changes: []params.IngressNetworksChangeEvent{
 			{
 				RelationToken: "token-db2:db django:db",
@@ -407,7 +407,7 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChangesRejected(c *g
 		}, bakery.Op{"db2:db django:db", "relate"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.PublishIngressNetworkChanges(params.IngressNetworksChanges{
+	results, err := s.api.PublishIngressNetworkChanges(context.Background(), params.IngressNetworksChanges{
 		Changes: []params.IngressNetworksChangeEvent{
 			{
 				RelationToken: "token-db2:db django:db",
@@ -459,7 +459,7 @@ func (s *crossmodelRelationsSuite) TestWatchEgressAddressesForRelations(c *gc.C)
 			},
 		},
 	}
-	results, err := s.api.WatchEgressAddressesForRelations(args)
+	results, err := s.api.WatchEgressAddressesForRelations(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error.ErrorCode(), gc.Equals, params.CodeNotFound)
@@ -508,7 +508,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatus(c *gc.C) {
 			},
 		},
 	}
-	results, err := s.api.WatchRelationsSuspendedStatus(args)
+	results, err := s.api.WatchRelationsSuspendedStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error.ErrorCode(), gc.Equals, params.CodeNotFound)
@@ -551,7 +551,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatusRelationNotFound(c *g
 	}
 
 	// First check that when not migrating, we see the relation as dead.
-	results, err := s.api.WatchRelationsSuspendedStatus(args)
+	results, err := s.api.WatchRelationsSuspendedStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -566,7 +566,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatusRelationNotFound(c *g
 	// Now indicate that a migration is active
 	// and ensure that the error flows to us.
 	s.st.migrationActive = true
-	results, err = s.api.WatchRelationsSuspendedStatus(args)
+	results, err = s.api.WatchRelationsSuspendedStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error.Code, gc.Equals, params.CodeNotFound)
@@ -659,7 +659,7 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettings(c *
 		}, bakery.Op{"db2:db django:db", "relate"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.PublishRelationChanges(params.RemoteRelationsChanges{
+	results, err := s.api.PublishRelationChanges(context.Background(), params.RemoteRelationsChanges{
 		Changes: []params.RemoteRelationChangeEvent{
 			{
 				Life:                    life.Alive,
@@ -733,7 +733,7 @@ func (s *crossmodelRelationsSuite) TestResumeRelationPermissionCheck(c *gc.C) {
 		}, bakery.Op{"db2:db django:db", "relate"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.api.PublishRelationChanges(params.RemoteRelationsChanges{
+	results, err := s.api.PublishRelationChanges(context.Background(), params.RemoteRelationsChanges{
 		Changes: []params.RemoteRelationChangeEvent{
 			{
 				Suspended:               ptr(false),
@@ -807,7 +807,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 		}, bakery.Op{"db2:db django:db", "relate"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.api.WatchRelationChanges(params.RemoteEntityArgs{
+	result, err := s.api.WatchRelationChanges(context.Background(), params.RemoteEntityArgs{
 		Args: []params.RemoteEntityArg{{
 			Token:     "token-db2:db django:db",
 			Macaroons: macaroon.Slice{mac.M()},
@@ -902,7 +902,7 @@ func (s *crossmodelRelationsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 			},
 		},
 	}
-	results, err := s.api.WatchConsumedSecretsChanges(args)
+	results, err := s.api.WatchConsumedSecretsChanges(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error, gc.IsNil)

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -67,7 +67,7 @@ func NewCrossModelSecretsAPI(
 }
 
 // GetSecretAccessScope returns the tokens for the access scope of the specified secrets and consumers.
-func (s *CrossModelSecretsAPI) GetSecretAccessScope(args params.GetRemoteSecretAccessArgs) (params.StringResults, error) {
+func (s *CrossModelSecretsAPI) GetSecretAccessScope(ctx stdcontext.Context, args params.GetRemoteSecretAccessArgs) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
@@ -142,7 +142,7 @@ func (s *CrossModelSecretsAPI) checkRelationMacaroons(consumerTag names.Tag, mac
 }
 
 // GetSecretContentInfo returns the secret values for the specified secrets.
-func (s *CrossModelSecretsAPI) GetSecretContentInfo(args params.GetRemoteSecretContentArgs) (params.SecretContentResults, error) {
+func (s *CrossModelSecretsAPI) GetSecretContentInfo(ctx stdcontext.Context, args params.GetRemoteSecretContentArgs) (params.SecretContentResults, error) {
 	result := params.SecretContentResults{
 		Results: make([]params.SecretContentResult, len(args.Args)),
 	}

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -218,7 +218,7 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 			Refresh:          true,
 		}},
 	}
-	results, err := s.facade.GetSecretContentInfo(args)
+	results, err := s.facade.GetSecretContentInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
 		Results: []params.SecretContentResult{{


### PR DESCRIPTION
This PR adds context.Context parameter to:
- controller/actionpruner
- controller/agenttools
- controller/applicationscaler
- controller/caasapplicationprovisioner
- controller/caasfirewaller
- controller/caasmodelconfigmanager
- controller/caasmodeloperator
- controller/caasoperatorupgrader
- controller/caasunitprovisioner
- controller/charmdownloader
- controller/charmrevisionupdater
- controller/cleaner
- controller/crosscontroller
- controller/crossmodelrelations
- controller/crossmodelsecrets 

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/controller/actionpruner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/agenttools/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/applicationscaler/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasapplicationprovisioner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasfirewaller/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasmodelconfigmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasmodeloperator/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasoperatorupgrader/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/charmdownloader/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/cleaner/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/crosscontroller/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/crossmodelrelations/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets/... -gocheck.v 

make build && make install && juju version
juju boostrap lxd lxd
```
