### PR TITLE
[JUJU-4484] Add context.Context in controller/(e-m)* facades

### DIFF
--- a/apiserver/facades/controller/environupgrader/upgrader.go
+++ b/apiserver/facades/controller/environupgrader/upgrader.go
@@ -4,6 +4,8 @@
 package environupgrader
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -62,7 +64,7 @@ func NewFacade(
 
 // ModelEnvironVersion returns the current version of the environ corresponding
 // to each specified model.
-func (f *Facade) ModelEnvironVersion(args params.Entities) (params.IntResults, error) {
+func (f *Facade) ModelEnvironVersion(ctx context.Context, args params.Entities) (params.IntResults, error) {
 	result := params.IntResults{
 		Results: make([]params.IntResult, len(args.Entities)),
 	}
@@ -93,7 +95,7 @@ func (f *Facade) modelEnvironVersion(arg params.Entity) (int, error) {
 // ModelTargetEnvironVersion returns the target version of the environ
 // corresponding to each specified model. The target version is the
 // environ provider's version.
-func (f *Facade) ModelTargetEnvironVersion(args params.Entities) (params.IntResults, error) {
+func (f *Facade) ModelTargetEnvironVersion(ctx context.Context, args params.Entities) (params.IntResults, error) {
 	result := params.IntResults{
 		Results: make([]params.IntResult, len(args.Entities)),
 	}
@@ -131,7 +133,7 @@ func (f *Facade) modelTargetEnvironVersion(arg params.Entity) (int, error) {
 
 // SetModelEnvironVersion sets the current version of the environ corresponding
 // to each specified model.
-func (f *Facade) SetModelEnvironVersion(args params.SetModelEnvironVersions) (params.ErrorResults, error) {
+func (f *Facade) SetModelEnvironVersion(ctx context.Context, args params.SetModelEnvironVersions) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Models)),
 	}
@@ -162,11 +164,11 @@ func (f *Facade) setModelEnvironVersion(arg params.SetModelEnvironVersion) error
 //
 // NOTE(axw) this is currently implemented in terms of state.Model.Watch, so
 // the client may be notified of changes unrelated to the environ version.
-func (f *Facade) WatchModelEnvironVersion(args params.Entities) (params.NotifyWatchResults, error) {
+func (f *Facade) WatchModelEnvironVersion(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	return f.entityWatcher.Watch(args)
 }
 
 // SetModelStatus sets the status of each given model.
-func (f *Facade) SetModelStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (f *Facade) SetModelStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	return f.statusSetter.SetStatus(args)
 }

--- a/apiserver/facades/controller/environupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/environupgrader/upgrader_test.go
@@ -4,6 +4,8 @@
 package environupgrader_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -77,7 +79,7 @@ func (s *EnvironUpgraderSuite) TestAuthNonController(c *gc.C) {
 func (s *EnvironUpgraderSuite) TestModelEnvironVersion(c *gc.C) {
 	facade, err := environupgrader.NewFacade(&s.backend, &s.pool, &s.providers, &s.watcher, &s.statusSetter, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.ModelEnvironVersion(params.Entities{
+	results, err := facade.ModelEnvironVersion(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: modelTag1.String()},
 			{Tag: modelTag2.String()},
@@ -106,7 +108,7 @@ func (s *EnvironUpgraderSuite) TestModelTargetEnvironVersion(c *gc.C) {
 	s.providers.SetErrors(nil, errors.New("blargh"))
 	facade, err := environupgrader.NewFacade(&s.backend, &s.pool, &s.providers, &s.watcher, &s.statusSetter, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.ModelTargetEnvironVersion(params.Entities{
+	results, err := facade.ModelTargetEnvironVersion(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: modelTag1.String()},
 			{Tag: modelTag2.String()},
@@ -143,7 +145,7 @@ func (s *EnvironUpgraderSuite) TestModelTargetEnvironVersion(c *gc.C) {
 func (s *EnvironUpgraderSuite) TestSetModelEnvironVersion(c *gc.C) {
 	facade, err := environupgrader.NewFacade(&s.backend, &s.pool, &s.providers, &s.watcher, &s.statusSetter, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.SetModelEnvironVersion(params.SetModelEnvironVersions{
+	results, err := facade.SetModelEnvironVersion(context.Background(), params.SetModelEnvironVersions{
 		Models: []params.SetModelEnvironVersion{
 			{ModelTag: modelTag1.String(), Version: 1},
 			{ModelTag: "machine-0", Version: 0},
@@ -183,7 +185,7 @@ func (s *EnvironUpgraderSuite) TestSetModelStatus(c *gc.C) {
 
 	facade, err := environupgrader.NewFacade(&s.backend, &s.pool, &s.providers, &s.watcher, &s.statusSetter, &s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := facade.SetModelStatus(args)
+	results, err := facade.SetModelStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, s.statusSetter.results)
 	s.backend.CheckNoCalls(c)

--- a/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
@@ -44,7 +44,7 @@ func NewAPI(
 
 // WatchExternalControllers watches for the addition and removal of external
 // controller records to the local controller's database.
-func (api *ExternalControllerUpdaterAPI) WatchExternalControllers() (params.StringsWatchResults, error) {
+func (api *ExternalControllerUpdaterAPI) WatchExternalControllers(ctx context.Context) (params.StringsWatchResults, error) {
 	w, err := api.ecService.Watch()
 	if err != nil {
 		return params.StringsWatchResults{
@@ -70,7 +70,7 @@ func (api *ExternalControllerUpdaterAPI) WatchExternalControllers() (params.Stri
 }
 
 // ExternalControllerInfo returns the info for the specified external controllers.
-func (s *ExternalControllerUpdaterAPI) ExternalControllerInfo(args params.Entities) (params.ExternalControllerInfoResults, error) {
+func (s *ExternalControllerUpdaterAPI) ExternalControllerInfo(ctx context.Context, args params.Entities) (params.ExternalControllerInfoResults, error) {
 	result := params.ExternalControllerInfoResults{
 		Results: make([]params.ExternalControllerInfoResult, len(args.Entities)),
 	}
@@ -96,7 +96,7 @@ func (s *ExternalControllerUpdaterAPI) ExternalControllerInfo(args params.Entiti
 }
 
 // SetExternalControllerInfo saves the info for the specified external controllers.
-func (s *ExternalControllerUpdaterAPI) SetExternalControllerInfo(args params.SetExternalControllersInfoParams) (params.ErrorResults, error) {
+func (s *ExternalControllerUpdaterAPI) SetExternalControllerInfo(ctx context.Context, args params.SetExternalControllersInfoParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Controllers)),
 	}

--- a/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater_test.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater_test.go
@@ -4,6 +4,8 @@
 package externalcontrollerupdater_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -52,7 +54,7 @@ func (s *CrossControllerSuite) TestExternalControllerInfo(c *gc.C) {
 
 	api, err := externalcontrollerupdater.NewAPI(s.resources, ecService)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := api.ExternalControllerInfo(params.Entities{
+	results, err := api.ExternalControllerInfo(context.Background(), params.Entities{
 		Entities: []params.Entity{
 			{coretesting.ControllerTag.String()},
 			{"controller-" + coretesting.ModelTag.Id()},
@@ -108,7 +110,7 @@ func (s *CrossControllerSuite) TestSetExternalControllerInfo(c *gc.C) {
 	api, err := externalcontrollerupdater.NewAPI(s.resources, ecService)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := api.SetExternalControllerInfo(params.SetExternalControllersInfoParams{
+	results, err := api.SetExternalControllerInfo(context.Background(), params.SetExternalControllersInfoParams{
 		[]params.SetExternalControllerInfoParams{{
 			params.ExternalControllerInfo{
 				ControllerTag: firstControllerTag,
@@ -156,7 +158,7 @@ func (s *CrossControllerSuite) TestWatchExternalControllers(c *gc.C) {
 
 	changes <- []string{"a", "b"} // initial value
 
-	results, err := api.WatchExternalControllers()
+	results, err := api.WatchExternalControllers(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.StringsWatchResults{
 		[]params.StringsWatchResult{{
@@ -184,7 +186,7 @@ func (s *CrossControllerSuite) TestWatchControllerInfoError(c *gc.C) {
 	api, err := externalcontrollerupdater.NewAPI(s.resources, ecService)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := api.WatchExternalControllers()
+	results, err := api.WatchExternalControllers(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.StringsWatchResults{
 		[]params.StringsWatchResult{{

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -4,6 +4,7 @@
 package firewaller
 
 import (
+	"context"
 	"sort"
 	"strconv"
 
@@ -127,7 +128,7 @@ func NewStateFirewallerAPI(
 
 // WatchOpenedPorts returns a new StringsWatcher for each given
 // model tag.
-func (f *FirewallerAPI) WatchOpenedPorts(args params.Entities) (params.StringsWatchResults, error) {
+func (f *FirewallerAPI) WatchOpenedPorts(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -172,7 +173,7 @@ func (f *FirewallerAPI) watchOneModelOpenedPorts(tag names.Tag) (string, []strin
 
 // ModelFirewallRules returns the firewall rules that this model is
 // configured to open
-func (f *FirewallerAPI) ModelFirewallRules() (params.IngressRulesResult, error) {
+func (f *FirewallerAPI) ModelFirewallRules(ctx context.Context) (params.IngressRulesResult, error) {
 	cfg, err := f.st.ModelConfig()
 	if err != nil {
 		return params.IngressRulesResult{Error: apiservererrors.ServerError(err)}, nil
@@ -204,7 +205,7 @@ func (f *FirewallerAPI) ModelFirewallRules() (params.IngressRulesResult, error) 
 
 // WatchModelFirewallRules returns a NotifyWatcher that notifies of
 // potential changes to a model's configured firewall rules
-func (f *FirewallerAPI) WatchModelFirewallRules() (params.NotifyWatchResult, error) {
+func (f *FirewallerAPI) WatchModelFirewallRules(ctx context.Context) (params.NotifyWatchResult, error) {
 	watch, err := NewModelFirewallRulesWatcher(f.st)
 	if err != nil {
 		return params.NotifyWatchResult{Error: apiservererrors.ServerError(err)}, nil
@@ -220,7 +221,7 @@ func (f *FirewallerAPI) WatchModelFirewallRules() (params.NotifyWatchResult, err
 
 // GetAssignedMachine returns the assigned machine tag (if any) for
 // each given unit.
-func (f *FirewallerAPI) GetAssignedMachine(args params.Entities) (params.StringResults, error) {
+func (f *FirewallerAPI) GetAssignedMachine(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}
@@ -314,13 +315,13 @@ func (f *FirewallerAPI) getMachine(canAccess common.AuthFunc, tag names.MachineT
 // WatchEgressAddressesForRelations creates a watcher that notifies when addresses, from which
 // connections will originate for the relation, change.
 // Each event contains the entire set of addresses which are required for ingress for the relation.
-func (f *FirewallerAPI) WatchEgressAddressesForRelations(relations params.Entities) (params.StringsWatchResults, error) {
+func (f *FirewallerAPI) WatchEgressAddressesForRelations(ctx context.Context, relations params.Entities) (params.StringsWatchResults, error) {
 	return firewall.WatchEgressAddressesForRelations(f.resources, f.st, relations)
 }
 
 // WatchIngressAddressesForRelations creates a watcher that returns the ingress networks
 // that have been recorded against the specified relations.
-func (f *FirewallerAPI) WatchIngressAddressesForRelations(relations params.Entities) (params.StringsWatchResults, error) {
+func (f *FirewallerAPI) WatchIngressAddressesForRelations(ctx context.Context, relations params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		make([]params.StringsWatchResult, len(relations.Entities)),
 	}
@@ -357,7 +358,7 @@ func (f *FirewallerAPI) WatchIngressAddressesForRelations(relations params.Entit
 }
 
 // MacaroonForRelations returns the macaroon for the specified relations.
-func (f *FirewallerAPI) MacaroonForRelations(args params.Entities) (params.MacaroonResults, error) {
+func (f *FirewallerAPI) MacaroonForRelations(ctx context.Context, args params.Entities) (params.MacaroonResults, error) {
 	var result params.MacaroonResults
 	result.Results = make([]params.MacaroonResult, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -377,7 +378,7 @@ func (f *FirewallerAPI) MacaroonForRelations(args params.Entities) (params.Macar
 }
 
 // SetRelationsStatus sets the status for the specified relations.
-func (f *FirewallerAPI) SetRelationsStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (f *FirewallerAPI) SetRelationsStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	result.Results = make([]params.ErrorResult, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -402,7 +403,7 @@ func (f *FirewallerAPI) SetRelationsStatus(args params.SetStatus) (params.ErrorR
 
 // AreManuallyProvisioned returns whether each given entity is
 // manually provisioned or not. Only machine tags are accepted.
-func (f *FirewallerAPI) AreManuallyProvisioned(args params.Entities) (params.BoolResults, error) {
+func (f *FirewallerAPI) AreManuallyProvisioned(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	result := params.BoolResults{
 		Results: make([]params.BoolResult, len(args.Entities)),
 	}
@@ -429,7 +430,7 @@ func (f *FirewallerAPI) AreManuallyProvisioned(args params.Entities) (params.Boo
 // specified machines where each result is broken down by unit. The list of
 // opened ports for each unit is further grouped by endpoint name and includes
 // the subnet CIDRs that belong to the space that each endpoint is bound to.
-func (f *FirewallerAPI) OpenedMachinePortRanges(args params.Entities) (params.OpenMachinePortRangesResults, error) {
+func (f *FirewallerAPI) OpenedMachinePortRanges(ctx context.Context, args params.Entities) (params.OpenMachinePortRangesResults, error) {
 	result := params.OpenMachinePortRangesResults{
 		Results: make([]params.OpenMachinePortRangesResult, len(args.Entities)),
 	}
@@ -567,7 +568,7 @@ func mapUnitPortsAndResolveSubnetCIDRs(portRangesByEndpoint network.GroupedPortR
 
 // GetExposeInfo returns the expose flag and per-endpoint expose settings
 // for the specified applications.
-func (f *FirewallerAPI) GetExposeInfo(args params.Entities) (params.ExposeInfoResults, error) {
+func (f *FirewallerAPI) GetExposeInfo(ctx context.Context, args params.Entities) (params.ExposeInfoResults, error) {
 	canAccess, err := f.accessApplication()
 	if err != nil {
 		return params.ExposeInfoResults{}, err
@@ -610,7 +611,7 @@ func (f *FirewallerAPI) GetExposeInfo(args params.Entities) (params.ExposeInfoRe
 
 // SpaceInfos returns a comprehensive representation of either all spaces or
 // a filtered subset of the known spaces and their associated subnet details.
-func (f *FirewallerAPI) SpaceInfos(args params.SpaceInfosParams) (params.SpaceInfos, error) {
+func (f *FirewallerAPI) SpaceInfos(ctx context.Context, args params.SpaceInfosParams) (params.SpaceInfos, error) {
 	if !f.authorizer.AuthController() {
 		return params.SpaceInfos{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
 	}
@@ -640,7 +641,7 @@ func (f *FirewallerAPI) SpaceInfos(args params.SpaceInfosParams) (params.SpaceIn
 
 // WatchSubnets returns a new StringsWatcher that watches the specified
 // subnet tags or all tags if no entities are specified.
-func (f *FirewallerAPI) WatchSubnets(args params.Entities) (params.StringsWatchResult, error) {
+func (f *FirewallerAPI) WatchSubnets(ctx context.Context, args params.Entities) (params.StringsWatchResult, error) {
 	if !f.authorizer.AuthController() {
 		return params.StringsWatchResult{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
 	}

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -355,7 +357,7 @@ func (s *firewallerBaseSuite) testWatchUnits(
 func (s *firewallerBaseSuite) testGetAssignedMachine(
 	c *gc.C,
 	facade interface {
-		GetAssignedMachine(args params.Entities) (params.StringResults, error)
+		GetAssignedMachine(ctx context.Context, args params.Entities) (params.StringResults, error)
 	},
 ) {
 	// Unassign a unit first.
@@ -367,7 +369,7 @@ func (s *firewallerBaseSuite) testGetAssignedMachine(
 		{Tag: s.units[1].Tag().String()},
 		{Tag: s.units[2].Tag().String()},
 	}})
-	result, err := facade.GetAssignedMachine(args)
+	result, err := facade.GetAssignedMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -390,7 +392,7 @@ func (s *firewallerBaseSuite) testGetAssignedMachine(
 	args = params.Entities{Entities: []params.Entity{
 		{Tag: s.units[2].Tag().String()},
 	}}
-	result, err = facade.GetAssignedMachine(args)
+	result, err = facade.GetAssignedMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -4,6 +4,7 @@
 package firewaller_test
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -158,7 +159,7 @@ func (s *firewallerSuite) TestWatchOpenedPorts(c *gc.C) {
 		{Tag: s.application.Tag().String()},
 		{Tag: s.units[0].Tag().String()},
 	}})
-	result, err := s.firewaller.WatchOpenedPorts(args)
+	result, err := s.firewaller.WatchOpenedPorts(context.Background(), args)
 	sort.Strings(result.Results[0].Changes)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
@@ -207,7 +208,7 @@ func (s *firewallerSuite) TestAreManuallyProvisioned(c *gc.C) {
 		{Tag: s.units[0].Tag().String()},
 	}})
 
-	result, err := s.firewaller.AreManuallyProvisioned(args)
+	result, err := s.firewaller.AreManuallyProvisioned(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -241,7 +242,7 @@ func (s *firewallerSuite) TestGetExposeInfo(c *gc.C) {
 	args := addFakeEntities(params.Entities{Entities: []params.Entity{
 		{Tag: s.application.Tag().String()},
 	}})
-	result, err := s.firewaller.GetExposeInfo(args)
+	result, err := s.firewaller.GetExposeInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ExposeInfoResults{
 		Results: []params.ExposeInfoResult{
@@ -270,7 +271,7 @@ func (s *firewallerSuite) TestGetExposeInfo(c *gc.C) {
 	args = params.Entities{Entities: []params.Entity{
 		{Tag: s.application.Tag().String()},
 	}}
-	result, err = s.firewaller.GetExposeInfo(args)
+	result, err = s.firewaller.GetExposeInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ExposeInfoResults{
 		Results: []params.ExposeInfoResult{
@@ -332,7 +333,7 @@ drain:
 		entities.Entities[i].Tag = tag.String()
 	}
 
-	got, err := s.firewaller.WatchSubnets(entities)
+	got, err := s.firewaller.WatchSubnets(context.Background(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	want := params.StringsWatchResult{
 		StringsWatcherId: "1",

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -67,6 +69,7 @@ func (s *RemoteFirewallerSuite) TestWatchIngressAddressesForRelations(c *gc.C) {
 	s.st.EXPECT().KeyRelation("remote-db2:db django:db").Return(db2Relation, nil)
 
 	result, err := s.api.WatchIngressAddressesForRelations(
+		context.Background(),
 		params.Entities{Entities: []params.Entity{{
 			Tag: names.NewRelationTag("remote-db2:db django:db").String(),
 		}}},
@@ -92,6 +95,7 @@ func (s *RemoteFirewallerSuite) TestMacaroonForRelations(c *gc.C) {
 	s.st.EXPECT().GetMacaroon(entity).Return(mac, nil)
 
 	result, err := s.api.MacaroonForRelations(
+		context.Background(),
 		params.Entities{Entities: []params.Entity{{
 			Tag: entity.String(),
 		}}},
@@ -112,6 +116,7 @@ func (s *RemoteFirewallerSuite) TestSetRelationStatus(c *gc.C) {
 	s.st.EXPECT().KeyRelation("remote-db2:db django:db").Return(db2Relation, nil)
 
 	result, err := s.api.SetRelationsStatus(
+		context.Background(),
 		params.SetStatus{Entities: []params.EntityStatusArgs{{
 			Tag:    entity.String(),
 			Status: "suspended",
@@ -169,7 +174,7 @@ func (s *FirewallerSuite) TestModelFirewallRules(c *gc.C) {
 	s.st.EXPECT().ControllerConfig().Return(controller.NewConfig(coretesting.ControllerTag.Id(), coretesting.CACert, map[string]interface{}{}))
 	s.st.EXPECT().IsController().Return(false)
 
-	rules, err := s.api.ModelFirewallRules()
+	rules, err := s.api.ModelFirewallRules(context.Background())
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rules, gc.DeepEquals, params.IngressRulesResult{Rules: []params.IngressRule{{
@@ -193,7 +198,7 @@ func (s *FirewallerSuite) TestModelFirewallRulesController(c *gc.C) {
 	s.st.EXPECT().ControllerConfig().Return(controller.NewConfig(coretesting.ControllerTag.Id(), coretesting.CACert, ctrlAttrs))
 	s.st.EXPECT().IsController().Return(true)
 
-	rules, err := s.api.ModelFirewallRules()
+	rules, err := s.api.ModelFirewallRules(context.Background())
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rules, gc.DeepEquals, params.IngressRulesResult{Rules: []params.IngressRule{{
@@ -223,7 +228,7 @@ func (s *FirewallerSuite) TestWatchModelFirewallRules(c *gc.C) {
 	s.st.EXPECT().WatchForModelConfigChanges().Return(w)
 	s.st.EXPECT().ModelConfig().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 
-	result, err := s.api.WatchModelFirewallRules()
+	result, err := s.api.WatchModelFirewallRules(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.NotifyWatcherId, gc.Equals, "1")
@@ -287,7 +292,7 @@ func (s *FirewallerSuite) TestOpenedMachinePortRanges(c *gc.C) {
 			{Tag: names.NewMachineTag("0").String()},
 		},
 	}
-	res, err := s.api.OpenedMachinePortRanges(req)
+	res, err := s.api.OpenedMachinePortRanges(context.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 
@@ -351,7 +356,7 @@ func (s *FirewallerSuite) TestAllSpaceInfos(c *gc.C) {
 	req := params.SpaceInfosParams{
 		FilterBySpaceIDs: []string{network.AlphaSpaceId, "42"},
 	}
-	res, err := s.api.SpaceInfos(req)
+	res, err := s.api.SpaceInfos(context.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Hydrate a network.SpaceInfos from the response

--- a/apiserver/facades/controller/imagemetadata/metadata.go
+++ b/apiserver/facades/controller/imagemetadata/metadata.go
@@ -3,11 +3,15 @@
 
 package imagemetadata
 
+import (
+	"context"
+)
+
 // API is a dummy struct for compatibility.
 type API struct{}
 
 // UpdateFromPublishedImages is now a no-op.
 // It is retained for compatibility.
-func (api *API) UpdateFromPublishedImages() error {
+func (api *API) UpdateFromPublishedImages(ctx context.Context) error {
 	return nil
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -4,6 +4,8 @@
 package instancepoller
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -115,6 +117,7 @@ func (a *InstancePollerAPI) getOneMachine(tag string, canAccess common.AuthFunc)
 // link layer devices (and their addresses) and merge in any missing
 // provider-specific information.
 func (a *InstancePollerAPI) SetProviderNetworkConfig(
+	ctx context.Context,
 	req params.SetProviderNetworkConfig,
 ) (params.SetProviderNetworkConfigResults, error) {
 	result := params.SetProviderNetworkConfigResults{
@@ -270,7 +273,7 @@ func spaceInfoForAddress(
 
 // ProviderAddresses returns the list of all known provider addresses
 // for each given entity. Only machine tags are accepted.
-func (a *InstancePollerAPI) ProviderAddresses(args params.Entities) (params.MachineAddressesResults, error) {
+func (a *InstancePollerAPI) ProviderAddresses(ctx context.Context, args params.Entities) (params.MachineAddressesResults, error) {
 	result := params.MachineAddressesResults{
 		Results: make([]params.MachineAddressesResult, len(args.Entities)),
 	}
@@ -299,7 +302,7 @@ func (a *InstancePollerAPI) ProviderAddresses(args params.Entities) (params.Mach
 
 // SetProviderAddresses updates the list of known provider addresses
 // for each given entity. Only machine tags are accepted.
-func (a *InstancePollerAPI) SetProviderAddresses(args params.SetMachinesAddresses) (params.ErrorResults, error) {
+func (a *InstancePollerAPI) SetProviderAddresses(ctx context.Context, args params.SetMachinesAddresses) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.MachineAddresses)),
 	}
@@ -328,7 +331,7 @@ func (a *InstancePollerAPI) SetProviderAddresses(args params.SetMachinesAddresse
 
 // InstanceStatus returns the instance status for each given entity.
 // Only machine tags are accepted.
-func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StatusResults, error) {
+func (a *InstancePollerAPI) InstanceStatus(ctx context.Context, args params.Entities) (params.StatusResults, error) {
 	result := params.StatusResults{
 		Results: make([]params.StatusResult, len(args.Entities)),
 	}
@@ -355,7 +358,7 @@ func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StatusR
 
 // SetInstanceStatus updates the instance status for each given entity.
 // Only machine tags are accepted.
-func (a *InstancePollerAPI) SetInstanceStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (a *InstancePollerAPI) SetInstanceStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -388,7 +391,7 @@ func (a *InstancePollerAPI) SetInstanceStatus(args params.SetStatus) (params.Err
 
 // AreManuallyProvisioned returns whether each given entity is
 // manually provisioned or not. Only machine tags are accepted.
-func (a *InstancePollerAPI) AreManuallyProvisioned(args params.Entities) (params.BoolResults, error) {
+func (a *InstancePollerAPI) AreManuallyProvisioned(ctx context.Context, args params.Entities) (params.BoolResults, error) {
 	result := params.BoolResults{
 		Results: make([]params.BoolResult, len(args.Entities)),
 	}

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -4,6 +4,7 @@
 package instancepoller_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -439,7 +440,7 @@ func (s *InstancePollerSuite) TestProviderAddressesSuccess(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: addrs})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
 
-	result, err := s.api.ProviderAddresses(s.mixedEntities)
+	result, err := s.api.ProviderAddresses(context.Background(), s.mixedEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MachineAddressesResults{
 		Results: []params.MachineAddressesResult{
@@ -472,7 +473,7 @@ func (s *InstancePollerSuite) TestProviderAddressesFailure(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1"})
 	s.st.SetMachineInfo(c, machineInfo{id: "2"})
 
-	result, err := s.api.ProviderAddresses(s.machineEntities)
+	result, err := s.api.ProviderAddresses(context.Background(), s.machineEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MachineAddressesResults{
 		Results: []params.MachineAddressesResult{
@@ -499,7 +500,7 @@ func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: oldAddrs})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
 
-	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
+	result, err := s.api.SetProviderAddresses(context.Background(), params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
 			{Tag: "machine-1", Addresses: nil},
 			{Tag: "machine-2", Addresses: toParamAddresses(newAddrs)},
@@ -543,7 +544,7 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: oldAddrs})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
 
-	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
+	result, err := s.api.SetProviderAddresses(context.Background(), params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
 			{Tag: "machine-1"},
 			{Tag: "machine-2", Addresses: toParamAddresses(newAddrs)},
@@ -582,7 +583,7 @@ func (s *InstancePollerSuite) TestInstanceStatusSuccess(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: statusInfo("")})
 
-	result, err := s.api.InstanceStatus(s.mixedEntities)
+	result, err := s.api.InstanceStatus(context.Background(), s.mixedEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
@@ -615,7 +616,7 @@ func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: statusInfo("")})
 
-	result, err := s.api.InstanceStatus(s.machineEntities)
+	result, err := s.api.InstanceStatus(context.Background(), s.machineEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
@@ -635,7 +636,7 @@ func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: statusInfo("")})
 
-	result, err := s.api.SetInstanceStatus(params.SetStatus{
+	result, err := s.api.SetInstanceStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-1", Status: ""},
 			{Tag: "machine-2", Status: "new status"},
@@ -685,7 +686,7 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: statusInfo("")})
 
-	result, err := s.api.SetInstanceStatus(params.SetStatus{
+	result, err := s.api.SetInstanceStatus(context.Background(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-1", Status: "new"},
 			{Tag: "machine-2", Status: "invalid"},
@@ -706,7 +707,7 @@ func (s *InstancePollerSuite) TestAreManuallyProvisionedSuccess(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", isManual: true})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", isManual: false})
 
-	result, err := s.api.AreManuallyProvisioned(s.mixedEntities)
+	result, err := s.api.AreManuallyProvisioned(context.Background(), s.mixedEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -738,7 +739,7 @@ func (s *InstancePollerSuite) TestAreManuallyProvisionedFailure(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", isManual: true})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", isManual: false})
 
-	result, err := s.api.AreManuallyProvisioned(s.machineEntities)
+	result, err := s.api.AreManuallyProvisioned(context.Background(), s.machineEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -759,7 +760,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
 
 	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
 
-	results, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	results, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",
@@ -869,7 +870,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigNoChange(c *gc.C) {
 		},
 	})
 
-	results, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	results, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",
@@ -938,7 +939,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigNoChange(c *gc.C) {
 func (s *InstancePollerSuite) TestSetProviderNetworkConfigNotAlive(c *gc.C) {
 	s.st.SetMachineInfo(c, machineInfo{id: "1", life: state.Dying})
 
-	results, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	results, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{{
 			Tag: "machine-1",
 			Configs: []params.NetworkConfig{{
@@ -980,7 +981,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 		addresses:        []networkingcommon.LinkLayerAddress{addr},
 	})
 
-	result, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	result, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag:     "machine-1",
@@ -1035,7 +1036,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 		addresses:        []networkingcommon.LinkLayerAddress{addr},
 	})
 
-	result, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	result, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",
@@ -1113,7 +1114,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkProviderIDGoesToEthernetDev(
 		addresses:        []networkingcommon.LinkLayerAddress{},
 	})
 
-	result, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	result, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",
@@ -1167,7 +1168,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkProviderIDMultipleRefsError(
 	})
 
 	// Same provider ID for both.
-	result, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+	result, err := s.api.SetProviderNetworkConfig(context.Background(), params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",

--- a/apiserver/facades/controller/logfwd/lastsent.go
+++ b/apiserver/facades/controller/logfwd/lastsent.go
@@ -4,6 +4,7 @@
 package logfwd
 
 import (
+	"context"
 	"io"
 
 	"github.com/juju/errors"
@@ -52,7 +53,7 @@ func NewLogForwardingAPI(st LogForwardingState, auth facade.Authorizer) (*LogFor
 
 // GetLastSent is a bulk call that gets the log forwarding "last sent"
 // record ID for each requested target.
-func (api *LogForwardingAPI) GetLastSent(args params.LogForwardingGetLastSentParams) params.LogForwardingGetLastSentResults {
+func (api *LogForwardingAPI) GetLastSent(ctx context.Context, args params.LogForwardingGetLastSentParams) params.LogForwardingGetLastSentResults {
 	results := make([]params.LogForwardingGetLastSentResult, len(args.IDs))
 	for i, id := range args.IDs {
 		results[i] = api.get(id)
@@ -86,7 +87,7 @@ func (api *LogForwardingAPI) get(id params.LogForwardingID) params.LogForwarding
 
 // SetLastSent is a bulk call that sets the log forwarding "last sent"
 // record ID for each requested target.
-func (api *LogForwardingAPI) SetLastSent(args params.LogForwardingSetLastSentParams) params.ErrorResults {
+func (api *LogForwardingAPI) SetLastSent(ctx context.Context, args params.LogForwardingSetLastSentParams) params.ErrorResults {
 	results := make([]params.ErrorResult, len(args.Params), len(args.Params))
 	for i, arg := range args.Params {
 		results[i].Error = api.set(arg)

--- a/apiserver/facades/controller/logfwd/lastsent_test.go
+++ b/apiserver/facades/controller/logfwd/lastsent_test.go
@@ -4,6 +4,8 @@
 package logfwd_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -66,7 +68,7 @@ func (s *LastSentSuite) TestGetLastSentOne(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	res := api.GetLastSent(params.LogForwardingGetLastSentParams{
+	res := api.GetLastSent(context.Background(), params.LogForwardingGetLastSentParams{
 		IDs: []params.LogForwardingID{{
 			ModelTag: modelTag.String(),
 			Sink:     "spam",
@@ -95,7 +97,7 @@ func (s *LastSentSuite) TestGetLastSentBulk(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	res := api.GetLastSent(params.LogForwardingGetLastSentParams{
+	res := api.GetLastSent(context.Background(), params.LogForwardingGetLastSentParams{
 		IDs: []params.LogForwardingID{{
 			ModelTag: modelTag.String(),
 			Sink:     "spam",
@@ -139,7 +141,7 @@ func (s *LastSentSuite) TestSetLastSentOne(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	res := api.SetLastSent(params.LogForwardingSetLastSentParams{
+	res := api.SetLastSent(context.Background(), params.LogForwardingSetLastSentParams{
 		Params: []params.LogForwardingSetLastSentParam{{
 			LogForwardingID: params.LogForwardingID{
 				ModelTag: modelTag.String(),
@@ -171,7 +173,7 @@ func (s *LastSentSuite) TestSetLastSentBulk(c *gc.C) {
 	model := "deadbeef-2f18-4fd2-967d-db9663db7bea"
 	modelTag := names.NewModelTag(model)
 
-	res := api.SetLastSent(params.LogForwardingSetLastSentParams{
+	res := api.SetLastSent(context.Background(), params.LogForwardingSetLastSentParams{
 		Params: []params.LogForwardingSetLastSentParam{{
 			LogForwardingID: params.LogForwardingID{
 				ModelTag: modelTag.String(),

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -4,6 +4,8 @@
 package machineundertaker
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -41,7 +43,7 @@ func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Autho
 
 // AllMachineRemovals returns tags for all of the machines that have
 // been marked for removal in the requested model.
-func (m *API) AllMachineRemovals(models params.Entities) params.EntitiesResults {
+func (m *API) AllMachineRemovals(ctx context.Context, models params.Entities) params.EntitiesResults {
 	results := make([]params.EntitiesResult, len(models.Entities))
 	for i, entity := range models.Entities {
 		entities, err := m.allRemovalsForTag(entity.Tag)
@@ -71,7 +73,7 @@ func (m *API) allRemovalsForTag(tag string) ([]params.Entity, error) {
 
 // GetMachineProviderInterfaceInfo returns the provider details for
 // all network interfaces attached to the machines requested.
-func (m *API) GetMachineProviderInterfaceInfo(machines params.Entities) params.ProviderInterfaceInfoResults {
+func (m *API) GetMachineProviderInterfaceInfo(ctx context.Context, machines params.Entities) params.ProviderInterfaceInfoResults {
 	results := make([]params.ProviderInterfaceInfoResult, len(machines.Entities))
 	for i, entity := range machines.Entities {
 		results[i].MachineTag = entity.Tag
@@ -113,7 +115,7 @@ func (m *API) getInterfaceInfoForOneMachine(machineTag string) ([]network.Provid
 // CompleteMachineRemovals removes the specified machines from the
 // model database. It should only be called once any provider-level
 // cleanup has been done for those machines.
-func (m *API) CompleteMachineRemovals(machines params.Entities) error {
+func (m *API) CompleteMachineRemovals(ctx context.Context, machines params.Entities) error {
 	machineIDs, err := collectMachineIDs(machines)
 	if err != nil {
 		return errors.Trace(err)
@@ -123,7 +125,7 @@ func (m *API) CompleteMachineRemovals(machines params.Entities) error {
 
 // WatchMachineRemovals returns a watcher that will signal each time a
 // machine is marked for removal.
-func (m *API) WatchMachineRemovals(models params.Entities) params.NotifyWatchResults {
+func (m *API) WatchMachineRemovals(ctx context.Context, models params.Entities) params.NotifyWatchResults {
 	results := make([]params.NotifyWatchResult, len(models.Entities))
 	for i, entity := range models.Entities {
 		id, err := m.watchRemovalsForTag(entity.Tag)

--- a/apiserver/facades/controller/metricsmanager/metricsmanager.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager.go
@@ -4,6 +4,7 @@
 package metricsmanager
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/clock"
@@ -29,8 +30,8 @@ var (
 
 // MetricsManager defines the methods on the metricsmanager API end point.
 type MetricsManager interface {
-	CleanupOldMetrics(arg params.Entities) (params.ErrorResults, error)
-	SendMetrics(args params.Entities) (params.ErrorResults, error)
+	CleanupOldMetrics(ctx context.Context, arg params.Entities) (params.ErrorResults, error)
+	SendMetrics(ctx context.Context, args params.Entities) (params.ErrorResults, error)
 }
 
 // MetricsManagerAPI implements the metrics manager interface and is the concrete
@@ -100,7 +101,7 @@ func NewMetricsManagerAPI(
 // The single arg params is expected to contain and model uuid.
 // Even though the call will delete all metrics across models
 // it serves to validate that the connection has access to at least one model.
-func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.ErrorResults, error) {
+func (api *MetricsManagerAPI) CleanupOldMetrics(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -139,7 +140,7 @@ func (api *MetricsManagerAPI) CleanupOldMetrics(args params.Entities) (params.Er
 
 // AddJujuMachineMetrics adds a metric that counts the number of
 // non-container machines in the current model.
-func (api *MetricsManagerAPI) AddJujuMachineMetrics() error {
+func (api *MetricsManagerAPI) AddJujuMachineMetrics(ctx context.Context) error {
 	sla, err := api.state.SLACredential()
 	if err != nil {
 		return errors.Trace(err)
@@ -186,8 +187,8 @@ func (api *MetricsManagerAPI) AddJujuMachineMetrics() error {
 }
 
 // SendMetrics will send any unsent metrics onto the metric collection service.
-func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorResults, error) {
-	if err := api.AddJujuMachineMetrics(); err != nil {
+func (api *MetricsManagerAPI) SendMetrics(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
+	if err := api.AddJujuMachineMetrics(ctx); err != nil {
 		logger.Warningf("failed to add juju-machines metrics: %v", err)
 	}
 	result := params.ErrorResults{

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -80,7 +80,7 @@ func NewAPI(
 // Watch starts watching for an active migration for the model
 // associated with the API connection. The returned id should be used
 // with the NotifyWatcher facade to receive events.
-func (api *API) Watch() params.NotifyWatchResult {
+func (api *API) Watch(ctx context.Context) params.NotifyWatchResult {
 	watch := api.backend.WatchForMigration()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{
@@ -94,7 +94,7 @@ func (api *API) Watch() params.NotifyWatchResult {
 
 // MigrationStatus returns the details and progress of the latest
 // model migration.
-func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
+func (api *API) MigrationStatus(ctx context.Context) (params.MasterMigrationStatus, error) {
 	empty := params.MasterMigrationStatus{}
 
 	mig, err := api.backend.LatestMigration()
@@ -133,7 +133,7 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 
 // ModelInfo returns essential information about the model to be
 // migrated.
-func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
+func (api *API) ModelInfo(ctx context.Context) (params.MigrationModelInfo, error) {
 	empty := params.MigrationModelInfo{}
 
 	name, err := api.backend.ModelName()
@@ -161,7 +161,7 @@ func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
 
 // SourceControllerInfo returns the details required to connect to
 // the source controller for model migration.
-func (api *API) SourceControllerInfo() (params.MigrationSourceInfo, error) {
+func (api *API) SourceControllerInfo(ctx context.Context) (params.MigrationSourceInfo, error) {
 	empty := params.MigrationSourceInfo{}
 
 	localRelatedModels, err := api.backend.AllLocalRelatedModels()
@@ -198,7 +198,7 @@ func (api *API) SourceControllerInfo() (params.MigrationSourceInfo, error) {
 // SetPhase sets the phase of the active model migration. The provided
 // phase must be a valid phase value, for example QUIESCE" or
 // "ABORT". See the core/migration package for the complete list.
-func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
+func (api *API) SetPhase(ctx context.Context, args params.SetMigrationPhaseArgs) error {
 	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return errors.Annotate(err, "could not get migration")
@@ -215,7 +215,7 @@ func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
 
 // Prechecks performs pre-migration checks on the model and
 // (source) controller.
-func (api *API) Prechecks(arg params.PrechecksArgs) error {
+func (api *API) Prechecks(ctx context.Context, arg params.PrechecksArgs) error {
 	model, err := api.precheckBackend.Model()
 	if err != nil {
 		return errors.Annotate(err, "retrieving model")
@@ -239,7 +239,7 @@ func (api *API) Prechecks(arg params.PrechecksArgs) error {
 // SetStatusMessage sets a human readable status message containing
 // information about the migration's progress. This will be shown in
 // status output shown to the end user.
-func (api *API) SetStatusMessage(args params.SetMigrationStatusMessageArgs) error {
+func (api *API) SetStatusMessage(ctx context.Context, args params.SetMigrationStatusMessageArgs) error {
 	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return errors.Annotate(err, "could not get migration")
@@ -277,13 +277,13 @@ func (api *API) Export(ctx context.Context) (params.SerializedModel, error) {
 
 // ProcessRelations processes any relations that need updating after an export.
 // This should help fix any remoteApplications that have been migrated.
-func (api *API) ProcessRelations(args params.ProcessRelations) error {
+func (api *API) ProcessRelations(ctx context.Context, args params.ProcessRelations) error {
 	return nil
 }
 
 // Reap removes all documents for the model associated with the API
 // connection.
-func (api *API) Reap() error {
+func (api *API) Reap(ctx context.Context) error {
 	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return errors.Trace(err)
@@ -300,7 +300,7 @@ func (api *API) Reap() error {
 
 // WatchMinionReports sets up a watcher which reports when a report
 // for a migration minion has arrived.
-func (api *API) WatchMinionReports() params.NotifyWatchResult {
+func (api *API) WatchMinionReports(ctx context.Context) params.NotifyWatchResult {
 	mig, err := api.backend.LatestMigration()
 	if err != nil {
 		return params.NotifyWatchResult{Error: apiservererrors.ServerError(err)}
@@ -323,7 +323,7 @@ func (api *API) WatchMinionReports() params.NotifyWatchResult {
 
 // MinionReports returns details of the reports made by migration
 // minions to the controller for the current migration phase.
-func (api *API) MinionReports() (params.MinionReports, error) {
+func (api *API) MinionReports(ctx context.Context) (params.MinionReports, error) {
 	var out params.MinionReports
 
 	mig, err := api.backend.LatestMigration()
@@ -372,7 +372,7 @@ func (api *API) MinionReports() (params.MinionReports, error) {
 // MinionReportTimeout returns the configuration value for this controller that
 // indicates how long the migration master worker should wait for minions to
 // reported on phases of a migration.
-func (api *API) MinionReportTimeout() (params.StringResult, error) {
+func (api *API) MinionReportTimeout(ctx context.Context) (params.StringResult, error) {
 	cfg, err := api.backend.ControllerConfig()
 	if err != nil {
 		return params.StringResult{Error: apiservererrors.ServerError(err)}, nil

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -98,7 +98,7 @@ func (s *Suite) TestWatch(c *gc.C) {
 
 	s.backend.EXPECT().WatchForMigration().Return(w)
 
-	result := s.mustMakeAPI(c).Watch()
+	result := s.mustMakeAPI(c).Watch(context.Background())
 	c.Assert(result.Error, gc.IsNil)
 
 	resource := s.resources.Get(result.NotifyWatcherId)
@@ -143,7 +143,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
 	api := s.mustMakeAPI(c)
-	status, err := api.MigrationStatus()
+	status, err := api.MigrationStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(status, gc.DeepEquals, params.MasterMigrationStatus{
@@ -173,7 +173,7 @@ func (s *Suite) TestModelInfo(c *gc.C) {
 	exp.ModelOwner().Return(names.NewUserTag("owner"), nil)
 	exp.AgentVersion().Return(version.MustParse("1.2.3"), nil)
 
-	mod, err := s.mustMakeAPI(c).ModelInfo()
+	mod, err := s.mustMakeAPI(c).ModelInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(mod.UUID, gc.Equals, "model-uuid")
@@ -202,7 +202,7 @@ func (s *Suite) TestSourceControllerInfo(c *gc.C) {
 	}}}
 	s.controllerBackend.EXPECT().APIHostPortsForClients(cfg).Return(apiAddr, nil)
 
-	info, err := s.mustMakeAPI(c).SourceControllerInfo()
+	info, err := s.mustMakeAPI(c).SourceControllerInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(info, jc.DeepEquals, params.MigrationSourceInfo{
@@ -223,7 +223,7 @@ func (s *Suite) TestSetPhase(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	err := s.mustMakeAPI(c).SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	err := s.mustMakeAPI(c).SetPhase(context.Background(), params.SetMigrationPhaseArgs{Phase: "ABORT"})
 	c.Assert(err, jc.ErrorIsNil)
 
 }
@@ -233,12 +233,12 @@ func (s *Suite) TestSetPhaseNoMigration(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(nil, errors.New("boom"))
 
-	err := s.mustMakeAPI(c).SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	err := s.mustMakeAPI(c).SetPhase(context.Background(), params.SetMigrationPhaseArgs{Phase: "ABORT"})
 	c.Assert(err, gc.ErrorMatches, "could not get migration: boom")
 }
 
 func (s *Suite) TestSetPhaseBadPhase(c *gc.C) {
-	err := s.mustMakeAPI(c).SetPhase(params.SetMigrationPhaseArgs{Phase: "wat"})
+	err := s.mustMakeAPI(c).SetPhase(context.Background(), params.SetMigrationPhaseArgs{Phase: "wat"})
 	c.Assert(err, gc.ErrorMatches, `invalid phase: "wat"`)
 }
 
@@ -251,7 +251,7 @@ func (s *Suite) TestSetPhaseError(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	err := s.mustMakeAPI(c).SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	err := s.mustMakeAPI(c).SetPhase(context.Background(), params.SetMigrationPhaseArgs{Phase: "ABORT"})
 	c.Assert(err, gc.ErrorMatches, "failed to set phase: blam")
 }
 
@@ -264,7 +264,7 @@ func (s *Suite) TestSetStatusMessage(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	err := s.mustMakeAPI(c).SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	err := s.mustMakeAPI(c).SetStatusMessage(context.Background(), params.SetMigrationStatusMessageArgs{Message: "foo"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -273,7 +273,7 @@ func (s *Suite) TestSetStatusMessageNoMigration(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(nil, errors.New("boom"))
 
-	err := s.mustMakeAPI(c).SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	err := s.mustMakeAPI(c).SetStatusMessage(context.Background(), params.SetMigrationStatusMessageArgs{Message: "foo"})
 	c.Assert(err, gc.ErrorMatches, "could not get migration: boom")
 }
 
@@ -286,7 +286,7 @@ func (s *Suite) TestSetStatusMessageError(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	err := s.mustMakeAPI(c).SetStatusMessage(params.SetMigrationStatusMessageArgs{Message: "foo"})
+	err := s.mustMakeAPI(c).SetStatusMessage(context.Background(), params.SetMigrationStatusMessageArgs{Message: "foo"})
 	c.Assert(err, gc.ErrorMatches, "failed to set status message: blam")
 }
 
@@ -295,13 +295,13 @@ func (s *Suite) TestPrechecksModelError(c *gc.C) {
 
 	s.precheckBackend.EXPECT().Model().Return(nil, errors.New("boom"))
 
-	err := s.mustMakeAPI(c).Prechecks(params.PrechecksArgs{TargetControllerVersion: version.MustParse("2.9.32")})
+	err := s.mustMakeAPI(c).Prechecks(context.Background(), params.PrechecksArgs{TargetControllerVersion: version.MustParse("2.9.32")})
 	c.Assert(err, gc.ErrorMatches, "retrieving model: boom")
 }
 
 func (s *Suite) TestProcessRelations(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.ProcessRelations(params.ProcessRelations{ControllerAlias: "foo"})
+	err := api.ProcessRelations(context.Background(), params.ProcessRelations{ControllerAlias: "foo"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -457,7 +457,7 @@ func (s *Suite) TestReap(c *gc.C) {
 	exp.RemoveExportingModelDocs().Return(nil)
 	mig.EXPECT().SetPhase(coremigration.DONE).Return(nil)
 
-	err := s.mustMakeAPI(c).Reap()
+	err := s.mustMakeAPI(c).Reap(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 
 }
@@ -471,7 +471,7 @@ func (s *Suite) TestReapError(c *gc.C) {
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 	s.backend.EXPECT().RemoveExportingModelDocs().Return(errors.New("boom"))
 
-	err := s.mustMakeAPI(c).Reap()
+	err := s.mustMakeAPI(c).Reap(context.Background())
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 
@@ -493,7 +493,7 @@ func (s *Suite) TestWatchMinionReports(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	result := s.mustMakeAPI(c).WatchMinionReports()
+	result := s.mustMakeAPI(c).WatchMinionReports(context.Background())
 	c.Assert(result.Error, gc.IsNil)
 
 	resource := s.resources.Get(result.NotifyWatcherId)
@@ -538,7 +538,7 @@ func (s *Suite) TestMinionReports(c *gc.C) {
 
 	s.backend.EXPECT().LatestMigration().Return(mig, nil)
 
-	reports, err := s.mustMakeAPI(c).MinionReports()
+	reports, err := s.mustMakeAPI(c).MinionReports(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Expect the sample of unknowns to be in order and be limited to
@@ -573,7 +573,7 @@ func (s *Suite) TestMinionReportTimeout(c *gc.C) {
 		controller.MigrationMinionWaitMax: timeout,
 	}, nil)
 
-	res, err := s.mustMakeAPI(c).MinionReportTimeout()
+	res, err := s.mustMakeAPI(c).MinionReportTimeout(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Error, gc.IsNil)
 	c.Check(res.Result, gc.Equals, timeout)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -98,7 +98,7 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 
 // Prechecks ensure that the target controller is ready to accept a
 // model migration.
-func (api *API) Prechecks(model params.MigrationModelInfo) error {
+func (api *API) Prechecks(ctx context.Context, model params.MigrationModelInfo) error {
 	ownerTag, err := names.ParseUserTag(model.OwnerTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -169,7 +169,7 @@ func (api *API) getImportingModel(tag string) (*state.Model, func(), error) {
 
 // Abort removes the specified model from the database. It is an error to
 // attempt to Abort a model that has a migration mode other than importing.
-func (api *API) Abort(args params.ModelArgs) error {
+func (api *API) Abort(ctx context.Context, args params.ModelArgs) error {
 	model, releaseModel, err := api.getImportingModel(args.ModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -187,7 +187,7 @@ func (api *API) Abort(args params.ModelArgs) error {
 // Activate sets the migration mode of the model to "none", meaning it
 // is ready for use. It is an error to attempt to Abort a model that
 // has a migration mode other than importing.
-func (api *APIV1) Activate(args params.ModelArgs) error {
+func (api *APIV1) Activate(ctx context.Context, args params.ModelArgs) error {
 	model, release, err := api.getImportingModel(args.ModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -278,7 +278,7 @@ func (api *API) Activate(ctx context.Context, args params.ActivateModelArgs) err
 // can't be used to avoid duplicates when logtransfer is restarted.
 //
 // Returns the zero time if no logs have been transferred.
-func (api *API) LatestLogTime(args params.ModelArgs) (time.Time, error) {
+func (api *API) LatestLogTime(ctx context.Context, args params.ModelArgs) (time.Time, error) {
 	model, release, err := api.getModel(args.ModelTag)
 	if err != nil {
 		return time.Time{}, errors.Trace(err)
@@ -301,7 +301,7 @@ func (api *API) LatestLogTime(args params.ModelArgs) (time.Time, error) {
 // tags for a model's resources. This prevents the resources from
 // being destroyed if the source controller is destroyed after the
 // model is migrated away.
-func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
+func (api *API) AdoptResources(ctx context.Context, args params.AdoptResourcesArgs) error {
 	tag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -336,7 +336,7 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 
 // CheckMachines compares the machines in state with the ones reported
 // by the provider and reports any discrepancies.
-func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error) {
+func (api *API) CheckMachines(ctx context.Context, args params.ModelArgs) (params.ErrorResults, error) {
 	tag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -364,7 +364,7 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 }
 
 // CACert returns the certificate used to validate the state connection.
-func (api *API) CACert() (params.BytesResult, error) {
+func (api *API) CACert(ctx context.Context) (params.BytesResult, error) {
 	cfg, err := api.state.ControllerConfig()
 	if err != nil {
 		return params.BytesResult{}, errors.Trace(err)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -110,13 +110,13 @@ func (s *Suite) TestPrechecks(c *gc.C) {
 		AgentVersion:           s.controllerVersion(c),
 		ControllerAgentVersion: s.controllerVersion(c),
 	}
-	err := api.Prechecks(args)
+	err := api.Prechecks(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *Suite) TestCACert(c *gc.C) {
 	api := s.mustNewAPI(c)
-	r, err := api.CACert()
+	r, err := api.CACert(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(r.Result), gc.Equals, jujutesting.CACert)
 }
@@ -132,7 +132,7 @@ func (s *Suite) TestPrechecksFail(c *gc.C) {
 	args := params.MigrationModelInfo{
 		AgentVersion: modelVersion,
 	}
-	err := api.Prechecks(args)
+	err := api.Prechecks(context.Background(), args)
 	c.Assert(err, gc.NotNil)
 }
 
@@ -151,7 +151,7 @@ func (s *Suite) TestAbort(c *gc.C) {
 	api := s.mustNewAPI(c)
 	tag := s.importModel(c, api)
 
-	err := api.Abort(params.ModelArgs{ModelTag: tag.String()})
+	err := api.Abort(context.Background(), params.ModelArgs{ModelTag: tag.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The model should no longer exist.
@@ -162,14 +162,14 @@ func (s *Suite) TestAbort(c *gc.C) {
 
 func (s *Suite) TestAbortNotATag(c *gc.C) {
 	api := s.mustNewAPI(c)
-	err := api.Abort(params.ModelArgs{ModelTag: "not-a-tag"})
+	err := api.Abort(context.Background(), params.ModelArgs{ModelTag: "not-a-tag"})
 	c.Assert(err, gc.ErrorMatches, `"not-a-tag" is not a valid tag`)
 }
 
 func (s *Suite) TestAbortMissingModel(c *gc.C) {
 	api := s.mustNewAPI(c)
 	newUUID := utils.MustNewUUID().String()
-	err := api.Abort(params.ModelArgs{ModelTag: names.NewModelTag(newUUID).String()})
+	err := api.Abort(context.Background(), params.ModelArgs{ModelTag: names.NewModelTag(newUUID).String()})
 	c.Assert(err, gc.ErrorMatches, `model "`+newUUID+`" not found`)
 }
 
@@ -180,7 +180,7 @@ func (s *Suite) TestAbortNotImportingModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	api := s.mustNewAPI(c)
-	err = api.Abort(params.ModelArgs{ModelTag: model.ModelTag().String()})
+	err = api.Abort(context.Background(), params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, gc.ErrorMatches, `migration mode for the model is not importing`)
 }
 
@@ -269,7 +269,7 @@ func (s *Suite) TestLatestLogTime(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	api := s.mustNewAPI(c)
-	latest, err := api.LatestLogTime(params.ModelArgs{ModelTag: model.ModelTag().String()})
+	latest, err := api.LatestLogTime(context.Background(), params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(latest, gc.Equals, t)
 }
@@ -281,7 +281,7 @@ func (s *Suite) TestLatestLogTimeNeverSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	api := s.mustNewAPI(c)
-	latest, err := api.LatestLogTime(params.ModelArgs{ModelTag: model.ModelTag().String()})
+	latest, err := api.LatestLogTime(context.Background(), params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(latest, gc.Equals, time.Time{})
 }
@@ -302,7 +302,7 @@ func (s *Suite) TestAdoptIAASResources(c *gc.C) {
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = api.AdoptResources(params.AdoptResourcesArgs{
+	err = api.AdoptResources(context.Background(), params.AdoptResourcesArgs{
 		ModelTag:                m.ModelTag().String(),
 		SourceControllerVersion: version.MustParse("3.2.1"),
 	})
@@ -331,7 +331,7 @@ func (s *Suite) TestAdoptCAASResources(c *gc.C) {
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = api.AdoptResources(params.AdoptResourcesArgs{
+	err = api.AdoptResources(context.Background(), params.AdoptResourcesArgs{
 		ModelTag:                m.ModelTag().String(),
 		SourceControllerVersion: version.MustParse("3.2.1"),
 	})
@@ -368,6 +368,7 @@ func (s *Suite) TestCheckMachinesSuccess(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
+		context.Background(),
 		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
@@ -391,6 +392,7 @@ func (s *Suite) TestCheckMachinesHandlesContainers(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
+		context.Background(),
 		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
@@ -417,6 +419,7 @@ func (s *Suite) TestCheckMachinesIgnoresManualMachines(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
+		context.Background(),
 		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
@@ -462,6 +465,7 @@ func (s *Suite) TestCheckMachinesManualCloud(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := api.CheckMachines(
+		context.Background(),
 		params.ModelArgs{ModelTag: model.ModelTag().String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})


### PR DESCRIPTION
This PR adds context.Context parameter to:
- controller/environupgrader
- controller/externalcontrollerupdater
- controller/firewaller
- controller/imagemetadata
- controller/instancepoller
- controller/logfwd
- controller/machineundertaker
- controller/metricsmanager
- controller/migrationmaster
- controller/migrationtarget

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/controller/environupgrader/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/externalcontrollerupdater/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/firewaller/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/imagemetadata/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/instancepoller/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/logfwd/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/machineundertaker/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/metricsmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/migrationmaster/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/migrationtarget/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```