### PR TITLE
[JUJU-4485] Add context.Context in controller/(r-u)* facades

### DIFF
--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -63,7 +63,7 @@ func NewRemoteRelationsAPI(
 }
 
 // ImportRemoteEntities adds entities to the remote entities collection with the specified opaque tokens.
-func (api *API) ImportRemoteEntities(args params.RemoteEntityTokenArgs) (params.ErrorResults, error) {
+func (api *API) ImportRemoteEntities(ctx context.Context, args params.RemoteEntityTokenArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -83,7 +83,7 @@ func (api *API) importRemoteEntity(arg params.RemoteEntityTokenArg) error {
 }
 
 // ExportEntities allocates unique, remote entity IDs for the given entities in the local model.
-func (api *API) ExportEntities(entities params.Entities) (params.TokenResults, error) {
+func (api *API) ExportEntities(ctx context.Context, entities params.Entities) (params.TokenResults, error) {
 	results := params.TokenResults{
 		Results: make([]params.TokenResult, len(entities.Entities)),
 	}
@@ -106,7 +106,7 @@ func (api *API) ExportEntities(entities params.Entities) (params.TokenResults, e
 }
 
 // GetTokens returns the token associated with the entities with the given tags for the given models.
-func (api *API) GetTokens(args params.GetTokenArgs) (params.StringResults, error) {
+func (api *API) GetTokens(ctx context.Context, args params.GetTokenArgs) (params.StringResults, error) {
 	results := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
@@ -126,7 +126,7 @@ func (api *API) GetTokens(args params.GetTokenArgs) (params.StringResults, error
 }
 
 // SaveMacaroons saves the macaroons for the given entities.
-func (api *API) SaveMacaroons(args params.EntityMacaroonArgs) (params.ErrorResults, error) {
+func (api *API) SaveMacaroons(ctx context.Context, args params.EntityMacaroonArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -188,7 +188,7 @@ func (api *API) remoteRelation(entity params.Entity) (*params.RemoteRelation, er
 
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (api *API) Relations(entities params.Entities) (params.RemoteRelationResults, error) {
+func (api *API) Relations(ctx context.Context, entities params.Entities) (params.RemoteRelationResults, error) {
 	results := params.RemoteRelationResults{
 		Results: make([]params.RemoteRelationResult, len(entities.Entities)),
 	}
@@ -205,7 +205,7 @@ func (api *API) Relations(entities params.Entities) (params.RemoteRelationResult
 
 // RemoteApplications returns the current state of the remote applications with
 // the specified names in the local model.
-func (api *API) RemoteApplications(entities params.Entities) (params.RemoteApplicationResults, error) {
+func (api *API) RemoteApplications(ctx context.Context, entities params.Entities) (params.RemoteApplicationResults, error) {
 	results := params.RemoteApplicationResults{
 		Results: make([]params.RemoteApplicationResult, len(entities.Entities)),
 	}
@@ -247,7 +247,7 @@ func (api *API) RemoteApplications(entities params.Entities) (params.RemoteAppli
 // removal, and lifecycle changes of remote applications in the model; and
 // returns the watcher ID and initial IDs of remote applications, or an error if
 // watching failed.
-func (api *API) WatchRemoteApplications() (params.StringsWatchResult, error) {
+func (api *API) WatchRemoteApplications(ctx context.Context) (params.StringsWatchResult, error) {
 	w := api.st.WatchRemoteApplications()
 	// TODO(jam): 2019-10-27 Watching Changes() should be protected with a select with api.ctx.Cancel()
 	if changes, ok := <-w.Changes(); ok {
@@ -262,7 +262,7 @@ func (api *API) WatchRemoteApplications() (params.StringsWatchResult, error) {
 // WatchLocalRelationChanges starts a RemoteRelationWatcher for each
 // specified relation, returning the watcher IDs and initial values,
 // or an error if the remote relations couldn't be watched.
-func (api *API) WatchLocalRelationChanges(args params.Entities) (params.RemoteRelationWatchResults, error) {
+func (api *API) WatchLocalRelationChanges(ctx context.Context, args params.Entities) (params.RemoteRelationWatchResults, error) {
 	results := params.RemoteRelationWatchResults{
 		make([]params.RemoteRelationWatchResult, len(args.Entities)),
 	}
@@ -315,7 +315,7 @@ func (api *API) WatchLocalRelationChanges(args params.Entities) (params.RemoteRe
 // each specified application in the local model, and returns the watcher IDs
 // and initial values, or an error if the services' relations could not be
 // watched.
-func (api *API) WatchRemoteApplicationRelations(args params.Entities) (params.StringsWatchResults, error) {
+func (api *API) WatchRemoteApplicationRelations(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -347,7 +347,7 @@ func (api *API) WatchRemoteApplicationRelations(args params.Entities) (params.St
 // removal, and lifecycle changes of remote relations in the model; and
 // returns the watcher ID and initial IDs of remote relations, or an error if
 // watching failed.
-func (api *API) WatchRemoteRelations() (params.StringsWatchResult, error) {
+func (api *API) WatchRemoteRelations(ctx context.Context) (params.StringsWatchResult, error) {
 	w := api.st.WatchRemoteRelations()
 	// TODO(jam): 2019-10-27 Watching Changes() should be protected with a select with api.ctx.Cancel()
 	if changes, ok := <-w.Changes(); ok {
@@ -361,7 +361,7 @@ func (api *API) WatchRemoteRelations() (params.StringsWatchResult, error) {
 
 // ConsumeRemoteRelationChanges consumes changes to settings originating
 // from the remote/offering side of relations.
-func (api *API) ConsumeRemoteRelationChanges(changes params.RemoteRelationsChanges) (params.ErrorResults, error) {
+func (api *API) ConsumeRemoteRelationChanges(ctx context.Context, changes params.RemoteRelationsChanges) (params.ErrorResults, error) {
 	api.logger.Debugf("ConsumeRemoteRelationChanges: %+v", changes)
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(changes.Changes)),
@@ -390,7 +390,7 @@ func (api *API) ConsumeRemoteRelationChanges(changes params.RemoteRelationsChang
 }
 
 // SetRemoteApplicationsStatus sets the status for the specified remote applications.
-func (api *API) SetRemoteApplicationsStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (api *API) SetRemoteApplicationsStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	result.Results = make([]params.ErrorResult, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -460,7 +460,7 @@ func (api *API) UpdateControllersForModels(ctx context.Context, args params.Upda
 
 // ConsumeRemoteSecretChanges updates the local model with secret revision changes
 // originating from the remote/offering model.
-func (api *API) ConsumeRemoteSecretChanges(args params.LatestSecretRevisionChanges) (params.ErrorResults, error) {
+func (api *API) ConsumeRemoteSecretChanges(ctx context.Context, args params.LatestSecretRevisionChanges) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	result.Results = make([]params.ErrorResult, len(args.Changes))
 	for i, arg := range args.Changes {

--- a/apiserver/facades/controller/secretbackendmanager/backends.go
+++ b/apiserver/facades/controller/secretbackendmanager/backends.go
@@ -4,6 +4,7 @@
 package secretbackendmanager
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -36,7 +37,7 @@ type SecretBackendsManagerAPI struct {
 }
 
 // WatchSecretBackendsRotateChanges sets up a watcher to notify of changes to secret backend rotations.
-func (s *SecretBackendsManagerAPI) WatchSecretBackendsRotateChanges() (params.SecretBackendRotateWatchResult, error) {
+func (s *SecretBackendsManagerAPI) WatchSecretBackendsRotateChanges(ctx context.Context) (params.SecretBackendRotateWatchResult, error) {
 	result := params.SecretBackendRotateWatchResult{}
 	w, err := s.backendRotate.WatchSecretBackendRotationChanges()
 	if err != nil {
@@ -69,7 +70,7 @@ var (
 )
 
 // RotateBackendTokens rotates the tokens for the specified backends.
-func (s *SecretBackendsManagerAPI) RotateBackendTokens(args params.RotateSecretBackendArgs) (params.ErrorResults, error) {
+func (s *SecretBackendsManagerAPI) RotateBackendTokens(ctx context.Context, args params.RotateSecretBackendArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.BackendIDs)),
 	}

--- a/apiserver/facades/controller/secretbackendmanager/backends_test.go
+++ b/apiserver/facades/controller/secretbackendmanager/backends_test.go
@@ -4,6 +4,7 @@
 package secretbackendmanager_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -88,7 +89,7 @@ func (s *SecretsManagerSuite) TestWatchBackendRotateChanges(c *gc.C) {
 	}}
 	s.backendRotateWatcher.EXPECT().Changes().Return(rotateChan)
 
-	result, err := s.facade.WatchSecretBackendsRotateChanges()
+	result, err := s.facade.WatchSecretBackendsRotateChanges(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.SecretBackendRotateWatchResult{
 		WatcherId: "1",
@@ -140,7 +141,7 @@ func (s *SecretsManagerSuite) TestRotateBackendTokens(c *gc.C) {
 	nextRotateTime := s.clock.Now().Add(150 * time.Minute)
 	s.backendState.EXPECT().SecretBackendRotated("backend-id", nextRotateTime).Return(errors.New("boom"))
 
-	result, err := s.facade.RotateBackendTokens(params.RotateSecretBackendArgs{
+	result, err := s.facade.RotateBackendTokens(context.Background(), params.RotateSecretBackendArgs{
 		BackendIDs: []string{"backend-id"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{
@@ -182,7 +183,7 @@ func (s *SecretsManagerSuite) TestRotateBackendTokensRetry(c *gc.C) {
 
 	s.backendState.EXPECT().SecretBackendRotated("backend-id", nextRotateTime).Return(errors.New("boom"))
 
-	result, err := s.facade.RotateBackendTokens(params.RotateSecretBackendArgs{
+	result, err := s.facade.RotateBackendTokens(context.Background(), params.RotateSecretBackendArgs{
 		BackendIDs: []string{"backend-id"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{

--- a/apiserver/facades/controller/singular/singular.go
+++ b/apiserver/facades/controller/singular/singular.go
@@ -87,7 +87,7 @@ func (facade *Facade) Wait(ctx context.Context, args params.Entities) (result pa
 // Claim makes the supplied singular-controller lease requests. (In practice,
 // any requests not for the connection's model or controller, or not on behalf
 // of the connected ModelManager machine, will be rejected.)
-func (facade *Facade) Claim(args params.SingularClaims) (result params.ErrorResults) {
+func (facade *Facade) Claim(ctx context.Context, args params.SingularClaims) (result params.ErrorResults) {
 	result.Results = make([]params.ErrorResult, len(args.Claims))
 	for i, claim := range args.Claims {
 		err := facade.claim(claim)

--- a/apiserver/facades/controller/singular/singular_test.go
+++ b/apiserver/facades/controller/singular/singular_test.go
@@ -71,7 +71,7 @@ func (s *SingularSuite) TestInvalidClaims(c *gc.C) {
 	backend := &mockBackend{}
 	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
-	result := facade.Claim(claims)
+	result := facade.Claim(context.Background(), claims)
 	c.Assert(result.Results, gc.HasLen, count)
 
 	for i, result := range result.Results {
@@ -126,7 +126,7 @@ func (s *SingularSuite) TestValidClaims(c *gc.C) {
 	backend.stub.SetErrors(errors...)
 	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
-	result := facade.Claim(claims)
+	result := facade.Claim(context.Background(), claims)
 	c.Assert(result.Results, gc.HasLen, count)
 
 	for i, err := range result.Results {

--- a/apiserver/facades/controller/statushistory/api.go
+++ b/apiserver/facades/controller/statushistory/api.go
@@ -4,6 +4,8 @@
 package statushistory
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -30,7 +32,7 @@ var Prune = state.PruneStatusHistory
 // Prune endpoint removes status history entries until
 // only the ones newer than now - p.MaxHistoryTime remain and
 // the history is smaller than p.MaxHistoryMB.
-func (api *API) Prune(p params.StatusHistoryPruneArgs) error {
+func (api *API) Prune(ctx context.Context, p params.StatusHistoryPruneArgs) error {
 	if !api.authorizer.AuthController() {
 		return apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/controller/statushistory/pruner_test.go
+++ b/apiserver/facades/controller/statushistory/pruner_test.go
@@ -4,6 +4,7 @@
 package statushistory_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -44,7 +45,7 @@ func (s *StatusHistoryPrunerSuite) TestPruneNonController(c *gc.C) {
 	s.context.Auth_ = testing.FakeAuthorizer{}
 	api, err := statushistory.NewAPI(s.context)
 	c.Assert(err, jc.ErrorIsNil)
-	err = api.Prune(params.StatusHistoryPruneArgs{})
+	err = api.Prune(context.Background(), params.StatusHistoryPruneArgs{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -56,7 +57,7 @@ func (s *StatusHistoryPrunerSuite) TestPrune(c *gc.C) {
 		called = true
 		return nil
 	})
-	err := s.api.Prune(params.StatusHistoryPruneArgs{
+	err := s.api.Prune(context.Background(), params.StatusHistoryPruneArgs{
 		MaxHistoryTime: time.Hour,
 		MaxHistoryMB:   666,
 	})

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -4,6 +4,8 @@
 package undertaker
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -67,7 +69,7 @@ func newUndertakerAPI(st State, resources facade.Resources, authorizer facade.Au
 }
 
 // ModelInfo returns information on the model needed by the undertaker worker.
-func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
+func (u *UndertakerAPI) ModelInfo(ctx context.Context) (params.UndertakerModelInfoResult, error) {
 	result := params.UndertakerModelInfoResult{}
 	model, err := u.st.Model()
 
@@ -90,12 +92,12 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 
 // ProcessDyingModel checks if a dying model has any machines or applications.
 // If there are none, the model's life is changed from dying to dead.
-func (u *UndertakerAPI) ProcessDyingModel() error {
+func (u *UndertakerAPI) ProcessDyingModel(ctx context.Context) error {
 	return u.st.ProcessDyingModel()
 }
 
 // RemoveModel removes any records of this model from Juju.
-func (u *UndertakerAPI) RemoveModel() error {
+func (u *UndertakerAPI) RemoveModel(ctx context.Context) error {
 	secretBackendCfg, err := u.secretBackendConfigGetter()
 	if err != nil {
 		return errors.Annotate(err, "getting secrets backends config")
@@ -130,7 +132,7 @@ func (u *UndertakerAPI) modelEntitiesWatcher() params.NotifyWatchResult {
 
 // WatchModelResources creates watchers for changes to the lifecycle of an
 // model's machines and applications and storage.
-func (u *UndertakerAPI) WatchModelResources() params.NotifyWatchResults {
+func (u *UndertakerAPI) WatchModelResources(ctx context.Context) params.NotifyWatchResults {
 	return params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
 			u.modelEntitiesWatcher(),
@@ -156,7 +158,7 @@ func (u *UndertakerAPI) modelWatcher() params.NotifyWatchResult {
 }
 
 // WatchModel creates a watcher for the current model.
-func (u *UndertakerAPI) WatchModel() params.NotifyWatchResults {
+func (u *UndertakerAPI) WatchModel(ctx context.Context) params.NotifyWatchResults {
 	return params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
 			u.modelWatcher(),

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -4,6 +4,7 @@
 package undertaker_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -99,7 +100,7 @@ func (s *undertakerSuite) TestModelInfo(c *gc.C) {
 		minute := time.Minute
 		test.st.model.timeout = &minute
 
-		result, err := test.api.ModelInfo()
+		result, err := test.api.ModelInfo(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 
 		info := result.Result
@@ -122,12 +123,12 @@ func (s *undertakerSuite) TestProcessDyingModel(c *gc.C) {
 	model, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = hostedAPI.ProcessDyingModel()
+	err = hostedAPI.ProcessDyingModel(context.Background())
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 	c.Assert(model.Life(), gc.Equals, state.Alive)
 
 	otherSt.model.life = state.Dying
-	err = hostedAPI.ProcessDyingModel()
+	err = hostedAPI.ProcessDyingModel(context.Background())
 	c.Assert(err, gc.IsNil)
 	c.Assert(model.Life(), gc.Equals, state.Dead)
 }
@@ -137,7 +138,7 @@ func (s *undertakerSuite) TestRemoveAliveModel(c *gc.C) {
 	_, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = hostedAPI.RemoveModel()
+	err = hostedAPI.RemoveModel(context.Background())
 	c.Assert(err, gc.ErrorMatches, "model not dying or dead")
 }
 
@@ -147,7 +148,7 @@ func (s *undertakerSuite) TestRemoveDyingModel(c *gc.C) {
 	// Set model to dying
 	otherSt.model.life = state.Dying
 
-	c.Assert(hostedAPI.RemoveModel(), jc.ErrorIsNil)
+	c.Assert(hostedAPI.RemoveModel(context.Background()), jc.ErrorIsNil)
 }
 
 func (s *undertakerSuite) TestDeadRemoveModel(c *gc.C) {
@@ -155,10 +156,10 @@ func (s *undertakerSuite) TestDeadRemoveModel(c *gc.C) {
 
 	// Set model to dead
 	otherSt.model.life = state.Dying
-	err := hostedAPI.ProcessDyingModel()
+	err := hostedAPI.ProcessDyingModel(context.Background())
 	c.Assert(err, gc.IsNil)
 
-	err = hostedAPI.RemoveModel()
+	err = hostedAPI.RemoveModel(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(otherSt.removed, jc.IsTrue)


### PR DESCRIPTION
This PR adds context.Context parameter to:
- controller/remoterelations
- controller/secretbackendmanager
- controller/singular
- controller/statushistory
- controller/undertaker

facade calls and fixes the unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/controller/remoterelations/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/secretbackendmanager/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/singular/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/statushistory/... -gocheck.v 
go test github.com/juju/juju/apiserver/facades/controller/undertaker/... -gocheck.v 

make build && make install && juju version
juju bootstrap lxd lxd
```
