### PR TITLE
ci(generate): print the full diff for debugging

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 0 -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           git add -A
           if [[ -n $(git diff HEAD) ]]; then
+            # Print the full diff for debugging purposes
+            git diff HEAD
             echo "*****"
             echo "The following generated files have been modified:"
             git diff --name-status HEAD

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Regenerate code
         shell: bash
-        run: go generate -x ./...
+        run: |
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 0 -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
+          # Running go generate by itself is slow over a large codebase, where
+          # all generate directives are dispersed over many files. Instead, the
+          # following uses tools for locating and extracting the directives,
+          # before piping them to go generate in parallel.
+          #
+          #  1. grep for go generate directive in the go files recursively.
+          #  2. Grab the file name of each select file.
+          #  3. Unique every file, so we only go generate the file once.
+          #  4. Using xargs perform go generate in parallel.
+          #
           grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
 
       - name: Check diff


### PR DESCRIPTION
We've recently been seeing some strange failures in the Generate GitHub action (e.g. [here](https://github.com/juju/juju/actions/runs/5885781405/job/15962709553)):
```
The following generated files have been modified:
M	go.sum
Please regenerate these files and check in the changes.
```

Unfortunately, the output doesn't include the full diff, so it's hard to work out what's going on.

Print the full diff in case of a failure, so we can debug.

Also, backport #15010 to 2.9, so we can get faster runs of this workflow.