### PR TITLE
Fix/lp 2030943

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -300,7 +300,7 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
 		for _, authenticator := range a.srv.loginAuthenticators {
 			var err error
 			authInfo, err = authenticator.AuthenticateLoginRequest(ctx, a.root.serverHost, modelUUID, authParams)
-			if errors.Is(err, errors.NotFound) || errors.Is(err, errors.NotImplemented) {
+			if errors.Is(err, errors.NotFound) || errors.Is(err, errors.NotImplemented) || errors.Is(err, errors.NotSupported) {
 				continue
 			} else if err != nil {
 				return nil, a.handleAuthError(err)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -300,7 +300,7 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
 		for _, authenticator := range a.srv.loginAuthenticators {
 			var err error
 			authInfo, err = authenticator.AuthenticateLoginRequest(ctx, a.root.serverHost, modelUUID, authParams)
-			if errors.Is(err, errors.NotFound) || errors.Is(err, errors.NotImplemented) || errors.Is(err, errors.NotSupported) {
+			if errors.Is(err, errors.NotSupported) {
 				continue
 			} else if err != nil {
 				return nil, a.handleAuthError(err)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -606,7 +606,7 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	// anonymous user; this should also be allowed on account of CMRs.
 	info.Tag = names.NewUserTag(api.AnonymousUsername)
 	_, err = api.Open(info, fastDialOpts)
-	redirErr, ok = errors.Cause(err).(*api.RedirectError)
+	_, ok = errors.Cause(err).(*api.RedirectError)
 	c.Assert(ok, gc.Equals, true)
 }
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -340,10 +340,10 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 
 	httpAuthenticators := []authentication.HTTPAuthenticator{cfg.LocalMacaroonAuthenticator}
 	loginAuthenticators := []authentication.LoginAuthenticator{cfg.LocalMacaroonAuthenticator}
-	// We only want to add the jwt authenticator if it's not nil
+	// We only want to add the jwt authenticator if it's not nil.
 	if cfg.JWTAuthenticator != nil {
-		httpAuthenticators = append(httpAuthenticators, cfg.JWTAuthenticator)
-		loginAuthenticators = append(loginAuthenticators, cfg.JWTAuthenticator)
+		httpAuthenticators = append([]authentication.HTTPAuthenticator{cfg.JWTAuthenticator}, httpAuthenticators...)
+		loginAuthenticators = append([]authentication.LoginAuthenticator{cfg.JWTAuthenticator}, loginAuthenticators...)
 	}
 
 	srv := &Server{

--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -195,8 +195,6 @@ func PermissionFromToken(token jwt.Token, subject names.Tag) (permission.Access,
 		validate = permission.ValidateControllerAccess
 	case names.ModelTagKind:
 		validate = permission.ValidateModelAccess
-	case names.ApplicationOfferTagKind:
-
 	case names.CloudTagKind:
 		validate = permission.ValidateCloudAccess
 	default:

--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -88,7 +88,7 @@ func (j *JWTAuthenticator) AuthenticateLoginRequest(
 	authParams authentication.AuthParams,
 ) (authentication.AuthInfo, error) {
 	if authParams.Token == "" {
-		return authentication.AuthInfo{}, fmt.Errorf("auth token %w", errors.NotFound)
+		return authentication.AuthInfo{}, fmt.Errorf("auth token %w", errors.NotSupported)
 	}
 
 	token, entity, err := j.Parse(ctx, authParams.Token)

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -69,6 +69,12 @@ func (s *loginTokenSuite) TestCacheRegistrationFailureWithBadURL(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 }
 
+func (s *loginTokenSuite) TestAuthenticateLoginRequestNotSupported(c *gc.C) {
+	authenticator := jwt.NewAuthenticator(s.url)
+	_, err := authenticator.AuthenticateLoginRequest(context.Background(), "", "", authentication.AuthParams{Token: ""})
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
 func (s *loginTokenSuite) TestUsesLoginToken(c *gc.C) {
 	modelTag := names.NewModelTag("test")
 	tok, err := EncodedJWT(JWTParams{

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -138,6 +138,10 @@ func (a *Authenticator) AuthenticateLoginRequest(
 	modelUUID string,
 	authParams authentication.AuthParams,
 ) (authentication.AuthInfo, error) {
+	if authParams.Credentials == "" && len(authParams.Macaroons) == 0 {
+		return authentication.AuthInfo{}, errors.NewNotSupported(nil, "no credentials or macaroons")
+	}
+
 	st, err := a.statePool.Get(modelUUID)
 	if err != nil {
 		return authentication.AuthInfo{}, errors.Trace(err)

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -137,10 +137,12 @@ func (a *Authenticator) AuthenticateLoginRequest(
 	serverHost string,
 	modelUUID string,
 	authParams authentication.AuthParams,
-) (authentication.AuthInfo, error) {
-	if authParams.Credentials == "" && len(authParams.Macaroons) == 0 {
-		return authentication.AuthInfo{}, errors.NewNotSupported(nil, "no credentials or macaroons")
-	}
+) (_ authentication.AuthInfo, err error) {
+	defer func() {
+		if errors.Is(err, apiservererrors.ErrNoCreds) {
+			err = errors.NewNotSupported(err, "")
+		}
+	}()
 
 	st, err := a.statePool.Get(modelUUID)
 	if err != nil {

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -32,6 +33,11 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	authenticator, err := stateauthenticator.NewAuthenticator(s.StatePool, clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.authenticator = authenticator
+}
+
+func (s *agentAuthenticatorSuite) TestAuthenticateLoginRequestHandleNotSupportedRequests(c *gc.C) {
+	_, err := s.authenticator.AuthenticateLoginRequest(context.TODO(), "", "", authentication.AuthParams{Token: "token"})
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {


### PR DESCRIPTION
Currently, the apiserver installs in the JWT authenticator but it's never used because of a bug in the admin.authenticate() method in the apiserver package. A login request with a JWT token is processed by the stateauthenticator before the JWT authenticator. For sure, stateauthenticator will reject/fail the JWT request. The authentication aggregator then returns the error directly rather than trying the next available authenticator.
This PR adds request validation logic to the stateauthenticator and JWT authenticator. These authenticators return not supported error if the requests do not have the required auth content. The authentication aggregator ignores the not supported error then try the next one.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
wscat -n -c wss://3.81.1.40:17070/model/94f1439b-1587-4131-8b19-f0eda9af48ca/api
Connected (press CTRL+C to quit)
> {"request-id":1,"type":"Admin","version":3,"request":"Login","params":{"auth-tag":"","credentials":"","nonce":"","macaroons":null,"bakery-version":3,"cli-args":"/snap/juju/23878/bin/jujustatus","user-data":"","client-version":"3.2.3","token":"test"}}
< {"request-id":1,"error":"parsing login access token: invalid JWT","response":{}}
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2030943
