### PR TITLE
Make controller-config a dependency in state

### DIFF
--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -334,17 +334,20 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
-	err := s.machine0.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopePublic)),
-		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)))
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine0.SetProviderAddresses(controllerConfig,
+		network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Default host port scope is public, so change the cloud-local one
 	hostPorts := network.NewSpaceHostPorts(1234, "0.1.2.3", "1.2.3.4")
 	hostPorts[1].Scope = network.ScopeCloudLocal
 
-	st := s.ControllerModel(c).State()
-	controllerConfig, err := st.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
 	err = st.SetAPIHostPorts(controllerConfig, []network.SpaceHostPorts{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -85,6 +85,10 @@ func (api *MachinerAPI) SetMachineAddresses(ctx context.Context, args params.Set
 	if err != nil {
 		return results, err
 	}
+	controllerConfig, err := api.st.ControllerConfig()
+	if err != nil {
+		return results, err
+	}
 	for i, arg := range args.MachineAddresses {
 		m, err := api.getMachine(arg.Tag, canModify)
 		if err != nil {
@@ -96,7 +100,7 @@ func (api *MachinerAPI) SetMachineAddresses(ctx context.Context, args params.Set
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if err := m.SetMachineAddresses(addresses...); err != nil {
+		if err := m.SetMachineAddresses(controllerConfig, addresses...); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 		}
 	}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -55,10 +55,16 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
@@ -135,10 +141,13 @@ func (s *networkInfoSuite) TestProcessAPIRequestForBinding(c *gc.C) {
 	machine, err := st.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// We need at least one address on the machine itself, because these are
 	// retrieved up-front to use as a fallback when we fail to locate addresses
 	// on link-layer devices.
-	err = machine.SetProviderAddresses(network.NewSpaceAddress("10.2.3.4/16"))
+	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("10.2.3.4/16"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.addDevicesWithAddresses(c, machine, "10.2.3.4/16", "100.2.3.4/24")
@@ -194,10 +203,13 @@ func (s *networkInfoSuite) TestProcessAPIRequestBridgeWithSameIPOverNIC(c *gc.C)
 
 	ip := "10.2.3.4/16"
 
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// We need at least one address on the machine itself, because these are
 	// retrieved up-front to use as a fallback when we fail to locate addresses
 	// on link-layer devices.
-	err = machine.SetProviderAddresses(network.NewSpaceAddress(ip))
+	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress(ip))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a NIC and bridge, but also add the IP to the NIC to simulate
@@ -244,8 +256,13 @@ func (s *networkInfoSuite) TestAPIRequestForRelationIAASHostNameIngressNoEgress(
 	host := "host.at.somewhere"
 	ip := "100.2.3.4"
 
+	st := s.ControllerModel(c).State()
+
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	addr := network.NewSpaceAddress(host)
-	err = machine.SetProviderAddresses(addr)
+	err = machine.SetProviderAddresses(controllerConfig, addr)
 	c.Assert(err, jc.ErrorIsNil)
 
 	lookup := func(addr string) ([]string, error) {
@@ -356,7 +373,12 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	addresses := []network.SpaceAddress{
@@ -365,7 +387,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 		network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	}
-	err = machine.SetProviderAddresses(addresses...)
+	err = machine.SetProviderAddresses(controllerConfig, addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.addDevicesWithAddresses(c, machine, "1.2.3.4/16", "2.2.3.4/16", "10.2.3.4/16", "4.3.2.1/16")
@@ -393,10 +415,16 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
@@ -418,10 +446,16 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -442,7 +476,12 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	retryFactory := func() retry.CallArgs {
@@ -454,7 +493,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 				// Set the address after one failed retrieval attempt.
 				if attempt == 1 {
 					err := machine.SetProviderAddresses(
-						network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)))
+						controllerConfig,
+						network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
+					)
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -477,7 +518,12 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.ControllerModel(c).State().Machine(id)
+
+	st := s.ControllerModel(c).State()
+	machine, err := st.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The first attempt is for the public address.
@@ -502,7 +548,10 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the private address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopeCloudLocal)))
+					err := machine.SetProviderAddresses(
+						controllerConfig,
+						network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopeCloudLocal)),
+					)
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -712,7 +761,8 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	machine, err := s.ControllerModel(c).State().AddOneMachine(state.MachineTemplate{
+	st := s.ControllerModel(c).State()
+	machine, err := st.AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("12.10"),
 		Jobs: []state.MachineJob{state.JobHostUnits},
 	})
@@ -725,10 +775,16 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetMachineAddresses(
+		controllerConfig,
+		network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
 		network.NewSpaceAddress("10.10.0.20", network.WithScope(network.ScopePublic)),
 		network.NewSpaceAddress("10.10.0.30", network.WithScope(network.ScopePublic)),
-		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)))
+		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil, nil)
@@ -777,7 +833,8 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	machine, err := s.ControllerModel(c).State().AddOneMachine(state.MachineTemplate{
+	st := s.ControllerModel(c).State()
+	machine, err := st.AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("12.10"),
 		Jobs: []state.MachineJob{state.JobHostUnits},
 	})
@@ -790,10 +847,16 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetMachineAddresses(
+		controllerConfig,
+		network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
 		network.NewSpaceAddress("10.10.0.20", network.WithScope(network.ScopePublic)),
 		network.NewSpaceAddress("10.10.0.30", network.WithScope(network.ScopePublic)),
-		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)))
+		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil, nil)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -567,7 +567,11 @@ func (s *uniterSuite) TestPublicAddress(c *gc.C) {
 	})
 
 	// Now set it an try again.
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine0.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -607,7 +611,11 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 	})
 
 	// Now set it and try again.
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine0.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -629,7 +637,11 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 // TestNetworkInfoSpaceless is in uniterSuite and not uniterNetworkInfoSuite since we don't want
 // all the spaces set up.
 func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
-	err := s.machine0.SetProviderAddresses(
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine0.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1971,7 +1983,11 @@ func (s *uniterSuite) TestProviderType(c *gc.C) {
 
 func (s *uniterSuite) TestEnterScope(c *gc.C) {
 	// Set wordpressUnit's private address first.
-	err := s.machine0.SetProviderAddresses(
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine0.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3376,14 +3392,18 @@ func (s *uniterSuite) TestSLALevel(c *gc.C) {
 func (s *uniterSuite) setupRemoteRelationScenario(c *gc.C) (names.Tag, *state.RelationUnit) {
 	s.makeRemoteWordpress(c)
 
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Set mysql's addresses first.
-	err := s.machine1.SetProviderAddresses(
+	err = s.machine1.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st := s.ControllerModel(c).State()
 	eps, err := st.InferEndpoints("mysql", "remote-wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := st.AddRelation(eps...)
@@ -3423,8 +3443,14 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
 	relTag, relUnit := s.setupRemoteRelationScenario(c)
 
 	thisUniter := s.makeMysqlUniter(c)
+
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Set mysql's addresses - no public address.
-	err := s.machine1.SetProviderAddresses(
+	err = s.machine1.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3914,7 +3940,10 @@ func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c 
 	for i, addr := range machineAddrs {
 		netAddrs[i] = network.NewSpaceAddress(addr.Value())
 	}
-	err = machine.SetProviderAddresses(netAddrs...)
+	st := s.ControllerModel(c).State()
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProviderAddresses(controllerConfig, netAddrs...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return machine

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -515,12 +515,12 @@ func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, s.mixedErrorResults)
 
-	s.st.CheckMachineCall(c, 0, "1")
-	s.st.CheckSetProviderAddressesCall(c, 1, []network.SpaceAddress{})
-	s.st.CheckMachineCall(c, 2, "2")
-	s.st.CheckCall(c, 3, "AllSpaceInfos")
-	s.st.CheckSetProviderAddressesCall(c, 4, newAddrs)
-	s.st.CheckMachineCall(c, 5, "42")
+	s.st.CheckMachineCall(c, 1, "1")
+	s.st.CheckSetProviderAddressesCall(c, 2, []network.SpaceAddress{})
+	s.st.CheckMachineCall(c, 3, "2")
+	s.st.CheckCall(c, 4, "AllSpaceInfos")
+	s.st.CheckSetProviderAddressesCall(c, 5, newAddrs)
+	s.st.CheckMachineCall(c, 6, "42")
 
 	// Ensure machines were updated.
 	machine, err := s.st.Machine("1")
@@ -554,11 +554,11 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, s.machineErrorResults)
 
-	s.st.CheckMachineCall(c, 0, "1")
-	s.st.CheckMachineCall(c, 1, "2")
-	s.st.CheckCall(c, 2, "AllSpaceInfos")
-	s.st.CheckSetProviderAddressesCall(c, 3, newAddrs)
-	s.st.CheckMachineCall(c, 4, "3")
+	s.st.CheckMachineCall(c, 1, "1")
+	s.st.CheckMachineCall(c, 2, "2")
+	s.st.CheckCall(c, 3, "AllSpaceInfos")
+	s.st.CheckSetProviderAddressesCall(c, 4, newAddrs)
+	s.st.CheckMachineCall(c, 5, "3")
 
 	// Ensure machine 2 wasn't updated.
 	machine, err := s.st.Machine("2")

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/facades/controller/instancepoller"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 // mockState implements StateInterface and allows inspection of called
@@ -258,6 +260,12 @@ func (m *mockState) ApplyOperation(op state.ModelOperation) error {
 	return err
 }
 
+func (m *mockState) ControllerConfig() (controller.Config, error) {
+	m.MethodCall(m, "ControllerConfig")
+
+	return jujutesting.FakeControllerConfig(), nil
+}
+
 type machineInfo struct {
 	id                string
 	instanceId        instance.Id
@@ -323,7 +331,7 @@ func (m *mockMachine) ProviderAddresses() network.SpaceAddresses {
 }
 
 // SetProviderAddresses implements StateMachine.
-func (m *mockMachine) SetProviderAddresses(addrs ...network.SpaceAddress) error {
+func (m *mockMachine) SetProviderAddresses(controllerConfig controller.Config, addrs ...network.SpaceAddress) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -5,6 +5,7 @@ package instancepoller
 
 import (
 	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -18,7 +19,7 @@ type StateMachine interface {
 
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() network.SpaceAddresses
-	SetProviderAddresses(...network.SpaceAddress) error
+	SetProviderAddresses(controller.Config, ...network.SpaceAddress) error
 	InstanceStatus() (status.StatusInfo, error)
 	SetInstanceStatus(status.StatusInfo) error
 	SetStatus(status.StatusInfo) error
@@ -39,6 +40,8 @@ type StateInterface interface {
 
 	// ApplyOperation applies a given ModelOperation to the model.
 	ApplyOperation(state.ModelOperation) error
+
+	ControllerConfig() (controller.Config, error)
 }
 
 type machineShim struct {
@@ -86,9 +89,9 @@ func (s stateShim) Machine(id string) (StateMachine, error) {
 		return nil, err
 	}
 
-	return machineShim{m}, nil
+	return machineShim{Machine: m}, nil
 }
 
 var getState = func(st *state.State, m *state.Model) StateInterface {
-	return stateShim{st, m}
+	return stateShim{State: st, Model: m}
 }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -276,8 +276,11 @@ func (s *commonMachineSuite) newBufferedLogWriter() *logsender.BufferedLogWriter
 }
 
 func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Machine) {
+	controllerConfig, err := s.ControllerModel(c).State().ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	addrs := network.NewSpaceAddresses("0.1.2.3")
-	err := machine.SetProviderAddresses(addrs...)
+	err = machine.SetProviderAddresses(controllerConfig, addrs...)
 	c.Assert(err, jc.ErrorIsNil)
 	// Set the addresses in the environ instance as well so that if the instance poller
 	// runs it won't overwrite them.

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -127,11 +127,11 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 func AddControllerMachine(c *gc.C, st *state.State) *state.Machine {
 	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3"))
-	c.Assert(err, jc.ErrorIsNil)
-
 	controllerConfig, err := st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("0.1.2.3"))
+	c.Assert(err, jc.ErrorIsNil)
+
 	hostPorts := []network.SpaceHostPorts{network.NewSpaceHostPorts(1234, "0.1.2.3")}
 	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -139,7 +139,11 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 	providerAddr := network.NewSpaceAddress("example.com")
 	providerAddr.SpaceID = space.Id()
-	err = m.SetProviderAddresses(providerAddr)
+
+	controllerConfig, err := st.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = m.SetProviderAddresses(controllerConfig, providerAddr)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var addresses []network.ProviderAddress
@@ -3111,10 +3115,13 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		if flag&openPorts != 0 {
+			controllerConfig, err := st.ControllerConfig()
+			c.Assert(err, jc.ErrorIsNil)
+
 			// Add a network to the machine and open a port.
 			publicAddress := network.NewSpaceAddress("1.2.3.4", corenetwork.WithScope(corenetwork.ScopePublic))
 			privateAddress := network.NewSpaceAddress("4.3.2.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal))
-			err = m.SetProviderAddresses(publicAddress, privateAddress)
+			err = m.SetProviderAddresses(controllerConfig, publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
 
 			unitPortRanges, err := u.OpenedPortRanges()

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -191,7 +191,10 @@ func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses
 
 	m, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.SetMachineAddresses(network.NewSpaceAddress("192.168.9.9")), jc.ErrorIsNil)
+
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("192.168.9.9")), jc.ErrorIsNil)
 
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.JujuManagementSpace: "mgmt-space",
@@ -210,7 +213,10 @@ func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c 
 	addr := network.NewSpaceAddress("192.168.9.9")
 	addr.SpaceID = sp.Id()
 
-	c.Assert(m.SetProviderAddresses(addr), jc.ErrorIsNil)
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(m.SetProviderAddresses(controllerConfig, addr), jc.ErrorIsNil)
 
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.JujuManagementSpace: "mgmt-space",
@@ -244,13 +250,16 @@ func (s *ControllerSuite) TestSetMachineAddressesControllerCharm(c *gc.C) {
 		Machine:     controller,
 	})
 
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
 	addresses := network.NewSpaceAddresses("10.0.0.1")
-	err = controller.SetMachineAddresses(addresses...)
+	err = controller.SetMachineAddresses(controllerConfig, addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Updating a worker machine does not affect charm config.
 	addresses = network.NewSpaceAddresses("10.0.0.2")
-	err = worker.SetMachineAddresses(addresses...)
+	err = worker.SetMachineAddresses(controllerConfig, addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := controllerApp.CharmConfig(model.GenerationMaster)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1201,7 +1201,9 @@ func (s *WatchRelationUnitsSuite) TestPeer(c *gc.C) {
 			fmt.Sprintf("riak%d.example.com", i),
 			network.WithScope(network.ScopeCloudLocal),
 		)
-		err = machine.SetProviderAddresses(privateAddr)
+		controllerConfig, err := s.State.ControllerConfig()
+		c.Assert(err, jc.ErrorIsNil)
+		err = machine.SetProviderAddresses(controllerConfig, privateAddr)
 		c.Assert(err, jc.ErrorIsNil)
 		ru, err := rel.Unit(unit)
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -777,8 +777,11 @@ func (s *StateSuite) TestAddresses(c *gc.C) {
 	machines[3], err = s.State.Machine("3")
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 	for i, m := range machines {
 		err := m.SetProviderAddresses(
+			controllerConfig,
 			network.NewSpaceAddress(fmt.Sprintf("10.0.0.%d", i), network.WithScope(network.ScopeCloudLocal)),
 			network.NewSpaceAddress("::1", network.WithScope(network.ScopeCloudLocal)),
 			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -800,7 +800,10 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(
+		controllerConfig,
 		network.NewSpaceAddress("private.address.example.com", network.WithScope(network.ScopeCloudLocal)),
 		network.NewSpaceAddress("public.address.example.com", network.WithScope(network.ScopePublic)),
 	)
@@ -836,7 +839,10 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
 	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
-	err = machine.SetProviderAddresses(public, private)
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(controllerConfig, public, private)
 	c.Assert(err, jc.ErrorIsNil)
 
 	address, err := s.unit.PublicAddress()
@@ -850,12 +856,15 @@ func (s *UnitSuite) TestStablePrivateAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.2"))
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"), network.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.1"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -870,12 +879,15 @@ func (s *UnitSuite) TestStablePublicAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -894,15 +906,18 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	privateProvider := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 	privateMachine := network.NewSpaceAddress("127.0.0.2")
 
-	err = machine.SetProviderAddresses(privateProvider)
+	controllerConfig, err := s.State.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetMachineAddresses(privateMachine)
+
+	err = machine.SetProviderAddresses(controllerConfig, privateProvider)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetMachineAddresses(controllerConfig, privateMachine)
 	c.Assert(err, jc.ErrorIsNil)
 	address, err := s.unit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(address.Value, gc.Equals, "127.0.0.1")
 
-	err = machine.SetProviderAddresses(publicProvider, privateProvider)
+	err = machine.SetProviderAddresses(controllerConfig, publicProvider, privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
 	address, err = s.unit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
@@ -931,7 +946,10 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
 	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
-	err = machine.SetProviderAddresses(public, private)
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(controllerConfig, public, private)
 	c.Assert(err, jc.ErrorIsNil)
 
 	address, err := s.unit.PrivateAddress()
@@ -2902,7 +2920,11 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 		ConfigMethod: network.ConfigStatic,
 	})
 	c.Assert(err, gc.IsNil)
-	err = m1.SetProviderAddresses(network.NewSpaceAddress("10.0.0.100"))
+
+	controllerConfig, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = m1.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.100"))
 	c.Assert(err, gc.IsNil)
 	wc.AssertChange("46ed851765a963e100161210a7b4fbb28d59b24edb580a60f86dbbaebea14d37")
 

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -379,7 +379,9 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 	err = machine.SetPassword(params.Password)
 	c.Assert(err, jc.ErrorIsNil)
 	if len(params.Addresses) > 0 {
-		err := machine.SetProviderAddresses(params.Addresses...)
+		controllerConfig, err := factory.st.ControllerConfig()
+		c.Assert(err, jc.ErrorIsNil)
+		err = machine.SetProviderAddresses(controllerConfig, params.Addresses...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	current := testing.CurrentVersion()


### PR DESCRIPTION
This is another follow up PR that removes controller config from being called directly inside of state. This should nearly clean up the last of the controller config call sites from inside state.

Once this is done, and after the peergrouper has removed it controller config dependency, then we should be able to remove controller config from state.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```

## Links

JUJU-4511