### PR TITLE
Only log when the addresses really do change.

### DIFF
--- a/juju/api.go
+++ b/juju/api.go
@@ -149,7 +149,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 	if !apiInfo.SkipLogin {
 		if ok {
 			if accountDetails, err = args.Store.AccountDetails(args.ControllerName); err != nil {
-				if !errors.IsNotFound(err) {
+				if !errors.Is(err, errors.NotFound) {
 					logger.Errorf("cannot load local account information: %v", err)
 				}
 			} else {

--- a/juju/api.go
+++ b/juju/api.go
@@ -232,18 +232,31 @@ func usableHostPorts(hps []network.MachineHostPorts) network.HostPorts {
 	return collapsed.FilterUnusable().Unique()
 }
 
-// addrsChanged reports whether the two slices
-// are different. Order is important.
-func addrsChanged(a, b []string) bool {
+// addrsChanged reports whether the two slices are different.
+// The first return tells if they are different in any way (including reordering),
+// the second indicates if the set of addresses are different.
+func addrsChanged(a, b []string) (bool, bool) {
 	if len(a) != len(b) {
-		return true
+		return true, true
 	}
+	aKeys := make(map[string]struct{}, len(a))
+	for _, k := range a {
+		aKeys[k] = struct{}{}
+	}
+	outOfOrder := false
 	for i := range a {
+		bKey := b[i]
+		if _, ok := aKeys[bKey]; ok {
+			delete(aKeys, bKey)
+		} else {
+			// b has a key that is not in a, therefore we must not match at all
+			return true, true
+		}
 		if a[i] != b[i] {
-			return true
+			outOfOrder = true
 		}
 	}
-	return false
+	return outOfOrder, false
 }
 
 // UpdateControllerParams holds values used to update a controller details
@@ -336,8 +349,11 @@ func updateControllerDetailsFromLogin(
 		// Nothing has changed - no need to update the controller details.
 		return nil
 	}
-	if addrsChanged(newDetails.APIEndpoints, details.APIEndpoints) {
+	reordered, diffContents := addrsChanged(newDetails.APIEndpoints, details.APIEndpoints)
+	if diffContents {
 		logger.Infof("API endpoints changed from %v to %v", details.APIEndpoints, newDetails.APIEndpoints)
+	} else if reordered {
+		logger.Debugf("API endpoints reordered from %v to %v", details.APIEndpoints, newDetails.APIEndpoints)
 	}
 	err = store.UpdateController(controllerName, *newDetails)
 	return errors.Trace(err)

--- a/juju/api.go
+++ b/juju/api.go
@@ -353,7 +353,7 @@ func updateControllerDetailsFromLogin(
 	if diffContents {
 		logger.Infof("API endpoints changed from %v to %v", details.APIEndpoints, newDetails.APIEndpoints)
 	} else if reordered {
-		logger.Debugf("API endpoints reordered from %v to %v", details.APIEndpoints, newDetails.APIEndpoints)
+		logger.Tracef("API endpoints reordered from %v to %v", details.APIEndpoints, newDetails.APIEndpoints)
 	}
 	err = store.UpdateController(controllerName, *newDetails)
 	return errors.Trace(err)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -515,7 +515,7 @@ func newAPIConnectionFromNames(
 		OpenAPI:        apiOpen,
 	}
 	accountDetails, err := store.AccountDetails(controller)
-	if !errors.IsNotFound(err) {
+	if !errors.Is(err, errors.NotFound) {
 		c.Assert(err, jc.ErrorIsNil)
 		args.AccountDetails = accountDetails
 	}

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -37,7 +36,6 @@ import (
 
 type NewAPIClientSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
-	mgotesting.MgoSuite
 	envtesting.ToolsFixture
 }
 
@@ -47,26 +45,22 @@ var _ = gc.Suite(&NewAPIClientSuite{})
 
 func (s *NewAPIClientSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *NewAPIClientSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
 }
 
 func (s *NewAPIClientSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
 	s.PatchValue(&dummy.LogDir, c.MkDir())
 }
 
 func (s *NewAPIClientSuite) TearDownTest(c *gc.C) {
 	dummy.Reset(c)
 	s.ToolsFixture.TearDownTest(c)
-	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
@@ -451,40 +445,6 @@ func (s *NewAPIClientSuite) TestEndpointFiltering(c *gc.C) {
 		"10.0.0.1:1234",
 		"0.1.2.3:1235",
 	})
-}
-
-var moveToFrontTests = []struct {
-	item   string
-	items  []string
-	expect []string
-}{{
-	item:   "x",
-	items:  []string{"y", "x"},
-	expect: []string{"x", "y"},
-}, {
-	item:   "z",
-	items:  []string{"y", "x"},
-	expect: []string{"y", "x"},
-}, {
-	item:   "y",
-	items:  []string{"y", "x"},
-	expect: []string{"y", "x"},
-}, {
-	item:   "x",
-	items:  []string{"y", "x", "z"},
-	expect: []string{"x", "y", "z"},
-}, {
-	item:   "d",
-	items:  []string{"a", "b", "c", "d", "e", "f"},
-	expect: []string{"d", "a", "b", "c", "e", "f"},
-}}
-
-func (s *NewAPIClientSuite) TestMoveToFront(c *gc.C) {
-	for i, test := range moveToFrontTests {
-		c.Logf("test %d: moveToFront %q %v", i, test.item, test.items)
-		juju.MoveToFront(test.item, test.items)
-		c.Assert(test.items, jc.DeepEquals, test.expect)
-	}
 }
 
 type testRootAPI struct {

--- a/juju/api_whitebox_test.go
+++ b/juju/api_whitebox_test.go
@@ -5,7 +5,7 @@ package juju
 
 import (
 	gc "gopkg.in/check.v1"
-	
+
 	jc "github.com/juju/testing/checkers"
 )
 
@@ -44,7 +44,7 @@ func (s *APIHelperSuite) TestMoveToFront(c *gc.C) {
 	for i, test := range moveToFrontTests {
 		c.Logf("test %d: moveToFront %q %v", i, test.item, test.items)
 		moveToFront(test.item, test.items)
-		c.Assert(test.items, jc.DeepEquals, test.expect)
+		c.Check(test.items, jc.DeepEquals, test.expect)
 	}
 }
 

--- a/juju/api_whitebox_test.go
+++ b/juju/api_whitebox_test.go
@@ -4,9 +4,8 @@
 package juju
 
 import (
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 type APIHelperSuite struct {

--- a/juju/api_whitebox_test.go
+++ b/juju/api_whitebox_test.go
@@ -5,6 +5,7 @@ package juju
 
 import (
 	gc "gopkg.in/check.v1"
+	
 	jc "github.com/juju/testing/checkers"
 )
 

--- a/juju/api_whitebox_test.go
+++ b/juju/api_whitebox_test.go
@@ -1,0 +1,105 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package juju
+
+import (
+	gc "gopkg.in/check.v1"
+	jc "github.com/juju/testing/checkers"
+)
+
+type APIHelperSuite struct {
+}
+
+var _ = gc.Suite(&APIHelperSuite{})
+
+var moveToFrontTests = []struct {
+	item   string
+	items  []string
+	expect []string
+}{{
+	item:   "x",
+	items:  []string{"y", "x"},
+	expect: []string{"x", "y"},
+}, {
+	item:   "z",
+	items:  []string{"y", "x"},
+	expect: []string{"y", "x"},
+}, {
+	item:   "y",
+	items:  []string{"y", "x"},
+	expect: []string{"y", "x"},
+}, {
+	item:   "x",
+	items:  []string{"y", "x", "z"},
+	expect: []string{"x", "y", "z"},
+}, {
+	item:   "d",
+	items:  []string{"a", "b", "c", "d", "e", "f"},
+	expect: []string{"d", "a", "b", "c", "e", "f"},
+}}
+
+func (s *APIHelperSuite) TestMoveToFront(c *gc.C) {
+	for i, test := range moveToFrontTests {
+		c.Logf("test %d: moveToFront %q %v", i, test.item, test.items)
+		moveToFront(test.item, test.items)
+		c.Assert(test.items, jc.DeepEquals, test.expect)
+	}
+}
+
+var addrsChangedTests = []struct {
+	description string
+	source      []string
+	target      []string
+	changed     bool
+	setDiff     bool
+}{{
+	description: "first longer",
+	source:      []string{"a", "b"},
+	target:      []string{"a"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "second longer",
+	source:      []string{"a"},
+	target:      []string{"a", "b"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "identical",
+	source:      []string{"a", "b"},
+	target:      []string{"a", "b"},
+	changed:     false,
+	setDiff:     false,
+}, {
+	description: "reordered",
+	source:      []string{"b", "a"},
+	target:      []string{"a", "b"},
+	changed:     true,
+	setDiff:     false,
+}, {
+	description: "repeated",
+	source:      []string{"a", "b", "c"},
+	target:      []string{"a", "b", "b"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "repeated reversed",
+	source:      []string{"a", "b", "b"},
+	target:      []string{"a", "b", "c"},
+	changed:     true,
+	setDiff:     true,
+}}
+
+func (s *APIHelperSuite) TestAddrsChanged(c *gc.C) {
+	for i, test := range addrsChangedTests {
+		c.Logf("test %d: addrsChanged %v %v", i, test.description)
+		anyChange, differentSet := addrsChanged(test.source, test.target)
+		c.Check(anyChange, gc.Equals, test.changed,
+			gc.Commentf("%v vs %v declared that %t but expected %t",
+				test.source, test.target, anyChange, test.changed))
+		c.Check(differentSet, gc.Equals, test.setDiff,
+			gc.Commentf("%v vs %v declared that %t but expected %t",
+				test.source, test.target, differentSet, test.setDiff))
+	}
+}

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -4,6 +4,5 @@
 package juju
 
 var (
-	MoveToFront    = moveToFront
 	ConnectionInfo = connectionInfo
 )

--- a/juju/package_test.go
+++ b/juju/package_test.go
@@ -6,9 +6,9 @@ package juju_test
 import (
 	stdtesting "testing"
 
-	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func Test(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -329,7 +329,7 @@ func (s *JujuConnSuite) EnsureCachedModel(c *gc.C, uuid string) {
 			if err == nil {
 				return
 			}
-			if !errors.IsNotFound(err) {
+			if !errors.Is(err, errors.NotFound) {
 				c.Fatalf("problem getting model from cache: %v", err)
 			}
 			retry = time.After(testing.ShortWait)


### PR DESCRIPTION
By default `juju status --debug` has been reporting that "API addresses have changed" when the only actual change is that the values were re-ordered. This is confusing, so instead check to see if the set of addresses is actually different, and change the log message accordingly.

Also, I discovered that the packages tests did not actually depend on Mongo in any way, so we don't need to import the mongo test suite, nor depend on mongo when running any of these tests. I *did* change from the pattern that "everything is externally tested, so if you want to test a helper function, you must export it", to the newer pattern of just using package tests for whitebox testing when it is appropriate.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a controller, and enable-ha. Juju intentionally reorders the API address list so that clients don't swarm one controller for all requests. However, you don't want to see API addresses have changed when the actual addresses have just been reordered.
```sh
$ juju bootstrap lxd
$ juju enable-ha
$ juju switch controller
$ watch -n 0.5 -e juju status --debug
```
Previously, you would see lines like:
```
12:49:19 INFO  juju.juju api.go:340 API endpoints changed from [10.25.164.89:17070 10.25.164.34:17070 10.25.164.56:17070] to [10.25.164.89:17070 10.25.164.56:17070 10.25.164.34:17070]
```
But if you look closely, those are the same API endpoints, just in a different order.

You should still see the lines:
```
12:54:39 INFO  juju.juju api.go:86 connecting to API addresses: [10.25.164.89:17070 10.25.164.56:17070 10.25.164.34:17070]
12:54:39 DEBUG juju.api apiclient.go:1166 successfully dialed "wss://10.25.164.56:17070/model/9c93714e-2340-4bf6-8578-3bb8ead423c7/api"
```
Changing to indicate that we are changing the order that we attempt connections, and the one that we actually connect to should be different. But we just don't emit log messages that are misleading.

## Documentation changes

None

## Bug reference

None
