### PR TITLE
juju-txn-helper: Allow querying of the full transaction collection

### DIFF
--- a/scripts/juju-txn-helper/README.txt
+++ b/scripts/juju-txn-helper/README.txt
@@ -7,20 +7,26 @@ What this does:
 
 For now, this repository contains a single script, txn_helper.py.
 
-Given a model UUID, this script walks through each transaction's
-operations, tests each operation's assertions and provides details
-about each failed assertion.  It also provides details about
-insert/update records as well as records already existing in the
-database.
+This script walks through a subset of Juju's transactions collection ("txns"),
+examining each operation, testing each operation's assertions and providing
+details about each failed assertion, as well as details about the proposed
+database modifications.
+
+This script has two modes:
+
+* The default mode is for this script to examine the entire transactions
+  collection, filtering by a specific integer state code, e.g. 5 for the
+  ABORTED state, which is the default filter. The specific filter can be
+  modified via the --state argument.  Supported codes can be found by examining
+  the OpState enumeration in the source code.
+
+* If a model name or UUID is specified, the script will examine all
+  transactions referenced in the txn-queue field of the specified model's
+  document.  In this case, the --state filter has no effect; it is assumed that
+  the full set of queries in the txn-queue field provide important context.
 
 
-Important caveats:
-
-* The script does not filter out any transactions which have already
-  completed; it literally just goes through the full list of
-  transactions specified in a model's txn-queue field.
-
-* This script must be run against the MongoDB primary.
+Important caveat: This script must be run against the MongoDB primary.
 
 
 Snap support:
@@ -35,11 +41,11 @@ Usage:
 A typical live Juju MongoDB instance will typically require an
 invocation like this:
 
-  python3 txn_helper.py -s -H mongodb://127.0.0.1:37017 -u $user -p $password $MODEL
+  python3 txn_helper.py -s -H mongodb://127.0.0.1:37017 -u $user -p $password
 
 If using the snap, this would change to:
 
-  juju-txn-helper -s -H mongodb://127.0.0.1:37017 -u $user -p $password $MODEL
+  juju-txn-helper -s -H mongodb://127.0.0.1:37017 -u $user -p $password
 
 See --help for additional helpful options.  Some suggestions are
 -d/--dump-transaction and -P/--include-passes.

--- a/scripts/juju-txn-helper/test_txn_helper.py
+++ b/scripts/juju-txn-helper/test_txn_helper.py
@@ -1,0 +1,236 @@
+import unittest
+from unittest import mock
+
+from bson import ObjectId
+
+import txn_helper
+
+
+class TestGetModelUuid(unittest.TestCase):
+
+    def test_valid_uuid(self):
+        model_uuid = "01234567-89ab-cdef-0123-456789abcdef"
+        args = mock.Mock()
+        args.model = model_uuid
+        result = txn_helper.get_model_uuid(None, args)
+        self.assertEqual(result, model_uuid)
+
+    def test_name_found(self):
+        model_name = "foo"
+        model_uuid = "01234567-89ab-cdef-0123-456789abcdef"
+
+        client = mock.MagicMock()
+        client.juju.models.find_one.return_value = {"_id": model_uuid}
+        args = mock.Mock()
+        args.model = model_name
+
+        result = txn_helper.get_model_uuid(client, args)
+        self.assertEqual(result, model_uuid)
+
+    def test_name_not_found(self):
+        model_name = "foo"
+
+        client = mock.MagicMock()
+        client.juju.models.find_one.return_value = None
+        args = mock.Mock()
+        args.model = model_name
+
+        with self.assertRaises(SystemExit) as cm:
+            txn_helper.get_model_uuid(client, args)
+        self.assertEqual(cm.exception.code, "Could not find the specified model (foo)")
+
+
+class BaseTxnQueueTest(unittest.TestCase):
+    SAMPLE_ABORTED_TRANSACTION = {
+        "_id": ObjectId("0123456789abcdef01234567"),
+        "s": 5,
+        "o": [
+            {
+                "c": "models",
+                "d": "01234567-891b-cdef-0123-456789abcdef",
+                "a": {
+                    "life": 0,
+                    "migration-mode": ""
+                }
+            },
+            {
+                "c": "remoteApplications",
+                "d": "01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef",
+                "a": "d-",
+                "i": {
+                    "_id": "01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef",
+                    "name": "remote-0123456789abcdef0123456789abcdef",
+                    "offer-uuid": "01010101-0101-0101-0101-010101010101",
+                    "source-model-uuid": "23232323-2323-2323-2323-232323232323",
+                    "endpoints": [
+                        {
+                            "name": "monitors",
+                            "role": "provider",
+                            "interface": "monitors",
+                            "limit": 0,
+                            "scope": ""
+                        }
+                    ],
+                    "spaces": [],
+                    "bindings": {
+
+                    },
+                    "life": 0,
+                    "relationcount": 0,
+                    "is-consumer-proxy": True,
+                    "version": 0,
+                    "model-uuid": "01234567-891b-cdef-0123-456789abcdef"
+                }
+            },
+            {
+                "c": "applications",
+                "d": "01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef",
+                "a": "d-"
+            },
+            {
+                "c": "remoteEntities",
+                "d": "01234567-891b-cdef-0123-456789abcdef:application-remote-0123456789abcdef0123456789abcdef",
+                "a": "d-",
+                "i": {
+                    "_id": "01234567-891b-cdef-0123-456789abcdef:",
+                    "token": "45454545-4545-4545-4545-454545454545",
+                    "model-uuid": "01234567-891b-cdef-0123-456789abcdef"
+                }
+            }
+        ],
+        "n": "fedcba98"
+    }
+
+
+class TestWalkTxnQueue(BaseTxnQueueTest):
+
+    SAMPLE_TRANSACTION_REFERENCES = [
+        "0123456789abcdef01234567_78787878",
+    ]
+    SAMPLE_TRANSACTIONS = [
+        BaseTxnQueueTest.SAMPLE_ABORTED_TRANSACTION,
+    ]
+
+    expected_stdout = """\
+Retrieved model transaction queue:
+- 0123456789abcdef01234567_78787878
+Converting to transaction IDs:
+- 0123456789abcdef01234567
+
+Transaction 0123456789abcdef01234567 (state: aborted):
+  Transaction dump:
+    {'_id': ObjectId('0123456789abcdef01234567'),
+     'n': 'fedcba98',
+     'o': [{'a': {'life': 0, 'migration-mode': ''},
+            'c': 'models',
+            'd': '01234567-891b-cdef-0123-456789abcdef'},
+           {'a': 'd-',
+            'c': 'remoteApplications',
+            'd': '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef',
+            'i': {'_id': '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef',
+                  'bindings': {},
+                  'endpoints': [{'interface': 'monitors',
+                                 'limit': 0,
+                                 'name': 'monitors',
+                                 'role': 'provider',
+                                 'scope': ''}],
+                  'is-consumer-proxy': True,
+                  'life': 0,
+                  'model-uuid': '01234567-891b-cdef-0123-456789abcdef',
+                  'name': 'remote-0123456789abcdef0123456789abcdef',
+                  'offer-uuid': '01010101-0101-0101-0101-010101010101',
+                  'relationcount': 0,
+                  'source-model-uuid': '23232323-2323-2323-2323-232323232323',
+                  'spaces': [],
+                  'version': 0}},
+           {'a': 'd-',
+            'c': 'applications',
+            'd': '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef'},
+           {'a': 'd-',
+            'c': 'remoteEntities',
+            'd': '01234567-891b-cdef-0123-456789abcdef:application-remote-0123456789abcdef0123456789abcdef',
+            'i': {'_id': '01234567-891b-cdef-0123-456789abcdef:',
+                  'model-uuid': '01234567-891b-cdef-0123-456789abcdef',
+                  'token': '45454545-4545-4545-4545-454545454545'}}],
+     's': 5}
+
+  Op 0: QUERY_DOC assertion passed
+  Collection 'models', ID '01234567-891b-cdef-0123-456789abcdef'
+  Query doc tested was:
+    {'_id': '01234567-891b-cdef-0123-456789abcdef', 'life': 0, 'migration-mode': ''}
+  Existing doc is:
+    {'txn-queue': ['0123456789abcdef01234567_78787878']}
+
+  Op 1: DOC_MISSING assertion FAILED
+  Collection 'remoteApplications', ID '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef'
+  Existing doc is:
+    {'dummy': 'remoteApplication'}
+  Insert doc is:
+    {'_id': '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef',
+     'bindings': {},
+     'endpoints': [{'interface': 'monitors',
+                    'limit': 0,
+                    'name': 'monitors',
+                    'role': 'provider',
+                    'scope': ''}],
+     'is-consumer-proxy': True,
+     'life': 0,
+     'model-uuid': '01234567-891b-cdef-0123-456789abcdef',
+     'name': 'remote-0123456789abcdef0123456789abcdef',
+     'offer-uuid': '01010101-0101-0101-0101-010101010101',
+     'relationcount': 0,
+     'source-model-uuid': '23232323-2323-2323-2323-232323232323',
+     'spaces': [],
+     'version': 0}
+
+  Op 2: DOC_MISSING assertion FAILED
+  Collection 'applications', ID '01234567-891b-cdef-0123-456789abcdef:remote-0123456789abcdef0123456789abcdef'
+  Existing doc is:
+    {'dummy': 'application'}
+
+  Op 3: DOC_MISSING assertion FAILED
+  Collection 'remoteEntities', ID '01234567-891b-cdef-0123-456789abcdef:application-remote-0123456789abcdef0123456789abcdef'
+  Existing doc is:
+    {'dummy': 'remoteEntity'}
+  Insert doc is:
+    {'_id': '01234567-891b-cdef-0123-456789abcdef:',
+     'model-uuid': '01234567-891b-cdef-0123-456789abcdef',
+     'token': '45454545-4545-4545-4545-454545454545'}
+
+"""
+
+    @mock.patch('txn_helper.print')
+    def test_happy_path_single_match(self, print_mock: mock.MagicMock):
+        client = mock.MagicMock()
+
+        # In the single transaction case, there is next to no difference between querying for a model or going over the
+        # full set of transactions since in either way we control the returned data via a mock.
+        # We'll use the model query path here for the sake of covering slightly more code.
+        model_uuid = "01234567-89ab-cdef-0123-456789abcdef"
+        state_filter = None
+
+        dump_transaction = True
+        include_passes = True
+        max_transaction_count = None
+
+        # Mock out the model to include a model transaction queue
+        client.juju.models.find_one.return_value = {"txn-queue": self.SAMPLE_TRANSACTION_REFERENCES}
+        # Mock the result of the transaction query
+        client.juju.txns.find.return_value = self.SAMPLE_TRANSACTIONS
+        # Mock out other specific objects checked by the assertions
+        client.juju.remoteApplications.find_one.return_value = {"dummy": "remoteApplication"}
+        client.juju.applications.find_one.return_value = {"dummy": "application"}
+        client.juju.remoteEntities.find_one.return_value = {"dummy": "remoteEntity"}
+
+        txn_queue = txn_helper.get_model_transaction_queue(client, model_uuid)
+        txn_helper.walk_transaction_queue(client, txn_queue, state_filter, dump_transaction, include_passes, max_transaction_count)
+
+        captured_stdout = "\n".join([call.args[0] if call.args else "" for call in print_mock.mock_calls])
+
+        # Yes, this is a very fragile test - any change to stdout can make it fail - but it will work for now.
+        self.assertEqual(captured_stdout, self.expected_stdout)
+
+    # Consider adding:
+    # * Model query with multiple transactions - this would result in iterating over multiple distinct queries' cursors.
+    # * All transactions query with mulitple transactions - this would result in iterating over a single query's cursor.
+    # (The above paths have been directly tested on a test database.)

--- a/scripts/juju-txn-helper/txn_helper.py
+++ b/scripts/juju-txn-helper/txn_helper.py
@@ -9,19 +9,35 @@ import pprint
 import re
 import sys
 import textwrap
+from enum import Enum
 
 from bson import ObjectId
 from pymongo import MongoClient
 
 
-STATE_MAP = {
-        1: "preparing",
-        2: "prepared",
-        3: "aborting",
-        4: "applying",
-        5: "aborted",
-        6: "applied",
-        }
+class OpState(Enum):
+    """Juju transaction operation states."""
+    PREPARING = 1
+    PREPARED = 2
+    ABORTING = 3
+    APPLYING = 4
+    ABORTED = 5
+    APPLIED = 6
+
+
+class AssertionType(Enum):
+    """Transaction assertion types.
+
+    Note that these are simply names used for convenience in this script;
+    DOC_EXISTS/DOC_MISSING refer to the d+/d- assertion codes, while QUERY_DOC
+    refers to assertions which specify MongoDB query documents.
+    """
+    DOC_EXISTS = 1
+    DOC_MISSING = 2
+    QUERY_DOC = 3
+
+
+STATE_MAP = {enum_entry.value: enum_entry.name.lower() for enum_entry in OpState}
 
 DOC_EXISTS = "d+"
 DOC_MISSING = "d-"
@@ -35,19 +51,33 @@ def main():
     args = parse_args()
     client_args = create_client_args(args)
     client = MongoClient(**client_args)
-    model_uuid = get_model_uuid(client, args)
-    walk_transaction_queue(client, model_uuid, args.dump_transaction, args.include_passes, args.count)
+    if args.model:
+        # Target all transactions from the specified model's txn-queue.
+        model_uuid = get_model_uuid(client, args)
+        txn_queue = get_model_transaction_queue(client, model_uuid)
+        state_filter = None
+    else:
+        # Default behavior is to filter by transaction state, usually on the "aborted" state.
+        txn_queue = None
+        state_filter = args.state_filter
+    walk_transaction_queue(client, txn_queue, state_filter, args.dump_transaction, args.include_passes, args.count)
 
 
 def parse_args():
     """Parse the command line arguments."""
     ap = argparse.ArgumentParser()    # pylint: disable=invalid-name
-    ap.add_argument('model', help='Name or UUID of model to examine')
+    ap.add_argument('model', nargs='?',
+                    help='Name or UUID of model to examine.  If not specified, the full '
+                         'transaction collection will be examined instead.')
     ap.add_argument('-H', '--host', help='Mongo hostname or URI to use, if required.')
     ap.add_argument('-u', '--user', help='Mongo username to use, if required.')
     ap.add_argument('-p', '--password', help='Mongo password to use, if required.')
     ap.add_argument('--auth-database', default='admin',
                     help='Mongo auth database to use, if required.  (Default: %(default)s)')
+    ap.add_argument('--state', dest='state_filter', type=int, default=OpState.ABORTED.value,
+                    help="Filter by state number.  This is used when querying the full "
+                         "transaction queue; it is ignored if querying a specific object's "
+                         "transaction queue.  (Default: %(default)s)")
     ap.add_argument('-c', '--count', type=int, help='Count of entries to examine')
     ap.add_argument('-d', '--dump-transaction', action='store_true',
                     help='Additionally pretty-print entire transactions to stdout')
@@ -74,39 +104,66 @@ def create_client_args(args):
 
 def get_model_uuid(client, args):
     """Given a model argument, convert it (if necessary) to a model UUID."""
-    if UUID_REGEX.match(args.model):
-        model_uuid = args.model
+    model = args.model
+    print("Examining supplied model:", model)
+    if UUID_REGEX.match(model):
+        model_uuid = model
+        print('Supplied model is a valid UUID; using as-is.')
     else:
-        model_doc = client.juju.models.find_one({'name': args.model})
+        model_doc = client.juju.models.find_one({'name': model})
         if model_doc:
             model_uuid = model_doc['_id']
+            print('Found matching UUID:', model_uuid)
         else:
-            sys.exit('Could not find the specified model ({})'.format(args.model))
+            sys.exit('Could not find the specified model ({})'.format(model))
     return model_uuid
 
 
-def walk_transaction_queue(client, model_uuid, dump_transaction, include_passes, max_transaction_count):
-    """Walk through the model's transaction queue, printing details about each transaction."""
-    db_client = client.juju
-    model_doc = db_client.models.find_one({"_id": model_uuid})
+def get_model_transaction_queue(client, model_uuid):
+    """Retrieves a list of transaction IDs from the specified model's document."""
+    model_doc = client.juju.models.find_one({"_id": model_uuid})
     if not model_doc:
         sys.exit('Could not find model with specified UUID ({})'.format(model_uuid))
     txn_queue = model_doc['txn-queue']
-    for txn_index, txn in enumerate(txn_queue):
-        if max_transaction_count and txn_index >= max_transaction_count:
-            break
-        id_ = txn.split('_')[0]   # discard the suffix (probably the nonce field?)
-        matches = list(db_client.txns.find({"_id": ObjectId(id_)}))
-        for match_index, match in enumerate(matches):
-            print('TXN {} found: {} (state: {}):'.format(txn_index, id_, get_state_as_string(match['s'])))
-            if match_index > 0:
-                # Probably will never happen, but just in case
-                print('WARNING: multiple transactions with the same transaction ID detected')
+    print('Retrieved model transaction queue:')
+    for ref in txn_queue:
+        print('- {}'.format(ref))
+    print('Converting to transaction IDs:')
+    txn_ids = [ref.split("_")[0] for ref in txn_queue]
+    for id_ in txn_ids:
+        print('- {}'.format(id_))
+    print()
+    return txn_ids
+
+
+def walk_transaction_queue(client, txn_queue, state_filter, dump_transaction, include_passes, max_transaction_count):
+    """Examine part or all of the transactions collection."""
+    db_client = client.juju
+    state_filter_args = {} if state_filter is None else {"s": state_filter}
+    if txn_queue:
+        # We'll perform one query for each specific transaction ID
+        query_docs = [dict(state_filter_args, _id=ObjectId(txn)) for txn in txn_queue]
+    else:
+        # We'll use a single cursor and iterate over the full collection of transactions
+        query_docs = [state_filter_args]
+
+    txn_counter = 0
+    for query_doc in query_docs:
+        matches = db_client.txns.find(query_doc)
+        for match in matches:
+            print('Transaction {} (state: {}):'.format(str(match['_id']), get_state_as_string(match['s'])))
             if dump_transaction:
                 print('  Transaction dump:\n{}'.format(textwrap.indent(pprint.pformat(match), '    ')))
+                print()
             for op_index, op in enumerate(match['o']):                      # pylint: disable=invalid-name
                 _print_op_details(db_client, op_index, op, include_passes)  # pylint: disable=invalid-name
+            txn_counter += 1
             print()
+
+            if max_transaction_count and txn_counter >= max_transaction_count:
+                break
+        if max_transaction_count and txn_counter >= max_transaction_count:
+            break
 
 
 def get_state_as_string(i):
@@ -123,25 +180,25 @@ def _print_op_details(db_client, op_index, op, include_passes):  # pylint: disab
             print('  Op {}: no assertion present; passes'.format(op_index))
     else:
         if op['a'] == DOC_MISSING:
-            assertion_type = 'DOC_MISSING'
+            assertion_type = AssertionType.DOC_MISSING
             existing_doc = collection.find_one(find_filter)
             failed = existing_doc
         elif op['a'] == DOC_EXISTS:
-            assertion_type = 'DOC_EXISTS'
+            assertion_type = AssertionType.DOC_EXISTS
             existing_doc = collection.find_one(find_filter)
             failed = not existing_doc
         else:
             # Standard assertion.  Uses a query doc.
-            assertion_type = 'query-doc-style'
+            assertion_type = AssertionType.QUERY_DOC
             find_filter.update(op['a'])
             existing_doc = collection.find_one(find_filter)
             failed = not existing_doc
 
         should_print = failed or include_passes
         if should_print:
-            print('  Op {}: {} assertion {}'.format(op_index, assertion_type, 'FAILED' if failed else 'passed'))
-            print('  Collection {}, ID {}'.format(op['c'], match_doc_id))
-            if assertion_type == "query-doc-style":
+            print('  Op {}: {} assertion {}'.format(op_index, assertion_type.name, 'FAILED' if failed else 'passed'))
+            print("  Collection '{}', ID '{}'".format(op['c'], match_doc_id))
+            if assertion_type == AssertionType.QUERY_DOC:
                 print(
                     '  Query doc tested was:\n{}'.format(textwrap.indent(pprint.pformat(find_filter), '    ')))
             if existing_doc:
@@ -150,7 +207,8 @@ def _print_op_details(db_client, op_index, op, include_passes):  # pylint: disab
                 print('  Insert doc is:\n{}'.format(textwrap.indent(pprint.pformat(op['i']), '    ')))
             if 'u' in op:
                 print('  Update doc is:\n{}'.format(textwrap.indent(pprint.pformat(op['u']), '    ')))
-    print()
+    if should_print:
+        print()
 
 
 if __name__ == "__main__":

--- a/scripts/juju-txn-helper/txn_helper.py
+++ b/scripts/juju-txn-helper/txn_helper.py
@@ -175,6 +175,7 @@ def _print_op_details(db_client, op_index, op, include_passes):  # pylint: disab
     collection = getattr(db_client, op['c'])
     match_doc_id = op['d']
     find_filter = {"_id": match_doc_id}
+    should_print = False
     if 'a' not in op:
         if include_passes:
             print('  Op {}: no assertion present; passes'.format(op_index))


### PR DESCRIPTION
The first version of this script worked to walk the transactions associated with a specific model's txn-queue.  Failing transactions may be found in other documents, thus this update allows for searching the full transaction collection, filtering by status code.

It is backwards compatible with the previous version.

While limited, some unit tests have also been added for the sake of preserving existing behavior and adding minimal, albeit incomplete, test coverage.