### PR TITLE
Add api_address table to controller schema

### DIFF
--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -68,6 +68,7 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 
 		// Controller nodes
 		"controller_node",
+		"api_address",
 
 		// Model migration
 		"model_migration",


### PR DESCRIPTION
JUJU-4426

We currently have in the Mongo `controllers` collection, 2 documents; one for `apiHostPorts` and another for `apiHostPortsForAgents`.

Here we represent this denormalisation in the Dqlite controller schema by adding the `api_addresses` table.

## QA steps

- Bootstrap to LXD
- `make repl-install repl` and paste the command from the prompt.
- `select * from api_address`. There will be no rows, but the table exists.
