### PR TITLE
[JUJU-4323] Inject controllerConfig service in agent/agent facade

### DIFF
--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -39,6 +39,8 @@ func newAgentAPIV3(ctx facade.Context) (*AgentAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
+	controllerConfigGetter := ctx.ServiceFactory().ControllerConfig()
+
 	resources := ctx.Resources()
 	return &AgentAPI{
 		PasswordChanger:   common.NewPasswordChanger(st, getCanChange),
@@ -56,8 +58,9 @@ func newAgentAPIV3(ctx facade.Context) (*AgentAPI, error) {
 			cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
-		st:        st,
-		auth:      auth,
-		resources: resources,
+		controllerConfigGetter: controllerConfigGetter,
+		st:                     st,
+		auth:                   auth,
+		resources:              resources,
 	}, nil
 }


### PR DESCRIPTION
This PR injects controllerConfig service in agent/agent facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test github.com/juju/juju/apiserver/facades/agent/agent/... -gocheck.v

juju boostrap lxd lxd
juju add-model m
juju deploy tiny-bash
```
