### PR TITLE
Remove some redundant upgrade validations

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -40,11 +40,6 @@ import (
 	upgradevalidationmocks "github.com/juju/juju/upgrades/upgradevalidation/mocks"
 )
 
-var winVersions = []string{
-	"win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2012r2",
-	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
-}
-
 var ubuntuVersions = []string{
 	"12.04",
 	"12.10",
@@ -261,13 +256,8 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	}, nil)
 	// - check mongo version;
 	s.statePool.EXPECT().MongoVersion().Return("4.4", nil)
-	// - check if the model has win machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check LXD version.
-	// - check if model has charm store charms;
-	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
@@ -281,12 +271,8 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	model1.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
 	//  - check if model migration is ongoing;
 	model1.EXPECT().MigrationMode().Return(state.MigrationModeNone)
-	// - check if the model has win machines;
-	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
 	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check if model has charm store charms;
-	state1.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -388,13 +374,9 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerDyingHostedModelJuju3(c
 	}, nil)
 	// - check mongo version;
 	s.statePool.EXPECT().MongoVersion().Return("4.4", nil)
-	// - check if the model has win machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
 	// - check LXD version.
-	// - check if model has charm store charms;
-	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
@@ -494,12 +476,8 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	}, nil)
 	// - check mongo version;
 	s.statePool.EXPECT().MongoVersion().Return("4.3", nil)
-	// - check if the model has win machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 2}, nil)
 	// - check if the model has deprecated ubuntu machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 2}, nil)
-	// - check if model has charm store charms;
-	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
@@ -515,8 +493,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	model1.EXPECT().AgentVersion().Return(version.MustParse("2.9.0"), nil)
 	//  - check if model migration is ongoing;
 	model1.EXPECT().MigrationMode().Return(state.MigrationModeExporting)
-	// - check if the model has win machines;
-	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 3}, nil)
 	// - check if the model has deprecated ubuntu machines;
 	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{
 		"artful": 1, "cosmic": 2, "disco": 3, "eoan": 4, "groovy": 5,
@@ -524,8 +500,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 		"saucy": 11, "trusty": 12, "utopic": 13, "vivid": 14, "wily": 15,
 		"xenial": 16, "yakkety": 17, "zesty": 18,
 	}, nil)
-	// - check if model has charm store charms;
-	state1.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
@@ -546,13 +520,11 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - upgrading a controller to a newer major.minor version 3.9 not supported
 - unable to upgrade, database node 1 (1.1.1.1) has state FATAL, node 2 (2.2.2.2) has state ARBITER, node 3 (3.3.3.3) has state RECOVERING
 - mongo version has to be "4.4" at least, but current version is "4.3"
-- the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): xenial(2)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"
 "admin/model-1":
 - current model ("2.9.0") has to be upgraded to "2.9.2" at least
 - model is under "exporting" mode, upgrade blocked
-- the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
@@ -601,10 +573,6 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
 
 	// - check no upgrade series in process.
 	st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
-	// - check if model has charm store charms;
-	st.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
-	// - check if the model has win machines;
-	st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
 	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
 	// - check LXD version.
@@ -682,8 +650,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	// - check no upgrade series in process.
 	st.EXPECT().HasUpgradeSeriesLocks().Return(true, nil)
 
-	// - check if the model has win machines;
-	st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 3}, nil)
 	// - check if the model has deprecated ubuntu machines;
 	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{
 		"artful": 1, "cosmic": 2, "disco": 3, "eoan": 4, "groovy": 5,
@@ -691,8 +657,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 		"saucy": 11, "trusty": 12, "utopic": 13, "vivid": 14, "wily": 15,
 		"xenial": 16, "yakkety": 17, "zesty": 18,
 	}, nil)
-	// - check if model has charm store charms;
-	st.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
@@ -711,7 +675,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 cannot upgrade to "3.9.99" due to issues with these models:
 "admin/model-1":
 - unexpected upgrade series lock found
-- the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -5,7 +5,6 @@ package migration_test
 
 import (
 	"context"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -106,7 +105,6 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	backend := newFakeBackend()
 	hasUpgradeSeriesLocks := true
 	backend.hasUpgradeSeriesLocks = &hasUpgradeSeriesLocks
-	backend.machineCountForSeriesWin = map[string]int{"win10": 1, "win7": 2}
 	backend.machineCountForSeriesUbuntu = map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}
 	agentVersion := version.MustParse("2.9.35")
 	backend.model.agentVersion = &agentVersion
@@ -129,7 +127,6 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 cannot migrate to controller due to issues:
 "foo/model-1":
 - unexpected upgrade series lock found
-- the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
@@ -138,7 +135,6 @@ func (*SourcePrecheckSuite) TestTargetController2Failed(c *gc.C) {
 	backend := newFakeBackend()
 	hasUpgradeSeriesLocks := true
 	backend.hasUpgradeSeriesLocks = &hasUpgradeSeriesLocks
-	backend.machineCountForSeriesWin = map[string]int{"win10": 1, "win7": 2}
 	backend.machineCountForSeriesUbuntu = map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}
 	agentVersion := version.MustParse("2.9.31")
 	backend.model.agentVersion = &agentVersion
@@ -156,7 +152,6 @@ func (*SourcePrecheckSuite) TestTargetController2Failed(c *gc.C) {
 cannot migrate to controller due to issues:
 "foo/model-1":
 - unexpected upgrade series lock found
-- the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)`[1:])
 }
 
@@ -848,7 +843,6 @@ type fakeBackend struct {
 	hasUpgradeSeriesLocks    *bool
 	hasUpgradeSeriesLocksErr error
 
-	machineCountForSeriesWin    map[string]int
 	machineCountForSeriesUbuntu map[string]int
 	machineCountForSeriesErr    error
 
@@ -907,12 +901,6 @@ func (b *fakeBackend) HasUpgradeSeriesLocks() (bool, error) {
 }
 
 func (b *fakeBackend) MachineCountForBase(base ...state.Base) (map[string]int, error) {
-	if strings.HasPrefix(base[0].Channel, "win") {
-		if b.machineCountForSeriesWin == nil {
-			return nil, nil
-		}
-		return b.machineCountForSeriesWin, b.machineCountForSeriesErr
-	}
 	if b.machineCountForSeriesUbuntu == nil {
 		return nil, nil
 	}

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -15,9 +15,7 @@ func ValidatorsForModelMigrationSource(
 ) []Validator {
 	return []Validator{
 		getCheckUpgradeSeriesLockForModel(false),
-		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
-		checkForCharmStoreCharms,
 	}
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -4,7 +4,6 @@
 package upgradevalidation_test
 
 import (
-	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -17,11 +16,6 @@ import (
 	"github.com/juju/juju/upgrades/upgradevalidation"
 	"github.com/juju/juju/upgrades/upgradevalidation/mocks"
 )
-
-var winVersions = []string{
-	"win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2012r2",
-	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
-}
 
 var ubuntuVersions = []string{
 	"12.04",
@@ -117,10 +111,7 @@ func (s *migrateSuite) setupMocks(c *gc.C) (*gomock.Controller, environscloudspe
 	// - check no upgrade series in process.
 	s.st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines;
-	s.st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 
 	return ctrl, cloudSpec.CloudSpec
 }

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -18,12 +18,10 @@ func TestAll(t *stdtesting.T) {
 
 var (
 	CheckForDeprecatedUbuntuSeriesForModel      = checkForDeprecatedUbuntuSeriesForModel
-	CheckNoWinMachinesForModel                  = checkNoWinMachinesForModel
 	GetCheckUpgradeSeriesLockForModel           = getCheckUpgradeSeriesLockForModel
 	GetCheckTargetVersionForModel               = getCheckTargetVersionForModel
 	CheckModelMigrationModeForControllerUpgrade = checkModelMigrationModeForControllerUpgrade
 	CheckMongoStatusForControllerUpgrade        = checkMongoStatusForControllerUpgrade
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
-	CheckForCharmStoreCharms                    = checkForCharmStoreCharms
 )

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -20,12 +20,8 @@ func ValidatorsForControllerUpgrade(
 			getCheckTargetVersionForControllerModel(targetVersion),
 			checkMongoStatusForControllerUpgrade,
 			checkMongoVersionForControllerModel,
-			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
-		}
-		if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-			validators = append(validators, checkForCharmStoreCharms)
 		}
 		return validators
 	}
@@ -33,12 +29,8 @@ func ValidatorsForControllerUpgrade(
 	validators := []Validator{
 		getCheckTargetVersionForModel(targetVersion, UpgradeControllerAllowed),
 		checkModelMigrationModeForControllerUpgrade,
-		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
-	}
-	if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-		validators = append(validators, checkForCharmStoreCharms)
 	}
 	return validators
 }
@@ -50,12 +42,8 @@ func ValidatorsForModelUpgrade(
 ) []Validator {
 	validators := []Validator{
 		getCheckUpgradeSeriesLockForModel(force),
-		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
-	}
-	if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-		validators = append(validators, checkForCharmStoreCharms)
 	}
 	return validators
 }

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -4,7 +4,6 @@
 package upgradevalidation_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v3"
 	jc "github.com/juju/testing/checkers"
@@ -72,11 +71,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	}, nil)
 	// - check mongo version;
 	statePool.EXPECT().MongoVersion().Return("4.4", nil)
-	// - check if the model has win machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	ctrlState.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -85,11 +80,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	model1.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
 	//  - check if model migration is ongoing;
 	model1.EXPECT().MigrationMode().Return(state.MigrationModeNone)
-	// - check if the model has win machines;
-	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
-	// - check no charm store charms
-	state1.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -128,8 +119,6 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 
 	// - check no upgrade series in process.
 	state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
-	// - check if the model has win machines.
-	state.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	state.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v11"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/replicaset/v3"
@@ -154,29 +152,6 @@ func getCheckUpgradeSeriesLockForModel(force bool) Validator {
 	}
 }
 
-var windowsSeries = []string{
-	"win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2012r2",
-	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
-}
-
-func checkNoWinMachinesForModel(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
-	windowsBases := make([]state.Base, len(windowsSeries))
-	for i, s := range windowsSeries {
-		windowsBases[i] = state.Base{OS: "windows", Channel: s}
-	}
-	result, err := st.MachineCountForBase(windowsBases...)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot count windows machines")
-	}
-	if len(result) > 0 {
-		return NewBlocker(
-			"the model hosts deprecated windows machine(s): %s",
-			stringifyMachineCounts(result),
-		), nil
-	}
-	return nil, nil
-}
-
 func stringifyMachineCounts(result map[string]int) string {
 	var keys []string
 	for k := range result {
@@ -212,39 +187,6 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	if len(result) > 0 {
 		return NewBlocker("the model hosts deprecated ubuntu machine(s): %s",
 			stringifyMachineCounts(result),
-		), nil
-	}
-	return nil, nil
-}
-
-func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
-	curls, err := st.AllCharmURLs()
-	if errors.Is(err, errors.NotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	result := set.NewStrings()
-	for _, curlStr := range curls {
-		if curlStr == nil {
-			return nil, errors.New("malformed charm in database with no URL")
-		}
-		curl, err := charm.ParseURL(*curlStr)
-		if err != nil {
-			logger.Errorf("error from ParseURL: %s", err)
-			return nil, errors.New(fmt.Sprintf("malformed charm url in database: %q", *curlStr))
-		}
-		// TODO 6-dec-2022
-		// Update check once charm's ValidateSchema rejects charm store charms.
-		if !charm.CharmHub.Matches(curl.Schema) && !charm.Local.Matches(curl.Schema) {
-			c := curl.WithSeries("").WithArchitecture("")
-			result.Add(c.String())
-		}
-	}
-	if !result.IsEmpty() {
-		return NewBlocker("the model hosts deprecated charm store charms(s): %s",
-			strings.Join(result.SortedValues(), ", "),
 		), nil
 	}
 	return nil, nil

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -110,25 +110,6 @@ func (s *upgradeValidationSuite) TestModelUpgradeCheck(c *gc.C) {
 - unexpected upgrade series lock found`[1:])
 }
 
-func (s *upgradeValidationSuite) TestCheckNoWinMachinesForModel(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	gomock.InOrder(
-		st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil),
-		st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 2}, nil),
-	)
-
-	blocker, err := upgradevalidation.CheckNoWinMachinesForModel("", nil, st, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker, gc.IsNil)
-
-	blocker, err = upgradevalidation.CheckNoWinMachinesForModel("", nil, st, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker.Error(), gc.Equals, `the model hosts deprecated windows machine(s): win10(1) win7(2)`)
-}
-
 func (s *upgradeValidationSuite) TestCheckForDeprecatedUbuntuSeriesForModel(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -400,27 +381,4 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
-}
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsNotFound(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
-
-	blocker, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker, gc.IsNil)
-}
-
-func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsError(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	st := mocks.NewMockState(ctrl)
-	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.BadRequestf("charm urls"))
-
-	_, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
-	c.Assert(err, jc.ErrorIs, errors.BadRequest)
 }


### PR DESCRIPTION
Remove some redundant upgrade validations

Note it is only possible to upgrade to 4.x from 3.x

It is impossible to deploy a charmstore charm to 3.x, so we don't need to
check for them when upgrading

It is also impossible to deploy to a windows machine in 3.x, so we don't
need to check for that either

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure model integration tests pass

Migrate a model from 3.1 to 4.0-beta

Before building juju from this PR, make sure to run `git revert ad90127` to undo a change which broke migrations

```
juju-3.1 bootstrap lxd lxd
juju-3.1 add-model m
juju-3.1 deploy ubuntu -n2

juju-4.0 bootstrap lxd lxd-4.0
juju-3.1 migrate m lxd-4.0
```
Wait and verify the model migrates correctly