### PR TITLE
Increase SSH timeouts

### DIFF
--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -125,11 +125,10 @@ See also:
 const (
 	// SSHRetryDelay is the time to wait for an SSH connection to be established
 	// to a single endpoint of a target.
-	SSHRetryDelay = 500 * time.Millisecond
+	SSHRetryDelay = 2 * time.Second
 
-	// SSHTimeout is the time to wait for before giving up trying to establish
-	// an SSH connection to a target, after retrying.
-	SSHTimeout = 5 * time.Second
+	// SSHTimeout is the time to wait for all SSH negotiation and authentication process.
+	SSHTimeout = 20 * time.Second
 )
 
 func newSSHCommand(


### PR DESCRIPTION
Some user deployments might have long latency times. This allows such deployments to be accessed via 'juju ssh' commands.

The timeouts were increased from 500ms to 2000ms since this won't affect faster connections and if something has a TTL slower than 2 seconds, will be pretty unusable.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
- Setup a juju 2.9.x controller
- Create a model with a machine
- juju ssh to the machine confirming that SSH works
- add a synthetic packet delaying on the machine: `sudo tc qdisc add dev ens3 root netem delay 510ms`
- juju ssh to the machine confirming that SSH works (it fails on the unpatched version) 
```

## Documentation changes

- No changes needed

## Bug reference

https://bugs.launchpad.net/juju/+bug/2009008
