### PR TITLE
Store Dqlite node ID as text

### DIFF
--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -6,6 +6,7 @@ package state
 import (
 	"context"
 	"database/sql"
+	"strconv"
 
 	"github.com/juju/errors"
 
@@ -73,7 +74,7 @@ WHERE  controller_id = ?
 AND    (dqlite_node_id != ? OR bind_address != ?)`
 
 	return errors.Trace(db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, q, nodeID, addr, controllerID, nodeID, addr)
+		_, err := tx.ExecContext(ctx, q, nodeID, addr, controllerID, strconv.FormatUint(nodeID, 10), addr)
 		return errors.Trace(err)
 	}))
 }

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -59,13 +59,13 @@ func (s *stateSuite) TestUpdateUpdateDqliteNode(c *gc.C) {
 	c.Assert(row.Err(), jc.ErrorIsNil)
 
 	var (
-		id   int
+		id   uint64
 		addr string
 	)
 	err = row.Scan(&id, &addr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(id, gc.Equals, 12345)
+	c.Check(id, gc.Equals, uint64(12345))
 	c.Check(addr, gc.Equals, "192.168.5.60")
 }
 

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -284,7 +284,7 @@ func controllerNodeTable() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE controller_node (
     controller_id  TEXT PRIMARY KEY, 
-    dqlite_node_id INT,               -- This is the uint64 from Dqlite NodeInfo.
+    dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
     bind_address   TEXT               -- IP address (no port) that Dqlite is bound to. 
 );
 

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -98,7 +98,7 @@ func (s *baseSuite) expectNodeStartupAndShutdown() {
 	appExp.Ready(gomock.Any()).Return(nil)
 	appExp.Client(gomock.Any()).Return(s.client, nil).MinTimes(1)
 	appExp.ID().Return(uint64(666)).MinTimes(1)
-	appExp.Address().Return("192.168.6.6")
+	appExp.Address().Return("192.168.6.6:17666")
 	appExp.Close().Return(nil)
 }
 

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -538,7 +538,12 @@ func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
 	// Once initialised, set the details for the node.
 	// This is a no-op if the details are unchanged.
 	// We do this before serving any other requests.
-	if err := w.nodeService().UpdateDqliteNode(ctx, w.cfg.ControllerID, w.dbApp.ID(), w.dbApp.Address()); err != nil {
+	addr, _, err := net.SplitHostPort(w.dbApp.Address())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := w.nodeService().UpdateDqliteNode(ctx, w.cfg.ControllerID, w.dbApp.ID(), addr); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
JUJU-4531

During testing, the following error was recurrent for one HA node:
```
ERROR juju.worker.dependency "db-accessor" manifold worker returned unexpected error: updating Dqlite node details for "2": sql: converting argument $1 type: uint64 values with high bit set are not supported
```
This comes from the driver attempt to store `uint64` as `INT`.

Here, we change the table column definition to be `TEXT`. This change is very isolated - we can still just parse this back to `uint64` when we select it.

In addition, we ensure that the Dqlite bind address is stored in the `controller_node` table without the port. A new integration test verifies this.

## QA steps

Bootstrap and `enable-ha`. Check that the logs indicate quiescence of the cluster.
