### PR TITLE
Merge 3.1 into 3.2

### DIFF
--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -37,7 +36,6 @@ import (
 
 type NewAPIClientSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
-	mgotesting.MgoSuite
 	envtesting.ToolsFixture
 }
 
@@ -47,26 +45,22 @@ var _ = gc.Suite(&NewAPIClientSuite{})
 
 func (s *NewAPIClientSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *NewAPIClientSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
 }
 
 func (s *NewAPIClientSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
 	s.PatchValue(&dummy.LogDir, c.MkDir())
 }
 
 func (s *NewAPIClientSuite) TearDownTest(c *gc.C) {
 	dummy.Reset(c)
 	s.ToolsFixture.TearDownTest(c)
-	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
@@ -453,40 +447,6 @@ func (s *NewAPIClientSuite) TestEndpointFiltering(c *gc.C) {
 	})
 }
 
-var moveToFrontTests = []struct {
-	item   string
-	items  []string
-	expect []string
-}{{
-	item:   "x",
-	items:  []string{"y", "x"},
-	expect: []string{"x", "y"},
-}, {
-	item:   "z",
-	items:  []string{"y", "x"},
-	expect: []string{"y", "x"},
-}, {
-	item:   "y",
-	items:  []string{"y", "x"},
-	expect: []string{"y", "x"},
-}, {
-	item:   "x",
-	items:  []string{"y", "x", "z"},
-	expect: []string{"x", "y", "z"},
-}, {
-	item:   "d",
-	items:  []string{"a", "b", "c", "d", "e", "f"},
-	expect: []string{"d", "a", "b", "c", "e", "f"},
-}}
-
-func (s *NewAPIClientSuite) TestMoveToFront(c *gc.C) {
-	for i, test := range moveToFrontTests {
-		c.Logf("test %d: moveToFront %q %v", i, test.item, test.items)
-		juju.MoveToFront(test.item, test.items)
-		c.Assert(test.items, jc.DeepEquals, test.expect)
-	}
-}
-
 type testRootAPI struct {
 	serverAddrs [][]params.HostPort
 }
@@ -555,7 +515,7 @@ func newAPIConnectionFromNames(
 		OpenAPI:        apiOpen,
 	}
 	accountDetails, err := store.AccountDetails(controller)
-	if !errors.IsNotFound(err) {
+	if !errors.Is(err, errors.NotFound) {
 		c.Assert(err, jc.ErrorIsNil)
 		args.AccountDetails = accountDetails
 	}

--- a/juju/api_whitebox_test.go
+++ b/juju/api_whitebox_test.go
@@ -1,0 +1,105 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package juju
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type APIHelperSuite struct {
+}
+
+var _ = gc.Suite(&APIHelperSuite{})
+
+var moveToFrontTests = []struct {
+	item   string
+	items  []string
+	expect []string
+}{{
+	item:   "x",
+	items:  []string{"y", "x"},
+	expect: []string{"x", "y"},
+}, {
+	item:   "z",
+	items:  []string{"y", "x"},
+	expect: []string{"y", "x"},
+}, {
+	item:   "y",
+	items:  []string{"y", "x"},
+	expect: []string{"y", "x"},
+}, {
+	item:   "x",
+	items:  []string{"y", "x", "z"},
+	expect: []string{"x", "y", "z"},
+}, {
+	item:   "d",
+	items:  []string{"a", "b", "c", "d", "e", "f"},
+	expect: []string{"d", "a", "b", "c", "e", "f"},
+}}
+
+func (s *APIHelperSuite) TestMoveToFront(c *gc.C) {
+	for i, test := range moveToFrontTests {
+		c.Logf("test %d: moveToFront %q %v", i, test.item, test.items)
+		moveToFront(test.item, test.items)
+		c.Check(test.items, jc.DeepEquals, test.expect)
+	}
+}
+
+var addrsChangedTests = []struct {
+	description string
+	source      []string
+	target      []string
+	changed     bool
+	setDiff     bool
+}{{
+	description: "first longer",
+	source:      []string{"a", "b"},
+	target:      []string{"a"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "second longer",
+	source:      []string{"a"},
+	target:      []string{"a", "b"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "identical",
+	source:      []string{"a", "b"},
+	target:      []string{"a", "b"},
+	changed:     false,
+	setDiff:     false,
+}, {
+	description: "reordered",
+	source:      []string{"b", "a"},
+	target:      []string{"a", "b"},
+	changed:     true,
+	setDiff:     false,
+}, {
+	description: "repeated",
+	source:      []string{"a", "b", "c"},
+	target:      []string{"a", "b", "b"},
+	changed:     true,
+	setDiff:     true,
+}, {
+	description: "repeated reversed",
+	source:      []string{"a", "b", "b"},
+	target:      []string{"a", "b", "c"},
+	changed:     true,
+	setDiff:     true,
+}}
+
+func (s *APIHelperSuite) TestAddrsChanged(c *gc.C) {
+	for i, test := range addrsChangedTests {
+		c.Logf("test %d: addrsChanged %v %v", i, test.description)
+		anyChange, differentSet := addrsChanged(test.source, test.target)
+		c.Check(anyChange, gc.Equals, test.changed,
+			gc.Commentf("%v vs %v declared that %t but expected %t",
+				test.source, test.target, anyChange, test.changed))
+		c.Check(differentSet, gc.Equals, test.setDiff,
+			gc.Commentf("%v vs %v declared that %t but expected %t",
+				test.source, test.target, differentSet, test.setDiff))
+	}
+}

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -4,6 +4,5 @@
 package juju
 
 var (
-	MoveToFront    = moveToFront
 	ConnectionInfo = connectionInfo
 )

--- a/juju/package_test.go
+++ b/juju/package_test.go
@@ -6,9 +6,9 @@ package juju_test
 import (
 	stdtesting "testing"
 
-	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func Test(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -329,7 +329,7 @@ func (s *JujuConnSuite) EnsureCachedModel(c *gc.C, uuid string) {
 			if err == nil {
 				return
 			}
-			if !errors.IsNotFound(err) {
+			if !errors.Is(err, errors.NotFound) {
 				c.Fatalf("problem getting model from cache: %v", err)
 			}
 			retry = time.After(testing.ShortWait)

--- a/worker/actionpruner/worker_test.go
+++ b/worker/actionpruner/worker_test.go
@@ -14,6 +14,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/environs/config"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/actionpruner"
 	"github.com/juju/juju/worker/pruner"
 	"github.com/juju/juju/worker/pruner/mocks"
@@ -27,18 +29,33 @@ func (s *PrunerSuite) TestRunStop(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
+	cfg, err := config.New(false, map[string]interface{}{
+		"name":                    "test",
+		"type":                    "manual",
+		"uuid":                    coretesting.ModelTag.Id(),
+		"max-action-results-age":  "2h",
+		"max-action-results-size": "2GiB",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	ch := make(chan struct{}, 1)
 	ch <- struct{}{}
 	w := watchertest.NewMockNotifyWatcher(ch)
 
 	facade := mocks.NewMockFacade(ctrl)
 	facade.EXPECT().WatchForModelConfigChanges().Return(w, nil)
+
+	// Depending on the host compute speed, the loop may select either
+	// the watcher change event, or the catacomb's dying event first.
+	facade.EXPECT().ModelConfig().Return(cfg, nil).AnyTimes()
+
 	updater, err := actionpruner.New(pruner.Config{
 		Facade:        facade,
-		PruneInterval: 0,
+		PruneInterval: time.Minute,
 		Clock:         testclock.NewClock(time.Now()),
 		Logger:        loggo.GetLogger("test"),
 	})
+
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CleanKill(c, updater)
 }


### PR DESCRIPTION
Zero-conflict merge to bring forward:
- #16143 from manadart/3.1-upgrade-binding-logs
- #16126 from jameinel/3.1-api-addrs-logging-changed
- #16115 from manadart/3.1-action-pruner-test-fix
