### PR TITLE
Fix the other uint64 value passed to controller node update

### DIFF
--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -73,8 +73,14 @@ SET    dqlite_node_id = ?,
 WHERE  controller_id = ?
 AND    (dqlite_node_id != ? OR bind_address != ?)`
 
+	// uint64 values with the high bit set cause the driver to throw an error,
+	// so we parse them as strings. The node_id is defined as being TEXT,
+	// which makes no difference - it can still be scanned directly into
+	// uint64 when querying the table.
+	nodeStr := strconv.FormatUint(nodeID, 10)
+
 	return errors.Trace(db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, q, nodeID, addr, controllerID, strconv.FormatUint(nodeID, 10), addr)
+		_, err := tx.ExecContext(ctx, q, nodeStr, addr, controllerID, nodeStr, addr)
 		return errors.Trace(err)
 	}))
 }

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -51,8 +51,12 @@ func (s *stateSuite) TestCurateNodes(c *gc.C) {
 }
 
 func (s *stateSuite) TestUpdateUpdateDqliteNode(c *gc.C) {
+	// This value would cause a driver error to be emitted if we
+	// tried to pass it directly as a uint64 query parameter.
+	nodeID := uint64(15237855465837235027)
+
 	err := NewState(testing.TxnRunnerFactory(s.TxnRunner())).UpdateDqliteNode(
-		context.Background(), "0", 12345, "192.168.5.60")
+		context.Background(), "0", nodeID, "192.168.5.60")
 	c.Assert(err, jc.ErrorIsNil)
 
 	row := s.DB().QueryRow("SELECT dqlite_node_id, bind_address FROM controller_node WHERE controller_id = '0'")
@@ -65,7 +69,7 @@ func (s *stateSuite) TestUpdateUpdateDqliteNode(c *gc.C) {
 	err = row.Scan(&id, &addr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(id, gc.Equals, uint64(12345))
+	c.Check(id, gc.Equals, nodeID)
 	c.Check(addr, gc.Equals, "192.168.5.60")
 }
 


### PR DESCRIPTION
JUJU-4531

The solution landed under #16145 was sloppy, and fixed only one of the `uint64` values passed to the controller node update statement.

This rectifies the omission and ensures the specific case is covered by a unit test using a value that caused it to fail in-theatre.

## QA steps

Bootstrap, `enable-ha`, then ensure the Dqlite cluster quiesces.
