### PR TITLE
Remove redundant context assignment in db-accessor worker

### DIFF
--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -575,8 +575,6 @@ func (w *dbWorker) startDqliteNode(ctx context.Context, options ...app.Option) e
 		return errors.Trace(err)
 	}
 
-	ctx, pCancel := w.scopedContext()
-	defer pCancel()
 	ctx, cCancel := context.WithTimeout(ctx, time.Minute)
 	defer cCancel()
 


### PR DESCRIPTION
We are assigning a context that is already passed into the method. 

The redundant lines are deleted here.

No functional change.
