### PR TITLE
[JUJU-4504] Retry transaction when entering scope of a relation unit

### DIFF
--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/sync/errgroup"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
@@ -1064,14 +1066,18 @@ func (prr *ProReqRelation) watches() []*state.RelationScopeWatcher {
 	}
 }
 
+// allEnterScope will run EnterScope on all relationUnits in ProReqRelation,
+// and it will do it concurrently to make sure there are no write conflicts
+// on EnterScope's transactions.
 func (prr *ProReqRelation) allEnterScope(c *gc.C) {
-	err := prr.pru0.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.pru1.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.rru0.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.rru1.EnterScope(nil)
+	g, _ := errgroup.WithContext(context.Background())
+
+	g.Go(func() error { return prr.pru0.EnterScope(nil) })
+	g.Go(func() error { return prr.pru1.EnterScope(nil) })
+	g.Go(func() error { return prr.rru0.EnterScope(nil) })
+	g.Go(func() error { return prr.rru1.EnterScope(nil) })
+
+	err := g.Wait()
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
_TLDR: Under some load (a few apps and units) sometimes a newly created relation fails to enter scope with error `inconsistent state in EnterScope`. This is due to the transactions involved being aborted with `WriteConflict error`. 
The main hypothesis behind this patch is that this error is purely transient (due to transactions that write to the same document being run concurrently, and on different transaction runners) and can therefore be retried._

This patch fixes a bug (https://bugs.launchpad.net/juju/+bug/2031631) on which the relation unit doesn't enter scope in the case multiple units and applications are present before creating a relation on them.
The observed behaviour is that 

When using server-side transactions, mgo retries (hard-coded 3 times) transactions that fail with WriteConflict error, and after that it aborts the (mgo) transaction.
For example:
```
juju debug-log --replay --level TRACE --tail -m controller | grep "juju.txn.*Please retry"
controller-0: 15:44:17 TRACE juju.txn update op: txn.Op{C:"modelEntityRefs", Id:"03b60bbf-53e8-48e9-819c-dfaf1e71b954", Assert:"d+", Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$addToSet", Value:bson.D{bson.DocElem{Name:"applications", Value:"database"}}}}, Remove:false} write conflict: WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.
```
These retries are seen many times on multiple scenarios in juju, and therefore the business logic decides on each case how to treat the (mgo server-side) aborted transactions. In the case of EnterScope, it is necessary to retry the (mgo server-side) transaction (which includs retrying the mongodb transaction) because EnterScope is called concurrently (via the EnterScope facade) and therefore WriteConflict errors are transient errors.
_Note: This last observation means that the true solution would be sequential transactions for EnterScope, but since each relationunit has its own runner, this would mean a huge change._

The first approach was to simply increase the number of retries in https://github.com/juju/mgo/blob/master/sstxn/sstxn.go#L139 but then I relalised this is a bit too agressive and large scoped since all juju transactions would be impacted, and preferred to solve the issue locally on EnterScope.


### Reproducing the bug

The first way to reproduce this behaviour is simply by modifying the `func (prr *ProReqRelation) allEnterScope(c *gc.C)` function on `state/relationunit_test.go` in a way that the calls to `EnterScope()` are run concurrently:
```go
func (prr *ProReqRelation) allEnterScope(c *gc.C) {
       g, _ := errgroup.WithContext(context.Background())

       g.Go(func() error { return prr.pru0.EnterScope(nil) })
       g.Go(func() error { return prr.pru1.EnterScope(nil) })
       g.Go(func() error { return prr.rru0.EnterScope(nil) })
       g.Go(func() error { return prr.rru1.EnterScope(nil) })

       err := g.Wait()
	c.Assert(err, jc.ErrorIsNil)
}
```
This change only should make some tests fail, for example:
```
go test github.com/juju/juju/state/... -gocheck.v -gocheck.f=TestWatchAppSettings
...
[LOG] 0:01.324 DEBUG juju.state.pool.txnwatcher txn watcher: relations eea4884f-5783-4a66-897a-5d55f6a41daf:wordpress:db mysql:server #5
    prr.allEnterScope(c)
relationunit_test.go:1081:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.errorString = &errors.errorString{s:"cannot enter scope for unit \"wordpress/1\" in relation \"wordpress:db mysql:server\": inconsistent state in EnterScope"} ("cannot enter scope for unit \"wordpress/1\" in relation \"wordpress:db mysql:server\": inconsistent state in EnterScope")
...
```
Another way is by bootstrapping a microk8s controller, adding a model and simply deploying two apps with multiple units and a relation between them, it won't fail systematically but if you delete and recreate the relation it will eventually fail:
```
juju deploy kafka-k8s -n 5 --channel 3/edge && juju deploy zookeeper-k8s -n 5 --channel 3/edge && juju relate kafka-k8s zookeeper-k8s
juju debug-log --replay --level DEBUG --tail | grep "enterscope\|EnterScope" 
```
The last way is by reproducing the scenario in https://bugs.launchpad.net/juju/+bug/2031631. This is the longest setup but it failed systematically locally on my PC:

```
# using juju 3.1 (from snap) bootstrap a microk8s controller and add a model
juju bootstrap microk8s c --config logging-config="<root>=DEBUG;juju.txn=TRACE;juju.worker.uniter.relation=TRACE"
juju add-model testing
# clone the data project and checkout the correct PR:
git clone git@github.com:canonical/data-platform-libs.git && gh pr checkout 84 
# setup python virtual environment
python3 -m venv data-platform-libs
# activate the virtual env and install dependencies
cd data-platform-libs
source bin/activate 
pip install -r requirements.txt
# set the correct pylibjuju version and run the tests
export LIBJUJU_VERSION_SPECIFIER="==3.2.0.1"
tox run -e integration-database -- -m 'not unstable' --model testing
```
by checking the logs you should see the error:
```
juju debug-log --replay --level DEBUG --tail | grep "enterscope\|EnterScope"
unit-database-1: 15:45:33 ERROR juju.worker.uniter resolver loop error: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
unit-database-1: 15:45:33 INFO juju.worker.uniter unit "database/1" shutting down: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
unit-database-1: 15:45:33 DEBUG juju.worker.dependency "uniter" manifold worker stopped: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
github.com/juju/juju/api/agent/uniter.(*RelationUnit).EnterScope:71:
```

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

QA steps include to run the scenarios described in the `Reproducing the bug` section above. These should always pass now.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2031631
