### PR TITLE
Fix incorrect error check & backport test

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -56,7 +56,7 @@ jobs:
           libdqlite-dev \
           libsqlite3-dev \
           sqlite3
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
         sudo snap install shfmt
 
     - name: Download Dependencies

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -1283,10 +1283,10 @@ func getSeries(application *charm.ApplicationSpec, defaultBase corebase.Base) (s
 
 	if charm.IsValidLocalCharmOrBundlePath(application.Charm) {
 		_, charmURL, err := corecharm.NewCharmAtPath(application.Charm, defaultBase)
-		if corecharm.IsMissingSeriesError(err) {
+		if corecharm.IsMissingBaseError(err) {
 			// local charm path is valid but the charm doesn't declare a default series.
 			return "", nil
-		} else if corecharm.IsUnsupportedSeriesError(err) {
+		} else if corecharm.IsUnsupportedBaseError(err) {
 			// The bundle's default series is not supported by the charm, but we'll
 			// use it anyway. This is no different to the case above where application.Series
 			// is used without checking for potential charm incompatibility.

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,7 +1,7 @@
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.53" ]] && [[ ${VER} != "v1.53" ]]; then
-		(echo >&2 -e '\nError: golangci-lint version does not match 1.53. Please upgrade/downgrade to the right version.')
+	if [[ ${VER} != "1.54" ]] && [[ ${VER} != "v1.54" ]]; then
+		(echo >&2 -e '\nError: golangci-lint version does not match 1.54. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
 	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)


### PR DESCRIPTION
In a previous PR, this change was forgotten. It was only picked up on merge into main (4.0) by a test which is disabled in this branch.

Backport this test as well. In 4.0 it is restored properly alongside other tests disabled in this file, so doesn't need to be upstreamed in the next forward merge

As a flyby rev the version of golangci-lint

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

All that should be required is passing unit tests