### PR TITLE
[JUJU-4439] Export bundles with bases

### DIFF
--- a/api/client/bundle/client.go
+++ b/api/client/bundle/client.go
@@ -53,10 +53,11 @@ func (c *Client) GetChangesMapArgs(bundleURL, bundleDataYAML string) (params.Bun
 }
 
 // ExportBundle exports the current model configuration.
-func (c *Client) ExportBundle(includeDefaults bool) (string, error) {
+func (c *Client) ExportBundle(includeDefaults bool, includeSeries bool) (string, error) {
 	var result params.StringResult
 	arg := params.ExportBundleParams{
 		IncludeCharmDefaults: includeDefaults,
+		IncludeSeries:        includeSeries,
 	}
 	if err := c.facade.FacadeCall("ExportBundle", arg, &result); err != nil {
 		return "", errors.Trace(err)

--- a/api/client/bundle/client_test.go
+++ b/api/client/bundle/client_test.go
@@ -207,13 +207,13 @@ func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
 	bundleStr := `applications:
 	ubuntu:
 		charm: ch:ubuntu
-		series: jammy
+		base: ubuntu@22.04/stable
 		num_units: 1
 		to:
 			- \"0\"
 		options:
 			key: value
-			series: focal
+			base: ubuntu@22.04/stable
 		relations:
 			- []`
 
@@ -227,7 +227,7 @@ func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ExportBundle", args, res).SetArg(2, results).Return(nil)
 	client := bundle.NewClientFromCaller(mockFacadeCaller)
-	result, err := client.ExportBundle(true)
+	result, err := client.ExportBundle(true, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, bundleStr)
 }

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -260,7 +260,7 @@ func (b *BundleAPI) ExportBundle(arg params.ExportBundleParams) (params.StringRe
 	}
 
 	// Fill it in charm.BundleData data structure.
-	bundleData, err := b.fillBundleData(model, arg.IncludeCharmDefaults, b.backend)
+	bundleData, err := b.fillBundleData(model, arg.IncludeCharmDefaults, arg.IncludeSeries, b.backend)
 	if err != nil {
 		return fail(err)
 	}
@@ -312,10 +312,11 @@ func (b *BundleAPI) ExportBundle(arg params.ExportBundleParams) (params.StringRe
 
 // bundleOutput has the same top level keys as the charm.BundleData
 // but in a more user oriented output order, with the description first,
-// then the distro series, then the apps, machines and releations.
+// then the distro base/series, then the apps, machines and releations.
 type bundleOutput struct {
 	Type         string                            `yaml:"bundle,omitempty"`
 	Description  string                            `yaml:"description,omitempty"`
+	DefaultBase  string                            `yaml:"default-base,omitempty"`
 	Series       string                            `yaml:"series,omitempty"`
 	Saas         map[string]*charm.SaasSpec        `yaml:"saas,omitempty"`
 	Applications map[string]*charm.ApplicationSpec `yaml:"applications,omitempty"`
@@ -327,6 +328,7 @@ func bundleOutputFromBundleData(bd *charm.BundleData) *bundleOutput {
 	return &bundleOutput{
 		Type:         bd.Type,
 		Description:  bd.Description,
+		DefaultBase:  bd.DefaultBase,
 		Series:       bd.Series,
 		Saas:         bd.Saas,
 		Applications: bd.Applications,
@@ -335,25 +337,21 @@ func bundleOutputFromBundleData(bd *charm.BundleData) *bundleOutput {
 	}
 }
 
-func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults bool, backend Backend) (*charm.BundleData, error) {
+func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults, includeSeries bool, backend Backend) (*charm.BundleData, error) {
 	cfg, err := config.New(config.NoDefaults, model.Config())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	var base corebase.Base
+	var defaultBase corebase.Base
 	value, ok := cfg.DefaultBase()
 	if ok {
 		var err error
-		base, err = corebase.ParseBaseFromString(value)
+		defaultBase, err = corebase.ParseBaseFromString(value)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		base = version.DefaultSupportedLTSBase()
-	}
-	defaultSeries, err := corebase.GetSeriesFromBase(base)
-	if err != nil {
-		return nil, err
+		defaultBase = version.DefaultSupportedLTSBase()
 	}
 
 	data := &charm.BundleData{}
@@ -362,7 +360,14 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 	if isCAAS {
 		data.Type = "kubernetes"
 	} else {
-		data.Series = defaultSeries
+		data.DefaultBase = defaultBase.String()
+		if includeSeries {
+			defaultSeries, err := corebase.GetSeriesFromBase(defaultBase)
+			if err != nil {
+				return nil, err
+			}
+			data.Series = defaultSeries
+		}
 	}
 
 	if len(model.Applications()) == 0 {
@@ -370,19 +375,22 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 	}
 
 	// Application bundle data.
-	applications, machineIds, usedSeries, err := b.bundleDataApplications(model.Applications(), defaultSeries, isCAAS, includeCharmDefaults, backend)
+	var (
+		usedBases  set.Strings
+		machineIds set.Strings
+	)
+	data.Applications, machineIds, usedBases, err = b.bundleDataApplications(model.Applications(), defaultBase, isCAAS, includeCharmDefaults, includeSeries, backend)
 	if err != nil {
 		return nil, err
 	}
-	data.Applications = applications
 
 	// Machine bundle data.
-	var machineSeries set.Strings
-	data.Machines, machineSeries, err = b.bundleDataMachines(model.Machines(), machineIds, defaultSeries)
+	var machineBases set.Strings
+	data.Machines, machineBases, err = b.bundleDataMachines(model.Machines(), machineIds, defaultBase, includeSeries)
 	if err != nil {
 		return nil, err
 	}
-	usedSeries = usedSeries.Union(machineSeries)
+	usedBases = usedBases.Union(machineBases)
 
 	// Remote Application bundle data.
 	data.Saas = bundleDataRemoteApplications(model.RemoteApplications())
@@ -390,29 +398,43 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 	// Relation bundle data.
 	data.Relations = bundleDataRelations(model.Relations())
 
-	// If there is only one series used, make it the default and remove
-	// series from all the apps and machines.
-	size := usedSeries.Size()
+	// If there is only one base used, make it the default and remove
+	// base from all the apps and machines.
+	size := usedBases.Size()
 	switch {
 	case size == 1:
-		used := usedSeries.Values()[0]
-		if used != defaultSeries {
-			data.Series = used
+		used, err := corebase.ParseBaseFromString(usedBases.Values()[0])
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if used != defaultBase {
+			data.DefaultBase = used.String()
+			if includeSeries {
+				series, err := corebase.GetSeriesFromBase(used)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				data.Series = series
+			}
 			for _, app := range data.Applications {
+				app.Base = ""
 				app.Series = ""
 			}
 			for _, mac := range data.Machines {
+				mac.Base = ""
 				mac.Series = ""
 			}
 		}
 	case size > 1:
-		if !usedSeries.Contains(defaultSeries) {
+		if !usedBases.Contains(defaultBase.String()) {
+			data.DefaultBase = ""
 			data.Series = ""
 		}
 	}
 
 	if isCAAS {
 		// Kubernetes bundles don't specify series right now.
+		data.DefaultBase = ""
 		data.Series = ""
 	}
 
@@ -421,8 +443,8 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 
 func (b *BundleAPI) bundleDataApplications(
 	apps []description.Application,
-	defaultSeries string,
-	isCAAS, includeCharmDefaults bool,
+	defaultBase corebase.Base,
+	isCAAS, includeCharmDefaults, includeSeries bool,
 	backend Backend,
 ) (map[string]*charm.ApplicationSpec, set.Strings, set.Strings, error) {
 
@@ -433,7 +455,7 @@ func (b *BundleAPI) bundleDataApplications(
 
 	applicationData := make(map[string]*charm.ApplicationSpec)
 	machineIds := set.NewStrings()
-	usedSeries := set.NewStrings()
+	usedBases := set.NewStrings()
 
 	charmConfigCache := make(map[string]*charm.Config)
 	printEndpointBindingSpaceNames := b.printSpaceNamesInEndpointBindings(apps)
@@ -448,12 +470,19 @@ func (b *BundleAPI) bundleDataApplications(
 			return nil, nil, nil, fmt.Errorf("extracting charm origin from application description %w", err)
 		}
 
-		appSeries, err := corebase.GetSeriesFromChannel(p.OS, p.Channel)
+		appBase, err := corebase.ParseBase(p.OS, p.Channel)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("extracting series from application description %w", err)
+			return nil, nil, nil, fmt.Errorf("extracting base from application description %w", err)
 		}
+		usedBases.Add(appBase.String())
 
-		usedSeries.Add(appSeries)
+		var appSeries string
+		if includeSeries {
+			appSeries, err = corebase.GetSeriesFromBase(appBase)
+			if err != nil {
+				return nil, nil, nil, errors.Trace(err)
+			}
+		}
 
 		endpointsWithSpaceNames, err := b.endpointBindings(application.EndpointBindings(), allSpacesInfoLookup, printEndpointBindingSpaceNames)
 		if err != nil {
@@ -582,8 +611,11 @@ func (b *BundleAPI) bundleDataApplications(
 
 		newApplication.Resources = applicationDataResources(application.Resources())
 
-		if appSeries != defaultSeries {
-			newApplication.Series = appSeries
+		if appBase != defaultBase {
+			newApplication.Base = appBase.String()
+			if includeSeries {
+				newApplication.Series = appSeries
+			}
 		}
 		if result := b.constraints(application.Constraints()); len(result) != 0 {
 			newApplication.Constraints = strings.Join(result, " ")
@@ -626,7 +658,7 @@ func (b *BundleAPI) bundleDataApplications(
 
 		applicationData[application.Name()] = newApplication
 	}
-	return applicationData, machineIds, usedSeries, nil
+	return applicationData, machineIds, usedBases, nil
 }
 
 func applicationDataResources(resources []description.Resource) map[string]interface{} {
@@ -644,8 +676,8 @@ func applicationDataResources(resources []description.Resource) map[string]inter
 	return resourceData
 }
 
-func (b *BundleAPI) bundleDataMachines(machines []description.Machine, machineIds set.Strings, defaultSeries string) (map[string]*charm.MachineSpec, set.Strings, error) {
-	usedSeries := set.NewStrings()
+func (b *BundleAPI) bundleDataMachines(machines []description.Machine, machineIds set.Strings, defaultBase corebase.Base, includeSeries bool) (map[string]*charm.MachineSpec, set.Strings, error) {
+	usedBases := set.NewStrings()
 	machineData := make(map[string]*charm.MachineSpec)
 	for _, machine := range machines {
 		if !machineIds.Contains(machine.Tag().Id()) {
@@ -655,16 +687,23 @@ func (b *BundleAPI) bundleDataMachines(machines []description.Machine, machineId
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		macSeries, err := corebase.GetSeriesFromBase(macBase)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
+		usedBases.Add(macBase.String())
+
+		var macSeries string
+		if includeSeries {
+			macSeries, err = corebase.GetSeriesFromBase(macBase)
+			if err != nil {
+				return nil, nil, errors.Trace(err)
+			}
 		}
-		usedSeries.Add(macSeries)
 		newMachine := &charm.MachineSpec{
 			Annotations: machine.Annotations(),
 		}
-		if macSeries != defaultSeries {
-			newMachine.Series = macSeries
+		if macBase != defaultBase {
+			newMachine.Base = macBase.String()
+			if includeSeries {
+				newMachine.Series = macSeries
+			}
 		}
 
 		if result := b.constraints(machine.Constraints()); len(result) != 0 {
@@ -673,7 +712,7 @@ func (b *BundleAPI) bundleDataMachines(machines []description.Machine, machineId
 
 		machineData[machine.Id()] = newMachine
 	}
-	return machineData, usedSeries, nil
+	return machineData, usedBases, nil
 }
 
 func bundleDataRemoteApplications(remoteApps []description.RemoteApplication) map[string]*charm.SaasSpec {

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -159,7 +159,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
                     charm: haproxy
                     revision: 42
                     channel: stable
-                    series: jammy
+                    base: ubuntu@22.04/stable
             relations:
                 - - django:web
                   - haproxy:web
@@ -489,7 +489,7 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
                     charm: ch:haproxy
                     revision: 42
                     channel: stable
-                    series: jammy
+                    base: ubuntu@22.04/stable
             relations:
                 - - django:web
                   - haproxy:web
@@ -792,7 +792,7 @@ func (s *bundleSuite) TestExportBundleWithApplication(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -841,7 +841,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationResources(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -895,7 +895,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -940,7 +940,7 @@ func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   ubuntu:
     charm: ubuntu
@@ -1003,7 +1003,7 @@ func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   foo:
     charm: ubuntu
@@ -1150,7 +1150,7 @@ UGNmDMvj8tUYI7+SvffHrTBwBPvcGeXa7XP4Au+GoJUN0jHspCeik/04KwanRCmu
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   foo:
     charm: ubuntu
@@ -1277,7 +1277,7 @@ func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 saas:
   awesome:
     url: test:admin/default.awesome
@@ -1388,7 +1388,7 @@ func (s *bundleSuite) TestExportBundleModelWithSettingsRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1431,7 +1431,7 @@ func (s *bundleSuite) TestExportBundleModelWithCharmDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mariadb:
     charm: mariadb
@@ -1461,6 +1461,71 @@ relations:
   - mysql:mysql
 `[1:]
 	expectedResult := params.StringResult{Result: output}
+
+	c.Assert(result, gc.Equals, expectedResult)
+	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
+}
+
+func (s *bundleSuite) TestExportBundleModelWithIncludeSeries(c *gc.C) {
+	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
+		Config: coretesting.FakeConfig().Merge(map[string]interface{}{
+			"default-base": "ubuntu@20.04",
+		}),
+		CloudRegion: "some-region"})
+
+	application := s.st.model.AddApplication(description.ApplicationArgs{
+		Tag:      names.NewApplicationTag("magic"),
+		CharmURL: "ch:magic",
+	})
+	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/20.04/stable"})
+	application.AddUnit(description.UnitArgs{
+		Tag:     names.NewUnitTag("magic/0"),
+		Machine: names.NewMachineTag("0"),
+	})
+	s.st.model.AddMachine(description.MachineArgs{
+		Id:   names.NewMachineTag("0"),
+		Base: "ubuntu@20.04",
+	})
+
+	application = s.st.model.AddApplication(description.ApplicationArgs{
+		Tag:      names.NewApplicationTag("mojo"),
+		CharmURL: "ch:mojo",
+	})
+	application.SetCharmOrigin(description.CharmOriginArgs{Platform: "amd64/ubuntu/22.04/stable"})
+	application.AddUnit(description.UnitArgs{
+		Tag:     names.NewUnitTag("mojo/0"),
+		Machine: names.NewMachineTag("1"),
+	})
+	s.st.model.AddMachine(description.MachineArgs{
+		Id:   names.NewMachineTag("1"),
+		Base: "ubuntu@22.04",
+	})
+
+	result, err := s.facade.ExportBundle(params.ExportBundleParams{IncludeSeries: true})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedResult := params.StringResult{Result: `
+default-base: ubuntu@20.04/stable
+series: focal
+applications:
+  magic:
+    charm: magic
+    num_units: 1
+    to:
+    - "0"
+  mojo:
+    charm: mojo
+    series: jammy
+    base: ubuntu@22.04/stable
+    num_units: 1
+    to:
+    - "1"
+machines:
+  "0": {}
+  "1":
+    series: jammy
+    base: ubuntu@22.04/stable
+`[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
@@ -1507,7 +1572,7 @@ func (s *bundleSuite) TestExportBundleModelRelationsWithSubordinates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1576,7 +1641,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplication(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: bionic
+default-base: ubuntu@18.04/stable
 applications:
   magic:
     charm: magic
@@ -1635,12 +1700,12 @@ applications:
   magic:
     charm: magic
     channel: stable
-    series: bionic
+    base: ubuntu@18.04/stable
     expose: true
   ubuntu:
     charm: ubuntu
     channel: stable
-    series: focal
+    base: ubuntu@20.04/stable
     options:
       key: value
 `[1:]}
@@ -1657,7 +1722,7 @@ applications:
   magic:
     charm: magic
     channel: stable
-    series: bionic
+    base: ubuntu@18.04/stable
     expose: true
     bindings:
       another: vlan2
@@ -1665,7 +1730,7 @@ applications:
   ubuntu:
     charm: ubuntu
     channel: stable
-    series: focal
+    base: ubuntu@20.04/stable
     options:
       key: value
     bindings:
@@ -1699,7 +1764,7 @@ func (s *bundleSuite) TestExportBundleSubordinateApplicationAndMachine(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: zesty
+default-base: ubuntu@17.04/stable
 applications:
   magic:
     charm: magic
@@ -1750,7 +1815,7 @@ func (s *bundleSuite) TestExportBundleModelWithConstraints(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mediawiki:
     charm: mediawiki
@@ -1806,7 +1871,7 @@ func (s *bundleSuite) TestExportBundleModelWithAnnotations(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1892,7 +1957,7 @@ func (s *bundleSuite) TestExportBundleWithContainers(c *gc.C) {
 	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -1954,7 +2019,7 @@ func (s *bundleSuite) TestMixedSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedResult := params.StringResult{Result: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -1963,14 +2028,14 @@ applications:
     - "0"
   mojo:
     charm: mojo
-    series: jammy
+    base: ubuntu@22.04/stable
     num_units: 1
     to:
     - "1"
 machines:
   "0": {}
   "1":
-    series: jammy
+    base: ubuntu@22.04/stable
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
@@ -2023,21 +2088,21 @@ func (s *bundleSuite) TestMixedSeriesNoDefaultSeries(c *gc.C) {
 applications:
   magic:
     charm: magic
-    series: hirsute
+    base: ubuntu@21.04/stable
     num_units: 1
     to:
     - "0"
   mojo:
     charm: mojo
-    series: jammy
+    base: ubuntu@22.04/stable
     num_units: 1
     to:
     - "1"
 machines:
   "0":
-    series: hirsute
+    base: ubuntu@21.04/stable
   "1":
-    series: jammy
+    base: ubuntu@22.04/stable
 `[1:]}
 
 	c.Assert(result, gc.Equals, expectedResult)
@@ -2078,7 +2143,7 @@ func (s *bundleSuite) TestExportCharmhubBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: mysql
@@ -2114,7 +2179,7 @@ func (s *bundleSuite) TestExportLocalBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: local:mysql
@@ -2148,7 +2213,7 @@ func (s *bundleSuite) TestExportLocalBundleWithSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   mysql:
     charm: local:mysql
@@ -2185,7 +2250,7 @@ func (s *bundleSuite) TestExportBundleWithExposedEndpointSettings(c *gc.C) {
 			descr:   "exposed application without exposed endpoint settings (upgraded 2.8 controller)",
 			exposed: true,
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -2206,7 +2271,7 @@ applications:
 				},
 			},
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic
@@ -2231,7 +2296,7 @@ applications:
 			},
 			// The exposed:true will be omitted and only the exposed-endpoints section (in the overlay) will be present
 			expBundle: `
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   magic:
     charm: magic

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -5966,6 +5966,9 @@
                     "properties": {
                         "include-charm-defaults": {
                             "type": "boolean"
+                        },
+                        "include-series": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -87,7 +87,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store))
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false}},
+		{"ExportBundle", []interface{}{false, false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -130,7 +130,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false}},
+		{"ExportBundle", []interface{}{false, false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -164,7 +164,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false}},
+		{"ExportBundle", []interface{}{false, false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -180,7 +180,23 @@ func (s *ExportBundleCommandSuite) TestExportBundleIncludeCharmDefaults(c *gc.C)
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--include-charm-defaults", "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{true}},
+		{"ExportBundle", []interface{}{true, false}},
+	})
+
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
+	output, err := os.ReadFile(s.fakeBundle.filename)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Equals, "fake-data")
+}
+
+func (s *ExportBundleCommandSuite) TestExportBundleIncludeSeries(c *gc.C) {
+	s.fakeBundle.filename = filepath.Join(c.MkDir(), "mymodel")
+	s.fakeBundle.result = "fake-data"
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--include-series", "--filename", s.fakeBundle.filename)
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
+		{"ExportBundle", []interface{}{false, true}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -198,8 +214,8 @@ type fakeExportBundleClient struct {
 
 func (f *fakeExportBundleClient) Close() error { return nil }
 
-func (f *fakeExportBundleClient) ExportBundle(includeDefaults bool) (string, error) {
-	f.MethodCall(f, "ExportBundle", includeDefaults)
+func (f *fakeExportBundleClient) ExportBundle(includeDefaults bool, includeSeries bool) (string, error) {
+	f.MethodCall(f, "ExportBundle", includeDefaults, includeSeries)
 	if err := f.NextErr(); err != nil {
 		return "", err
 	}

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1110,6 +1110,7 @@ type LeaseOperationCommand struct {
 // ExportBundleParams holds parameters for exporting Bundles.
 type ExportBundleParams struct {
 	IncludeCharmDefaults bool `json:"include-charm-defaults,omitempty"`
+	IncludeSeries        bool `json:"include-series,omitempty"`
 }
 
 // BundleChangesParams holds parameters for making Bundle.GetChanges calls.


### PR DESCRIPTION
Transfer over to bases when exporting bundles. Drop series by default

For reasons of compatibility, we need to provide an option, --export-with-series, which exports series alongside bases

You can find a spec for this feature here:
https://docs.google.com/document/d/1WBuWD_nFu6KX4dW0UiOosp0MQhm89SIsnTGqxPLaBvk/edit?usp=sharing

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu ubu1 --base ubuntu@20.04
$ juju deploy ubuntu ubu2 --base ubuntu@22.04
$ juju export-bundle
default-base: ubuntu@22.04/stable
applications:
  ubu1:
    charm: ubuntu
    channel: stable
    revision: 24
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
  ubu2:
    charm: ubuntu
    channel: stable
    revision: 24
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
    base: ubuntu@20.04/stable
  "2":
    constraints: arch=amd64

$ juju export-bundle --export-with-series
default-base: ubuntu@22.04/stable
series: jammy
applications:
  ubu1:
    charm: ubuntu
    channel: stable
    revision: 24
    series: focal
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
  ubu2:
    charm: ubuntu
    channel: stable
    revision: 24
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
    series: focal
    base: ubuntu@20.04/stable
  "2":
    constraints: arch=amd64
```