### PR TITLE
improvements to "check for merge conflicts" action

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -46,6 +46,9 @@ jobs:
         if: success() || failure()
         shell: bash
         run: |
+          # The generation sometimes adds things to go.sum. Tidy to remove these.
+          go mod tidy
+          
           git add -A
           if [[ -n $(git diff HEAD) ]]; then
             echo "*****"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ steps.branch.outputs.target }}
+          ref: ${{ steps.branch.outputs.source }}
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -46,15 +46,17 @@ jobs:
         id: merge
         env:
           SOURCE_BRANCH: ${{ steps.branch.outputs.source }}
+          TARGET_BRANCH: ${{ steps.branch.outputs.target }}
         run: |
           set -x
-          git fetch origin "$SOURCE_BRANCH"
-          git branch "$SOURCE_BRANCH" "origin/$SOURCE_BRANCH"
+          git fetch origin "$TARGET_BRANCH"
+          git branch "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
           # Need to set Git username/email to do the merge (yawn)
           git config user.name 'jujubot'
           git config user.email 'fake@address.me'
           
           set +e
+          git switch "$TARGET_BRANCH"
           git merge "$SOURCE_BRANCH"
           case $? in
           0)

--- a/scripts/try-merge/main.go
+++ b/scripts/try-merge/main.go
@@ -217,12 +217,6 @@ func check(err error) {
 	}
 }
 
-// Print to stdout. Only the actual result should go here (the generated
-// notification message).
-func stdoutf(f string, v ...any) {
-	_, _ = fmt.Fprintf(os.Stdout, f, v...)
-}
-
 // Print to stderr. Logging/debug info should go here, so that it is kept
 // separate from the actual output.
 func stderrf(f string, v ...any) {

--- a/scripts/try-merge/main.go
+++ b/scripts/try-merge/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/juju/collections/set"
 )
@@ -109,17 +110,9 @@ func printErrMsg() {
 		}
 	}
 
-	// If no-one to notify: don't send a message
-	if peopleToNotify.IsEmpty() {
-		return
+	if !peopleToNotify.IsEmpty() {
+		printMessage(peopleToNotify)
 	}
-
-	// Construct the message
-	taggedUsers := strings.Join(peopleToNotify.Values(), ", ")
-	message := fmt.Sprintf(
-		"%[1]s: your recent changes to `%[2]s` have caused merge conflicts. Please merge `%[2]s` into `%[3]s` and resolve the conflicts.",
-		taggedUsers, sourceBranch, targetBranch)
-	stdoutf(message)
 }
 
 // findOffendingCommits returns a list of commits that may be causing merge
@@ -197,6 +190,24 @@ func commitHasOpenPR(commit commitInfo) (prNumber int, ok bool) {
 		}
 	}
 	return -1, false
+}
+
+func printMessage(peopleToNotify set.Strings) {
+	messageData := struct{ TaggedUsers, SourceBranch, TargetBranch, LogsLink string }{
+		TaggedUsers:  strings.Join(peopleToNotify.Values(), ", "),
+		SourceBranch: sourceBranch,
+		TargetBranch: targetBranch,
+		LogsLink: fmt.Sprintf("https://github.com/%s/actions/runs/%s",
+			os.Getenv("GITHUB_REPOSITORY"), os.Getenv("GITHUB_RUN_ID")),
+	}
+
+	tmpl, err := template.New("test").Parse(
+		"{{.TaggedUsers}}: your recent changes to `{{.SourceBranch}}` have caused merge conflicts. " +
+			"Please merge `{{.SourceBranch}}` into `{{.TargetBranch}}` and resolve the conflicts." +
+			"[[logs]({{.LogsLink}})]",
+	)
+	check(err)
+	check(tmpl.Execute(os.Stdout, messageData))
 }
 
 func check(err error) {


### PR DESCRIPTION
- In the generated notification message, add a link to the logs for the GitHub action run, for easy debugging.
- Checkout source branch instead of target branch, so that we are getting the right version of the Go script (and can test changes).
- Refactor Go code using templates for clarity.

Example run [here](https://github.com/barrettj12/juju/actions/runs/6034848300/job/16374043651).