### PR TITLE
Ensure ControllerConfigAPI facade plugin is only constructed with the system state.

### DIFF
--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -81,6 +81,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	endpoint, err := controller.TestingAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -73,6 +73,7 @@ func (s *agentSuite) TestAgentFailsWithNonAgent(c *gc.C) {
 	auth.Tag = names.NewUserTag("admin")
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -86,6 +87,7 @@ func (s *agentSuite) TestAgentSucceedsWithUnitAgent(c *gc.C) {
 	auth.Tag = names.NewUnitTag("foosball/1")
 	_, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -105,6 +107,7 @@ func (s *agentSuite) TestGetEntities(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -131,6 +134,7 @@ func (s *agentSuite) TestGetEntitiesContainer(c *gc.C) {
 
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -176,6 +180,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -197,6 +202,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 func (s *agentSuite) TestSetPasswords(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -225,6 +231,7 @@ func (s *agentSuite) TestSetPasswords(c *gc.C) {
 func (s *agentSuite) TestSetPasswordsShort(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -243,6 +250,7 @@ func (s *agentSuite) TestSetPasswordsShort(c *gc.C) {
 func (s *agentSuite) TestClearReboot(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -281,6 +289,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      authorizer,
 	})
@@ -309,6 +318,7 @@ func (s *agentSuite) TestWatchAuthError(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      authorizer,
 	})

--- a/apiserver/facades/agent/agent/model_test.go
+++ b/apiserver/facades/agent/agent/model_test.go
@@ -44,6 +44,7 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 
 	s.api, err = agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -40,11 +40,15 @@ func newAgentAPIV3(ctx facade.Context) (*AgentAPI, error) {
 	}
 
 	resources := ctx.Resources()
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &AgentAPI{
 		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(model, resources, auth),
-		ControllerConfigAPI: common.NewStateControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		CloudSpecer: cloudspec.NewCloudSpecV2(
 			resources,
 			cloudspec.MakeCloudSpecGetterForModel(st),

--- a/apiserver/facades/agent/caasadmission/register.go
+++ b/apiserver/facades/agent/caasadmission/register.go
@@ -6,6 +6,8 @@ package caasadmission
 import (
 	"reflect"
 
+	jujuerrors "github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -24,8 +26,12 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 		return nil, errors.ErrPerm
 	}
 
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, jujuerrors.Trace(err)
+	}
 	return &Facade{
 		auth:                authorizer,
-		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 	}, nil
 }

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -42,10 +42,14 @@ func newStateFacadeV2(ctx facade.Context) (*FacadeV2, error) {
 		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(ctx.State()),
 		common.AuthFuncForTag(model.ModelTag()),
 	)
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &FacadeV2{
 		CloudSpecer:         cloudSpecAPI,
 		ModelWatcher:        common.NewModelWatcher(model, resources, authorizer),
-		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		auth:                authorizer,
 		resources:           resources,
 	}, nil

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -151,7 +151,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		APIAddresser:            common.NewAPIAddresser(systemState, resources),
 		ModelWatcher:            common.NewModelWatcher(model, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),
-		ControllerConfigAPI:     common.NewStateControllerConfig(st),
+		ControllerConfigAPI:     common.NewStateControllerConfig(systemState),
 		NetworkConfigAPI:        netConfigAPI,
 		st:                      st,
 		m:                       model,

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -72,7 +72,11 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		}
 		return secrets.DrainBackendConfigInfo(backendID, secrets.SecretsModel(model), context.Auth().GetAuthTag(), leadershipChecker)
 	}
-	controllerAPI := common.NewStateControllerConfig(context.State())
+	systemState, err := context.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	controllerAPI := common.NewStateControllerConfig(systemState)
 	remoteClientGetter := func(uri *coresecrets.URI) (CrossModelSecretsClient, error) {
 		info, err := controllerAPI.ControllerAPIInfoForModels(params.Entities{Entities: []params.Entity{{
 			Tag: names.NewModelTag(uri.SourceUUID).String(),
@@ -82,6 +86,9 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		}
 		if len(info.Results) < 1 {
 			return nil, errors.Errorf("no controller api for model %q", uri.SourceUUID)
+		}
+		if err := info.Results[0].Error; err != nil {
+			return nil, errors.Trace(err)
 		}
 		apiInfo := api.Info{
 			Addrs:    info.Results[0].Addresses,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -93,8 +93,12 @@ func NewControllerAPI(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	systemState, err := pool.SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &ControllerAPI{
-		ControllerConfigAPI: common.NewStateControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		ModelStatusAPI: common.NewModelStatusAPI(
 			common.NewModelManagerBackend(model, pool),
 			authorizer,

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -134,6 +134,7 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	endPoint, err := controller.LatestAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -345,6 +346,7 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	controller, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     st,
+			StatePool_: s.StatePool,
 			Resources_: common.NewResources(),
 			Auth_:      authorizer,
 		})
@@ -388,6 +390,7 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	var disposed bool
 	watcherAPI_, err := apiserver.NewAllWatcher(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 		ID_:        watcherId.AllWatcherId,
@@ -894,6 +897,7 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	endpoint, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -980,6 +984,7 @@ func (s *controllerSuite) TestConfigSetRequiresSuperUser(c *gc.C) {
 	endpoint, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -1101,6 +1106,7 @@ func (s *controllerSuite) TestWatchAllModelSummariesByNonAdmin(c *gc.C) {
 	endPoint, err := controller.LatestAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})

--- a/apiserver/facades/controller/caasmodelconfigmanager/register.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/register.go
@@ -6,6 +6,8 @@ package caasmodelconfigmanager
 import (
 	"reflect"
 
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -24,8 +26,13 @@ func newFacade(ctx facade.Context) (*Facade, error) {
 	if !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm
 	}
+
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &Facade{
 		auth:                authorizer,
-		controllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		controllerConfigAPI: common.NewStateControllerConfig(systemState),
 	}, nil
 }

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -91,6 +91,7 @@ func (s *firewallerBaseSuite) testFirewallerFailsWithNonControllerUser(
 		Auth_:      anAuthorizer,
 		Resources_: s.resources,
 		State_:     s.State,
+		StatePool_: s.StatePool,
 	}
 	err := factory(ctx)
 	c.Assert(err, gc.NotNil)

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -36,7 +36,11 @@ func newFirewallerAPIV7(context facade.Context) (*FirewallerAPI, error) {
 		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
-	controllerConfigAPI := common.NewStateControllerConfig(st)
+	systemState, err := context.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	controllerConfigAPI := common.NewStateControllerConfig(systemState)
 
 	stShim := stateShim{st: st, State: firewall.StateShim(st, m)}
 	return NewStateFirewallerAPI(stShim, context.Resources(), context.Auth(), cloudSpecAPI, controllerConfigAPI)


### PR DESCRIPTION
The ControllerConfigAPI facade plugin should use the system state since some of its operations (like getting k8s controller addresses) need it. Fix the facades which create this api to pass the system state.

Fixes getting cmr secrets on k8s.

## QA steps

bootstrap microk8s
juju deploy postgresql-k8s
juju offer posgresql-k8s:database
juju add-model c
juju deploy data-integrator
juju relate data-integrator controller.postgresql-k8s
juju switch controller
juju exec --unit postgresql-k8s/0 -- secret-add foo=bar
juju exec --unit postgresql-k8s/0 -- secret-grant -r 2 $uri
juju switch c
juju exec --unit data-integrator/0 -- secret-get $uri

## Bug reference

https://bugs.launchpad.net/juju/+bug/2033486
