### PR TITLE
Do not return catacomb.ErrDying to 3rd party callers

### DIFF
--- a/core/database/changestream.go
+++ b/core/database/changestream.go
@@ -1,0 +1,13 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import "github.com/juju/errors"
+
+// ErrChangeStreamDying is used to indicate to *third parties* that the
+// change-stream worker is dying, instead of catacomb.ErrDying, which is
+// unsuitable for propagating inter-worker.
+// This error indicates to consuming workers that their dependency has
+// become unmet and a restart by the dependency engine is imminent.
+const ErrChangeStreamDying = errors.ConstError("change-stream worker is dying")

--- a/core/database/changestream.go
+++ b/core/database/changestream.go
@@ -5,9 +5,18 @@ package database
 
 import "github.com/juju/errors"
 
-// ErrChangeStreamDying is used to indicate to *third parties* that the
-// change-stream worker is dying, instead of catacomb.ErrDying, which is
-// unsuitable for propagating inter-worker.
-// This error indicates to consuming workers that their dependency has
-// become unmet and a restart by the dependency engine is imminent.
-const ErrChangeStreamDying = errors.ConstError("change-stream worker is dying")
+const (
+	// ErrChangeStreamDying is used to indicate to *third parties* that the
+	// change-stream worker is dying, instead of catacomb.ErrDying, which is
+	// unsuitable for propagating inter-worker.
+	// This error indicates to consuming workers that their dependency has
+	// become unmet and a restart by the dependency engine is imminent.
+	ErrChangeStreamDying = errors.ConstError("change-stream worker is dying")
+
+	// ErrEventMultiplexerDying is used to indicate to *third parties* that the
+	// event multiplexer worker is dying, instead of catacomb.ErrDying, which
+	// is unsuitable for propagating inter-worker.
+	// This error indicates to consuming workers that their dependency has
+	// become unmet and a restart by the dependency engine is imminent.
+	ErrEventMultiplexerDying = errors.ConstError("event multiplexer worker is dying")
+)

--- a/core/database/dbmanager.go
+++ b/core/database/dbmanager.go
@@ -8,14 +8,14 @@ import "github.com/juju/errors"
 const (
 	// ControllerNS is the namespace for the controller database.
 	ControllerNS = "controller"
-)
 
-// ErrDBAccessorDying is used to indicate to *third parties* that the
-// db-accessor worker is dying, instead of catacomb.ErrDying, which is
-// unsuitable for propagating inter-worker.
-// This error indicates to consuming workers that their dependency has
-// become unmet and a restart by the dependency engine is imminent.
-const ErrDBAccessorDying = errors.ConstError("db-accessor worker is dying")
+	// ErrDBAccessorDying is used to indicate to *third parties* that the
+	// db-accessor worker is dying, instead of catacomb.ErrDying, which is
+	// unsuitable for propagating inter-worker.
+	// This error indicates to consuming workers that their dependency has
+	// become unmet and a restart by the dependency engine is imminent.
+	ErrDBAccessorDying = errors.ConstError("db-accessor worker is dying")
+)
 
 // DBGetter describes the ability to supply a transaction runner
 // for a particular database.

--- a/core/database/dbmanager.go
+++ b/core/database/dbmanager.go
@@ -3,6 +3,20 @@
 
 package database
 
+import "github.com/juju/errors"
+
+const (
+	// ControllerNS is the namespace for the controller database.
+	ControllerNS = "controller"
+)
+
+// ErrDBAccessorDying is used to indicate to *third parties* that the
+// db-accessor worker is dying, instead of catacomb.ErrDying, which is
+// unsuitable for propagating inter-worker.
+// This error indicates to consuming workers that their dependency has
+// become unmet and a restart by the dependency engine is imminent.
+const ErrDBAccessorDying = errors.ConstError("db-accessor worker is dying")
+
 // DBGetter describes the ability to supply a transaction runner
 // for a particular database.
 type DBGetter interface {
@@ -25,8 +39,3 @@ type DBDeleter interface {
 	//    handled once it's supported by dqlite.
 	DeleteDB(namespace string) error
 }
-
-const (
-	// ControllerNS is the namespace for the controller database.
-	ControllerNS = "controller"
-)

--- a/core/database/runner.go
+++ b/core/database/runner.go
@@ -36,11 +36,3 @@ func NewTxnRunnerFactoryForNamespace[T TxnRunner](f func(string) (T, error), ns 
 		return r, errors.Trace(err)
 	}
 }
-
-// ConstFactory returns a TxnRunnerFactory that always returns the
-// same database.TxnRunner.
-func ConstFactory(r TxnRunner) TxnRunnerFactory {
-	return func() (TxnRunner, error) {
-		return r, nil
-	}
-}

--- a/worker/changestream/eventmultiplexer/eventmultiplexer.go
+++ b/worker/changestream/eventmultiplexer/eventmultiplexer.go
@@ -8,14 +8,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/juju/juju/core/database"
-
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3/catacomb"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 )
 
 // Logger represents the logging methods called.

--- a/worker/changestream/eventmultiplexer/eventmultiplexer_test.go
+++ b/worker/changestream/eventmultiplexer/eventmultiplexer_test.go
@@ -5,16 +5,15 @@ package eventmultiplexer
 
 import (
 	"sync"
-	time "time"
-
-	"github.com/juju/juju/core/database"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	changestream "github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/testing"
 )
 

--- a/worker/changestream/watchabledb.go
+++ b/worker/changestream/watchabledb.go
@@ -94,7 +94,8 @@ func (w *WatchableDB) StdTxn(ctx context.Context, fn func(context.Context, *sql.
 	return w.db.StdTxn(ctx, fn)
 }
 
-// EventSource returns the event source for this worker.
+// Subscribe returns a subscription for the input options.
+// The subscription is then used to drive watchers.
 func (w *WatchableDB) Subscribe(opts ...changestream.SubscriptionOption) (changestream.Subscription, error) {
 	return w.mux.Subscribe(opts...)
 }

--- a/worker/changestream/worker.go
+++ b/worker/changestream/worker.go
@@ -168,7 +168,7 @@ func (w *changeStreamWorker) workerFromCache(namespace string) (WatchableDBWorke
 		// worker dying.
 		select {
 		case <-w.catacomb.Dying():
-			return nil, w.catacomb.ErrDying()
+			return nil, coredatabase.ErrChangeStreamDying
 		default:
 			return nil, errors.Trace(err)
 		}

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/juju/juju/core/database"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -17,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/dqlite"
 	"github.com/juju/juju/internal/pubsub/apiserver"
 	"github.com/juju/juju/testing"

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/juju/juju/core/database"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -62,7 +64,7 @@ func (s *workerSuite) TestKilledGetDBErrDying(c *gc.C) {
 	w.Kill()
 
 	_, err := dbw.GetDB("anything")
-	c.Assert(err, gc.ErrorMatches, "db-accessor worker is dying")
+	c.Assert(err, jc.ErrorIs, database.ErrDBAccessorDying)
 }
 
 func (s *workerSuite) TestStartupTimeoutSingleControllerReconfigure(c *gc.C) {


### PR DESCRIPTION
The audience for `catacomb.ErrDying()` must only be the worker's own catacomb. 

For workers with `outputs` that provide public methods to dependents, those methods should never return `catacomb.ErrDying()` because it is an error to kill a catacomb with a another catacomb's ErrDying.

Here we create custom errors used by the following workers to indicate their pending death:
- `dbaccessor`
- `changestream`
- `eventmultiplexer`

## QA steps

- Bootstrap and enable HA.
- The rebind (and restart) of the db-accessor should cause dependent workers to bounce, indicated by log messages such as:
```
machine-0: 18:48:21 ERROR juju.worker.dependency "http-server" manifold worker returned unexpected error: unable to get controller config: invoking getDB: change-stream worker is dying
```
