### PR TITLE
Add a transaction runner factory on dqlite suite

### DIFF
--- a/database/testing/dqlitesuite.go
+++ b/database/testing/dqlitesuite.go
@@ -146,6 +146,13 @@ func (s *DqliteSuite) OpenDB(c *gc.C) (coredatabase.TxnRunner, *sql.DB) {
 	return trackedDB, trackedDB.db.PlainDB()
 }
 
+// TxnRunnerFactory returns a DBFactory that returns the given database.
+func (s *DqliteSuite) TxnRunnerFactory() func() (coredatabase.TxnRunner, error) {
+	return func() (coredatabase.TxnRunner, error) {
+		return s.trackedDB, nil
+	}
+}
+
 // FindTCPPort finds an unused TCP port and returns it.
 // It is prone to racing, so the port should be used as soon as it is acquired
 // to minimise the change of another process using it in the interim.

--- a/database/testing/runner.go
+++ b/database/testing/runner.go
@@ -43,16 +43,6 @@ func (t *txnRunner) StdTxn(ctx context.Context, fn func(context.Context, *sql.Tx
 	})
 }
 
-// TxnRunnerFactory returns a DBFactory that returns the given database.
-func TxnRunnerFactory(db coredatabase.TxnRunner) func() (coredatabase.TxnRunner, error) {
-	return func() (coredatabase.TxnRunner, error) {
-		if db == nil {
-			return nil, errors.New("nil db")
-		}
-		return db, nil
-	}
-}
-
 type singularDBGetter struct {
 	runner coredatabase.TxnRunner
 }

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -196,26 +195,26 @@ func (s *stateSuite) assertInsertCloud(c *gc.C, st *State, cloud cloud.Cloud) st
 }
 
 func (s *stateSuite) TestUpsertCloudNew(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	s.assertInsertCloud(c, st, testCloud)
 }
 
 func (s *stateSuite) TestUpsertCloudNewNoRegions(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	cld := testCloud
 	cld.Regions = nil
 	s.assertInsertCloud(c, st, cld)
 }
 
 func (s *stateSuite) TestUpsertCloudNewNoCertificates(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	cld := testCloud
 	cld.CACertificates = nil
 	s.assertInsertCloud(c, st, cld)
 }
 
 func (s *stateSuite) TestUpsertCloudUpdateExisting(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	originalUUID := s.assertInsertCloud(c, st, testCloud)
 
 	cld := cloud.Cloud{
@@ -251,7 +250,7 @@ func (s *stateSuite) TestUpsertCloudInvalidType(c *gc.C) {
 	cld := testCloud
 	cld.Type = "mycloud"
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, gc.ErrorMatches, `.* cloud type "mycloud" not valid`)
 }
@@ -260,7 +259,7 @@ func (s *stateSuite) TestCloudWithEmptyNameFails(c *gc.C) {
 	cld := testCloud
 	cld.Name = ""
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
 }
@@ -268,7 +267,7 @@ func (s *stateSuite) TestCloudWithEmptyNameFails(c *gc.C) {
 func (s *stateSuite) TestUpdateCloudDefaults(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -289,7 +288,7 @@ func (s *stateSuite) TestUpdateCloudDefaults(c *gc.C) {
 func (s *stateSuite) TestComplexUpdateCloudDefaults(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -321,7 +320,7 @@ func (s *stateSuite) TestComplexUpdateCloudDefaults(c *gc.C) {
 }
 
 func (s *stateSuite) TestCloudDefaultsUpdateForNonExistentCloud(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpdateCloudDefaults(context.Background(), "noexist", map[string]string{
 		"wallyworld": "peachy",
 	}, nil)
@@ -331,7 +330,7 @@ func (s *stateSuite) TestCloudDefaultsUpdateForNonExistentCloud(c *gc.C) {
 func (s *stateSuite) TestCloudRegionDefaults(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -374,7 +373,7 @@ func (s *stateSuite) TestCloudRegionDefaults(c *gc.C) {
 func (s *stateSuite) TestCloudRegionDefaultsComplex(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -454,7 +453,7 @@ func (s *stateSuite) TestCloudRegionDefaultsComplex(c *gc.C) {
 func (s *stateSuite) TestCloudRegionDefaultsNoExist(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(context.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -471,7 +470,7 @@ func (s *stateSuite) TestCloudRegionDefaultsNoExist(c *gc.C) {
 func (s *stateSuite) TestCloudDefaultsRemoval(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -503,7 +502,7 @@ func (s *stateSuite) TestCloudDefaultsRemoval(c *gc.C) {
 func (s *stateSuite) TestEmptyCloudDefaults(c *gc.C) {
 	cld := testCloud
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -513,7 +512,7 @@ func (s *stateSuite) TestEmptyCloudDefaults(c *gc.C) {
 }
 
 func (s *stateSuite) TestNonFoundCloudDefaults(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	defaults, err := st.CloudDefaults(context.Background(), "notfound")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(defaults), gc.Equals, 0)
@@ -523,13 +522,13 @@ func (s *stateSuite) TestUpsertCloudInvalidAuthType(c *gc.C) {
 	cld := testCloud
 	cld.AuthTypes = []cloud.AuthType{"myauth"}
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), cld)
 	c.Assert(err, gc.ErrorMatches, `.* auth type "myauth" not valid`)
 }
 
 func (s *stateSuite) TestListClouds(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), testCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.UpsertCloud(ctx.Background(), testCloud2)
@@ -548,7 +547,7 @@ func (s *stateSuite) TestListClouds(c *gc.C) {
 }
 
 func (s *stateSuite) TestListCloudsFilter(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	err := st.UpsertCloud(ctx.Background(), testCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.UpsertCloud(ctx.Background(), testCloud2)

--- a/domain/controllerconfig/service/controllerconfig_test.go
+++ b/domain/controllerconfig/service/controllerconfig_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/juju/database/testing"
 	domainstate "github.com/juju/juju/domain/controllerconfig/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
@@ -23,7 +22,7 @@ type controllerconfigSuite struct {
 var _ = gc.Suite(&controllerconfigSuite{})
 
 func (s *controllerconfigSuite) TestControllerConfigRoundTrips(c *gc.C) {
-	st := domainstate.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := domainstate.NewState(s.TxnRunnerFactory())
 	srv := NewService(st, nil)
 
 	cfgIn := jujucontroller.Config{

--- a/domain/controllerconfig/state/state_test.go
+++ b/domain/controllerconfig/state/state_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -21,7 +20,7 @@ type stateSuite struct {
 var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) TestControllerConfigRead(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cc := map[string]interface{}{
 		jujucontroller.AuditingEnabled:     "1",
@@ -41,7 +40,7 @@ func (s *stateSuite) TestControllerConfigRead(c *gc.C) {
 }
 
 func (s *stateSuite) TestUpdateControllerConfigNewData(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	err := st.UpdateControllerConfig(ctx.Background(), jujucontroller.Config{
 		jujucontroller.PublicDNSAddress: "controller.test.com:1234",
@@ -68,7 +67,7 @@ func (s *stateSuite) TestUpdateControllerConfigNewData(c *gc.C) {
 }
 
 func (s *stateSuite) TestUpdateExternalControllerUpsertAndReplace(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cc := jujucontroller.Config{
 		jujucontroller.PublicDNSAddress: "controller.test.com:1234",

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -28,7 +27,7 @@ func (s *stateSuite) TestCurateNodes(c *gc.C) {
 	_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES ('1')")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = NewState(testing.TxnRunnerFactory(s.TxnRunner())).CurateNodes(
+	err = NewState(s.TxnRunnerFactory()).CurateNodes(
 		context.Background(), []string{"2", "3"}, []string{"1"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -55,7 +54,7 @@ func (s *stateSuite) TestUpdateUpdateDqliteNode(c *gc.C) {
 	// tried to pass it directly as a uint64 query parameter.
 	nodeID := uint64(15237855465837235027)
 
-	err := NewState(testing.TxnRunnerFactory(s.TxnRunner())).UpdateDqliteNode(
+	err := NewState(s.TxnRunnerFactory()).UpdateDqliteNode(
 		context.Background(), "0", nodeID, "192.168.5.60")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -79,7 +78,7 @@ func (s *stateSuite) TestSelectModelUUID(c *gc.C) {
 	_, err := db.Exec("INSERT INTO model_list (uuid) VALUES ('some-uuid')")
 	c.Assert(err, jc.ErrorIsNil)
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	uuid, err := st.SelectModelUUID(context.Background(), "not-there")
 	c.Assert(errors.Is(err, jujuerrors.NotFound), jc.IsTrue)

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -37,7 +37,7 @@ func (s *credentialSuite) SetUpTest(c *gc.C) {
 
 	s.events = make(chan []changestream.ChangeEvent, 1)
 
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	s.addCloud(c, st, cloud.Cloud{
 		Name:      "stratus",
 		Type:      "ec2",
@@ -46,7 +46,7 @@ func (s *credentialSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialSuite) addCloud(c *gc.C, st *State, cloud cloud.Cloud) string {
-	cloudSt := dbcloud.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	cloudSt := dbcloud.NewState(s.TxnRunnerFactory())
 	ctx := ctx.Background()
 	err := cloudSt.UpsertCloud(ctx, cloud)
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *credentialSuite) addCloud(c *gc.C, st *State, cloud cloud.Cloud) string
 }
 
 func (s *credentialSuite) TestUpdateCloudCredentialNew(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewNamedCredential("foobar", cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -78,7 +78,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 }
 
 func (s *credentialSuite) TestUpdateCloudCredentialNoValues(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewNamedCredential("foobar", cloud.AccessKeyAuthType, map[string]string{}, true)
 	ctx := ctx.Background()
@@ -91,7 +91,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialNoValues(c *gc.C) {
 }
 
 func (s *credentialSuite) TestUpdateCloudCredentialMissingName(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -103,7 +103,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialMissingName(c *gc.C) {
 }
 
 func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -118,7 +118,7 @@ func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
 }
 
 func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewNamedCredential("foobar", cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -141,7 +141,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 }
 
 func (s *credentialSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewNamedCredential("foobar", cloud.OAuth2AuthType, map[string]string{
 		"foo": "foo val",
@@ -154,7 +154,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
 }
 
 func (s *credentialSuite) TestCloudCredentialsEmpty(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	creds, err := st.CloudCredentials(ctx.Background(), "bob", "dummy")
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +162,7 @@ func (s *credentialSuite) TestCloudCredentialsEmpty(c *gc.C) {
 }
 
 func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred1 := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -219,7 +219,7 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, cloudN
 }
 
 func (s *credentialSuite) TestInvalidateCredential(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
 }
 
@@ -234,7 +234,7 @@ func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, cloudN
 }
 
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidExplicitly(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	// This call will ensure that there is an invalid credential to test with.
 	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
 
@@ -247,7 +247,7 @@ func (s *credentialSuite) TestMarkInvalidCredentialAsValidExplicitly(c *gc.C) {
 }
 
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidImplicitly(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	// This call will ensure that there is an invalid credential to test with.
 	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
 
@@ -259,7 +259,7 @@ func (s *credentialSuite) TestMarkInvalidCredentialAsValidImplicitly(c *gc.C) {
 }
 
 func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	cred1 := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
@@ -277,7 +277,7 @@ func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
 }
 
 func (s *credentialSuite) TestAllCloudCredentialsNotFound(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	out, err := st.AllCloudCredentials(ctx.Background(), "bob")
 	c.Assert(err, gc.ErrorMatches, "cloud credentials for \"bob\" not found")
@@ -304,7 +304,7 @@ func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, credentialNa
 }
 
 func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	one := s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
 	two := s.createCloudCredential(c, st, "foobar", "stratus", "bob")
@@ -321,7 +321,7 @@ func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
 }
 
 func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	one := s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
 	c.Assert(one.Invalid, jc.IsFalse)
@@ -338,7 +338,7 @@ func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
 }
 
 func (s *credentialSuite) TestInvalidateCloudCredentialNotFound(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	ctx := ctx.Background()
 	err := st.InvalidateCloudCredential(ctx, "foobar", "cirrus", "bob", "reason")
@@ -373,7 +373,7 @@ type stubEvent struct {
 }
 
 func (s *credentialSuite) TestWatchCredentialNotFound(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	ctx := ctx.Background()
 	_, err := st.WatchCredential(ctx, s.watcherFunc(c, ""), "foobar", "cirrus", "bob")
@@ -381,7 +381,7 @@ func (s *credentialSuite) TestWatchCredentialNotFound(c *gc.C) {
 }
 
 func (s *credentialSuite) TestWatchCredential(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
 
 	var uuid string

--- a/domain/externalcontroller/state/state_test.go
+++ b/domain/externalcontroller/state/state_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -25,7 +24,7 @@ type stateSuite struct {
 var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) TestRetrieveExternalController(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -50,7 +49,7 @@ func (s *stateSuite) TestRetrieveExternalController(c *gc.C) {
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerWithoutAddresses(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -69,7 +68,7 @@ func (s *stateSuite) TestRetrieveExternalControllerWithoutAddresses(c *gc.C) {
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerWithoutAlias(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -89,7 +88,7 @@ func (s *stateSuite) TestRetrieveExternalControllerWithoutAlias(c *gc.C) {
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerNotFound(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	// Retrieve a not-existent controller.
 	_, err := st.Controller(ctx.Background(), "ctrl1")
@@ -97,7 +96,7 @@ func (s *stateSuite) TestRetrieveExternalControllerNotFound(c *gc.C) {
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerForModel(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -126,7 +125,7 @@ func (s *stateSuite) TestRetrieveExternalControllerForModel(c *gc.C) {
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerForModelWithoutAddresses(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -150,7 +149,7 @@ func (s *stateSuite) TestRetrieveExternalControllerForModelWithoutAddresses(c *g
 }
 
 func (s *stateSuite) TestRetrieveExternalControllerForModelWithoutAlias(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -174,7 +173,7 @@ func (s *stateSuite) TestRetrieveExternalControllerForModelWithoutAlias(c *gc.C)
 }
 
 func (s *stateSuite) TestUpdateExternalControllerNewData(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	ecUUID := utils.MustNewUUID().String()
 	m1 := utils.MustNewUUID().String()
@@ -227,7 +226,7 @@ func (s *stateSuite) TestUpdateExternalControllerNewData(c *gc.C) {
 }
 
 func (s *stateSuite) TestUpdateExternalControllerUpsertAndReplace(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	ecUUID := utils.MustNewUUID().String()
 	ec := crossmodel.ControllerInfo{
@@ -276,7 +275,7 @@ func (s *stateSuite) TestUpdateExternalControllerUpsertAndReplace(c *gc.C) {
 }
 
 func (s *stateSuite) TestUpdateExternalControllerUpdateModel(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 
 	m1 := utils.MustNewUUID().String()
 	// This is an existing controller with a model reference.
@@ -313,7 +312,7 @@ func (s *stateSuite) TestUpdateExternalControllerUpdateModel(c *gc.C) {
 }
 
 func (s *stateSuite) TestModelsForController(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert a single external controller.
@@ -337,7 +336,7 @@ func (s *stateSuite) TestModelsForController(c *gc.C) {
 }
 
 func (s *stateSuite) TestControllersForModels(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert an external controller with one model.
@@ -407,7 +406,7 @@ func (s *stateSuite) TestControllersForModels(c *gc.C) {
 }
 
 func (s *stateSuite) TestControllersForModelsOneSingleModel(c *gc.C) {
-	st := NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
 
 	// Insert an external controller with one model.

--- a/domain/lease/state/state_test.go
+++ b/domain/lease/state/state_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corelease "github.com/juju/juju/core/lease"
-	"github.com/juju/juju/database/testing"
 	"github.com/juju/juju/domain/lease/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	jujutesting "github.com/juju/juju/testing"
@@ -30,7 +29,7 @@ var _ = gc.Suite(&stateSuite{})
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	s.store = state.NewState(testing.TxnRunnerFactory(s.TxnRunner()), jujutesting.CheckLogger{Log: c})
+	s.store = state.NewState(s.TxnRunnerFactory(), jujutesting.CheckLogger{Log: c})
 }
 
 func (s *stateSuite) TestClaimLeaseSuccessAndLeaseQueries(c *gc.C) {

--- a/domain/modelmanager/state/state_test.go
+++ b/domain/modelmanager/state/state_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/database/testing"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/modelmanager/service"
 	"github.com/juju/juju/domain/modelmanager/state"
@@ -25,13 +24,13 @@ type stateSuite struct {
 var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) TestStateCreate(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 	err := st.Create(context.TODO(), mustUUID(c))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *stateSuite) TestStateCreateCalledTwice(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 
 	uuid := mustUUID(c)
 
@@ -45,21 +44,21 @@ func (s *stateSuite) TestStateCreateCalledTwice(c *gc.C) {
 // Note: This will pass as we don't validate the UUID at this level, and we
 // don't compile UUID module into sqlite3 either.
 func (s *stateSuite) TestStateCreateWithInvalidUUID(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 
 	err := st.Create(context.TODO(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *stateSuite) TestStateDeleteWithNoMatchingUUID(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 	err := st.Delete(context.TODO(), mustUUID(c))
 	c.Assert(err, gc.ErrorMatches, domain.ErrNoRecord.Error()+".*")
 	c.Assert(errors.Is(errors.Cause(err), domain.ErrNoRecord), jc.IsTrue)
 }
 
 func (s *stateSuite) TestStateDelete(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 
 	uuid := mustUUID(c)
 
@@ -71,7 +70,7 @@ func (s *stateSuite) TestStateDelete(c *gc.C) {
 }
 
 func (s *stateSuite) TestStateDeleteCalledTwice(c *gc.C) {
-	st := state.NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	st := state.NewState(s.TxnRunnerFactory())
 
 	uuid := mustUUID(c)
 

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -6,7 +6,6 @@ package domain
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -17,7 +16,7 @@ type stateSuite struct {
 var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) TestStateBaseGetDB(c *gc.C) {
-	f := testing.TxnRunnerFactory(s.TxnRunner())
+	f := s.TxnRunnerFactory()
 	base := NewStateBase(f)
 	db, err := base.DB()
 	c.Assert(err, gc.IsNil)
@@ -28,11 +27,4 @@ func (s *stateSuite) TestStateBaseGetDBNilFactory(c *gc.C) {
 	base := NewStateBase(nil)
 	_, err := base.DB()
 	c.Assert(err, gc.ErrorMatches, `nil getDB`)
-}
-
-func (s *stateSuite) TestStateBaseGetDBNilDB(c *gc.C) {
-	f := testing.TxnRunnerFactory(nil)
-	base := NewStateBase(f)
-	_, err := base.DB()
-	c.Assert(err, gc.ErrorMatches, `invoking getDB: nil db`)
 }

--- a/domain/upgrade/state/state_test.go
+++ b/domain/upgrade/state/state_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/database"
-	"github.com/juju/juju/database/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -31,7 +30,7 @@ var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
-	s.st = NewState(testing.TxnRunnerFactory(s.TxnRunner()))
+	s.st = NewState(s.TxnRunnerFactory())
 
 	// Add a completed upgrade before tests start
 	uuid, err := s.st.CreateUpgrade(context.Background(), version.MustParse("2.9.42"), version.MustParse("3.0.0"))

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
@@ -161,7 +162,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cjlapao/common-go v0.0.39 // indirect
 	github.com/creack/pty v1.1.15 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect


### PR DESCRIPTION
This small patch moves the TxnRunnerFactory, currently present in ./database/testing/runner.go into ./database/testing/dqlitesuite.go and make use of the trackedDB that we already have in the dqlitesuite, therefore not taking any arguments.

This cleans up our domain tests.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```
go test github.com/juju/juju/database/... -gocheck.v
go test github.com/juju/juju/domain/... -gocheck.v
```
