### PR TITLE
Prevent filenotify watcher from bouncing the world

### DIFF
--- a/worker/changestream/worker.go
+++ b/worker/changestream/worker.go
@@ -84,8 +84,10 @@ func newWorker(cfg WorkerConfig) (*changeStreamWorker, error) {
 		runner: worker.NewRunner(worker.RunnerParams{
 			// Prevent the runner from restarting the worker, if one of the
 			// workers dies, we want to stop the whole thing.
-			IsFatal: func(err error) bool { return false },
-			Clock:   cfg.Clock,
+			IsFatal: func(err error) bool {
+				return false
+			},
+			Clock: cfg.Clock,
 		}),
 	}
 
@@ -102,7 +104,7 @@ func newWorker(cfg WorkerConfig) (*changeStreamWorker, error) {
 	return w, nil
 }
 
-func (w *changeStreamWorker) loop() (err error) {
+func (w *changeStreamWorker) loop() error {
 	defer w.runner.Kill()
 
 	<-w.catacomb.Dying()


### PR DESCRIPTION
If the file notify watcher can't find the path to watch, then don't force the bouncing of the world. Instead, just return a noop version that allows everything to continue. We log a warning when this happens.

This only happens really sporadically, and I've not happened to replicate what @manadart saw. Although, we shouldn't allow something that is purely for debugging to stop the world.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
```
