### PR TITLE
[JUJU-4504] Retry transactions when entering scope of a relation unit

### DIFF
--- a/state/errors/common.go
+++ b/state/errors/common.go
@@ -18,12 +18,12 @@ import (
 const (
 	// ErrCannotEnterScope indicates that a relation unit failed to enter its scope
 	// due to either the unit or the relation not being Alive.
-	ErrCannotEnterScope = errors.ConstError("cannot enter scope: unit or relation is not alive")
+	ErrCannotEnterScope = errors.ConstError("cannot enter scope")
 
 	// ErrCannotEnterScopeYet indicates that a relation unit failed to enter its
 	// scope due to a required and pre-existing subordinate unit that is not Alive.
 	// Once that subordinate has been removed, a new one can be created.
-	ErrCannotEnterScopeYet = errors.ConstError("cannot enter scope yet: non-alive subordinate unit has not been removed")
+	ErrCannotEnterScopeYet = errors.ConstError("cannot enter scope yet")
 
 	// ErrCharmRevisionAlreadyModified is returned when a pending or
 	// placeholder charm is no longer pending or a placeholder, signaling

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -76,79 +76,91 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	defer dbCloser()
 	relationScopes, rsCloser := db.GetCollection(relationScopesC)
 	defer rsCloser()
-
-	// Verify that the unit is not already in scope, and abort without error
-	// if it is.
 	ruKey := ru.key()
-	if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
-		return err
-	} else if count != 0 {
-		return nil
-	}
-
-	// Collect the operations necessary to enter scope, as follows:
-	// * Check unit and relation state, and incref the relation.
-	// * TODO(fwereade): check unit status == params.StatusActive (this
-	//   breaks a bunch of tests in a boring but noisy-to-fix way, and is
-	//   being saved for a followup).
 	relationDocID := ru.relation.doc.DocID
-	var ops []txn.Op
-	if ru.isLocalUnit {
-		ops = append(ops, txn.Op{
-			C:      unitsC,
-			Id:     ru.unitName,
-			Assert: isAliveDoc,
-		})
-	}
-	ops = append(ops, txn.Op{
-		C:      relationsC,
-		Id:     relationDocID,
-		Assert: isAliveDoc,
-		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
-	})
 
-	// * Create the unit settings in this relation, if they do not already
-	//   exist; or completely overwrite them if they do. This must happen
-	//   before we create the scope doc, because the existence of a scope doc
-	//   is considered to be a guarantee of the existence of a settings doc.
-	settingsChanged := func() (bool, error) { return false, nil }
-	settingsColl, sCloser := db.GetCollection(settingsC)
-	defer sCloser()
-	if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
-		return err
-	} else if count == 0 {
-		ops = append(ops, createSettingsOp(settingsC, ruKey, settings))
-	} else {
-		var rop txn.Op
-		rop, settingsChanged, err = replaceSettingsOp(ru.st.db(), settingsC, ruKey, settings)
-		if err != nil {
-			return err
-		}
-		ops = append(ops, rop)
-	}
+	var settingsChanged func() (bool, error)
 
-	// * Create the scope doc.
-	ops = append(ops, txn.Op{
-		C:      relationScopesC,
-		Id:     ruKey,
-		Assert: txn.DocMissing,
-		Insert: relationScopeDoc{
-			Key: ruKey,
-		},
-	})
-
-	// * If the unit should have a subordinate, and does not, create it.
 	var existingSubName string
-	if subOps, subName, err := ru.subordinateOps(); err != nil {
-		return err
-	} else {
-		existingSubName = subName
-		ops = append(ops, subOps...)
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+
+		// Verify that the unit is not already in scope, and abort without error
+		// if it is.
+		if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
+			return nil, err
+		} else if count != 0 {
+			return nil, nil
+		}
+
+		// Collect the operations necessary to enter scope, as follows:
+		// * Check unit and relation state, and incref the relation.
+		// * TODO(fwereade): check unit status == params.StatusActive (this
+		//   breaks a bunch of tests in a boring but noisy-to-fix way, and is
+		//   being saved for a followup).
+		var ops []txn.Op
+		if ru.isLocalUnit {
+			ops = append(ops, txn.Op{
+				C:      unitsC,
+				Id:     ru.unitName,
+				Assert: isAliveDoc,
+			})
+		}
+		ops = append(ops, txn.Op{
+			C:      relationsC,
+			Id:     relationDocID,
+			Assert: isAliveDoc,
+			Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
+		})
+
+		// * Create the unit settings in this relation, if they do not already
+		//   exist; or completely overwrite them if they do. This must happen
+		//   before we create the scope doc, because the existence of a scope doc
+		//   is considered to be a guarantee of the existence of a settings doc.
+		settingsColl, sCloser := db.GetCollection(settingsC)
+		defer sCloser()
+		if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
+			return nil, err
+		} else if count == 0 {
+			ops = append(ops, createSettingsOp(settingsC, ruKey, settings))
+			settingsChanged = func() (bool, error) { return false, nil }
+		} else {
+			var rop txn.Op
+			rop, settingsChanged, err = replaceSettingsOp(ru.st.db(), settingsC, ruKey, settings)
+			if err != nil {
+				return nil, err
+			}
+			ops = append(ops, rop)
+		}
+
+		// * Create the scope doc.
+		ops = append(ops, txn.Op{
+			C:      relationScopesC,
+			Id:     ruKey,
+			Assert: txn.DocMissing,
+			Insert: relationScopeDoc{
+				Key: ruKey,
+			},
+		})
+
+		// * If the unit should have a subordinate, and does not, create it.
+		if subOps, subName, err := ru.subordinateOps(); err != nil {
+			return nil, err
+		} else {
+			existingSubName = subName
+			ops = append(ops, subOps...)
+		}
+		return ops, nil
 	}
 
+	prefix := fmt.Sprintf("cannot enter scope for unit %q in relation %q: ", ru.unitName, ru.relation)
 	// Now run the complete transaction, or figure out why we can't.
-	if err := ru.st.db().RunTransaction(ops); err != txn.ErrAborted {
+	if err := ru.st.db().Run(buildTxn); err != txn.ErrAborted {
 		return err
+	} else if err == txn.ErrAborted {
+		// Apparently, all our assertions should have passed, but the txn was
+		// aborted: something is really seriously wrong.
+		return fmt.Errorf(prefix+"transaction error: %s", err)
 	}
 	if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
 		return err
@@ -193,16 +205,13 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	// has changed under our feet, preventing us from clearing it properly; if
 	// that is the case, something is seriously wrong (nobody else should be
 	// touching that doc under our feet) and we should bail out.
-	prefix := fmt.Sprintf("cannot enter scope for unit %q in relation %q: ", ru.unitName, ru.relation)
 	if changed, err := settingsChanged(); err != nil {
 		return err
 	} else if changed {
 		return fmt.Errorf(prefix + "concurrent settings change detected")
 	}
 
-	// Apparently, all our assertions should have passed, but the txn was
-	// aborted: something is really seriously wrong.
-	return fmt.Errorf(prefix + "inconsistent state in EnterScope")
+	return nil
 }
 
 // CounterpartApplications returns the slice of application names that are the counterpart of this unit.

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -80,15 +80,68 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	relationDocID := ru.relation.doc.DocID
 
 	var settingsChanged func() (bool, error)
-
 	var existingSubName string
+	prefix := fmt.Sprintf("unit %q in relation %q: ", ru.unitName, ru.relation)
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// Before retrying the transaction, check the following
+		// assertions:
+		if attempt > 0 {
+			if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
+				return nil, errors.Trace(err)
+			} else if count != 0 {
+				// The scope document exists, so we're actually already in scope.
+				return nil, nil
+			}
 
-		// Verify that the unit is not already in scope, and abort without error
+			// The relation or unit might no longer be Alive. (Note that there is no
+			// need for additional checks if we're trying to create a subordinate
+			// unit: this could fail due to the subordinate applications not being Alive,
+			// but this case will always be caught by the check for the relation's
+			// life (because a relation cannot be Alive if its applications are not).)
+			relations, rCloser := db.GetCollection(relationsC)
+			defer rCloser()
+			if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
+				return nil, errors.Trace(err)
+			} else if !alive {
+				return nil, errors.Annotate(stateerrors.ErrCannotEnterScope, prefix+"relation is no longer alive")
+			}
+			if ru.isLocalUnit {
+				units, uCloser := db.GetCollection(unitsC)
+				defer uCloser()
+				if alive, err := isAliveWithSession(units, ru.unitName); err != nil {
+					return nil, errors.Trace(err)
+				} else if !alive {
+					return nil, errors.Annotate(stateerrors.ErrCannotEnterScope, prefix+"unit is no longer alive")
+
+				}
+
+				// Maybe a subordinate used to exist, but is no longer alive. If that is
+				// case, we will be unable to enter scope until that unit is gone.
+				if existingSubName != "" {
+					if alive, err := isAliveWithSession(units, existingSubName); err != nil {
+						return nil, errors.Trace(err)
+					} else if !alive {
+						return nil, errors.Annotatef(stateerrors.ErrCannotEnterScopeYet, prefix+"subordinate %v is no longer alive", existingSubName)
+					}
+				}
+			}
+
+			// It's possible that there was a pre-existing settings doc whose version
+			// has changed under our feet, preventing us from clearing it properly; if
+			// that is the case, something is seriously wrong (nobody else should be
+			// touching that doc under our feet) and we should bail out.
+			if changed, err := settingsChanged(); err != nil {
+				return nil, errors.Trace(err)
+			} else if changed {
+				return nil, fmt.Errorf(prefix + "concurrent settings change detected")
+			}
+		}
+
+		// Verify that the unit is not already in scope, and exit without error
 		// if it is.
 		if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		} else if count != 0 {
 			return nil, nil
 		}
@@ -120,7 +173,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		settingsColl, sCloser := db.GetCollection(settingsC)
 		defer sCloser()
 		if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		} else if count == 0 {
 			ops = append(ops, createSettingsOp(settingsC, ruKey, settings))
 			settingsChanged = func() (bool, error) { return false, nil }
@@ -128,7 +181,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 			var rop txn.Op
 			rop, settingsChanged, err = replaceSettingsOp(ru.st.db(), settingsC, ruKey, settings)
 			if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 			ops = append(ops, rop)
 		}
@@ -145,7 +198,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 
 		// * If the unit should have a subordinate, and does not, create it.
 		if subOps, subName, err := ru.subordinateOps(); err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		} else {
 			existingSubName = subName
 			ops = append(ops, subOps...)
@@ -153,65 +206,8 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		return ops, nil
 	}
 
-	prefix := fmt.Sprintf("cannot enter scope for unit %q in relation %q: ", ru.unitName, ru.relation)
-	// Now run the complete transaction, or figure out why we can't.
-	if err := ru.st.db().Run(buildTxn); err != txn.ErrAborted {
-		return err
-	} else if err == txn.ErrAborted {
-		// Apparently, all our assertions should have passed, but the txn was
-		// aborted: something is really seriously wrong.
-		return fmt.Errorf(prefix+"transaction error: %s", err)
-	}
-	if count, err := relationScopes.FindId(ruKey).Count(); err != nil {
-		return err
-	} else if count != 0 {
-		// The scope document exists, so we're actually already in scope.
-		return nil
-	}
-
-	// The relation or unit might no longer be Alive. (Note that there is no
-	// need for additional checks if we're trying to create a subordinate
-	// unit: this could fail due to the subordinate applications not being Alive,
-	// but this case will always be caught by the check for the relation's
-	// life (because a relation cannot be Alive if its applications are not).)
-	relations, rCloser := db.GetCollection(relationsC)
-	defer rCloser()
-	if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
-		return err
-	} else if !alive {
-		return stateerrors.ErrCannotEnterScope
-	}
-	if ru.isLocalUnit {
-		units, uCloser := db.GetCollection(unitsC)
-		defer uCloser()
-		if alive, err := isAliveWithSession(units, ru.unitName); err != nil {
-			return err
-		} else if !alive {
-			return stateerrors.ErrCannotEnterScope
-		}
-
-		// Maybe a subordinate used to exist, but is no longer alive. If that is
-		// case, we will be unable to enter scope until that unit is gone.
-		if existingSubName != "" {
-			if alive, err := isAliveWithSession(units, existingSubName); err != nil {
-				return err
-			} else if !alive {
-				return stateerrors.ErrCannotEnterScopeYet
-			}
-		}
-	}
-
-	// It's possible that there was a pre-existing settings doc whose version
-	// has changed under our feet, preventing us from clearing it properly; if
-	// that is the case, something is seriously wrong (nobody else should be
-	// touching that doc under our feet) and we should bail out.
-	if changed, err := settingsChanged(); err != nil {
-		return err
-	} else if changed {
-		return fmt.Errorf(prefix + "concurrent settings change detected")
-	}
-
-	return nil
+	// Now run the complete transaction.
+	return ru.st.db().Run(buildTxn)
 }
 
 // CounterpartApplications returns the slice of application names that are the counterpart of this unit.

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -399,7 +399,7 @@ func (s *RelationUnitSuite) TestContainerCreateSubordinate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertNotInScope(c, pru)
 	err = pru.EnterScope(nil)
-	c.Assert(err, gc.Equals, stateerrors.ErrCannotEnterScopeYet)
+	c.Assert(err, jc.ErrorIs, stateerrors.ErrCannotEnterScopeYet)
 	assertNotInScope(c, pru)
 
 	// Remove the subordinate, and enter scope again; this should work, and
@@ -440,7 +440,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 	// Check that we can't add a new unit now.
 	assertNotInScope(c, pr.ru2)
 	err = pr.ru2.EnterScope(nil)
-	c.Assert(err, gc.Equals, stateerrors.ErrCannotEnterScope)
+	c.Assert(err, jc.ErrorIs, stateerrors.ErrCannotEnterScope)
 	assertNotInScope(c, pr.ru2)
 
 	// Check that we created no settings for the unit we failed to add.
@@ -530,7 +530,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertNotInScope(c, pr.ru3)
 	err = pr.ru3.EnterScope(nil)
-	c.Assert(err, gc.Equals, stateerrors.ErrCannotEnterScope)
+	c.Assert(err, jc.ErrorIs, stateerrors.ErrCannotEnterScope)
 	assertNotInScope(c, pr.ru3)
 }
 

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/sync/errgroup"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
@@ -1065,13 +1067,14 @@ func (prr *ProReqRelation) watches() []*state.RelationScopeWatcher {
 }
 
 func (prr *ProReqRelation) allEnterScope(c *gc.C) {
-	err := prr.pru0.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.pru1.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.rru0.EnterScope(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.rru1.EnterScope(nil)
+	g, _ := errgroup.WithContext(context.Background())
+
+	g.Go(func() error { return prr.pru0.EnterScope(nil) })
+	g.Go(func() error { return prr.pru1.EnterScope(nil) })
+	g.Go(func() error { return prr.rru0.EnterScope(nil) })
+	g.Go(func() error { return prr.rru1.EnterScope(nil) })
+
+	err := g.Wait()
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
_TLDR: Under some load (a few apps and units) sometimes a newly created relation fails to enter scope with error `inconsistent state in EnterScope`. This is due to the transactions involved being aborted with `WriteConflict error`. 
The main hypothesis behind this patch is that this error is purely transient (due to transactions that write to the same document being run concurrently, and on different transaction runners) and can therefore be retried._

This patch fixes a bug (https://bugs.launchpad.net/juju/+bug/2031631) on which the relation unit doesn't enter scope in the case multiple units and applications are present before creating a relation on them.

When using server-side transactions, mgo retries (hard-coded 3 times) transactions that fail with WriteConflict error, and after that it aborts the (mgo) transaction.
For example:
```
juju debug-log --replay --level TRACE --tail -m controller | grep "juju.txn.*Please retry"
controller-0: 15:44:17 TRACE juju.txn update op: txn.Op{C:"modelEntityRefs", Id:"03b60bbf-53e8-48e9-819c-dfaf1e71b954", Assert:"d+", Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$addToSet", Value:bson.D{bson.DocElem{Name:"applications", Value:"database"}}}}, Remove:false} write conflict: WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.
```
These retries are seen many times on multiple scenarios in juju, and therefore the business logic decides on each case how to treat the (mgo server-side) aborted transactions.

In the case of EnterScope, it is necessary to retry the (mgo server-side) transaction (which includes retrying the mongodb transaction) because EnterScope is called concurrently (via the EnterScope facade) and therefore WriteConflict errors are transient errors. By calling Run(jujutxn.TransactionSource) instead of RunTransaction(ops []txn.Op) we make use of the retries applied to the function (jujutxn.TransactionSource) passed to Run(...).

Note: This last observation means that the true solution would be sequential transactions for EnterScope, but since each relationunit has it's own runner, this would mean a huge change.

### Reproducing the bug

The first way to reproduce this behaviour is simply by modifying the `func (prr *ProReqRelation) allEnterScope(c *gc.C)` function on `state/relationunit_test.go` in a way that the calls to `EnterScope()` are run concurrently:
```go
func (prr *ProReqRelation) allEnterScope(c *gc.C) {
       g, _ := errgroup.WithContext(context.Background())

       g.Go(func() error { return prr.pru0.EnterScope(nil) })
       g.Go(func() error { return prr.pru1.EnterScope(nil) })
       g.Go(func() error { return prr.rru0.EnterScope(nil) })
       g.Go(func() error { return prr.rru1.EnterScope(nil) })

       err := g.Wait()
	c.Assert(err, jc.ErrorIsNil)
}
```
This change only should make some tests fail, for example:
```
go test github.com/juju/juju/state/... -gocheck.v -gocheck.f=TestWatchAppSettings
...
[LOG] 0:01.324 DEBUG juju.state.pool.txnwatcher txn watcher: relations eea4884f-5783-4a66-897a-5d55f6a41daf:wordpress:db mysql:server #5
    prr.allEnterScope(c)
relationunit_test.go:1081:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.errorString = &errors.errorString{s:"cannot enter scope for unit \"wordpress/1\" in relation \"wordpress:db mysql:server\": inconsistent state in EnterScope"} ("cannot enter scope for unit \"wordpress/1\" in relation \"wordpress:db mysql:server\": inconsistent state in EnterScope")
...
```
Another way is by bootstrapping a microk8s controller, adding a model and simply deploying two apps with multiple units and a relation between them, it won't fail systematically but if you delete and recreate the relation it will eventually fail:
```
juju deploy kafka-k8s -n 5 --channel 3/edge && juju deploy zookeeper-k8s -n 5 --channel 3/edge && juju relate kafka-k8s zookeeper-k8s
juju debug-log --replay --level DEBUG --tail | grep "enterscope\|EnterScope" 
```
The last way is by reproducing the scenario in https://bugs.launchpad.net/juju/+bug/2031631. This is the longest setup but it failed systematically locally on my PC:

```
# using juju 3.1 (from snap) bootstrap a microk8s controller and add a model
juju bootstrap microk8s c --config logging-config="<root>=DEBUG;juju.txn=TRACE;juju.worker.uniter.relation=TRACE"
juju add-model testing
# clone the data project and checkout the correct PR:
git clone git@github.com:canonical/data-platform-libs.git && gh pr checkout 84 
# setup python virtual environment
python3 -m venv data-platform-libs
# activate the virtual env and install dependencies
cd data-platform-libs
source bin/activate 
pip install -r requirements.txt
# set the correct pylibjuju version and run the tests
export LIBJUJU_VERSION_SPECIFIER="==3.2.0.1"
tox run -e integration-database -- -m 'not unstable' --model testing
```
by checking the logs you should see the error:
```
juju debug-log --replay --level DEBUG --tail | grep "enterscope\|EnterScope"
unit-database-1: 15:45:33 ERROR juju.worker.uniter resolver loop error: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
unit-database-1: 15:45:33 INFO juju.worker.uniter unit "database/1" shutting down: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
unit-database-1: 15:45:33 DEBUG juju.worker.dependency "uniter" manifold worker stopped: cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
cannot enter scope for unit "database/1" in relation "application:first-database database:database": inconsistent state in EnterScope
github.com/juju/juju/api/agent/uniter.(*RelationUnit).EnterScope:71:
```


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

QA steps include to run the scenarios described in the `Reproducing the bug` section above. These should always pass now.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2031631