### PR TITLE
Merge 3.1 to 3.2 with actions changes

### DIFF
--- a/.github/reg.yml
+++ b/.github/reg.yml
@@ -63,9 +63,8 @@ spec:
             claimName: registry-claim
         - name: tls-certs
           hostPath:
-            path: /home/runner/certs
+            path: $CERT_DIR
             type: Directory
-
 ---
 apiVersion: v1
 kind: Service

--- a/.github/verify-prometheus-k8s.sh
+++ b/.github/verify-prometheus-k8s.sh
@@ -15,7 +15,7 @@ while true; do
   ip=$(juju status --format json | jq -r '.applications."prometheus-k8s".address' || echo "")
   port="9090"
   app_status=$(curl --silent --max-time 3 "${ip}:${port}/-/ready" || echo "")
-  [ "$app_status" == "Prometheus is Ready." ] && break
+  [ "$app_status" == "Prometheus Server is Ready." ] && break
 
   sleep 10
 done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: "Build"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -18,7 +17,7 @@ permissions:
 jobs:
   Build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,19 @@ permissions:
 jobs:
   Build:
     name: Build
-    runs-on: [self-hosted, linux, arm64, aws, large]
+    runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", aws, large]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
         platform:
-           - { os: linux, arch: amd64 }
-           - { os: linux, arch: arm64 }
-           - { os: linux, arch: s390x }
-           - { os: linux, arch: ppc64le }
-           - { os: windows, arch: amd64 }
-           - { os: darwin, arch: amd64 }
+           - { os: linux, arch: amd64, host_arch: x64 }
+           - { os: linux, arch: arm64, host_arch: arm64 }
+# Until we get rid of musl, lets just disable these to save build time.
+#           - { os: linux, arch: s390x }
+#           - { os: linux, arch: ppc64le }
+           - { os: windows, arch: amd64, host_arch: arm64 }
+           - { os: darwin, arch: arm64, host_arch: arm64 }
 
     steps:
     - name: "Checkout"
@@ -39,12 +40,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
-    
-    - name: "Install musl"
-      if: (matrix.os == 'linux')
-      shell: bash
-      run: |
-        sudo make MUSL_CROSS_COMPILE=0 MUSL_PLACEMENT=local musl-install
 
     - name: "Build"
       run: |

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,6 +1,5 @@
 name: "Client Tests"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -24,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [macOS-latest]
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -49,7 +49,7 @@ jobs:
           #  3. Unique every file, so we only go generate the file once.
           #  4. Using xargs perform go generate in parallel.
           #
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 8 -I% go generate -x $(realpath %)
 
       - name: "Check diff"
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,6 +1,5 @@
 name: "Generate"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -17,7 +16,7 @@ permissions:
 jobs:
   Generate:
     name: Generate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, xxlarge]
     if: github.event.pull_request.draft == false
 
     steps:
@@ -61,6 +60,8 @@ jobs:
           
           git add -A
           if [[ -n $(git diff HEAD) ]]; then
+            # Print the full diff for debugging purposes
+            git diff HEAD
             echo "*****"
             echo "The following generated files have been modified:"
             git diff --name-status HEAD

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,6 +1,5 @@
 name: "Licenses"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -15,7 +14,7 @@ permissions:
 jobs:
   go-license-check:
     name: "go.mod license check"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     name: Test Kubeflow
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-    - uses: balchua/microk8s-actions@v0.3.2
+    - uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.
@@ -50,8 +50,8 @@ jobs:
             sudo snap install $snap --classic
         done
 
-        sudo apt update
-        sudo apt install -y libssl-dev python3-setuptools
+        sudo DEBIAN_FRONTEND=noninteractive apt update
+        sudo DEBIAN_FRONTEND=noninteractive apt install -y libssl-dev python3-setuptools
         sudo usermod -a -G microk8s $USER
 
     - name: Build juju and operator image

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,6 +1,5 @@
 name: "Migrate"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -19,7 +18,7 @@ permissions:
 jobs:
   migrate:
     name: 2.9-to-3.x via ${{ matrix.client }} client
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -33,6 +32,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Set up Go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
       - name: Setup LXD
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@v0.1.1
@@ -44,20 +54,13 @@ jobs:
       - name: Bootstrap a 2.9 controller and model
         run: |
           /snap/bin/juju version
-          /snap/bin/juju bootstrap lxd test29
+          /snap/bin/juju bootstrap lxd test29 --constraints "arch=$(go env GOARCH)"
           /snap/bin/juju add-model test-migrate
+          /snap/bin/juju set-model-constraints arch=$(go env GOARCH)
           /snap/bin/juju deploy ubuntu
           
           # TODO: use juju-restore
           # TODO: add users/permissions/models and test that those migrate over
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-
-      - name: Set up Go env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Upgrade client to 3.x
         run: |
@@ -66,7 +69,7 @@ jobs:
       - name: Bootstrap 3.x controller
         run: |
           juju version
-          juju bootstrap lxd test3x
+          juju bootstrap lxd test3x --constraints "arch=$(go env GOARCH)"
           juju switch controller
           juju wait-for application controller
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,6 +1,5 @@
 name: "Smoke"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
@@ -12,7 +11,7 @@ jobs:
 
   smoke:
     name: Smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, xlarge]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -25,7 +24,7 @@ jobs:
       run: |
         set -euxo pipefail
         echo "/snap/bin" >> $GITHUB_PATH
-        sudo apt install expect
+        sudo DEBIAN_FRONTEND=noninteractive apt install -y expect
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -36,7 +35,7 @@ jobs:
 
     - name: Setup MicroK8s
       if: matrix.cloud == 'microk8s'
-      uses: balchua/microk8s-actions@v0.3.2
+      uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
       with:
         channel: "1.25-strict/stable"
         addons: '["dns", "hostpath-storage", "rbac"]'
@@ -69,6 +68,7 @@ jobs:
       shell: bash
       run: |
         cd tests
+        export MODEL_ARCH=$(go env GOARCH)
         ./main.sh -v -s 'test_build' smoke
 
     - name: Smoke test (MicroK8s)
@@ -76,4 +76,5 @@ jobs:
       shell: bash
       run: |
         cd tests
+        export MODEL_ARCH=$(go env GOARCH)
         sg snap_microk8s './main.sh -c microk8s -s test_build -v smoke'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,5 @@
 name: "Snapcraft"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -19,8 +18,8 @@ permissions:
 jobs:
 
   snap:
-    name: linux-amd64
-    runs-on: ubuntu-latest
+    name: linux-arm64
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     steps:
 
@@ -67,5 +66,5 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        mkdir ~/.ssh
+        mkdir -p ~/.ssh
         juju bootstrap localhost --debug

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,5 @@
 name: "Static Analysis"
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 #   paths:
@@ -13,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, xxlarge]
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout
@@ -57,8 +56,9 @@ jobs:
           libsqlite3-dev \
           sqlite3
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
-        sudo snap install shfmt
-
+        sudo curl -sSfL https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_$(go env GOARCH) -o /usr/bin/shfmt
+        sudo chmod +x /usr/bin/shfmt
+    
     - name: Download Dependencies
       run: go mod download
 
@@ -95,7 +95,7 @@ jobs:
 
   schema:
     name: Schema
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -23,8 +23,7 @@ jobs:
   Upgrade:
     name: Upgrade
     runs-on: [self-hosted, linux, x64, aws, large]
-    # Disabled until 3.2.0 is released.
-    if: false && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +44,7 @@ jobs:
           set -euxo pipefail
           sudo snap install snapcraft --classic
           sudo snap install yq
-          sudo snap install juju --channel=3.1/stable
+          sudo snap install juju --channel=3.2/stable
           mkdir -p ~/.local/share
           echo "/snap/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,8 +1,5 @@
 name: "Upgrade"
 on:
-  push:
-    branches-ignore:
-      - 'develop'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -15,7 +12,7 @@ on:
       - 'Makefile'
       - 'make_functions.sh'
     branches-ignore:
-      - 'develop'
+      - 'main'
   workflow_dispatch:
 
 permissions:
@@ -25,7 +22,7 @@ jobs:
 
   Upgrade:
     name: Upgrade
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, aws, large]
     # Disabled until 3.2.0 is released.
     if: false && github.event.pull_request.draft == false
     strategy:
@@ -90,7 +87,7 @@ jobs:
 
       - name: Setup k8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
-        uses: balchua/microk8s-actions@v0.3.2
+        uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
         with:
           channel: "1.25-strict/stable"
           addons: '["dns", "hostpath-storage"]'
@@ -121,7 +118,7 @@ jobs:
             -out ~/certs/registry.crt -CAcreateserial -days 365 -sha256 -extfile .github/registry.ext
           
           # Deploy registry
-          sg snap_microk8s "microk8s kubectl create -f .github/reg.yml"
+          cat .github/reg.yml | CERT_DIR=$HOME/certs envsubst | sg snap_microk8s "microk8s kubectl create -f -"
           
           # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
           sudo microk8s refresh-certs --cert ca.crt
@@ -169,11 +166,13 @@ jobs:
         run: |
           set -euxo pipefail
           
-          juju bootstrap localhost c
-          juju add-model m
-          
-          juju status
+          juju bootstrap localhost c \
+            --constraints "arch=$(go env GOARCH)"
           juju version
+          
+          juju add-model m
+          juju set-model-constraints arch=$(go env GOARCH)
+          juju status
 
       - name: Bootstrap Juju - microk8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
@@ -186,13 +185,15 @@ jobs:
           
           sg snap_microk8s <<EOF
             juju bootstrap microk8s c \
+              --constraints "arch=$(go env GOARCH)" \
               --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
               --config features="[developer-mode]"
           EOF
-          juju add-model m
-          
-          juju status
           juju version
+
+          juju add-model m
+          juju set-model-constraints arch=$(go env GOARCH)
+          juju status
 
       - name: Deploy some applications
         if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -22,7 +22,7 @@ jobs:
 
   Upgrade:
     name: Upgrade
-    runs-on: [self-hosted, linux, x64, aws, large]
+    runs-on: [self-hosted, linux, x64, aws, xlarge]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -23,7 +23,7 @@ jobs:
   Upgrade:
     name: Upgrade
     runs-on: [self-hosted, linux, x64, aws, xlarge]
-    if: github.event.pull_request.draft == false
+    if: false && github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -42,8 +42,6 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          sudo snap install snapcraft --classic
-          sudo snap install yq
           sudo snap install juju --channel=3.2/stable
           mkdir -p ~/.local/share
           echo "/snap/bin" >> $GITHUB_PATH

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -295,6 +295,10 @@ type Config interface {
 	// lower the threshold, the more queries will be output. A value of 0
 	// means all queries will be output.
 	QueryTracingThreshold() time.Duration
+
+	// DqlitePort returns the port that should be used by Dqlite. This should
+	// only be set during testing.
+	DqlitePort() (int, bool)
 }
 
 type configSetterOnly interface {
@@ -425,6 +429,7 @@ type configInternal struct {
 	agentLogfileMaxBackups int
 	queryTracingEnabled    bool
 	queryTracingThreshold  time.Duration
+	dqlitePort             int
 }
 
 // AgentConfigParams holds the parameters required to create
@@ -447,6 +452,7 @@ type AgentConfigParams struct {
 	AgentLogfileMaxBackups int
 	QueryTracingEnabled    bool
 	QueryTracingThreshold  time.Duration
+	DqlitePort             int
 }
 
 // NewAgentConfig returns a new config object suitable for use for a
@@ -512,6 +518,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		agentLogfileMaxBackups: configParams.AgentLogfileMaxBackups,
 		queryTracingEnabled:    configParams.QueryTracingEnabled,
 		queryTracingThreshold:  configParams.QueryTracingThreshold,
+		dqlitePort:             configParams.DqlitePort,
 	}
 	if len(configParams.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -977,4 +984,9 @@ func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 		Password: c.statePassword,
 		Tag:      c.tag,
 	}, true
+}
+
+// DqlitePort is defined on Config interface.
+func (c *configInternal) DqlitePort() (int, bool) {
+	return c.dqlitePort, c.dqlitePort > 0
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -66,6 +66,7 @@ type format_2_0Serialization struct {
 	JujuDBSnapChannel     string        `yaml:"juju-db-snap-channel,omitempty"`
 	QueryTracingEnabled   bool          `yaml:"querytracingenabled,omitempty"`
 	QueryTracingThreshold time.Duration `yaml:"querytracingthreshold,omitempty"`
+	DqlitePort            int           `yaml:"dqlite-port,omitempty"`
 }
 
 func init() {
@@ -119,6 +120,8 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 
 		queryTracingEnabled:   format.QueryTracingEnabled,
 		queryTracingThreshold: format.QueryTracingThreshold,
+
+		dqlitePort: format.DqlitePort,
 	}
 	if len(format.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -189,6 +192,8 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 
 		QueryTracingEnabled:   config.queryTracingEnabled,
 		QueryTracingThreshold: config.queryTracingThreshold,
+
+		DqlitePort: config.dqlitePort,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/allowed_signers
+++ b/allowed_signers
@@ -2,6 +2,7 @@ heather.lanigan@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5A
 ian.booth@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPKjQDDaO24INaGFnUdVebD1wYcDXmm/cLKH+27S2SnC wallyworld-git-signing-key
 jack.shaw@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINP0LQkkiiHuMdVz4aF7ypsxNLQscgGd1UrmHrjyEd9F jack-w-shaw-git-signing-key
 joe.phillips@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKdk2GDbpmHUP/FQVunGu6Bl9TD1Hh5Z8oYAD17CzPP6 joe-signing-key
+joe.phillips@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFk9Tf6k0uZaUEYpeY49rJQvwxCTf05EyCuaf63pTGfB joe-signing-key-notebook
 john.meinel@canonical.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHu5ROyG1P7OQnNE5uNw0JVjKzZdbqGg3cHqywTt/Ynb jameinel-git-signing-key
 john@arbash-meinel.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHu5ROyG1P7OQnNE5uNw0JVjKzZdbqGg3cHqywTt/Ynb jameinel-git-signing-key
 stickupkid@gmail.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPqO5HpXaSh6MJ9FVt8nyoxhWN+AqlFxIXE68JGrRysb stickupkid@gmail.com

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -81,6 +81,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	endpoint, err := controller.TestingAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -73,6 +73,7 @@ func (s *agentSuite) TestAgentFailsWithNonAgent(c *gc.C) {
 	auth.Tag = names.NewUserTag("admin")
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -86,6 +87,7 @@ func (s *agentSuite) TestAgentSucceedsWithUnitAgent(c *gc.C) {
 	auth.Tag = names.NewUnitTag("foosball/1")
 	_, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -105,6 +107,7 @@ func (s *agentSuite) TestGetEntities(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -131,6 +134,7 @@ func (s *agentSuite) TestGetEntitiesContainer(c *gc.C) {
 
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      auth,
 	})
@@ -176,6 +180,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -197,6 +202,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 func (s *agentSuite) TestSetPasswords(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -225,6 +231,7 @@ func (s *agentSuite) TestSetPasswords(c *gc.C) {
 func (s *agentSuite) TestSetPasswordsShort(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -243,6 +250,7 @@ func (s *agentSuite) TestSetPasswordsShort(c *gc.C) {
 func (s *agentSuite) TestClearReboot(c *gc.C) {
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})
@@ -281,6 +289,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      authorizer,
 	})
@@ -309,6 +318,7 @@ func (s *agentSuite) TestWatchAuthError(c *gc.C) {
 	}
 	api, err := agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      authorizer,
 	})

--- a/apiserver/facades/agent/agent/model_test.go
+++ b/apiserver/facades/agent/agent/model_test.go
@@ -44,6 +44,7 @@ func (s *modelSuite) SetUpTest(c *gc.C) {
 
 	s.api, err = agent.NewAgentAPIV3(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	})

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -40,11 +40,15 @@ func newAgentAPIV3(ctx facade.Context) (*AgentAPI, error) {
 	}
 
 	resources := ctx.Resources()
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &AgentAPI{
 		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(model, resources, auth),
-		ControllerConfigAPI: common.NewStateControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		CloudSpecer: cloudspec.NewCloudSpecV2(
 			resources,
 			cloudspec.MakeCloudSpecGetterForModel(st),

--- a/apiserver/facades/agent/caasadmission/register.go
+++ b/apiserver/facades/agent/caasadmission/register.go
@@ -6,6 +6,8 @@ package caasadmission
 import (
 	"reflect"
 
+	jujuerrors "github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -24,8 +26,12 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 		return nil, errors.ErrPerm
 	}
 
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, jujuerrors.Trace(err)
+	}
 	return &Facade{
 		auth:                authorizer,
-		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 	}, nil
 }

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -42,10 +42,14 @@ func newStateFacadeV2(ctx facade.Context) (*FacadeV2, error) {
 		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(ctx.State()),
 		common.AuthFuncForTag(model.ModelTag()),
 	)
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &FacadeV2{
 		CloudSpecer:         cloudSpecAPI,
 		ModelWatcher:        common.NewModelWatcher(model, resources, authorizer),
-		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		auth:                authorizer,
 		resources:           resources,
 	}, nil

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -151,7 +151,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		APIAddresser:            common.NewAPIAddresser(systemState, resources),
 		ModelWatcher:            common.NewModelWatcher(model, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),
-		ControllerConfigAPI:     common.NewStateControllerConfig(st),
+		ControllerConfigAPI:     common.NewStateControllerConfig(systemState),
 		NetworkConfigAPI:        netConfigAPI,
 		st:                      st,
 		m:                       model,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -94,8 +94,12 @@ func NewControllerAPI(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	systemState, err := pool.SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &ControllerAPI{
-		ControllerConfigAPI: common.NewStateControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(systemState),
 		ModelStatusAPI: common.NewModelStatusAPI(
 			common.NewModelManagerBackend(model, pool),
 			authorizer,

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -134,6 +134,7 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	endPoint, err := controller.LatestAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -345,6 +346,7 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 	controller, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     st,
+			StatePool_: s.StatePool,
 			Resources_: common.NewResources(),
 			Auth_:      authorizer,
 		})
@@ -388,6 +390,7 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	var disposed bool
 	watcherAPI_, err := apiserver.NewAllWatcher(facadetest.Context{
 		State_:     s.State,
+		StatePool_: s.StatePool,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 		ID_:        watcherId.AllWatcherId,
@@ -894,6 +897,7 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	endpoint, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -980,6 +984,7 @@ func (s *controllerSuite) TestConfigSetRequiresSuperUser(c *gc.C) {
 	endpoint, err := controller.NewControllerAPIv11(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})
@@ -1101,6 +1106,7 @@ func (s *controllerSuite) TestWatchAllModelSummariesByNonAdmin(c *gc.C) {
 	endPoint, err := controller.LatestAPI(
 		facadetest.Context{
 			State_:     s.State,
+			StatePool_: s.StatePool,
 			Resources_: s.resources,
 			Auth_:      anAuthoriser,
 		})

--- a/apiserver/facades/controller/caasmodelconfigmanager/register.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/register.go
@@ -6,6 +6,8 @@ package caasmodelconfigmanager
 import (
 	"reflect"
 
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -24,8 +26,13 @@ func newFacade(ctx facade.Context) (*Facade, error) {
 	if !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm
 	}
+
+	systemState, err := ctx.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &Facade{
 		auth:                authorizer,
-		controllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
+		controllerConfigAPI: common.NewStateControllerConfig(systemState),
 	}, nil
 }

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -91,6 +91,7 @@ func (s *firewallerBaseSuite) testFirewallerFailsWithNonControllerUser(
 		Auth_:      anAuthorizer,
 		Resources_: s.resources,
 		State_:     s.State,
+		StatePool_: s.StatePool,
 	}
 	err := factory(ctx)
 	c.Assert(err, gc.NotNil)

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -36,7 +36,11 @@ func newFirewallerAPIV7(context facade.Context) (*FirewallerAPI, error) {
 		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
-	controllerConfigAPI := common.NewStateControllerConfig(st)
+	systemState, err := context.StatePool().SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	controllerConfigAPI := common.NewStateControllerConfig(systemState)
 
 	stShim := stateShim{st: st, State: firewall.StateShim(st, m)}
 	return NewStateFirewallerAPI(stShim, context.Resources(), context.Auth(), cloudSpecAPI, controllerConfigAPI)

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -139,6 +139,10 @@ func (c *configFromEnv) QueryTracingThreshold() time.Duration {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) DqlitePort() (int, bool) {
+	panic("not implemented")
+}
+
 type configFunc func() agent.Config
 
 func defaultConfig() agent.Config {

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -55,7 +55,7 @@ func (c *scaleApplicationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "scale-application",
 		Args:     "<application> <scale>",
-		Purpose:  "Set the desired number of application units.",
+		Purpose:  "Set the desired number of k8s application units.",
 		Doc:      scaleApplicationDoc,
 		Examples: scaleApplicationExamples,
 	})

--- a/cmd/juju/application/scaleapplication_test.go
+++ b/cmd/juju/application/scaleapplication_test.go
@@ -76,7 +76,7 @@ func (s *ScaleApplicationSuite) TestScaleApplicationBlocked(c *gc.C) {
 func (s *ScaleApplicationSuite) TestScaleApplicationWrongModel(c *gc.C) {
 	store := jujuclienttesting.MinimalStore()
 	_, err := cmdtesting.RunCommand(c, NewScaleCommandForTest(s.mockAPI, store), "foo", "2")
-	c.Assert(err, gc.ErrorMatches, `Juju command "scale-application" not supported on non-container models`)
+	c.Assert(err, gc.ErrorMatches, `Juju command "scale-application" only supported on k8s container models`)
 }
 
 func (s *ScaleApplicationSuite) TestInvalidArgs(c *gc.C) {

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -159,6 +159,8 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 	paths.LogDir = s.LogDir
 	paths.MetricsSpoolDir = c.MkDir()
 
+	dqlitePort := mgotesting.FindTCPPort()
+
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
 			Paths:             paths,
@@ -173,6 +175,8 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 
 			QueryTracingEnabled:   controller.DefaultQueryTracingEnabled,
 			QueryTracingThreshold: controller.DefaultQueryTracingThreshold,
+
+			DqlitePort: dqlitePort,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -229,6 +233,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 	apiPort := mgotesting.FindTCPPort()
 	s.SetControllerConfigAPIPort(c, apiPort)
 	apiAddr := []string{fmt.Sprintf("localhost:%d", apiPort)}
+	dqlitePort := mgotesting.FindTCPPort()
 	conf, err := agent.NewStateMachineConfig(
 		agent.AgentConfigParams{
 			Paths: agent.NewPathsWithDefaults(agent.Paths{
@@ -246,6 +251,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			MongoMemoryProfile:    controller.DefaultMongoMemoryProfile,
 			QueryTracingEnabled:   controller.DefaultQueryTracingEnabled,
 			QueryTracingThreshold: controller.DefaultQueryTracingThreshold,
+			DqlitePort:            dqlitePort,
 		},
 		controller.StateServingInfo{
 			Cert:         coretesting.ServerCert,

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -599,7 +599,7 @@ func (w *modelCommandWrapper) validateCommandForModelType(runStarted bool) error
 		err = errors.Errorf("Juju command %q not supported on container models", w.Info().Name)
 	}
 	if modelType == model.IAAS && caasOnly {
-		err = errors.Errorf("Juju command %q not supported on non-container models", w.Info().Name)
+		err = errors.Errorf("Juju command %q only supported on k8s container models", w.Info().Name)
 	}
 
 	if c, ok := w.inner().(modelSpecificCommand); ok {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -335,7 +335,7 @@ func (s *ModelCommandSuite) TestCAASOnlyCommandIAASModel(c *gc.C) {
 	s.setupIAASModel(c)
 
 	_, err := runCaasCommand(c, s.store)
-	c.Assert(err, gc.ErrorMatches, `Juju command "caas-command" not supported on non-container models`)
+	c.Assert(err, gc.ErrorMatches, `Juju command "caas-command" only supported on k8s container models`)
 }
 
 func (s *ModelCommandSuite) TestAllowedCommandCAASModel(c *gc.C) {

--- a/database/node.go
+++ b/database/node.go
@@ -49,12 +49,18 @@ type NodeManager struct {
 // NewNodeManager returns a new NodeManager reference
 // based on the input agent configuration.
 func NewNodeManager(cfg agent.Config, logger Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
-	return &NodeManager{
+	m := &NodeManager{
 		cfg:             cfg,
 		port:            dqlitePort,
 		logger:          logger,
 		slowQueryLogger: slowQueryLogger,
 	}
+	if cfg != nil {
+		if port, ok := cfg.DqlitePort(); ok {
+			m.port = port
+		}
+	}
+	return m
 }
 
 // IsBootstrappedNode returns true if this machine or container was where we

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -344,6 +344,11 @@ func (cfg fakeAgentConfig) APIAddresses() ([]string, error) {
 	return cfg.apiAddrs, nil
 }
 
+// DqlitePort implements agent.Config.
+func (cfg fakeAgentConfig) DqlitePort() (int, bool) {
+	return 0, false
+}
+
 type slowQuerySuite struct {
 	testing.IsolationSuite
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
 	github.com/canonical/go-dqlite v1.20.0
 	github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0
-	github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35
+	github.com/canonical/pebble v1.3.0
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0 h1:1JfA4hOWjPoF18ebpKFWafOWFplCh0jvHhAethmLQFo=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0/go.mod h1:BAaklWDYuotKE0eQnwO6NArKc6rEwnTheuOPrtlLBYA=
-github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35 h1:9g6zJXqo0JktO+51qS6K971sAKyNGXK+vFO7RDEbw+Q=
-github.com/canonical/pebble v0.0.0-20230808003337-02ad28a16a35/go.mod h1:Ore8BG+F6AknKKT6EmtI6EUXISstdcKSwjO5NuXjV6Q=
+github.com/canonical/pebble v1.3.0 h1:h1lCe0jlhAUKUMkKTqQaxUIjIMW0MlGnjAp/sjK35KM=
+github.com/canonical/pebble v1.3.0/go.mod h1:Ore8BG+F6AknKKT6EmtI6EUXISstdcKSwjO5NuXjV6Q=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -1969,8 +1968,6 @@ func (e *environ) openPortsInGroup(ctx context.ProviderCallContext, name string,
 		return err
 	}
 	ipPerms := rulesToIPPerms(rules)
-	fmt.Println("this is the rules")
-	spew.Dump(rules)
 	_, err = e.ec2Client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       g.GroupId,
 		IpPermissions: ipPerms,
@@ -2093,8 +2090,6 @@ func (e *environ) OpenModelPorts(ctx context.ProviderCallContext, rules firewall
 }
 
 func (e *environ) CloseModelPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
-	fmt.Println("closing these ports")
-	spew.Dump(rules)
 	if err := e.closePortsInGroup(ctx, e.jujuGroupName(), rules); err != nil {
 		return errors.Trace(err)
 	}

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -113,8 +113,9 @@ musl_install_cross_arch() {
 }
 
 sha() {
-    case ${BUILD_ARCH} in
-        amd64) echo "c19e7337cd28232b44b19db7da68089dd1b957a474440046c113e507b5af0290" ;;
+    case ${BUILD_ARCH}-$(GOOS= go env GOOS)-$(GOARCH= go env GOARCH) in
+        amd64-linux-amd64) echo "d5d551f3590f7770018b178c04de04d30ae8924db25520b28d51eed390155fe8" ;; # https://jenkins.juju.canonical.com/job/build-musl-amd64/16/consoleText
+        arm64-linux-arm64) echo "7ee8ddeee5d6bb9aedeb0edff3718f682949452059ec3bcd717f15d70918b886" ;; # https://jenkins.juju.canonical.com/job/build-musl-arm64/11/consoleText
         *) echo "" ;;
     esac
 }

--- a/scripts/try-merge/main.go
+++ b/scripts/try-merge/main.go
@@ -203,7 +203,7 @@ func printMessage(peopleToNotify set.Strings) {
 
 	tmpl, err := template.New("test").Parse(
 		"{{.TaggedUsers}}: your recent changes to `{{.SourceBranch}}` have caused merge conflicts. " +
-			"Please merge `{{.SourceBranch}}` into `{{.TargetBranch}}` and resolve the conflicts." +
+			"Please merge `{{.SourceBranch}}` into `{{.TargetBranch}}` and resolve the conflicts. " +
 			"[[logs]({{.LogsLink}})]",
 	)
 	check(err)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3984,7 +3984,7 @@ func (s *StateSuite) TestWatchCleanupsBulk(c *gc.C) {
 	// Clean them both up, check one change.
 	err = s.State.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChanges(2)
+	wc.AssertAtleastOneChange()
 }
 
 func (s *StateSuite) TestWatchMinUnits(c *gc.C) {

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -107,6 +107,22 @@ loop:
 	c.AssertNoChange()
 }
 
+func (c NotifyWatcherC) AssertAtleastOneChange() {
+	longTimeout := time.After(testing.LongWait)
+loop:
+	for {
+		select {
+		case _, ok := <-c.Watcher.Changes():
+			c.C.Logf("got change")
+			c.Assert(ok, jc.IsTrue)
+			break loop
+		case <-longTimeout:
+			c.Fatalf("watcher did not send change")
+			break loop
+		}
+	}
+}
+
 // TODO(quiescence): reimplement quiescence and delete this utility
 func (c NotifyWatcherC) AssertChanges(n int) {
 	longTimeout := time.After(testing.LongWait)

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,7 +58,7 @@ sudo snap install expect
 The static analysis tests also require `golangci-lint`:
 
 ```
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.0
 ```
 
 To get started, it's best to quickly look at the help command from the runner.

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -19,18 +19,9 @@ run() {
 	set_verbosity
 
 	if [[ ${VERBOSE} -gt 1 ]]; then
-		touch "${TEST_DIR}/${TEST_CURRENT}.log"
-		tail -f "${TEST_DIR}/${TEST_CURRENT}.log" 2>/dev/null &
-		pid=$!
-
-		# SIGKILL it with fire, as we don't know what state we're in.
-		trap 'kill -9 "${pid}" >/dev/null 2>&1 || true' EXIT
-	fi
-
-	"${CMD}" "$@" >"${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
-	if [[ ${VERBOSE} -gt 1 ]]; then
-		# SIGKILL because it should be safe to do so.
-		kill -9 "${pid}" >/dev/null 2>&1 || true
+		"${CMD}" "$@" 2>&1 | tee -a "${TEST_DIR}/${TEST_CURRENT}.log"
+	else
+		"${CMD}" "$@" >>"${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
 	fi
 
 	END_TIME=$(date +%s)

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -6,9 +6,10 @@
 run_local_deploy() {
 	echo
 
-	file="${2}"
+	model_name="test-local-deploy"
+	file="${TEST_DIR}/${model_name}.log"
 
-	ensure "test-local-deploy" "${file}"
+	ensure "${model_name}" "${file}"
 
 	juju deploy --revision=1 --channel=stable --base ubuntu@20.04 juju-qa-refresher
 	wait_for "refresher" "$(idle_condition "refresher")"
@@ -21,15 +22,16 @@ run_local_deploy() {
 	# On microk8s, there's a bug where the application blocks the model teardown
 	# TODO: remove the next line once this bug is fixed.
 	juju remove-application refresher
-	destroy_model "test-local-deploy"
+	destroy_model "${model_name}"
 }
 
 run_charmstore_deploy() {
 	echo
 
-	file="${2}"
+	model_name="test-charmstore-deploy"
+	file="${TEST_DIR}/${model_name}.log"
 
-	ensure "test-charmstore-deploy" "${file}"
+	ensure "${model_name}" "${file}"
 
 	juju deploy jameinel-ubuntu-lite --revision 9 --channel stable
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
@@ -40,7 +42,7 @@ run_charmstore_deploy() {
 	# On microk8s, there's a bug where the application blocks the model teardown
 	# TODO: remove the next line once this bug is fixed.
 	juju remove-application ubuntu-lite
-	destroy_model "test-charmstore-deploy"
+	destroy_model "${model_name}"
 }
 
 test_deploy() {
@@ -54,11 +56,8 @@ test_deploy() {
 
 		cd .. || exit
 
-		file="${1}"
-
-		# Check that deploy runs on LXD§
-		run "run_local_deploy" "${file}"
-		run "run_charmstore_deploy" "${file}"
+		run "run_local_deploy"
+		run "run_charmstore_deploy"
 	)
 }
 

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -15,7 +15,7 @@ test_smoke() {
 	echo "====> Logging to ${file}"
 	bootstrap "test-smoke" "${file}"
 
-	test_deploy "${file}"
+	test_deploy
 
 	destroy_controller "test-smoke"
 }

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -207,6 +207,21 @@ func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
+// DqlitePort mocks base method.
+func (m *MockConfig) DqlitePort() (int, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DqlitePort")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// DqlitePort indicates an expected call of DqlitePort.
+func (mr *MockConfigMockRecorder) DqlitePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DqlitePort", reflect.TypeOf((*MockConfig)(nil).DqlitePort))
+}
+
 // Jobs mocks base method.
 func (m *MockConfig) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -207,6 +207,21 @@ func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
+// DqlitePort mocks base method.
+func (m *MockConfig) DqlitePort() (int, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DqlitePort")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// DqlitePort indicates an expected call of DqlitePort.
+func (mr *MockConfigMockRecorder) DqlitePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DqlitePort", reflect.TypeOf((*MockConfig)(nil).DqlitePort))
+}
+
 // Jobs mocks base method.
 func (m *MockConfig) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()

--- a/worker/stateconverter/mocks/agent_mock.go
+++ b/worker/stateconverter/mocks/agent_mock.go
@@ -207,6 +207,21 @@ func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
+// DqlitePort mocks base method.
+func (m *MockConfig) DqlitePort() (int, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DqlitePort")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// DqlitePort indicates an expected call of DqlitePort.
+func (mr *MockConfigMockRecorder) DqlitePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DqlitePort", reflect.TypeOf((*MockConfig)(nil).DqlitePort))
+}
+
 // Jobs mocks base method.
 func (m *MockConfig) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -828,7 +828,7 @@ func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.
 		if md.Label == nil || md.URI == nil {
 			continue
 		}
-		if *md.Label == label && md.OwnerTag.Id() == ctx.unit.Tag().Id() {
+		if *md.Label == label {
 			return md.URI, nil
 		}
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -937,6 +937,7 @@ func (s *mockHookContextSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.mockUnit = mocks.NewMockHookUnit(ctrl)
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).AnyTimes()
+	s.mockUnit.EXPECT().ApplicationName().Return("wordpress").AnyTimes()
 	s.mockLeadership = mocks.NewMockLeadershipContext(ctrl)
 	return ctrl
 }
@@ -1100,6 +1101,19 @@ func (s *mockHookContextSuite) TestSecretGetFromPendingCreateChanges(c *gc.C) {
 	s.assertSecretGetFromPendingChanges(c,
 		func(hc *context.HookContext, uri *coresecrets.URI, label string, value map[string]string) {
 			arg := uniter.SecretCreateArg{OwnerTag: s.mockUnit.Tag()}
+			arg.URI = uri
+			arg.Label = ptr(label)
+			arg.Value = coresecrets.NewSecretValue(value)
+			hc.SetPendingSecretCreates(
+				map[string]uniter.SecretCreateArg{uri.ID: arg})
+		},
+	)
+}
+
+func (s *mockHookContextSuite) TestAppSecretGetFromPendingCreateChanges(c *gc.C) {
+	s.assertSecretGetFromPendingChanges(c,
+		func(hc *context.HookContext, uri *coresecrets.URI, label string, value map[string]string) {
+			arg := uniter.SecretCreateArg{OwnerTag: names.NewApplicationTag(s.mockUnit.ApplicationName())}
 			arg.URI = uri
 			arg.Label = ptr(label)
 			arg.Value = coresecrets.NewSecretValue(value)

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -208,6 +208,21 @@ func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
+// DqlitePort mocks base method.
+func (m *MockConfig) DqlitePort() (int, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DqlitePort")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// DqlitePort indicates an expected call of DqlitePort.
+func (mr *MockConfigMockRecorder) DqlitePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DqlitePort", reflect.TypeOf((*MockConfig)(nil).DqlitePort))
+}
+
 // Jobs mocks base method.
 func (m *MockConfig) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()
@@ -626,6 +641,21 @@ func (m *MockConfigSetter) Dir() string {
 func (mr *MockConfigSetterMockRecorder) Dir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfigSetter)(nil).Dir))
+}
+
+// DqlitePort mocks base method.
+func (m *MockConfigSetter) DqlitePort() (int, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DqlitePort")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// DqlitePort indicates an expected call of DqlitePort.
+func (mr *MockConfigSetterMockRecorder) DqlitePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DqlitePort", reflect.TypeOf((*MockConfigSetter)(nil).DqlitePort))
 }
 
 // Jobs mocks base method.


### PR DESCRIPTION
This is both a merge PR and makes changes for actions to get it land-able.

Changes:
- Remove spew.Dump/fmt.Println debug logging in ec2 left by a recent PR. Ran `go mod tidy`
- Enable the Upgrade job (it was turned off until 3.2.0 release), then turned it off again as it was getting to complex to fix in this PR. Will follow-up with a new PR to fix it and enable it for the first time on 3.2.0.
- Change musl toolchain to select on target and host arch. Add new SHAs for amd64-on-amd64 and arm64-on-arm64. See https://github.com/juju/juju-qa-jenkins/pull/158
- Drop s390x and ppc64le building here. They consume a lot of resources due to musl not being prebuilt and having to cross-compile. These builds will continue to be handled in jenkins jobs.
- Drop most builds on "push". They consume action runners, and we don't even look at or alert on these jobs. Jenkins is testing what actually ends up being merged much better. (I will need to backport this change to 3.1 and 2.9)
- Revert change made in https://github.com/juju/juju/pull/15969 for log tailing in `run.sh`

Forward ports:
- #16179
- #16122
- #16182
- #16183
- #15969
- #16186
- #15882
- #16200
- #16203
- #15878 
- #16210 
- #16204

Conflicts:
- .github/workflows/client-tests.yml
- .github/workflows/microk8s-tests.yml
- .github/workflows/migrate.yml
- .github/workflows/smoke.yml
- .github/workflows/static-analysis.yml
- .github/workflows/upgrade.yml
- cmd/juju/application/scaleapplication.go