### PR TITLE
[JUJU-4473] Add autocert cache schema for dqlite domain

### DIFF
--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -34,6 +34,10 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 
 	// Ensure that each table is present.
 	expected := set.NewStrings(
+		// Autocert cache
+		"autocert_cache",
+		"autocert_cache_encoding",
+
 		// Leases
 		"lease",
 		"lease_type",


### PR DESCRIPTION
Simple commit to add the autocert cache table creation schema on the new autocert domain for

~One thing to look at is the `data` column type, which is set to `BLOB` since the legacy mongo state used 
`Data []byte bson:"data"`~
Data is finally stored as TEXT sql type.

(https://github.com/juju/juju/blob/main/state/autocertcache.go#L28)

Also, this cache table was added on the controller.go file for the schema, assuming this is more controller-related than model.

## Checklist


- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not applicable
