### PR TITLE
Remove redundant expensive build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
         platform:
            - { os: linux, arch: amd64 }
            - { os: linux, arch: arm64 }
-           - { os: linux, arch: s390x }
-           - { os: linux, arch: ppc64le }
            - { os: windows, arch: amd64 }
            - { os: darwin, arch: amd64 }
 


### PR DESCRIPTION
These tests are meant to test that we don't accidentally break the building of juju(d) because of some architecture-dependent issue. Initially designed as a smoke test and therefore meant to be quick. In addition to that, they're supposed to mirror production builds via the snap infrastructure. Unfortunately, powerpc64 and s390x are neither quick to build nor replicate production builds.

Just to be clear arm64 and amd64 don't replicate production building via snaps, but at least they are quick and do at least service as smoke tests.

We do have additional jenkins jobs to verify that do the do correctly build on all architectures in the correct way, so this should be fine. Allowing us to release some github runners to be able service other jobs.
