### PR TITLE
Ensure pending app owned secrets can be retrieved by label

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -828,7 +828,7 @@ func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.
 		if md.Label == nil || md.URI == nil {
 			continue
 		}
-		if *md.Label == label && md.OwnerTag.Id() == ctx.unit.Tag().Id() {
+		if *md.Label == label {
 			return md.URI, nil
 		}
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -937,6 +937,7 @@ func (s *mockHookContextSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.mockUnit = mocks.NewMockHookUnit(ctrl)
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).AnyTimes()
+	s.mockUnit.EXPECT().ApplicationName().Return("wordpress").AnyTimes()
 	s.mockLeadership = mocks.NewMockLeadershipContext(ctrl)
 	return ctrl
 }
@@ -1100,6 +1101,19 @@ func (s *mockHookContextSuite) TestSecretGetFromPendingCreateChanges(c *gc.C) {
 	s.assertSecretGetFromPendingChanges(c,
 		func(hc *context.HookContext, uri *coresecrets.URI, label string, value map[string]string) {
 			arg := uniter.SecretCreateArg{OwnerTag: s.mockUnit.Tag()}
+			arg.URI = uri
+			arg.Label = ptr(label)
+			arg.Value = coresecrets.NewSecretValue(value)
+			hc.SetPendingSecretCreates(
+				map[string]uniter.SecretCreateArg{uri.ID: arg})
+		},
+	)
+}
+
+func (s *mockHookContextSuite) TestAppSecretGetFromPendingCreateChanges(c *gc.C) {
+	s.assertSecretGetFromPendingChanges(c,
+		func(hc *context.HookContext, uri *coresecrets.URI, label string, value map[string]string) {
+			arg := uniter.SecretCreateArg{OwnerTag: names.NewApplicationTag(s.mockUnit.ApplicationName())}
 			arg.URI = uri
 			arg.Label = ptr(label)
 			arg.Value = coresecrets.NewSecretValue(value)


### PR DESCRIPTION
When getting a secret by label from the same hook that created it, filtering was done on unit name which excluded app owned secrets. No filtering was needed so it is removed. 

## QA steps

bootstrap
```
$ juju exec --unit controller/0 -- "secret-add --label baz4 foo=bar && secret-get --label baz4"
secret://77cd3461-5fd5-44f1-859d-bcb130e9d414/cjs45ool1hni6890f5n0
foo: bar
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2034050
