### PR TITLE
Adds support for model metadata to the controller.

### DIFF
--- a/database/txn/transaction.go
+++ b/database/txn/transaction.go
@@ -250,7 +250,7 @@ func defaultRetryStrategy(clock clock.Clock, logger Logger) func(context.Context
 			Clock:       clock,
 			Stop:        ctx.Done(),
 		})
-		return errors.Trace(err)
+		return err
 	}
 }
 

--- a/domain/credential/credential.go
+++ b/domain/credential/credential.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package credential
+
+import (
+	"fmt"
+)
+
+// ID represents the id of a cloud credential.
+type ID struct {
+	// Cloud is the cloud name that the credential applies to.
+	Cloud string
+
+	// Owner is the owner of the credential.
+	Owner string
+
+	// Name is the name of the credential.
+	Name string
+}
+
+// String implements the stringer interface.
+func (i ID) String() string {
+	return fmt.Sprintf("%s/%s/%s", i.Cloud, i.Owner, i.Name)
+}

--- a/domain/model/errors/errors.go
+++ b/domain/model/errors/errors.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import (
+	"github.com/juju/errors"
+)
+
+const (
+	// NotFound describes an error that occurs when the model being operated on
+	// does not exist.
+	NotFound = errors.ConstError("model not found")
+)

--- a/domain/model/service/package_test.go
+++ b/domain/model/service/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	. "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/credential"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelmanager/service"
+)
+
+type dummyState struct {
+	credentials      map[string]credential.ID
+	modelCredentials map[string]credential.ID
+}
+
+type serviceSuite struct {
+	testing.IsolationSuite
+
+	state *dummyState
+}
+
+var _ = Suite(&serviceSuite{})
+
+var (
+	modelUUID = service.UUID("123")
+)
+
+func (d *dummyState) addCredential(cred credential.ID) {
+	d.credentials[cred.String()] = cred
+}
+
+func (d *dummyState) SetCloudCredential(
+	_ context.Context,
+	uuid service.UUID,
+	id credential.ID,
+) error {
+	cred, exists := d.credentials[id.String()]
+	if !exists {
+		return fmt.Errorf("%w credential %q", errors.NotFound, id)
+	}
+
+	if _, exists = d.modelCredentials[uuid.String()]; !exists {
+		return fmt.Errorf("%w with uuid %q", modelerrors.NotFound, uuid)
+	}
+
+	d.modelCredentials[uuid.String()] = cred
+	return nil
+}
+
+func (s *serviceSuite) SetUpTest(c *C) {
+	s.state = &dummyState{
+		credentials: map[string]credential.ID{},
+		modelCredentials: map[string]credential.ID{
+			modelUUID.String(): {},
+		},
+	}
+}
+
+func (s *serviceSuite) TestSetModelCredential(c *C) {
+	cred := credential.ID{
+		Cloud: "testcloud",
+		Owner: "wallyworld",
+		Name:  "ipv6world",
+	}
+
+	s.state.addCredential(cred)
+
+	tag, err := names.ParseCloudCredentialTag("cloudcred-testcloud_wallyworld_ipv6world")
+	c.Assert(err, jc.ErrorIsNil)
+
+	svc := NewService(modelUUID, s.state)
+	err = svc.SetCloudCredential(context.Background(), tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	foundCred, exists := s.state.modelCredentials[modelUUID.String()]
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(foundCred, jc.DeepEquals, cred)
+}
+
+func (s *serviceSuite) TestSetModelCredentialModelNotFound(c *C) {
+	cred := credential.ID{
+		Cloud: "testcloud",
+		Owner: "wallyworld",
+		Name:  "ipv6world",
+	}
+
+	s.state.addCredential(cred)
+
+	tag, err := names.ParseCloudCredentialTag("cloudcred-testcloud_wallyworld_ipv6world")
+	c.Assert(err, jc.ErrorIsNil)
+
+	svc := NewService("noexist", s.state)
+	err = svc.SetCloudCredential(context.Background(), tag)
+	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
+}
+
+func (s *serviceSuite) TestSetModelCredentialNotFound(c *C) {
+	tag, err := names.ParseCloudCredentialTag("cloudcred-testcloud_wallyworld_ipv6world")
+	c.Assert(err, jc.ErrorIsNil)
+
+	svc := NewService(modelUUID, s.state)
+	err = svc.SetCloudCredential(context.Background(), tag)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
+}

--- a/domain/model/state/package_test.go
+++ b/domain/model/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/database"
+	jujudb "github.com/juju/juju/database"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/credential"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelmanager/service"
+)
+
+// State represents a type for interacting with the underlying model state.
+type State struct {
+	*domain.StateBase
+}
+
+// NewState returns a new State for interacting with the underlying model state.
+func NewState(
+	factory database.TxnRunnerFactory,
+) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// SetCloudCredential sets the cloud credential that will be used by this model
+// identified by the cloud, owner and name of the cloud credential. If the cloud
+// credential or the model do not exist then an error that satisfies NotFound is
+// returned.
+func (s *State) SetCloudCredential(
+	ctx context.Context,
+	modelUUID service.UUID,
+	id credential.ID,
+) error {
+	db, err := s.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	cloudCredUUIDStmt := `
+SELECT cloud_credential.uuid,
+       cloud.uuid
+FROM cloud_credential
+INNER JOIN cloud
+ON cloud.uuid = cloud_credential.cloud_uuid
+WHERE cloud.name = ?
+AND cloud_credential.owner_uuid = ?
+AND cloud_credential.name = ?
+`
+
+	stmt := `
+INSERT INTO model_metadata (model_uuid, cloud_uuid, cloud_credential_uuid) VALUES (?, ?, ?)
+ON CONFLICT(model_uuid) DO UPDATE
+SET cloud_uuid = excluded.cloud_uuid,
+    cloud_credential_uuid = excluded.cloud_credential_uuid
+WHERE model_uuid = excluded.model_uuid
+`
+
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var cloudCredUUID, cloudUUID string
+		err := tx.QueryRowContext(ctx, cloudCredUUIDStmt, id.Cloud, id.Owner, id.Name).
+			Scan(&cloudCredUUID, &cloudUUID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf(
+				"%w cloud credential %q%w",
+				errors.NotFound, id, errors.Hide(err),
+			)
+		} else if err != nil {
+			return fmt.Errorf(
+				"getting cloud credential uuid for %q: %w",
+				id, err,
+			)
+		}
+
+		_, err = tx.ExecContext(ctx, stmt, modelUUID, cloudUUID, cloudCredUUID)
+		if jujudb.IsErrConstraintForeignKey(err) {
+			return fmt.Errorf(
+				"%w %q when setting cloud credential %q%w",
+				modelerrors.NotFound, modelUUID, id, errors.Hide(err))
+		} else if err != nil {
+			return fmt.Errorf(
+				"setting cloud credential %q for model %q: %w",
+				id, modelUUID, err)
+		}
+		return nil
+	})
+}

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -1,0 +1,109 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	dbcloud "github.com/juju/juju/domain/cloud/state"
+	"github.com/juju/juju/domain/credential"
+	credentialstate "github.com/juju/juju/domain/credential/state"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelmanager/service"
+	modelmanagerstate "github.com/juju/juju/domain/modelmanager/state"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type modelSuite struct {
+	schematesting.ControllerSuite
+}
+
+const (
+	modelUUID = service.UUID("12345")
+)
+
+var _ = gc.Suite(&modelSuite{})
+
+func (m *modelSuite) SetUpTest(c *gc.C) {
+	m.ControllerSuite.SetUpTest(c)
+
+	cloudSt := dbcloud.NewState(m.TxnRunnerFactory())
+	err := cloudSt.UpsertCloud(context.Background(), cloud.Cloud{
+		Name:      "testmctestface",
+		Type:      "ec2",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred := cloud.NewNamedCredential(
+		"foobar",
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"foo": "foo val",
+			"bar": "bar val",
+		},
+		false)
+
+	credSt := credentialstate.NewState(m.TxnRunnerFactory())
+	err = credSt.UpsertCloudCredential(
+		context.Background(),
+		"foobar",
+		"testmctestface",
+		"bob",
+		cred,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mmSt := modelmanagerstate.NewState(m.TxnRunnerFactory())
+	err = mmSt.Create(context.Background(), modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (m *modelSuite) TestModelSetCredential(c *gc.C) {
+	st := NewState(m.TxnRunnerFactory())
+	err := st.SetCloudCredential(
+		context.Background(),
+		modelUUID,
+		credential.ID{
+			Cloud: "testmctestface",
+			Owner: "bob",
+			Name:  "foobar",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (m *modelSuite) TestModelSetNonExistentCredential(c *gc.C) {
+	st := NewState(m.TxnRunnerFactory())
+	err := st.SetCloudCredential(
+		context.Background(),
+		modelUUID,
+		credential.ID{
+			Cloud: "testmctestface",
+			Owner: "bob",
+			Name:  "noexist",
+		},
+	)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
+}
+
+func (m *modelSuite) TestModelSetCredentialNoModel(c *gc.C) {
+	st := NewState(m.TxnRunnerFactory())
+	err := st.SetCloudCredential(
+		context.Background(),
+		"noexist",
+		credential.ID{
+			Cloud: "testmctestface",
+			Owner: "bob",
+			Name:  "foobar",
+		},
+	)
+	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
+}

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -19,6 +19,7 @@ func ControllerDDL(nodeID uint64) *schema.Schema {
 		externalControllerSchema,
 		changeLogTriggersForTable("external_controller", "uuid", 1),
 		modelListSchema,
+		modelMetadataSchema,
 		controllerConfigSchema,
 		changeLogTriggersForTable("controller_config", "key", 3),
 		// These are broken up for 2 reasons:
@@ -309,6 +310,25 @@ func modelListSchema() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE model_list (
     uuid    TEXT PRIMARY KEY
+);`)
+}
+
+func modelMetadataSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE model_metadata (
+    model_uuid TEXT PRIMARY KEY,
+    cloud_uuid TEXT,
+    cloud_credential_uuid TEXT,
+
+    CONSTRAINT fk_model_metadata_model
+        FOREIGN KEY (model_uuid)
+        REFERENCES model_list(uuid),
+    CONSTRAINT fk_model_metadata_cloud
+        FOREIGN KEY (cloud_uuid)
+        REFERENCES cloud(uuid),
+    CONSTRAINT fk_model_metadata_cloud_credential
+        FOREIGN KEY (cloud_credential_uuid)
+        REFERENCES cloud_credential(uuid)
 );`)
 }
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -62,8 +62,9 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"external_controller_address",
 		"external_model",
 
-		// Model list
+		// Model
 		"model_list",
+		"model_metadata",
 
 		// Controller config
 		"controller_config",


### PR DESCRIPTION
With this work we can now start assigning model based metadata into dqlite. Specifically this is useful for both assigning the current cloud and cloud credential in use by the model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the tests for now

## Documentation changes

N/A

## Bug reference

N/A

## Jira Issue
JIRA-4294
