### PR TITLE
Ensure we subscribe inside the loop

### DIFF
--- a/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
@@ -100,7 +100,7 @@ func (s *eventMultiplexerSuite) TestMultipleDispatch(c *gc.C) {
 	s.testMultipleDispatch(c, changestream.Namespace("topic", changestream.Update))
 }
 
-func (s *eventMultiplexerSuite) TestDispatchWithNoOptions(c *gc.C) {
+func (s *eventMultiplexerSuite) TestMultipleDispatchWithNoOptions(c *gc.C) {
 	s.testMultipleDispatch(c)
 }
 
@@ -695,8 +695,10 @@ func (s *eventMultiplexerSuite) TestStreamDyingOnSubscribe(c *gc.C) {
 	terms := make(chan changestream.Term)
 	s.stream.EXPECT().Terms().Return(terms).MinTimes(1)
 
-	s.metrics.EXPECT().SubscriptionsInc()
-	s.metrics.EXPECT().SubscriptionsDec()
+	// We don't care for the metrics recording here, as we might not
+	// have recorded the metrics in time before dying.
+	s.metrics.EXPECT().SubscriptionsInc().AnyTimes()
+	s.metrics.EXPECT().SubscriptionsDec().AnyTimes()
 
 	queue, err := New(s.stream, s.clock, s.metrics, s.logger)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/changestream/eventmultiplexer/subscription.go
+++ b/internal/changestream/eventmultiplexer/subscription.go
@@ -21,9 +21,14 @@ const (
 	DefaultSignalTimeout = time.Second * 10
 )
 
-type subscriptionOpts struct {
-	*subscription
-	opts []changestream.SubscriptionOption
+type requestSubscription struct {
+	opts   []changestream.SubscriptionOption
+	result chan requestSubscriptionResult
+}
+
+type requestSubscriptionResult struct {
+	sub *subscription
+	err error
 }
 
 // subscription represents a subscriber in the event queue. It holds a tomb, so


### PR DESCRIPTION
The following updates the eventmultiplexer to ensure that the subscription is added in the loop. This ensures that the race during creating a subscription and then returns the sub, but it's not actually registered yet. Thus you can act upon a sub that is not yet available.

The fix is to push everything into the loop and only return a subscription once everything has officially been subscribed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

JUJU-4585