### PR TITLE
Add additional stream tests

### DIFF
--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -532,8 +532,6 @@ func (s *Stream) updateWatermark() error {
 	ctx, cancel := s.scopedContext()
 	defer cancel()
 
-	s.metrics.WatermarkInsertsInc()
-
 	return s.db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// Run this per transaction, so that we're using the latest lower bound
 		// and upper bound.
@@ -553,6 +551,9 @@ func (s *Stream) updateWatermark() error {
 			if _, err := result.RowsAffected(); err != nil {
 				return errors.Annotate(err, "recording watermark")
 			}
+
+			s.metrics.WatermarkInsertsInc()
+
 			return nil
 		})
 	})


### PR DESCRIPTION
The following adds an additional test to the stream based on a discussion of how the change stream works.

In testing the code I noticed that the metric for inserting a watermark is in the wrong place. We should only record the metric on success, otherwise, it will seem like we're recording every ask. This isn't the case as there might be no additional work to be done.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootrap lxd test --build-agent
$ for i in {0..12]; do juju controller-config "migration-agent-wait-time=15m$is" && sleep 2; done
$ juju ssh -m controller 0
$ juju_metrics | grep watermark
# HELP juju_db_watermark_inserts_total Total number of watermark insertions on the changelog witness table.
# TYPE juju_db_watermark_inserts_total counter
juju_db_watermark_inserts_total{namespace="controller"} 2
```

JUJU-4586