### PR TITLE
Fix TestWatchCleanupsBulk by not caring about superfluous events.

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3985,7 +3985,7 @@ func (s *StateSuite) TestWatchCleanupsBulk(c *gc.C) {
 	// Clean them both up, check one change.
 	err = s.State.Cleanup()
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChanges(2)
+	wc.AssertAtleastOneChange()
 }
 
 func (s *StateSuite) TestWatchMinUnits(c *gc.C) {

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -107,6 +107,22 @@ loop:
 	c.AssertNoChange()
 }
 
+func (c NotifyWatcherC) AssertAtleastOneChange() {
+	longTimeout := time.After(testing.LongWait)
+loop:
+	for {
+		select {
+		case _, ok := <-c.Watcher.Changes():
+			c.C.Logf("got change")
+			c.Assert(ok, jc.IsTrue)
+			break loop
+		case <-longTimeout:
+			c.Fatalf("watcher did not send change")
+			break loop
+		}
+	}
+}
+
 // TODO(quiescence): reimplement quiescence and delete this utility
 func (c NotifyWatcherC) AssertChanges(n int) {
 	longTimeout := time.After(testing.LongWait)


### PR DESCRIPTION
Fix TestWatchCleanupsBulk by not caring about superfluous events as we only need to guarantee at least once delivery,
this test failing is not helpful.

## QA steps

```
$ cd state
$ go test -c
$ go run golang.org/x/tools/cmd/stress ./state.test -check.f=TestWatchCleanupsBulk
5s: 0 runs so far, 0 failures
10s: 24 runs so far, 0 failures
15s: 24 runs so far, 0 failures
20s: 48 runs so far, 0 failures
25s: 72 runs so far, 0 failures
30s: 72 runs so far, 0 failures
35s: 96 runs so far, 0 failures
40s: 103 runs so far, 0 failures
```

## Documentation changes

N/A

## Bug reference

https://jenkins.juju.canonical.com/job/github-make-check-juju/8847/consoleText
and many others