### PR TITLE
bootstrap/k8s: surface ErrImagePull

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -989,6 +989,11 @@ func (c *controllerStack) waitForPod(podWatcher watcher.NotifyWatcher, podName s
 					c.ctx.Infof(evt.Message)
 				}
 			}
+			// All warnings should be surfaced to the user.
+			if evt.Type == core.EventTypeWarning && !printedMsg.Contains(evt.Message) {
+				printedMsg.Add(evt.Message)
+				logger.Warningf(evt.Message)
+			}
 		}
 		return nil
 	}

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -989,10 +989,13 @@ func (c *controllerStack) waitForPod(podWatcher watcher.NotifyWatcher, podName s
 					c.ctx.Infof(evt.Message)
 				}
 			}
-			// All warnings should be surfaced to the user.
-			if evt.Type == core.EventTypeWarning && !printedMsg.Contains(evt.Message) {
-				printedMsg.Add(evt.Message)
-				logger.Warningf(evt.Message)
+			// Surface "image not found" errors
+			if notFound, imageTag := isImageNotFound(evt); notFound {
+				message := fmt.Sprintf("image not found: %q", imageTag)
+				if !printedMsg.Contains(message) {
+					printedMsg.Add(message)
+					logger.Warningf(message)
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
During bootstrap, we should surface k8s pod warnings such as `ErrImagePull`, so that the user can clearly see what's gone wrong with the bootstrap, and doesn't have to dig into the kubernetes logs.

## QA steps

Induce an `ErrImagePull`.
```console
$ make go-client-build
$ juju bootstrap microk8s c --agent-version=3.1-fake1
Creating Juju controller "c" on microk8s/localhost
Bootstrap to Kubernetes cluster identified as microk8s/localhost
Creating k8s resources for controller "controller-c"
Downloading images
WARNING image not found: "jujusolutions/jujud-operator:3.1-fake1"

```