### PR TITLE
[JUJU-4474] Implement the state layer for the new autocert domain

### DIFF
--- a/domain/autocert/state/package_test.go
+++ b/domain/autocert/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/autocert/state/state.go
+++ b/domain/autocert/state/state.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+	"github.com/juju/utils/v3"
+
+	coreDB "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain"
+)
+
+// ExternalController represents a single row from the database when
+// external_controller is joined with external_controller_address and
+// external_model.
+type Autocert struct {
+	// Name is the autocert cache name (primary key).
+	Name string `db:"name"`
+
+	// Data represents the binary (encoded) contents of the autocert.
+	Data string `db:"data"`
+}
+
+// State represents a type for interacting with the underlying state.
+type State struct {
+	*domain.StateBase
+}
+
+// NewState returns a new State for interacting with the underlying state.
+func NewState(factory coreDB.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// Put implements autocert.Cache.Put.
+func (st *State) Put(ctx context.Context, name string, data []byte) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	q := `
+INSERT INTO autocert_cache (uuid, name, data, encoding)
+VALUES (?, ?, ?, 0)
+  ON CONFLICT(name) DO UPDATE SET data=excluded.data`
+
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, q, uuid.String(), name, string(data)); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	return errors.Trace(err)
+}
+
+// Get implements autocert.Cache.Get.
+func (st *State) Get(ctx context.Context, name string) ([]byte, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	q := `
+SELECT (name, data) AS &Autocert.*
+FROM   autocert_cache 
+WHERE  name = $M.name`
+	s, err := sqlair.Prepare(q, Autocert{}, sqlair.M{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q", q)
+	}
+
+	var row Autocert
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, s, sqlair.M{"name": name}).Get(&row))
+	}); err != nil {
+		if err.Error() == sql.ErrNoRows.Error() {
+			return nil, errors.Annotatef(errors.NotFound, "autocert %s", name)
+		}
+		return nil, errors.Annotate(err, "querying autocert cache")
+	}
+
+	return []byte(row.Data), nil
+}
+
+// Delete implements autocert.Cache.Delete.
+func (st *State) Delete(ctx context.Context, name string) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	q := `DELETE FROM autocert_cache WHERE name = ?`
+
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, q, name); err != nil {
+			return errors.Trace(err)
+		}
+
+		return nil
+	})
+
+	return errors.Trace(err)
+}

--- a/domain/autocert/state/state_test.go
+++ b/domain/autocert/state/state_test.go
@@ -1,0 +1,281 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
+	gc "gopkg.in/check.v1"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type stateSuite struct {
+	schematesting.ControllerSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func (s *stateSuite) TestRetrieveCertX509(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	certUUID := utils.MustNewUUID().String()
+	x509Cert := `
+	-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	_, err := db.Exec(`INSERT INTO autocert_cache VALUES
+(?, "cert1", ?, 0)`, certUUID, x509Cert)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	retrievedCertBytes, err := st.Get(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(string(retrievedCertBytes), gc.Equals, x509Cert)
+}
+
+func (s *stateSuite) TestRetrieveSpecialChars(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	certUUID := utils.MustNewUUID().String()
+	specialCharsCert := `
+	-----BEGIN CERTIFICATE-----
+abc123!?$*&()'-=@~;\|/"
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	_, err := db.Exec(`INSERT INTO autocert_cache VALUES
+(?, "cert1", ?, 0)`, certUUID, specialCharsCert)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	retrievedCertBytes, err := st.Get(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(string(retrievedCertBytes), gc.Equals, specialCharsCert)
+}
+
+func (s *stateSuite) TestRetrieveNoCert(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Retrieve an arbitrary non existent cert.
+	_, err := st.Get(context.Background(), "cert1")
+	c.Assert(err, gc.ErrorMatches, "autocert cert1: not found")
+}
+
+func (s *stateSuite) TestInsertX509(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	x509Cert := `
+	-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`
+
+	err := st.Put(context.Background(), "cert1", []byte(x509Cert))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	row := db.QueryRow("SELECT name, data FROM autocert_cache WHERE name = 'cert1'")
+	var (
+		name, data string
+	)
+	err = row.Scan(&name, &data)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(name, gc.Equals, "cert1")
+	c.Check(data, gc.Equals, x509Cert)
+}
+
+func (s *stateSuite) TestInsertSpecialChars(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	specialCharsCert := `
+	-----BEGIN CERTIFICATE-----
+abc123!?$*&()'-=@~;\|/"
+-----END CERTIFICATE-----`
+
+	err := st.Put(context.Background(), "cert1", []byte(specialCharsCert))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	row := db.QueryRow("SELECT name, data FROM autocert_cache WHERE name = 'cert1'")
+	var (
+		name, data string
+	)
+	err = row.Scan(&name, &data)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(name, gc.Equals, "cert1")
+	c.Check(data, gc.Equals, specialCharsCert)
+}
+
+func (s *stateSuite) TestDeleteCertX509(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	certUUID := utils.MustNewUUID().String()
+	x509Cert := `
+	-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	_, err := db.Exec(`INSERT INTO autocert_cache VALUES
+(?, "cert1", ?, 0)`, certUUID, x509Cert)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Delete the inserted cert.
+	err = st.Delete(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	row := db.QueryRow("SELECT name, data FROM autocert_cache WHERE name = 'cert1'")
+	var (
+		name, data string
+	)
+	err = row.Scan(&name, &data)
+	c.Assert(err, gc.Equals, sql.ErrNoRows)
+}
+
+func (s *stateSuite) TestDeleteSpecialChars(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	certUUID := utils.MustNewUUID().String()
+	specialCharsCert := `
+	-----BEGIN CERTIFICATE-----
+abc123!?$*&()'-=@~;\|/"
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	_, err := db.Exec(`INSERT INTO autocert_cache VALUES
+(?, "cert1", ?, 0)`, certUUID, specialCharsCert)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Delete the inserted cert.
+	err = st.Delete(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	row := db.QueryRow("SELECT name, data FROM autocert_cache WHERE name = 'cert1'")
+	var (
+		name, data string
+	)
+	err = row.Scan(&name, &data)
+	c.Assert(err, gc.Equals, sql.ErrNoRows)
+}
+
+func (s *stateSuite) TestReplaceCert(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Insert one cert.
+	specialCharsCert := `
+	-----BEGIN CERTIFICATE-----
+abc123!?$*&()'-=@~;\|/"
+-----END CERTIFICATE-----`
+	err := st.Put(context.Background(), "cert1", []byte(specialCharsCert))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Replace the contents of the cert "cert1".
+	x509Cert := `
+	-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	err = st.Put(context.Background(), "cert1", []byte(x509Cert))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	retrievedCertBytes, err := st.Get(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(retrievedCertBytes), gc.Equals, x509Cert)
+}
+
+func (s *stateSuite) TestFullCRUD(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	x509Cert := `
+	-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`
+
+	// Insert a cert.
+	err := st.Put(context.Background(), "cert1", []byte(x509Cert))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the inserted cert.
+	retrievedCertBytes, err := st.Get(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(retrievedCertBytes), gc.Equals, x509Cert)
+
+	// Delete the inserted cert.
+	err = st.Delete(context.Background(), "cert1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Retrieve the non-existent cert.
+	_, err = st.Get(context.Background(), "cert1")
+	c.Assert(err, gc.ErrorMatches, "autocert cert1: not found")
+}

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -36,7 +36,6 @@ func ControllerDDL(nodeID uint64) *schema.Schema {
 		changeLogTriggersForTable("upgrade_info", "uuid", 6),
 		modelDefaults,
 		autocertCacheSchema,
-		changeLogTriggersForTable("autocert_cache", "uuid", 10),
 	}
 
 	schema := schema.New()


### PR DESCRIPTION
Adds the state layer to the new domain, based on the legacy mongodb implementation of the autocert cache: `state/autocertcache.go`.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No new features here yet, so only unit tests to run:
```sh
go test github.com/juju/juju/domain/... -gocheck.v 
```
