### PR TITLE
[test harness] forcibly kill controllers after a test failure

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -426,6 +426,12 @@ cleanup_jujus() {
 	if [[ -f "${TEST_DIR}/jujus" ]]; then
 		echo "====> Cleaning up jujus"
 
+		# If this test has failed, nuke the controllers - no need to wait for a
+		# graceful teardown.
+		if [[ ${TEST_RESULT} == "failure" ]]; then
+			KILL_CONTROLLER="true"
+		fi
+
 		while read -r juju_name; do
 			destroy_controller "${juju_name}"
 		done <"${TEST_DIR}/jujus"


### PR DESCRIPTION
If the test run has already failed, there is no point waiting for the controller/model to gracefully tear down. Kill it with fire.

## QA steps

tbc