### PR TITLE
Prevent a panic, dont use result after err logged

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1604,14 +1604,16 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 			if subUnit != nil {
 				subUnitAppCharm := ""
 				subUnitApp, err := subUnit.Application()
-				if err != nil {
-					logger.Debugf("error fetching subordinate application for %q", subUnit.ApplicationName())
-				}
-				subUnitAppCh, _, err := subUnitApp.Charm()
 				if err == nil {
-					subUnitAppCharm = subUnitAppCh.String()
+					if subUnitAppCh, _, err := subUnitApp.Charm(); err == nil {
+						subUnitAppCharm = subUnitAppCh.String()
+					} else {
+						logger.Debugf("error fetching subordinate application charm for %q: %q", subUnit.ApplicationName(), err.Error())
+					}
 				} else {
-					logger.Debugf("error fetching subordinate application charm for %q", subUnit.ApplicationName())
+					// We can still run processUnit with an empty string for
+					// the ApplicationCharm.
+					logger.Debugf("error fetching subordinate application for %q: %q", subUnit.ApplicationName(), err.Error())
 				}
 				result.Subordinates[name] = context.processUnit(subUnit, subUnitAppCharm, true)
 			}


### PR DESCRIPTION
Logging an error and continuing on can be tricky. Ensure that you do not use the result of a failed method after the error is logged.

If you're logging and error happened rather than returning it, include the actual error. Makes it easier for debugging later.


## QA steps

Not being able to get the unit's Application happened during a time for mongo errors in the db. Removing the subordinate unit's application name in the db, resulted in other failures. 

The happy case is:
```
$ juju deploy ubuntu
$ juju deploy ntp
$ juju relate ntp ubuntu
# wait for the subordinate units to appear.
$ juju status 
# check controller logs for panics.

## Bug reference
https://bugs.launchpad.net/juju/+bug/2034707
