### PR TITLE
Drop the prune log from info to debug

### DIFF
--- a/state/prune.go
+++ b/state/prune.go
@@ -164,7 +164,7 @@ func (p *collectionPruner) pruneByAge() error {
 		return errors.Trace(err)
 	}
 	if deleted > 0 {
-		logger.Infof("%s age pruning (%s): %d rows deleted", p.coll.Name, modelName, deleted)
+		logger.Debugf("%s age pruning (%s): %d rows deleted", p.coll.Name, modelName, deleted)
 	}
 	return errors.Trace(iter.Close())
 }


### PR DESCRIPTION
The pruner log just spams logging info at info level about prunning the status history on long-lived controllers. This information doesn't really tell you anything that should be at info level. Ideally, we should add a metric for this information, so it can be easily displayed in some external tool.

*Why this change is needed and what it does.*

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
