### PR TITLE
Model metadata into service factory

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -558,7 +558,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserInfo, gc.IsNil)
 	c.Assert(result.ControllerTag, gc.Equals, s.ControllerModel(c).State().ControllerTag().String())
-	c.Assert(result.ModelTag, gc.Equals, s.ControllerModel(c).Tag().String())
+	c.Assert(result.ModelTag, gc.Equals, names.NewModelTag(s.ControllerModelUUID()).String())
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
 		{Name: "CrossModelRelations", Versions: []int{2}},
 		{Name: "CrossModelSecrets", Versions: []int{1}},

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -221,6 +221,7 @@ func (s *auditConfigSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 func (s *auditConfigSuite) TestNewServerValidatesConfig(c *gc.C) {
 	cfg := testing.DefaultServerConfig(c, nil)
 	cfg.GetAuditConfig = nil
+	cfg.ServiceFactoryGetter = s.ServiceFactoryGetter(c)
 
 	srv, err := apiserver.NewServer(cfg)
 	c.Assert(err, gc.ErrorMatches, "missing GetAuditConfig not valid")

--- a/apiserver/facades/agent/provisioner/container_test.go
+++ b/apiserver/facades/agent/provisioner/container_test.go
@@ -54,7 +54,7 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 		State_:          st,
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()),
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(aProvisioner, gc.NotNil)
@@ -109,7 +109,7 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 		State_:          st,
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()),
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(aProvisioner, gc.NotNil)

--- a/apiserver/facades/agent/provisioner/imagemetadata_test.go
+++ b/apiserver/facades/agent/provisioner/imagemetadata_test.go
@@ -60,7 +60,7 @@ func (s *ImageMetadataSuite) TestMetadataNone(c *gc.C) {
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()),
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -81,7 +81,7 @@ func (s *ImageMetadataSuite) TestMetadataFromState(c *gc.C) {
 		State_:          st,
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()),
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -687,7 +687,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()),
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(aProvisioner, gc.NotNil)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -21,7 +21,6 @@ import (
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/internal/storage/poolmanager"
-	jujujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -54,7 +53,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	serviceFactory := s.ServiceFactory(jujujujutesting.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(m, serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
-	jujujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -48,7 +47,7 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	serviceFactory := s.ServiceFactory(jujujujutesting.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.ControllerModel(c), serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/package_test.go
+++ b/apiserver/facades/agent/uniter/package_test.go
@@ -134,7 +134,7 @@ func (s *uniterSuiteBase) facadeContext(c *gc.C) facadetest.Context {
 		Resources_:         s.resources,
 		Auth_:              s.authorizer,
 		LeadershipChecker_: s.leadershipChecker,
-		ServiceFactory_:    s.ServiceFactory(testing.DefaultModelUUID),
+		ServiceFactory_:    s.DefaultModelServiceFactory(c),
 	}
 }
 

--- a/apiserver/facades/agent/uniter/uniter_apierror_test.go
+++ b/apiserver/facades/agent/uniter/uniter_apierror_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&uniterAPIErrorSuite{})
 func (s *uniterAPIErrorSuite) SetupTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
 	serviceFactory.Credential().UpdateCloudCredential(context.Background(), testing.DefaultCredentialTag, cred)
@@ -47,7 +47,7 @@ func (s *uniterAPIErrorSuite) TestGetStorageStateError(c *gc.C) {
 		LeadershipChecker_: &fakeLeadershipChecker{isLeader: false},
 	}
 
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 	_, err := uniter.NewUniterAPIWithServices(facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, gc.ErrorMatches, "kaboom")
 }

--- a/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
+++ b/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -37,7 +36,7 @@ func (s *cloudSpecUniterSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	facadeContext := s.facadeContext(c)
 	uniterAPI, err := uniter.NewUniterAPIWithServices(facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/cloud"
-	controller "github.com/juju/juju/controller"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/feature"
@@ -45,7 +45,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 	s.ApiServerSuite.SeedCAASCloud(c)
 
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 	cloudService := serviceFactory.Cloud()
 	err := cloudService.Save(context.Background(), testing.DefaultCloud)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	_ "github.com/juju/juju/internal/secrets/provider/all"
-	jujujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -3664,7 +3663,7 @@ func (s *uniterSuite) TestCommitHookChangesWithPortsSidecarApplication(c *gc.C) 
 		Resources_:         s.resources,
 		Auth_:              s.authorizer,
 		LeadershipChecker_: s.leadershipChecker,
-		ServiceFactory_:    s.ServiceFactory(jujujujutesting.DefaultModelUUID),
+		ServiceFactory_:    s.DefaultModelServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -79,7 +79,7 @@ func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	s.upgrader, err = upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, s.authorizer,
@@ -137,7 +137,7 @@ func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	upgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, authorizer,
@@ -181,7 +181,7 @@ func (s *upgraderSuite) TestWatchAPIVersionUnit(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	upgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, authorizer,
@@ -220,7 +220,7 @@ func (s *upgraderSuite) TestWatchAPIVersionControllerAgent(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	upgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, authorizer,
@@ -258,7 +258,7 @@ func (s *upgraderSuite) TestWatchAPIVersionRefusesWrongAgent(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	anUpgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, anAuthorizer,
@@ -290,7 +290,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	anUpgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, anAuthorizer,
@@ -367,7 +367,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	anUpgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, anAuthorizer,
@@ -429,7 +429,7 @@ func (s *upgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	anUpgrader, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, anAuthorizer,
@@ -508,7 +508,7 @@ func (s *upgraderSuite) TestDesiredVersionUnrestrictedForAPIAgents(c *gc.C) {
 	systemState, err := s.StatePool().SystemState()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	upgraderAPI, err := upgrader.NewUpgraderAPI(
 		s.controllerConfigGetter, systemState, s.hosted, s.resources, authorizer,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -74,7 +74,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIBase {
 	c.Assert(err, jc.ErrorIsNil)
 	blockChecker := common.NewBlockChecker(st)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	env, err := stateenvirons.GetNewEnvironFunc(
 		environs.New)(s.ControllerModel(c), serviceFactory.Cloud(), serviceFactory.Credential())

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -56,7 +56,7 @@ func (s *DeployLocalSuite) TestDeployControllerNotAllowed(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
 
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	ch := f.MakeCharm(c, &factory.CharmParams{Name: "juju-controller"})
 	_, err := application.DeployApplication(
@@ -75,7 +75,7 @@ func (s *DeployLocalSuite) TestDeployControllerNotAllowed(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	app, err := application.DeployApplication(
 		context.Background(),
@@ -98,7 +98,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployChannel(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	_, err := application.DeployApplication(
@@ -122,7 +122,7 @@ func (s *DeployLocalSuite) TestDeployChannel(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 
@@ -184,7 +184,7 @@ func (s *DeployLocalSuite) assertBindings(c *gc.C, app application.Application, 
 }
 
 func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	wordpressCharm := s.addWordpressCharm(c)
 	st := s.ControllerModel(c).State()
@@ -231,7 +231,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 	st := s.ControllerModel(c).State()
@@ -281,7 +281,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 }
 
 func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	wordpressCharm := s.addWordpressCharm(c)
 	st := s.ControllerModel(c).State()
@@ -304,7 +304,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 			Charm:           wordpressCharm,
 			EndpointBindings: map[string]string{
 				"":   publicSpace.Id(),
-				"db": "42", //unknown space id
+				"db": "42", // unknown space id
 			},
 			CharmOrigin: corecharm.Origin{Platform: corecharm.Platform{OS: "ubuntu", Channel: "22.04"}},
 		},
@@ -317,7 +317,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	_, err := application.DeployApplication(
@@ -344,7 +344,7 @@ func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	app, err := application.DeployApplication(
 		context.Background(),
@@ -370,7 +370,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploySettingsError(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	st := s.ControllerModel(c).State()
 	_, err := application.DeployApplication(
@@ -404,7 +404,7 @@ func sampleApplicationConfigSchema() environschema.Fields {
 }
 
 func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	cfg, err := coreconfig.NewConfig(map[string]interface{}{
 		"outlook":     "good",
@@ -433,7 +433,7 @@ func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	st := s.ControllerModel(c).State()
 	err := st.SetModelConstraints(constraints.MustParse("mem=2G"))
@@ -458,7 +458,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	applicationCons := constraints.MustParse("cores=2")
@@ -485,7 +485,7 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	applicationCons := constraints.MustParse("cores=2")
@@ -515,7 +515,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	applicationCons := constraints.MustParse("cores=2")
@@ -544,7 +544,7 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	applicationCons := constraints.MustParse("cores=2")
@@ -579,7 +579,7 @@ func (s *DeployLocalSuite) TestDeploy(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirements(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	curl := charm.MustParseURL("local:focal/juju-qa-test-assumes-v2")
 	ch := testcharms.Hub.CharmDir("juju-qa-test-assumes-v2")
@@ -609,7 +609,7 @@ func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirements(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirementsAndForce(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	curl := charm.MustParseURL("local:focal/juju-qa-test-assumes-v2")
 	ch := testcharms.Hub.CharmDir("juju-qa-test-assumes-v2")
@@ -640,7 +640,7 @@ func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirementsAndForce(c *gc.C)
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
-	serviceFactory := s.ServiceFactory(testing.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	var f fakeDeployer
 	applicationCons := constraints.MustParse("cores=2")

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -50,7 +50,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	api, err := application.NewAPIBase(
 		application.GetState(st),
@@ -181,7 +181,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 	mod, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(jujutesting.DefaultModelUUID)
+	serviceFactory := s.DefaultModelServiceFactory(c)
 
 	api, err := application.NewAPIBase(
 		application.GetState(st),

--- a/apiserver/facades/client/credentialmanager/client_integration_test.go
+++ b/apiserver/facades/client/credentialmanager/client_integration_test.go
@@ -42,7 +42,7 @@ func (s *CredentialManagerIntegrationSuite) TestInvalidateModelCredential(c *gc.
 	tag, set := model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 
-	credService := s.ServiceFactoryGetter.FactoryForModel(s.ControllerModelUUID()).Credential()
+	credService := s.ControllerServiceFactory(c).Credential()
 	credential, err := credService.CloudCredential(ctx.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credential.Invalid, jc.IsFalse)

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -18,9 +18,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/domain/servicefactory"
-	servicefactorytesting "github.com/juju/juju/domain/servicefactory/testing"
-	databasetesting "github.com/juju/juju/internal/database/testing"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -54,13 +51,9 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	var err error
 	s.haServer, err = highavailability.NewHighAvailabilityAPI(facadetest.Context{
-		State_: st,
-		Auth_:  s.authorizer,
-		ServiceFactory_: servicefactory.NewServiceFactory(
-			databasetesting.ConstFactory(s.ControllerSuite.TxnRunner()),
-			nil, nil,
-			servicefactorytesting.NewCheckLogger(c),
-		),
+		State_:          st,
+		Auth_:           s.authorizer,
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -531,13 +524,9 @@ func (s *clientSuite) TestEnableHAHostedModelErrors(c *gc.C) {
 	defer st2.Close()
 
 	haServer, err := highavailability.NewHighAvailabilityAPI(facadetest.Context{
-		State_: st2,
-		Auth_:  s.authorizer,
-		ServiceFactory_: servicefactory.NewServiceFactory(
-			databasetesting.ConstFactory(s.ControllerSuite.TxnRunner()),
-			nil, nil,
-			servicefactorytesting.NewCheckLogger(c),
-		),
+		State_:          st2,
+		Auth_:           s.authorizer,
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -597,13 +586,9 @@ func (s *clientSuite) TestHighAvailabilityCAASFails(c *gc.C) {
 	defer st.Close()
 
 	_, err := highavailability.NewHighAvailabilityAPI(facadetest.Context{
-		State_: st,
-		Auth_:  s.authorizer,
-		ServiceFactory_: servicefactory.NewServiceFactory(
-			databasetesting.ConstFactory(s.ControllerSuite.TxnRunner()),
-			nil, nil,
-			servicefactorytesting.NewCheckLogger(c),
-		),
+		State_:          st,
+		Auth_:           s.authorizer,
+		ServiceFactory_: s.ControllerServiceFactory(c),
 	})
 	c.Assert(err, gc.ErrorMatches, "high availability on kubernetes controllers not supported")
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
-	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -376,8 +376,8 @@ func (s *modelInfoSuite) TestModelInfoErrorModelConfig(c *gc.C) {
 
 func (s *modelInfoSuite) TestModelInfoErrorModelUsers(c *gc.C) {
 	s.st.model.SetErrors(
-		nil,                               //Config
-		nil,                               //Status
+		nil,                               // Config
+		nil,                               // Status
 		errors.Errorf("no users for you"), // Users
 	)
 	s.testModelInfoError(c, coretesting.ModelTag.String(), `no users for you`)
@@ -566,16 +566,16 @@ func (s *modelInfoSuite) setModelConfigError() {
 
 func (s *modelInfoSuite) setModelStatusError() {
 	s.st.model.SetErrors(
-		nil,                        //Config
-		errors.NotFoundf("status"), //Status
+		nil,                        // Config
+		errors.NotFoundf("status"), // Status
 	)
 }
 
 func (s *modelInfoSuite) setModelUsersError() {
 	s.st.model.SetErrors(
-		nil,                       //Config
-		nil,                       //Status
-		errors.NotFoundf("users"), //Users
+		nil,                       // Config
+		nil,                       // Status
+		errors.NotFoundf("users"), // Users
 	)
 }
 
@@ -1312,11 +1312,11 @@ func (m *mockMigration) EndTime() time.Time {
 
 type mockModelManagerService struct{}
 
-func (mockModelManagerService) Create(ctx stdcontext.Context, uuid modelmanagerservice.UUID) error {
+func (mockModelManagerService) Create(_ stdcontext.Context, _ model.UUID) error {
 	return nil
 }
 
-func (mockModelManagerService) Delete(ctx stdcontext.Context, uuid modelmanagerservice.UUID) error {
+func (mockModelManagerService) Delete(_ stdcontext.Context, _ model.UUID) error {
 	return nil
 }
 

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -900,7 +900,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	st := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 	ctlrSt := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), ctlrSt)
 	model, err := st.Model()
@@ -928,7 +928,7 @@ func (s *modelManagerStateSuite) TestNewAPIAcceptsClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUserTag("external@remote")
 	st := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	endPoint, err := modelmanager.NewModelManagerAPI(
 		st,
@@ -949,7 +949,7 @@ func (s *modelManagerStateSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
 	st := common.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	endPoint, err := modelmanager.NewModelManagerAPI(
 		st,
@@ -1159,7 +1159,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	backend := common.NewModelManagerBackend(model, s.StatePool())
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
 		backend,
@@ -1214,7 +1214,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	s.authoriser.Tag = jujutesting.AdminUser
 	backend := common.NewModelManagerBackend(model, s.StatePool())
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
 		backend,
@@ -1256,7 +1256,7 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	backend := common.NewModelManagerBackend(model, s.StatePool())
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
@@ -1731,7 +1731,7 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(modelState.RemoveDyingModel(), jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	anAuthoriser := s.authoriser
 	anAuthoriser.Tag = user

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -49,7 +49,7 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.subnet = subnet
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	cloudSpecAPI := cloudspec.NewCloudSpec(
 		s.resources,

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -105,7 +105,15 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		return nil, errors.Trace(err)
 	}
 
-	serviceFactory := srv.shared.serviceFactoryGetter.FactoryForModel(modelUUID)
+	// TODO (tlm) We need to better fix up model not found here. When a model
+	// has been migrated it's valid for the model to not exist any more and we
+	// allow this code to run so that we can get a redirect out of the login
+	// process. The better way to handle this is just redirect and don't allow
+	// standing up api's on models that don't exist.
+	var serviceFactory servicefactory.ServiceFactory
+	if m != nil {
+		serviceFactory = srv.shared.serviceFactoryGetter.FactoryForModel(m.UUID())
+	}
 
 	r := &apiHandler{
 		state:           st,

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -262,7 +262,7 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (*state.User, names.Co
 func (s *serverSuite) TestAPIHandlerHasPermissionLogin(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	st := s.ControllerModel(c).State()
 	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.StatePool(), st, serviceFactory.ControllerConfig(), u)
@@ -276,7 +276,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	u, ctag := s.bootstrapHasPermissionTest(c)
 	user := u.UserTag()
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	st := s.ControllerModel(c).State()
 	handler, _ := apiserver.TestingAPIHandlerWithEntity(c, s.StatePool(), st, serviceFactory.ControllerConfig(), u)
@@ -302,7 +302,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionLoginToken(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	delegator := &jwt.PermissionDelegator{Token: token}
 	st := s.ControllerModel(c).State()
@@ -326,7 +326,7 @@ func (s *serverSuite) TestAPIHandlerMissingPermissionLoginToken(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	delegator := &jwt.PermissionDelegator{token}
 	st := s.ControllerModel(c).State()
@@ -360,7 +360,7 @@ func (s *serverSuite) TestAPIHandlerConnectedModel(c *gc.C) {
 	otherState := f.MakeModel(c, nil)
 	defer otherState.Close()
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	handler, _ := apiserver.TestingAPIHandler(c, s.StatePool(), otherState, serviceFactory.ControllerConfig())
 	defer handler.Kill()
@@ -412,7 +412,7 @@ func assertStateBecomesClosed(c *gc.C, st *state.State) {
 }
 
 func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, st *state.State) {
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	handler, resources := apiserver.TestingAPIHandler(c, s.StatePool(), st, serviceFactory.ControllerConfig())
 	resource := new(fakeResource)

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -88,7 +88,7 @@ func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error
 	}, nil
 }
 
-func (f *FakeEnsureMongo) EnsureMongo(ctx context.Context, args mongo.EnsureServerParams) error {
+func (f *FakeEnsureMongo) EnsureMongo(_ context.Context, args mongo.EnsureServerParams) error {
 	f.EnsureCount++
 	f.DataDir, f.OplogSize = args.DataDir, args.OplogSize
 	f.Info = controller.StateServingInfo{
@@ -121,7 +121,7 @@ type AgentSuite struct {
 func (s *AgentSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 
 	var err error
 	s.Environ, err = stateenvirons.GetNewEnvironFunc(environs.New)(
@@ -220,7 +220,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tools1, gc.DeepEquals, agentTools)
 
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 	cfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	apiPort, ok := cfg[controller.APIPort].(int)

--- a/cmd/jujud/agent/machine_legacy_test.go
+++ b/cmd/jujud/agent/machine_legacy_test.go
@@ -253,7 +253,7 @@ func (s *MachineLegacySuite) TestWorkersForHostedModelWithInvalidCredential(c *g
 	uuid := st.ModelUUID()
 
 	// invalidate cloud credential for this model
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 	err := serviceFactory.Credential().InvalidateCredential(stdcontext.Background(), testing.DefaultCredentialTag, "coz i can")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -284,7 +284,7 @@ func (s *MachineLegacySuite) TestWorkersForHostedModelWithDeletedCredential(c *g
 
 	ctx := stdcontext.Background()
 	credentialTag := names.NewCloudCredentialTag("dummy/admin/another")
-	serviceFactory := s.ServiceFactory(s.ControllerModelUUID())
+	serviceFactory := s.ControllerServiceFactory(c)
 	err := serviceFactory.Credential().UpdateCloudCredential(ctx, credentialTag, cloud.NewCredential(cloud.UserPassAuthType, nil))
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/core/changestream/eventsource.go
+++ b/core/changestream/eventsource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
 )
 
 // EventSource describes the ability to subscribe
@@ -36,22 +37,44 @@ type WatchableDBGetter interface {
 // change-stream into a state object.
 // State objects should only be concerned with persistence and retrieval.
 // Watchers are the concern of the service layer.
-func NewTxnRunnerFactory(f func() (WatchableDB, error)) database.TxnRunnerFactory {
+func NewTxnRunnerFactory(f WatchableDBFactory) database.TxnRunnerFactory {
 	return func() (database.TxnRunner, error) {
 		r, err := f()
 		return r, errors.Trace(err)
 	}
 }
 
-// WatchableDBFactory aliases a function that
-// returns a database.TxnRunner or an error.
+// WatchableDBFactory provides a function for getting a database.TxnRunner or
+// an error.
 type WatchableDBFactory = func() (WatchableDB, error)
+
+// WatchableModelDBFactory provides an interface for getting a
+// database.TxnRunner or error that is scoped to a specific model.
+type WatchableModelDBFactory struct {
+	WatchableDBFactory
+	ModelUUID model.UUID
+}
 
 // NewWatchableDBFactoryForNamespace returns a WatchableDBFactory
 // for the input namespaced factory function and namespace.
-func NewWatchableDBFactoryForNamespace[T WatchableDB](f func(string) (T, error), ns string) WatchableDBFactory {
+func NewWatchableDBFactoryForNamespace[T WatchableDB](
+	ns string,
+	f func(string) (T, error),
+) WatchableDBFactory {
 	return func() (WatchableDB, error) {
 		r, err := f(ns)
 		return r, errors.Trace(err)
+	}
+}
+
+// NewWatchableModelDBFactory returns a WatchableModelDBFactory for model that
+// is used as the namespace for the factory.
+func NewWatchableModelDBFactory[T WatchableDB](
+	modelUUID model.UUID,
+	f func(string) (T, error),
+) WatchableModelDBFactory {
+	return WatchableModelDBFactory{
+		WatchableDBFactory: NewWatchableDBFactoryForNamespace(modelUUID.String(), f),
+		ModelUUID:          modelUUID,
 	}
 }

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -42,6 +42,7 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/status",
 		"core/watcher",
+		"domain/model",
 		"internal/docker",
 	})
 

--- a/domain/model/package_test.go
+++ b/domain/model/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -11,34 +11,33 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
-	"github.com/juju/juju/domain/modelmanager/service"
 )
 
 // State is the model state required by this service.
 type State interface {
 	// SetCloudCredential sets the cloud credential for the given mode.
-	SetCloudCredential(context.Context, service.UUID, credential.ID) error
+	SetCloudCredential(context.Context, model.UUID, credential.ID) error
 }
 
 // Service defines a service for interacting with the underlying state based
 // information of a model.
 type Service struct {
-	uuid service.UUID
-	st   State
+	st State
 }
 
 // NewService returns a new Service for interacting with a models state.
-func NewService(modelUUID service.UUID, st State) *Service {
+func NewService(st State) *Service {
 	return &Service{
-		uuid: modelUUID,
-		st:   st,
+		st: st,
 	}
 }
 
 // SetCloudCredential takes a cloud credential tag to set for this model.
 func (s *Service) SetCloudCredential(
 	ctx context.Context,
+	modelUUID model.UUID,
 	cred names.CloudCredentialTag,
 ) error {
 	id := credential.ID{
@@ -46,7 +45,7 @@ func (s *Service) SetCloudCredential(
 		Owner: cred.Owner().Id(),
 		Name:  cred.Name(),
 	}
-	err := s.st.SetCloudCredential(ctx, s.uuid, id)
+	err := s.st.SetCloudCredential(ctx, modelUUID, id)
 	if errors.Is(err, errors.NotFound) {
 		return fmt.Errorf("cloud credential %q %w", cred.String(), errors.NotFound)
 	} else if errors.Is(err, modelerrors.NotFound) {

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
-	"github.com/juju/juju/domain/modelmanager/service"
 	jujudb "github.com/juju/juju/internal/database"
 )
 
@@ -38,7 +38,7 @@ func NewState(
 // returned.
 func (s *State) SetCloudCredential(
 	ctx context.Context,
-	modelUUID service.UUID,
+	uuid model.UUID,
 	id credential.ID,
 ) error {
 	db, err := s.DB()
@@ -81,15 +81,15 @@ WHERE model_uuid = excluded.model_uuid
 			)
 		}
 
-		_, err = tx.ExecContext(ctx, stmt, modelUUID, cloudUUID, cloudCredUUID)
+		_, err = tx.ExecContext(ctx, stmt, uuid, cloudUUID, cloudCredUUID)
 		if jujudb.IsErrConstraintForeignKey(err) {
 			return fmt.Errorf(
 				"%w %q when setting cloud credential %q%w",
-				modelerrors.NotFound, modelUUID, id, errors.Hide(err))
+				modelerrors.NotFound, uuid, id, errors.Hide(err))
 		} else if err != nil {
 			return fmt.Errorf(
 				"setting cloud credential %q for model %q: %w",
-				id, modelUUID, err)
+				id, uuid, err)
 		}
 		return nil
 	})

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -14,19 +14,17 @@ import (
 	dbcloud "github.com/juju/juju/domain/cloud/state"
 	"github.com/juju/juju/domain/credential"
 	credentialstate "github.com/juju/juju/domain/credential/state"
+	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
-	"github.com/juju/juju/domain/modelmanager/service"
+	modeltesting "github.com/juju/juju/domain/model/testing"
 	modelmanagerstate "github.com/juju/juju/domain/modelmanager/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
 type modelSuite struct {
 	schematesting.ControllerSuite
+	uuid model.UUID
 }
-
-const (
-	modelUUID = service.UUID("12345")
-)
 
 var _ = gc.Suite(&modelSuite{})
 
@@ -61,8 +59,10 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	m.uuid = modeltesting.GenModelUUID(c)
+
 	mmSt := modelmanagerstate.NewState(m.TxnRunnerFactory())
-	err = mmSt.Create(context.Background(), modelUUID)
+	err = mmSt.Create(context.Background(), m.uuid)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -70,7 +70,7 @@ func (m *modelSuite) TestModelSetCredential(c *gc.C) {
 	st := NewState(m.TxnRunnerFactory())
 	err := st.SetCloudCredential(
 		context.Background(),
-		modelUUID,
+		m.uuid,
 		credential.ID{
 			Cloud: "testmctestface",
 			Owner: "bob",
@@ -84,7 +84,7 @@ func (m *modelSuite) TestModelSetNonExistentCredential(c *gc.C) {
 	st := NewState(m.TxnRunnerFactory())
 	err := st.SetCloudCredential(
 		context.Background(),
-		modelUUID,
+		m.uuid,
 		credential.ID{
 			Cloud: "testmctestface",
 			Owner: "bob",

--- a/domain/model/testing/testing.go
+++ b/domain/model/testing/testing.go
@@ -1,0 +1,20 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/model"
+)
+
+// GenModelUUID can be used in testing for generating a model uuid that is
+// checked for subsequent errors using the test suits go check instance.
+func GenModelUUID(c *gc.C) model.UUID {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	return model.UUID(uuid.String())
+}

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -1,7 +1,7 @@
 // Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package service
+package model
 
 import (
 	"github.com/juju/errors"
@@ -22,6 +22,7 @@ func (u UUID) Validate() error {
 	return nil
 }
 
+// String implements the stringer interface for UUID.
 func (u UUID) String() string {
 	return string(u)
 }

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package service
+package model
 
 import (
 	"github.com/juju/testing"

--- a/domain/modelmanager/bootstrap/bootstrap.go
+++ b/domain/modelmanager/bootstrap/bootstrap.go
@@ -1,0 +1,23 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
+	modelmanagerstate "github.com/juju/juju/domain/modelmanager/state"
+)
+
+// InsertModel is a bootstrap convenience function for inserting a new model into
+// the controllers model list.
+func InsertModel(uuid model.UUID) func(context.Context, database.TxnRunner) error {
+	return func(ctx context.Context, db database.TxnRunner) error {
+		return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			return modelmanagerstate.Create(ctx, uuid, tx)
+		})
+	}
+}

--- a/domain/modelmanager/service/service.go
+++ b/domain/modelmanager/service/service.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/model"
 )
 
 // State defines a interface for interacting with the underlying state.
 type State interface {
-	Create(context.Context, UUID) error
-	Delete(context.Context, UUID) error
+	Create(context.Context, model.UUID) error
+	Delete(context.Context, model.UUID) error
 }
 
 // Service defines a service for interacting with the underlying state.
@@ -33,7 +34,7 @@ func NewService(st State, dbDeleter database.DBDeleter) *Service {
 }
 
 // Create takes a model UUID and creates a new model.
-func (s *Service) Create(ctx context.Context, uuid UUID) error {
+func (s *Service) Create(ctx context.Context, uuid model.UUID) error {
 	if err := uuid.Validate(); err != nil {
 		return errors.Annotatef(err, "validating model uuid %q", uuid)
 	}
@@ -43,7 +44,7 @@ func (s *Service) Create(ctx context.Context, uuid UUID) error {
 }
 
 // Delete takes a model UUID and deletes the model if it exists.
-func (s *Service) Delete(ctx context.Context, uuid UUID) error {
+func (s *Service) Delete(ctx context.Context, uuid model.UUID) error {
 	if err := uuid.Validate(); err != nil {
 		return errors.Annotatef(err, "validating model uuid %q", uuid)
 	}

--- a/domain/modelmanager/service/service_test.go
+++ b/domain/modelmanager/service/service_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	"github.com/mattn/go-sqlite3"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain"
+	modeltesting "github.com/juju/juju/domain/model/testing"
 )
 
 type serviceSuite struct {
@@ -30,8 +30,7 @@ var _ = gc.Suite(&serviceSuite{})
 func (s *serviceSuite) TestServiceCreate(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
-
+	uuid := modeltesting.GenModelUUID(c)
 	s.state.EXPECT().Create(gomock.Any(), uuid).Return(nil)
 
 	svc := NewService(s.state, s.dbDeleter)
@@ -42,7 +41,7 @@ func (s *serviceSuite) TestServiceCreate(c *gc.C) {
 func (s *serviceSuite) TestServiceCreateError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Create(gomock.Any(), uuid).Return(fmt.Errorf("boom"))
 
@@ -54,7 +53,7 @@ func (s *serviceSuite) TestServiceCreateError(c *gc.C) {
 func (s *serviceSuite) TestServiceCreateDuplicateError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Create(gomock.Any(), uuid).Return(sqlite3.Error{
 		ExtendedCode: sqlite3.ErrConstraintUnique,
@@ -77,7 +76,7 @@ func (s *serviceSuite) TestServiceCreateInvalidUUID(c *gc.C) {
 func (s *serviceSuite) TestServiceDelete(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Delete(gomock.Any(), uuid).Return(nil)
 	s.dbDeleter.EXPECT().DeleteDB(uuid.String()).Return(nil)
@@ -90,7 +89,7 @@ func (s *serviceSuite) TestServiceDelete(c *gc.C) {
 func (s *serviceSuite) TestServiceDeleteStateError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Delete(gomock.Any(), uuid).Return(fmt.Errorf("boom"))
 
@@ -102,7 +101,7 @@ func (s *serviceSuite) TestServiceDeleteStateError(c *gc.C) {
 func (s *serviceSuite) TestServiceDeleteNoRecordsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Delete(gomock.Any(), uuid).Return(domain.ErrNoRecord)
 
@@ -114,7 +113,7 @@ func (s *serviceSuite) TestServiceDeleteNoRecordsError(c *gc.C) {
 func (s *serviceSuite) TestServiceDeleteStateSqliteError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Delete(gomock.Any(), uuid).Return(sqlite3.Error{
 		Code:         sqlite3.ErrPerm,
@@ -129,7 +128,7 @@ func (s *serviceSuite) TestServiceDeleteStateSqliteError(c *gc.C) {
 func (s *serviceSuite) TestServiceDeleteManagerError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	uuid := mustUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
 
 	s.state.EXPECT().Delete(gomock.Any(), uuid).Return(nil)
 	s.dbDeleter.EXPECT().DeleteDB(uuid.String()).Return(fmt.Errorf("boom"))
@@ -154,8 +153,4 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.dbDeleter = NewMockDBDeleter(ctrl)
 
 	return ctrl
-}
-
-func mustUUID(c *gc.C) UUID {
-	return UUID(utils.MustNewUUID().String())
 }

--- a/domain/modelmanager/service/state_mock_test.go
+++ b/domain/modelmanager/service/state_mock_test.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	model "github.com/juju/juju/domain/model"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -35,7 +36,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockState) Create(arg0 context.Context, arg1 UUID) error {
+func (m *MockState) Create(arg0 context.Context, arg1 model.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -49,7 +50,7 @@ func (mr *MockStateMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockState) Delete(arg0 context.Context, arg1 UUID) error {
+func (m *MockState) Delete(arg0 context.Context, arg1 model.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/domain/modelmanager/state/state_test.go
+++ b/domain/modelmanager/state/state_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain"
-	"github.com/juju/juju/domain/modelmanager/service"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/domain/modelmanager/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
@@ -84,6 +84,6 @@ func (s *stateSuite) TestStateDeleteCalledTwice(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, domain.ErrNoRecord.Error()+".*")
 }
 
-func mustUUID(c *gc.C) service.UUID {
-	return service.UUID(utils.MustNewUUID().String())
+func mustUUID(c *gc.C) model.UUID {
+	return model.UUID(utils.MustNewUUID().String())
 }

--- a/domain/schema/testing/controllermodelsuite.go
+++ b/domain/schema/testing/controllermodelsuite.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	gc "gopkg.in/check.v1"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/schema"
+)
+
+// ControllerModelSuite is used to provide a sql.DB reference for tests that
+// can both be used for controller and model operations and their separate DB
+// requirements.
+type ControllerModelSuite struct {
+	ControllerSuite
+}
+
+// ModelTxnRunner returns a transaction runner on to the model database for the
+// provided model uuid.
+func (s *ControllerModelSuite) ModelTxnRunner(c *gc.C, modelUUID string) coredatabase.TxnRunner {
+	txnRunner, _ := s.DqliteSuite.OpenDBForNamespace(c, modelUUID)
+	s.DqliteSuite.ApplyDDLForRunner(c, &SchemaApplier{
+		schema: schema.ModelDDL(),
+	}, txnRunner)
+	return txnRunner
+}

--- a/domain/schema/testing/controllersuite.go
+++ b/domain/schema/testing/controllersuite.go
@@ -17,6 +17,11 @@ type ControllerSuite struct {
 	testing.DqliteSuite
 }
 
+// ControllerTxnRunner returns a txn runner attached to the controller database.
+func (s *ControllerSuite) ControllerTxnRunner() coredatabase.TxnRunner {
+	return s.TxnRunner()
+}
+
 // SetUpTest is responsible for setting up a testing database suite initialised
 // with the controller schema.
 func (s *ControllerSuite) SetUpTest(c *gc.C) {

--- a/domain/schema/testing/schema.go
+++ b/domain/schema/testing/schema.go
@@ -23,6 +23,5 @@ func (s *SchemaApplier) Apply(c *gc.C, ctx context.Context, runner database.TxnR
 	})
 	changeSet, err := s.schema.Ensure(ctx, runner)
 	c.Assert(err, gc.IsNil)
-	c.Check(changeSet.Current, gc.Equals, 0)
-	c.Check(changeSet.Post > 0, gc.Equals, true)
+	c.Check(changeSet.Post, gc.Equals, s.schema.Len())
 }

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -23,6 +23,8 @@ import (
 	credentialstate "github.com/juju/juju/domain/credential/state"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
 	externalcontrollerstate "github.com/juju/juju/domain/externalcontroller/state"
+	modelservice "github.com/juju/juju/domain/model/service"
+	modelstate "github.com/juju/juju/domain/model/state"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 	modelmanagerstate "github.com/juju/juju/domain/modelmanager/state"
 	"github.com/juju/juju/environs/config"
@@ -72,6 +74,13 @@ func (s *ControllerFactory) ControllerConfig() *controllerconfigservice.Service 
 func (s *ControllerFactory) ControllerNode() *controllernodeservice.Service {
 	return controllernodeservice.NewService(
 		controllernodestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+	)
+}
+
+// Model returns the model service for the model UUID.
+func (s *ControllerFactory) Model() *modelservice.Service {
+	return modelservice.NewService(
+		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 	)
 }
 

--- a/domain/servicefactory/model.go
+++ b/domain/servicefactory/model.go
@@ -5,26 +5,28 @@ package servicefactory
 
 import (
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/domain/model"
 )
 
 // ModelFactory provides access to the services required by the apiserver.
 type ModelFactory struct {
-	modelDB changestream.WatchableDBFactory
 	logger  Logger
+	modelDB changestream.WatchableModelDBFactory
 }
 
 // NewModelFactory returns a new registry which uses the provided modelDB
 // function to obtain a model database.
 func NewModelFactory(
-	modelDB changestream.WatchableDBFactory,
+	modelDB changestream.WatchableModelDBFactory,
 	logger Logger,
 ) *ModelFactory {
 	return &ModelFactory{
-		modelDB: modelDB,
 		logger:  logger,
+		modelDB: modelDB,
 	}
 }
 
-func (f *ModelFactory) Name() string {
-	return "ModelFactory"
+// ModelUUID is the current UUID for the model.
+func (f *ModelFactory) ModelUUID() model.UUID {
+	return f.modelDB.ModelUUID
 }

--- a/domain/servicefactory/service.go
+++ b/domain/servicefactory/service.go
@@ -17,12 +17,17 @@ type ServiceFactory struct {
 // NewServiceFactory returns a new service factory which can be used to
 // get new services from.
 func NewServiceFactory(
-	controllerDB, modelDB changestream.WatchableDBFactory,
+	controllerDB changestream.WatchableDBFactory,
+	modelDB changestream.WatchableModelDBFactory,
 	deleterDB database.DBDeleter,
 	logger Logger,
 ) *ServiceFactory {
+	controllerFactory := NewControllerFactory(controllerDB, deleterDB, logger)
 	return &ServiceFactory{
-		ControllerFactory: NewControllerFactory(controllerDB, deleterDB, logger),
-		ModelFactory:      NewModelFactory(modelDB, logger),
+		ControllerFactory: controllerFactory,
+		ModelFactory: NewModelFactory(
+			modelDB,
+			logger,
+		),
 	}
 }

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -10,6 +10,8 @@ import (
 	controllernodeservice "github.com/juju/juju/domain/controllernode/service"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
+	"github.com/juju/juju/domain/model"
+	modelservice "github.com/juju/juju/domain/model/service"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 )
 
@@ -37,9 +39,19 @@ func (s *TestingServiceFactory) ControllerNode() *controllernodeservice.Service 
 	return nil
 }
 
+// Model returns the model service.
+func (s *TestingServiceFactory) Model() *modelservice.Service {
+	return nil
+}
+
 // ModelManager returns the model manager service.
 func (s *TestingServiceFactory) ModelManager() *modelmanagerservice.Service {
 	return nil
+}
+
+// ModelUUID is the current UUID for the model.
+func (s *TestingServiceFactory) ModelUUID() model.UUID {
+	return model.UUID("")
 }
 
 // ExternalController returns the external controller service.

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -1,0 +1,91 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/model"
+	modeltesting "github.com/juju/juju/domain/model/testing"
+	"github.com/juju/juju/domain/modelmanager/bootstrap"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	domainservicefactory "github.com/juju/juju/domain/servicefactory"
+	databasetesting "github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/internal/servicefactory"
+)
+
+// ServiceFactorySuite is a test suite that can be composed into tests that
+// require a Juju ServiceFactory and database access. It holds the notion of a
+// controller model uuid and that of a default model uuid. Both of these models
+// will be instantiated into the database upon test setup.
+type ServiceFactorySuite struct {
+	schematesting.ControllerModelSuite
+
+	// ControllerModelUUID is the unique id for the controller model. If not set
+	// will be set during test set up.
+	ControllerModelUUID model.UUID
+
+	// DefaultModelUUID is the unique id for the default model. If not set
+	// will be set during test set up.
+	DefaultModelUUID model.UUID
+}
+
+type stubDBDeleter struct {
+	DB *sql.DB
+}
+
+func (s stubDBDeleter) DeleteDB(namespace string) error {
+	return nil
+}
+
+// ControllerServiceFactory conveniently constructs a service factory for the
+// controller model.
+func (s *ServiceFactorySuite) ControllerServiceFactory(c *gc.C) servicefactory.ServiceFactory {
+	return s.ServiceFactoryGetter(c)(string(s.ControllerModelUUID))
+}
+
+// DefaultModelServiceFactory conveniently constructs a service factory for the
+// default model.
+func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory.ServiceFactory {
+	return s.ServiceFactoryGetter(c)(string(s.ControllerModelUUID))
+}
+
+// SeedModelDatabases makes sure that model's for both the controller and default
+// model have been created in the database.
+func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
+	err := bootstrap.InsertModel(s.ControllerModelUUID)(context.Background(), s.TxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+	err = bootstrap.InsertModel(s.DefaultModelUUID)(context.Background(), s.TxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// ServiceFactoryGetter provides an implementation of the ServiceFactoryGetter
+// interface to use in tests.
+func (s *ServiceFactorySuite) ServiceFactoryGetter(c *gc.C) servicefactory.ServiceFactoryGetterFunc {
+	return func(modelUUID string) servicefactory.ServiceFactory {
+		return domainservicefactory.NewServiceFactory(
+			databasetesting.ConstFactory(s.TxnRunner()),
+			databasetesting.ConstModelFactory(model.UUID(modelUUID), s.ModelTxnRunner(c, modelUUID)),
+			stubDBDeleter{DB: s.DB()},
+			NewCheckLogger(c),
+		)
+	}
+}
+
+// SetUpTest creates the controller and default model unique identifiers if they
+// have not already been set. Also seeds the initial database with the models.
+func (s *ServiceFactorySuite) SetUpTest(c *gc.C) {
+	s.ControllerModelSuite.SetUpTest(c)
+	if s.ControllerModelUUID == "" {
+		s.ControllerModelUUID = modeltesting.GenModelUUID(c)
+	}
+	if s.DefaultModelUUID == "" {
+		s.DefaultModelUUID = modeltesting.GenModelUUID(c)
+	}
+	s.SeedModelDatabases(c)
+}

--- a/domain/testing/controllerconfigsuite.go
+++ b/domain/testing/controllerconfigsuite.go
@@ -12,27 +12,18 @@ import (
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
-	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
-// ControllerConfigSuite is used to provide a sql.DB reference to tests.
-// It is pre-populated with the controller config.
-type ControllerConfigSuite struct {
-	schematesting.ControllerSuite
-
-	ControllerConfig controller.Config
+type ControllerTxnProvider interface {
+	ControllerTxnRunner() coredatabase.TxnRunner
 }
 
-// SetUpTest is responsible for setting up a testing database suite initialised
-// with the controller config.
-func (s *ControllerConfigSuite) SetUpTest(c *gc.C) {
-	s.ControllerSuite.SetUpTest(c)
-	s.SeedControllerConfig(c, s.TxnRunner(), s.ControllerConfig)
-}
-
-// SeedControllerConfig is responsible for applying the controller config to
-// the given database.
-func (s *ControllerConfigSuite) SeedControllerConfig(c *gc.C, runner coredatabase.TxnRunner, config controller.Config) {
-	err := bootstrap.InsertInitialControllerConfig(config)(context.Background(), runner)
+func SeedControllerConfig(
+	c *gc.C,
+	config controller.Config,
+	provider ControllerTxnProvider,
+) controller.Config {
+	err := bootstrap.InsertInitialControllerConfig(config)(context.Background(), provider.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
+	return config
 }

--- a/internal/database/testing/runner.go
+++ b/internal/database/testing/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/internal/database/txn"
 )
 
@@ -67,6 +68,15 @@ func ConstFactory(runner coredatabase.TxnRunner) func() (changestream.WatchableD
 		return constWatchableDB{
 			TxnRunner: runner,
 		}, nil
+	}
+}
+
+// ConstModelFactory returns a changestream.WatchableModelDBFactory from just a
+// model.UUID and a database.TxnRunner.
+func ConstModelFactory(modelUUID model.UUID, runner coredatabase.TxnRunner) changestream.WatchableModelDBFactory {
+	return changestream.WatchableModelDBFactory{
+		WatchableDBFactory: ConstFactory(runner),
+		ModelUUID:          modelUUID,
 	}
 }
 

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -10,6 +10,8 @@ import (
 	controllernodeservice "github.com/juju/juju/domain/controllernode/service"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
+	"github.com/juju/juju/domain/model"
+	modelservice "github.com/juju/juju/domain/model/service"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 )
 
@@ -20,6 +22,8 @@ type ControllerServiceFactory interface {
 	ControllerConfig() *controllerconfigservice.Service
 	// ControllerNode returns the controller node service.
 	ControllerNode() *controllernodeservice.Service
+	// Model returns the model service.
+	Model() *modelservice.Service
 	// ModelManager returns the model manager service.
 	ModelManager() *modelmanagerservice.Service
 	// ExternalController returns the external controller service.
@@ -35,7 +39,8 @@ type ControllerServiceFactory interface {
 // ModelServiceFactory provides access to the services required by the
 // apiserver for a given model.
 type ModelServiceFactory interface {
-	Name() string
+	// ModelUUID returns the model UUID for the current model.
+	ModelUUID() model.UUID
 }
 
 // ServiceFactory provides access to the services required by the apiserver.
@@ -49,4 +54,13 @@ type ServiceFactory interface {
 type ServiceFactoryGetter interface {
 	// FactoryForModel returns a ServiceFactory for the given model.
 	FactoryForModel(modelUUID string) ServiceFactory
+}
+
+// ServiceFactoryGetterFunc is a convenience type for translating a getter
+// function into the ServiceFactoryGetter interface.
+type ServiceFactoryGetterFunc func(string) ServiceFactory
+
+// FactoryForModel implements the ServiceFactoryGetter interface.
+func (s ServiceFactoryGetterFunc) FactoryForModel(modelUUID string) ServiceFactory {
+	return s(modelUUID)
 }

--- a/worker/servicefactory/manifold.go
+++ b/worker/servicefactory/manifold.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
-	domainsf "github.com/juju/juju/domain/servicefactory"
+	"github.com/juju/juju/domain/model"
+	domainservicefactory "github.com/juju/juju/domain/servicefactory"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/worker/common"
 )
@@ -53,8 +54,8 @@ type ControllerServiceFactoryFn func(
 
 // ModelServiceFactoryFn is a function that returns a model service factory.
 type ModelServiceFactoryFn func(
+	model.UUID,
 	changestream.WatchableDBGetter,
-	string,
 	Logger,
 ) servicefactory.ModelServiceFactory
 
@@ -152,8 +153,8 @@ func NewControllerServiceFactory(
 	dbDeleter coredatabase.DBDeleter,
 	logger Logger,
 ) servicefactory.ControllerServiceFactory {
-	return domainsf.NewControllerFactory(
-		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
+	return domainservicefactory.NewControllerFactory(
+		changestream.NewWatchableDBFactoryForNamespace(coredatabase.ControllerNS, dbGetter.GetWatchableDB),
 		dbDeleter,
 		serviceFactoryLogger{
 			Logger: logger,
@@ -162,9 +163,13 @@ func NewControllerServiceFactory(
 }
 
 // NewModelServiceFactory returns a new model service factory.
-func NewModelServiceFactory(dbGetter changestream.WatchableDBGetter, modelUUID string, logger Logger) servicefactory.ModelServiceFactory {
-	return domainsf.NewModelFactory(
-		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID),
+func NewModelServiceFactory(
+	modelUUID model.UUID,
+	dbGetter changestream.WatchableDBGetter,
+	logger Logger,
+) servicefactory.ModelServiceFactory {
+	return domainservicefactory.NewModelFactory(
+		changestream.NewWatchableModelDBFactory(modelUUID, dbGetter.GetWatchableDB),
 		serviceFactoryLogger{
 			Logger: logger,
 		},

--- a/worker/servicefactory/manifold_test.go
+++ b/worker/servicefactory/manifold_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/internal/servicefactory"
 )
 
@@ -142,7 +143,11 @@ func (s *manifoldSuite) TestNewControllerServiceFactory(c *gc.C) {
 }
 
 func (s *manifoldSuite) TestNewModelServiceFactory(c *gc.C) {
-	factory := NewModelServiceFactory(s.dbGetter, "model", s.logger)
+	factory := NewModelServiceFactory(
+		"model",
+		s.dbGetter,
+		s.logger,
+	)
 	c.Assert(factory, gc.NotNil)
 }
 
@@ -169,7 +174,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewControllerServiceFactory: func(changestream.WatchableDBGetter, coredatabase.DBDeleter, Logger) servicefactory.ControllerServiceFactory {
 			return nil
 		},
-		NewModelServiceFactory: func(changestream.WatchableDBGetter, string, Logger) servicefactory.ModelServiceFactory {
+		NewModelServiceFactory: func(model.UUID, changestream.WatchableDBGetter, Logger) servicefactory.ModelServiceFactory {
 			return nil
 		},
 	}

--- a/worker/servicefactory/servicefactory_mock_test.go
+++ b/worker/servicefactory/servicefactory_mock_test.go
@@ -13,7 +13,9 @@ import (
 	service2 "github.com/juju/juju/domain/controllernode/service"
 	service3 "github.com/juju/juju/domain/credential/service"
 	service4 "github.com/juju/juju/domain/externalcontroller/service"
-	service5 "github.com/juju/juju/domain/modelmanager/service"
+	model "github.com/juju/juju/domain/model"
+	service5 "github.com/juju/juju/domain/model/service"
+	service6 "github.com/juju/juju/domain/modelmanager/service"
 	servicefactory "github.com/juju/juju/internal/servicefactory"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -125,11 +127,25 @@ func (mr *MockControllerServiceFactoryMockRecorder) ExternalController() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalController", reflect.TypeOf((*MockControllerServiceFactory)(nil).ExternalController))
 }
 
+// Model mocks base method.
+func (m *MockControllerServiceFactory) Model() *service5.Service {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Model")
+	ret0, _ := ret[0].(*service5.Service)
+	return ret0
+}
+
+// Model indicates an expected call of Model.
+func (mr *MockControllerServiceFactoryMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockControllerServiceFactory)(nil).Model))
+}
+
 // ModelManager mocks base method.
-func (m *MockControllerServiceFactory) ModelManager() *service5.Service {
+func (m *MockControllerServiceFactory) ModelManager() *service6.Service {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelManager")
-	ret0, _ := ret[0].(*service5.Service)
+	ret0, _ := ret[0].(*service6.Service)
 	return ret0
 }
 
@@ -162,18 +178,18 @@ func (m *MockModelServiceFactory) EXPECT() *MockModelServiceFactoryMockRecorder 
 	return m.recorder
 }
 
-// Name mocks base method.
-func (m *MockModelServiceFactory) Name() string {
+// ModelUUID mocks base method.
+func (m *MockModelServiceFactory) ModelUUID() model.UUID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Name")
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "ModelUUID")
+	ret0, _ := ret[0].(model.UUID)
 	return ret0
 }
 
-// Name indicates an expected call of Name.
-func (mr *MockModelServiceFactoryMockRecorder) Name() *gomock.Call {
+// ModelUUID indicates an expected call of ModelUUID.
+func (mr *MockModelServiceFactoryMockRecorder) ModelUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockModelServiceFactory)(nil).Name))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockModelServiceFactory)(nil).ModelUUID))
 }
 
 // MockServiceFactory is a mock of ServiceFactory interface.
@@ -283,11 +299,25 @@ func (mr *MockServiceFactoryMockRecorder) ExternalController() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalController", reflect.TypeOf((*MockServiceFactory)(nil).ExternalController))
 }
 
+// Model mocks base method.
+func (m *MockServiceFactory) Model() *service5.Service {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Model")
+	ret0, _ := ret[0].(*service5.Service)
+	return ret0
+}
+
+// Model indicates an expected call of Model.
+func (mr *MockServiceFactoryMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockServiceFactory)(nil).Model))
+}
+
 // ModelManager mocks base method.
-func (m *MockServiceFactory) ModelManager() *service5.Service {
+func (m *MockServiceFactory) ModelManager() *service6.Service {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelManager")
-	ret0, _ := ret[0].(*service5.Service)
+	ret0, _ := ret[0].(*service6.Service)
 	return ret0
 }
 
@@ -297,18 +327,18 @@ func (mr *MockServiceFactoryMockRecorder) ModelManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelManager", reflect.TypeOf((*MockServiceFactory)(nil).ModelManager))
 }
 
-// Name mocks base method.
-func (m *MockServiceFactory) Name() string {
+// ModelUUID mocks base method.
+func (m *MockServiceFactory) ModelUUID() model.UUID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Name")
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "ModelUUID")
+	ret0, _ := ret[0].(model.UUID)
 	return ret0
 }
 
-// Name indicates an expected call of Name.
-func (mr *MockServiceFactoryMockRecorder) Name() *gomock.Call {
+// ModelUUID indicates an expected call of ModelUUID.
+func (mr *MockServiceFactoryMockRecorder) ModelUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockServiceFactory)(nil).Name))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockServiceFactory)(nil).ModelUUID))
 }
 
 // MockServiceFactoryGetter is a mock of ServiceFactoryGetter interface.

--- a/worker/servicefactory/worker.go
+++ b/worker/servicefactory/worker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
 	domainservicefactory "github.com/juju/juju/domain/servicefactory"
 	"github.com/juju/juju/internal/servicefactory"
 )
@@ -140,7 +141,9 @@ type serviceFactoryGetter struct {
 func (s *serviceFactoryGetter) FactoryForModel(modelUUID string) servicefactory.ServiceFactory {
 	return &serviceFactory{
 		ControllerServiceFactory: s.ctrlFactory,
-		ModelServiceFactory:      s.newModelServiceFactory(s.dbGetter, modelUUID, s.logger),
+		ModelServiceFactory: s.newModelServiceFactory(
+			model.UUID(modelUUID), s.dbGetter, s.logger,
+		),
 	}
 }
 

--- a/worker/servicefactory/worker_test.go
+++ b/worker/servicefactory/worker_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/internal/servicefactory"
 )
 
@@ -63,7 +64,7 @@ func (s *workerSuite) getConfig() Config {
 		NewControllerServiceFactory: func(changestream.WatchableDBGetter, coredatabase.DBDeleter, Logger) servicefactory.ControllerServiceFactory {
 			return s.controllerServiceFactory
 		},
-		NewModelServiceFactory: func(changestream.WatchableDBGetter, string, Logger) servicefactory.ModelServiceFactory {
+		NewModelServiceFactory: func(model.UUID, changestream.WatchableDBGetter, Logger) servicefactory.ModelServiceFactory {
 			return s.modelServiceFactory
 		},
 	}


### PR DESCRIPTION
Wires in model database into ServiceFactory.

This commit aims to introduce both the model services layer and database
via the ServiceFactory. As such the PR has touched a lot of small points
in the code base to introduce the new changes.

    - Adds a new ModelWatachbleDBFactory that extends the existing watchable
      db but carries along with it the model uuid that the database is
      scoped to.
    - Adds a new ServiceFactory test suite that can be composed into
      existing sweets to both provide the db access for tests and
      establishing new service factories on to both the controller and model
      databases.
    - Implements the ModelServiceFactory so that model operations can be
      performed as part of the ServiceFactory.
    - ServiceFactory suite introduces default controller and model
      namespace's for tests to work off of.
    - Adds convenience getters for fetching the ServiceFactory for both the
      controller and default model. This is instead of composing a few
      sources in the test suite together to build the same thing. The actual
      testing layer now doesn't need to worry about how the ServiceFactory
      for x gets made just that it is available.
    - Removes the need for a ControllerConfig suite that composes in the
      DQlite databases. They are now introduced by the ServiceFactorySuite.
      The controller config suite is now replaced with a database seeding
      function.
    - Moves the model uuid type out of the model manager and into the model
      domain. This allows better referencing. Have also introduced the
      stronger type into more places where we are describing model uuid's.
    - Adds testing functions for generating model uuids in tests.
    - Adds an assertion for opening testing databases with empty namespace
      id's. There are some places in the Juju code base where it is valid to
      have an empty model uuid to imply a third state. It's possible that
      during this migration we could send this to DQlite for opening a
      database and the subsequent error is very cryptic if we don't catch it
      before hand.
    - Adds a new bootstrap method for making models in a bootstrap context.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None at the moment. This is just plumbing for the time being.

## Documentation changes

N/A

## Bug reference

N/A

## Jira Ref
JUJU-4594
