### PR TITLE
Bootstrap k8s faster/cleaner by waiting for mongo tls key.

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -607,6 +607,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		`if [ $ipv6Disabled -eq 0 ]; then`,
 		`  args="${args} --ipv6"`,
 		`fi`,
+		`while [ ! -f "/var/lib/juju/server.pem" ]; do`,
+		`  echo "Waiting for /var/lib/juju/server.pem to be created..."`,
+		`  sleep 1`,
+		`done`,
 		`exec mongod ${args}`,
 		`'>/root/mongo.sh && chmod a+x /root/mongo.sh && /root/mongo.sh`,
 	}

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -17,11 +17,15 @@ cp /opt/jujud $JUJU_TOOLS_DIR/jujud
 
 	// MongoStartupShTemplate is used to generate the start script for mongodb.
 	MongoStartupShTemplate = `
-args="%s"
+args="%[1]s"
 ipv6Disabled=$(sysctl net.ipv6.conf.all.disable_ipv6 -n)
 if [ $ipv6Disabled -eq 0 ]; then
   args="${args} --ipv6"
 fi
+while [ ! -f "%[2]s" ]; do
+  echo "Waiting for %[2]s to be created..."
+  sleep 1
+done
 exec mongod ${args}
 `[1:]
 )


### PR DESCRIPTION
TLS key for mongo is generated by the api-server container during the bootstrap command, since the mongodb container starts up at the same time, this has the unfortunate side-effect of the mongodb container restarting many times until the tls key file exists. This change just simply waits for that file to exist first before starting mongodb.

## QA steps

Bootstrap k8s can check controller pod restart count is 0 and controller works.

## Documentation changes

N/A

## Bug reference

N/A