### PR TITLE
Fix k8s storage detaching hook during model/controller destruction.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2895,6 +2895,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	}
 	if m.Type() == ModelTypeCAAS {
 		ops = append(ops, u.removeCloudContainerOps()...)
+		ops = append(ops, newCleanupOp(cleanupDyingUnitResources, u.doc.Name, op.Force, op.MaxWait))
 	}
 	branchOps, err := unassignUnitFromBranchOp(u.doc.Name, a.doc.Name, m)
 	if err != nil {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -55,6 +55,7 @@ const (
 	cleanupMachinesForDyingModel cleanupKind = "modelMachines"
 
 	// CAAS models require storage to be cleaned up.
+	// TODO: should be renamed to something like deadCAASUnitResources.
 	cleanupDyingUnitResources cleanupKind = "dyingUnitResources"
 
 	cleanupResourceBlob          cleanupKind = "resourceBlob"

--- a/state/storage.go
+++ b/state/storage.go
@@ -480,9 +480,6 @@ func (sb *storageBackend) destroyStorageInstanceOps(
 	ops := []txn.Op{
 		newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id, force, maxWait),
 	}
-	if owner != nil && sb.modelType == ModelTypeCAAS {
-		ops = append(ops, newCleanupOp(cleanupDyingUnitResources, owner.Id(), force, maxWait))
-	}
 	ops = append(ops, validateRemoveOps...)
 	ops = append(ops, txn.Op{
 		C:      storageInstancesC,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils/v3/exec"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
+	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api/agent/uniter"
@@ -296,6 +297,14 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		errorString := "<unknown>"
 		if err != nil {
 			errorString = err.Error()
+		}
+		// If something else killed the tomb, then use that error.
+		if errors.Is(err, tomb.ErrDying) {
+			select {
+			case <-u.catacomb.Dying():
+				errorString = u.catacomb.Err().Error()
+			default:
+			}
 		}
 		if errors.Is(err, ErrCAASUnitDead) {
 			errorString = err.Error()


### PR DESCRIPTION
Destroying a k8s controller or model would immediately move unit storage attachments from alive to dying to dead/removed instead of just marking them as dying and letting the uniter remove the attachments gracefully.

This change makes model destruction to be more graceful on k8s units with storage attached, allowing them to correctly run their storage-detaching hooks.

The reason this is happening now is due to [this](https://github.com/juju/juju/pull/15313) fix for [this storage bug](https://bugs.launchpad.net/juju/+bug/2018147).

## QA steps

This should not work before this change and should cleanup correctly with this change.
```
$ juju bootstrap k8s
$ juju add-model a
$ juju deploy prometheus-k8s --trust
# wait for it to settle
$ juju destroy-controller k8s --destroy-all-models --destroy-storage # or release-storage
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2035058
