### PR TITLE
[JUJU-4595] Remove `--include-series` flag from export-bundle

### DIFF
--- a/api/client/bundle/client.go
+++ b/api/client/bundle/client.go
@@ -40,11 +40,10 @@ func (c *Client) GetChangesMapArgs(bundleURL, bundleDataYAML string) (params.Bun
 }
 
 // ExportBundle exports the current model configuration.
-func (c *Client) ExportBundle(includeDefaults bool, includeSeries bool) (string, error) {
+func (c *Client) ExportBundle(includeDefaults bool) (string, error) {
 	var result params.StringResult
 	arg := params.ExportBundleParams{
 		IncludeCharmDefaults: includeDefaults,
-		IncludeSeries:        includeSeries,
 	}
 	if err := c.facade.FacadeCall("ExportBundle", arg, &result); err != nil {
 		return "", errors.Trace(err)

--- a/api/client/bundle/client_test.go
+++ b/api/client/bundle/client_test.go
@@ -135,7 +135,7 @@ func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ExportBundle", args, res).SetArg(2, results).Return(nil)
 	client := bundle.NewClientFromCaller(mockFacadeCaller)
-	result, err := client.ExportBundle(true, false)
+	result, err := client.ExportBundle(true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, bundleStr)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -24,7 +24,7 @@ var FacadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      3,
 	"Block":                        2,
-	"Bundle":                       7,
+	"Bundle":                       8,
 	"CAASAgent":                    2,
 	"CAASAdmission":                1,
 	"CAASApplication":              1,

--- a/apiserver/facades/client/bundle/register.go
+++ b/apiserver/facades/client/bundle/register.go
@@ -13,17 +13,17 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Bundle", 7, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV7(ctx)
-	}, reflect.TypeOf((*APIv7)(nil)))
+	registry.MustRegister("Bundle", 8, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV8(ctx)
+	}, reflect.TypeOf((*APIv8)(nil)))
 }
 
-// newFacadeV7 provides the signature required for facade registration
-// for version 7.
-func newFacadeV7(ctx facade.Context) (*APIv7, error) {
+// newFacadeV8 provides the signature required for facade registration
+// for version 8.
+func newFacadeV8(ctx facade.Context) (*APIv8, error) {
 	api, err := newFacade(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv7{api}, nil
+	return &APIv8{api}, nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -5773,8 +5773,8 @@
     },
     {
         "Name": "Bundle",
-        "Description": "APIv7 provides the Bundle API facade for version 7. It drops GetChanges\nfrom the facade, which was deprecated in favour of GetChangesMapArgs. It\nalso drops series from GetChangesMapArgs",
-        "Version": 7,
+        "Description": "APIv8 provides the Bundle API facade for version 8. It drops IncludeSeries\nfrom ExportBundle params, and drops series entirely from ExportBundle output",
+        "Version": 8,
         "AvailableTo": [
             "controller-user",
             "model-user"
@@ -5904,9 +5904,6 @@
                     "type": "object",
                     "properties": {
                         "include-charm-defaults": {
-                            "type": "boolean"
-                        },
-                        "include-series": {
                             "type": "boolean"
                         }
                     },

--- a/apiserver/restrict_controller_test.go
+++ b/apiserver/restrict_controller_test.go
@@ -31,7 +31,7 @@ func (s *restrictControllerSuite) TestAllowed(c *gc.C) {
 	s.assertMethod(c, "ModelManager", modelManagerFacadeVersion, "CreateModel")
 	s.assertMethod(c, "ModelManager", modelManagerFacadeVersion, "ListModels")
 	s.assertMethod(c, "Pinger", pingerFacadeVersion, "Ping")
-	s.assertMethod(c, "Bundle", 7, "GetChangesMapArgs")
+	s.assertMethod(c, "Bundle", 8, "GetChangesMapArgs")
 	s.assertMethod(c, "HighAvailability", highAvailabilityFacadeVersion, "EnableHA")
 	s.assertMethod(c, "ApplicationOffers", 4, "ApplicationOffers")
 }

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -30,7 +30,6 @@ type exportBundleCommand struct {
 	newAPIFunc           func() (ExportBundleAPI, error)
 	Filename             string
 	includeCharmDefaults bool
-	includeSeries        bool
 }
 
 const exportBundleHelpDoc = `
@@ -38,17 +37,12 @@ Exports the current model configuration as a reusable bundle.
 
 If --filename is not used, the configuration is printed to stdout.
  --filename specifies an output file.
-
-If --include-series is used, the exported bundle will include the OS series
- alongside bases. This should be used as a compatibility option for older
- versions of Juju before bases were added.
 `
 
 const exportBundleHelpExamples = `
     juju export-bundle
     juju export-bundle --filename mymodel.yaml
     juju export-bundle --include-charm-defaults
-    juju export-bundle --include-series
 `
 
 // Info implements Command.
@@ -66,7 +60,6 @@ func (c *exportBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.StringVar(&c.Filename, "filename", "", "Bundle file")
 	f.BoolVar(&c.includeCharmDefaults, "include-charm-defaults", false, "Whether to include charm config default values in the exported bundle")
-	f.BoolVar(&c.includeSeries, "include-series", false, "Comaptibility option. Set to include series in the bundle alongside bases")
 }
 
 // Init implements Command.
@@ -77,7 +70,7 @@ func (c *exportBundleCommand) Init(args []string) error {
 // ExportBundleAPI specifies the used function calls of the BundleFacade.
 type ExportBundleAPI interface {
 	Close() error
-	ExportBundle(includeCharmDefaults bool, includeSeries bool) (string, error)
+	ExportBundle(includeCharmDefaults bool) (string, error)
 }
 
 func (c *exportBundleCommand) getAPIs() (ExportBundleAPI, error) {
@@ -97,7 +90,7 @@ func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
 	}
 	defer bundleClient.Close()
 
-	result, err := bundleClient.ExportBundle(c.includeCharmDefaults, c.includeSeries)
+	result, err := bundleClient.ExportBundle(c.includeCharmDefaults)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -87,7 +87,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store))
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false, false}},
+		{"ExportBundle", []interface{}{false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -130,7 +130,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false, false}},
+		{"ExportBundle", []interface{}{false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -164,7 +164,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false, false}},
+		{"ExportBundle", []interface{}{false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -180,23 +180,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleIncludeCharmDefaults(c *gc.C)
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--include-charm-defaults", "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{true, false}},
-	})
-
-	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
-	output, err := os.ReadFile(s.fakeBundle.filename)
-	c.Check(err, jc.ErrorIsNil)
-	c.Assert(string(output), gc.Equals, "fake-data")
-}
-
-func (s *ExportBundleCommandSuite) TestExportBundleIncludeSeries(c *gc.C) {
-	s.fakeBundle.filename = filepath.Join(c.MkDir(), "mymodel")
-	s.fakeBundle.result = "fake-data"
-	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.store), "--include-series", "--filename", s.fakeBundle.filename)
-	c.Assert(err, jc.ErrorIsNil)
-	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", []interface{}{false, true}},
+		{"ExportBundle", []interface{}{true}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -214,8 +198,8 @@ type fakeExportBundleClient struct {
 
 func (f *fakeExportBundleClient) Close() error { return nil }
 
-func (f *fakeExportBundleClient) ExportBundle(includeDefaults bool, includeSeries bool) (string, error) {
-	f.MethodCall(f, "ExportBundle", includeDefaults, includeSeries)
+func (f *fakeExportBundleClient) ExportBundle(includeDefaults bool) (string, error) {
+	f.MethodCall(f, "ExportBundle", includeDefaults)
 	if err := f.NextErr(); err != nil {
 		return "", err
 	}

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1094,7 +1094,6 @@ type LeaseOperationCommand struct {
 // ExportBundleParams holds parameters for exporting Bundles.
 type ExportBundleParams struct {
 	IncludeCharmDefaults bool `json:"include-charm-defaults,omitempty"`
-	IncludeSeries        bool `json:"include-series,omitempty"`
 }
 
 // BundleChangesParams holds parameters for making Bundle.GetChanges calls.


### PR DESCRIPTION
Drop the IncludeSeries option that was added as a compatibility option in 3.3. This means we can drop a load of code from the facade

This means we have to rev the facade version. Since we are still developing a major release, we can drop support for all but the latest facade

This is in line with the following spec:
https://docs.google.com/document/d/1WBuWD_nFu6KX4dW0UiOosp0MQhm89SIsnTGqxPLaBvk/edit?usp=sharing

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju export-bundle --include-series
ERROR option provided but not defined: --include-series
```

```
$ juju deploy ubuntu ubu1 --base ubuntu@20.04
$ juju deploy ubuntu ubu2 --base ubuntu@22.04
$ juju export-bundle
default-base: ubuntu@22.04/stable
applications:
  ubu1:
    charm: ubuntu
    channel: stable
    revision: 24
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
  ubu2:
    charm: ubuntu
    channel: stable
    revision: 24
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=amd64
    base: ubuntu@20.04/stable
  "1":
    constraints: arch=amd64
```