### PR TITLE
Compare strings with `strings.EqualFold`

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -51,7 +51,7 @@ func NewNetworkConfigAPI(st *state.State, getCanModify common.GetAuthFunc) (*Net
 	getModelOp := func(machine LinkLayerMachine, incoming network.InterfaceInfos) state.ModelOperation {
 		// We discover subnets via reported link-layer devices for the
 		// manual provider, which allows us to use spaces there.
-		return newUpdateMachineLinkLayerOp(machine, incoming, strings.ToLower(cloud.Type) == "manual", st)
+		return newUpdateMachineLinkLayerOp(machine, incoming, strings.EqualFold(cloud.Type, "manual"), st)
 	}
 
 	return &NetworkConfigAPI{

--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -202,7 +202,7 @@ func buildApplicationMatcherShims(a *state.Application, patterns ...string) (shi
 	// Match on name.
 	shims = append(shims, func() (bool, bool, error) {
 		for _, p := range patterns {
-			if strings.ToLower(a.Name()) == strings.ToLower(p) {
+			if strings.EqualFold(a.Name(), p) {
 				return true, true, nil
 			}
 		}

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -667,7 +667,7 @@ func queryCloudType(pollster *interact.Pollster) (string, error) {
 		// Print out a different message if they entered a valid provider that
 		// just isn't something we want people to add (like ec2).
 		for _, name := range unsupported {
-			if strings.ToLower(name) == strings.ToLower(s) {
+			if strings.EqualFold(name, s) {
 				return false, fmt.Sprintf("Cloud type %q not supported for interactive add-cloud.", s), nil
 			}
 		}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -369,7 +369,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 	// by cloud, by region
 	loaded := map[string]map[string]map[string]jujucloud.Credential{}
 	quit := func(in string) bool {
-		return strings.ToLower(in) == "q"
+		return strings.EqualFold(in, "q")
 	}
 	var localErr error
 	for {

--- a/cmd/juju/interact/pollster.go
+++ b/cmd/juju/interact/pollster.go
@@ -260,7 +260,7 @@ func VerifyOptions(singular string, options []string, hasDefault bool) VerifyFun
 			return hasDefault, "", nil
 		}
 		for _, opt := range options {
-			if strings.ToLower(opt) == strings.ToLower(s) {
+			if strings.EqualFold(opt, s) {
 				return true, "", nil
 			}
 		}

--- a/cmd/juju/interact/query.go
+++ b/cmd/juju/interact/query.go
@@ -75,7 +75,7 @@ func QueryVerify(question string, scanner *bufio.Scanner, out, errOut io.Writer,
 func MatchOptions(options []string, errmsg string) VerifyFunc {
 	return func(s string) (ok bool, msg string, err error) {
 		for _, opt := range options {
-			if strings.ToLower(opt) == strings.ToLower(s) {
+			if strings.EqualFold(opt, s) {
 				return true, "", nil
 			}
 		}
@@ -87,7 +87,7 @@ func MatchOptions(options []string, errmsg string) VerifyFunc {
 // matching option.  Found reports whether s was found in the options.
 func FindMatch(s string, options []string) (match string, found bool) {
 	for _, opt := range options {
-		if strings.ToLower(opt) == strings.ToLower(s) {
+		if strings.EqualFold(opt, s) {
 			return opt, true
 		}
 	}

--- a/cmd/juju/machine/upgrademachine.go
+++ b/cmd/juju/machine/upgrademachine.go
@@ -565,7 +565,7 @@ func checkSubCommands(validCommands []string, argCommand string) (string, error)
 
 func checkSeries(supportedSeries []string, seriesArgument string) (string, error) {
 	for _, s := range supportedSeries {
-		if s == strings.ToLower(seriesArgument) {
+		if strings.EqualFold(s, seriesArgument) {
 			return s, nil
 		}
 	}

--- a/cmd/output/yamlformatter.go
+++ b/cmd/output/yamlformatter.go
@@ -192,10 +192,7 @@ func (f *YamlFormatter) isComment() bool {
 }
 
 func (f *YamlFormatter) isValueBoolean() bool {
-	if (strings.ToLower(f.val) == "true") || (strings.ToLower(f.val) == "false") {
-		return true
-	}
-	return false
+	return strings.EqualFold(f.val, "true") || strings.EqualFold(f.val, "false")
 }
 
 func (f *YamlFormatter) isValueNumber() bool {

--- a/core/payloads/filter.go
+++ b/core/payloads/filter.go
@@ -57,24 +57,22 @@ func BuildPredicatesFor(patterns []string) ([]PayloadPredicate, error) {
 
 // Match determines if the given payload matches the pattern.
 func Match(payload FullPayloadInfo, pattern string) bool {
-	pattern = strings.ToLower(pattern)
-
 	switch {
-	case strings.ToLower(payload.Name) == pattern:
+	case strings.EqualFold(payload.Name, pattern):
 		return true
-	case strings.ToLower(payload.Type) == pattern:
+	case strings.EqualFold(payload.Type, pattern):
 		return true
-	case strings.ToLower(payload.ID) == pattern:
+	case strings.EqualFold(payload.ID, pattern):
 		return true
-	case strings.ToLower(payload.Status) == pattern:
+	case strings.EqualFold(payload.Status, pattern):
 		return true
-	case strings.ToLower(payload.Unit) == pattern:
+	case strings.EqualFold(payload.Unit, pattern):
 		return true
-	case strings.ToLower(payload.Machine) == pattern:
+	case strings.EqualFold(payload.Machine, pattern):
 		return true
 	default:
 		for _, tag := range payload.Labels {
-			if strings.ToLower(tag) == pattern {
+			if strings.EqualFold(tag, pattern) {
 				return true
 			}
 		}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -2170,7 +2170,7 @@ func (env *azureEnviron) getInstanceTypesLocked(ctx context.ProviderCallContext)
 			locationOk := false
 			if resource.Locations != nil {
 				for _, loc := range resource.Locations {
-					if strings.ToLower(toValue(loc)) == env.location {
+					if strings.EqualFold(toValue(loc), env.location) {
 						locationOk = true
 						break
 					}

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -286,7 +286,7 @@ func (z *lxdAvailabilityZone) Name() string {
 
 // Available implements AvailabilityZone.
 func (z *lxdAvailabilityZone) Available() bool {
-	return strings.ToLower(z.Status) == "online"
+	return strings.EqualFold(z.Status, "online")
 }
 
 // AvailabilityZones (ZonedEnviron) returns all availability zones in the


### PR DESCRIPTION
![image](https://github.com/micro/micro/assets/20135478/2ec249fc-c1f5-457a-8660-05c8e4284452)

This PR fixes a Staticcheck warning (https://staticcheck.dev/docs/checks/#SA6005). Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
func BenchmarkToLowerSingle(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != "foobar" {
			b.Fail()
		}
	}
}

func BenchmarkToLowerDouble(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("FOOBAR", "foobar") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/juju/juju
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToLowerSingle-16    	28793859	        77.18 ns/op	       8 B/op	       1 allocs/op
BenchmarkToLowerDouble-16    	12058461	        87.01 ns/op	       8 B/op	       1 allocs/op
BenchmarkEqualFold-16        	141907288	         7.937 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/juju/juju	5.897s
```

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
go test github.com/juju/juju/...
```
