### PR TITLE
Kill the controller once test passed;

### DIFF
--- a/tests/suites/secrets_k8s/task.sh
+++ b/tests/suites/secrets_k8s/task.sh
@@ -16,5 +16,7 @@ test_secrets_k8s() {
 	test_secrets
 	test_secret_drain
 
+	# Takes too long to tear down, so forcibly destroy it
+	export KILL_CONTROLLER=true
 	destroy_controller "test-secrets-k8s"
 }


### PR DESCRIPTION
Kill the controller once the test passes to shorten the test run.