### PR TITLE
Document some of the env vars in the Bash tests

### DIFF
--- a/tests/ENV.md
+++ b/tests/ENV.md
@@ -1,0 +1,14 @@
+The following is a list of environment variables that are used to control
+behaviour in the Bash tests. This list may not be complete, and as always, the
+definitive source is the code.
+
+| Variable name               | Description                                                                   |
+|-----------------------------|-------------------------------------------------------------------------------|
+| `BOOTSTRAP_ADDITIONAL_ARGS` | Additional arguments passed to `juju bootstrap`.                              |
+| `BOOTSTRAP_ARCH`            | Architecture to bootstrap on - passed to `--bootstrap-constraints`.           |
+| `BOOTSTRAP_REUSE`           | Reuse an existing controller when asked to bootstrap (true/false).            |
+| `BOOTSTRAP_REUSE_LOCAL`     | The name of a local controller to reuse for testing. Set using the `-l` flag. |
+| `KILL_CONTROLLER`           | If `'true'`, controllers will be forcibly killed during teardown.             |
+| `MODEL_ARCH`                | Will be set as a model constraint on newly added models.                      |
+| `OPERATOR_IMAGE_ACCOUNT`    | Passed as the value of `--config caas-image-repo` when bootstrapping.         |
+| `TEST_INSPECT`              | If set, pause before teardown to allow inspection of the controller.          |

--- a/tests/ENV.md
+++ b/tests/ENV.md
@@ -8,6 +8,7 @@ definitive source is the code.
 | `BOOTSTRAP_ARCH`            | Architecture to bootstrap on - passed to `--bootstrap-constraints`.           |
 | `BOOTSTRAP_REUSE`           | Reuse an existing controller when asked to bootstrap (true/false).            |
 | `BOOTSTRAP_REUSE_LOCAL`     | The name of a local controller to reuse for testing. Set using the `-l` flag. |
+| `BOOTSTRAP_SERIES`          | Series to use for the controller. Set using the `-S` flag.                    |
 | `KILL_CONTROLLER`           | If `'true'`, controllers will be forcibly killed during teardown.             |
 | `MODEL_ARCH`                | Will be set as a model constraint on newly added models.                      |
 | `OPERATOR_IMAGE_ACCOUNT`    | Passed as the value of `--config caas-image-repo` when bootstrapping.         |


### PR DESCRIPTION
There are a lot of environment variables used in the Bash test suite to control the behaviour of the test harness. Almost none of these are documented, and one has to dig into the code to find out what they do.

Document some of the environment variables for reference and easier discovery.