### PR TITLE
Bump balchua/microk8s-actions

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -44,7 +44,7 @@ jobs:
         sudo systemctl restart docker
         docker system info
 
-    - uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
+    - uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Setup MicroK8s
       if: matrix.cloud == 'microk8s'
-      uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
+      uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
       with:
         channel: "1.28/stable"
         addons: '["dns", "hostpath-storage", "rbac"]'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Setup k8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
-        uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
+        uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
         with:
           channel: "1.28/stable"
           addons: '["dns", "storage"]'


### PR DESCRIPTION
We are seeing intermittent failures on tests involving microk8s, due to an issue balchua/microk8s-actions#20 where the action is timing out waiting for storage to become available.

Update to the latest version, where the timeout has been increased to 15 minutes - hopefully this will alleviate this issue somewhat.