### PR TITLE
[JUJU-4624] Ensure storage bind mounts are idempotent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.14.0
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/oracle/oci-go-sdk/v47 v47.1.0
 	github.com/packethost/packngo v0.28.1
 	github.com/pkg/sftp v1.13.5

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
+github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -1196,6 +1198,7 @@ golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -48,14 +48,8 @@ func testDetachFilesystems(
 	mounted bool,
 	etcDir, fstab string,
 ) {
-	cmd := commands.expect("df", "--output=source", filepath.Dir(testMountPoint))
-	cmd.respond("headers\n/same/as/rootfs", nil)
-	cmd = commands.expect("df", "--output=source", testMountPoint)
 	if mounted {
-		cmd.respond("headers\n/different/to/rootfs", nil)
 		commands.expect("umount", testMountPoint)
-	} else {
-		cmd.respond("headers\n/same/as/rootfs", nil)
 	}
 
 	results, err := source.DetachFilesystems(callCtx, []storage.FilesystemAttachmentParams{{

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -59,7 +59,7 @@ func (lp *loopProvider) VolumeSource(sourceConfig *storage.Config) (storage.Volu
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
 	return &loopVolumeSource{
-		&osDirFuncs{lp.run},
+		&osDirFuncs{run: lp.run},
 		lp.run,
 		storageDir,
 	}, nil

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -50,7 +50,7 @@ func NewManagedFilesystemSource(
 ) storage.FilesystemSource {
 	return &managedFilesystemSource{
 		logAndExec,
-		&osDirFuncs{logAndExec},
+		&osDirFuncs{run: logAndExec},
 		volumeBlockDevices, filesystems,
 	}
 }

--- a/storage/provider/mountinfo.go
+++ b/storage/provider/mountinfo.go
@@ -1,0 +1,17 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build !linux
+
+package provider
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+	"github.com/moby/sys/mountinfo"
+)
+
+func getMountsFromReader(r io.Reader, filter mountinfo.FilterFunc) ([]*mountinfo.Info, error) {
+	return nil, errors.NotSupported
+}

--- a/storage/provider/mountinfo_linux.go
+++ b/storage/provider/mountinfo_linux.go
@@ -1,0 +1,10 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/moby/sys/mountinfo"
+)
+
+var getMountsFromReader = mountinfo.GetMountsFromReader

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -61,7 +61,7 @@ func (p *rootfsProvider) FilesystemSource(sourceConfig *storage.Config) (storage
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
 	return &rootfsFilesystemSource{
-		&osDirFuncs{p.run},
+		&osDirFuncs{run: p.run},
 		p.run,
 		storageDir,
 	}, nil

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -87,9 +87,9 @@ func (s *rootfsSuite) TestScope(c *gc.C) {
 	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
 }
 
-func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C) storage.FilesystemSource {
+func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C, fakeMountInfo ...string) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
-	source, d := provider.RootfsFilesystemSource(s.fakeEtcDir, s.storageDir, s.commands.run)
+	source, d := provider.RootfsFilesystemSource(s.fakeEtcDir, s.storageDir, s.commands.run, fakeMountInfo...)
 	s.mockDirFuncs = d
 	return source
 }
@@ -189,10 +189,7 @@ func (s *rootfsSuite) TestAttachFilesystemsNoPathSpecified(c *gc.C) {
 func (s *rootfsSuite) TestAttachFilesystemsBind(c *gc.C) {
 	source := s.rootfsFilesystemSource(c)
 
-	cmd := s.commands.expect("df", "--output=source", "/srv")
-	cmd.respond("headers\n/src/of/root", nil)
-
-	cmd = s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
+	cmd := s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
 	cmd.respond("", nil)
 
 	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
@@ -212,11 +209,52 @@ func (s *rootfsSuite) TestAttachFilesystemsBind(c *gc.C) {
 }
 
 func (s *rootfsSuite) TestAttachFilesystemsBound(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
-
 	// already bind-mounted storage-dir/6 to the target
-	cmd := s.commands.expect("df", "--output=source", "/srv")
-	cmd.respond("headers\n"+filepath.Join(s.storageDir, "6"), nil)
+	mountInfo := mountInfoLine(666, 0, filepath.Join(s.storageDir, "6"), "/srv", "/dev/sda1")
+	source := s.rootfsFilesystemSource(c, mountInfo)
+
+	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
+		Filesystem:   names.NewFilesystemTag("6"),
+		FilesystemId: "6",
+		Path:         "/srv",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []storage.AttachFilesystemsResult{{
+		FilesystemAttachment: &storage.FilesystemAttachment{
+			Filesystem: names.NewFilesystemTag("6"),
+			FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+				Path: "/srv",
+			},
+		},
+	}})
+}
+
+func (s *rootfsSuite) TestAttachFilesystemsBoundViaParent(c *gc.C) {
+	mountInfo1 := mountInfoLine(666, 667, filepath.Join("/some/parent/path", s.storageDir, "6"), "/srv", "/dev/sda1")
+	mountInfo2 := mountInfoLine(667, 668, "/some/parent/path", "/", "/dev/sda1")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2)
+
+	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
+		Filesystem:   names.NewFilesystemTag("6"),
+		FilesystemId: "6",
+		Path:         "/srv",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []storage.AttachFilesystemsResult{{
+		FilesystemAttachment: &storage.FilesystemAttachment{
+			Filesystem: names.NewFilesystemTag("6"),
+			FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+				Path: "/srv",
+			},
+		},
+	}})
+}
+
+func (s *rootfsSuite) TestAttachFilesystemsBoundViaMultipleParents(c *gc.C) {
+	mountInfo1 := mountInfoLine(666, 667, filepath.Join("/some/parent/path", s.storageDir, "6"), "/srv", "/dev/sda1")
+	mountInfo2 := mountInfoLine(667, 668, "/some/parent/path", "/another/parent/path", "/dev/sda1")
+	mountInfo3 := mountInfoLine(668, 669, "/another/parent/path", "/", "/dev/sda1")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2, mountInfo3)
 
 	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("6"),
@@ -235,19 +273,12 @@ func (s *rootfsSuite) TestAttachFilesystemsBound(c *gc.C) {
 }
 
 func (s *rootfsSuite) TestAttachFilesystemsBindFailsDifferentFS(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
+	mountInfo1 := mountInfoLine(666, 0, "/somewhere", filepath.Join(s.storageDir, "6"), "/dev")
+	mountInfo2 := mountInfoLine(667, 0, "/src/of/root", "/srv", "/proc")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2)
 
-	cmd := s.commands.expect("df", "--output=source", "/srv")
-	cmd.respond("headers\n/src/of/root", nil)
-
-	cmd = s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
+	cmd := s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
 	cmd.respond("", errors.New("mount --bind fails"))
-
-	cmd = s.commands.expect("df", "--output=target", filepath.Join(s.storageDir, "6"))
-	cmd.respond("headers\n/dev", nil)
-
-	cmd = s.commands.expect("df", "--output=target", "/srv")
-	cmd.respond("headers\n/proc", nil)
 
 	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("6"),
@@ -259,19 +290,12 @@ func (s *rootfsSuite) TestAttachFilesystemsBindFailsDifferentFS(c *gc.C) {
 }
 
 func (s *rootfsSuite) TestAttachFilesystemsBindSameFSEmptyDir(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
+	mountInfo1 := mountInfoLine(666, 0, "/somewhere", filepath.Join(s.storageDir, "6"), "/dev")
+	mountInfo2 := mountInfoLine(667, 0, "/src/of/root", "/srv", "/dev")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2)
 
-	cmd := s.commands.expect("df", "--output=source", "/srv")
-	cmd.respond("headers\n/src/of/root", nil)
-
-	cmd = s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
+	cmd := s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv")
 	cmd.respond("", errors.New("mount --bind fails"))
-
-	cmd = s.commands.expect("df", "--output=target", filepath.Join(s.storageDir, "6"))
-	cmd.respond("headers\n/dev", nil)
-
-	cmd = s.commands.expect("df", "--output=target", "/srv")
-	cmd.respond("headers\n/dev", nil)
 
 	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("6"),
@@ -290,19 +314,12 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSEmptyDir(c *gc.C) {
 }
 
 func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirUnclaimed(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
+	mountInfo1 := mountInfoLine(666, 0, "/somewhere", filepath.Join(s.storageDir, "6"), "/dev")
+	mountInfo2 := mountInfoLine(667, 0, "/src/of/root", "/srv/666", "/dev")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2)
 
-	cmd := s.commands.expect("df", "--output=source", "/srv/666")
-	cmd.respond("headers\n/src/of/root", nil)
-
-	cmd = s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv/666")
+	cmd := s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv/666")
 	cmd.respond("", errors.New("mount --bind fails"))
-
-	cmd = s.commands.expect("df", "--output=target", filepath.Join(s.storageDir, "6"))
-	cmd.respond("headers\n/dev", nil)
-
-	cmd = s.commands.expect("df", "--output=target", "/srv/666")
-	cmd.respond("headers\n/dev", nil)
 
 	results, err := source.AttachFilesystems(s.callCtx, []storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("6"),
@@ -314,19 +331,12 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirUnclaimed(c *gc.
 }
 
 func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
+	mountInfo1 := mountInfoLine(666, 0, "/somewhere", filepath.Join(s.storageDir, "6"), "/dev")
+	mountInfo2 := mountInfoLine(667, 0, "/src/of/root", "/srv/666", "/dev")
+	source := s.rootfsFilesystemSource(c, mountInfo1, mountInfo2)
 
-	cmd := s.commands.expect("df", "--output=source", "/srv/666")
-	cmd.respond("headers\n/src/of/root", nil)
-
-	cmd = s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv/666")
+	cmd := s.commands.expect("mount", "--bind", filepath.Join(s.storageDir, "6"), "/srv/666")
 	cmd.respond("", errors.New("mount --bind fails"))
-
-	cmd = s.commands.expect("df", "--output=target", filepath.Join(s.storageDir, "6"))
-	cmd.respond("headers\n/dev", nil)
-
-	cmd = s.commands.expect("df", "--output=target", "/srv/666")
-	cmd.respond("headers\n/dev", nil)
 
 	s.mockDirFuncs.Dirs.Add(filepath.Join(s.storageDir, "6", "juju-target-claimed"))
 
@@ -347,7 +357,8 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C)
 }
 
 func (s *rootfsSuite) TestDetachFilesystems(c *gc.C) {
-	source := s.rootfsFilesystemSource(c)
+	mountInfo := mountInfoLine(666, 0, "/src/of/root", testMountPoint, "/dev/sda1")
+	source := s.rootfsFilesystemSource(c, mountInfo)
 	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, "")
 }
 

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -63,7 +63,7 @@ func (p *tmpfsProvider) FilesystemSource(sourceConfig *storage.Config) (storage.
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
 	return &tmpfsFilesystemSource{
-		&osDirFuncs{p.run},
+		&osDirFuncs{run: p.run},
 		p.run,
 		storageDir,
 	}, nil

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -176,7 +176,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 				// set the status to "error" for permanent errors.
 				entityStatus.Status = status.Attaching.String()
 				entityStatus.Info = result.Error.Error()
-				ctx.config.Logger.Debugf(
+				ctx.config.Logger.Warningf(
 					"failed to attach %s to %s: %v",
 					names.ReadableString(p.Volume),
 					names.ReadableString(p.Machine),


### PR DESCRIPTION
Juju uses a bind mount to attach filesystem charm storage. This is supposed to be idempotent, but the method to detect if the bind mount already exists was flawed. It was using `df` which just didn't work. This PR changes that to look at the content of the `/proc/self/mountinfo` file instead. Each entry in that file possibly contains a parent record so fully resolving the source of a target mount point involves taking account of any parent mounts as well. The crux of the changes are `mountPoint() and `mountPointSource()` in `dirfuncs`.

## QA steps

Deploy a charm with filesystem storage that does and does not specify a location for the storage mount.
eg
```
  cache:
    type: filesystem
  pgdata:
    type: filesystem
    location: /srv/pgdata
```

Deploy 3 times, each time using either rootfs, tmpfs, or provider attached storage.

`juju deploy somecharm app1 --storage pgdata=rootfs --storage cache=rootfs`
`juju deploy somecharm app2 --storage pgdata=tmpfs --storage cache=tmpfs`
`juju deploy somecharm app3 --storage pgdata=ebs --storage cache=ebs`

Check that the storage is attached correctly via juju status and juju storage.

Restart the controller agent and look in `/proc/self/mountinfo` to ensure that there's no duplicate entries.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830228
