### PR TITLE
Remove deployedBase from refresher.

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -33,7 +33,6 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
@@ -408,17 +407,12 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	chBase, err := corebase.ParseBase(applicationInfo.Base.Name, applicationInfo.Base.Channel)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	cfg := refresher.RefresherConfig{
 		ApplicationName: c.ApplicationName,
 		CharmURL:        oldURL,
 		CharmOrigin:     oldOrigin.CoreCharmOrigin(),
 		CharmRef:        newRef,
 		Channel:         c.Channel,
-		DeployedBase:    chBase,
 		Force:           c.Force,
 		ForceBase:       c.ForceBase,
 		Switch:          c.SwitchURL != "",

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -71,6 +71,9 @@ type BaseRefreshSuite struct {
 	resourceLister       mockResourceLister
 	spacesClient         mockSpacesClient
 	downloadBundleClient mockDownloadBundleClient
+
+	testPlatform corecharm.Platform
+	testBase     corebase.Base
 }
 
 func (s *BaseRefreshSuite) runRefresh(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -97,6 +100,9 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 	// Create persistent cookies in a temporary location.
 	cookieFile := filepath.Join(c.MkDir(), "cookies")
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookieFile)
+
+	s.testPlatform = corecharm.MustParsePlatform("amd64/ubuntu/22.04")
+	s.testBase = corebase.MakeDefaultBase("ubuntu", "22.04")
 
 	s.deployResources = func(
 		applicationID string,
@@ -150,9 +156,11 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 			"": network.AlphaSpaceName,
 		},
 		charmOrigin: commoncharm.Origin{
-			ID:     "testing",
-			Source: schemaToOriginScource(currentCharmURL.Schema),
-			Risk:   "stable",
+			ID:           "testing",
+			Source:       schemaToOriginScource(currentCharmURL.Schema),
+			Risk:         "stable",
+			Architecture: arch.DefaultArchitecture,
+			Base:         s.testBase,
 		},
 	}
 	s.modelConfigGetter = newMockModelConfigGetter()
@@ -249,9 +257,11 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		StorageConstraints: map[string]storage.Constraints{
@@ -277,9 +287,11 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettingsYAML: "foo:{}",
@@ -298,9 +310,11 @@ func (s *RefreshSuite) TestConfigSettingsWithTrust(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{"trust": "true", "foo": "bar"},
@@ -318,9 +332,11 @@ func (s *RefreshSuite) TestConfigSettingsWithTrustFalse(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{"trust": "false", "foo": "bar"},
@@ -343,9 +359,11 @@ func (s *RefreshSuite) TestConfigSettingsWithKeyValuesAndFile(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettingsYAML: "foo:{}",
@@ -389,9 +407,11 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -627,7 +647,8 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 	})
 	origin.ID = "testing"
 	origin.Revision = (*int)(nil)
-	origin.Architecture = ""
+	origin.Architecture = arch.DefaultArchitecture
+	origin.Base = s.testBase
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -635,9 +656,11 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "beta",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "beta",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -660,9 +683,11 @@ func (s *RefreshSuite) TestUpgradeWithChannelNoNewCharmURL(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "beta",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "beta",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -676,10 +701,9 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Beta}, corecharm.Platform{})
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Beta}, s.testPlatform)
 	origin.ID = "testing"
 	origin.Revision = (*int)(nil)
-	origin.Architecture = ""
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -687,9 +711,11 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "beta",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "beta",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -713,7 +739,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	s.charmClient.CheckCallNames(c, "CharmInfo", "CharmInfo")
 	s.charmClient.CheckCall(c, 0, "CharmInfo", s.resolvedCharmURL.String())
 	s.charmAdder.CheckCallNames(c, "CheckCharmPlacement", "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Stable}, corecharm.Platform{})
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Stable}, s.testPlatform)
 
 	parsedSwitchUrl, err := charm.ParseURL("ch:trusty/anotherriak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -729,6 +755,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 				Source:       "charm-hub",
 				Architecture: arch.DefaultArchitecture,
 				Risk:         "stable",
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -967,9 +994,11 @@ func (s *RefreshSuite) TestUpgradeSameVersionWithResourceUpload(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				ID:     "testing",
-				Source: "charm-hub",
-				Risk:   "stable",
+				ID:           "testing",
+				Source:       "charm-hub",
+				Risk:         "stable",
+				Architecture: arch.DefaultArchitecture,
+				Base:         s.testBase,
 			},
 		},
 		ConfigSettings:   map[string]string{},
@@ -1027,9 +1056,11 @@ func (s *RefreshCharmHubSuite) TestUpgradeResourceRevision(c *gc.C) {
 	s.CheckCall(c, 9, "DeployResources", "foo", resources.CharmID{
 		URL: s.resolvedCharmURL,
 		Origin: commoncharm.Origin{
-			ID:     "testing",
-			Source: "charm-hub",
-			Risk:   "stable"}},
+			ID:           "testing",
+			Source:       "charm-hub",
+			Risk:         "stable",
+			Architecture: arch.DefaultArchitecture,
+			Base:         s.testBase}},
 		map[string]string(nil),
 		map[string]charmresource.Meta{"bar": {Name: "bar", Type: charmresource.TypeFile}},
 	)
@@ -1068,9 +1099,11 @@ func (s *RefreshCharmHubSuite) TestUpgradeResourceRevisionSupplied(c *gc.C) {
 	s.CheckCall(c, 9, "DeployResources", "foo", resources.CharmID{
 		URL: s.resolvedCharmURL,
 		Origin: commoncharm.Origin{
-			ID:     "testing",
-			Source: "charm-hub",
-			Risk:   "stable"}},
+			ID:           "testing",
+			Source:       "charm-hub",
+			Risk:         "stable",
+			Architecture: arch.DefaultArchitecture,
+			Base:         s.testBase}},
 		map[string]string{"bar": "3"},
 		map[string]charmresource.Meta{"bar": {Name: "bar", Type: charmresource.TypeFile}},
 	)


### PR DESCRIPTION
With juju 3.x, all applications have a charm origin with the correct operating system and architecture. One source of truth for the operating system the application is deployed on is best, no need to have 2 in the refresh code. In juju 2.9, it was necessary for compatibility with older controllers which didn't understand charm origins.

## QA steps

Deploy both charm hub and local charms, then refresh them. There should be no change in functionality.

## Additional Info
JUJU-4626