### PR TITLE
Bug: fix refresh by revision for charm hub charms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,8 @@ go-install: $(INSTALL_TARGETS)
 .PHONY: clean
 clean:
 ## clean: Clean the cache and test caches
-	go clean -n -r --cache --testcache $(PROJECT)/...
+	go clean -r --cache --testcache
+	go clean $(PROJECT)/...
 
 .PHONY: vendor-dependencies
 vendor-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -359,8 +359,8 @@ go-install: $(INSTALL_TARGETS)
 .PHONY: clean
 clean:
 ## clean: Clean the cache and test caches
-	go clean -r --cache --testcache
-	go clean $(PROJECT)/...
+	go clean -x --cache --testcache
+	go clean -x -r $(PROJECT)/...
 
 .PHONY: vendor-dependencies
 vendor-dependencies:

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -431,8 +431,10 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		DeployedBase:    chBase,
 		Force:           c.Force,
 		ForceSeries:     c.ForceSeries,
-		Switch:          c.SwitchURL != "",
-		Logger:          ctx,
+		// If revision is supplied by the user, treat it as a switch operation,
+		// the revision has already been added to the "newRef" above.
+		Switch: c.SwitchURL != "" || c.Revision != -1,
+		Logger: ctx,
 	}
 	factory, err := c.getRefresherFactory(apiRoot)
 	if err != nil {

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -141,6 +141,39 @@ run_refresh_channel_no_new_revision() {
 	destroy_model "${model_name}"
 }
 
+run_refresh_revision() {
+	# Test juju refresh from revision to another
+	echo
+
+	model_name="test-refresh-revision"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-test --revision 22 --channel stable --series focal
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	# refresh to a revision not at the tip of the stable channel
+	juju refresh juju-qa-test --revision 23
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "23")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	# do a generic refresh, should pick up revision from latest stable
+	OUT=$(juju refresh juju-qa-test 2>&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	destroy_model "${model_name}"
+}
+
 test_basic() {
 	if [ "$(skip 'test_basic')" ]; then
 		echo "==> TEST SKIPPED: basic refresh"
@@ -157,5 +190,6 @@ test_basic() {
 		run "run_refresh_local_resources"
 		run "run_refresh_channel"
 		run "run_refresh_channel_no_new_revision"
+		run "run_refresh_revision"
 	)
 }


### PR DESCRIPTION
This is a patch for juju 2.9 to fix juju refresh by revision for charm hub charms, utilizing the `--revision` flag, based on a workaround found in the bug. The workaround was to supply a full charmurl including the new revision via the `--switch` flag. 

The real fix will involve correctly modeling both deploy and refresh actions for charm hub charms within juju and not using ResolveCharm as it is today. Today charm hub and charm store charms share ResolveCharm in both deploy and refresh code paths and it's very difficult to separate them out. In juju 3.1+, charm store charms are no longer supported by juju. As well the juju 3.1 client does not support versions prior to juju 2.9 which have no knowledge of charm hub charms.

To correctly model the refresh action, we must send both the actual current values for the application end the requested values if they have changed to charm hub.

There is a drive by to update the clean target of the Makefile, I'm tired of it not working with go 1.20.x

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ make clean
```

Test charm hub charms
```sh
# revision 23 is the tip of 2.0/stable
$ juju deploy juju-qa-test --revision 22 --channel stable --series focal
# wait for refresh to complete and settle, verify revision 22
# revision 23 is the tip of 2.0/edge
$ juju refresh again --revision 23
# wait for refresh to complete and settle, verify revision 23
$ juju refresh again
# should be at revision 26, the tip of stable
```

Ensure charm store charms aren't broken here.
```sh
$ juju deploy cs:ubuntu-20 --series focal
$ juju refresh ubuntu --revision 21
$ juju refresh ubuntu
# should be at revision 24, the latest
```

```sh
$ (cd tests ; ./main.sh -v refresh)
```

## Links

https://bugs.launchpad.net/juju/+bug/1988556

JUJU-4602
