### PR TITLE
Use docker cache/mirror on aws runners.

### DIFF
--- a/.github/microk8s-juju-2.8-fix.yaml
+++ b/.github/microk8s-juju-2.8-fix.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: kube-system
+  name: juju-credential-microk8s
+  labels:
+    juju-credential: microk8s
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+- nonResourceURLs: ["*"]
+  verbs: ["*"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kube-system
+  name: juju-credential-microk8s
+  labels:
+    juju-credential: microk8s
+secrets:
+- kind: Secret
+  name: juju-credential-microk8s
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: kube-system
+  name: juju-credential-microk8s
+  labels:
+    juju-credential: microk8s
+subjects:
+- kind: ServiceAccount
+  name: juju-credential-microk8s
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: juju-credential-microk8s
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: kube-system
+  name: juju-credential-microk8s
+  labels:
+    juju-credential: microk8s
+  annotations:
+    kubernetes.io/service-account.name: juju-credential-microk8s
+type: kubernetes.io/service-account-token

--- a/.github/microk8s-launch-config-aws.yaml
+++ b/.github/microk8s-launch-config-aws.yaml
@@ -10,3 +10,8 @@ containerdRegistryConfigs:
     [host."http://10.0.1.123:80"]
       capabilities = ["pull", "resolve"]
       skip_verify = true
+  10.152.183.69: |
+    [host."https://10.152.183.69:443"]
+      capabilities = ["pull", "resolve", "push"]
+      skip_verify = true
+  

--- a/.github/microk8s-launch-config-aws.yaml
+++ b/.github/microk8s-launch-config-aws.yaml
@@ -1,0 +1,12 @@
+---
+version: 0.1.0
+extraKubeletArgs:
+  --cluster-domain: cluster.local
+  --cluster-dns: 10.152.183.10
+addons:
+  - name: dns
+containerdRegistryConfigs:
+  docker.io: |
+    [host."http://10.0.1.123:80"]
+      capabilities = ["pull", "resolve"]
+      skip_verify = true

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        microk8s: [1.21/stable]
+        microk8s: [1.28/stable]
 
     steps:
     - name: Checking out repo
@@ -37,11 +37,19 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
+    - name: Setup Docker Mirror
+      shell: bash
+      run: |
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+        docker system info
+
     - uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.
         addons: '["dns", "storage", "dashboard", "ingress", "metallb:10.64.140.43-10.64.140.49"]'
+        launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -42,12 +42,20 @@ jobs:
       if: matrix.cloud == 'localhost'
       uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
+    - name: Setup Docker Mirror
+      shell: bash
+      run: |
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+        docker system info
+
     - name: Setup MicroK8s
       if: matrix.cloud == 'microk8s'
       uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
       with:
-        channel: "1.25/stable"
+        channel: "1.28/stable"
         addons: '["dns", "hostpath-storage", "rbac"]'
+        launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -78,12 +78,21 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
+      - name: Setup Docker Mirror
+        if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
+        shell: bash
+        run: |
+          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker system info
+
       - name: Setup k8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
         uses: balchua/microk8s-actions@1e8e626239c2befe7cd5d258c96ae152a7259c74
         with:
-          channel: "1.23/stable"
+          channel: "1.28/stable"
           addons: '["dns", "storage"]'
+          launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
       - name: Setup local caas registry
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
@@ -174,6 +183,7 @@ jobs:
           set -euxo pipefail
           
           sg microk8s <<EOF
+            microk8s.kubectl apply -f "$GITHUB_WORKSPACE/.github/microk8s-juju-2.8-fix.yaml"
             juju bootstrap microk8s c \
               --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
               --config features="[developer-mode]"

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           set -euxo pipefail
           sudo snap install snapcraft --classic
-          sudo snap install yq
           sudo snap install juju --classic --channel=${{ matrix.snap_version }}
           echo "/snap/bin" >> $GITHUB_PATH
 
@@ -45,8 +44,8 @@ jobs:
         if: env.RUN_TEST == 'RUN'
         uses: actions/checkout@v3
 
-        # We use LXD in the microk8s test too, to build the snap.
       - name: Setup LXD
+        if: env.RUN_TEST == 'RUN' && matrix.model_type == 'localhost'
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
         with:
           channel: 4.0/candidate
@@ -83,6 +82,7 @@ jobs:
         shell: bash
         run: |
           (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json ".insecure-registries += [\"${DOCKER_REGISTRY}\"]" | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker system info
 
@@ -109,23 +109,15 @@ jobs:
           # Recognise CA
           sudo cp ~/certs/ca.crt /usr/local/share/ca-certificates
           sudo update-ca-certificates
-          
-          sudo mkdir -p /etc/docker/certs.d/${DOCKER_REGISTRY}/
-          sudo cp ~/certs/ca.crt /etc/docker/certs.d/${DOCKER_REGISTRY}/
-          
+                    
           # Generate certs
           openssl req -nodes -newkey rsa:2048 -keyout ~/certs/registry.key -out ~/certs/registry.csr -subj "/CN=registry"
           
           openssl x509 -req -in ~/certs/registry.csr -CA ~/certs/ca.crt -CAkey ~/certs/ca.key \
-            -out ~/certs/registry.crt -CAcreateserial -days 365 -sha256 -extfile .github/registry.ext
+            -out ~/certs/registry.crt -CAcreateserial -days 365 -sha256 -extfile $GITHUB_WORKSPACE/.github/registry.ext
           
           # Deploy registry
-          cat .github/reg.yml | CERT_DIR=$HOME/certs envsubst | sg microk8s "microk8s kubectl create -f -"
-          
-          # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
-          sudo microk8s refresh-certs --cert ca.crt
-          sudo microk8s refresh-certs --cert server.crt
-          sg microk8s "microk8s status --wait-ready"
+          cat $GITHUB_WORKSPACE/.github/reg.yml | CERT_DIR=$HOME/certs envsubst | sg microk8s "microk8s kubectl create -f -"
           
           # Wait for registry
           sg microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true
@@ -200,12 +192,7 @@ jobs:
       - name: Add `wait-for` plugin
         shell: bash
         run: |
-          # Download a stable version of Juju
-          curl -L -O https://github.com/juju/juju/archive/refs/tags/juju-2.9.29.tar.gz
-          tar -xf juju-2.9.29.tar.gz
-          cd juju-juju-2.9.29/
           go install github.com/juju/juju/cmd/plugins/juju-wait-for
-          cd ..
 
       - name: Deploy some applications
         if: env.RUN_TEST == 'RUN'
@@ -225,21 +212,17 @@ jobs:
           
           juju wait-for application ${CHARM_${{ matrix.model_type }}}
           
-          .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
+          $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
-      - name: Build snap
+      - name: Install local juju
         if: env.RUN_TEST == 'RUN'
         shell: bash
         run: |
           set -euxo pipefail
-          snapcraft --use-lxd
-
-      - name: Install snap
-        if: env.RUN_TEST == 'RUN'
-        shell: bash
-        run: |
-          set -euxo pipefail
-          sudo snap install juju*.snap --dangerous --classic
+          which juju
+          sudo snap remove juju --purge
+          make install
+          which juju
 
       - name: Build jujud image
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
@@ -295,17 +278,10 @@ jobs:
           
           # Upgrade to the latest stable.
           juju upgrade-controller --debug
-          .github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
           
-          make go-install
-          $GOPATH/bin/juju upgrade-controller --build-agent --debug
-          .github/verify-agent-version.sh "${UPSTREAM_JUJU_TAG}.1"
-          rm -rf $GOPATH/bin/juju*
-          
-          # Upgrade to local built snap version - upload snap jujud.
-          snap_version=$(juju version | cut -d '-' -f 1);
-          juju upgrade-controller --agent-version $snap_version
-          .github/verify-agent-version.sh "${UPSTREAM_JUJU_TAG}.2"
+          juju upgrade-controller --build-agent --debug
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh "${UPSTREAM_JUJU_TAG}.1"
           
           PANIC=$(juju debug-log --replay --no-tail -m controller | grep "panic" || true)
           if [ "$PANIC" != "" ]; then
@@ -314,7 +290,7 @@ jobs:
               exit 1
           fi
           
-          .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
+          $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
       - name: Test upgrade controller - microk8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
@@ -327,11 +303,11 @@ jobs:
           
           # Upgrade to the latest stable.
           juju upgrade-controller --debug
-          .github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
           
           # Upgrade to local built version.
           juju upgrade-controller --agent-stream=develop --debug
-          .github/verify-agent-version.sh $UPSTREAM_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $UPSTREAM_JUJU_TAG
           
           PANIC=$(juju debug-log --replay --no-tail -m controller | grep "panic" || true)
           if [ "$PANIC" != "" ]; then
@@ -340,7 +316,7 @@ jobs:
               exit 1
           fi
           
-          .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
+          $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
       - name: Test upgrade model
         if: env.RUN_TEST == 'RUN'
@@ -379,7 +355,7 @@ jobs:
             exit 1
           fi
           
-          .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
+          $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
       - name: Wrap up
         if: env.RUN_TEST == 'RUN'


### PR DESCRIPTION
Due to docker.io rate limiting, we need to use a [pull-through cache](https://docs.docker.com/registry/recipes/mirror/) to provide docker.io images. 

Adding the pull-through cache is done here via a microk8s launch config and modifying the dockerd config. 10.0.1.123 is the hard coded address for the cache in the vpc. Containerd should fallback to docker.io if it is dead.

Additionally, to use the launch configuration, microk8s 1.27 or higher is required. So this requires a little bit of hacking just for juju 2.8 to bootstrap for the microk8s upgrade job (slight changes in creating k8s service account secrets). This will be simplified in the newer versions of juju.

This PR includes a slight simplification of the upgrade tests to not build the snap. This is much to heavy for a PR run.

## QA steps

All the action jobs should pass.

## Links

https://microk8s.io/docs/dockerhub-limits
https://docs.docker.com/registry/recipes/mirror/
https://github.com/containerd/containerd/blob/main/docs/hosts.md