### PR TITLE
Add controllercharm facade

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasagent"
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
+	"github.com/juju/juju/apiserver/facades/agent/controllercharm"
 	"github.com/juju/juju/apiserver/facades/agent/credentialvalidator"
 	"github.com/juju/juju/apiserver/facades/agent/deployer"
 	"github.com/juju/juju/apiserver/facades/agent/diskmanager"
@@ -147,6 +148,7 @@ func AllFacades() *facade.Registry {
 	caasunitprovisioner.Register(registry)
 
 	controller.Register(registry)
+	controllercharm.Register(registry)
 	crossmodelrelations.Register(registry)
 	crossmodelsecrets.Register(registry)
 	crosscontroller.Register(registry)

--- a/apiserver/facades/agent/controllercharm/controllercharm.go
+++ b/apiserver/facades/agent/controllercharm/controllercharm.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllercharm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
+)
+
+const (
+	// JujuMetricsUserPrefix defines the "namespace" in which this facade is
+	// allowed to create/remove users.
+	JujuMetricsUserPrefix = "juju-metrics-"
+
+	// UserCreator is the listed "creator" of metrics users in state.
+	UserCreator = "admin"
+)
+
+// API provides API methods to the controllercharm worker.
+type API struct {
+	state backend
+}
+
+// backend defines the state methods that API needs.
+type backend interface {
+	AddUser(name string, displayName string, password string, creator string) (*state.User, error)
+	RemoveUser(tag names.UserTag) error
+	Model() (model, error)
+}
+
+// model defines the model methods that API needs.
+type model interface {
+	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
+}
+
+// stateShim allows the real state to implement backend.
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Model() (model, error) {
+	return s.State.Model()
+}
+
+// AddMetricsUser creates a user with the given username and password, and
+// grants the new user permission to read the metrics endpoint.
+func (api *API) AddMetricsUser(args params.AddUsers) (params.AddUserResults, error) {
+	var results params.AddUserResults
+	for _, user := range args.Users {
+		err := api.addMetricsUser(user)
+		results.Results = append(results.Results, params.AddUserResult{
+			Tag:   user.Username, // TODO: should we populate this in the error case?
+			Error: apiservererrors.ServerError(err),
+		})
+	}
+	return results, nil
+}
+
+func (api *API) addMetricsUser(args params.AddUser) error {
+	if !strings.HasPrefix(args.Username, JujuMetricsUserPrefix) {
+		return errors.NotValidf("username %q missing prefix %q", args.Username, JujuMetricsUserPrefix)
+	}
+
+	if args.Password == "" {
+		return errors.NotValidf("empty password for user %q", args.Username)
+	}
+
+	_, err := api.state.AddUser(args.Username, args.DisplayName, args.Password, UserCreator)
+	if err != nil {
+		return errors.Annotatef(err, "failed to create user %q", args.Username)
+	}
+
+	model, err := api.state.Model()
+	if err != nil {
+		return errors.Annotatef(err, "retrieving current model")
+	}
+
+	userTag := names.NewUserTag(args.Username)
+	_, err = model.AddUser(state.UserAccessSpec{
+		User:      userTag,
+		CreatedBy: names.NewUserTag(UserCreator),
+		Access:    permission.ReadAccess,
+	})
+	return errors.Annotatef(err, "adding user %q to model %q",
+		args.Username, bootstrap.ControllerModelName)
+}
+
+// RemoveMetricsUser removes the given user from the controller.
+func (api *API) RemoveMetricsUser(entities params.Entities) (params.ErrorResults, error) {
+	var results params.ErrorResults
+	for _, e := range entities.Entities {
+		err := api.removeMetricsUser(e)
+		results.Results = append(results.Results, params.ErrorResult{
+			Error: apiservererrors.ServerError(err),
+		})
+	}
+	return results, nil
+}
+
+func (api *API) removeMetricsUser(e params.Entity) error {
+	user, err := names.ParseUserTag(e.Tag)
+	if err != nil {
+		return errors.Annotatef(err, "couldn't parse user tag %q", e.Tag)
+	}
+
+	if !strings.HasPrefix(user.Name(), JujuMetricsUserPrefix) {
+		return fmt.Errorf("username %q should have prefix %q", user.Name(), JujuMetricsUserPrefix)
+	}
+
+	err = api.state.RemoveUser(user)
+	if err != nil && !errors.Is(err, errors.UserNotFound) {
+		return errors.Annotatef(err, "failed to delete user %q", user.Name())
+	}
+	return nil
+}

--- a/apiserver/facades/agent/controllercharm/controllercharm.go
+++ b/apiserver/facades/agent/controllercharm/controllercharm.go
@@ -18,12 +18,12 @@ import (
 )
 
 const (
-	// JujuMetricsUserPrefix defines the "namespace" in which this facade is
+	// jujuMetricsUserPrefix defines the "namespace" in which this facade is
 	// allowed to create/remove users.
-	JujuMetricsUserPrefix = "juju-metrics-"
+	jujuMetricsUserPrefix = "juju-metrics-"
 
-	// UserCreator is the listed "creator" of metrics users in state.
-	UserCreator = "admin"
+	// userCreator is the listed "creator" of metrics users in state.
+	userCreator = "admin"
 )
 
 // API provides API methods to the controllercharm worker.
@@ -59,7 +59,7 @@ func (api *API) AddMetricsUser(args params.AddUsers) (params.AddUserResults, err
 	for _, user := range args.Users {
 		err := api.addMetricsUser(user)
 		results.Results = append(results.Results, params.AddUserResult{
-			Tag:   user.Username, // TODO: should we populate this in the error case?
+			Tag:   user.Username,
 			Error: apiservererrors.ServerError(err),
 		})
 	}
@@ -67,15 +67,15 @@ func (api *API) AddMetricsUser(args params.AddUsers) (params.AddUserResults, err
 }
 
 func (api *API) addMetricsUser(args params.AddUser) error {
-	if !strings.HasPrefix(args.Username, JujuMetricsUserPrefix) {
-		return errors.NotValidf("username %q missing prefix %q", args.Username, JujuMetricsUserPrefix)
+	if !strings.HasPrefix(args.Username, jujuMetricsUserPrefix) {
+		return errors.NotValidf("username %q missing prefix %q", args.Username, jujuMetricsUserPrefix)
 	}
 
 	if args.Password == "" {
 		return errors.NotValidf("empty password for user %q", args.Username)
 	}
 
-	_, err := api.state.AddUser(args.Username, args.DisplayName, args.Password, UserCreator)
+	_, err := api.state.AddUser(args.Username, args.DisplayName, args.Password, userCreator)
 	if err != nil {
 		return errors.Annotatef(err, "failed to create user %q", args.Username)
 	}
@@ -88,7 +88,7 @@ func (api *API) addMetricsUser(args params.AddUser) error {
 	userTag := names.NewUserTag(args.Username)
 	_, err = model.AddUser(state.UserAccessSpec{
 		User:      userTag,
-		CreatedBy: names.NewUserTag(UserCreator),
+		CreatedBy: names.NewUserTag(userCreator),
 		Access:    permission.ReadAccess,
 	})
 	return errors.Annotatef(err, "adding user %q to model %q",
@@ -113,8 +113,8 @@ func (api *API) removeMetricsUser(e params.Entity) error {
 		return errors.Annotatef(err, "couldn't parse user tag %q", e.Tag)
 	}
 
-	if !strings.HasPrefix(user.Name(), JujuMetricsUserPrefix) {
-		return fmt.Errorf("username %q should have prefix %q", user.Name(), JujuMetricsUserPrefix)
+	if !strings.HasPrefix(user.Name(), jujuMetricsUserPrefix) {
+		return fmt.Errorf("username %q should have prefix %q", user.Name(), jujuMetricsUserPrefix)
 	}
 
 	err = api.state.RemoveUser(user)

--- a/apiserver/facades/agent/controllercharm/controllercharm_test.go
+++ b/apiserver/facades/agent/controllercharm/controllercharm_test.go
@@ -1,0 +1,193 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllercharm_test
+
+import (
+	"testing"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facades/agent/controllercharm"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+func (*suite) TestAuth(c *gc.C) {
+	tests := []struct {
+		description string
+		authorizer  facade.Authorizer
+		modelType   state.ModelType
+		expected    string
+	}{{
+		description: "unit containeragent on k8s",
+		authorizer: apiservertesting.FakeAuthorizer{
+			Tag: names.NewUnitTag("controller/0"),
+		},
+		modelType: state.ModelTypeCAAS,
+		expected:  "",
+	}, {
+		description: "machine agent on lxd",
+		authorizer: apiservertesting.FakeAuthorizer{
+			Tag:        names.NewMachineTag("0"),
+			Controller: true,
+		},
+		modelType: state.ModelTypeIAAS,
+		expected:  "",
+	}, {
+		description: "non-controller application",
+		authorizer: apiservertesting.FakeAuthorizer{
+			Tag: names.NewUnitTag("mysql/0"),
+		},
+		modelType: state.ModelTypeCAAS,
+		expected:  `application name should be "controller", received "mysql"`,
+	}, {
+		description: "client can't access facade",
+		authorizer: apiservertesting.FakeAuthorizer{
+			Tag: names.NewUserTag("bob"),
+		},
+		modelType: state.ModelTypeCAAS,
+		expected:  "permission denied",
+	}}
+
+	for _, test := range tests {
+		err := controllercharm.CheckAuth(test.authorizer, test.modelType)
+		if test.expected == "" {
+			c.Check(err, jc.ErrorIsNil, gc.Commentf(test.description))
+		} else {
+			c.Check(err, gc.ErrorMatches, test.expected, gc.Commentf(test.description))
+		}
+	}
+}
+
+func (*suite) TestAddMetricsUser(c *gc.C) {
+	tests := []struct {
+		description string
+		username    string
+		initUsers   []string
+		expectedRes *params.Error
+	}{{
+		description: "Add non-existent user",
+		username:    "juju-metrics-r0",
+		initUsers:   []string{},
+		expectedRes: nil,
+	}, {
+		description: "Missing metrics user prefix",
+		username:    "foo",
+		expectedRes: &params.Error{
+			Message: `username "foo" missing prefix "juju-metrics-" not valid`,
+			Code:    params.CodeNotValid,
+		},
+	}, {
+		description: "User already exists",
+		username:    "juju-metrics-r0",
+		initUsers:   []string{"juju-metrics-r0"},
+		expectedRes: &params.Error{
+			Message: `failed to create user "juju-metrics-r0": user "juju-metrics-r0" already exists`,
+			Code:    params.CodeAlreadyExists,
+		},
+	}}
+
+	for _, test := range tests {
+		api := controllercharm.NewAPI(newFakeState(test.initUsers...))
+		res, err := api.AddMetricsUser(params.AddUsers{[]params.AddUser{{
+			Username:    test.username,
+			DisplayName: test.username,
+			Password:    "supersecret",
+		}}})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(res, gc.DeepEquals, params.AddUserResults{[]params.AddUserResult{{
+			Tag:   test.username,
+			Error: test.expectedRes,
+		}}})
+	}
+
+}
+
+func (*suite) TestRemoveMetricsUser(c *gc.C) {
+	tests := []struct {
+		description string
+		username    string
+		initUsers   []string
+		expectedRes *params.Error
+	}{{
+		description: "Remove existing user",
+		username:    "juju-metrics-r0",
+		initUsers:   []string{"juju-metrics-r0"},
+		expectedRes: nil,
+	}, {
+		description: "Missing metrics user prefix",
+		username:    "foo",
+		expectedRes: &params.Error{Message: `username "foo" should have prefix "juju-metrics-"`},
+	}, {
+		description: "User doesn't exist",
+		username:    "juju-metrics-r0",
+		initUsers:   []string{},
+		// TODO: should this succeed as a no-op ??
+		expectedRes: &params.Error{
+			Message: `failed to delete user "juju-metrics-r0": user "juju-metrics-r0" not found`,
+			Code:    params.CodeNotFound,
+		},
+	}}
+
+	for _, test := range tests {
+		api := controllercharm.NewAPI(newFakeState(test.initUsers...))
+		res, err := api.RemoveMetricsUser(params.Entities{[]params.Entity{{
+			Tag: names.NewUserTag(test.username).String(),
+		}}})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(res, gc.DeepEquals, params.ErrorResults{[]params.ErrorResult{{test.expectedRes}}})
+	}
+}
+
+type fakeState struct {
+	users set.Strings
+}
+
+func newFakeState(initUsers ...string) *fakeState {
+	return &fakeState{
+		users: set.NewStrings(initUsers...),
+	}
+}
+
+func (s *fakeState) AddUser(name string, _, _, _ string) (*state.User, error) {
+	if s.users.Contains(name) {
+		return nil, errors.AlreadyExistsf("user %q", name)
+	}
+	s.users.Add(name)
+	return nil, nil
+}
+
+func (s *fakeState) RemoveUser(tag names.UserTag) error {
+	name := tag.Name()
+	if s.users.Contains(name) {
+		s.users.Remove(name)
+		return nil
+	}
+	return errors.NotFoundf("user %q", name)
+}
+
+func (s *fakeState) Model() (controllercharm.Model, error) {
+	return fakeModel{}, nil
+}
+
+type fakeModel struct{}
+
+func (m fakeModel) AddUser(state.UserAccessSpec) (permission.UserAccess, error) {
+	return permission.UserAccess{}, nil
+}

--- a/apiserver/facades/agent/controllercharm/doc.go
+++ b/apiserver/facades/agent/controllercharm/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controllercharm defines a facade that the controller charm can use
+// to affect changes in the Juju controller. Currently, these changes include:
+//   - adding/removing user credentials that a related Prometheus instance can
+//     use to access the Juju controller's metrics endpoint.
+package controllercharm

--- a/apiserver/facades/agent/controllercharm/export_test.go
+++ b/apiserver/facades/agent/controllercharm/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllercharm
+
+func NewAPI(state backend) *API {
+	return &API{state}
+}
+
+type Model = model
+
+var CheckAuth = checkAuth

--- a/apiserver/facades/agent/controllercharm/register.go
+++ b/apiserver/facades/agent/controllercharm/register.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllercharm
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/state"
+)
+
+// Register is called to expose a package of facades onto a given registry.
+func Register(registry facade.FacadeRegistry) {
+	registry.MustRegister("ControllerCharm", 1, func(ctx facade.Context) (facade.Facade, error) {
+		return newAPI(ctx)
+	}, reflect.TypeOf((*API)(nil)))
+}
+
+// newAPI creates a new server-side controllercharm API facade.
+func newAPI(ctx facade.Context) (*API, error) {
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Annotate(err, "error getting model")
+	}
+
+	err = checkAuth(ctx.Auth(), model.Type())
+	if err != nil {
+		return nil, err
+	}
+
+	return &API{
+		state: stateShim{ctx.State()},
+	}, nil
+}
+
+// Check if the given client is authorized to access this facade.
+func checkAuth(authorizer facade.Authorizer, modelType state.ModelType) error {
+	switch modelType {
+	case state.ModelTypeCAAS:
+		return checkAuthCAAS(authorizer)
+	case state.ModelTypeIAAS:
+		return checkAuthIAAS(authorizer)
+	default:
+		return errors.NotValidf("unknown model type %q", modelType)
+	}
+}
+
+// On CAAS, we are looking for unit-controller-x.
+func checkAuthCAAS(authorizer facade.Authorizer) error {
+	if !authorizer.AuthUnitAgent() {
+		return apiservererrors.ErrPerm
+	}
+
+	// Check this is the controller application
+	unitName := authorizer.GetAuthTag().Id()
+	applicationName, err := names.UnitApplication(unitName)
+	if err != nil {
+		return errors.Annotatef(err, "invalid unit name %s", unitName)
+	}
+	if applicationName != bootstrap.ControllerApplicationName {
+		return fmt.Errorf("application name should be %q, received %q",
+			bootstrap.ControllerApplicationName, applicationName)
+	}
+	return nil
+}
+
+// On IAAS, we are looking for the controller machine.
+func checkAuthIAAS(authorizer facade.Authorizer) error {
+	if !authorizer.AuthMachineAgent() || !authorizer.AuthController() {
+		return apiservererrors.ErrPerm
+	}
+	return nil
+}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19729,6 +19729,191 @@
         }
     },
     {
+        "Name": "ControllerCharm",
+        "Description": "API provides API methods to the controllercharm worker.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddMetricsUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddUsers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddUserResults"
+                        }
+                    },
+                    "description": "AddMetricsUser creates a user with the given username and password, and\ngrants the new user permission to read the metrics endpoint."
+                },
+                "RemoveMetricsUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemoveMetricsUser removes the given user from the controller."
+                }
+            },
+            "definitions": {
+                "AddUser": {
+                    "type": "object",
+                    "properties": {
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "username",
+                        "display-name"
+                    ]
+                },
+                "AddUserResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "secret-key": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "AddUserResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddUserResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "AddUsers": {
+                    "type": "object",
+                    "properties": {
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddUser"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "users"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
         "Name": "CredentialManager",
         "Description": "",
         "Version": 1,

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -27,6 +27,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Cleaner",
 	"Client",
 	"Cloud",
+	"ControllerCharm",
 	"CredentialValidator",
 	"CrossController",
 	"CrossModelRelations",

--- a/state/user.go
+++ b/state/user.go
@@ -57,7 +57,7 @@ func (st *State) AddUser(name, displayName, password, creator string) (*User, er
 
 // AddUserWithSecretKey adds the user with the specified name, and assigns it
 // a randomly generated secret key. This secret key may be used for the user
-// and controller to mutually authenticate one another, without without relying
+// and controller to mutually authenticate one another, without relying
 // on TLS certificates.
 //
 // The new user will not have a password. A password must be set, clearing the


### PR DESCRIPTION
This is the first part of ongoing work to integrate the Juju `controller` charm with `prometheus-k8s`. It contains the first part of #15319.

The controller charm needs to create/remove user credentials on the fly, to pass to Prometheus to access Juju's metrics endpoint. Here, we define a new `controllercharm` facade, which contains Add/RemoveMetricsUser methods to be used for exactly this purpose.

Future work will define a method for the controllercharm to access this facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run unit tests.

## Links

**Jira card:** JUJU-4631