### PR TITLE
Rework of SNI logic.

### DIFF
--- a/worker/httpserver/tls_test.go
+++ b/worker/httpserver/tls_test.go
@@ -128,6 +128,18 @@ func (s *TLSAutocertSuite) TestAutocertHostPolicy(c *gc.C) {
 	c.Assert(s.autocertQueried, jc.IsFalse)
 }
 
+func (s *TLSAutocertSuite) TestAutoCertNotCalledBadDNS(c *gc.C) {
+	tlsConfig := httpserver.NewTLSConfig(
+		s.dnsName,
+		s.serverURL,
+		s.cache,
+		testSNIGetter(s.cert),
+		loggo.GetLogger("test"),
+	)
+	s.testGetCertificate(c, tlsConfig, "invalid")
+	c.Assert(s.autocertQueried, jc.IsFalse)
+}
+
 func (s *TLSAutocertSuite) testGetCertificate(c *gc.C, tlsConfig *tls.Config, serverName string) {
 	cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
 		ServerName: serverName,


### PR DESCRIPTION
To accommodate the move to autocert caching in DQlite we have made a few changes to the way SNI is being performed in the Juju http server.

- The first change is we have solidifed the errors that need to be returned by our SNI getters. This allows the aggregation process to understand what is going on better and log potential problems.
- The autocert SNI getter has been updated to quick escape on invalid dns names in the server name to reduce noise out of the autocert process.
- We now also don't error log on auto cert white list failures.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests. Units tests cover the desired behaviour perfectly.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4632