### PR TITLE
[JUJU-4615] Ask user to create local share after installing snap

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -146,6 +146,7 @@ func (m jujuMain) Run(args []string) int {
 
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		cmd.WriteError(ctx.Stderr, err)
+		ctx.Warningf("Installing juju from a snap, the .local/share directory should be manually created as it is strictly confined.")
 		return 2
 	}
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -146,7 +146,9 @@ func (m jujuMain) Run(args []string) int {
 
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		cmd.WriteError(ctx.Stderr, err)
-		ctx.Warningf("Installing juju from a snap, the .local/share directory should be manually created as it is strictly confined.")
+		if errors.Is(err, errors.NotFound) {
+			ctx.Warningf("Installing juju from a snap, the .local/share directory should be manually created as it is strictly confined.")
+		}
 		return 2
 	}
 


### PR DESCRIPTION
This PR adds a warning that asks to create the .local/share directory manually. This warning should appear every time Juju fails directory existence checks (including installation). This would enhance usability during working with juju strictly confined snap.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
go test github.com/juju/juju/cmd/juju/commands/... -gocheck.v

snapcraft --use-lxd
sudo snap install <juju_snap_filename>.snap
juju clouds
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2031483

**Jira card:** JUJU-4615
