### PR TITLE
Find relation via id not endpoint names in cleanup job.

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/juju/charm/v8"
@@ -282,13 +283,20 @@ func (st *State) cleanupRelationSettings(prefix string) error {
 }
 
 func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
-	relation, err := st.KeyRelation(prefix)
+	var relation *Relation
+	var relId int
+	if relId, err = strconv.Atoi(prefix); err == nil {
+		relation, err = st.Relation(relId)
+	} else if err != nil {
+		logger.Warningf("handling legacy cleanupForceDestroyedRelation with relation key %q", prefix)
+		relation, err = st.KeyRelation(prefix)
+	}
 	if errors.IsNotFound(err) {
 		return nil
-	}
-	if err != nil {
+	} else if err != nil {
 		return errors.Annotatef(err, "getting relation %q", prefix)
 	}
+
 	scopes, closer := st.db().GetCollection(relationScopesC)
 	defer closer()
 

--- a/state/relation.go
+++ b/state/relation.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -484,7 +485,7 @@ func (r *Relation) destroyOps(ignoreApplication string, op *ForcedOperation) (op
 		// Since we are force destroying, life assert should be current relation's life.
 		lifeAssert = bson.D{{"life", r.doc.Life}}
 		deadline := r.st.stateClock.Now().Add(op.MaxWait)
-		ops = append(ops, newCleanupAtOp(deadline, cleanupForceDestroyedRelation, relationKey(r.Endpoints())))
+		ops = append(ops, newCleanupAtOp(deadline, cleanupForceDestroyedRelation, strconv.Itoa(r.Id())))
 	}
 
 	ops = append(ops, txn.Op{


### PR DESCRIPTION
When force destroying an application, a cleanup job for each relation is scheduled in the future, which unfortunately uses the relation endpoint names to find the relation during the cleanup job. This has a race condition with deploying a new application and finding the new applications relation with the same endpoint names, causing it for force leave the new application's relation scopes.

This change moves to using the relation id to find the relation.

## QA steps

Apply this hack patch which increases the delay for cleanupForceDestroyedRelation cleanup job. This will give you enough time to force remove the app, redeploy, wait for peer relations to enter scope, then watch them force leave scope.
```
diff --git a/state/relation.go b/state/relation.go
index 39e4c22772..82480f8296 100644
--- a/state/relation.go
+++ b/state/relation.go
@@ -483,7 +483,7 @@ func (r *Relation) destroyOps(ignoreApplication string, op *ForcedOperation) (op
        if op.Force {
                // Since we are force destroying, life assert should be current relation's life.
                lifeAssert = bson.D{{"life", r.doc.Life}}
-               deadline := r.st.stateClock.Now().Add(op.MaxWait)
+               deadline := r.st.stateClock.Now().Add(5 * time.Minute)
                ops = append(ops, newCleanupAtOp(deadline, cleanupForceDestroyedRelation, relationKey(r.Endpoints())))
        }
```

An example of it cleaning up the wrong relation...
```
$ juju show-unit lxd-cloud-cell/3
lxd-cloud-cell/3:
  machine: "3"
  opened-ports: []
  public-address: 10.192.3.31
  charm: local:jammy/lxd-cloud-cell-1
  leader: true
  life: alive
  relation-info:
  - relation-id: 1
    endpoint: cluster
    related-endpoint: cluster
    application-data: {}
    local-unit:
      in-scope: true
      data:
        egress-subnets: 10.192.3.31/32
        ingress-address: 10.192.3.31
        private-address: 10.192.3.31
    related-units:
      lxd-cloud-cell/4:
        in-scope: true
        data:
          egress-subnets: 10.192.3.207/32
          ingress-address: 10.192.3.207
          private-address: 10.192.3.207
      lxd-cloud-cell/5:
        in-scope: true
        data:
          egress-subnets: 10.192.3.170/32
          ingress-address: 10.192.3.170
          private-address: 10.192.3.170
$ juju show-unit lxd-cloud-cell/3
lxd-cloud-cell/3:
  machine: "3"
  opened-ports: []
  public-address: 10.192.3.31
  charm: local:jammy/lxd-cloud-cell-1
  leader: true
  life: alive
  relation-info:
  - relation-id: 1
    endpoint: cluster
    related-endpoint: cluster
    application-data: {}
    related-units:
      lxd-cloud-cell/4:
        in-scope: false
        data: {}
      lxd-cloud-cell/5:
        in-scope: false
        data: {}
```

## Documentation changes

N/A

## Links

https://bugs.launchpad.net/juju/+bug/2011277
[JUJU-4431](https://warthogs.atlassian.net/browse/JUJU-4431)

[JUJU-4431]: https://warthogs.atlassian.net/browse/JUJU-4431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ