### PR TITLE
Ensure API Client can call 3.x API Facades

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -86,7 +86,7 @@ var FacadeVersions = map[string][]int{
 	"MigrationTarget":              {1, 2},
 	"ModelConfig":                  {3},
 	"ModelGeneration":              {4},
-	"ModelManager":                 {10},
+	"ModelManager":                 {9, 10},
 	"ModelSummaryWatcher":          {1},
 	"ModelUpgrader":                {1},
 	"NotifyWatcher":                {1},

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -55,7 +55,10 @@ func newFacadeV10(ctx facade.Context) (*ModelManagerAPI, error) {
 	}
 
 	configGetter := stateenvirons.EnvironConfigGetter{
-		Model: model, CloudService: ctx.ServiceFactory().Cloud(), CredentialService: ctx.ServiceFactory().Credential()}
+		Model:             model,
+		CloudService:      ctx.ServiceFactory().Cloud(),
+		CredentialService: ctx.ServiceFactory().Credential(),
+	}
 	newEnviron := common.EnvironFuncForModel(model, ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential(), configGetter)
 
 	ctrlModel, err := ctlrSt.Model()

--- a/apiserver/facadeversions_test.go
+++ b/apiserver/facadeversions_test.go
@@ -39,10 +39,15 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	// First check that both sides know about all the same versions
 	c.Check(serverFacadeNames.Difference(clientFacadeNames).SortedValues(), gc.HasLen, 0)
 	c.Check(clientFacadeNames.Difference(serverFacadeNames).SortedValues(), gc.HasLen, 0)
-	// Next check that the best versions match
+
+	// Next check that the latest version of each facade is the same
+	// on both sides.
 	apiFacadeVersions := make(map[string]int)
 	for name, versions := range api.FacadeVersions {
-		apiFacadeVersions[name] = versions[len(versions)-1]
+		// Sort the versions so that we can easily pick the latest, without
+		// a requirement that the versions are listed in order.
+		sorted := set.NewInts(versions...).SortedValues()
+		apiFacadeVersions[name] = sorted[len(sorted)-1]
 	}
 	c.Check(apiFacadeVersions, jc.DeepEquals, serverFacadeBestVersions)
 }

--- a/apiserver/facadeversions_test.go
+++ b/apiserver/facadeversions_test.go
@@ -31,14 +31,72 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	}
 	allServerFacades := apiserver.AllFacades().List()
 	serverFacadeNames := set.NewStrings()
-	serverFacadeBestVersions := make(map[string][]int, len(allServerFacades))
+	serverFacadeBestVersions := make(map[string]int, len(allServerFacades))
 	for _, facade := range allServerFacades {
 		serverFacadeNames.Add(facade.Name)
-		serverFacadeBestVersions[facade.Name] = facade.Versions
+		serverFacadeBestVersions[facade.Name] = facade.Versions[len(facade.Versions)-1]
 	}
 	// First check that both sides know about all the same versions
 	c.Check(serverFacadeNames.Difference(clientFacadeNames).SortedValues(), gc.HasLen, 0)
 	c.Check(clientFacadeNames.Difference(serverFacadeNames).SortedValues(), gc.HasLen, 0)
 	// Next check that the best versions match
-	c.Check(api.FacadeVersions, jc.DeepEquals, serverFacadeBestVersions)
+	apiFacadeVersions := make(map[string]int)
+	for name, versions := range api.FacadeVersions {
+		apiFacadeVersions[name] = versions[len(versions)-1]
+	}
+	c.Check(apiFacadeVersions, jc.DeepEquals, serverFacadeBestVersions)
+}
+
+// TestClient3xSupport checks that the client facade supports the 3.x for
+// certain tasks. You must be very careful when removing support for facades
+// as it can break model migrations, upgrades, and state reports.
+func (s *facadeVersionSuite) TestClient3xSupport(c *gc.C) {
+	tests := []struct {
+		facadeName       string
+		summary          string
+		apiClientVersion int
+	}{
+		{
+			facadeName:       "Client",
+			summary:          "Ensure that the Client facade supports 3.x for status requests",
+			apiClientVersion: 6,
+		},
+		{
+			facadeName:       "ModelManager",
+			summary:          "Ensure that the ModelManager facade supports 3.x for model migration and status requests",
+			apiClientVersion: 9,
+		},
+	}
+	for _, test := range tests {
+		c.Logf(test.summary)
+		c.Check(api.FacadeVersions[test.facadeName], Contains, test.apiClientVersion)
+	}
+}
+
+type containsChecker struct {
+	*gc.CheckerInfo
+}
+
+// Contains checks that the obtained slice contains the expected value.
+var Contains gc.Checker = &containsChecker{
+	CheckerInfo: &gc.CheckerInfo{Name: "Contains", Params: []string{"obtained", "expected"}},
+}
+
+func (checker *containsChecker) Check(params []interface{}, names []string) (result bool, err string) {
+	expected, ok := params[1].(int)
+	if !ok {
+		return false, "expected must be a string"
+	}
+
+	obtained, ok := params[0].([]int)
+	if ok {
+		for _, v := range obtained {
+			if v == expected {
+				return true, ""
+			}
+		}
+		return false, ""
+	}
+
+	return false, "obtained value is not an []int"
 }


### PR DESCRIPTION
The following ensures that with the new API clients 4.x can call 3.x API facades. This is required now that we're dropping support for restricting clients based on version numbers.

Validation of client facade versions can then ensure that we don't drop support for vital paths. Luckily, the dropping of ModelManager v9 was dropping away series support, but newer clients could talk to v9 facades via bases. If this was different, we would need to ensure that 4.x clients could still talk to 3.x latest facades.

Removing old facades is quite difficult, as each facade is a collection of methods and not a singular method. So viewing them as a whole is fundamental. Thus attempting to drop any facade without a major release is prohibited and even then we should validate if it's even possible.

The code changes are simple, allow the client to pick a 3.x client version and add a test that locks in the change. Changing these tests will ensure that it can't just be done willy-nilly.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Install the 3.1 snap bootstrap it

```sh
$ snap install juju --channel=3.1/stable
$ /snap/bin/juju bootstrap lxd test --build-agent
$ /snap/bin/juju add-model default
$ /snap/bin/juju deploy ubuntu
# Use the juju from this PR.
$ juju status
```

## Links

**Jira card:** JUJU-4636