### PR TITLE
Add support for ARM shapes on Oracle OCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ ${BUILD_DIR}/%/bin/pebble: phony_explicit
 # build for pebble
 	$(run_go_build)
 
-${JUJU_METADATA_SOURCE}/tools/released/juju-${JUJU_VERSION}-%.tgz: phony_explicit juju $(BUILD_AGENT_TARGETS) $(BUILD_CGO_AGENT_TARGETS)
+${JUJU_METADATA_SOURCE}/tools/released/juju-${JUJU_VERSION}-%.tgz: phony_explicit juju $(BUILD_AGENT_TARGETS)
 	@echo "Packaging simplestream tools for juju ${JUJU_VERSION} on $*"
 	@mkdir -p ${JUJU_METADATA_SOURCE}/tools/released
 	@tar czf "$@" -C $(call bin_platform_paths,$(subst -,/,$*)) .

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mittwald/vaultgo v0.1.1
 	github.com/moby/sys/mountinfo v0.6.2
-	github.com/oracle/oci-go-sdk/v65 v65.34.0
+	github.com/oracle/oci-go-sdk/v65 v65.49.0
 	github.com/packethost/packngo v0.28.1
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5

--- a/go.sum
+++ b/go.sum
@@ -1152,8 +1152,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
-github.com/oracle/oci-go-sdk/v65 v65.34.0 h1:uG1KucBxAbn8cYRgQHxtQKogtl85nOX8LhimZCPfMqw=
-github.com/oracle/oci-go-sdk/v65 v65.34.0/go.mod h1:MXMLMzHnnd9wlpgadPkdlkZ9YrwQmCOmbX5kjVEJodw=
+github.com/oracle/oci-go-sdk/v65 v65.49.0 h1:A/G4SuzLixNy43DsXj9Vok9TygRZRX15I62ebGTHj2Y=
+github.com/oracle/oci-go-sdk/v65 v65.49.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/packethost/packngo v0.28.1 h1:2Bo64Ku3F869oUmE2IrnURanN0XAmZmhI8wTem2sq64=
 github.com/packethost/packngo v0.28.1/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
-	"github.com/juju/juju/core/arch"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
@@ -333,7 +333,7 @@ var unsupportedConstraints = []string{
 func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
-	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64})
+	validator.RegisterVocabulary(constraints.Arch, []string{corearch.AMD64, corearch.ARM64})
 	logger.Infof("Returning constraints validator: %v", validator)
 	return validator, nil
 }
@@ -498,8 +498,6 @@ func (e *Environ) startInstance(
 		return nil, errors.Trace(err)
 	}
 
-	types := imgCache.SupportedShapes(args.InstanceConfig.Base)
-
 	defaultType := VirtualMachine.String()
 	if args.Constraints.VirtType == nil {
 		args.Constraints.VirtType = &defaultType
@@ -507,16 +505,11 @@ func (e *Environ) startInstance(
 
 	// check if we find an image that is compliant with the
 	// constraints provided in the oracle cloud account
-	args.ImageMetadata = imgCache.ImageMetadata(args.InstanceConfig.Base, *args.Constraints.VirtType)
-
 	spec, image, err := findInstanceSpec(
-		args.ImageMetadata,
-		types,
-		&instances.InstanceConstraint{
-			Base:        args.InstanceConfig.Base,
-			Arch:        arch,
-			Constraints: args.Constraints,
-		},
+		args.InstanceConfig.Base,
+		arch,
+		args.Constraints,
+		imgCache,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/oci/images_integration_test.go
+++ b/provider/oci/images_integration_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	corearch "github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/oci"
@@ -153,7 +154,7 @@ func (s *imagesSuite) TestInstanceTypesNilClient(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot use nil client")
 }
 
-func (s *imagesSuite) TestNewInstanceImage(c *gc.C) {
+func (s *imagesSuite) TestNewInstanceImageUbuntu(c *gc.C) {
 	image := ociCore.Image{
 		CompartmentId:          &s.testCompartment,
 		Id:                     &s.testImageID,
@@ -162,13 +163,84 @@ func (s *imagesSuite) TestNewInstanceImage(c *gc.C) {
 		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.11-0"),
 	}
 
-	imgType, err := oci.NewInstanceImage(image, &s.testCompartment)
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Check(imgType.ImageType, gc.Equals, oci.ImageTypeGeneric)
 	c.Check(imgType.Base.DisplayString(), gc.Equals, "ubuntu@22.04")
 	c.Check(imgType.CompartmentId, gc.NotNil)
 	c.Check(*imgType.CompartmentId, gc.Equals, s.testCompartment)
 	c.Check(imgType.Id, gc.Equals, s.testImageID)
+	c.Check(arch, gc.Equals, corearch.AMD64)
+}
+
+func (s *imagesSuite) TestNewInstanceImageUbuntuMinimal(c *gc.C) {
+	image := ociCore.Image{
+		CompartmentId:          &s.testCompartment,
+		Id:                     &s.testImageID,
+		OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+		OperatingSystemVersion: makeStringPointer("22.04 Minimal"),
+		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-Minimal-2018.01.11-0"),
+	}
+
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
+	c.Assert(err, gc.IsNil)
+	c.Check(imgType.ImageType, gc.Equals, oci.ImageTypeGeneric)
+	c.Check(imgType.Base.DisplayString(), gc.Equals, "ubuntu@22.04")
+	c.Check(imgType.CompartmentId, gc.NotNil)
+	c.Check(*imgType.CompartmentId, gc.Equals, s.testCompartment)
+	c.Check(imgType.Id, gc.Equals, s.testImageID)
+	c.Check(arch, gc.Equals, corearch.AMD64)
+}
+
+func (s *imagesSuite) TestNewInstanceImageUbuntuAARCH64(c *gc.C) {
+	image := ociCore.Image{
+		CompartmentId:          &s.testCompartment,
+		Id:                     &s.testImageID,
+		OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+		OperatingSystemVersion: makeStringPointer("22.04 aarch64"),
+		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-aarch64-2018.01.11-0"),
+	}
+
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
+	c.Assert(err, gc.IsNil)
+	c.Check(imgType.ImageType, gc.Equals, oci.ImageTypeGeneric)
+	c.Check(imgType.Base.DisplayString(), gc.Equals, "ubuntu@22.04")
+	c.Check(imgType.CompartmentId, gc.NotNil)
+	c.Check(*imgType.CompartmentId, gc.Equals, s.testCompartment)
+	c.Check(imgType.Id, gc.Equals, s.testImageID)
+	c.Check(arch, gc.Equals, corearch.ARM64)
+}
+
+func (s *imagesSuite) TestNewInstanceImageUbuntuAARCH64OnDisplayName(c *gc.C) {
+	image := ociCore.Image{
+		CompartmentId:          &s.testCompartment,
+		Id:                     &s.testImageID,
+		OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+		OperatingSystemVersion: makeStringPointer("22.04"),
+		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-aarch64-2018.01.11-0"),
+	}
+
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
+	c.Assert(err, gc.IsNil)
+	c.Check(imgType.ImageType, gc.Equals, oci.ImageTypeGeneric)
+	c.Check(imgType.Base.DisplayString(), gc.Equals, "ubuntu@22.04")
+	c.Check(imgType.CompartmentId, gc.NotNil)
+	c.Check(*imgType.CompartmentId, gc.Equals, s.testCompartment)
+	c.Check(imgType.Id, gc.Equals, s.testImageID)
+	c.Check(arch, gc.Equals, corearch.ARM64)
+}
+
+func (s *imagesSuite) TestNewInstanceImageUbuntuMinimalAARCH64NotSupported(c *gc.C) {
+	image := ociCore.Image{
+		CompartmentId:          &s.testCompartment,
+		Id:                     &s.testImageID,
+		OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+		OperatingSystemVersion: makeStringPointer("22.04 Minimal aarch64"),
+		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-Minimal-aarch64-2018.01.11-0"),
+	}
+
+	_, _, err := oci.NewInstanceImage(image, &s.testCompartment)
+	c.Assert(err, gc.ErrorMatches, "ubuntu minimal aarch64 image Canonical-Ubuntu-22.04-Minimal-aarch64-2018.01.11-0 not supported")
 }
 
 func (s *imagesSuite) TestNewInstanceImageUnknownOS(c *gc.C) {
@@ -180,7 +252,7 @@ func (s *imagesSuite) TestNewInstanceImageUnknownOS(c *gc.C) {
 		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.11-0"),
 	}
 
-	_, err := oci.NewInstanceImage(image, &s.testCompartment)
+	_, _, err := oci.NewInstanceImage(image, &s.testCompartment)
 	c.Assert(err, gc.ErrorMatches, "os NotKnownToJuju not supported")
 }
 
@@ -189,24 +261,40 @@ func (s *imagesSuite) TestRefreshImageCache(c *gc.C) {
 	compute := ocitesting.NewMockComputeClient(ctrl)
 	defer ctrl.Finish()
 
-	fakeUbuntuID := "fakeUbuntu1"
-	fakeUbuntuIDSecond := "fakeUbuntu2"
+	fakeUbuntu1 := "fakeUbuntu1"
+	fakeUbuntu2 := "fakeUbuntu2"
+	fakeUbuntu3 := "fakeUbuntu3"
+	fakeUbuntu4 := "fakeUbuntu4"
 	fakeCentOSID := "fakeCentOS"
 
 	listImageResponse := []ociCore.Image{
 		{
 			CompartmentId:          &s.testCompartment,
-			Id:                     &fakeUbuntuID,
+			Id:                     &fakeUbuntu1,
 			OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
 			OperatingSystemVersion: makeStringPointer("22.04"),
 			DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.11-0"),
 		},
 		{
 			CompartmentId:          &s.testCompartment,
-			Id:                     &fakeUbuntuIDSecond,
+			Id:                     &fakeUbuntu2,
 			OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
 			OperatingSystemVersion: makeStringPointer("22.04"),
 			DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.12-0"),
+		},
+		{
+			CompartmentId:          &s.testCompartment,
+			Id:                     &fakeUbuntu3,
+			OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+			OperatingSystemVersion: makeStringPointer("22.04 aarch64"),
+			DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.11-0"),
+		},
+		{
+			CompartmentId:          &s.testCompartment,
+			Id:                     &fakeUbuntu4,
+			OperatingSystem:        makeStringPointer("Canonical Ubuntu"),
+			OperatingSystemVersion: makeStringPointer("22.04"),
+			DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-aarch64-2018.01.12-0"),
 		},
 		{
 			CompartmentId:          &s.testCompartment,
@@ -218,8 +306,10 @@ func (s *imagesSuite) TestRefreshImageCache(c *gc.C) {
 	}
 
 	compute.EXPECT().ListImages(context.Background(), &s.testCompartment).Return(listImageResponse, nil)
-	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntuID).Return(listShapesResponse(), nil)
-	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntuIDSecond).Return(listShapesResponse(), nil)
+	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu1).Return(listShapesResponse(), nil)
+	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu2).Return(listShapesResponse(), nil)
+	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu3).Return(listShapesResponse(), nil)
+	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu4).Return(listShapesResponse(), nil)
 	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeCentOSID).Return(listShapesResponse()[:2], nil)
 
 	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
@@ -229,17 +319,25 @@ func (s *imagesSuite) TestRefreshImageCache(c *gc.C) {
 
 	imageMap := imgCache.ImageMap()
 	jammy := corebase.MakeDefaultBase("ubuntu", "22.04")
+	// Both archs AMD64 and ARM64 should be on the base jammy
 	c.Check(imageMap[jammy], gc.HasLen, 2)
+	// Two images on each arch
+	c.Check(imageMap[jammy][corearch.AMD64], gc.HasLen, 2)
+	c.Check(imageMap[jammy][corearch.ARM64], gc.HasLen, 2)
+	// Only AMD64 on centos base
 	c.Check(imageMap[corebase.MakeDefaultBase("centos", "7")], gc.HasLen, 1)
+	c.Check(imageMap[corebase.MakeDefaultBase("centos", "7")][corearch.AMD64], gc.HasLen, 1)
 
 	timeStamp, _ := time.Parse("2006.01.02", "2018.01.12")
 
 	// Check that the first image in the array is the newest one
-	c.Assert(imageMap[jammy][0].Version.TimeStamp, gc.Equals, timeStamp)
+	c.Assert(imageMap[jammy][corearch.AMD64][0].Version.TimeStamp, gc.Equals, timeStamp)
+	c.Assert(imageMap[jammy][corearch.ARM64][0].Version.TimeStamp, gc.Equals, timeStamp)
 
 	// Check that InstanceTypes are set
-	c.Assert(imageMap[jammy][0].InstanceTypes, gc.HasLen, 5)
-	c.Assert(imageMap[corebase.MakeDefaultBase("centos", "7")][0].InstanceTypes, gc.HasLen, 2)
+	c.Assert(imageMap[jammy][corearch.AMD64][0].InstanceTypes, gc.HasLen, 5)
+	c.Assert(imageMap[jammy][corearch.ARM64][0].InstanceTypes, gc.HasLen, 5)
+	c.Assert(imageMap[corebase.MakeDefaultBase("centos", "7")][corearch.AMD64][0].InstanceTypes, gc.HasLen, 2)
 }
 
 func (s *imagesSuite) TestRefreshImageCacheFetchFromCache(c *gc.C) {
@@ -300,11 +398,11 @@ func (s *imagesSuite) TestRefreshImageCacheWithInvalidImage(c *gc.C) {
 		},
 	}
 	fakeUbuntuID := "fakeUbuntu1"
-	fakeBadID := "fake image id for bad image"
 
 	compute.EXPECT().ListImages(context.Background(), &s.testCompartment).Return(listImageResponse, nil)
+	// Only list shapes from "fakeUbuntu1" image, because the other one
+	// is invalid.
 	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntuID).Return(listShapesResponse(), nil)
-	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeBadID).Return(listShapesResponse(), nil)
 
 	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
@@ -313,7 +411,7 @@ func (s *imagesSuite) TestRefreshImageCacheWithInvalidImage(c *gc.C) {
 	imageMap := imgCache.ImageMap()
 
 	jammy := corebase.MakeDefaultBase("ubuntu", "22.04")
-	c.Check(imageMap[jammy][0].Id, gc.Equals, "fakeUbuntu1")
+	c.Check(imageMap[jammy][corearch.AMD64][0].Id, gc.Equals, "fakeUbuntu1")
 }
 
 func (s *imagesSuite) TestImageMetadataFromCache(c *gc.C) {
@@ -325,24 +423,32 @@ func (s *imagesSuite) TestImageMetadataFromCache(c *gc.C) {
 		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-2018.01.11-0"),
 	}
 
-	imgType, err := oci.NewInstanceImage(image, &s.testCompartment)
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
+	instanceTypes := []instances.InstanceType{
+		{
+			Arch: "amd64",
+		},
+	}
+	imgType.SetInstanceTypes(instanceTypes)
 
 	cache := &oci.ImageCache{}
 	jammy := corebase.MakeDefaultBase("ubuntu", "22.04")
-	images := map[corebase.Base][]oci.InstanceImage{
+	images := map[corebase.Base]map[string][]oci.InstanceImage{
 		jammy: {
-			imgType,
+			corearch.AMD64: {
+				imgType,
+			},
 		},
 	}
 	cache.SetImages(images)
-	metadata := cache.ImageMetadata(jammy, "")
+	metadata := cache.ImageMetadata(jammy, arch, "")
 	c.Assert(metadata, gc.HasLen, 1)
 	// generic images default to ImageTypeVM
 	c.Assert(metadata[0].VirtType, gc.Equals, string(oci.ImageTypeVM))
 
 	// explicitly set ImageTypeBM on generic images
-	metadata = cache.ImageMetadata(jammy, string(oci.ImageTypeBM))
+	metadata = cache.ImageMetadata(jammy, arch, string(oci.ImageTypeBM))
 	c.Assert(metadata, gc.HasLen, 1)
 	c.Assert(metadata[0].VirtType, gc.Equals, string(oci.ImageTypeBM))
 }
@@ -356,24 +462,32 @@ func (s *imagesSuite) TestImageMetadataSpecificImageType(c *gc.C) {
 		DisplayName:            makeStringPointer("Canonical-Ubuntu-22.04-Gen2-GPU-2018.01.11-0"),
 	}
 
-	imgType, err := oci.NewInstanceImage(image, &s.testCompartment)
+	imgType, arch, err := oci.NewInstanceImage(image, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
+	instanceTypes := []instances.InstanceType{
+		{
+			Arch: "amd64",
+		},
+	}
+	imgType.SetInstanceTypes(instanceTypes)
 
 	cache := &oci.ImageCache{}
 	jammy := corebase.MakeDefaultBase("ubuntu", "22.04")
-	images := map[corebase.Base][]oci.InstanceImage{
+	images := map[corebase.Base]map[string][]oci.InstanceImage{
 		jammy: {
-			imgType,
+			corearch.AMD64: {
+				imgType,
+			},
 		},
 	}
 	cache.SetImages(images)
-	metadata := cache.ImageMetadata(jammy, "")
+	metadata := cache.ImageMetadata(jammy, arch, "")
 	c.Assert(metadata, gc.HasLen, 1)
 	// generic images default to ImageTypeVM
 	c.Assert(metadata[0].VirtType, gc.Equals, string(oci.ImageTypeGPU))
 
 	// explicitly set ImageTypeBM on generic images
-	metadata = cache.ImageMetadata(jammy, string(oci.ImageTypeBM))
+	metadata = cache.ImageMetadata(jammy, arch, string(oci.ImageTypeBM))
 	c.Assert(metadata, gc.HasLen, 1)
 	c.Assert(metadata[0].VirtType, gc.Equals, string(oci.ImageTypeGPU))
 }


### PR DESCRIPTION
By correctly parsing the version of the ubuntu cloud images returned by OCI's API, we can then create different bases for ubuntu aarch64 (the cloud image needed to target arm-based shapes).

It is important to note that we will not be supporting `Minimal aarch64` ubuntu images, based on what is documented for using ARM-based shapes: https://docs.oracle.com/en-us/iaas/Content/Compute/References/images.htm
> ...For Arm-based shapes, use the Ubuntu image, not Minimal Ubuntu.


Bonus: By moving the retrieve of `instanceTypes()` *after* we correctly parsed the `InstanceImage`, we avoid useless calls to the API to retrieve the shapes for images that we don't support anyways.
 
Bonus 2: Fixed the Makefile for building cross-compiled versions (thx to @hmlanigan and @tlm).

Bonus 3: Fixed the `TestRefreshImageCacheWithInvalidImage` test which had incorrect logic.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

- Build
```
rm -rf _build/
make go-install
GOOS=linux GOARCH=arm64 make go-build
AGENT_PACKAGE_PLATFORMS=linux/arm64 make simplestreams
export JUJU_METADATA_SOURCE="/home/nicolas/workspace/canonical/juju/_build/simplestreams"
```
- Bootstrap and add model
```
juju bootstrap --debug --constraints arch=arm64 --config compartment-id=ocid1.compartment.oc1..aaaaaaaanvu2racnlczevenu73dlcf3nokgsjpdkbdgp4xbrz3lb2y4giyjq oci-canonical c
juju add-model m
```
- Add machines
```
juju add-machine --constraints "arch=arm64"
juju add-machine --constraints "arch=arm64 cores=3 mem=11G"
```

If you log in the OCI dashboard, you should see 3 `VM.Standard.A1.Flex` instances (one for the controller, two for the added machines) with 1 Ocpu for two of them and 3 Ocpus/ 11GB for the third one.

## Links

**Jira card:** [JUJU-4514](https://warthogs.atlassian.net/browse/JUJU-4514)



[JUJU-4514]: https://warthogs.atlassian.net/browse/JUJU-4514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ