### PR TITLE
Rpcreflect internal rpcreflect

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/rpcreflect"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/api"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/pinger"
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -4,8 +4,7 @@
 package apiserver
 
 import (
-	"github.com/juju/rpcreflect"
-
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 )
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/rpcreflect"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -29,6 +28,7 @@ import (
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/watcher/registry"
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/names/v4"
-	"github.com/juju/rpcreflect"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/pinger"
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/testing"
 )
 

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -14,12 +14,12 @@ import (
 	"github.com/bmizerany/pat"
 	"github.com/gorilla/websocket"
 	jujuhttp "github.com/juju/http/v2"
-	"github.com/juju/rpcreflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/observer"
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	apiwebsocket "github.com/juju/juju/apiserver/websocket"
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/testing"

--- a/generate/schemagen/gen/generator.go
+++ b/generate/schemagen/gen/generator.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/jsonschema-gen"
 	"golang.org/x/tools/go/packages"
 
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/generate/schemagen/jsonschema-gen"
 	"github.com/juju/juju/internal/rpcreflect"
 )
 

--- a/generate/schemagen/gen/generator.go
+++ b/generate/schemagen/gen/generator.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema-gen"
-	"github.com/juju/rpcreflect"
 	"golang.org/x/tools/go/packages"
 
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/internal/rpcreflect"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package gen -destination describeapi_mock.go -write_package_comment=false github.com/juju/juju/generate/schemagen/gen APIServer,Registry,PackageRegistry,Linker

--- a/generate/schemagen/gen/generator_test.go
+++ b/generate/schemagen/gen/generator_test.go
@@ -7,13 +7,13 @@ import (
 	"reflect"
 
 	jsonschema "github.com/juju/jsonschema-gen"
-	"github.com/juju/rpcreflect"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/internal/rpcreflect"
 )
 
 type GenSuite struct {

--- a/generate/schemagen/gen/generator_test.go
+++ b/generate/schemagen/gen/generator_test.go
@@ -6,13 +6,13 @@ package gen
 import (
 	"reflect"
 
-	jsonschema "github.com/juju/jsonschema-gen"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/facade"
+	jsonschema "github.com/juju/juju/generate/schemagen/jsonschema-gen"
 	"github.com/juju/juju/internal/rpcreflect"
 )
 

--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/rpcreflect"
 
 	facade "github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/internal/rpcreflect"
 )
 
 // FacadeGroup defines the grouping you want to export.

--- a/generate/schemagen/jsonschema-gen/COPYING
+++ b/generate/schemagen/jsonschema-gen/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Alec Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/generate/schemagen/jsonschema-gen/reflect.go
+++ b/generate/schemagen/jsonschema-gen/reflect.go
@@ -1,0 +1,224 @@
+// Package jsonschema uses reflection to generate JSON Schemas from Go types [1].
+//
+// If json tags are present on struct fields, they will be used to infer
+// property names and if a property is required (omitempty is present).
+//
+// [1] http://json-schema.org/latest/json-schema-validation.html
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/juju/juju/internal/rpcreflect"
+)
+
+var (
+	timeType = reflect.TypeOf(time.Time{})
+	ipType   = reflect.TypeOf(net.IP{})
+	urlType  = reflect.TypeOf(url.URL{})
+	objType  = reflect.TypeOf(rpcreflect.ObjType{})
+)
+
+type Type struct {
+	Type                 string           `json:"type,omitempty"`
+	Format               string           `json:"format,omitempty"`
+	Items                *Type            `json:"items,omitempty"`
+	Properties           map[string]*Type `json:"properties,omitempty"`
+	PatternProperties    map[string]*Type `json:"patternProperties,omitempty"`
+	AdditionalProperties json.RawMessage  `json:"additionalProperties,omitempty"`
+	Ref                  string           `json:"$ref,omitempty"`
+	Required             []string         `json:"required,omitempty"`
+	MaxLength            int              `json:"maxLength,omitempty"`
+	MinLength            int              `json:"minLength,omitempty"`
+	Pattern              string           `json:"pattern,omitempty"`
+	Enum                 []interface{}    `json:"enum,omitempty"`
+	Default              interface{}      `json:"default,omitempty"`
+	Title                string           `json:"title,omitempty"`
+	Description          string           `json:"description,omitempty"`
+}
+
+type Schema struct {
+	*Type
+	Definitions Definitions `json:"definitions,omitempty"`
+}
+
+// Reflect a Schema from a value.
+func Reflect(v interface{}) *Schema {
+	return ReflectFromType(reflect.TypeOf(v))
+}
+
+func ReflectFromType(t reflect.Type) *Schema {
+	definitions := Definitions{}
+	s := &Schema{
+		Type:        reflectTypeToSchema(definitions, t),
+		Definitions: definitions,
+	}
+	return s
+}
+
+// rpcreflect is itself a description so we provide additional handling here
+func ReflectFromObjType(objtype *rpcreflect.ObjType) *Schema {
+	definitions := Definitions{}
+	s := &Schema{
+		Definitions: definitions,
+	}
+
+	methodNames := objtype.MethodNames()
+	props := make(map[string]*Type, len(methodNames))
+	for _, n := range methodNames {
+		method, err := objtype.Method(n)
+		if err == nil {
+			callmap := make(map[string]*Type)
+			if method.Params != nil {
+				callmap["Params"] = reflectTypeToSchema(definitions, method.Params)
+			}
+			if method.Result != nil {
+				callmap["Result"] = reflectTypeToSchema(definitions, method.Result)
+			}
+
+			props[n] = &Type{
+				Type:       "object",
+				Properties: callmap,
+			}
+		}
+	}
+
+	s.Type = &Type{
+		Type:       "object",
+		Properties: props,
+	}
+	return s
+}
+
+type Definitions map[string]*Type
+
+func reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
+	switch t.Kind() {
+	case reflect.Struct:
+		switch t {
+		case timeType:
+			return &Type{Type: "string", Format: "date-time"}
+
+		case ipType:
+			return &Type{Type: "string", Format: "ipv4"}
+
+		case urlType:
+			return &Type{Type: "string", Format: "uri"}
+
+		default:
+			if _, ok := definitions[t.Name()]; ok {
+				return &Type{Ref: "#/definitions/" + t.Name()}
+			}
+
+			return reflectStruct(definitions, t)
+		}
+
+	case reflect.Map:
+		rt := &Type{
+			Type: "object",
+			PatternProperties: map[string]*Type{
+				".*": reflectTypeToSchema(definitions, t.Elem()),
+			},
+		}
+		delete(rt.PatternProperties, "additionalProperties")
+		return rt
+
+	case reflect.Array, reflect.Slice:
+		return &Type{
+			Type:  "array",
+			Items: reflectTypeToSchema(definitions, t.Elem()),
+		}
+
+	case reflect.Interface:
+		return &Type{
+			Type:                 "object",
+			AdditionalProperties: []byte("true"),
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &Type{Type: "integer"}
+
+	case reflect.Float32, reflect.Float64:
+		return &Type{Type: "number"}
+
+	case reflect.Bool:
+		return &Type{Type: "boolean"}
+
+	case reflect.String:
+		return &Type{Type: "string"}
+
+	case reflect.Ptr:
+		return reflectTypeToSchema(definitions, t.Elem())
+	}
+
+	fmt.Fprintf(os.Stderr, "Unsupported Type %s", t.String())
+	return nil
+}
+
+func reflectStruct(definitions Definitions, t reflect.Type) *Type {
+	st := &Type{
+		Type:                 "object",
+		Properties:           map[string]*Type{},
+		AdditionalProperties: []byte("false"),
+	}
+	definitions[t.Name()] = st
+	reflectStructFields(st, definitions, t)
+
+	return &Type{Ref: "#/definitions/" + t.Name()}
+}
+
+func reflectStructFields(st *Type, definitions Definitions, t reflect.Type) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		name, required, embedded := reflectFieldName(f)
+		if name == "" {
+			continue
+		}
+
+		// anonymous and exported type should be processed recursively
+		// current type should inherit properties of anonymous one
+		if embedded {
+			reflectStructFields(st, definitions, f.Type)
+		}
+
+		st.Properties[name] = reflectTypeToSchema(definitions, f.Type)
+		if required {
+			st.Required = append(st.Required, name)
+		}
+	}
+}
+
+func reflectFieldName(f reflect.StructField) (string, bool, bool) {
+	if f.PkgPath != "" { // unexported field, ignore it
+		return "", false, false
+	}
+	parts := strings.Split(f.Tag.Get("json"), ",")
+	if parts[0] == "-" {
+		return "", false, false
+	}
+
+	name := f.Name
+	required := true
+
+	if parts[0] != "" {
+		name = parts[0]
+	}
+
+	if len(parts) > 1 && parts[1] == "omitempty" {
+		required = false
+	}
+	embedded := len(parts) == 1 && parts[0] == "" && f.Type.Kind() == reflect.Struct && f.Name == f.Type.Name() && f.Anonymous
+	return name, required, embedded
+}

--- a/generate/schemagen/jsonschema-gen/reflect_test.go
+++ b/generate/schemagen/jsonschema-gen/reflect_test.go
@@ -1,0 +1,82 @@
+package jsonschema
+
+import (
+	"testing"
+	"time"
+)
+
+type GrandfatherType struct {
+	FamilyName string `json:"family_name"`
+}
+
+type SomeBaseType struct {
+	SomeBaseProperty int `json:"some_base_property"`
+	//nolint:unused
+	somePrivateBaseProperty string          `json:"i_am_private"`
+	SomeIgnoredBaseProperty string          `json:"-"`
+	Grandfather             GrandfatherType `json:"grand"`
+
+	SomeUntaggedBaseProperty bool
+	//nolint:unused
+	someUnexportedUntaggedBaseProperty bool
+}
+
+type nonExported struct {
+	PublicNonExported int
+	//nolint:unused
+	privateNonExported int
+}
+
+type TestUser struct {
+	SomeBaseType
+	nonExported
+
+	ID        int                    `json:"id"`
+	Name      string                 `json:"name"`
+	Friends   []int                  `json:"friends,omitempty"`
+	Tags      map[string]interface{} `json:"tags,omitempty"`
+	BirthDate time.Time              `json:"birth_date,omitempty"`
+
+	TestFlag       bool
+	IgnoredCounter int `json:"-"`
+}
+
+// TestSchemaGeneration checks if schema generated correctly:
+// - fields marked with "-" are ignored
+// - non-exported fields are ignored
+// - anonymous fields are expanded
+func TestSchemaGeneration(t *testing.T) {
+	s := Reflect(&TestUser{})
+
+	expectedProperties := map[string]string{
+		"id":                       "integer",
+		"name":                     "string",
+		"friends":                  "array",
+		"tags":                     "object",
+		"birth_date":               "string",
+		"TestFlag":                 "boolean",
+		"some_base_property":       "integer",
+		"grand":                    "#/definitions/GrandfatherType",
+		"SomeUntaggedBaseProperty": "boolean",
+		"SomeBaseType":             "#/definitions/SomeBaseType",
+	}
+
+	props := s.Definitions["TestUser"].Properties
+	for defKey, prop := range props {
+		typeOrRef, ok := expectedProperties[defKey]
+		if !ok {
+			t.Fatalf("unexpected property '%s'", defKey)
+		}
+		if prop.Type != "" && prop.Type != typeOrRef {
+			t.Fatalf("expected property type '%s', got '%s' for property '%s'", typeOrRef, prop.Type, defKey)
+		} else if prop.Ref != "" && prop.Ref != typeOrRef {
+			t.Fatalf("expected reference to '%s', got '%s' for property '%s'", typeOrRef, prop.Ref, defKey)
+		}
+	}
+
+	for defKey := range expectedProperties {
+		if _, ok := props[defKey]; !ok {
+			t.Fatalf("expected property missing '%s'", defKey)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/juju/http/v2 v2.0.0
 	github.com/juju/idmclient/v2 v2.0.0
 	github.com/juju/jsonschema v1.0.0
-	github.com/juju/jsonschema-gen v1.0.0
 	github.com/juju/loggo v1.0.0
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mgo/v3 v3.0.4
@@ -220,7 +219,6 @@ require (
 	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
 	github.com/juju/lru v1.0.0 // indirect
 	github.com/juju/mgo/v2 v2.0.2 // indirect
-	github.com/juju/rpcreflect v1.2.0 // indirect
 	github.com/juju/usso v1.0.1 // indirect
 	github.com/juju/version v0.0.0-20210303051006-2015802527a8 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 	github.com/juju/retry v1.0.0
 	github.com/juju/rfc/v2 v2.0.0
 	github.com/juju/romulus v1.0.0
-	github.com/juju/rpcreflect v1.2.0
 	github.com/juju/schema v1.0.1
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.1.0
@@ -221,6 +220,7 @@ require (
 	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
 	github.com/juju/lru v1.0.0 // indirect
 	github.com/juju/mgo/v2 v2.0.2 // indirect
+	github.com/juju/rpcreflect v1.2.0 // indirect
 	github.com/juju/usso v1.0.1 // indirect
 	github.com/juju/version v0.0.0-20210303051006-2015802527a8 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -829,8 +829,6 @@ github.com/juju/idmclient/v2 v2.0.0 h1:PsGa092JGy6iFNHZCcao+bigVsTyz1C+tHNRdYmKv
 github.com/juju/idmclient/v2 v2.0.0/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
 github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
 github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
-github.com/juju/jsonschema-gen v1.0.0 h1:u1Tq/fIWA7R7joNM8YNYxg/2RLdOP9/jgKSBibEfYXQ=
-github.com/juju/jsonschema-gen v1.0.0/go.mod h1:DPYruztGGtnf5neurmVhVAbRnk3nIrIh7ANyS15rBZs=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
@@ -882,8 +880,6 @@ github.com/juju/rfc/v2 v2.0.0 h1:oj3UYJFp+zNNwbhVv4EV1fCvIV+hSTB03l/2/5hmFpI=
 github.com/juju/rfc/v2 v2.0.0/go.mod h1:fhE7z2y6DFUvYdWy93m40oA3lJIs+P3WrK6barpChj0=
 github.com/juju/romulus v1.0.0 h1:THzHnztB7JgFTkr4bmvcpTa2fK6YQTJyKpQwsNoPKRA=
 github.com/juju/romulus v1.0.0/go.mod h1:NTUb3tUldFPZLWbieglCiV4SpccHuiFUNRY+bsIkohA=
-github.com/juju/rpcreflect v1.2.0 h1:eokqqHg13bji8S3IRTuN7f5rfUkn+KnLiItoNfcSLoY=
-github.com/juju/rpcreflect v1.2.0/go.mod h1:yWSyMkWOwQGqUVxvboHn1c3CuCQrQ5LgV//8c/K1DqE=
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.0.1 h1:GBEiwxZQeoQuXI6gOTG58W/ZpdongMwl9pfZq1KcNgM=
 github.com/juju/schema v1.0.1/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=

--- a/internal/rpcreflect/export_test.go
+++ b/internal/rpcreflect/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpcreflect
+
+import "reflect"
+
+func ResetCaches() {
+	typeMutex.Lock()
+	typesByGoType = make(map[reflect.Type]*Type)
+	typeMutex.Unlock()
+
+	objTypeMutex.Lock()
+	objTypesByGoType = make(map[reflect.Type]*ObjType)
+	objTypeMutex.Unlock()
+}

--- a/internal/rpcreflect/package_test.go
+++ b/internal/rpcreflect/package_test.go
@@ -1,0 +1,233 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpcreflect_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+func callName(narg, nret int, retErr bool) string {
+	e := ""
+	if retErr {
+		e = "e"
+	}
+	return fmt.Sprintf("Call%dr%d%s", narg, nret, e)
+}
+
+type callInfo struct {
+	rcvr   interface{}
+	method string
+	arg    interface{}
+}
+
+type callError callInfo
+
+func (e *callError) Error() string {
+	return fmt.Sprintf("error calling %s", e.method)
+}
+
+type stringVal struct {
+	Val string
+}
+
+type Root struct {
+	mu          sync.Mutex
+	calls       []*callInfo
+	returnErr   bool
+	simple      map[string]*SimpleMethods
+	delayed     map[string]*DelayedMethods
+	errorInst   *ErrorMethods
+	contextInst *ContextMethods
+}
+
+func (r *Root) callError(rcvr interface{}, name string, arg interface{}) error {
+	if r.returnErr {
+		return &callError{rcvr, name, arg}
+	}
+	return nil
+}
+
+func (r *Root) SimpleMethods(id string) (*SimpleMethods, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if a := r.simple[id]; a != nil {
+		return a, nil
+	}
+	return nil, fmt.Errorf("unknown SimpleMethods id")
+}
+
+func (r *Root) DelayedMethods(id string) (*DelayedMethods, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if a := r.delayed[id]; a != nil {
+		return a, nil
+	}
+	return nil, fmt.Errorf("unknown DelayedMethods id")
+}
+
+func (r *Root) ErrorMethods(id string) (*ErrorMethods, error) {
+	if r.errorInst == nil {
+		return nil, fmt.Errorf("no error methods")
+	}
+	return r.errorInst, nil
+}
+
+func (r *Root) ContextMethods(id string) (*ContextMethods, error) {
+	if r.contextInst == nil {
+		return nil, fmt.Errorf("no context methods")
+	}
+	return r.contextInst, nil
+}
+
+func (r *Root) Discard1() {}
+
+func (r *Root) Discard2(id string) error { return nil }
+
+func (r *Root) Discard3(id string) int { return 0 }
+
+func (r *Root) CallbackMethods(string) (*CallbackMethods, error) {
+	return &CallbackMethods{r}, nil
+}
+
+func (r *Root) InterfaceMethods(id string) (InterfaceMethods, error) {
+	m, err := r.SimpleMethods(id)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+type InterfaceMethods interface {
+	Call1r1e(s stringVal) (stringVal, error)
+}
+
+type ChangeAPIMethods struct {
+	r *Root
+}
+
+func (r *Root) ChangeAPIMethods(string) (*ChangeAPIMethods, error) {
+	return &ChangeAPIMethods{r}, nil
+}
+
+func (t *Root) called(rcvr interface{}, method string, arg interface{}) {
+	t.mu.Lock()
+	t.calls = append(t.calls, &callInfo{rcvr, method, arg})
+	t.mu.Unlock()
+}
+
+type SimpleMethods struct {
+	root *Root
+	id   string
+}
+
+// Each Call method is named in this standard form:
+//
+//     Call<narg>r<nret><e>
+//
+// where narg is the number of arguments, nret is the number of returned
+// values (not including the error) and e is the letter 'e' if the
+// method returns an error.
+
+func (a *SimpleMethods) Call0r0() {
+	a.root.called(a, "Call0r0", nil)
+}
+
+func (a *SimpleMethods) Call0r1() stringVal {
+	a.root.called(a, "Call0r1", nil)
+	return stringVal{"Call0r1 ret"}
+}
+
+func (a *SimpleMethods) Call0r1e() (stringVal, error) {
+	a.root.called(a, "Call0r1e", nil)
+	return stringVal{"Call0r1e ret"}, a.root.callError(a, "Call0r1e", nil)
+}
+
+func (a *SimpleMethods) Call0r0e() error {
+	a.root.called(a, "Call0r0e", nil)
+	return a.root.callError(a, "Call0r0e", nil)
+}
+
+func (a *SimpleMethods) Call1r0(s stringVal) {
+	a.root.called(a, "Call1r0", s)
+}
+
+func (a *SimpleMethods) Call1r1(s stringVal) stringVal {
+	a.root.called(a, "Call1r1", s)
+	return stringVal{"Call1r1 ret"}
+}
+
+func (a *SimpleMethods) Call1r1e(s stringVal) (stringVal, error) {
+	a.root.called(a, "Call1r1e", s)
+	return stringVal{"Call1r1e ret"}, a.root.callError(a, "Call1r1e", s)
+}
+
+func (a *SimpleMethods) Call1r0e(s stringVal) error {
+	a.root.called(a, "Call1r0e", s)
+	return a.root.callError(a, "Call1r0e", s)
+}
+
+func (a *SimpleMethods) SliceArg(struct{ X []string }) stringVal {
+	return stringVal{"SliceArg ret"}
+}
+
+func (a *SimpleMethods) Discard1(int) {}
+
+func (a *SimpleMethods) Discard2(struct{}, struct{}) {}
+
+func (a *SimpleMethods) Discard3() int { return 0 }
+
+func (a *SimpleMethods) Discard4() (_, _ struct{}) { return }
+
+type ContextMethods struct {
+	root *Root
+}
+
+func (c *ContextMethods) Call0(ctx context.Context) error {
+	c.root.called(c, "Call0", nil)
+	return nil
+}
+
+func (c *ContextMethods) Call1(ctx context.Context, s stringVal) error {
+	c.root.called(c, "Call1", nil)
+	return nil
+}
+
+type DelayedMethods struct {
+	ready     chan struct{}
+	done      chan string
+	doneError chan error
+}
+
+func (a *DelayedMethods) Delay() (stringVal, error) {
+	if a.ready != nil {
+		a.ready <- struct{}{}
+	}
+	select {
+	case s := <-a.done:
+		return stringVal{s}, nil
+	case err := <-a.doneError:
+		return stringVal{}, err
+	}
+}
+
+type ErrorMethods struct {
+	err error
+}
+
+func (e *ErrorMethods) Call() error {
+	return e.err
+}
+
+type CallbackMethods struct {
+	root *Root
+}

--- a/internal/rpcreflect/type.go
+++ b/internal/rpcreflect/type.go
@@ -1,0 +1,383 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpcreflect
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"sync"
+)
+
+var (
+	errorType   = reflect.TypeOf((*error)(nil)).Elem()
+	stringType  = reflect.TypeOf("")
+	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+)
+
+var (
+	typeMutex     sync.RWMutex
+	typesByGoType = make(map[reflect.Type]*Type)
+
+	objTypeMutex     sync.RWMutex
+	objTypesByGoType = make(map[reflect.Type]*ObjType)
+)
+
+var ErrMethodNotFound = errors.New("no such method")
+
+// Type holds information about a type that implements RPC server methods,
+// a root-level RPC type.
+type Type struct {
+	// method maps from root-object method name to
+	// information about that method. The term "obtain"
+	// is because these methods obtain an object to
+	// call an action on.
+	method map[string]*RootMethod
+
+	// discarded holds names of all discarded methods.
+	discarded []string
+}
+
+// MethodNames returns the names of all the root object
+// methods on the receiving object.
+func (r *Type) MethodNames() []string {
+	names := make([]string, 0, len(r.method))
+	for name := range r.method {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Method returns information on the method with the given name,
+// or the zero Method and ErrMethodNotFound if there is no such method
+// (the only possible error).
+func (r *Type) Method(name string) (RootMethod, error) {
+	m, ok := r.method[name]
+	if !ok {
+		return RootMethod{}, ErrMethodNotFound
+	}
+	return *m, nil
+}
+
+// RemoveMethod removes the method with the given name from the type.
+// This is useful for removing methods that are not supported by the
+// server. It returns whether the method was found.
+func (r *Type) RemoveMethod(name string) bool {
+	if _, ok := r.method[name]; !ok {
+		return false
+	}
+	delete(r.method, name)
+	r.discarded = append(r.discarded, name)
+	return true
+}
+
+func (r *Type) DiscardedMethods() []string {
+	return append([]string(nil), r.discarded...)
+}
+
+// RootMethod holds information on a root-level method.
+type RootMethod struct {
+	// Call invokes the method. The rcvr parameter must be
+	// the same type as the root object. The given id is passed
+	// as an argument to the method.
+	Call func(rcvr reflect.Value, id string) (reflect.Value, error)
+
+	// Methods holds RPC object-method information about
+	// objects returned from the above call.
+	ObjType *ObjType
+}
+
+// TypeOf returns information on all root-level RPC methods
+// implemented by an object of the given Go type.
+// If goType is nil, it returns nil.
+func TypeOf(goType reflect.Type) *Type {
+	if goType == nil {
+		return nil
+	}
+	typeMutex.RLock()
+	t := typesByGoType[goType]
+	typeMutex.RUnlock()
+	if t != nil {
+		return t
+	}
+	typeMutex.Lock()
+	defer typeMutex.Unlock()
+	t = typesByGoType[goType]
+	if t != nil {
+		return t
+	}
+	t = typeOf(goType)
+	typesByGoType[goType] = t
+	return t
+}
+
+// typeOf is like TypeOf but without the cache - it
+// always allocates. Called with rootTypeMutex locked.
+func typeOf(goType reflect.Type) *Type {
+	rm := &Type{
+		method: make(map[string]*RootMethod),
+	}
+	for i := 0; i < goType.NumMethod(); i++ {
+		m := goType.Method(i)
+		if m.PkgPath != "" || isKillMethod(m) {
+			// The Kill method gets a special exception because
+			// it fulfils the Killer interface which we're expecting,
+			// so it's not really discarded as such.
+			continue
+		}
+		if o := newRootMethod(m); o != nil {
+			rm.method[m.Name] = o
+		} else {
+			rm.discarded = append(rm.discarded, m.Name)
+		}
+	}
+	return rm
+}
+
+func isKillMethod(m reflect.Method) bool {
+	return m.Name == "Kill" && m.Type.NumIn() == 1 && m.Type.NumOut() == 0
+}
+
+func newRootMethod(m reflect.Method) *RootMethod {
+	if m.PkgPath != "" {
+		return nil
+	}
+	t := m.Type
+	if t.NumIn() != 2 ||
+		t.NumOut() != 2 ||
+		t.In(1) != stringType ||
+		t.Out(1) != errorType {
+		return nil
+	}
+	f := func(rcvr reflect.Value, id string) (r reflect.Value, err error) {
+		out := rcvr.Method(m.Index).Call([]reflect.Value{reflect.ValueOf(id)})
+		if !out[1].IsNil() {
+			// Workaround LP 1251076.
+			// gccgo appears to get confused and thinks that out[1] is not nil when
+			// in fact it is an interface value of type error and value nil.
+			// This workaround solves the problem by leaving error as nil if in fact
+			// it was nil and causes no harm for gc because the predicates above
+			// assert that if out[1] is not nil, then it is an error type.
+			err, _ = out[1].Interface().(error)
+		}
+		r = out[0]
+		return
+	}
+	return &RootMethod{
+		Call:    f,
+		ObjType: ObjTypeOf(t.Out(0)),
+	}
+}
+
+// ObjType holds information on RPC methods implemented on
+// an RPC object.
+type ObjType struct {
+	goType    reflect.Type
+	method    map[string]*ObjMethod
+	discarded []string
+}
+
+func (t *ObjType) GoType() reflect.Type {
+	return t.goType
+}
+
+// Method returns information on the method with the given name,
+// or the zero Method and ErrMethodNotFound if there is no such method
+// (the only possible error).
+func (t *ObjType) Method(name string) (ObjMethod, error) {
+	m, ok := t.method[name]
+	if !ok {
+		return ObjMethod{}, ErrMethodNotFound
+	}
+	return *m, nil
+}
+
+// RemoveMethod removes the method with the given name from the type.
+// This is useful for removing methods that are not supported by the
+// server. It returns whether the method was found.
+func (r *ObjType) RemoveMethod(name string) bool {
+	if _, ok := r.method[name]; !ok {
+		return false
+	}
+	delete(r.method, name)
+	r.discarded = append(r.discarded, name)
+	return true
+}
+
+// DiscardedMethods returns the names of all methods that cannot
+// implement RPC calls because their type signature is inappropriate.
+func (t *ObjType) DiscardedMethods() []string {
+	return append([]string(nil), t.discarded...)
+}
+
+// MethodNames returns the names of all the RPC methods
+// defined on the type.
+func (t *ObjType) MethodNames() []string {
+	names := make([]string, 0, len(t.method))
+	for name := range t.method {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ObjMethod holds information about an RPC method on an
+// object returned by a root-level method.
+type ObjMethod struct {
+	// Params holds the argument type of the method, or nil
+	// if there is no argument.
+	Params reflect.Type
+
+	// Result holds the return type of the method, or nil
+	// if the method returns no value.
+	Result reflect.Type
+
+	// Call calls the method with the given argument
+	// on the given receiver value, and given context
+	// if the method has a context parameter. If the
+	// method does not return a value, the returned
+	// value will not be valid.
+	Call func(ctx context.Context, rcvr, arg reflect.Value) (reflect.Value, error)
+}
+
+// ObjTypeOf returns information on all RPC methods
+// implemented by an object of the given Go type,
+// as returned from a root-level method.
+// If objType is nil, it returns nil.
+func ObjTypeOf(objType reflect.Type) *ObjType {
+	if objType == nil {
+		return nil
+	}
+	objTypeMutex.RLock()
+	methods := objTypesByGoType[objType]
+	objTypeMutex.RUnlock()
+	if methods != nil {
+		return methods
+	}
+	objTypeMutex.Lock()
+	defer objTypeMutex.Unlock()
+	methods = objTypesByGoType[objType]
+	if methods != nil {
+		return methods
+	}
+	methods = objTypeOf(objType)
+	objTypesByGoType[objType] = methods
+	return methods
+}
+
+// objTypeOf is like ObjTypeOf but without the cache.
+// Called with objTypeMutex locked.
+func objTypeOf(goType reflect.Type) *ObjType {
+	objType := &ObjType{
+		method: make(map[string]*ObjMethod),
+		goType: goType,
+	}
+	for i := 0; i < goType.NumMethod(); i++ {
+		m := goType.Method(i)
+		if m.PkgPath != "" {
+			continue
+		}
+		if objm := newMethod(m, goType.Kind()); objm != nil {
+			objType.method[m.Name] = objm
+		} else {
+			objType.discarded = append(objType.discarded, m.Name)
+		}
+	}
+	return objType
+}
+
+func newMethod(m reflect.Method, receiverKind reflect.Kind) *ObjMethod {
+	if m.PkgPath != "" {
+		return nil
+	}
+	var p ObjMethod
+	var assemble func(ctx context.Context, arg reflect.Value) []reflect.Value
+	// N.B. The method type has the receiver as its first argument
+	// unless the receiver is an interface.
+	receiverArgCount := 1
+	if receiverKind == reflect.Interface {
+		receiverArgCount = 0
+	}
+	t := m.Type
+	switch t.NumIn() - receiverArgCount {
+	case 0:
+		// Method() ...
+		assemble = func(_ context.Context, arg reflect.Value) []reflect.Value {
+			return nil
+		}
+	case 2:
+		// Method(context.Context, T) ...
+		contextParam := t.In(receiverArgCount)
+		if !contextType.AssignableTo(contextParam) {
+			return nil
+		}
+		p.Params = t.In(receiverArgCount + 1)
+		assemble = func(ctx context.Context, arg reflect.Value) []reflect.Value {
+			return []reflect.Value{reflect.ValueOf(ctx), arg}
+		}
+	case 1:
+		// Method([context.Context,]T) ...
+		param := t.In(receiverArgCount)
+		if contextType.AssignableTo(param) {
+			assemble = func(ctx context.Context, _ reflect.Value) []reflect.Value {
+				return []reflect.Value{reflect.ValueOf(ctx)}
+			}
+		} else {
+			p.Params = param
+			assemble = func(_ context.Context, arg reflect.Value) []reflect.Value {
+				return []reflect.Value{arg}
+			}
+		}
+	default:
+		return nil
+	}
+
+	switch {
+	case t.NumOut() == 0:
+		// Method(...)
+		p.Call = func(ctx context.Context, rcvr, arg reflect.Value) (r reflect.Value, err error) {
+			rcvr.Method(m.Index).Call(assemble(ctx, arg))
+			return
+		}
+	case t.NumOut() == 1 && t.Out(0) == errorType:
+		// Method(...) error
+		p.Call = func(ctx context.Context, rcvr, arg reflect.Value) (r reflect.Value, err error) {
+			out := rcvr.Method(m.Index).Call(assemble(ctx, arg))
+			if !out[0].IsNil() {
+				err = out[0].Interface().(error)
+			}
+			return
+		}
+	case t.NumOut() == 1:
+		// Method(...) R
+		p.Result = t.Out(0)
+		p.Call = func(ctx context.Context, rcvr, arg reflect.Value) (reflect.Value, error) {
+			out := rcvr.Method(m.Index).Call(assemble(ctx, arg))
+			return out[0], nil
+		}
+	case t.NumOut() == 2 && t.Out(1) == errorType:
+		// Method(...) (R, error)
+		p.Result = t.Out(0)
+		p.Call = func(ctx context.Context, rcvr, arg reflect.Value) (r reflect.Value, err error) {
+			out := rcvr.Method(m.Index).Call(assemble(ctx, arg))
+			r = out[0]
+			if !out[1].IsNil() {
+				err = out[1].Interface().(error)
+			}
+			return
+		}
+	default:
+		return nil
+	}
+	// The parameters and return value must be of struct type.
+	if p.Params != nil && p.Params.Kind() != reflect.Struct {
+		return nil
+	}
+	if p.Result != nil && p.Result.Kind() != reflect.Struct {
+		return nil
+	}
+	return &p
+}

--- a/internal/rpcreflect/value.go
+++ b/internal/rpcreflect/value.go
@@ -1,0 +1,150 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpcreflect
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+// CallNotImplementedError is the error returned when an attempt to call to
+// an unknown API method is made.
+type CallNotImplementedError struct {
+	RootMethod string
+	Version    int
+	Method     string
+}
+
+func (e *CallNotImplementedError) Error() string {
+	if e.Method == "" {
+		if e.Version != 0 {
+			return fmt.Sprintf("unknown version (%d) of interface %q", e.Version, e.RootMethod)
+		}
+		return fmt.Sprintf("unknown object type %q", e.RootMethod)
+	}
+	methodVersion := e.RootMethod
+	if e.Version != 0 {
+		methodVersion = fmt.Sprintf("%s(%d)", e.RootMethod, e.Version)
+	}
+	return fmt.Sprintf("no such request - method %s.%s is not implemented", methodVersion, e.Method)
+}
+
+// methodCaller knows how to call a particular RPC method.
+type methodCaller struct {
+	// paramsType holds the required type of the parameter to the object method.
+	paramsType reflect.Type
+	// resultType holds the result type of the result of caling the object method.
+	resultType reflect.Type
+
+	rootValue  reflect.Value
+	rootMethod RootMethod
+	objMethod  ObjMethod
+}
+
+// methodCaller holds the value of the root of an RPC server that
+// can call methods directly on a Go value.
+type Value struct {
+	rootValue reflect.Value
+	rootType  *Type
+}
+
+// ValueOf returns a value that can be used to call RPC-style
+// methods on the given root value. It returns the zero
+// Value if rootValue.IsValid is false.
+func ValueOf(rootValue reflect.Value) Value {
+	if !rootValue.IsValid() {
+		return Value{}
+	}
+	return Value{
+		rootValue: rootValue,
+		rootType:  TypeOf(rootValue.Type()),
+	}
+}
+
+// IsValid returns whether the Value has been initialized with ValueOf.
+func (v Value) IsValid() bool {
+	return v.rootType != nil
+}
+
+// GoValue returns the value that was passed to ValueOf to create v.
+func (v Value) GoValue() reflect.Value {
+	return v.rootValue
+}
+
+// FindMethod returns an object that can be used to make calls on
+// the given root value to the given root method and object method.
+// It returns an error if either the root method or the object
+// method were not found.
+// It panics if called on the zero Value.
+// The version argument is ignored - all versions will find
+// the same method.
+func (v Value) FindMethod(rootMethodName string, version int, objMethodName string) (MethodCaller, error) {
+	if !v.IsValid() {
+		panic("FindMethod called on invalid Value")
+	}
+	caller := methodCaller{
+		rootValue: v.rootValue,
+	}
+	var err error
+	caller.rootMethod, err = v.rootType.Method(rootMethodName)
+	if err != nil {
+		return nil, &CallNotImplementedError{
+			RootMethod: rootMethodName,
+		}
+	}
+	caller.objMethod, err = caller.rootMethod.ObjType.Method(objMethodName)
+	if err != nil {
+		return nil, &CallNotImplementedError{
+			RootMethod: rootMethodName,
+			Method:     objMethodName,
+		}
+	}
+	return caller, nil
+}
+
+// killer is the same interface as rpc.Killer, but redeclared
+// here to avoid cyclic dependency.
+type killer interface {
+	Kill()
+}
+
+// Kill implements rpc.Killer.Kill by calling Kill on the root
+// value if it implements Killer.
+func (v Value) Kill() {
+	if killer, ok := v.rootValue.Interface().(killer); ok {
+		killer.Kill()
+	}
+}
+
+func (caller methodCaller) Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	obj, err := caller.rootMethod.Call(caller.rootValue, objId)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	return caller.objMethod.Call(ctx, obj, arg)
+}
+
+func (caller methodCaller) ParamsType() reflect.Type {
+	return caller.objMethod.Params
+}
+
+func (caller methodCaller) ResultType() reflect.Type {
+	return caller.objMethod.Result
+}
+
+type MethodCaller interface {
+	// ParamsType holds the required type of the parameter to the object method.
+	ParamsType() reflect.Type
+
+	// ResultType holds the result type of the result of calling the object method.
+	ResultType() reflect.Type
+
+	// Call is actually placing a call to instantiate an given instance and
+	// call the method on that instance.
+	Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error)
+}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/rpcreflect"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/rpc/params"

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/rpcreflect"
+
+	"github.com/juju/juju/internal/rpcreflect"
 )
 
 const codeNotImplemented = "not implemented"

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -1,5 +1,5 @@
 run_copyright() {
-	OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig|./core/output/progress|./_deps)" | sort | xargs grep -L -E '// (Copyright|Code generated)' || true)
+	OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig|./core/output/progress|./_deps|./generate/schemagen/jsonschema-gen)" | sort | xargs grep -L -E '// (Copyright|Code generated)' || true)
 	LINES=$(echo "${OUT}" | wc -w)
 	if [ "$LINES" != 0 ]; then
 		echo ""


### PR DESCRIPTION
The rpcreflect repo was externalized some years ago to help with
iteration. We no longer need to do that anymore, so we can bring
it back to the internal package.

This should allow us to expose a better error message when a facade
is not found. The preliminary work is required to improve migration
between major versions when facades and facade versions are dropped.

---

I wonder if the `generate/schemagen` package should be in it's current
location, or moved to internal as well.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ make rebuild-schema
```

## Links

**Jira card:** JUJU-4637
