### PR TITLE
[JUJU-4638] Drop charm.URL in flight where possible

### DIFF
--- a/api/agent/uniter/charm.go
+++ b/api/agent/uniter/charm.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"fmt"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/rpc/params"
@@ -18,16 +17,11 @@ import (
 // Charm represents the state of a charm in the model.
 type Charm struct {
 	st   *State
-	curl *charm.URL
-}
-
-// String returns the charm URL as a string.
-func (c *Charm) String() string {
-	return c.curl.String()
+	curl string
 }
 
 // URL returns the URL that identifies the charm.
-func (c *Charm) URL() *charm.URL {
+func (c *Charm) URL() string {
 	return c.curl
 }
 
@@ -44,7 +38,7 @@ func (c *Charm) URL() *charm.URL {
 func (c *Charm) ArchiveSha256() (string, error) {
 	var results params.StringResults
 	args := params.CharmURLs{
-		URLs: []params.CharmURL{{URL: c.curl.String()}},
+		URLs: []params.CharmURL{{URL: c.curl}},
 	}
 	err := c.st.facade.FacadeCall("CharmArchiveSha256", args, &results)
 	if err != nil {
@@ -65,7 +59,7 @@ func (c *Charm) ArchiveSha256() (string, error) {
 func (c *Charm) LXDProfileRequired() (bool, error) {
 	var results params.BoolResults
 	args := params.CharmURLs{
-		URLs: []params.CharmURL{{URL: c.curl.String()}},
+		URLs: []params.CharmURL{{URL: c.curl}},
 	}
 	err := c.st.facade.FacadeCall("LXDProfileRequired", args, &results)
 	if err != nil {

--- a/api/agent/uniter/charm_test.go
+++ b/api/agent/uniter/charm_test.go
@@ -4,7 +4,6 @@
 package uniter_test
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -26,8 +25,8 @@ func (s *charmSuite) TestCharmWithNilFails(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	_, err := client.Charm(nil)
-	c.Assert(err, gc.ErrorMatches, "charm url cannot be nil")
+	_, err := client.Charm("")
+	c.Assert(err, gc.ErrorMatches, "charm url cannot be empty")
 }
 
 func (s *charmSuite) TestCharm(c *gc.C) {
@@ -35,21 +34,20 @@ func (s *charmSuite) TestCharm(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	curl := charm.MustParseURL("ch:mysql")
+	curl := "ch:mysql"
 	ch, err := client.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), jc.DeepEquals, curl)
-	c.Assert(ch.String(), gc.Equals, curl.String())
 }
 
 func (s *charmSuite) TestArchiveSha256(c *gc.C) {
-	curl := charm.MustParseURL("ch:mysql")
+	curl := "ch:mysql"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "CharmArchiveSha256")
 		c.Assert(arg, jc.DeepEquals, params.CharmURLs{
-			URLs: []params.CharmURL{{URL: curl.String()}},
+			URLs: []params.CharmURL{{URL: curl}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
 		*(result.(*params.StringResults)) = params.StringResults{
@@ -68,13 +66,13 @@ func (s *charmSuite) TestArchiveSha256(c *gc.C) {
 }
 
 func (s *charmSuite) TestLXDProfileRequired(c *gc.C) {
-	curl := charm.MustParseURL("ch:mysql")
+	curl := "ch:mysql"
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
 		c.Assert(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "LXDProfileRequired")
 		c.Assert(arg, jc.DeepEquals, params.CharmURLs{
-			URLs: []params.CharmURL{{URL: curl.String()}},
+			URLs: []params.CharmURL{{URL: curl}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.BoolResults{})
 		*(result.(*params.BoolResults)) = params.BoolResults{

--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"fmt"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -233,9 +232,9 @@ func (st *State) ProviderType() (string, error) {
 }
 
 // Charm returns the charm with the given URL.
-func (st *State) Charm(curl *charm.URL) (*Charm, error) {
-	if curl == nil {
-		return nil, fmt.Errorf("charm url cannot be nil")
+func (st *State) Charm(curl string) (*Charm, error) {
+	if curl == "" {
+		return nil, fmt.Errorf("charm url cannot be empty")
 	}
 	return &Charm{
 		st:   st,

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -165,9 +165,7 @@ func (s *charmsSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
 	// Add the dummy charm with revision 1.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := charm.MustParseURL(
-		fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision()),
-	)
+	curl := fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision())
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -183,11 +181,11 @@ func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer f.Close()
 	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", f)
-	expectedURL := charm.MustParseURL("local:quantal/dummy-2")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-2"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.URL(), gc.Equals, expectedURL)
 	c.Assert(sch.Revision(), gc.Equals, 2)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 	// No more checks for the hash here, because it is
@@ -212,8 +210,8 @@ func (s *charmsSuite) TestUploadVersion(c *gc.C) {
 	defer f.Close()
 	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", f)
 
-	inputURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, inputURL.String())
+	inputURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, inputURL)
 	sch, err := s.State.Charm(inputURL)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -235,11 +233,11 @@ func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
 
 	// Now try uploading it and ensure the revision persists.
 	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &buf)
-	expectedURL := charm.MustParseURL("local:quantal/dummy-123")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-123"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.URL(), gc.Equals, expectedURL)
 	c.Assert(sch.Revision(), gc.Equals, 123)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 	c.Assert(sch.BundleSha256(), gc.Equals, expectedSHA256)
@@ -256,8 +254,8 @@ func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
 func (s *charmsSuite) TestUploadWithMultiSeriesCharm(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	resp := s.uploadRequest(c, s.charmsURL("").String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := charm.MustParseURL("local:dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 }
 
 func (s *charmsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
@@ -267,8 +265,8 @@ func (s *charmsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
 	url := s.charmsURL("series=quantal")
 	url.Path = "/charms"
 	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 }
 
 func (s *charmsSuite) TestUploadAllowsModelUUIDPath(c *gc.C) {
@@ -276,8 +274,8 @@ func (s *charmsSuite) TestUploadAllowsModelUUIDPath(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	url := s.charmsURL("series=quantal")
 	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 }
 
 func (s *charmsSuite) TestUploadAllowsOtherModelUUIDPath(c *gc.C) {
@@ -289,8 +287,8 @@ func (s *charmsSuite) TestUploadAllowsOtherModelUUIDPath(c *gc.C) {
 	url := s.charmsURL("series=quantal")
 	url.Path = fmt.Sprintf("/model/%s/charms", newSt.ModelUUID())
 	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 }
 
 func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
@@ -312,11 +310,11 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 
 	// Now try uploading it - should succeed and be repackaged.
 	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &buf)
-	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.URL(), gc.Equals, expectedURL)
 	c.Assert(sch.Revision(), gc.Equals, 1)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 
@@ -346,9 +344,7 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 
 func (s *charmsSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := charm.MustParseURL(
-		fmt.Sprintf("ch:quantal/%s-%d", ch.Meta().Name, ch.Revision()),
-	)
+	curl := fmt.Sprintf("ch:quantal/%s-%d", ch.Meta().Name, ch.Revision())
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -370,8 +366,8 @@ func (s *charmsSuite) TestNonLocalCharmUpload(c *gc.C) {
 
 	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&series=quantal"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("ch:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "ch:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
@@ -384,7 +380,7 @@ func (s *charmsSuite) TestCharmHubCharmUpload(c *gc.C) {
 	// model migrations).
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	expectedURL := charm.MustParseURL("ch:s390x/bionic/dummy-15")
+	expectedURL := "ch:s390x/bionic/dummy-15"
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          expectedURL,
@@ -396,7 +392,7 @@ func (s *charmsSuite) TestCharmHubCharmUpload(c *gc.C) {
 
 	resp := s.uploadRequest(c, s.charmsURI("?arch=s390x&revision=15&schema=ch&series=bionic"), "application/zip", &fileReader{path: ch.Path})
 
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
@@ -421,8 +417,8 @@ func (s *charmsSuite) TestCharmUploadWithUserOverride(c *gc.C) {
 
 	resp := s.uploadRequest(c, s.charmsURI("?schema=ch"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("ch:dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "ch:dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
@@ -435,8 +431,8 @@ func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
 
 	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&&revision=99"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("ch:dummy-99")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "ch:dummy-99"
+	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
@@ -465,8 +461,8 @@ func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
 			params.MigrationModelHTTPHeader: importedModel.UUID(),
 		},
 	})
-	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/dummy-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 
 	// The charm was added to the migrated model.
 	_, err = newSt.Charm(expectedURL)
@@ -494,8 +490,8 @@ func (s *charmsSuite) TestMigrateCharmName(c *gc.C) {
 			params.MigrationModelHTTPHeader: importedModel.UUID(),
 		},
 	})
-	expectedURL := charm.MustParseURL("local:quantal/meshuggah-1")
-	s.assertUploadResponse(c, resp, expectedURL.String())
+	expectedURL := "local:quantal/meshuggah-1"
+	s.assertUploadResponse(c, resp, expectedURL)
 
 	// The charm was added to the migrated model.
 	_, err = newSt.Charm(expectedURL)
@@ -576,7 +572,7 @@ func (s *charmsSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 func (s *charmsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
 	// Add a charm in pending mode.
 	chInfo := state.CharmInfo{
-		ID:          charm.MustParseURL("ch:focal/dummy-1"),
+		ID:          "ch:focal/dummy-1",
 		Charm:       testcharms.Repo.CharmArchive(c.MkDir(), "dummy"),
 		StoragePath: "", // indicates that we don't have the data in the blobstore yet.
 		SHA256:      "", // indicates that we don't have the data in the blobstore yet.

--- a/apiserver/common/charms/appcharminfo_test.go
+++ b/apiserver/common/charms/appcharminfo_test.go
@@ -39,7 +39,7 @@ func (s *appCharmInfoSuite) TestBasic(c *gc.C) {
 
 	// The convertCharm logic is tested in the CharmInfo tests, so just test
 	// the minimal set of fields here.
-	ch.EXPECT().String().Return("ch:foo-1")
+	ch.EXPECT().URL().Return("ch:foo-1")
 	ch.EXPECT().Revision().Return(1)
 	ch.EXPECT().Config().Return(&charm.Config{})
 	ch.EXPECT().Meta().Return(&charm.Meta{Name: "foo"})

--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -31,7 +31,7 @@ func (s *charmInfoSuite) TestBasic(c *gc.C) {
 	st := mocks.NewMockState(ctrl)
 	st.EXPECT().Model().Return(nil, nil)
 	ch := mocks.NewMockCharm(ctrl)
-	st.EXPECT().Charm(&charm.URL{Schema: "ch", Name: "foo", Revision: 1}).Return(ch, nil)
+	st.EXPECT().Charm("foo-1").Return(ch, nil)
 
 	// The convertCharm logic is tested in the CharmInfo tests, so just test
 	// the minimal set of fields here.
@@ -42,7 +42,7 @@ func (s *charmInfoSuite) TestBasic(c *gc.C) {
 	ch.EXPECT().Metrics().Return(&charm.Metrics{})
 	ch.EXPECT().Manifest().Return(&charm.Manifest{})
 	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
-	ch.EXPECT().String().Return("ch:foo-1")
+	ch.EXPECT().URL().Return("ch:foo-1")
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)
 	authorizer.EXPECT().AuthController().Return(true)

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -17,7 +17,7 @@ import (
 
 type State interface {
 	Model() (Model, error)
-	Charm(curl *charm.URL) (Charm, error)
+	Charm(curl string) (Charm, error)
 	Application(appName string) (Application, error)
 }
 
@@ -26,7 +26,7 @@ type Application interface {
 }
 
 type Charm interface {
-	String() string
+	URL() string
 	Revision() int
 	Meta() *charm.Meta
 	Config() *charm.Config
@@ -73,11 +73,7 @@ func (a *CharmInfoAPI) CharmInfo(args params.CharmURL) (params.Charm, error) {
 		return params.Charm{}, errors.Trace(err)
 	}
 
-	curl, err := charm.ParseURL(args.URL)
-	if err != nil {
-		return params.Charm{}, errors.Trace(err)
-	}
-	aCharm, err := a.state.Charm(curl)
+	aCharm, err := a.state.Charm(args.URL)
 	if err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
@@ -123,7 +119,7 @@ func (a *ApplicationCharmInfoAPI) ApplicationCharmInfo(args params.Entity) (para
 func convertCharm(ch Charm) params.Charm {
 	charm := params.Charm{
 		Revision: ch.Revision(),
-		URL:      ch.String(),
+		URL:      ch.URL(),
 		Config:   params.ToCharmOptionMap(ch.Config()),
 		Meta:     convertCharmMeta(ch.Meta()),
 		Actions:  convertCharmActions(ch.Actions()),
@@ -440,7 +436,7 @@ func (s *StateShim) Model() (Model, error) {
 	return s.State.Model()
 }
 
-func (s *StateShim) Charm(curl *charm.URL) (Charm, error) {
+func (s *StateShim) Charm(curl string) (Charm, error) {
 	return s.State.Charm(curl)
 }
 

--- a/apiserver/common/charms/mocks/mocks.go
+++ b/apiserver/common/charms/mocks/mocks.go
@@ -53,7 +53,7 @@ func (mr *MockStateMockRecorder) Application(arg0 interface{}) *gomock.Call {
 }
 
 // Charm mocks base method.
-func (m *MockState) Charm(arg0 *charm.URL) (charms.Charm, error) {
+func (m *MockState) Charm(arg0 string) (charms.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(charms.Charm)
@@ -242,18 +242,18 @@ func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }
 
-// String mocks base method.
-func (m *MockCharm) String() string {
+// URL mocks base method.
+func (m *MockCharm) URL() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "String")
+	ret := m.ctrl.Call(m, "URL")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// String indicates an expected call of String.
-func (mr *MockCharmMockRecorder) String() *gomock.Call {
+// URL indicates an expected call of URL.
+func (mr *MockCharmMockRecorder) URL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockCharm)(nil).String))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockCharm)(nil).URL))
 }
 
 // MockModel is a mock of Model interface.

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -44,7 +44,7 @@ func newMockState() *mockState {
 			name: "gitlab",
 			life: state.Alive,
 			charm: mockCharm{
-				url:    charm.MustParseURL("ch:gitlab-1"),
+				url:    "ch:gitlab-1",
 				sha256: "fake-sha256",
 			},
 			unitsChanges: unitsChanges,
@@ -231,16 +231,12 @@ func (u *mockUnit) EnsureDead() error {
 }
 
 type mockCharm struct {
-	url    *charm.URL
+	url    string
 	sha256 string
 }
 
-func (ch *mockCharm) URL() *charm.URL {
+func (ch *mockCharm) URL() string {
 	return ch.url
-}
-
-func (ch *mockCharm) String() string {
-	return ch.url.String()
 }
 
 func (ch *mockCharm) BundleSha256() string {

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -148,7 +148,7 @@ func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, er
 			continue
 		}
 		results.Results[i].Result = &params.ApplicationCharm{
-			URL:                  ch.String(),
+			URL:                  ch.URL(),
 			ForceUpgrade:         force,
 			SHA256:               ch.BundleSha256(),
 			CharmModifiedVersion: application.CharmModifiedVersion(),

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -54,7 +54,7 @@ type Application interface {
 // Charm provides the subset of charm state required by the
 // CAAS operator facade.
 type Charm interface {
-	String() string
+	URL() string
 	BundleSha256() string
 	Meta() *charm.Meta
 }

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -4,7 +4,6 @@
 package instancemutater
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -348,13 +347,7 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 			continue
 		}
 		cURL := app.CharmURL()
-		chURL, err := charm.ParseURL(*cURL)
-		if err != nil {
-			changeResults = append(changeResults, params.ProfileInfoResult{
-				Error: apiservererrors.ServerError(err)})
-			continue
-		}
-		ch, err := api.st.Charm(chURL)
+		ch, err := api.st.Charm(*cURL)
 		if err != nil {
 			changeResults = append(changeResults, params.ProfileInfoResult{
 				Error: apiservererrors.ServerError(err)})

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -406,8 +406,8 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtraction() {
 	stateExp.Application("foo").Return(s.application, nil)
 	chURLStr := "ch:app-0"
 	appExp.CharmURL().Return(&chURLStr)
+	stateExp.Charm(chURLStr).Return(s.charm, nil)
 	chURL := charm.MustParseURL(chURLStr)
-	stateExp.Charm(chURL).Return(s.charm, nil)
 	charmExp.Revision().Return(chURL.Revision)
 	charmExp.LXDProfile().Return(lxdprofile.Profile{
 		Config: map[string]string{
@@ -432,8 +432,8 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtractionWithE
 	stateExp.Application("foo").Return(s.application, nil)
 	chURLStr := "ch:app-0"
 	appExp.CharmURL().Return(&chURLStr)
+	stateExp.Charm(chURLStr).Return(s.charm, nil)
 	chURL := charm.MustParseURL(chURLStr)
-	stateExp.Charm(chURL).Return(s.charm, nil)
 	charmExp.Revision().Return(chURL.Revision)
 	charmExp.LXDProfile().Return(lxdprofile.Profile{})
 }

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -6,8 +6,6 @@ package instancemutater
 import (
 	"time"
 
-	"github.com/juju/charm/v11"
-
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
@@ -20,7 +18,7 @@ type InstanceMutaterState interface {
 
 	ModelName() (string, error)
 	Application(appName string) (Application, error)
-	Charm(curl *charm.URL) (Charm, error)
+	Charm(curl string) (Charm, error)
 	Machine(id string) (Machine, error)
 	Unit(unitName string) (Unit, error)
 	ControllerTimestamp() (*time.Time, error)

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -4,7 +4,6 @@
 package instancemutater_test
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
@@ -233,7 +232,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateNoProfil
 	s.unit.EXPECT().ApplicationName().AnyTimes().Return("foo")
 	s.unit.EXPECT().Name().AnyTimes().Return("foo/0")
 
-	curl := charm.MustParseURL("ch:name-me")
+	curl := "ch:name-me"
 	s.state.EXPECT().Charm(curl).Return(s.charm, nil)
 	s.machine0.EXPECT().Units().Return(nil, nil)
 	s.charm.EXPECT().LXDProfile().Return(lxdprofile.Profile{})
@@ -324,7 +323,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherAppChangeCharmURLNo
 	s.state.EXPECT().Application("foo").Return(s.app, nil)
 	curl := "ch:name-me-3"
 	s.app.EXPECT().CharmURL().Return(&curl)
-	s.state.EXPECT().Charm(charm.MustParseURL(curl)).Return(nil, errors.NotFoundf(""))
+	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf(""))
 
 	s.appChanges <- []string{"foo"}
 	s.wc0.AssertNoChange()
@@ -355,9 +354,8 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeCharmURLN
 	s.machine0.EXPECT().Units().Return(nil, nil)
 
 	s.setupPrincipalUnit()
-	curlStr := "ch:name-me"
-	s.unit.EXPECT().CharmURL().Return(&curlStr)
-	curl := charm.MustParseURL(curlStr)
+	curl := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curl)
 	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf(""))
 
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
@@ -389,8 +387,7 @@ func (s *lxdProfileWatcherSuite) updateCharmForMachineLXDProfileWatcher(rev stri
 	}
 	s.state.EXPECT().Application("foo").Return(s.app, nil)
 	s.app.EXPECT().CharmURL().Return(&curl)
-	chURL := charm.MustParseURL(curl)
-	s.state.EXPECT().Charm(chURL).Return(s.charm, nil)
+	s.state.EXPECT().Charm(curl).Return(s.charm, nil)
 	s.charmChanges <- []string{curl}
 	s.appChanges <- []string{"foo"}
 }
@@ -440,15 +437,14 @@ func (s *lxdProfileWatcherSuite) setupScenario(startEmpty, withProfile bool) {
 	s.unit.EXPECT().ApplicationName().AnyTimes().Return("foo")
 	s.unit.EXPECT().Name().AnyTimes().Return("foo/0")
 
-	curlStr := "ch:name-me"
-	curl := charm.MustParseURL(curlStr)
+	curl := "ch:name-me"
 	s.state.EXPECT().Charm(curl).Return(s.charm, nil)
 	if startEmpty {
 		s.machine0.EXPECT().Units().Return(nil, nil)
 	} else {
 		s.machine0.EXPECT().Units().Return([]instancemutater.Unit{s.unit}, nil)
 		s.unit.EXPECT().Application().Return(s.app, nil)
-		s.app.EXPECT().CharmURL().Return(&curlStr)
+		s.app.EXPECT().CharmURL().Return(&curl)
 	}
 
 	if withProfile {

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	charm "github.com/juju/charm/v11"
 	instancemutater "github.com/juju/juju/apiserver/facades/agent/instancemutater"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
@@ -95,7 +94,7 @@ func (mr *MockInstanceMutaterStateMockRecorder) Application(arg0 interface{}) *g
 }
 
 // Charm mocks base method.
-func (m *MockInstanceMutaterState) Charm(arg0 *charm.URL) (instancemutater.Charm, error) {
+func (m *MockInstanceMutaterState) Charm(arg0 string) (instancemutater.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(instancemutater.Charm)

--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -4,7 +4,6 @@
 package instancemutater
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -45,7 +44,7 @@ func (s *instanceMutaterStateShim) Unit(unitName string) (Unit, error) {
 	}, nil
 }
 
-func (s *instanceMutaterStateShim) Charm(curl *charm.URL) (Charm, error) {
+func (s *instanceMutaterStateShim) Charm(curl string) (Charm, error) {
 	ch, err := s.State.Charm(curl)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/agent/metricsadder/metricsadder_test.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder_test.go
@@ -109,7 +109,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}},
@@ -124,7 +124,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 	c.Assert(batches, gc.HasLen, 1)
 	batch := batches[0]
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 2)
@@ -145,7 +145,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}})
@@ -159,7 +159,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	c.Assert(batches, gc.HasLen, 1)
 	batch := batches[0]
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)
@@ -196,7 +196,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 				Tag: test.tag,
 				Batch: params.MetricBatch{
 					UUID:     uuid,
-					CharmURL: s.meteredCharm.String(),
+					CharmURL: s.meteredCharm.URL(),
 					Created:  time.Now(),
 					Metrics:  metrics,
 				}}}})

--- a/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	reflect "reflect"
 
-	charm "github.com/juju/charm/v11"
 	uniter "github.com/juju/juju/apiserver/facades/agent/uniter"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
@@ -41,7 +40,7 @@ func (m *MockLXDProfileBackendV2) EXPECT() *MockLXDProfileBackendV2MockRecorder 
 }
 
 // Charm mocks base method.
-func (m *MockLXDProfileBackendV2) Charm(arg0 *charm.URL) (uniter.LXDProfileCharmV2, error) {
+func (m *MockLXDProfileBackendV2) Charm(arg0 string) (uniter.LXDProfileCharmV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(uniter.LXDProfileCharmV2)

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -4,7 +4,6 @@
 package uniter
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -21,7 +20,7 @@ import (
 )
 
 type LXDProfileBackendV2 interface {
-	Charm(*charm.URL) (LXDProfileCharmV2, error)
+	Charm(string) (LXDProfileCharmV2, error)
 	Machine(string) (LXDProfileMachineV2, error)
 	Unit(string) (LXDProfileUnitV2, error)
 	Model() (LXDProfileModelV2, error)
@@ -98,7 +97,7 @@ func (s LXDProfileStateV2) Unit(id string) (LXDProfileUnitV2, error) {
 	return s.st.Unit(id)
 }
 
-func (s LXDProfileStateV2) Charm(curl *charm.URL) (LXDProfileCharmV2, error) {
+func (s LXDProfileStateV2) Charm(curl string) (LXDProfileCharmV2, error) {
 	c, err := s.st.Charm(curl)
 	return &lxdProfileCharmV2{c}, err
 }
@@ -328,13 +327,7 @@ func (u *LXDProfileAPIv2) LXDProfileRequired(args params.CharmURLs) (params.Bool
 		Results: make([]params.BoolResult, len(args.URLs)),
 	}
 	for i, arg := range args.URLs {
-		curl, err := charm.ParseURL(arg.URL)
-		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-			continue
-		}
-
-		required, err := u.getOneLXDProfileRequired(curl)
+		required, err := u.getOneLXDProfileRequired(arg.URL)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
@@ -345,7 +338,7 @@ func (u *LXDProfileAPIv2) LXDProfileRequired(args params.CharmURLs) (params.Bool
 	return result, nil
 }
 
-func (u *LXDProfileAPIv2) getOneLXDProfileRequired(curl *charm.URL) (bool, error) {
+func (u *LXDProfileAPIv2) getOneLXDProfileRequired(curl string) (bool, error) {
 	ch, err := u.backend.Charm(curl)
 	if err != nil {
 		return false, err

--- a/apiserver/facades/agent/uniter/newlxdprofile_test.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile_test.go
@@ -4,7 +4,6 @@
 package uniter_test
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -269,10 +268,10 @@ func (s *newLxdProfileSuite) expectOneLXDProfileName() {
 }
 
 func (s *newLxdProfileSuite) expectOneLXDProfileRequired() {
-	s.backend.EXPECT().Charm(charm.MustParseURL("ch:mysql-1")).Return(s.charm, nil)
+	s.backend.EXPECT().Charm("ch:mysql-1").Return(s.charm, nil)
 	s.charm.EXPECT().LXDProfile().Return(lxdprofile.Profile{Config: map[string]string{"one": "two"}})
 
-	s.backend.EXPECT().Charm(charm.MustParseURL("ch:testme-3")).Return(nil, errors.NotFoundf("ch:testme-3"))
+	s.backend.EXPECT().Charm("ch:testme-3").Return(nil, errors.NotFoundf("ch:testme-3"))
 }
 
 func (s *newLxdProfileSuite) expectModel() {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -891,11 +891,11 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	curl := s.wordpressUnit.CharmURL()
 	c.Assert(curl, gc.NotNil)
-	c.Assert(*curl, gc.Equals, s.wpCharm.URL().String())
+	c.Assert(*curl, gc.Equals, s.wpCharm.URL())
 
 	// Make sure wordpress application's charm is what we expect.
 	curlStr, force := s.wordpress.CharmURL()
-	c.Assert(*curlStr, gc.Equals, s.wpCharm.String())
+	c.Assert(*curlStr, gc.Equals, s.wpCharm.URL())
 	c.Assert(force, jc.IsFalse)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -915,10 +915,10 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.wpCharm.String(), Ok: true},
+			{Result: s.wpCharm.URL(), Ok: true},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.wpCharm.String(), Ok: force},
+			{Result: s.wpCharm.URL(), Ok: force},
 			{Error: apiservertesting.ErrUnauthorized},
 			// see above
 			// {Error: apiservertesting.ErrUnauthorized},
@@ -932,7 +932,7 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 
 	args := params.EntitiesCharmURL{Entities: []params.EntityCharmURL{
 		{Tag: "unit-mysql-0", CharmURL: "ch:amd64/quantal/application-42"},
-		{Tag: "unit-wordpress-0", CharmURL: s.wpCharm.String()},
+		{Tag: "unit-wordpress-0", CharmURL: s.wpCharm.URL()},
 		{Tag: "unit-foo-42", CharmURL: "ch:amd64/quantal/foo-321"},
 	}}
 	result, err := s.uniter.SetCharmURL(args)
@@ -951,7 +951,7 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 
 	charmURL = s.wordpressUnit.CharmURL()
 	c.Assert(charmURL, gc.NotNil)
-	c.Assert(*charmURL, gc.Equals, s.wpCharm.String())
+	c.Assert(*charmURL, gc.Equals, s.wpCharm.URL())
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {
@@ -1320,7 +1320,7 @@ func (s *uniterSuite) TestConfigSettings(c *gc.C) {
 		Entities: []params.EntityCharmURL{
 			{
 				Tag:      s.wordpressUnit.Tag().String(),
-				CharmURL: s.wpCharm.String(),
+				CharmURL: s.wpCharm.URL(),
 			},
 		},
 	})
@@ -1598,8 +1598,8 @@ func (s *uniterSuite) TestCharmArchiveSha256(c *gc.C) {
 
 	args := params.CharmURLs{URLs: []params.CharmURL{
 		{URL: "something-invalid"},
-		{URL: s.wpCharm.String()},
-		{URL: dummyCharm.String()},
+		{URL: s.wpCharm.URL()},
+		{URL: dummyCharm.URL()},
 	}}
 	result, err := s.uniter.CharmArchiveSha256(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3840,7 +3840,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatch(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}},
@@ -3854,7 +3854,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatch(c *gc.C) {
 	batch, err := s.State.MetricBatch(uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)
@@ -3871,7 +3871,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}})
@@ -3884,7 +3884,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	batch, err := s.State.MetricBatch(uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -527,7 +527,7 @@ func deployApplication(
 	}
 
 	// Try to find the charm URL in state first.
-	ch, err := backend.Charm(curl)
+	ch, err := backend.Charm(args.CharmURL)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -573,7 +573,7 @@ func deployApplication(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	origin, err := convertCharmOrigin(args.CharmOrigin, curl)
+	origin, err := convertCharmOrigin(args.CharmOrigin)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -601,7 +601,7 @@ func deployApplication(
 // from the provided data. It is used in both deploying and refreshing
 // charms, including from old clients which aren't charm origin aware.
 // MaybeSeries is a fallback if the origin is not provided.
-func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL) (corecharm.Origin, error) {
+func convertCharmOrigin(origin *params.CharmOrigin) (corecharm.Origin, error) {
 	if origin == nil {
 		return corecharm.Origin{}, errors.NotValidf("nil charm origin")
 	}
@@ -1018,11 +1018,7 @@ func (api *APIBase) setCharmWithAgentValidation(
 	params setCharmParams,
 	url string,
 ) error {
-	curl, err := charm.ParseURL(url)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	newCharm, err := api.backend.Charm(curl)
+	newCharm, err := api.backend.Charm(url)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1031,7 +1027,7 @@ func (api *APIBase) setCharmWithAgentValidation(
 	if err != nil {
 		logger.Debugf("Unable to locate current charm: %v", err)
 	}
-	newOrigin, err := convertCharmOrigin(params.CharmOrigin, curl)
+	newOrigin, err := convertCharmOrigin(params.CharmOrigin)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -341,7 +341,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:something-else")
+	curl := "ch:something-else"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -351,7 +351,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -362,7 +362,7 @@ func (s *ApplicationSuite) TestSetCharmEverything(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:something-else")
+	curl := "ch:something-else"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -379,7 +379,7 @@ func (s *ApplicationSuite) TestSetCharmEverything(c *gc.C) {
 
 	err = s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName:    "postgresql",
-		CharmURL:           curl.String(),
+		CharmURL:           curl,
 		CharmOrigin:        createCharmOriginFromURL(curl),
 		ConfigSettings:     map[string]string{"trust": "true", "stringOption": "foo"},
 		ConfigSettingsYAML: `postgresql: {"stringOption": "bar", "intOption": 666}`,
@@ -421,7 +421,7 @@ func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:something-else")
+	curl := "ch:something-else"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -435,7 +435,7 @@ func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		ForceUnits:      true,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
@@ -452,10 +452,10 @@ func (s *ApplicationSuite) TestSetCharmInvalidApplication(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.backend.EXPECT().Application("badapplication").Return(nil, errors.NotFoundf(`application "badapplication"`))
-	curl := charm.MustParseURL("ch:something-else")
+	curl := "ch:something-else"
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "badapplication",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		ForceBase:       true,
 		ForceUnits:      true,
@@ -468,7 +468,7 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -508,7 +508,7 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectCharm(ctrl, &charm.Meta{Deployment: &charm.Deployment{}}, nil, nil)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -549,7 +549,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -573,7 +573,7 @@ func (s *ApplicationSuite) TestSetCharmDisallowDowngradeFormat(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectCharm(ctrl, &charm.Meta{Name: "charm-postgresql"}, &charm.Manifest{Bases: []charm.Base{{}}}, nil)
@@ -582,7 +582,7 @@ func (s *ApplicationSuite) TestSetCharmDisallowDowngradeFormat(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, gc.ErrorMatches, "cannot downgrade from v2 charm format to v1")
@@ -605,7 +605,7 @@ func (s *ApplicationSuite) TestSetCharmUpgradeFormat(c *gc.C) {
 			Risk:  "stable",
 		},
 	}}}, defaultCharmConfig)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	oldCharm := s.expectCharm(ctrl,
@@ -643,7 +643,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -655,7 +655,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettingsYAML: `
 postgresql:
@@ -678,7 +678,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultLxdProfilerCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
@@ -694,7 +694,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 	})
@@ -706,7 +706,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultLxdProfilerCharm(ctrl)
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
@@ -718,7 +718,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 	})
@@ -731,7 +731,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectLxdProfilerCharm(ctrl, &charm.LXDProfile{})
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
@@ -747,7 +747,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
@@ -779,7 +779,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 		},
 	)
 
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -820,7 +820,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 		},
 	)
 
-	curl := charm.MustParseURL("ch:postgresql")
+	curl := "ch:postgresql"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -1441,7 +1441,8 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	c.Assert(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
 }
 
-func createCharmOriginFromURL(curl *charm.URL) *params.CharmOrigin {
+func createCharmOriginFromURL(url string) *params.CharmOrigin {
+	curl := charm.MustParseURL(url)
 	switch curl.Schema {
 	case "local":
 		return &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
@@ -1450,7 +1451,8 @@ func createCharmOriginFromURL(curl *charm.URL) *params.CharmOrigin {
 	}
 }
 
-func createStateCharmOriginFromURL(curl *charm.URL) *state.CharmOrigin {
+func createStateCharmOriginFromURL(url string) *state.CharmOrigin {
+	curl := charm.MustParseURL(url)
 	switch curl.Schema {
 	case "local":
 		return &state.CharmOrigin{Source: "local", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04"}}
@@ -1467,7 +1469,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		"data":    {Type: charm.StorageBlock},
 		"allecto": {Type: charm.StorageBlock},
 	}}, nil, &charm.Config{})
-	curl := charm.MustParseURL("ch:utopic/storage-block-10")
+	curl := "ch:utopic/storage-block-10"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	storageConstraints := map[string]storage.Constraints{
@@ -1479,7 +1481,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	}
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Storage:         storageConstraints,
@@ -1502,12 +1504,12 @@ func (s *ApplicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 	ch := s.expectCharm(ctrl, &charm.Meta{Storage: map[string]charm.Storage{
 		"data": {Type: charm.StorageFilesystem, ReadOnly: true},
 	}}, nil, &charm.Config{})
-	curl := charm.MustParseURL("ch:utopic/storage-filesystem-1")
+	curl := "ch:utopic/storage-filesystem-1"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 	}
@@ -1525,7 +1527,7 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:precise/dummy-42")
+	curl := "ch:precise/dummy-42"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	machine := mocks.NewMockMachine(ctrl)
@@ -1538,7 +1540,7 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 	}
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Placement:       placement,
@@ -1569,20 +1571,20 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 	containerMachine.EXPECT().IsParentLockedForSeriesUpgrade().Return(true, nil).MinTimes(1)
 	s.backend.EXPECT().Machine("0/lxd/0").Return(containerMachine, nil).MinTimes(1)
 
-	curl := charm.MustParseURL("ch:precise/dummy-42")
+	curl := "ch:precise/dummy-42"
 	args := []params.ApplicationDeploy{{
 		ApplicationName: "machine-placement",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "#", Directive: "0"}},
 	}, {
 		ApplicationName: "container-placement",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "lxd", Directive: "0"}},
 	}, {
 		ApplicationName: "container-placement-locked-parent",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "#", Directive: "0/lxd/0"}},
 	}}
@@ -1598,9 +1600,9 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 }
 
 func (s *ApplicationSuite) TestApplicationDeployFailCharmOrigin(c *gc.C) {
-	originId := createCharmOriginFromURL(charm.MustParseURL("ch:jammy/test-42"))
+	originId := createCharmOriginFromURL("ch:jammy/test-42")
 	originId.ID = "testingID"
-	originHash := createCharmOriginFromURL(charm.MustParseURL("ch:jammy/test-42"))
+	originHash := createCharmOriginFromURL("ch:jammy/test-42")
 	originHash.Hash = "testing-hash"
 
 	args := []params.ApplicationDeploy{{
@@ -1647,13 +1649,13 @@ func (s *ApplicationSuite) TestApplicationDeploymentTrust(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:precise/dummy-42")
+	curl := "ch:precise/dummy-42"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil).MinTimes(1)
 
 	withTrust := map[string]string{"trust": "true"}
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Config:          withTrust,
@@ -1675,12 +1677,12 @@ func (s *ApplicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("ch:focal/riak-42")
+	curl := "ch:focal/riak-42"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil).MinTimes(1)
 
 	args := []params.ApplicationDeploy{{
 		ApplicationName: "old",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
 		NumUnits:        1,
 		EndpointBindings: map[string]string{
@@ -1690,7 +1692,7 @@ func (s *ApplicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 		},
 	}, {
 		ApplicationName: "regular",
-		CharmURL:        curl.String(),
+		CharmURL:        curl,
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
 		NumUnits:        1,
 		EndpointBindings: map[string]string{
@@ -1836,11 +1838,11 @@ func (s *ApplicationSuite) TestDeployCAASInvalidServiceType(c *gc.C) {
 	ch := s.expectDefaultCharm(ctrl)
 	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil)
 
-	curl := charm.MustParseURL("local:foo-0")
+	curl := "local:foo-0"
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
-			CharmURL:        curl.String(),
+			CharmURL:        curl,
 			CharmOrigin:     createCharmOriginFromURL(curl),
 			NumUnits:        1,
 			Config:          map[string]string{"kubernetes-service-type": "ClusterIP", "intOption": "2"},

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -44,7 +44,7 @@ type Backend interface {
 	RemoteApplication(string) (RemoteApplication, error)
 	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
 	AddRelation(...state.Endpoint) (Relation, error)
-	Charm(*charm.URL) (Charm, error)
+	Charm(string) (Charm, error)
 	Relation(int) (Relation, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
 	InferActiveRelation(...string) (Relation, error)
@@ -351,7 +351,7 @@ func (s stateShim) UpdateUploadedCharm(info state.CharmInfo) (services.UploadedC
 	return stateCharmShim{Charm: c}, nil
 }
 
-func (s stateShim) PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error) {
+func (s stateShim) PrepareCharmUpload(curl string) (services.UploadedCharm, error) {
 	c, err := s.State.PrepareCharmUpload(curl)
 	if err != nil {
 		return nil, err
@@ -399,7 +399,7 @@ func (s stateShim) SaveEgressNetworks(relationKey string, cidrs []string) (state
 	return api.Save(relationKey, false, cidrs)
 }
 
-func (s stateShim) Charm(curl *charm.URL) (Charm, error) {
+func (s stateShim) Charm(curl string) (Charm, error) {
 	ch, err := s.State.Charm(curl)
 	if err != nil {
 		return nil, err

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -570,9 +570,9 @@ func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
-func (s *DeployLocalSuite) assertCharm(c *gc.C, app application.Application, expect *charm.URL) {
+func (s *DeployLocalSuite) assertCharm(c *gc.C, app application.Application, expect string) {
 	curl, force := app.CharmURL()
-	c.Assert(*curl, gc.Equals, expect.String())
+	c.Assert(*curl, gc.Equals, expect)
 	c.Assert(force, jc.IsFalse)
 }
 

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -7,7 +7,6 @@ package application
 import (
 	reflect "reflect"
 
-	charm "github.com/juju/charm/v11"
 	resource "github.com/juju/charm/v11/resource"
 	services "github.com/juju/juju/apiserver/facades/client/charms/services"
 	cloud "github.com/juju/juju/cloud"
@@ -159,7 +158,7 @@ func (mr *MockDeployFromRepositoryStateMockRecorder) AllSpaceInfos() *gomock.Cal
 }
 
 // Charm mocks base method.
-func (m *MockDeployFromRepositoryState) Charm(arg0 *charm.URL) (Charm, error) {
+func (m *MockDeployFromRepositoryState) Charm(arg0 string) (Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(Charm)
@@ -248,7 +247,7 @@ func (mr *MockDeployFromRepositoryStateMockRecorder) ModelUUID() *gomock.Call {
 }
 
 // PrepareCharmUpload mocks base method.
-func (m *MockDeployFromRepositoryState) PrepareCharmUpload(arg0 *charm.URL) (services.UploadedCharm, error) {
+func (m *MockDeployFromRepositoryState) PrepareCharmUpload(arg0 string) (services.UploadedCharm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareCharmUpload", arg0)
 	ret0, _ := ret[0].(services.UploadedCharm)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -72,7 +72,7 @@ func (s *validatorSuite) TestValidateSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL,
+		charmURL:        resultURL.String(),
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
@@ -126,7 +126,7 @@ func (s *validatorSuite) testValidateIAASAttachStorage(c *gc.C, argStorage []str
 		c.Assert(dt, gc.DeepEquals, deployTemplate{
 			applicationName: "test-charm",
 			charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-			charmURL:        resultURL,
+			charmURL:        resultURL.String(),
 			numUnits:        1,
 			origin:          resolvedOrigin,
 			attachStorage:   expectedStorageTags,
@@ -183,7 +183,7 @@ func (s *validatorSuite) TestValidatePlacementSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL,
+		charmURL:        resultURL.String(),
 		numUnits:        1,
 		origin:          resolvedOrigin,
 		placement:       arg.Placement,
@@ -229,7 +229,7 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL,
+		charmURL:        resultURL.String(),
 		endpoints:       endpointMap,
 		numUnits:        1,
 		origin:          resolvedOrigin,
@@ -480,7 +480,7 @@ func (s *validatorSuite) TestGetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
 	c.Assert(obtainedCharm, gc.DeepEquals, corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata))
-	c.Assert(obtainedURL.String(), gc.Equals, resultURL.String())
+	c.Assert(obtainedURL, gc.Equals, resultURL.String())
 }
 
 func (s *validatorSuite) TestGetCharmAlreadyDeployed(c *gc.C) {
@@ -517,7 +517,7 @@ func (s *validatorSuite) TestGetCharmAlreadyDeployed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
 	c.Assert(obtainedCharm, gc.NotNil)
-	c.Assert(obtainedURL.String(), gc.Equals, resultURL.String())
+	c.Assert(obtainedURL, gc.Equals, resultURL.String())
 }
 
 func (s *validatorSuite) TestGetCharmFindsBundle(c *gc.C) {
@@ -911,7 +911,7 @@ func (s *validatorSuite) TestResolveResourcesSuccess(c *gc.C) {
 	deployResArg := map[string]string{"foo-file": "bar", "foo-file2": "3"}
 
 	s.repo.EXPECT().ResolveResources(resolveResourcesArgsMatcher{c: c, expected: &resArgs}, corecharm.CharmID{URL: curl, Origin: origin}).Return(resResult, nil)
-	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(curl, origin, deployResArg, resMeta)
+	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(curl.String(), origin, deployResArg, resMeta)
 	pendUp := &params.PendingResourceUpload{
 		Name:     "foo-resource",
 		Type:     "file",
@@ -958,7 +958,7 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 	c.Assert(obtainedDT, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL,
+		charmURL:        resultURL.String(),
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
@@ -1050,7 +1050,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		charmURL:        "ch:amd64/jammy/testme-5",
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{
@@ -1064,7 +1064,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
-		ID:    charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		ID:    "ch:amd64/jammy/testme-5",
 	}
 
 	s.state.EXPECT().AddCharmMetadata(info).Return(s.charm, nil)
@@ -1170,7 +1170,7 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		charmURL:        "ch:amd64/jammy/testme-5",
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{
@@ -1187,7 +1187,7 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
-		ID:    charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		ID:    "ch:amd64/jammy/testme-5",
 	}
 
 	s.state.EXPECT().AddCharmMetadata(info).Return(s.charm, nil)
@@ -1261,7 +1261,7 @@ func (s *deployRepositorySuite) TestRemovePendingResourcesWhenDeployErrors(c *gc
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		charmURL:        "ch:amd64/jammy/testme-5",
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{
@@ -1278,7 +1278,7 @@ func (s *deployRepositorySuite) TestRemovePendingResourcesWhenDeployErrors(c *gc
 	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
-		ID:    charm.MustParseURL("ch:amd64/jammy/testme-5"),
+		ID:    "ch:amd64/jammy/testme-5",
 	}
 
 	s.state.EXPECT().AddCharmMetadata(info).Return(s.charm, nil)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -72,7 +72,7 @@ func (s *validatorSuite) TestValidateSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL.String(),
+		charmURL:        resultURL,
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
@@ -126,7 +126,7 @@ func (s *validatorSuite) testValidateIAASAttachStorage(c *gc.C, argStorage []str
 		c.Assert(dt, gc.DeepEquals, deployTemplate{
 			applicationName: "test-charm",
 			charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-			charmURL:        resultURL.String(),
+			charmURL:        resultURL,
 			numUnits:        1,
 			origin:          resolvedOrigin,
 			attachStorage:   expectedStorageTags,
@@ -183,7 +183,7 @@ func (s *validatorSuite) TestValidatePlacementSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL.String(),
+		charmURL:        resultURL,
 		numUnits:        1,
 		origin:          resolvedOrigin,
 		placement:       arg.Placement,
@@ -229,7 +229,7 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL.String(),
+		charmURL:        resultURL,
 		endpoints:       endpointMap,
 		numUnits:        1,
 		origin:          resolvedOrigin,
@@ -480,7 +480,7 @@ func (s *validatorSuite) TestGetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
 	c.Assert(obtainedCharm, gc.DeepEquals, corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata))
-	c.Assert(obtainedURL, gc.Equals, resultURL.String())
+	c.Assert(obtainedURL, gc.DeepEquals, resultURL)
 }
 
 func (s *validatorSuite) TestGetCharmAlreadyDeployed(c *gc.C) {
@@ -517,7 +517,7 @@ func (s *validatorSuite) TestGetCharmAlreadyDeployed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
 	c.Assert(obtainedCharm, gc.NotNil)
-	c.Assert(obtainedURL, gc.Equals, resultURL.String())
+	c.Assert(obtainedURL, gc.DeepEquals, resultURL)
 }
 
 func (s *validatorSuite) TestGetCharmFindsBundle(c *gc.C) {
@@ -911,7 +911,7 @@ func (s *validatorSuite) TestResolveResourcesSuccess(c *gc.C) {
 	deployResArg := map[string]string{"foo-file": "bar", "foo-file2": "3"}
 
 	s.repo.EXPECT().ResolveResources(resolveResourcesArgsMatcher{c: c, expected: &resArgs}, corecharm.CharmID{URL: curl, Origin: origin}).Return(resResult, nil)
-	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(curl.String(), origin, deployResArg, resMeta)
+	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(curl, origin, deployResArg, resMeta)
 	pendUp := &params.PendingResourceUpload{
 		Name:     "foo-resource",
 		Type:     "file",
@@ -958,7 +958,7 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 	c.Assert(obtainedDT, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata),
-		charmURL:        resultURL.String(),
+		charmURL:        resultURL,
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
@@ -1050,7 +1050,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        "ch:amd64/jammy/testme-5",
+		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{
@@ -1170,7 +1170,7 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        "ch:amd64/jammy/testme-5",
+		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{
@@ -1261,7 +1261,7 @@ func (s *deployRepositorySuite) TestRemovePendingResourcesWhenDeployErrors(c *gc
 	template := deployTemplate{
 		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
-		charmURL:        "ch:amd64/jammy/testme-5",
+		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
 		endpoints:       map[string]string{"to": "from"},
 		numUnits:        1,
 		origin: corecharm.Origin{

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -223,7 +223,7 @@ func (mr *MockBackendMockRecorder) Branch(arg0 interface{}) *gomock.Call {
 }
 
 // Charm mocks base method.
-func (m *MockBackend) Charm(arg0 *charm.URL) (application.Charm, error) {
+func (m *MockBackend) Charm(arg0 string) (application.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(application.Charm)
@@ -394,7 +394,7 @@ func (mr *MockBackendMockRecorder) OfferConnectionForRelation(arg0 interface{}) 
 }
 
 // PrepareCharmUpload mocks base method.
-func (m *MockBackend) PrepareCharmUpload(arg0 *charm.URL) (services.UploadedCharm, error) {
+func (m *MockBackend) PrepareCharmUpload(arg0 string) (services.UploadedCharm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareCharmUpload", arg0)
 	ret0, _ := ret[0].(services.UploadedCharm)

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -297,7 +297,7 @@ func (m *mockState) ControllerTag() names.ControllerTag {
 	return testing.ControllerTag
 }
 
-func (m *mockState) Charm(*charm.URL) (crossmodel.Charm, error) {
+func (m *mockState) Charm(string) (crossmodel.Charm, error) {
 	return &mockCharm{}, nil
 }
 

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -4,7 +4,6 @@
 package applicationoffers
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -56,7 +55,7 @@ func (pool statePoolShim) GetModel(modelUUID string) (Model, func(), error) {
 // Backend provides selected methods off the state.State struct.
 type Backend interface {
 	commoncrossmodel.Backend
-	Charm(*charm.URL) (commoncrossmodel.Charm, error)
+	Charm(string) (commoncrossmodel.Charm, error)
 	ApplicationOffer(name string) (*crossmodel.ApplicationOffer, error)
 	Model() (Model, error)
 	OfferConnections(string) ([]OfferConnection, error)
@@ -127,7 +126,7 @@ type stateCharmShim struct {
 	*state.Charm
 }
 
-func (s stateShim) Charm(curl *charm.URL) (commoncrossmodel.Charm, error) {
+func (s stateShim) Charm(curl string) (commoncrossmodel.Charm, error) {
 	ch, err := s.st.Charm(curl)
 	if err != nil {
 		return nil, err

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -542,7 +542,7 @@ func (b *BundleAPI) bundleDataApplications(
 			// from the charm config metadata.
 			cfgInfo, ok := charmConfigCache[charmURL]
 			if !ok {
-				ch, err := backend.Charm(curl)
+				ch, err := backend.Charm(application.CharmURL())
 				if err != nil {
 					return nil, nil, nil, errors.Trace(err)
 				}

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -542,7 +542,7 @@ func (b *BundleAPI) bundleDataApplications(
 			// from the charm config metadata.
 			cfgInfo, ok := charmConfigCache[charmURL]
 			if !ok {
-				ch, err := backend.Charm(application.CharmURL())
+				ch, err := backend.Charm(curl.String())
 				if err != nil {
 					return nil, nil, nil, errors.Trace(err)
 				}

--- a/apiserver/facades/client/bundle/mock_test.go
+++ b/apiserver/facades/client/bundle/mock_test.go
@@ -52,7 +52,7 @@ func (m *mockState) GetExportConfig() state.ExportConfig {
 	}
 }
 
-func (m *mockState) Charm(url *charm.URL) (charm.Charm, error) {
+func (m *mockState) Charm(url string) (charm.Charm, error) {
 	return m.charm, nil
 }
 

--- a/apiserver/facades/client/bundle/state.go
+++ b/apiserver/facades/client/bundle/state.go
@@ -13,7 +13,7 @@ import (
 type Backend interface {
 	ExportPartial(cfg state.ExportConfig) (description.Model, error)
 	GetExportConfig() state.ExportConfig
-	Charm(url *charm.URL) (charm.Charm, error)
+	Charm(url string) (charm.Charm, error)
 	state.EndpointBinding
 }
 
@@ -21,7 +21,7 @@ type stateShim struct {
 	*state.State
 }
 
-func (m *stateShim) Charm(url *charm.URL) (charm.Charm, error) {
+func (m *stateShim) Charm(url string) (charm.Charm, error) {
 	return m.State.Charm(url)
 }
 

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -90,7 +90,7 @@ func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(
 		c, &factory.CharmParams{Name: "metered", URL: "ch:amd64/xenial/metered"})
 	info, err := s.api.CharmInfo(params.CharmURL{
-		URL: meteredCharm.String(),
+		URL: meteredCharm.URL(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := &params.CharmMetrics{
@@ -135,7 +135,7 @@ func (s *charmsSuite) assertListCharms(c *gc.C, someCharms, args, expected []str
 func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 	metered, err := s.api.IsMetered(params.CharmURL{
-		URL: charm.String(),
+		URL: charm.URL(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metered.Metered, jc.IsFalse)
@@ -144,7 +144,7 @@ func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 func (s *charmsSuite) TestIsMeteredTrue(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:amd64/quantal/metered"})
 	metered, err := s.api.IsMetered(params.CharmURL{
-		URL: meteredCharm.String(),
+		URL: meteredCharm.URL(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metered.Metered, jc.IsTrue)
@@ -172,10 +172,8 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 	s.expectResolveWithPreferredChannel(3, nil)
 	api := s.api(c)
 
-	curl, err := charm.ParseURL("ch:testme")
-	c.Assert(err, jc.ErrorIsNil)
-	seriesCurl, err := charm.ParseURL("ch:amd64/focal/testme")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:testme"
+	seriesCurl := "ch:amd64/focal/testme"
 
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
@@ -192,18 +190,18 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 
 	args := params.ResolveCharmsWithChannel{
 		Resolve: []params.ResolveCharmWithChannel{
-			{Reference: curl.String(), Origin: params.CharmOrigin{
+			{Reference: curl, Origin: params.CharmOrigin{
 				Source:       corecharm.CharmHub.String(),
 				Architecture: "amd64",
 			}},
-			{Reference: curl.String(), Origin: stableOrigin},
-			{Reference: seriesCurl.String(), Origin: edgeOrigin},
+			{Reference: curl, Origin: stableOrigin},
+			{Reference: seriesCurl, Origin: edgeOrigin},
 		},
 	}
 
 	expected := []params.ResolveCharmWithChannelResult{
 		{
-			URL:    curl.String(),
+			URL:    curl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -211,7 +209,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 				{Name: "ubuntu", Channel: "16.04"},
 			},
 		}, {
-			URL:    curl.String(),
+			URL:    curl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -220,7 +218,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 			},
 		},
 		{
-			URL:    seriesCurl.String(),
+			URL:    seriesCurl,
 			Origin: edgeOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -256,8 +254,7 @@ func (s *charmsMockSuite) TestResolveCharmNoDefinedSeries(c *gc.C) {
 	s.expectResolveWithPreferredChannelNoSeries()
 	api := s.api(c)
 
-	seriesCurl, err := charm.ParseURL("ch:focal/testme")
-	c.Assert(err, jc.ErrorIsNil)
+	seriesCurl := "ch:focal/testme"
 
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
@@ -268,12 +265,12 @@ func (s *charmsMockSuite) TestResolveCharmNoDefinedSeries(c *gc.C) {
 
 	args := params.ResolveCharmsWithChannel{
 		Resolve: []params.ResolveCharmWithChannel{
-			{Reference: seriesCurl.String(), Origin: edgeOrigin},
+			{Reference: seriesCurl, Origin: edgeOrigin},
 		},
 	}
 
 	expected := []params.ResolveCharmWithChannelResult{{
-		URL:            seriesCurl.String(),
+		URL:            seriesCurl,
 		Origin:         edgeOrigin,
 		SupportedBases: []params.Base{{Name: "ubuntu", Channel: "20.04/stable"}},
 	}}
@@ -292,10 +289,8 @@ func (s *charmsMockSuite) TestResolveCharmV6(c *gc.C) {
 		},
 	}
 
-	curl, err := charm.ParseURL("ch:testme")
-	c.Assert(err, jc.ErrorIsNil)
-	seriesCurl, err := charm.ParseURL("ch:amd64/focal/testme")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:testme"
+	seriesCurl := "ch:amd64/focal/testme"
 
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
@@ -312,27 +307,27 @@ func (s *charmsMockSuite) TestResolveCharmV6(c *gc.C) {
 
 	args := params.ResolveCharmsWithChannel{
 		Resolve: []params.ResolveCharmWithChannel{
-			{Reference: curl.String(), Origin: params.CharmOrigin{
+			{Reference: curl, Origin: params.CharmOrigin{
 				Source:       corecharm.CharmHub.String(),
 				Architecture: "amd64",
 			}},
-			{Reference: curl.String(), Origin: stableOrigin},
-			{Reference: seriesCurl.String(), Origin: edgeOrigin},
+			{Reference: curl, Origin: stableOrigin},
+			{Reference: seriesCurl, Origin: edgeOrigin},
 		},
 	}
 
 	expected := []params.ResolveCharmWithChannelResultV6{
 		{
-			URL:             curl.String(),
+			URL:             curl,
 			Origin:          stableOrigin,
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		}, {
-			URL:             curl.String(),
+			URL:             curl,
 			Origin:          stableOrigin,
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		},
 		{
-			URL:             seriesCurl.String(),
+			URL:             seriesCurl,
 			Origin:          edgeOrigin,
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		},
@@ -347,16 +342,15 @@ func (s *charmsMockSuite) TestAddCharmWithLocalSource(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	api := s.api(c)
 
-	curl, err := charm.ParseURL("local:testme")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "local:testme"
 	args := params.AddCharmWithOrigin{
-		URL: curl.String(),
+		URL: curl,
 		Origin: params.CharmOrigin{
 			Source: "local",
 		},
 		Force: false,
 	}
-	_, err = api.AddCharm(args)
+	_, err := api.AddCharm(args)
 	c.Assert(err, gc.ErrorMatches, `unknown schema for charm URL "local:testme"`)
 }
 
@@ -388,7 +382,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 		},
 	}
 
-	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf("%q", curl))
+	s.state.EXPECT().Charm(curl.String()).Return(nil, errors.NotFoundf("%q", curl))
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
 
 	expMeta := new(charm.Meta)
@@ -408,7 +402,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 
 	s.state.EXPECT().AddCharmMetadata(gomock.Any()).DoAndReturn(
 		func(ci state.CharmInfo) (*state.Charm, error) {
-			c.Assert(ci.ID, gc.DeepEquals, curl)
+			c.Assert(ci.ID, gc.DeepEquals, curl.String())
 			// Check that the essential metadata matches what
 			// the repository returned. We use pointer checks here.
 			c.Assert(ci.Charm.Meta(), gc.Equals, expMeta)
@@ -458,7 +452,7 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 		},
 	}
 
-	s.state.EXPECT().Charm(curl).Return(nil, nil) // a nil error indicates that the charm doc already exists
+	s.state.EXPECT().Charm(curl.String()).Return(nil, nil) // a nil error indicates that the charm doc already exists
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
 	s.repository.EXPECT().GetDownloadURL(curl, gomock.Any()).Return(resURL, resolvedOrigin, nil)
 
@@ -487,8 +481,7 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 func (s *charmsMockSuite) TestCheckCharmPlacementWithSubordinate(c *gc.C) {
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectSubordinateApplication(appName)
@@ -498,7 +491,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithSubordinate(c *gc.C) {
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 
@@ -511,8 +504,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
 	arch := arch.DefaultArchitecture
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
@@ -523,7 +515,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 
@@ -535,8 +527,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
 func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArch(c *gc.C) {
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
@@ -552,7 +543,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArch(c *gc.C) {
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 
@@ -565,8 +556,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *
 	arch := arch.DefaultArchitecture
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
@@ -581,7 +571,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 
@@ -593,8 +583,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *
 func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchAndHardwareArch(c *gc.C) {
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
@@ -610,7 +599,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchAndHardware
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 
@@ -622,8 +611,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchAndHardware
 func (s *charmsMockSuite) TestCheckCharmPlacementWithHeterogeneous(c *gc.C) {
 	appName := "winnie"
 
-	curl, err := charm.ParseURL("ch:poo")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "ch:poo"
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
@@ -645,7 +633,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithHeterogeneous(c *gc.C) {
 	args := params.ApplicationCharmPlacements{
 		Placements: []params.ApplicationCharmPlacement{{
 			Application: appName,
-			CharmURL:    curl.String(),
+			CharmURL:    curl,
 		}},
 	}
 

--- a/apiserver/facades/client/charms/interface.go
+++ b/apiserver/facades/client/charms/interface.go
@@ -30,7 +30,7 @@ func (s stateShim) UpdateUploadedCharm(charmInfo state.CharmInfo) (services.Uplo
 	return stateCharmShim{Charm: ch}, nil
 }
 
-func (s stateShim) PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error) {
+func (s stateShim) PrepareCharmUpload(curl string) (services.UploadedCharm, error) {
 	ch, err := s.State.PrepareCharmUpload(curl)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/charms/interfaces/state.go
+++ b/apiserver/facades/client/charms/interfaces/state.go
@@ -4,7 +4,6 @@
 package interfaces
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
@@ -29,10 +28,10 @@ type BackendState interface {
 	AddCharmMetadata(state.CharmInfo) (*state.Charm, error)
 	AllCharms() ([]*state.Charm, error)
 	Application(string) (Application, error)
-	Charm(curl *charm.URL) (*state.Charm, error)
+	Charm(curl string) (*state.Charm, error)
 	ControllerTag() names.ControllerTag
 	UpdateUploadedCharm(info state.CharmInfo) (services.UploadedCharm, error)
-	PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error)
+	PrepareCharmUpload(curl string) (services.UploadedCharm, error)
 	Machine(string) (Machine, error)
 	state.MongoSessioner
 	ModelUUID() string

--- a/apiserver/facades/client/charms/mocks/state_mock.go
+++ b/apiserver/facades/client/charms/mocks/state_mock.go
@@ -90,7 +90,7 @@ func (mr *MockBackendStateMockRecorder) Application(arg0 interface{}) *gomock.Ca
 }
 
 // Charm mocks base method.
-func (m *MockBackendState) Charm(arg0 *charm.URL) (*state.Charm, error) {
+func (m *MockBackendState) Charm(arg0 string) (*state.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(*state.Charm)
@@ -177,7 +177,7 @@ func (mr *MockBackendStateMockRecorder) MongoSession() *gomock.Call {
 }
 
 // PrepareCharmUpload mocks base method.
-func (m *MockBackendState) PrepareCharmUpload(arg0 *charm.URL) (services.UploadedCharm, error) {
+func (m *MockBackendState) PrepareCharmUpload(arg0 string) (services.UploadedCharm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareCharmUpload", arg0)
 	ret0, _ := ret[0].(services.UploadedCharm)

--- a/apiserver/facades/client/charms/services/interfaces.go
+++ b/apiserver/facades/client/charms/services/interfaces.go
@@ -6,8 +6,6 @@ package services
 import (
 	"io"
 
-	"github.com/juju/charm/v11"
-
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -15,7 +13,7 @@ import (
 // StateBackend describes an API for accessing/mutating information in state.
 type StateBackend interface {
 	UpdateUploadedCharm(info state.CharmInfo) (UploadedCharm, error)
-	PrepareCharmUpload(curl *charm.URL) (UploadedCharm, error)
+	PrepareCharmUpload(curl string) (UploadedCharm, error)
 	ModelUUID() string
 }
 

--- a/apiserver/facades/client/charms/services/mocks/interface_mocks.go
+++ b/apiserver/facades/client/charms/services/mocks/interface_mocks.go
@@ -8,7 +8,6 @@ import (
 	io "io"
 	reflect "reflect"
 
-	charm "github.com/juju/charm/v11"
 	services "github.com/juju/juju/apiserver/facades/client/charms/services"
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
@@ -53,7 +52,7 @@ func (mr *MockStateBackendMockRecorder) ModelUUID() *gomock.Call {
 }
 
 // PrepareCharmUpload mocks base method.
-func (m *MockStateBackend) PrepareCharmUpload(arg0 *charm.URL) (services.UploadedCharm, error) {
+func (m *MockStateBackend) PrepareCharmUpload(arg0 string) (services.UploadedCharm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareCharmUpload", arg0)
 	ret0, _ := ret[0].(services.UploadedCharm)

--- a/apiserver/facades/client/charms/services/storage.go
+++ b/apiserver/facades/client/charms/services/storage.go
@@ -6,7 +6,6 @@ package services
 import (
 	"fmt"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v3"
@@ -49,21 +48,21 @@ func NewCharmStorage(cfg CharmStorageConfig) *CharmStorage {
 // PrepareToStoreCharm ensures that the store is ready to process the specified
 // charm URL. If the blob for the charm is already stored, the method returns
 // an error to indicate this.
-func (s *CharmStorage) PrepareToStoreCharm(charmURL *charm.URL) error {
+func (s *CharmStorage) PrepareToStoreCharm(charmURL string) error {
 	ch, err := s.stateBackend.PrepareCharmUpload(charmURL)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	if ch.IsUploaded() {
-		return charmdownloader.NewCharmAlreadyStoredError(charmURL.String())
+		return charmdownloader.NewCharmAlreadyStoredError(charmURL)
 	}
 
 	return nil
 }
 
 // CharmStorage attempts to store the contents of a downloaded charm.
-func (s *CharmStorage) Store(charmURL *charm.URL, downloadedCharm charmdownloader.DownloadedCharm) error {
+func (s *CharmStorage) Store(charmURL string, downloadedCharm charmdownloader.DownloadedCharm) error {
 	s.logger.Tracef("store %q", charmURL)
 	storage := s.storageFactory(s.stateBackend.ModelUUID())
 	storagePath, err := s.charmArchiveStoragePath(charmURL)
@@ -108,10 +107,10 @@ func (s *CharmStorage) Store(charmURL *charm.URL, downloadedCharm charmdownloade
 // charmArchiveStoragePath returns a string that is suitable as a
 // storage path, using a random UUID to avoid colliding with concurrent
 // uploads.
-func (s *CharmStorage) charmArchiveStoragePath(charmURL *charm.URL) (string, error) {
+func (s *CharmStorage) charmArchiveStoragePath(charmURL string) (string, error) {
 	uuid, err := s.uuidGenerator()
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("charms/%s-%s", charmURL.String(), uuid), nil
+	return fmt.Sprintf("charms/%s-%s", charmURL, uuid), nil
 }

--- a/apiserver/facades/client/charms/services/storage_test.go
+++ b/apiserver/facades/client/charms/services/storage_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -38,7 +37,7 @@ type storageTestSuite struct {
 func (s *storageTestSuite) TestPrepareToStoreNotYetUploadedCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:ubuntu-lite")
+	curl := "ch:ubuntu-lite"
 
 	s.stateBackend.EXPECT().PrepareCharmUpload(curl).Return(s.uploadedCharm, nil)
 	s.uploadedCharm.EXPECT().IsUploaded().Return(false)
@@ -50,22 +49,22 @@ func (s *storageTestSuite) TestPrepareToStoreNotYetUploadedCharm(c *gc.C) {
 func (s *storageTestSuite) TestPrepareToStoreAlreadyUploadedCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:ubuntu-lite")
+	curl := "ch:ubuntu-lite"
 
 	s.stateBackend.EXPECT().PrepareCharmUpload(curl).Return(s.uploadedCharm, nil)
 	s.uploadedCharm.EXPECT().IsUploaded().Return(true)
 
 	err := s.storage.PrepareToStoreCharm(curl)
 
-	expErr := downloader.NewCharmAlreadyStoredError(curl.String())
+	expErr := downloader.NewCharmAlreadyStoredError(curl)
 	c.Assert(err, gc.Equals, expErr)
 }
 
 func (s *storageTestSuite) TestStoreBlobFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:ubuntu-lite")
-	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl.String(), s.uuid)
+	curl := "ch:ubuntu-lite"
+	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl, s.uuid)
 	dlCharm := downloader.DownloadedCharm{
 		CharmData: strings.NewReader("the-blob"),
 		Size:      7337,
@@ -81,8 +80,8 @@ func (s *storageTestSuite) TestStoreBlobFails(c *gc.C) {
 func (s *storageTestSuite) TestStoreBlobAlreadyStored(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:ubuntu-lite")
-	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl.String(), s.uuid)
+	curl := "ch:ubuntu-lite"
+	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl, s.uuid)
 	dlCharm := downloader.DownloadedCharm{
 		CharmData:    strings.NewReader("the-blob"),
 		Size:         7337,

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -47,7 +47,7 @@ type Backend interface {
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
 	Application(string) (Application, error)
-	Charm(*charm.URL) (*state.Charm, error)
+	Charm(string) (*state.Charm, error)
 	ControllerConfig() (controller.Config, error)
 	ControllerNodes() ([]state.ControllerNode, error)
 	ControllerTag() names.ControllerTag

--- a/apiserver/facades/client/client/mocks/client_mock.go
+++ b/apiserver/facades/client/client/mocks/client_mock.go
@@ -336,7 +336,7 @@ func (mr *MockBackendMockRecorder) Application(arg0 interface{}) *gomock.Call {
 }
 
 // Charm mocks base method.
-func (m *MockBackend) Charm(arg0 *charm.URL) (*state.Charm, error) {
+func (m *MockBackend) Charm(arg0 string) (*state.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(*state.Charm)

--- a/apiserver/facades/client/client/testing/suite.go
+++ b/apiserver/facades/client/client/testing/suite.go
@@ -11,7 +11,6 @@ package testing
 import (
 	"fmt"
 
-	"github.com/juju/charm/v11"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -58,7 +57,7 @@ func (s *CharmSuite) AddMachine(c *gc.C, machineId string, job state.MachineJob)
 func (s *CharmSuite) AddCharmhubCharmWithRevision(c *gc.C, charmName string, rev int) *state.Charm {
 	ch := testcharms.Hub.CharmDir(charmName)
 	name := ch.Meta().Name
-	curl := charm.MustParseURL(fmt.Sprintf("ch:amd64/jammy/%s-%d", name, rev))
+	curl := fmt.Sprintf("ch:amd64/jammy/%s-%d", name, rev)
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -116,7 +115,7 @@ func (s *CharmSuite) SetUnitRevision(c *gc.C, unitName string, rev int) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := u.Application()
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL(fmt.Sprintf("ch:amd64/jammy/%s-%d", svc.Name(), rev))
+	curl := fmt.Sprintf("ch:amd64/jammy/%s-%d", svc.Name(), rev)
 	err = u.SetCharmURL(curl)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -186,13 +186,7 @@ func (a applicationShim) Charm() (Charm, bool, error) {
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
-	return charmShim{
-		Charm: ch,
-	}, force, nil
-}
-
-type charmShim struct {
-	*state.Charm
+	return ch, force, nil
 }
 
 type machineShim struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -328,7 +328,7 @@ func (a *mockApplication) CharmModifiedVersion() int {
 
 func (a *mockApplication) CharmURL() (curl *string, force bool) {
 	a.MethodCall(a, "CharmURL")
-	cURL := a.charm.URL().String()
+	cURL := a.charm.URL()
 	return &cURL, false
 }
 
@@ -374,7 +374,7 @@ func (a *mockApplication) ProvisioningState() *state.ApplicationProvisioningStat
 type mockCharm struct {
 	meta     *charm.Meta
 	manifest *charm.Manifest
-	url      *charm.URL
+	url      string
 }
 
 func (ch *mockCharm) Meta() *charm.Meta {
@@ -385,7 +385,7 @@ func (ch *mockCharm) Manifest() *charm.Manifest {
 	return ch.manifest
 }
 
-func (ch *mockCharm) URL() *charm.URL {
+func (ch *mockCharm) URL() string {
 	return ch.url
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -90,11 +90,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 		life: state.Alive,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 		charmModifiedVersion: 10,
 		scale:                3,
@@ -130,11 +126,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoPendingCharmError(
 		charmPending: true,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 	}
 	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
@@ -147,11 +139,7 @@ func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 		life: state.Alive,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 	}
 	result, err := s.api.SetOperatorStatus(params.SetStatus{
@@ -172,11 +160,7 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 		life: state.Alive,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 		units: []*mockUnit{
 			{
@@ -244,11 +228,7 @@ func (s *CAASApplicationProvisionerSuite) TestApplicationOCIResources(c *gc.C) {
 					},
 				},
 			},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url: "ch:gitlab",
 		},
 	}
 	s.st.resource = &mockResources{
@@ -303,11 +283,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage
 					},
 				},
 			},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url: "ch:gitlab",
 		},
 		units: []*mockUnit{
 			{
@@ -494,11 +470,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 					},
 				},
 			},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url: "ch:gitlab",
 		},
 		units: []*mockUnit{
 			{
@@ -583,11 +555,7 @@ func (s *CAASApplicationProvisionerSuite) TestClearApplicationsResources(c *gc.C
 		life: state.Alive,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 	}
 
@@ -608,11 +576,7 @@ func (s *CAASApplicationProvisionerSuite) TestWatchUnits(c *gc.C) {
 		life: state.Alive,
 		charm: &mockCharm{
 			meta: &charm.Meta{},
-			url: &charm.URL{
-				Schema:   "ch",
-				Name:     "gitlab",
-				Revision: -1,
-			},
+			url:  "ch:gitlab",
 		},
 		unitsChanges: unitsChanges,
 		unitsWatcher: statetesting.NewMockStringsWatcher(unitsChanges),

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -77,7 +77,7 @@ type Application interface {
 
 type Charm interface {
 	Meta() *charm.Meta
-	URL() *charm.URL
+	URL() string
 }
 
 type Unit interface {

--- a/apiserver/facades/controller/caasfirewaller/firewaller_test.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller_test.go
@@ -200,7 +200,7 @@ func (s *firewallerBaseSuite) SetUpTest(c *gc.C) {
 					Deployment: &charm.Deployment{},
 				},
 				manifest: &charm.Manifest{},
-				url:      &charm.URL{Schema: "ch", Name: "gitlab", Revision: -1},
+				url:      "ch:gitlab",
 			},
 		},
 		applicationsWatcher: statetesting.NewMockStringsWatcher(s.applicationsChanges),

--- a/apiserver/facades/controller/caasfirewaller/mock_test.go
+++ b/apiserver/facades/controller/caasfirewaller/mock_test.go
@@ -50,7 +50,7 @@ func (st *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
 	return &st.application, nil
 }
 
-func (st *mockState) Charm(curl *charm.URL) (*state.Charm, error) {
+func (st *mockState) Charm(curl string) (*state.Charm, error) {
 	st.MethodCall(st, "Charm", curl)
 	if err := st.NextErr(); err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ type mockCharm struct {
 	charmscommon.Charm // Override only the methods the tests use
 	meta               *charm.Meta
 	manifest           *charm.Manifest
-	url                *charm.URL
+	url                string
 }
 
 func (s *mockCharm) Meta() *charm.Meta {
@@ -125,7 +125,7 @@ func (s *mockCharm) Manifest() *charm.Manifest {
 	return s.manifest
 }
 
-func (s *mockCharm) URL() *charm.URL {
+func (s *mockCharm) URL() string {
 	s.MethodCall(s, "URL")
 	return s.url
 }
@@ -138,7 +138,7 @@ func (s *mockCommonStateShim) Model() (charmscommon.Model, error) {
 	return s.mockState.Model()
 }
 
-func (s *mockCommonStateShim) Charm(curl *charm.URL) (charmscommon.Charm, error) {
+func (s *mockCommonStateShim) Charm(curl string) (charmscommon.Charm, error) {
 	return s.mockState.Charm(curl)
 }
 

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -6,6 +6,7 @@ package charmdownloader
 import (
 	"sync"
 
+	"github.com/juju/charm/v11"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/http/v2"
@@ -117,18 +118,21 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 		return nil // nothing to do
 	}
 
-	pendingCharm, force, err := app.Charm()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	pendingCharmURL := pendingCharm.URL()
-
 	resolvedOrigin := app.CharmOrigin()
 	if resolvedOrigin == nil {
 		return errors.NotFoundf("download charm for application %q; resolved origin", appTag.Name)
 	}
 
 	downloader, err := a.getDownloader()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	pendingCharm, force, err := app.Charm()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	pendingCharmURL, err := charm.ParseURL(pendingCharm.URL())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -87,7 +87,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeploy(c *gc.C) {
 	}
 
 	pendingCharm := mocks.NewMockCharm(ctrl)
-	pendingCharm.EXPECT().URL().Return(charmURL)
+	pendingCharm.EXPECT().URL().Return(charmURL.String())
 
 	app := mocks.NewMockApplication(ctrl)
 	app.EXPECT().CharmPendingToBeDownloaded().Return(true)
@@ -127,7 +127,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeployMultiAppOneCha
 	}
 
 	pendingCharm := mocks.NewMockCharm(ctrl)
-	pendingCharm.EXPECT().URL().Return(charmURL).AnyTimes()
+	pendingCharm.EXPECT().URL().Return(charmURL.String()).AnyTimes()
 
 	appOne := mocks.NewMockApplication(ctrl)
 	appOne.EXPECT().CharmPendingToBeDownloaded().Return(true)
@@ -178,7 +178,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsRefresh(c *gc.C) {
 	}
 
 	pendingCharm := mocks.NewMockCharm(ctrl)
-	pendingCharm.EXPECT().URL().Return(charmURL)
+	pendingCharm.EXPECT().URL().Return(charmURL.String())
 
 	app := mocks.NewMockApplication(ctrl)
 	app.EXPECT().CharmPendingToBeDownloaded().Return(true)
@@ -217,7 +217,7 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsSetStatusIfDownloadF
 	}
 
 	pendingCharm := mocks.NewMockCharm(ctrl)
-	pendingCharm.EXPECT().URL().Return(charmURL)
+	pendingCharm.EXPECT().URL().Return(charmURL.String())
 
 	app := mocks.NewMockApplication(ctrl)
 	app.EXPECT().CharmPendingToBeDownloaded().Return(true)

--- a/apiserver/facades/controller/charmdownloader/interfaces.go
+++ b/apiserver/facades/controller/charmdownloader/interfaces.go
@@ -19,7 +19,7 @@ type StateBackend interface {
 	WatchApplicationsWithPendingCharms() state.StringsWatcher
 	ControllerConfig() (controller.Config, error)
 	UpdateUploadedCharm(info state.CharmInfo) (services.UploadedCharm, error)
-	PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error)
+	PrepareCharmUpload(curl string) (services.UploadedCharm, error)
 	ModelUUID() string
 	Application(string) (Application, error)
 }
@@ -40,7 +40,7 @@ type Application interface {
 
 // Charm provides an API for querying charm details.
 type Charm interface {
-	URL() *charm.URL
+	URL() string
 }
 
 // Downloader defines an API for downloading and storing charms.

--- a/apiserver/facades/controller/charmdownloader/mocks/mocks.go
+++ b/apiserver/facades/controller/charmdownloader/mocks/mocks.go
@@ -86,7 +86,7 @@ func (mr *MockStateBackendMockRecorder) ModelUUID() *gomock.Call {
 }
 
 // PrepareCharmUpload mocks base method.
-func (m *MockStateBackend) PrepareCharmUpload(arg0 *charm.URL) (services.UploadedCharm, error) {
+func (m *MockStateBackend) PrepareCharmUpload(arg0 string) (services.UploadedCharm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareCharmUpload", arg0)
 	ret0, _ := ret[0].(services.UploadedCharm)
@@ -286,10 +286,10 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 }
 
 // URL mocks base method.
-func (m *MockCharm) URL() *charm.URL {
+func (m *MockCharm) URL() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 

--- a/apiserver/facades/controller/charmdownloader/shims.go
+++ b/apiserver/facades/controller/charmdownloader/shims.go
@@ -4,7 +4,6 @@
 package charmdownloader
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -31,7 +30,7 @@ func (s stateShim) UpdateUploadedCharm(info state.CharmInfo) (services.UploadedC
 	return s.st.UpdateUploadedCharm(info)
 }
 
-func (s stateShim) PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error) {
+func (s stateShim) PrepareCharmUpload(curl string) (services.UploadedCharm, error) {
 	return s.st.PrepareCharmUpload(curl)
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -18,7 +18,7 @@ import (
 type State interface {
 	AddCharmPlaceholder(curl *charm.URL) error
 	AllApplications() ([]Application, error)
-	Charm(curl *charm.URL) (*state.Charm, error)
+	Charm(curl string) (*state.Charm, error)
 	Cloud(name string) (cloud.Cloud, error)
 	ControllerUUID() string
 	Model() (Model, error)

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -342,7 +342,7 @@ func (mr *MockStateMockRecorder) AllApplications() *gomock.Call {
 }
 
 // Charm mocks base method.
-func (m *MockState) Charm(arg0 *charm.URL) (*state.Charm, error) {
+func (m *MockState) Charm(arg0 string) (*state.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
 	ret0, _ := ret[0].(*state.Charm)

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -72,7 +72,7 @@ func (h *objectsCharmHandler) ServeGet(w http.ResponseWriter, r *http.Request) e
 		return errors.Annotate(err, "cannot get charm from state")
 	}
 
-	query.Add("url", ch.URL().String())
+	query.Add("url", ch.URL())
 	query.Add("file", "*")
 	r.URL.RawQuery = query.Encode()
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/juju/charm/v11"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -120,8 +119,7 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	})
 	apitesting.AssertResponse(c, resp, http.StatusOK, "application/json")
 
-	curl, err := charm.ParseURL(fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision()))
-	c.Assert(err, jc.ErrorIsNil)
+	curl := fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision())
 	mysqlCh, err := s.State.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{

--- a/apiserver/testing/application.go
+++ b/apiserver/testing/application.go
@@ -13,7 +13,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Application {
+func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationName string, curl string, forced bool, bundle charm.Charm, cons constraints.Value) *state.Application {
 	app, err := st.Application(applicationName)
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := app.Charm()

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -212,7 +212,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 	err = s.runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:xenial/dummy-1")
-	ch, err := s.State.Charm(charm.MustParseURL("local:xenial/dummy-1"))
+	ch, err := s.State.Charm("local:xenial/dummy-1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy": {
@@ -241,7 +241,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
 	err := s.runDeploy(c, dir)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:bionic/dummy-resource-0")
-	ch, err := s.State.Charm(charm.MustParseURL("local:bionic/dummy-resource-0"))
+	ch, err := s.State.Charm("local:bionic/dummy-resource-0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy-resource": {
@@ -396,7 +396,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(
     `, lxdProfilePath))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:bionic/lxd-profile-0")
-	lxdProfile, err := s.State.Charm(charm.MustParseURL("local:bionic/lxd-profile-0"))
+	lxdProfile, err := s.State.Charm("local:bionic/lxd-profile-0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"lxd-profile": {
@@ -519,7 +519,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c
    `, mysqlPath))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharmsUploaded(c, "local:xenial/mysql-1", "ch:xenial/wordpress-42")
-	mysqlch, err := s.State.Charm(charm.MustParseURL("local:xenial/mysql-1"))
+	mysqlch, err := s.State.Charm("local:xenial/mysql-1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"mysql": {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -328,7 +328,7 @@ func (s *DeploySuite) TestCharmDir(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathRelativeDir(c *gc.C) {
@@ -354,7 +354,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharm(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@20.04", "--force")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "dummy", curl, 1, 0)
+	s.AssertApplication(c, "dummy", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeries(c *gc.C) {
@@ -381,7 +381,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c 
 
 	err = s.runDeployForState(c, charmDir.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "dummy", curl, 1, 0)
+	s.AssertApplication(c, "dummy", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
@@ -398,7 +398,7 @@ func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
 
 	err = s.runDeployForState(c, charmDir.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
@@ -409,7 +409,7 @@ func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesHaveOverlap(c *gc.C) {
@@ -449,7 +449,7 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@12.10", "--force")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "multi-series", curl, 1, 0)
+	s.AssertApplication(c, "multi-series", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedLXDProfileForce(c *gc.C) {
@@ -465,7 +465,7 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedLXDProfileForce(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@12.10", "--force")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "lxd-profile-fail", curl, 1, 0)
+	s.AssertApplication(c, "lxd-profile-fail", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {
@@ -486,8 +486,8 @@ func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {
 	err = s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
 	upgradedRev := dummyCharm.Revision() + 1
-	curl = dummyCharm.URL().WithRevision(upgradedRev)
-	s.AssertApplication(c, "dummy", curl, 1, 0)
+	curl = charm.MustParseURL(dummyCharm.URL()).WithRevision(upgradedRev)
+	s.AssertApplication(c, "dummy", curl.String(), 1, 0)
 	// Check the charm dir was left untouched.
 	ch, err = charm.ReadCharmDir(charmDir.Path)
 	c.Assert(err, jc.ErrorIsNil)
@@ -503,7 +503,7 @@ func (s *DeploySuite) TestCharmBundle(c *gc.C) {
 	err := s.runDeployForState(c, charmDir.Path, "some-application-name", "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:jammy/multi-series-1")
-	s.AssertApplication(c, "some-application-name", curl, 1, 0)
+	s.AssertApplication(c, "some-application-name", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestSubordinateCharm(c *gc.C) {
@@ -514,7 +514,7 @@ func (s *DeploySuite) TestSubordinateCharm(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "logging", curl, 0, 0)
+	s.AssertApplication(c, "logging", curl.String(), 0, 0)
 }
 
 func (s *DeploySuite) combinedSettings(ch charm.Charm, inSettings charm.Settings) charm.Settings {
@@ -637,7 +637,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	err := s.runDeployForState(c, charmDir.Path, "--constraints", "mem=2G cores=2", "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:jammy/multi-series-1")
-	app, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
+	app, _ := s.AssertApplication(c, "multi-series", curl.String(), 1, 0)
 	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2 arch=amd64"))
@@ -674,7 +674,7 @@ func (s *DeploySuite) TestLXDProfileLocalCharm(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "lxd-profile", curl, 1, 0)
+	s.AssertApplication(c, "lxd-profile", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestLXDProfileLocalCharmFails(c *gc.C) {
@@ -707,7 +707,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--storage", "data=machinescoped,1G", "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	app, _ := s.AssertApplication(c, "storage-block", curl, 1, 0)
+	app, _ := s.AssertApplication(c, "storage-block", curl.String(), 1, 0)
 
 	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1250,7 +1250,7 @@ func (s *DeploySuite) TestNumUnits(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "-n", "13", "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "multi-series", curl, 13, 0)
+	s.AssertApplication(c, "multi-series", curl.String(), 13, 0)
 }
 
 func (s *DeploySuite) TestNumUnitsSubordinate(c *gc.C) {
@@ -1389,7 +1389,7 @@ func (s *DeploySuite) TestDeployLocalWithTerms(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "terms1", curl, 1, 0)
+	s.AssertApplication(c, "terms1", curl.String(), 1, 0)
 }
 
 func (s *DeploySuite) TestDeployFlags(c *gc.C) {
@@ -1438,7 +1438,7 @@ func (s *DeploySuite) TestDeployLocalWithSeriesAndForce(c *gc.C) {
 
 	err := s.runDeployForState(c, charmDir.Path, "--base", "ubuntu@12.10", "--force")
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertApplication(c, "terms1", curl, 1, 0)
+	s.AssertApplication(c, "terms1", curl.String(), 1, 0)
 }
 
 // TODO (stickupkid): Remove this test once we remove series in 3.2. This is only
@@ -1692,7 +1692,7 @@ func (s *FakeStoreStateSuite) assertCharmsUploaded(c *gc.C, ids ...string) {
 	c.Assert(err, jc.ErrorIsNil)
 	uploaded := make([]string, len(allCharms))
 	for i, ch := range allCharms {
-		uploaded[i] = ch.URL().String()
+		uploaded[i] = ch.URL()
 	}
 	c.Assert(uploaded, jc.SameContents, ids)
 }

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -560,7 +560,7 @@ func (s *RefreshSuccessStateSuite) SetUpSuite(c *gc.C) {
 
 }
 
-func (s *RefreshSuccessStateSuite) assertUpgraded(c *gc.C, riak *state.Application, revision int, forced bool) *charm.URL {
+func (s *RefreshSuccessStateSuite) assertUpgraded(c *gc.C, riak *state.Application, revision int, forced bool) string {
 	err := riak.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	ch, force, err := riak.Charm()
@@ -592,7 +592,7 @@ func (s *RefreshSuccessStateSuite) SetUpTest(c *gc.C) {
 	s.path = testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
 	err := runDeploy(c, s.path, "--series", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:bionic/riak-7")
+	curl := "local:bionic/riak-7"
 	s.riak, _ = s.RepoSuite.AssertApplication(c, "riak", curl, 1, 1)
 
 	_, forced, err := s.riak.Charm()
@@ -854,7 +854,7 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	}
 
 	s.charmClient.charmInfo = &apicommoncharms.CharmInfo{
-		URL:      ch.String(),
+		URL:      ch.URL(),
 		Meta:     ch.Meta(),
 		Revision: ch.Revision(),
 	}
@@ -1161,7 +1161,7 @@ func (s *RefreshSuccessStateSuite) TestCharmPath(c *gc.C) {
 	_, err = s.runRefresh(c, s.cmd, "riak", "--path", myriakPath)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := s.assertUpgraded(c, s.riak, 42, false)
-	c.Assert(curl.String(), gc.Equals, "local:bionic/riak-42")
+	c.Assert(curl, gc.Equals, "local:bionic/riak-42")
 	s.assertLocalRevision(c, 42, myriakPath)
 }
 
@@ -1182,7 +1182,7 @@ func (s *RefreshSuccessStateSuite) TestSwitchToLocal(c *gc.C) {
 	_, err = s.runRefresh(c, s.cmd, "riak", "--switch", myriakPath)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := s.assertUpgraded(c, s.riak, 42, false)
-	c.Assert(curl.String(), gc.Equals, "local:bionic/riak-42")
+	c.Assert(curl, gc.Equals, "local:bionic/riak-42")
 	s.assertLocalRevision(c, 42, myriakPath)
 }
 
@@ -1201,7 +1201,7 @@ func (s *RefreshSuccessStateSuite) TestCharmPathNoRevUpgrade(c *gc.C) {
 	_, err := s.runRefresh(c, s.cmd, "riak", "--path", myriakPath)
 	c.Assert(err, jc.ErrorIsNil)
 	curl := s.assertUpgraded(c, s.riak, 8, false)
-	c.Assert(curl.String(), gc.Equals, "local:bionic/riak-8")
+	c.Assert(curl, gc.Equals, "local:bionic/riak-8")
 }
 
 func (s *RefreshSuccessStateSuite) TestCharmPathDifferentNameFails(c *gc.C) {

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -6,7 +6,6 @@ package application
 import (
 	"runtime"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -53,7 +52,7 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 	err := runDeploy(c, ch, "some-application-name", "--series", "jammy")
 
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:jammy/multi-series-1")
+	curl := "local:jammy/multi-series-1"
 	s.AssertApplication(c, "some-application-name", curl, 1, 0)
 
 	err = runExpose(c, "some-application-name")
@@ -76,7 +75,7 @@ func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {
 	err := runDeploy(c, ch, "some-application-name", "--series", "jammy")
 
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:jammy/multi-series-1")
+	curl := "local:jammy/multi-series-1"
 	s.AssertApplication(c, "some-application-name", curl, 1, 0)
 
 	// Block operation

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4222,7 +4222,7 @@ type addCharmHubCharm struct {
 func (ac addCharmHubCharm) addCharmStep(c *gc.C, ctx *context, scheme string, rev int) {
 	ch := testcharms.Hub.CharmDir(ac.name)
 	name := ch.Meta().Name
-	curl := charm.MustParseURL(fmt.Sprintf("%s:%s-%d", scheme, name, rev))
+	curl := fmt.Sprintf("%s:%s-%d", scheme, name, rev)
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -4256,7 +4256,7 @@ type addLocalCharm struct {
 func (ac addLocalCharm) addCharmStep(c *gc.C, ctx *context, scheme string, rev int) {
 	ch := testcharms.Repo.CharmDir(ac.name)
 	name := ch.Meta().Name
-	curl := charm.MustParseURL(fmt.Sprintf("%s:quantal/%s-%d", scheme, name, rev))
+	curl := fmt.Sprintf("%s:quantal/%s-%d", scheme, name, rev)
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -4294,7 +4294,7 @@ func (as addApplication) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
 
-	series := ch.URL().Series
+	series := charm.MustParseURL(ch.URL()).Series
 	if series == "" {
 		series = "quantal"
 	}
@@ -4409,7 +4409,7 @@ type setApplicationCharm struct {
 }
 
 func (ssc setApplicationCharm) step(c *gc.C, ctx *context) {
-	ch, err := ctx.st.Charm(charm.MustParseURL(ssc.charm))
+	ch, err := ctx.st.Charm(ssc.charm)
 	c.Assert(err, jc.ErrorIsNil)
 	s, err := ctx.st.Application(ssc.name)
 	c.Assert(err, jc.ErrorIsNil)
@@ -4560,7 +4560,7 @@ type setUnitCharmURL struct {
 func (uc setUnitCharmURL) step(c *gc.C, ctx *context) {
 	u, err := ctx.st.Unit(uc.unitName)
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL(uc.charm)
+	curl := uc.charm
 	err = u.SetCharmURL(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	// lp:1558657

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -294,7 +294,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 			defer closer()
 			_, err = st.AddCharm(state.CharmInfo{
 				Charm:       controllerCharm,
-				ID:          charmURL,
+				ID:          charmURL.String(),
 				StoragePath: "foo", // required to flag the charm as uploaded
 				SHA256:      "bar", // required to flag the charm as uploaded
 			})

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -217,7 +217,7 @@ type stateShim struct {
 	*state.State
 }
 
-func (st *stateShim) PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error) {
+func (st *stateShim) PrepareCharmUpload(curl string) (services.UploadedCharm, error) {
 	return st.State.PrepareCharmUpload(curl)
 }
 
@@ -276,7 +276,7 @@ func addLocalControllerCharm(st *state.State, base corebase.Base, charmFileName 
 		Revision: archive.Revision(),
 		Series:   series,
 	}
-	curl, err = st.PrepareLocalCharmUpload(curl)
+	curl, err = st.PrepareLocalCharmUpload(curl.String())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -298,7 +298,7 @@ func addControllerApplication(
 	cons constraints.Value,
 	address string,
 ) (*state.Unit, error) {
-	ch, err := st.Charm(curl)
+	ch, err := st.Charm(curl.String())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -67,7 +67,7 @@ func CharmChange(modelUUID string, ch *state.Charm) cache.CharmChange {
 
 	return cache.CharmChange{
 		ModelUUID:     modelUUID,
-		CharmURL:      ch.URL().String(),
+		CharmURL:      ch.URL(),
 		CharmVersion:  ch.Version(),
 		LXDProfile:    cProf,
 		DefaultConfig: ch.Config().DefaultSettings(),

--- a/core/charm/downloader/downloader_test.go
+++ b/core/charm/downloader/downloader_test.go
@@ -146,7 +146,7 @@ func (s downloaderSuite) TestCharmAlreadyStored(c *gc.C) {
 	requestedOrigin := corecharm.Origin{Source: corecharm.CharmHub, Channel: mustParseChannel(c, "20.04/edge")}
 	knownOrigin := corecharm.Origin{Source: corecharm.CharmHub, ID: "knowncharmhubid", Hash: "knowncharmhash", Channel: mustParseChannel(c, "20.04/candidate")}
 
-	s.storage.EXPECT().PrepareToStoreCharm(curl).Return(
+	s.storage.EXPECT().PrepareToStoreCharm(curl.String()).Return(
 		downloader.NewCharmAlreadyStoredError(curl.String()),
 	)
 	s.repoGetter.EXPECT().GetCharmRepository(corecharm.CharmHub).Return(repoAdapter{s.repo}, nil)
@@ -165,7 +165,7 @@ func (s downloaderSuite) TestPrepareToStoreCharmError(c *gc.C) {
 	curl := charm.MustParseURL("ch:redis-0")
 	requestedOrigin := corecharm.Origin{Source: corecharm.CharmHub, Channel: mustParseChannel(c, "20.04/edge")}
 
-	s.storage.EXPECT().PrepareToStoreCharm(curl).Return(
+	s.storage.EXPECT().PrepareToStoreCharm(curl.String()).Return(
 		errors.New("something went wrong"),
 	)
 
@@ -176,7 +176,7 @@ func (s downloaderSuite) TestPrepareToStoreCharmError(c *gc.C) {
 }
 
 func (s downloaderSuite) TestNormalizePlatform(c *gc.C) {
-	curl := charm.MustParseURL("ch:ubuntu-lite")
+	curl := "ch:ubuntu-lite"
 	requestedPlatform := corecharm.Platform{
 		Channel: "20.04",
 		OS:      "Ubuntu",
@@ -212,9 +212,10 @@ func (s downloaderSuite) TestDownloadAndStore(c *gc.C) {
 		},
 	}
 
-	s.storage.EXPECT().PrepareToStoreCharm(curl).Return(nil)
-	s.storage.EXPECT().Store(curl, gomock.AssignableToTypeOf(downloader.DownloadedCharm{})).DoAndReturn(
-		func(_ *charm.URL, dc downloader.DownloadedCharm) error {
+	c.Log(curl.String())
+	s.storage.EXPECT().PrepareToStoreCharm(curl.String()).Return(nil)
+	s.storage.EXPECT().Store(curl.String(), gomock.AssignableToTypeOf(downloader.DownloadedCharm{})).DoAndReturn(
+		func(_ string, dc downloader.DownloadedCharm) error {
 			c.Assert(dc.Size, gc.Equals, int64(10))
 
 			contents, err := io.ReadAll(dc.CharmData)

--- a/core/charm/downloader/export_test.go
+++ b/core/charm/downloader/export_test.go
@@ -13,7 +13,7 @@ func (dc DownloadedCharm) Verify(downloadOrigin corecharm.Origin, force bool) er
 	return dc.verify(downloadOrigin, force)
 }
 
-func (d *Downloader) NormalizePlatform(charmURL *charm.URL, platform corecharm.Platform) (corecharm.Platform, error) {
+func (d *Downloader) NormalizePlatform(charmURL string, platform corecharm.Platform) (corecharm.Platform, error) {
 	return d.normalizePlatform(charmURL, platform)
 }
 

--- a/core/charm/downloader/mocks/storage_mocks.go
+++ b/core/charm/downloader/mocks/storage_mocks.go
@@ -7,8 +7,7 @@ package mocks
 import (
 	reflect "reflect"
 
-	charm "github.com/juju/charm/v11"
-	charm0 "github.com/juju/juju/core/charm"
+	charm "github.com/juju/juju/core/charm"
 	downloader "github.com/juju/juju/core/charm/downloader"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -37,7 +36,7 @@ func (m *MockRepositoryGetter) EXPECT() *MockRepositoryGetterMockRecorder {
 }
 
 // GetCharmRepository mocks base method.
-func (m *MockRepositoryGetter) GetCharmRepository(arg0 charm0.Source) (downloader.CharmRepository, error) {
+func (m *MockRepositoryGetter) GetCharmRepository(arg0 charm.Source) (downloader.CharmRepository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmRepository", arg0)
 	ret0, _ := ret[0].(downloader.CharmRepository)
@@ -75,7 +74,7 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 }
 
 // PrepareToStoreCharm mocks base method.
-func (m *MockStorage) PrepareToStoreCharm(arg0 *charm.URL) error {
+func (m *MockStorage) PrepareToStoreCharm(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareToStoreCharm", arg0)
 	ret0, _ := ret[0].(error)
@@ -89,7 +88,7 @@ func (mr *MockStorageMockRecorder) PrepareToStoreCharm(arg0 interface{}) *gomock
 }
 
 // Store mocks base method.
-func (m *MockStorage) Store(arg0 *charm.URL, arg1 downloader.DownloadedCharm) error {
+func (m *MockStorage) Store(arg0 string, arg1 downloader.DownloadedCharm) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Store", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -683,7 +683,7 @@ func PutCharm(st *state.State, curl *charm.URL, ch *charm.CharmDir) (*state.Char
 	if curl.Revision == -1 {
 		curl.Revision = ch.Revision()
 	}
-	if sch, err := st.Charm(curl); err == nil {
+	if sch, err := st.Charm(curl.String()); err == nil {
 		return sch, nil
 	}
 	return AddCharm(st, curl, ch, false)
@@ -740,7 +740,7 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*st
 	}
 	info := state.CharmInfo{
 		Charm:       ch,
-		ID:          curl,
+		ID:          curl.String(),
 		StoragePath: storagePath,
 		SHA256:      digest,
 	}
@@ -840,7 +840,8 @@ func (s *JujuConnSuite) AddTestingCharmForSeries(c *gc.C, name, series string) *
 }
 
 func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm) *state.Application {
-	appSeries := ch.URL().Series
+	curl := charm.MustParseURL(ch.URL())
+	appSeries := curl.Series
 	if appSeries == "kubernetes" {
 		appSeries = corebase.LegacyKubernetesSeries()
 	}
@@ -871,7 +872,8 @@ func (s *JujuConnSuite) AddTestingApplicationWithOrigin(c *gc.C, name string, ch
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *state.Charm, arch string) *state.Application {
-	base, err := corebase.GetBaseFromSeries(ch.URL().Series)
+	curl := charm.MustParseURL(ch.URL())
+	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,
@@ -890,7 +892,8 @@ func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {
-	base, err := corebase.GetBaseFromSeries(ch.URL().Series)
+	curl := charm.MustParseURL(ch.URL())
+	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,
@@ -908,7 +911,8 @@ func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, c
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, ch *state.Charm, bindings map[string]string) *state.Application {
-	base, err := corebase.GetBaseFromSeries(ch.URL().Series)
+	curl := charm.MustParseURL(ch.URL())
+	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"sort"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
@@ -25,12 +24,12 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 }
 
-func (s *RepoSuite) AssertApplication(c *gc.C, name string, expectCurl *charm.URL, unitCount, relCount int) (*state.Application, []*state.Relation) {
+func (s *RepoSuite) AssertApplication(c *gc.C, name string, expectCurl string, unitCount, relCount int) (*state.Application, []*state.Relation) {
 	app, err := s.State.Application(name)
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, expectCurl)
+	c.Assert(ch.URL(), gc.Equals, expectCurl)
 	s.AssertCharmUploaded(c, expectCurl)
 
 	units, err := app.AllUnits()
@@ -44,7 +43,7 @@ func (s *RepoSuite) AssertApplication(c *gc.C, name string, expectCurl *charm.UR
 	return app, rels
 }
 
-func (s *RepoSuite) AssertCharmUploaded(c *gc.C, curl *charm.URL) {
+func (s *RepoSuite) AssertCharmUploaded(c *gc.C, curl string) {
 	ch, err := s.State.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -678,9 +678,9 @@ func (checker *ModelChecker) readModelCharms() {
 	charms, err := checker.model.State().AllCharms()
 	checkErr(err, "AllCharms")
 	for _, charm := range charms {
-		charmURL := charm.URL().String()
+		charmURL := charm.URL()
 		bucketPath := path.Join("buckets", modelUUID, charm.StoragePath())
-		res := checker.lookupResource(bucketPath, charm.String())
+		res := checker.lookupResource(bucketPath, charmURL)
 		if res.ID == "" {
 			continue
 		}

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -64,14 +63,14 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit.Base(), jc.DeepEquals, state.Base{OS: "ubuntu", Channel: "12.10/stable"})
 
-	err = s.unit.SetCharmURL(charm.MustParseURL(*sURL))
+	err = s.unit.SetCharmURL(*sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.unit2, err = s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit2.Base(), jc.DeepEquals, state.Base{OS: "ubuntu", Channel: "12.10/stable"})
 
-	err = s.unit2.SetCharmURL(charm.MustParseURL(*sURL))
+	err = s.unit2.SetCharmURL(*sURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmlessUnit, err = s.application.AddUnit(state.AddUnitParams{})
@@ -82,7 +81,7 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.actionlessUnit.Base(), jc.DeepEquals, state.Base{OS: "ubuntu", Channel: "12.10/stable"})
 
-	err = s.actionlessUnit.SetCharmURL(charm.MustParseURL(*actionlessSURL))
+	err = s.actionlessUnit.SetCharmURL(*actionlessSURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.model, err = s.State.Model()
@@ -164,11 +163,9 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 
 		if t.expectedErr == "" {
 			c.Assert(err, jc.ErrorIsNil)
-			curlStr := t.whichUnit.CharmURL()
-			c.Assert(curlStr, gc.NotNil)
-			curl, err := charm.ParseURL(*curlStr)
-			c.Assert(err, jc.ErrorIsNil)
-			ch, _ := s.State.Charm(curl)
+			curl := t.whichUnit.CharmURL()
+			c.Assert(curl, gc.NotNil)
+			ch, _ := s.State.Charm(*curl)
 			schema := ch.Actions()
 			c.Logf("Schema for unit %q:\n%#v", t.whichUnit.Name(), schema)
 
@@ -567,7 +564,7 @@ func makeUnits(c *gc.C, s *ActionSuite, units map[string]*state.Unit, schemas ma
 		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(u.Base(), jc.DeepEquals, state.Base{OS: "ubuntu", Channel: "12.10/stable"})
-		err = u.SetCharmURL(charm.MustParseURL(*sURL))
+		err = u.SetCharmURL(*sURL)
 		c.Assert(err, jc.ErrorIsNil)
 
 		units[name] = u

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2485,12 +2485,12 @@ func testChangeCharms(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, [
 				about: "charm is added if it's in backing but not in Store",
 				change: watcher.Change{
 					C:  "charms",
-					Id: st.docID(ch.String()),
+					Id: st.docID(ch.URL()),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.CharmInfo{
 						ModelUUID:     st.ModelUUID(),
-						CharmURL:      ch.String(),
+						CharmURL:      ch.URL(),
 						Life:          life.Alive,
 						DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 					}}}
@@ -3539,9 +3539,8 @@ func testChangeApplicationOffers(c *gc.C, runChangeTests func(*gc.C, []changeTes
 			applicationOfferInfo, owner := addOffer(c, st)
 			app, err := st.Application("mysql")
 			c.Assert(err, jc.ErrorIsNil)
-			curlStr, _ := app.CharmURL()
-			curl := charm.MustParseURL(*curlStr)
-			ch, err := st.Charm(curl)
+			curl, _ := app.CharmURL()
+			ch, err := st.Charm(*curl)
 			c.Assert(err, jc.ErrorIsNil)
 			AddTestingApplication(c, st, "another-mysql", ch)
 			offers := NewApplicationOffers(st)

--- a/state/applicationofferuser_test.go
+++ b/state/applicationofferuser_test.go
@@ -4,7 +4,6 @@
 package state_test
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -142,7 +141,7 @@ func (s *ApplicationOfferUserSuite) TestUpdateOfferAccessSetsRelationSuspendedRa
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		// Add another relation to the offered app.
-		curl := charm.MustParseURL("local:quantal/quantal-wordpress-3")
+		curl := "local:quantal/quantal-wordpress-3"
 		wpch, err := s.State.Charm(curl)
 		c.Assert(err, jc.ErrorIsNil)
 		wordpress2 := s.AddTestingApplication(c, "wordpress2", wpch)

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -6,7 +6,6 @@ package state_test
 import (
 	"time"
 
-	"github.com/juju/charm/v11"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
@@ -84,7 +83,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	applicationCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(charm.MustParseURL(*applicationCharmURL))
+	err = unit.SetCharmURL(*applicationCharmURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
@@ -118,7 +117,7 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	applicationCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(charm.MustParseURL(*applicationCharmURL))
+	err = unit.SetCharmURL(*applicationCharmURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {

--- a/state/charm.go
+++ b/state/charm.go
@@ -220,7 +220,7 @@ func (profile *LXDProfile) ValidateConfigDevices() error {
 // CharmInfo contains all the data necessary to store a charm's metadata.
 type CharmInfo struct {
 	Charm       charm.Charm
-	ID          *charm.URL
+	ID          string
 	StoragePath string
 	SHA256      string
 	Version     string
@@ -229,13 +229,13 @@ type CharmInfo struct {
 // insertCharmOps returns the txn operations necessary to insert the supplied
 // charm data. If curl is nil, an error will be returned.
 func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
-	if info.ID == nil {
-		return nil, errors.New("*charm.URL was nil")
+	if info.ID == "" {
+		return nil, errors.New("*charm.URL was empty")
 	}
 
 	pendingUpload := info.SHA256 == "" || info.StoragePath == ""
 
-	infoIDStr := info.ID.String()
+	infoIDStr := info.ID
 	doc := charmDoc{
 		DocID:         infoIDStr,
 		URL:           &infoIDStr,
@@ -333,7 +333,7 @@ func updateCharmOps(mb modelBackend, info CharmInfo, assert bson.D) ([]txn.Op, e
 	charms, closer := mb.db().GetCollection(charmsC)
 	defer closer()
 
-	charmKey := info.ID.String()
+	charmKey := info.ID
 	op, err := nsLife.aliveOp(charms, charmKey)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm")
@@ -544,7 +544,7 @@ func unescapeLXDProfile(profile *LXDProfile) *LXDProfile {
 // Tag returns a tag identifying the charm.
 // Implementing state.GlobalEntity interface.
 func (c *Charm) Tag() names.Tag {
-	return names.NewCharmTag(c.String())
+	return names.NewCharmTag(c.URL())
 }
 
 // Life returns the charm's life state.
@@ -568,7 +568,7 @@ func (c *Charm) Refresh() error {
 // the charm is not referenced by any application.
 func (c *Charm) Destroy() error {
 	buildTxn := func(_ int) ([]txn.Op, error) {
-		ops, err := charmDestroyOps(c.st, c.String())
+		ops, err := charmDestroyOps(c.st, c.URL())
 		if IsNotAlive(err) {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -627,22 +627,13 @@ func (c *Charm) globalKey() string {
 	return charmGlobalKey(c.doc.URL)
 }
 
-// String returns a string representation of the charm's URL.
-func (c *Charm) String() string {
+// URL returns the URL that identifies the charm.
+// Parse the charm's URL on demand, if required.
+func (c *Charm) URL() string {
 	if c.doc.URL == nil {
 		return ""
 	}
 	return *c.doc.URL
-}
-
-// URL returns the URL that identifies the charm.
-// Only use when you require the URL, otherwise use String().
-// Parse the charm's URL on demand, if required.
-func (c *Charm) URL() *charm.URL {
-	if c.charmURL == nil {
-		c.charmURL = charm.MustParseURL(c.String())
-	}
-	return c.charmURL
 }
 
 // Revision returns the monotonically increasing charm
@@ -650,7 +641,7 @@ func (c *Charm) URL() *charm.URL {
 // Parse the charm's URL on demand, if required.
 func (c *Charm) Revision() int {
 	if c.charmURL == nil {
-		c.charmURL = charm.MustParseURL(c.String())
+		c.charmURL = charm.MustParseURL(c.URL())
 	}
 	return c.charmURL.Revision
 }
@@ -732,19 +723,23 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 		return nil, errors.Trace(err)
 	}
 
-	query := charms.FindId(info.ID.String()).Select(bson.M{
+	query := charms.FindId(info.ID).Select(bson.M{
 		"placeholder":   1,
 		"pendingupload": 1,
 	})
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		var doc charmDoc
 		if err := query.One(&doc); err == mgo.ErrNotFound {
-			if info.ID.Schema == "local" {
-				curl, err := st.PrepareLocalCharmUpload(info.ID)
+			curl, err := charm.ParseURL(info.ID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if curl.Schema == "local" {
+				allocatedCurl, err := st.PrepareLocalCharmUpload(curl.String())
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
-				info.ID = curl
+				info.ID = allocatedCurl.String()
 				return updateCharmOps(st, info, stillPending)
 			}
 			return insertCharmOps(st, info)
@@ -779,13 +774,17 @@ func (st *State) AllCharms() ([]*Charm, error) {
 
 // Charm returns the charm with the given URL. Charms pending to be uploaded
 // are returned for Charmhub charms. Charm placeholders are never returned.
-func (st *State) Charm(curl *charm.URL) (*Charm, error) {
-	ch, err := st.findCharm(curl)
+func (st *State) Charm(curl string) (*Charm, error) {
+	parsedURL, err := charm.ParseURL(curl)
 	if err != nil {
 		return nil, err
 	}
-	if (!ch.IsUploaded() && !charm.CharmHub.Matches(curl.Schema)) || ch.IsPlaceholder() {
-		return nil, errors.NotFoundf("charm %q", curl.String())
+	ch, err := st.findCharm(curl, parsedURL.Schema)
+	if err != nil {
+		return nil, err
+	}
+	if (!ch.IsUploaded() && !charm.CharmHub.Matches(parsedURL.Schema)) || ch.IsPlaceholder() {
+		return nil, errors.NotFoundf("charm %q", curl)
 	}
 	return ch, nil
 }
@@ -798,14 +797,14 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 // refreshing a charm can happen before a charm is actually downloaded. Therefore
 // it must be able to find placeholders and update them to allow for a download
 // to happen as part of refresh.
-func (st *State) findCharm(curl *charm.URL) (*Charm, error) {
+func (st *State) findCharm(curl string, schema string) (*Charm, error) {
 	var cdoc charmDoc
 
 	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
 	what := bson.D{
-		{"_id", curl.String()},
+		{"_id", curl},
 	}
 	what = append(what, nsLife.notDead()...)
 	err := charms.Find(what).One(&cdoc)
@@ -816,8 +815,8 @@ func (st *State) findCharm(curl *charm.URL) (*Charm, error) {
 		return nil, errors.Annotatef(err, "cannot get charm %q", curl)
 	}
 
-	if cdoc.PendingUpload && !charm.CharmHub.Matches(curl.Schema) {
-		return nil, errors.NotFoundf("charm %q", curl.String())
+	if cdoc.PendingUpload && !charm.CharmHub.Matches(schema) {
+		return nil, errors.NotFoundf("charm %q", curl)
 	}
 	return newCharm(st, &cdoc), nil
 }
@@ -902,8 +901,12 @@ func (st *State) LatestPlaceholderCharm(curl *charm.URL) (*Charm, error) {
 // in state for the charm.
 //
 // The url's schema must be "local" and it must include a revision.
-func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenURL *charm.URL, err error) {
+func (st *State) PrepareLocalCharmUpload(url string) (chosenURL *charm.URL, err error) {
 	// Perform a few sanity checks first.
+	curl, err := charm.ParseURL(url)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	if curl.Schema != "local" {
 		return nil, errors.Errorf("expected charm URL with local schema, got %q", curl)
 	}
@@ -955,12 +958,16 @@ func isValidPlaceholderCharmURL(curl *charm.URL) bool {
 //
 // TODO(achilleas): This call will be removed once the server-side bundle
 // deployment work lands.
-func (st *State) PrepareCharmUpload(curl *charm.URL) (*Charm, error) {
+func (st *State) PrepareCharmUpload(curl string) (*Charm, error) {
 	// Perform a few sanity checks first.
-	if !isValidPlaceholderCharmURL(curl) {
+	parsedURL, err := charm.ParseURL(curl)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !isValidPlaceholderCharmURL(parsedURL) {
 		return nil, errors.Errorf("expected charm URL with a valid schema, got %q", curl)
 	}
-	if curl.Revision < 0 {
+	if parsedURL.Revision < 0 {
 		return nil, errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
 
@@ -969,17 +976,15 @@ func (st *State) PrepareCharmUpload(curl *charm.URL) (*Charm, error) {
 
 	var (
 		uploadedCharm charmDoc
-		err           error
 	)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// Find an uploaded or pending charm with the given exact curl.
-		curlStr := curl.String()
-		err := charms.FindId(curlStr).One(&uploadedCharm)
+		err := charms.FindId(curl).One(&uploadedCharm)
 		switch {
 		case err == mgo.ErrNotFound:
 			uploadedCharm = charmDoc{
-				DocID:         st.docID(curlStr),
-				URL:           &curlStr,
+				DocID:         st.docID(curl),
+				URL:           &curl,
 				PendingUpload: true,
 			}
 			return insertAnyCharmOps(st, &uploadedCharm)
@@ -1059,7 +1064,7 @@ func (st *State) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {
 	defer closer()
 
 	doc := &charmDoc{}
-	err := charms.FindId(info.ID.String()).One(&doc)
+	err := charms.FindId(info.ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charm %q", info.ID)
 	}
@@ -1095,16 +1100,20 @@ func (st *State) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {
 // a revision that isn't a negative value. Otherwise, an error will be returned.
 func (st *State) AddCharmMetadata(info CharmInfo) (*Charm, error) {
 	// Perform a few sanity checks first.
-	if !isValidPlaceholderCharmURL(info.ID) {
+	curl, err := charm.ParseURL(info.ID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !isValidPlaceholderCharmURL(curl) {
 		return nil, errors.Errorf("expected charm URL with a valid schema, got %q", info.ID)
 	}
-	if info.ID.Revision < 0 {
+	if curl.Revision < 0 {
 		return nil, errors.Errorf("expected charm URL with revision, got %q", info.ID)
 	}
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// Check if the charm doc already exists.
-		ch, err := st.findCharm(info.ID)
+		ch, err := st.findCharm(info.ID, curl.Schema)
 		if errors.Is(err, errors.NotFound) {
 			return insertCharmOps(st, info)
 		} else if err != nil {

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -28,7 +28,7 @@ import (
 type CharmSuite struct {
 	ConnSuite
 	charm *state.Charm
-	curl  *charm.URL
+	curl  string
 }
 
 var _ = gc.Suite(&CharmSuite{})
@@ -58,7 +58,7 @@ func (s *CharmSuite) checkRemoved(c *gc.C) {
 	// Ensure the document is actually gone.
 	coll, closer := state.GetCollection(s.State, "charms")
 	defer closer()
-	count, err := coll.FindId(s.curl.String()).Count()
+	count, err := coll.FindId(s.curl).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(count, gc.Equals, 0)
 }
@@ -75,7 +75,7 @@ func (s *CharmSuite) TestDyingCharm(c *gc.C) {
 func (s *CharmSuite) testCharm(c *gc.C) {
 	dummy, err := s.State.Charm(s.curl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.String(), gc.Equals, s.curl.String())
+	c.Assert(dummy.URL(), gc.Equals, s.curl)
 	c.Assert(dummy.Revision(), gc.Equals, 1)
 	c.Assert(dummy.StoragePath(), gc.Equals, "dummy-path")
 	c.Assert(dummy.BundleSha256(), gc.Equals, "quantal-dummy-1-sha256")
@@ -120,7 +120,7 @@ func (s *CharmSuite) TestCharmFromSha256(c *gc.C) {
 	dummy, err := s.State.CharmFromSha256(ch.BundleSha256()[0:7])
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.String(), gc.Equals, s.curl.String())
+	c.Assert(dummy.URL(), gc.Equals, s.curl)
 	c.Assert(dummy.Revision(), gc.Equals, 1)
 	c.Assert(dummy.StoragePath(), gc.Equals, "dummy-path")
 	c.Assert(dummy.BundleSha256(), gc.Equals, "quantal-dummy-1-sha256")
@@ -176,7 +176,7 @@ func (s *CharmSuite) TestRemoveWithoutDestroy(c *gc.C) {
 }
 
 func (s *CharmSuite) TestCharmNotFound(c *gc.C) {
-	curl := charm.MustParseURL("local:anotherseries/dummy-1")
+	curl := "local:anotherseries/dummy-1"
 	_, err := s.State.Charm(curl)
 	c.Assert(err, gc.ErrorMatches, `charm "local:anotherseries/dummy-1" not found`)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -196,11 +196,9 @@ func (s *CharmSuite) dummyCharm(c *gc.C, curlOverride string) state.CharmInfo {
 		Version:     "dummy-146-g725cfd3-dirty",
 	}
 	if curlOverride != "" {
-		info.ID = charm.MustParseURL(curlOverride)
+		info.ID = curlOverride
 	} else {
-		info.ID = charm.MustParseURL(
-			fmt.Sprintf("local:quantal/%s-%d", info.Charm.Meta().Name, info.Charm.Revision()),
-		)
+		info.ID = fmt.Sprintf("local:quantal/%s-%d", info.Charm.Meta().Name, info.Charm.Revision())
 	}
 	return info
 }
@@ -334,13 +332,13 @@ func (s *CharmSuite) TestAddCharm(c *gc.C) {
 	info := s.dummyCharm(c, "")
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.String(), gc.Equals, info.ID.String())
+	c.Assert(dummy.URL(), gc.Equals, info.ID)
 
 	doc := state.CharmDoc{}
-	err = s.charms.FindId(state.DocID(s.State, info.ID.String())).One(&doc)
+	err = s.charms.FindId(state.DocID(s.State, info.ID)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(*doc.URL, gc.DeepEquals, info.ID.String())
+	c.Assert(*doc.URL, gc.DeepEquals, info.ID)
 
 	expVersion := "dummy-146-g725cfd3-dirty"
 	c.Assert(doc.CharmVersion, gc.Equals, expVersion)
@@ -359,13 +357,13 @@ func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
 	// Add a deployed charm.
 	info := state.CharmInfo{
 		Charm:       ch,
-		ID:          curl,
+		ID:          curl.String(),
 		StoragePath: "dummy-1",
 		SHA256:      "dummy-1-sha256",
 	}
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.String(), gc.Equals, curl.String())
+	c.Assert(dummy.URL(), gc.Equals, curl.String())
 
 	// Charm doc has been updated.
 	var docs []state.CharmDoc
@@ -380,14 +378,14 @@ func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *CharmSuite) assertPendingCharmExists(c *gc.C, curl *charm.URL) {
+func (s *CharmSuite) assertPendingCharmExists(c *gc.C, curl string) {
 	// Find charm directly and verify only the charm URL and
 	// PendingUpload are set.
 	doc := state.CharmDoc{}
-	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
+	err := s.charms.FindId(state.DocID(s.State, curl)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
+	c.Assert(*doc.URL, gc.DeepEquals, curl)
 	c.Assert(doc.PendingUpload, jc.IsTrue)
 	c.Assert(doc.Placeholder, jc.IsFalse)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -418,36 +416,36 @@ func (s *CharmSuite) TestAddCharmWithInvalidMetaData(c *gc.C) {
 
 func (s *CharmSuite) TestPrepareLocalCharmUpload(c *gc.C) {
 	// First test the sanity checks.
-	curl, err := s.State.PrepareLocalCharmUpload(charm.MustParseURL("local:quantal/dummy"))
+	curl, err := s.State.PrepareLocalCharmUpload("local:quantal/dummy")
 	c.Assert(err, gc.ErrorMatches, "expected charm URL with revision, got .*")
 	c.Assert(curl, gc.IsNil)
-	curl, err = s.State.PrepareLocalCharmUpload(charm.MustParseURL("ch:quantal/dummy"))
+	curl, err = s.State.PrepareLocalCharmUpload("ch:quantal/dummy")
 	c.Assert(err, gc.ErrorMatches, "expected charm URL with local schema, got .*")
 	c.Assert(curl, gc.IsNil)
 
 	// No charm in state, so the call should respect given revision.
-	testCurl := charm.MustParseURL("local:quantal/missing-123")
+	testCurl := "local:quantal/missing-123"
 	curl, err = s.State.PrepareLocalCharmUpload(testCurl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl, gc.DeepEquals, testCurl)
-	s.assertPendingCharmExists(c, curl)
+	c.Assert(curl.String(), gc.Equals, testCurl)
+	s.assertPendingCharmExists(c, curl.String())
 
 	// Make sure we can't find it with st.Charm().
-	_, err = s.State.Charm(curl)
+	_, err = s.State.Charm(curl.String())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// Try adding it again with the same revision and ensure it gets bumped.
-	curl, err = s.State.PrepareLocalCharmUpload(curl)
+	curl, err = s.State.PrepareLocalCharmUpload(curl.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl.Revision, gc.Equals, 124)
 
 	// Also ensure the revision cannot decrease.
-	curl, err = s.State.PrepareLocalCharmUpload(curl.WithRevision(42))
+	curl, err = s.State.PrepareLocalCharmUpload(curl.WithRevision(42).String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl.Revision, gc.Equals, 125)
 
 	// Check the given revision is respected.
-	curl, err = s.State.PrepareLocalCharmUpload(curl.WithRevision(1234))
+	curl, err = s.State.PrepareLocalCharmUpload(curl.WithRevision(1234).String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl.Revision, gc.Equals, 1234)
 }
@@ -458,20 +456,20 @@ func (s *CharmSuite) TestPrepareLocalCharmUploadRemoved(c *gc.C) {
 	s.remove(c)
 	curl, err := s.State.PrepareLocalCharmUpload(s.curl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl.Revision, gc.Equals, s.curl.Revision+1)
+	c.Assert(curl.Revision, gc.Equals, charm.MustParseURL(s.curl).Revision+1)
 }
 
 func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 	// First test the sanity checks.
-	sch, err := s.State.PrepareCharmUpload(charm.MustParseURL("ch:quantal/dummy"))
+	sch, err := s.State.PrepareCharmUpload("ch:quantal/dummy")
 	c.Assert(err, gc.ErrorMatches, "expected charm URL with revision, got .*")
 	c.Assert(sch, gc.IsNil)
-	sch, err = s.State.PrepareCharmUpload(charm.MustParseURL("local:quantal/dummy"))
+	sch, err = s.State.PrepareCharmUpload("local:quantal/dummy")
 	c.Assert(err, gc.ErrorMatches, "expected charm URL with a valid schema, got .*")
 	c.Assert(sch, gc.IsNil)
 
 	// No charm in state, so the call should respect given revision.
-	testCurl := charm.MustParseURL("ch:quantal/missing-123")
+	testCurl := "ch:quantal/missing-123"
 	sch, err = s.State.PrepareCharmUpload(testCurl)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, testCurl)
@@ -481,7 +479,7 @@ func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 	// Make sure we can find it with st.Charm().
 	found, err := s.State.Charm(sch.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.String(), gc.Equals, sch.URL().String())
+	c.Assert(found.URL(), gc.Equals, sch.URL())
 
 	// Try adding it again with the same revision and ensure we get the same document.
 	schCopy, err := s.State.PrepareCharmUpload(testCurl)
@@ -509,7 +507,7 @@ func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	sch, err := s.State.UpdateUploadedCharm(info)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("charm %q already uploaded", info.ID))
 	c.Assert(sch, gc.IsNil)
-	info.ID = charm.MustParseURL("local:quantal/missing-1")
+	info.ID = "local:quantal/missing-1"
 	info.SHA256 = "missing"
 	sch, err = s.State.UpdateUploadedCharm(info)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -522,7 +520,7 @@ func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	sch, err = s.State.UpdateUploadedCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, info.ID)
-	c.Assert(sch.Revision(), gc.Equals, info.ID.Revision)
+	c.Assert(sch.Revision(), gc.Equals, charm.MustParseURL(info.ID).Revision)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
 	c.Assert(sch.Meta(), gc.DeepEquals, info.Charm.Meta())
@@ -557,21 +555,21 @@ options:
 	c.Assert(err, jc.ErrorIsNil)
 	ch, err := charm.ReadCharmDir(chDir)
 	c.Assert(err, jc.ErrorIsNil)
-	missingCurl := charm.MustParseURL("local:quantal/missing-1")
+	missingCurl := "local:quantal/missing-1"
 	storagePath := "dummy-1"
 
 	preparedCurl, err := s.State.PrepareLocalCharmUpload(missingCurl)
 	c.Assert(err, jc.ErrorIsNil)
 	info := state.CharmInfo{
 		Charm:       ch,
-		ID:          preparedCurl,
+		ID:          preparedCurl.String(),
 		StoragePath: "dummy-1",
 		SHA256:      "missing",
 	}
 	sch, err := s.State.UpdateUploadedCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, missingCurl)
-	c.Assert(sch.Revision(), gc.Equals, missingCurl.Revision)
+	c.Assert(sch.Revision(), gc.Equals, charm.MustParseURL(missingCurl).Revision)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
 	c.Assert(sch.Meta(), gc.DeepEquals, ch.Meta())
@@ -580,13 +578,13 @@ options:
 	c.Assert(sch.BundleSha256(), gc.Equals, "missing")
 }
 
-func (s *CharmSuite) assertPlaceholderCharmExists(c *gc.C, curl *charm.URL) {
+func (s *CharmSuite) assertPlaceholderCharmExists(c *gc.C, curl string) {
 	// Find charm directly and verify only the charm URL and
 	// Placeholder are set.
 	doc := state.CharmDoc{}
-	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
+	err := s.charms.FindId(state.DocID(s.State, curl)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
+	c.Assert(*doc.URL, gc.DeepEquals, curl)
 	c.Assert(doc.PendingUpload, jc.IsFalse)
 	c.Assert(doc.Placeholder, jc.IsTrue)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -619,20 +617,20 @@ func (s *CharmSuite) TestLatestPlaceholderCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Deployed charm not found.
-	_, err = s.State.LatestPlaceholderCharm(info.ID)
+	_, err = s.State.LatestPlaceholderCharm(charm.MustParseURL(info.ID))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// Add a charm reference
 	curl2 := charm.MustParseURL("ch:quantal/dummy-2")
 	err = s.State.AddCharmPlaceholder(curl2)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPlaceholderCharmExists(c, curl2)
+	s.assertPlaceholderCharmExists(c, curl2.String())
 
 	// Use a URL with an arbitrary rev to search.
 	curl := charm.MustParseURL("ch:quantal/dummy-23")
 	pending, err := s.State.LatestPlaceholderCharm(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pending.URL(), gc.DeepEquals, curl2)
+	c.Assert(pending.URL(), gc.Equals, curl2.String())
 	c.Assert(pending.IsPlaceholder(), jc.IsTrue)
 	c.Assert(pending.Meta(), gc.IsNil)
 	c.Assert(pending.Config(), gc.IsNil)
@@ -657,15 +655,15 @@ func (s *CharmSuite) TestAddCharmPlaceholder(c *gc.C) {
 	curl := charm.MustParseURL("ch:quantal/dummy-1")
 	err := s.State.AddCharmPlaceholder(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPlaceholderCharmExists(c, curl)
+	s.assertPlaceholderCharmExists(c, curl.String())
 
 	// Add the same one again, should be a no-op
 	err = s.State.AddCharmPlaceholder(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPlaceholderCharmExists(c, curl)
+	s.assertPlaceholderCharmExists(c, curl.String())
 }
 
-func (s *CharmSuite) assertAddCharmPlaceholder(c *gc.C) (*charm.URL, *charm.URL, *state.Charm) {
+func (s *CharmSuite) assertAddCharmPlaceholder(c *gc.C) (string, *charm.URL, *state.Charm) {
 	// Add a deployed charm
 	info := s.dummyCharm(c, "ch:quantal/dummy-1")
 	dummy, err := s.State.AddCharm(info)
@@ -675,7 +673,7 @@ func (s *CharmSuite) assertAddCharmPlaceholder(c *gc.C) (*charm.URL, *charm.URL,
 	curl2 := charm.MustParseURL("ch:quantal/dummy-2")
 	err = s.State.AddCharmPlaceholder(curl2)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPlaceholderCharmExists(c, curl2)
+	s.assertPlaceholderCharmExists(c, curl2.String())
 
 	// Deployed charm is still there.
 	existing, err := s.State.Charm(info.ID)
@@ -696,7 +694,7 @@ func (s *CharmSuite) TestAddCharmPlaceholderDeletesOlder(c *gc.C) {
 	curl3 := charm.MustParseURL("ch:quantal/dummy-3")
 	err := s.State.AddCharmPlaceholder(curl3)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPlaceholderCharmExists(c, curl3)
+	s.assertPlaceholderCharmExists(c, curl3.String())
 
 	// Deployed charm is still there.
 	existing, err := s.State.Charm(curl)
@@ -724,9 +722,9 @@ func (s *CharmSuite) TestAllCharms(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charms, gc.HasLen, 3)
 
-	c.Assert(charms[0].String(), gc.Equals, "local:quantal/quantal-dummy-1")
+	c.Assert(charms[0].URL(), gc.Equals, "local:quantal/quantal-dummy-1")
 	c.Assert(charms[1], gc.DeepEquals, sch)
-	c.Assert(charms[2].URL(), gc.DeepEquals, curl2)
+	c.Assert(charms[2].URL(), gc.Equals, curl2.String())
 }
 
 func (s *CharmSuite) TestAddCharmMetadata(c *gc.C) {
@@ -798,7 +796,7 @@ func assertCustomCharm(
 	c.Assert(ch.Revision(), gc.DeepEquals, revision)
 
 	// Test URL matches charm and expected series.
-	url := ch.URL()
+	url := charm.MustParseURL(ch.URL())
 	c.Assert(url.Series, gc.Equals, series)
 	c.Assert(url.Revision, gc.Equals, ch.Revision())
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
@@ -822,12 +821,7 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 // reasons, because it's triggered somewhat over-enthusiastically for
 // simplicity's sake.
 func (st *State) cleanupCharm(charmURL string) error {
-	curl, err := charm.ParseURL(charmURL)
-	if err != nil {
-		return errors.Annotatef(err, "invalid charm URL %v", charmURL)
-	}
-
-	ch, err := st.Charm(curl)
+	ch, err := st.Charm(charmURL)
 	if errors.IsNotFound(err) {
 		// Charm already removed.
 		logger.Tracef("cleanup charm(%s) no-op, charm already gone", charmURL)

--- a/state/errors/common.go
+++ b/state/errors/common.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/version/v2"
@@ -45,10 +44,10 @@ const (
 // the given charm is already uploaded and marked as not pending in
 // state.
 type errCharmAlreadyUploaded struct {
-	curl *charm.URL
+	curl string
 }
 
-func NewErrCharmAlreadyUploaded(curl *charm.URL) error {
+func NewErrCharmAlreadyUploaded(curl string) error {
 	return &errCharmAlreadyUploaded{curl: curl}
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -251,7 +251,7 @@ func AddTestingCharmForSeries(c *gc.C, st *State, series, name string) *Charm {
 func AddTestingCharmhubCharmForSeries(c *gc.C, st *State, series, name string) *Charm {
 	ch := getCharmRepo(series).CharmDir(name)
 	ident := fmt.Sprintf("amd64/%s/%s-%d", series, name, ch.Revision())
-	curl := charm.MustParseURL("ch:" + ident)
+	curl := "ch:" + ident
 	info := CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -266,7 +266,7 @@ func AddTestingCharmhubCharmForSeries(c *gc.C, st *State, series, name string) *
 func AddTestingCharmMultiSeries(c *gc.C, st *State, name string) *Charm {
 	ch := testcharms.Repo.CharmDir(name)
 	ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
-	curl := charm.MustParseURL("ch:" + ident)
+	curl := "ch:" + ident
 	info := CharmInfo{
 		Charm:       ch,
 		ID:          curl,
@@ -308,14 +308,15 @@ func AddTestingApplicationWithNumUnits(c *gc.C, st *State, numUnits int, name st
 }
 
 func AddTestingApplicationWithStorage(c *gc.C, st *State, name string, ch *Charm, storage map[string]StorageConstraints) *Application {
-	series := ch.URL().Series
+	curl := charm.MustParseURL(ch.URL())
+	series := curl.Series
 	if series == "kubernetes" {
 		series = "focal"
 	}
 	base, err := corebase.GetBaseFromSeries(series)
 	c.Assert(err, jc.ErrorIsNil)
 	var source string
-	switch ch.URL().Schema {
+	switch curl.Schema {
 	case "local":
 		source = "local"
 	case "ch":
@@ -371,16 +372,17 @@ type addTestingApplicationParams struct {
 func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Application {
 	c.Assert(params.ch, gc.NotNil)
 	origin := params.origin
+	curl := charm.MustParseURL(params.ch.URL())
 	if origin == nil {
-		base, err := corebase.GetBaseFromSeries(params.ch.URL().Series)
+		base, err := corebase.GetBaseFromSeries(curl.Series)
 		c.Assert(err, jc.ErrorIsNil)
 		var channel *Channel
 		// local charms cannot have a channel
-		if charm.CharmHub.Matches(params.ch.URL().Schema) {
+		if charm.CharmHub.Matches(curl.Schema) {
 			channel = &Channel{Risk: "stable"}
 		}
 		var source string
-		switch params.ch.URL().Schema {
+		switch curl.Schema {
 		case "local":
 			source = "local"
 		case "ch":
@@ -454,12 +456,11 @@ func AddCustomCharm(c *gc.C, st *State, name, filename, content, series string, 
 
 func addCharm(c *gc.C, st *State, series string, ch charm.Charm) *Charm {
 	ident := fmt.Sprintf("%s-%s-%d", series, ch.Meta().Name, ch.Revision())
-	url := "local:" + series + "/" + ident
+	curl := "local:" + series + "/" + ident
 	if series == "" {
 		ident = fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
-		url = "local:" + ident
+		curl = "local:" + ident
 	}
-	curl := charm.MustParseURL(url)
 	info := CharmInfo{
 		Charm:       ch,
 		ID:          curl,

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -96,20 +96,16 @@ func labelsKey(m map[string]string) string {
 
 // validate checks that the MetricBatch contains valid metrics.
 func (m *MetricBatch) validate() error {
-	charmURL, err := charm.ParseURL(m.doc.CharmURL)
+	ch, err := m.st.Charm(m.doc.CharmURL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	chrm, err := m.st.Charm(charmURL)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	chrmMetrics := chrm.Metrics()
-	if chrmMetrics == nil {
+	chMetrics := ch.Metrics()
+	if chMetrics == nil {
 		return errors.Errorf("charm doesn't implement metrics")
 	}
 	for _, m := range m.doc.Metrics {
-		if err := chrmMetrics.ValidateMetric(m.Key, m.Value); err != nil {
+		if err := chMetrics.ValidateMetric(m.Key, m.Value); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -36,7 +36,7 @@ func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	_, err := s.State.AddMetrics(state.BatchParam{
 		UUID:     utils.MustNewUUID().String(),
-		CharmURL: s.meteredCharm.String(),
+		CharmURL: s.meteredCharm.URL(),
 		Created:  now,
 		Metrics:  []state.Metric{},
 		Unit:     s.unit.UnitTag(),
@@ -67,7 +67,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  m,
 			Unit:     s.unit.UnitTag(),
 		},
@@ -123,7 +123,7 @@ func (s *MetricSuite) TestAddMetricOrderedLabels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  m,
 			Unit:     s.unit.UnitTag(),
 		},
@@ -208,7 +208,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     unitTag,
 		},
@@ -224,7 +224,7 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -239,7 +239,7 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -263,7 +263,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -275,7 +275,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -288,7 +288,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -320,7 +320,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  oldTime,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -333,7 +333,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -357,7 +357,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -406,7 +406,7 @@ func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -576,7 +576,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 		state.BatchParam{
 			UUID:     mUUID,
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -587,7 +587,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 		state.BatchParam{
 			UUID:     mUUID,
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -626,7 +626,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Metrics:  []state.Metric{m},
 				Unit:     s.unit.UnitTag(),
 			},
@@ -668,7 +668,7 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -681,7 +681,7 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: localMeteredCharm.String(),
+			CharmURL: localMeteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -730,7 +730,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -742,7 +742,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -776,7 +776,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -788,7 +788,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -821,7 +821,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -833,7 +833,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now.Add(time.Second),
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -851,7 +851,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: meteredCharm.String(),
+			CharmURL: meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -910,7 +910,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: t}},
 				Unit:     s.unit.UnitTag(),
 			},
@@ -921,7 +921,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
-				CharmURL: s.meteredCharm.String(),
+				CharmURL: s.meteredCharm.URL(),
 				Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: t}},
 				Unit:     newUnit.UnitTag(),
 			},
@@ -971,7 +971,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -984,7 +984,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: csMeteredCharm.String(),
+			CharmURL: csMeteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -1006,7 +1006,7 @@ func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  t0,
-			CharmURL: s.meteredCharm.String(),
+			CharmURL: s.meteredCharm.URL(),
 			Metrics: []state.Metric{{
 				Key:   "pings",
 				Value: "1",
@@ -1087,7 +1087,7 @@ func (s *CrossModelMetricSuite) TestMetricsAcrossmodels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.models[0].meteredCharm.String(),
+			CharmURL: s.models[0].meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.models[0].unit.UnitTag(),
 		},
@@ -1098,7 +1098,7 @@ func (s *CrossModelMetricSuite) TestMetricsAcrossmodels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.models[1].meteredCharm.String(),
+			CharmURL: s.models[1].meteredCharm.URL(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.models[1].unit.UnitTag(),
 		},

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -539,7 +539,7 @@ func (s *MigrationImportSuite) setupSourceApplications(
 		CharmOrigin: &state.CharmOrigin{
 			Source:   "charm-hub",
 			Type:     "charm",
-			Revision: &testCharm.URL().Revision,
+			Revision: &charm.MustParseURL(testCharm.URL()).Revision,
 			Channel: &state.Channel{
 				Risk: "edge",
 			},
@@ -663,7 +663,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.String(),
+		URL:      testCharm.URL(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, true)
@@ -725,7 +725,7 @@ func (s *MigrationImportSuite) TestApplicationStatus(c *gc.C) {
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.String(),
+		URL:      testCharm.URL(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, false)
@@ -769,7 +769,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
 		Series:   "kubernetes",
-		URL:      charm.String(),
+		URL:      charm.URL(),
 		Revision: strconv.Itoa(charm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, true)
@@ -844,7 +844,7 @@ func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
 		Series:   "kubernetes",
-		URL:      testCharm.String(),
+		URL:      testCharm.URL(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	newApp, err := newSt.Application(application.Name())
@@ -2988,14 +2988,14 @@ func (s *MigrationImportSuite) TestApplicationAddLatestCharmChannelTrack(c *gc.C
 	origin := &state.CharmOrigin{
 		Source:   "charm-hub",
 		Type:     "charm",
-		Revision: &testCharm.URL().Revision,
+		Revision: &charm.MustParseURL(testCharm.URL()).Revision,
 		Channel: &state.Channel{
 			Risk: "edge",
 		},
 		ID:   "charm-hub-id",
 		Hash: "charmhub-hash",
 		Platform: &state.Platform{
-			Architecture: testCharm.URL().Architecture,
+			Architecture: charm.MustParseURL(testCharm.URL()).Architecture,
 			OS:           "ubuntu",
 			Channel:      "12.10/stable",
 		},
@@ -3029,14 +3029,14 @@ func (s *MigrationImportSuite) TestApplicationFillInCharmOriginID(c *gc.C) {
 	origin := &state.CharmOrigin{
 		Source:   "charm-hub",
 		Type:     "charm",
-		Revision: &testCharm.URL().Revision,
+		Revision: &charm.MustParseURL(testCharm.URL()).Revision,
 		Channel: &state.Channel{
 			Risk: "edge",
 		},
 		ID:   "charm-hub-id",
 		Hash: "charmhub-hash",
 		Platform: &state.Platform{
-			Architecture: testCharm.URL().Architecture,
+			Architecture: charm.MustParseURL(testCharm.URL()).Architecture,
 			OS:           "ubuntu",
 			Channel:      "12.10/stable",
 		},
@@ -3316,7 +3316,7 @@ func (s *MigrationImportSuite) TestApplicationWithProvisioningState(c *gc.C) {
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
 		Series:   "kubernetes",
-		URL:      testCharm.String(),
+		URL:      testCharm.URL(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	importedApplication, err := newSt.Application(application.Name())

--- a/state/state.go
+++ b/state/state.go
@@ -909,12 +909,7 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 		}
 		return model.Operation(tag.Id())
 	case names.CharmTag:
-		if url, err := charm.ParseURL(id); err != nil {
-			logger.Warningf("Parsing charm URL %q failed: %v", id, err)
-			return nil, errors.NotFoundf("could not find charm %q in state", id)
-		} else {
-			return st.Charm(url)
-		}
+		return st.Charm(id)
 	case names.VolumeTag:
 		sb, err := NewStorageBackend(st)
 		if err != nil {
@@ -1301,7 +1296,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	// The doc defaults to CharmModifiedVersion = 0, which is correct, since it
 	// has, by definition, at its initial state.
-	cURL := args.Charm.String()
+	cURL := args.Charm.URL()
 	appDoc := &applicationDoc{
 		DocID:         applicationID,
 		Name:          args.Name,
@@ -1468,9 +1463,13 @@ func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) (Ba
 	if err != nil {
 		return Base{}, errors.Trace(err)
 	}
+	curl, err := charm.ParseURL(args.Charm.URL())
+	if err != nil {
+		return Base{}, errors.Trace(err)
+	}
 
 	var supportedSeries []string
-	if cSeries := args.Charm.URL().Series; cSeries != "" {
+	if cSeries := curl.Series; cSeries != "" {
 		supportedSeries = []string{cSeries}
 		// If a charm has a url, but is a kubernetes charm then we need to
 		// add this to the list of supported series.
@@ -2265,7 +2264,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 				ops = append(ops, txn.Op{
 					C:      applicationsC,
 					Id:     st.docID(ep.ApplicationName),
-					Assert: bson.D{{"life", Alive}, {"charmurl", ch.String()}},
+					Assert: bson.D{{"life", Alive}, {"charmurl", ch.URL()}},
 					Update: bson.D{{"$inc", bson.D{{"relationcount", 1}}}},
 				})
 			}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2301,13 +2301,13 @@ func (s *StateSuite) TestAddApplicationIncompatibleOSWithSeriesInURL(c *gc.C) {
 }
 
 func (s *StateSuite) TestAddApplicationCompatibleOSWithSeriesInURL(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
+	ch := s.AddTestingCharm(c, "dummy")
 	// A charm with a series in its URL is implicitly supported by that
 	// series only.
-	base, err := corebase.GetBaseFromSeries(charm.URL().Series)
+	base, err := corebase.GetBaseFromSeries(charm.MustParseURL(ch.URL()).Series)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
-		Name: "wordpress", Charm: charm,
+		Name: "wordpress", Charm: ch,
 		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
 			OS:      base.OS,
 			Channel: base.Channel.String(),

--- a/state/storage.go
+++ b/state/storage.go
@@ -635,7 +635,7 @@ func validateRemoveOwnerStorageInstanceOps(si *storageInstance) ([]txn.Op, error
 			Id: app.Name(),
 			Assert: bson.D{
 				{"life", Alive},
-				{"charmurl", ch.String()},
+				{"charmurl", ch.URL()},
 			},
 		})
 	case names.UnitTagKind:

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -150,7 +150,7 @@ func (s *StorageStateSuiteBase) setupSingleStorageDetachable(c *gc.C, kind, pool
 	testStorage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
 	}
-	app := s.AddTestingApplicationWithStorage(c, ch.URL().Name, ch, testStorage)
+	app := s.AddTestingApplicationWithStorage(c, charm.MustParseURL(ch.URL()).Name, ch, testStorage)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	storageTag := names.NewStorageTag("data/0")

--- a/state/unit.go
+++ b/state/unit.go
@@ -1510,9 +1510,9 @@ func (u *Unit) CharmURL() *string {
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.
 // An error will be returned if the unit is dead, or the charm URL not known.
-func (u *Unit) SetCharmURL(curl *charm.URL) error {
-	if curl == nil {
-		return errors.Errorf("cannot set nil charm url")
+func (u *Unit) SetCharmURL(curl string) error {
+	if curl == "" {
+		return errors.Errorf("cannot set empty charm url")
 	}
 
 	db, dbCloser := u.st.newDB()
@@ -1535,34 +1535,33 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 				return nil, stateerrors.ErrDead
 			}
 		}
-		sel := bson.D{{"_id", u.doc.DocID}, {"charmurl", curl.String()}}
+		sel := bson.D{{"_id", u.doc.DocID}, {"charmurl", curl}}
 		if count, err := units.Find(sel).Count(); err != nil {
 			return nil, errors.Trace(err)
 		} else if count == 1 {
 			// Already set
 			return nil, jujutxn.ErrNoOperations
 		}
-		if count, err := charms.FindId(curl.String()).Count(); err != nil {
+		if count, err := charms.FindId(curl).Count(); err != nil {
 			return nil, errors.Trace(err)
 		} else if count < 1 {
 			return nil, errors.Errorf("unknown charm url %q", curl)
 		}
 
 		// Add a reference to the application settings for the new charm.
-		cURL := curl.String()
-		incOps, err := appCharmIncRefOps(u.st, u.doc.Application, &cURL, false)
+		incOps, err := appCharmIncRefOps(u.st, u.doc.Application, &curl, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
 		// Set the new charm URL.
-		differentCharm := bson.D{{"charmurl", bson.D{{"$ne", curl.String()}}}}
+		differentCharm := bson.D{{"charmurl", bson.D{{"$ne", curl}}}}
 		ops := append(incOps,
 			txn.Op{
 				C:      unitsC,
 				Id:     u.doc.DocID,
 				Assert: append(notDeadDoc, differentCharm...),
-				Update: bson.D{{"$set", bson.D{{"charmurl", curl.String()}}}},
+				Update: bson.D{{"$set", bson.D{{"charmurl", curl}}}},
 			})
 
 		unitCURL := u.doc.CharmURL
@@ -1584,8 +1583,7 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 	}
 	err := u.st.db().Run(buildTxn)
 	if err == nil {
-		curlStr := curl.String()
-		u.doc.CharmURL = &curlStr
+		u.doc.CharmURL = &curl
 	}
 	return err
 }
@@ -1593,23 +1591,19 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 // charm returns the charm for the unit, or the application if the unit's charm
 // has not been set yet.
 func (u *Unit) charm() (*Charm, error) {
-	cURLStr := u.CharmURL()
-	if cURLStr == nil {
+	cURL := u.CharmURL()
+	if cURL == nil {
 		app, err := u.Application()
 		if err != nil {
 			return nil, err
 		}
-		cURLStr, _ = app.CharmURL()
+		cURL, _ = app.CharmURL()
 	}
 
-	if cURLStr == nil {
+	if cURL == nil {
 		return nil, errors.Errorf("missing charm URL for %q", u.Name())
 	}
-	cURL, err := charm.ParseURL(*cURLStr)
-	if err != nil {
-		return nil, errors.NotValidf("charm url %q", *cURLStr)
-	}
-	ch, err := u.st.Charm(cURL)
+	ch, err := u.st.Charm(*cURL)
 	return ch, errors.Annotatef(err, "getting charm for %s", u)
 }
 
@@ -1627,7 +1621,7 @@ func (u *Unit) assertCharmOps(ch *Charm) []txn.Op {
 		ops = append(ops, txn.Op{
 			C:      applicationsC,
 			Id:     appName,
-			Assert: bson.D{{"charmurl", ch.String()}},
+			Assert: bson.D{{"charmurl", ch.URL()}},
 		})
 	}
 	return ops
@@ -2839,7 +2833,7 @@ func (u *Unit) ActionSpecs() (ActionSpecsByName, error) {
 	}
 	chActions := ch.Actions()
 	if chActions == nil || len(chActions.ActionSpecs) == 0 {
-		return none, errors.Errorf("no actions defined on charm %q", ch.String())
+		return none, errors.Errorf("no actions defined on charm %q", ch.URL())
 	}
 	return chActions.ActionSpecs, nil
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1272,7 +1272,7 @@ func (s *UnitSuite) TestSetCharmURLSuccess(c *gc.C) {
 
 	curl = s.unit.CharmURL()
 	c.Assert(curl, gc.NotNil)
-	c.Assert(*curl, gc.Equals, s.charm.URL().String())
+	c.Assert(*curl, gc.Equals, s.charm.URL())
 }
 
 func (s *UnitSuite) TestSetCharmURLFailures(c *gc.C) {
@@ -1280,10 +1280,10 @@ func (s *UnitSuite) TestSetCharmURLFailures(c *gc.C) {
 	curl := s.unit.CharmURL()
 	c.Assert(curl, gc.IsNil)
 
-	err := s.unit.SetCharmURL(nil)
-	c.Assert(err, gc.ErrorMatches, "cannot set nil charm url")
+	err := s.unit.SetCharmURL("")
+	c.Assert(err, gc.ErrorMatches, "cannot set empty charm url")
 
-	err = s.unit.SetCharmURL(charm.MustParseURL("ch:missing/one-1"))
+	err = s.unit.SetCharmURL("ch:missing/one-1")
 	c.Assert(err, gc.ErrorMatches, `unknown charm url "ch:missing/one-1"`)
 
 	err = s.unit.EnsureDead()
@@ -1312,7 +1312,7 @@ func (s *UnitSuite) TestSetCharmURLWithDyingUnit(c *gc.C) {
 
 	curl := s.unit.CharmURL()
 	c.Assert(curl, gc.NotNil)
-	c.Assert(*curl, gc.Equals, s.charm.URL().String())
+	c.Assert(*curl, gc.Equals, s.charm.URL())
 }
 
 func (s *UnitSuite) TestSetCharmURLRetriesWithDeadUnit(c *gc.C) {
@@ -1361,7 +1361,7 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				c.Assert(err, jc.ErrorIsNil)
 				currentURL := s.unit.CharmURL()
 				c.Assert(currentURL, gc.NotNil)
-				c.Assert(*currentURL, gc.Equals, s.charm.URL().String())
+				c.Assert(*currentURL, gc.Equals, s.charm.URL())
 			},
 		},
 	).Check()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -417,11 +417,10 @@ func (factory *Factory) MakeCharm(c *gc.C, params *CharmParams) *state.Charm {
 
 	ch := testcharms.RepoForSeries(params.Series).CharmDir(params.Name)
 
-	curl := charm.MustParseURL(params.URL)
 	bundleSHA256 := uniqueString("bundlesha")
 	info := state.CharmInfo{
 		Charm:       ch,
-		ID:          curl,
+		ID:          params.URL,
 		StoragePath: "fake-storage-path",
 		SHA256:      bundleSHA256,
 	}
@@ -452,11 +451,10 @@ func (factory *Factory) MakeCharmV2(c *gc.C, params *CharmParams) *state.Charm {
 
 	ch := testcharms.Hub.CharmDir(params.Name)
 
-	curl := charm.MustParseURL(params.URL)
 	bundleSHA256 := uniqueString("bundlesha")
 	info := state.CharmInfo{
 		Charm:       ch,
-		ID:          curl,
+		ID:          params.URL,
 		StoragePath: "fake-storage-path",
 		SHA256:      bundleSHA256,
 	}
@@ -493,7 +491,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	if params.CharmOrigin == nil {
-		curl := params.Charm.URL()
+		curl := charm.MustParseURL(params.Charm.URL())
 		chSeries := curl.Series
 		// Legacy k8s charms - assume ubuntu focal.
 		if chSeries == "kubernetes" {
@@ -514,7 +512,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 			Channel: channel,
 			Source:  source,
 			Platform: &state.Platform{
-				Architecture: params.Charm.URL().Architecture,
+				Architecture: curl.Architecture,
 				OS:           base.OS,
 				Channel:      base.Channel.String(),
 			}}
@@ -658,9 +656,8 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 	}
 
 	if params.SetCharmURL {
-		applicationCharmURLStr, _ := params.Application.CharmURL()
-		applicationCharmURL, _ := charm.ParseURL(*applicationCharmURLStr)
-		err = unit.SetCharmURL(applicationCharmURL)
+		applicationCharmURL, _ := params.Application.CharmURL()
+		err = unit.SetCharmURL(*applicationCharmURL)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	err = unit.SetPassword(params.Password)

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -303,16 +302,16 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeCharmNil(c *gc.C) {
-	charm := s.Factory.MakeCharm(c, nil)
-	c.Assert(charm, gc.NotNil)
+	ch := s.Factory.MakeCharm(c, nil)
+	c.Assert(ch, gc.NotNil)
 
-	saved, err := s.State.Charm(charm.URL())
+	saved, err := s.State.Charm(ch.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(saved.URL(), gc.DeepEquals, charm.URL())
-	c.Assert(saved.Meta(), gc.DeepEquals, charm.Meta())
-	c.Assert(saved.StoragePath(), gc.Equals, charm.StoragePath())
-	c.Assert(saved.BundleSha256(), gc.Equals, charm.BundleSha256())
+	c.Assert(saved.URL(), gc.DeepEquals, ch.URL())
+	c.Assert(saved.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(saved.StoragePath(), gc.Equals, ch.StoragePath())
+	c.Assert(saved.BundleSha256(), gc.Equals, ch.BundleSha256())
 }
 
 func (s *factorySuite) TestMakeCharm(c *gc.C) {
@@ -326,7 +325,7 @@ func (s *factorySuite) TestMakeCharm(c *gc.C) {
 	})
 	c.Assert(ch, gc.NotNil)
 
-	c.Assert(ch.URL(), gc.DeepEquals, charm.MustParseURL(url))
+	c.Assert(ch.URL(), gc.DeepEquals, url)
 
 	saved, err := s.State.Charm(ch.URL())
 	c.Assert(err, jc.ErrorIsNil)
@@ -359,7 +358,7 @@ func (s *factorySuite) TestMakeApplication(c *gc.C) {
 
 	c.Assert(application.Name(), gc.Equals, "wordpress")
 	curl, _ := application.CharmURL()
-	c.Assert(*curl, gc.Equals, charm.String())
+	c.Assert(*curl, gc.Equals, charm.URL())
 
 	saved, err := s.State.Application(application.Name())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/caasoperator/download.go
+++ b/worker/caasoperator/download.go
@@ -4,7 +4,6 @@
 package caasoperator
 
 import (
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/status"
@@ -20,16 +19,12 @@ type Downloader interface {
 }
 
 type charmInfo struct {
-	curl   *charm.URL
+	curl   string
 	sha256 string
 }
 
-func (c *charmInfo) URL() *charm.URL {
+func (c *charmInfo) URL() string {
 	return c.curl
-}
-
-func (c *charmInfo) String() string {
-	return c.curl.String()
 }
 
 func (c *charmInfo) ArchiveSha256() (string, error) {
@@ -57,7 +52,7 @@ func (op *caasOperator) ensureCharm(localState *LocalState) error {
 		return errors.Trace(err)
 	}
 
-	info := &charmInfo{curl: curl, sha256: dbCharmInfo.SHA256}
+	info := &charmInfo{curl: curl.String(), sha256: dbCharmInfo.SHA256}
 	if err := op.deployer.Stage(info, op.catacomb.Dying()); err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -511,7 +511,7 @@ func (s *WorkerSuite) TestAddCharm(c *gc.C) {
 	change := s.nextChange(c, changes)
 	obtained, ok := change.(cache.CharmChange)
 	c.Assert(ok, jc.IsTrue)
-	c.Check(obtained.CharmURL, gc.Equals, charm.String())
+	c.Check(obtained.CharmURL, gc.Equals, charm.URL())
 
 	controller := s.getController(c, w)
 	modUUIDs := controller.ModelUUIDs()
@@ -520,7 +520,7 @@ func (s *WorkerSuite) TestAddCharm(c *gc.C) {
 	mod, err := controller.Model(modUUIDs[0])
 	c.Assert(err, jc.ErrorIsNil)
 
-	cachedCharm, err := mod.Charm(charm.String())
+	cachedCharm, err := mod.Charm(charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedCharm, gc.NotNil)
 }
@@ -548,7 +548,7 @@ func (s *WorkerSuite) TestRemoveCharm(c *gc.C) {
 			mod, err := controller.Model(modUUID)
 			c.Assert(err, jc.ErrorIsNil)
 
-			_, err = mod.Charm(charm.String())
+			_, err = mod.Charm(charm.URL())
 			c.Check(errors.IsNotFound(err), jc.IsTrue)
 			return
 		}

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -64,13 +64,13 @@ func (d *BundlesDir) Read(info BundleInfo, abort <-chan struct{}) (Bundle, error
 // download will be stopped.
 func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struct{}) error {
 	// First download...
-	curl, err := url.Parse(info.String())
+	curl, err := url.Parse(info.URL())
 	if err != nil {
 		return errors.Annotate(err, "could not parse charm URL")
 	}
 	expectedSha256, err := info.ArchiveSha256()
 	if err != nil {
-		return errors.Annotatef(err, "failed to get archive sha256 for charm %q", info.String())
+		return errors.Annotatef(err, "failed to get archive sha256 for charm %q", info.URL())
 	}
 	req := downloader.Request{
 		ArchiveSha256: expectedSha256,
@@ -79,10 +79,10 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 		Verify:        downloader.NewSha256Verifier(expectedSha256),
 		Abort:         abort,
 	}
-	d.logger.Infof("downloading %s from API server", info.String())
+	d.logger.Infof("downloading %s from API server", info.URL())
 	filename, err := d.downloader.Download(req)
 	if err != nil {
-		return errors.Annotatef(err, "failed to download charm %q from API server", info.String())
+		return errors.Annotatef(err, "failed to download charm %q from API server", info.URL())
 	}
 	defer errors.DeferredAnnotatef(&err, "downloaded but failed to copy charm to %q from %q", target, filename)
 
@@ -99,7 +99,7 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 // bundlePath returns the path to the location where the verified charm
 // bundle identified by info will be, or has been, saved.
 func (d *BundlesDir) bundlePath(info BundleInfo) string {
-	return d.bundleURLPath(info.String())
+	return d.bundleURLPath(info.URL())
 }
 
 // bundleURLPath returns the path to the location where the verified charm

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -85,9 +85,9 @@ type fakeBundleInfo struct {
 	sha256 string
 }
 
-func (f fakeBundleInfo) String() string {
+func (f fakeBundleInfo) URL() string {
 	if f.curl == "" {
-		return f.BundleInfo.String()
+		return f.BundleInfo.URL()
 	}
 	return f.curl
 }

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -37,8 +37,8 @@ type Bundle interface {
 // BundleInfo describes a Bundle.
 type BundleInfo interface {
 
-	// String return the charm URL as a string.
-	String() string
+	// URL return the charm URL as a string.
+	URL() string
 
 	// ArchiveSha256 returns the hex-encoded SHA-256 digest of the bundle data.
 	ArchiveSha256() (string, error)

--- a/worker/uniter/charm/charm_test.go
+++ b/worker/uniter/charm/charm_test.go
@@ -37,7 +37,7 @@ func (br *bundleReader) EnableWaitForAbort() (stopWaiting chan struct{}) {
 
 // Read implements the BundleReader interface.
 func (br *bundleReader) Read(info charm.BundleInfo, abort <-chan struct{}) (charm.Bundle, error) {
-	bundle, ok := br.bundles[info.String()]
+	bundle, ok := br.bundles[info.URL()]
 	if !ok {
 		return nil, fmt.Errorf("no such charm!")
 	}
@@ -88,7 +88,7 @@ type bundleInfo struct {
 	url string
 }
 
-func (info *bundleInfo) String() string {
+func (info *bundleInfo) URL() string {
 	return info.url
 }
 

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -71,7 +71,7 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	url := info.String()
+	url := info.URL()
 	if err := d.storeManifest(url, manifest); err != nil {
 		return err
 	}
@@ -267,8 +267,8 @@ func (rbr RetryingBundleReader) Read(bi BundleInfo, abort <-chan struct{}) (Bund
 		// If the charm is still not available something went wrong.
 		// Report a NotFound error instead
 		if errors.Is(fetchErr, errors.NotYetAvailable) {
-			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.String())
-			fetchErr = fmt.Errorf("blob data for %q %w", bi.String(), errors.NotFound)
+			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.URL())
+			fetchErr = fmt.Errorf("blob data for %q %w", bi.URL(), errors.NotFound)
 		}
 		return nil, errors.Trace(fetchErr)
 	}

--- a/worker/uniter/charm/manifest_deployer_test.go
+++ b/worker/uniter/charm/manifest_deployer_test.go
@@ -264,7 +264,7 @@ type RetryingBundleReaderSuite struct {
 func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
+	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
 	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
 
 	go func() {
@@ -283,7 +283,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
+	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
 	gomock.InOrder(
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(s.bundle, nil),

--- a/worker/uniter/charm/mocks/mocks.go
+++ b/worker/uniter/charm/mocks/mocks.go
@@ -88,18 +88,18 @@ func (mr *MockBundleInfoMockRecorder) ArchiveSha256() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockBundleInfo)(nil).ArchiveSha256))
 }
 
-// String mocks base method.
-func (m *MockBundleInfo) String() string {
+// URL mocks base method.
+func (m *MockBundleInfo) URL() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "String")
+	ret := m.ctrl.Call(m, "URL")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// String indicates an expected call of String.
-func (mr *MockBundleInfoMockRecorder) String() *gomock.Call {
+// URL indicates an expected call of URL.
+func (mr *MockBundleInfoMockRecorder) URL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockBundleInfo)(nil).String))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockBundleInfo)(nil).URL))
 }
 
 // MockBundle is a mock of Bundle interface.

--- a/worker/uniter/mockdeployer_test.go
+++ b/worker/uniter/mockdeployer_test.go
@@ -23,7 +23,7 @@ type mockDeployer struct {
 }
 
 func (m *mockDeployer) Stage(info charm.BundleInfo, abort <-chan struct{}) error {
-	m.staged = info.String()
+	m.staged = info.URL()
 	var err error
 	m.bundle, err = m.bundles.Read(info, abort)
 	return err

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"fmt"
 
-	corecharm "github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -133,11 +132,7 @@ func (opc *operationCallbacks) ActionStatus(actionId string) (string, error) {
 
 // GetArchiveInfo is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) GetArchiveInfo(url string) (charm.BundleInfo, error) {
-	charmURL, err := corecharm.ParseURL(url)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ch, err := opc.u.st.Charm(charmURL)
+	ch, err := opc.u.st.Charm(url)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -114,7 +113,7 @@ type mockState struct {
 	charm                       *mockCharm
 }
 
-func (st *mockState) Charm(*charm.URL) (remotestate.Charm, error) {
+func (st *mockState) Charm(string) (remotestate.Charm, error) {
 	if st.charm != nil {
 		return st.charm, nil
 	}

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -6,7 +6,6 @@ package remotestate
 import (
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/agent/uniter"
@@ -23,7 +22,7 @@ type Waiter interface {
 type UpdateStatusTimerFunc func(time.Duration) Waiter
 
 type State interface {
-	Charm(*charm.URL) (Charm, error)
+	Charm(string) (Charm, error)
 	Relation(names.RelationTag) (Relation, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
 	StorageAttachmentLife([]params.StorageAttachmentId) ([]params.LifeResult, error)
@@ -118,7 +117,7 @@ func (st apiState) Unit(tag names.UnitTag) (Unit, error) {
 	return apiUnit{u}, err
 }
 
-func (st apiState) Charm(charmURL *charm.URL) (Charm, error) {
+func (st apiState) Charm(charmURL string) (Charm, error) {
 	return st.State.Charm(charmURL)
 }
 

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -944,11 +943,7 @@ func (w *RemoteStateWatcher) applicationChanged() error {
 	}
 	required := false
 	if w.canApplyCharmProfile {
-		curl, err := charm.ParseURL(url)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		ch, err := w.st.Charm(curl)
+		ch, err := w.st.Charm(url)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -103,9 +103,9 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	// The API is used instead of direct state access, because the API call
 	// handles synchronisation with the cache where the data must reside for
 	// config watching and retrieval to work.
-	err = s.apiUnit.SetCharmURL(sch.String())
+	err = s.apiUnit.SetCharmURL(sch.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.meteredAPIUnit.SetCharmURL(s.meteredCharm.String())
+	err = s.meteredAPIUnit.SetCharmURL(s.meteredCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.relCh = s.AddTestingCharm(c, "mysql")

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -620,13 +620,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 }
 
 func (u *Uniter) verifyCharmProfile(url string) error {
-	curl, err := corecharm.ParseURL(url)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	// NOTE: this is very similar code to verifyCharmProfile.NextOp,
 	// if you make changes here, check to see if they are needed there.
-	ch, err := u.st.Charm(curl)
+	ch, err := u.st.Charm(url)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -636,7 +632,7 @@ func (u *Uniter) verifyCharmProfile(url string) error {
 	}
 	if !required {
 		// If no lxd profile is required for this charm, move on.
-		u.logger.Debugf("no lxd profile required for %s", curl)
+		u.logger.Debugf("no lxd profile required for %s", url)
 		return nil
 	}
 	profile, err := u.unit.LXDProfileName()
@@ -652,6 +648,10 @@ func (u *Uniter) verifyCharmProfile(url string) error {
 	}
 	// double check profile revision matches charm revision.
 	rev, err := lxdprofile.ProfileRevision(profile)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	curl, err := corecharm.ParseURL(url)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1350,7 +1350,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 	curl, err := corecharm.ParseURL("ch:quantal/logging")
 	c.Assert(err, jc.ErrorIsNil)
 	curl = curl.WithRevision(dir.Revision())
-	step(c, ctx, addCharm{dir, curl})
+	step(c, ctx, addCharm{dir, curl.String()})
 	ctx.application = s.AddTestingApplication(c, "u", ctx.sch)
 
 	// Create the principal application and add a relation.


### PR DESCRIPTION
Replace `charm.URL` with `string` in a number of places endemic to the code

Most noteworthy, `st.Charm` now takes a string param instead of a `charm.URL`. This has many ramifications throughout the codebase. However, generalizing this methods signature in this was is a significant step towards dropping series out of charm url entirely. It will now be much easier to pass in something completely different

Also the `Charm` structure in `api/agent/uniter` no longer has a `String` method, instead `URL` returns a stringified url. It doesn't really make sense to me that the string representation of the charm api is the charm URL. use `.URL()` instead

There are a couple of places where we retain charm.URLs, are extra places where we (semi-redundantly) parse strings into charm.URL. This is because the number of functions taking charm.URL is very large, and to keep the size of this PR down, instead of change them all, we parse at the edge 

This PR should result in no changes in behavior

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

All unit test pass 

A number of specific integration test pass:
```
./main.sh -v -c aws -p ec2 deploy test_deploy_charms
./main.sh -v -c aws -p ec2 refresh
```

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
juju deploy postgresql
```