### PR TITLE
Improve error message for missing facades/methods

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1247,12 +1247,20 @@ func isX509Error(err error) bool {
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (c *conn) APICall(facade string, vers int, id, method string, args, response interface{}) error {
-	return c.client.Call(rpc.Request{
+	err := c.client.Call(rpc.Request{
 		Type:    facade,
 		Version: vers,
 		Id:      id,
 		Action:  method,
 	}, args, response)
+	if err == nil {
+		return nil
+	}
+
+	if code := params.ErrCode(err); code == params.CodeNotImplemented {
+		return errors.NewNotImplemented(fmt.Errorf("%w\nre-install your juju client to match the version running on the controller", err), "\njuju client not compatible with server")
+	}
+	return errors.Trace(err)
 }
 
 func (c *conn) Close() error {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -140,10 +141,9 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			st := s.openAPIWithoutLogin(c)
 
 			_, err := apimachiner.NewClient(st).Machine(names.NewMachineTag("0"))
-			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-				Message: `unknown object type "Machiner"`,
-				Code:    "not implemented",
-			})
+			c.Assert(err, gc.NotNil)
+			c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+			c.Check(strings.Contains(err.Error(), `unknown facade type "Machiner"`), jc.IsTrue)
 
 			// Since these are user login tests, the nonce is empty.
 			err = st.Login(t.tag, t.password, "", nil)
@@ -151,10 +151,9 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
 			_, err = apimachiner.NewClient(st).Machine(names.NewMachineTag("0"))
-			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-				Message: `unknown object type "Machiner"`,
-				Code:    "not implemented",
-			})
+			c.Assert(err, gc.NotNil)
+			c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+			c.Check(strings.Contains(err.Error(), `unknown facade type "Machiner"`), jc.IsTrue)
 		}()
 	}
 }
@@ -168,10 +167,9 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	u := f.MakeUser(c, &factory.UserParams{Password: password, Disabled: true})
 
 	_, err := apiclient.NewClient(st, coretesting.NoopLogger{}).Status([]string{})
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(err, gc.NotNil)
+	c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+	c.Check(strings.Contains(err.Error(), `unknown facade type "Client"`), jc.IsTrue)
 
 	// Since these are user login tests, the nonce is empty.
 	err = st.Login(u.Tag(), password, "", nil)
@@ -181,10 +179,9 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	})
 
 	_, err = apiclient.NewClient(st, coretesting.NoopLogger{}).Status([]string{})
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(err, gc.NotNil)
+	c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+	c.Check(strings.Contains(err.Error(), `unknown facade type "Client"`), jc.IsTrue)
 }
 
 func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
@@ -196,10 +193,9 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 	u := f.MakeUser(c, &factory.UserParams{Password: password})
 
 	_, err := apiclient.NewClient(st, coretesting.NoopLogger{}).Status([]string{})
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(err, gc.NotNil)
+	c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+	c.Check(strings.Contains(err.Error(), `unknown facade type "Client"`), jc.IsTrue)
 
 	err = s.ControllerModel(c).State().RemoveUser(u.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -212,10 +208,9 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 	})
 
 	_, err = apiclient.NewClient(st, coretesting.NoopLogger{}).Status([]string{})
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(err, gc.NotNil)
+	c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
+	c.Check(strings.Contains(err.Error(), `unknown facade type "Client"`), jc.IsTrue)
 }
 
 func (s *loginSuite) setupManagementSpace(c *gc.C) *state.Space {

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -50,12 +50,12 @@ func (r *restrictedRootSuite) TestMethodNonExistentVersion(c *gc.C) {
 
 func (r *restrictedRootSuite) TestNonExistentFacade(c *gc.C) {
 	caller, err := r.root.FindMethod("SomeFacade", 0, "Method")
-	c.Assert(err, gc.ErrorMatches, `unknown object type "SomeFacade"`)
+	c.Assert(err, gc.ErrorMatches, `unknown facade type "SomeFacade"`)
 	c.Assert(caller, gc.IsNil)
 }
 
 func (r *restrictedRootSuite) TestNonExistentMethod(c *gc.C) {
 	caller, err := r.root.FindMethod("Client", 6, "Bar")
-	c.Assert(err, gc.ErrorMatches, `no such request.+`)
+	c.Assert(err, gc.ErrorMatches, `unknown method "Bar" at version 6 for facade type "Client"`)
 	c.Assert(caller, gc.IsNil)
 }

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -124,7 +124,7 @@ func (r *rootSuite) TestFindMethodUnknownFacade(c *gc.C) {
 	caller, err := root.FindMethod("unknown-testing-facade", 0, "Method")
 	c.Check(caller, gc.IsNil)
 	c.Check(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
-	c.Check(err, gc.ErrorMatches, `unknown object type "unknown-testing-facade"`)
+	c.Check(err, gc.ErrorMatches, `unknown facade type "unknown-testing-facade"`)
 }
 
 func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
@@ -137,7 +137,7 @@ func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
 	caller, err := srvRoot.FindMethod("my-testing-facade", 1, "Exposed")
 	c.Check(caller, gc.IsNil)
 	c.Check(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
-	c.Check(err, gc.ErrorMatches, `unknown version \(1\) of interface "my-testing-facade"`)
+	c.Check(err, gc.ErrorMatches, `unknown version 1 for facade type "my-testing-facade"`)
 }
 
 func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
@@ -343,12 +343,12 @@ func (r *rootSuite) TestFindMethodHandlesInterfaceTypes(c *gc.C) {
 	caller, err = srvRoot.FindMethod("my-interface-facade", 1, "AMethod")
 	c.Check(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Check(err, gc.ErrorMatches,
-		`no such request - method my-interface-facade\(1\)\.AMethod is not implemented`)
+		`unknown method "AMethod" at version 1 for facade type "my-interface-facade"`)
 	c.Check(caller, gc.IsNil)
 	caller, err = srvRoot.FindMethod("my-interface-facade", 1, "ZMethod")
 	c.Check(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Check(err, gc.ErrorMatches,
-		`no such request - method my-interface-facade\(1\)\.ZMethod is not implemented`)
+		`unknown method "ZMethod" at version 1 for facade type "my-interface-facade"`)
 	c.Check(caller, gc.IsNil)
 }
 

--- a/internal/rpcreflect/errors.go
+++ b/internal/rpcreflect/errors.go
@@ -19,13 +19,9 @@ type CallNotImplementedError struct {
 func (e *CallNotImplementedError) Error() string {
 	if e.Method == "" {
 		if e.Version != 0 {
-			return fmt.Sprintf("unknown version (%d) of interface %q", e.Version, e.RootMethod)
+			return fmt.Sprintf("unknown version %d for facade type %q", e.Version, e.RootMethod)
 		}
-		return fmt.Sprintf("unknown object type %q", e.RootMethod)
+		return fmt.Sprintf("unknown facade type %q", e.RootMethod)
 	}
-	methodVersion := e.RootMethod
-	if e.Version != 0 {
-		methodVersion = fmt.Sprintf("%s(%d)", e.RootMethod, e.Version)
-	}
-	return fmt.Sprintf("no such request - method %s.%s is not implemented", methodVersion, e.Method)
+	return fmt.Sprintf("unknown method %q at version %d for facade type %q", e.Method, e.Version, e.RootMethod)
 }

--- a/internal/rpcreflect/type_test.go
+++ b/internal/rpcreflect/type_test.go
@@ -116,12 +116,12 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	v := rpcreflect.ValueOf(reflect.ValueOf(root))
 
 	m, err := v.FindMethod("foo", 0, "bar")
-	c.Assert(err, gc.ErrorMatches, `unknown object type "foo"`)
+	c.Assert(err, gc.ErrorMatches, `unknown facade type "foo"`)
 	c.Assert(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Assert(m, gc.IsNil)
 
 	m, err = v.FindMethod("SimpleMethods", 0, "bar")
-	c.Assert(err, gc.ErrorMatches, "no such request - method SimpleMethods.bar is not implemented")
+	c.Assert(err, gc.ErrorMatches, `unknown method "bar" at version 0 for facade type "SimpleMethods"`)
 	c.Assert(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Assert(m, gc.IsNil)
 

--- a/rpc/reflect_test.go
+++ b/rpc/reflect_test.go
@@ -118,12 +118,12 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	v := rpcreflect.ValueOf(reflect.ValueOf(root))
 
 	m, err := v.FindMethod("foo", 0, "bar")
-	c.Assert(err, gc.ErrorMatches, `unknown object type "foo"`)
+	c.Assert(err, gc.ErrorMatches, `unknown facade type "foo"`)
 	c.Assert(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Assert(m, gc.IsNil)
 
 	m, err = v.FindMethod("SimpleMethods", 0, "bar")
-	c.Assert(err, gc.ErrorMatches, "no such request - method SimpleMethods.bar is not implemented")
+	c.Assert(err, gc.ErrorMatches, `unknown method "bar" at version 0 for facade type "SimpleMethods"`)
 	c.Assert(err, gc.FitsTypeOf, (*rpcreflect.CallNotImplementedError)(nil))
 	c.Assert(m, gc.IsNil)
 


### PR DESCRIPTION
The error message for when a facade is missing, or a method is missing on a facade is not ideal. The following just cleans that up, so it gives the user a nice error message to progress forward.

The hard part about fixing the error message is that if you exercise this on older controllers then you won't get a perfect response. To add context to those scenarios we add some information to their error message.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The following are contrived to exercise the error messages:

### Juju 4.x

```sh
$ juju bootstrap lxd test --build-agent
```

#### Missing facade

Apply the following diff to this PR

```
diff --git a/api/apiclient.go b/api/apiclient.go
index 9a969dc88b..a2eef4e95b 100644
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1247,6 +1247,7 @@ func isX509Error(err error) bool {
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (c *conn) APICall(facade string, vers int, id, method string, args, response interface{}) error {
+       facade = "foo"
        err := c.client.Call(rpc.Request{
                Type:    facade,
                Version: vers,
```

Then run:

```
$ juju status
ERROR refreshing models cache:
juju client not compatible with server: unknown version 3 for facade type "foo" (not implemented)
re-install your juju client to match the version running on the controller
```

#### Missing method

Apply the following diff to this PR:

```
diff --git a/api/apiclient.go b/api/apiclient.go
index 9a969dc88b..e93d866a41 100644
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1247,6 +1247,7 @@ func isX509Error(err error) bool {
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (c *conn) APICall(facade string, vers int, id, method string, args, response interface{}) error {
+       method = "foo"
        err := c.client.Call(rpc.Request{
                Type:    facade,
                Version: vers,
```

Then run:

```
$ juju status
ERROR refreshing models cache:
juju client not compatible with server: unknown method "foo" at version 0 for facade type "Admin" (not implemented)
re-install your juju client to match the version running on the controller
```

### Juju 3.x compatibility

Bootstrap a juju 3.x

```
$ snap install juju --channel=3.1/stable
$ /snap/bin/juju bootstrap lxd test3x
$ /snap/bin/juju add-model default
```

Bootstrap a juju 4.x

```
$ juju bootstrap lxd test4x --build-agent
```

Apply the diff:

```
diff --git a/api/facadeversions.go b/api/facadeversions.go
index e91387112b..e6cee967f1 100644
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -86,7 +86,7 @@ var FacadeVersions = map[string][]int{
        "MigrationTarget":              {1, 2},
        "ModelConfig":                  {3},
        "ModelGeneration":              {4},
-       "ModelManager":                 {9, 10},
+       "ModelManager":                 {10},
        "ModelSummaryWatcher":          {1},
        "ModelUpgrader":                {1},
        "NotifyWatcher":                {1},
```

Then run the following:

```
$ juju switch test3x:foo
ERROR refreshing models cache:
juju client not compatible with server: unknown object type "ModelManager" (not implemented)
re-install your juju client to match the version running on the controller
```

Notice that the original error message from juju 3.1 is still of the old type, but has been wrapped in a message on how to resolve it.

## Links

**Jira card:** JUJU-4637
