### PR TITLE
Target Dependabot PRs to 2.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+
+target-branch: 2.9


### PR DESCRIPTION
In line with our usual workflow to target patches to the earliest applicable branch and merge through, Dependabot PRs should target 2.9, instead of the default branch (e.g. #16282).