### PR TITLE
Fix NIC name assertion on spaces ec2 tests

### DIFF
--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -82,7 +82,7 @@ assert_net_iface_for_endpoint_matches() {
 	exp_if_name=${3}
 
 	# shellcheck disable=SC2086,SC2016
-	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
+	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: en" | awk '{print $2}')
 	if [ "$got_if" != "$exp_if_name" ]; then
 		# shellcheck disable=SC2086,SC2016,SC2046
 		echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")


### PR DESCRIPTION
Tests continously failed because we only tried to match on interfaces names starting with "ens" (`juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" `), while the interfaces were named starting with enp, (e.g. enp39s0). This fixes both `upgrade_charm_with_bind` and `juju_bind` tests.

This is an example output of `juju exec -a ${app_name} "network-get ${endpoint_name}" `:
```
$ juju exec -a space-defender "network-get defend-a"
bind-addresses:
- mac-address: 12:6c:24:89:28:67
  interface-name: enp39s0
  addresses:
  - hostname: ""
    value: 172.31.36.203
    cidr: 172.31.32.0/20
    address: 172.31.36.203
  macaddress: 12:6c:24:89:28:67
  interfacename: enp39s0
- mac-address: fe:28:cd:3e:fe:55
  interface-name: fan-252
  addresses:
  - hostname: ""
    value: 252.36.203.1
    cidr: 252.32.0.0/12
    address: 252.36.203.1
  macaddress: fe:28:cd:3e:fe:55
  interfacename: fan-252
egress-subnets:
- 172.31.36.203/32
ingress-addresses:
- 172.31.36.203
- 252.36.203.1
```

The choice is to match all ethernet interfaces, thus staring with en. This will match eno, ens, enp and enx names.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
cd tests
./main.sh -v -c aws -R us-east-1 spaces_ec2
```

## Links

**Jira card:** [JUJU-4639](https://warthogs.atlassian.net/browse/JUJU-4639)



[JUJU-4639]: https://warthogs.atlassian.net/browse/JUJU-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ