### PR TITLE
Fix jwt permission

### DIFF
--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -125,7 +125,7 @@ func (p *PermissionDelegator) SubjectPermissions(
 	// We need to make very sure that the entity the request pertains to
 	// is the same entity this function was seeded with.
 	if tokenEntity.Tag().String() != e.Tag().String() {
-		return permission.NoAccess, fmt.Errorf("%w to use token permissions for one entity on another", errors.NotValid)
+		return permission.NoAccess, fmt.Errorf("%w to use token permissions for one entity on another", apiservererrors.ErrPerm)
 	}
 	return PermissionFromToken(p.Token, subject)
 }

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/authentication/jwt"
 	"github.com/juju/juju/apiserver/common"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/testing"
@@ -141,7 +142,7 @@ func (s *loginTokenSuite) TestPermissionsForDifferentEntity(c *gc.C) {
 		User: names.NewUserTag("wallyworld"),
 	}
 	perm, err := authInfo.Delegator.SubjectPermissions(badUser, modelTag)
-	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
+	c.Assert(errors.Is(err, apiservererrors.ErrPerm), jc.IsTrue)
 	c.Assert(perm, gc.Equals, permission.NoAccess)
 
 	badUser = jwt.TokenEntity{


### PR DESCRIPTION
JWT authenticator should return a `permission denied` error to allow the client to handle the error easily. 
