### PR TITLE
Allow all kvms to have host-passthrough

### DIFF
--- a/internal/container/kvm/libvirt/domainxml.go
+++ b/internal/container/kvm/libvirt/domainxml.go
@@ -179,13 +179,10 @@ func generateFeaturesElement(p domainParams) *Features {
 // generateCPU infor generates any model/fallback related settings. These are
 // typically to allow for better compatibility across versions of libvirt/qemu AFAIU.
 func generateCPU(p domainParams) *CPU {
-	if p.Arch() == arch.ARM64 {
-		return &CPU{
-			Mode:  "host-passthrough",
-			Check: "none",
-		}
+	return &CPU{
+		Mode:  "host-passthrough",
+		Check: "none",
 	}
-	return nil
 }
 
 // deviceID generates a device id from and int. The limit of 26 is arbitrary,


### PR DESCRIPTION
There is a performance increase in having host-passthrough, even on amd64, the default virtio driver for the cpu lacks in performance if this is causing a bottle-neck

## QA steps

*Commands to run to verify that the change works.*

```sh
juju add-machine
juju add-machine kvm:0
juju run --machine 0 -- virsh dumpxml 1 | grep "cpu mode"
```