### PR TITLE
Add `controlsocket` worker

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1630,9 +1630,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		CharmModifiedVersion: 0,
 		InitialScale:         1,
 		Constraints:          c.pcfg.Bootstrap.BootstrapMachineConstraints,
-		// TODO(wallyworld) - use pebble to manage the controller workloads
-		//Containers:           containers,
-		ExistingContainers: []string{apiServerContainerName},
+		ExistingContainers:   []string{apiServerContainerName},
 		// TODO(wallyworld) - use storage so the volumes don't need to be manually set up
 		//Filesystems: nil,
 		Rootless: true,
@@ -1651,6 +1649,11 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		),
 		SubPath: constants.ControllerUnitAgentConfigFilename,
 	}
+	dataDirMount := core.VolumeMount{
+		Name:      storageName,
+		MountPath: c.pcfg.DataDir,
+	}
+
 	for i, ct := range spec.InitContainers {
 		if ct.Name != constants.ApplicationInitContainer {
 			continue
@@ -1664,14 +1667,23 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		if ct.Name != constants.ApplicationCharmContainer {
 			continue
 		}
-		ct.VolumeMounts = append(ct.VolumeMounts, agentConfigMount)
+
+		// Replace the /var/lib/juju mount
+		for j, mount := range ct.VolumeMounts {
+			if mount.MountPath == c.pcfg.DataDir {
+				ct.VolumeMounts = append(ct.VolumeMounts[:j], ct.VolumeMounts[j+1:]...)
+				break
+			}
+		}
+		ct.VolumeMounts = append(ct.VolumeMounts, agentConfigMount, dataDirMount)
+
 		// Remove probes to prevent controller death.
 		ct.LivenessProbe = nil
 		ct.ReadinessProbe = nil
 		ct.StartupProbe = nil
-		for i, env := range ct.Env {
+		for j, env := range ct.Env {
 			if env.Name == constants.EnvAgentHTTPProbePort {
-				ct.Env = append(ct.Env[:i], ct.Env[i+1:]...)
+				ct.Env = append(ct.Env[:j], ct.Env[j+1:]...)
 				break
 			}
 		}

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -678,11 +678,6 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				},
 				{
 					Name:      "charm-data",
-					MountPath: "/var/lib/juju",
-					SubPath:   "var/lib/juju",
-				},
-				{
-					Name:      "charm-data",
 					MountPath: "/charm/containers",
 					SubPath:   "charm/containers",
 				},
@@ -718,6 +713,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Name:      "juju-controller-test-agent-conf",
 					MountPath: "/var/lib/juju/template-agent.conf",
 					SubPath:   "controller-unit-agent.conf",
+				},
+				{
+					Name:      "storage",
+					MountPath: "/var/lib/juju",
 				},
 			},
 		},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/upgrades"
@@ -52,6 +53,7 @@ import (
 	"github.com/juju/juju/worker/common"
 	lxdbroker "github.com/juju/juju/worker/containerbroker"
 	"github.com/juju/juju/worker/controllerport"
+	"github.com/juju/juju/worker/controlsocket"
 	"github.com/juju/juju/worker/credentialvalidator"
 	"github.com/juju/juju/worker/dbaccessor"
 	"github.com/juju/juju/worker/deployer"
@@ -784,6 +786,14 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 				Logger:        loggo.GetLogger("juju.worker.secretbackendsrotate"),
 			},
 		))),
+
+		// The controlsocket worker runs on the controller machine.
+		controlSocketName: ifController(controlsocket.Manifold(controlsocket.ManifoldConfig{
+			StateName:  stateName,
+			Logger:     loggo.GetLogger("juju.worker.controlsocket"),
+			NewWorker:  controlsocket.NewWorker,
+			SocketName: paths.ControlSocket(paths.OSUnixLike),
+		})),
 	}
 
 	return manifolds
@@ -1157,4 +1167,6 @@ const (
 	brokerTrackerName = "broker-tracker"
 
 	charmhubHTTPClientName = "charmhub-http-client"
+
+	controlSocketName = "control-socket"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -72,6 +72,7 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
 			"change-stream",
 			"charmhub-http-client",
 			"clock",
+			"control-socket",
 			"controller-port",
 			"db-accessor",
 			"deployer",
@@ -152,6 +153,7 @@ func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"change-stream",
 			"charmhub-http-client",
 			"clock",
+			"control-socket",
 			"controller-port",
 			"db-accessor",
 			"external-controller-updater",
@@ -230,6 +232,7 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"change-stream",
 		"charmhub-http-client",
 		"clock",
+		"control-socket",
 		"controller-port",
 		"db-accessor",
 		"deployer",
@@ -305,6 +308,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"query-logger",
 		"change-stream",
 		"file-notify-watcher",
+		"control-socket",
 	)
 
 	// Explicitly guarded by ifPrimaryController.
@@ -539,6 +543,13 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 	"charmhub-http-client": {},
 
 	"clock": {},
+
+	"control-socket": {
+		"agent",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+	},
 
 	"controller-port": {
 		"agent",
@@ -1131,6 +1142,13 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 	"charmhub-http-client": {},
 
 	"clock": {},
+
+	"control-socket": {
+		"agent",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+	},
 
 	"controller-port": {
 		"agent",

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -36,6 +36,7 @@ const (
 	cloudInitCfgDir
 	curtinInstallConfig
 	transientDataDir
+	controlSocket
 )
 
 const (
@@ -66,6 +67,7 @@ var nixVals = map[osVarType]string{
 	instanceCloudInitDir: "/var/lib/cloud/instance",
 	cloudInitCfgDir:      "/etc/cloud/cloud.cfg.d",
 	curtinInstallConfig:  "/root/curtin-install-cfg.yaml",
+	controlSocket:        "/var/lib/juju/control.socket",
 }
 
 var winVals = map[osVarType]string{
@@ -195,4 +197,9 @@ func CurtinInstallConfig(os OS) string {
 // cloud config directory for a particular series.
 func CloudInitCfgDir(os OS) string {
 	return osVal(os, cloudInitCfgDir)
+}
+
+// ControlSocket returns the absolute path to the Juju control socket.
+func ControlSocket(os OS) string {
+	return osVal(os, controlSocket)
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/googleapis/gnostic v0.5.5
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/gosuri/uitable v0.0.1
@@ -186,7 +187,6 @@ require (
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/worker/controlsocket/doc.go
+++ b/worker/controlsocket/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controlsocket defines the controlsocket worker, which exposes a Unix
+// socket that the juju-controller charm can use to affect Juju state.
+package controlsocket

--- a/worker/controlsocket/handlers.go
+++ b/worker/controlsocket/handlers.go
@@ -1,0 +1,243 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/state"
+	stateerrors "github.com/juju/juju/state/errors"
+)
+
+const (
+	// jujuMetricsUserPrefix defines the "namespace" in which this worker is
+	// allowed to create/remove users.
+	jujuMetricsUserPrefix = "juju-metrics-"
+
+	// userCreator is the listed "creator" of metrics users in state.
+	// This user CANNOT be a local user (it must have a domain), otherwise the
+	// model addUser code will complain about the user not existing.
+	userCreator = "controller@juju"
+)
+
+func (w *Worker) registerHandlers(r *mux.Router) {
+	r.HandleFunc("/metrics-users", w.handleAddMetricsUser).
+		Methods(http.MethodPost)
+	r.HandleFunc("/metrics-users/{username}", w.handleRemoveMetricsUser).
+		Methods(http.MethodDelete)
+}
+
+type addMetricsUserBody struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (w *Worker) handleAddMetricsUser(resp http.ResponseWriter, req *http.Request) {
+	var parsedBody addMetricsUserBody
+	defer req.Body.Close()
+	err := json.NewDecoder(req.Body).Decode(&parsedBody)
+	if errors.Is(err, io.EOF) {
+		w.writeResponse(resp, http.StatusBadRequest, errorf("missing request body"))
+		return
+	} else if err != nil {
+		w.writeResponse(resp, http.StatusBadRequest, errorf("request body is not valid JSON: %v", err))
+		return
+	}
+
+	code, err := w.addMetricsUser(parsedBody.Username, parsedBody.Password)
+	if err != nil {
+		w.writeResponse(resp, code, errorf("%v", err))
+		return
+	}
+
+	w.writeResponse(resp, code, infof("created user %q", parsedBody.Username))
+}
+
+func (w *Worker) addMetricsUser(username, password string) (int, error) {
+	err := validateMetricsUsername(username)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	if password == "" {
+		return http.StatusBadRequest, errors.NotValidf("empty password")
+	}
+
+	user, err := w.config.State.AddUser(username, username, password, userCreator)
+	cleanup := true
+	// Error handling here is a bit subtle.
+	switch {
+	case errors.Is(err, errors.AlreadyExists):
+		// Retrieve existing user
+		user, err = w.config.State.User(names.NewUserTag(username))
+		if err != nil {
+			return http.StatusInternalServerError,
+				fmt.Errorf("retrieving existing user %q: %v", username, err)
+		}
+
+		// We want this operation to be idempotent, but at the same time, this
+		// worker shouldn't mess with users that have not been created by it.
+		// So ensure the user is identical to what we would have created, and
+		// otherwise error.
+		if user.CreatedBy() != userCreator {
+			return http.StatusConflict, errors.AlreadyExistsf("user %q (created by %q)", user.Name(), user.CreatedBy())
+		}
+		if !user.PasswordValid(password) {
+			return http.StatusConflict, errors.AlreadyExistsf("user %q", user.Name())
+		}
+
+	case err == nil:
+		// At this point, the operation is in a partially completed state - we've
+		// added the user, but haven't granted them the correct model permissions.
+		// If there is an error granting permissions, we should attempt to "rollback"
+		// and remove the user again.
+		defer func() {
+			if cleanup == false {
+				// Operation successful - nothing to clean up
+				return
+			}
+
+			err := w.config.State.RemoveUser(user.UserTag())
+			if err != nil {
+				// Best we can do here is log an error.
+				w.config.Logger.Warningf("add metrics user failed, but could not clean up user %q: %v",
+					username, err)
+			}
+		}()
+
+	default:
+		return http.StatusInternalServerError, errors.Annotatef(err, "failed to create user %q: %v", username, err)
+	}
+
+	// Give the new user permission to access the metrics endpoint.
+	var model model
+	model, err = w.config.State.Model()
+	if err != nil {
+		return http.StatusInternalServerError, errors.Annotatef(err, "retrieving current model: %v", err)
+	}
+
+	_, err = model.AddUser(state.UserAccessSpec{
+		User:      user.UserTag(),
+		CreatedBy: names.NewUserTag(userCreator),
+		Access:    permission.ReadAccess,
+	})
+	if err != nil && !errors.Is(err, errors.AlreadyExists) {
+		return http.StatusInternalServerError, errors.Annotatef(err, "adding user %q to model %q: %v", username, bootstrap.ControllerModelName, err)
+	}
+
+	cleanup = false
+	return http.StatusOK, nil
+}
+
+func (w *Worker) handleRemoveMetricsUser(resp http.ResponseWriter, req *http.Request) {
+	username := mux.Vars(req)["username"]
+	code, err := w.removeMetricsUser(username)
+	if err != nil {
+		w.writeResponse(resp, code, errorf("%v", err))
+		return
+	}
+
+	w.writeResponse(resp, code, infof("deleted user %q", username))
+}
+
+func (w *Worker) removeMetricsUser(username string) (int, error) {
+	err := validateMetricsUsername(username)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	userTag := names.NewUserTag(username)
+	// We shouldn't mess with users that weren't created by us.
+	user, err := w.config.State.User(userTag)
+	if errors.Is(err, errors.NotFound) || errors.Is(err, errors.UserNotFound) || stateerrors.IsDeletedUserError(err) {
+		// succeed as no-op
+		return http.StatusOK, nil
+	} else if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	if user.CreatedBy() != userCreator {
+		return http.StatusForbidden, errors.Forbiddenf("cannot remove user %q created by %q", user.Name(), user.CreatedBy())
+	}
+
+	err = w.config.State.RemoveUser(userTag)
+	// Any "not found" errors should have been caught above, so fail here.
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	return http.StatusOK, nil
+}
+
+func validateMetricsUsername(username string) error {
+	if username == "" {
+		return errors.BadRequestf("missing username")
+	}
+
+	if !names.IsValidUserName(username) {
+		return errors.NotValidf("username %q", username)
+	}
+
+	if !strings.HasPrefix(username, jujuMetricsUserPrefix) {
+		return errors.BadRequestf("metrics username %q should have prefix %q", username, jujuMetricsUserPrefix)
+	}
+
+	return nil
+}
+
+func (w *Worker) writeResponse(resp http.ResponseWriter, statusCode int, body any) {
+	w.config.Logger.Debugf("operation finished with HTTP status %v", statusCode)
+	resp.Header().Set("Content-Type", "application/json")
+
+	message, err := json.Marshal(body)
+	if err != nil {
+		w.config.Logger.Errorf("error marshalling response body to JSON: %v", err)
+		w.config.Logger.Errorf("response body was %#v", body)
+
+		// Mark this as an "internal server error"
+		statusCode = http.StatusInternalServerError
+		// Just write an empty response
+		message = []byte("{}")
+	}
+
+	resp.WriteHeader(statusCode)
+	w.config.Logger.Tracef("returning response %q", message)
+	_, err = resp.Write(message)
+	if err != nil {
+		w.config.Logger.Warningf("error writing HTTP response: %v", err)
+	}
+}
+
+// infof returns an informational response body that can be marshalled into
+// JSON (in the case of a successful operation). It has the form
+//
+//	{"message": <provided info message>}
+func infof(format string, args ...any) any {
+	return struct {
+		Message string `json:"message"`
+	}{
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// errorf returns an error response body that can be marshalled into JSON (in
+// the case of a failed operation). It has the form
+//
+//	{"error": <provided error message>}
+func errorf(format string, args ...any) any {
+	return struct {
+		Error string `json:"error"`
+	}{
+		Error: fmt.Sprintf(format, args...),
+	}
+}

--- a/worker/controlsocket/handlers_test.go
+++ b/worker/controlsocket/handlers_test.go
@@ -1,0 +1,446 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/state"
+	stateerrors "github.com/juju/juju/state/errors"
+)
+
+type handlerSuite struct {
+	state  *fakeState
+	logger Logger
+}
+
+var _ = gc.Suite(&handlerSuite{})
+
+type handlerTest struct {
+	// Request
+	method   string
+	endpoint string
+	body     string
+	// Response
+	statusCode int
+	response   string // response body
+	ignoreBody bool   // if true, test will not read the request body
+}
+
+func (s *handlerSuite) SetUpTest(c *gc.C) {
+	s.state = &fakeState{}
+	s.logger = loggo.GetLogger(c.TestName())
+}
+
+func (s *handlerSuite) runHandlerTest(c *gc.C, test handlerTest) {
+	tmpDir := c.MkDir()
+	socket := path.Join(tmpDir, "test.socket")
+
+	_, err := NewWorker(Config{
+		State:      s.state,
+		Logger:     s.logger,
+		SocketName: socket,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	serverURL := "http://localhost:8080"
+	req, err := http.NewRequest(
+		test.method,
+		serverURL+test.endpoint,
+		strings.NewReader(test.body),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp, err := client(socket).Do(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, test.statusCode)
+
+	if test.ignoreBody {
+		return
+	}
+	data, err := io.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	err = resp.Body.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Response should be valid JSON
+	c.Check(resp.Header.Get("Content-Type"), gc.Equals, "application/json")
+	err = json.Unmarshal(data, &struct{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	if test.response != "" {
+		c.Check(string(data), gc.Matches, test.response)
+	}
+}
+
+func (s *handlerSuite) assertState(c *gc.C, users []fakeUser) {
+	c.Assert(len(s.state.users), gc.Equals, len(users))
+
+	for _, expected := range users {
+		actual, ok := s.state.users[expected.name]
+		c.Assert(ok, gc.Equals, true)
+		c.Check(actual.creator, gc.Equals, expected.creator)
+		c.Check(actual.password, gc.Equals, expected.password)
+	}
+}
+
+func (s *handlerSuite) TestMetricsUsersAddInvalidMethod(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodGet,
+		endpoint:   "/metrics-users",
+		statusCode: http.StatusMethodNotAllowed,
+		ignoreBody: true,
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddMissingBody(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		statusCode: http.StatusBadRequest,
+		response:   ".*missing request body.*",
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddInvalidBody(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       "username foo, password bar",
+		statusCode: http.StatusBadRequest,
+		response:   ".*request body is not valid JSON.*",
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddMissingUsername(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"password":"bar"}`,
+		statusCode: http.StatusBadRequest,
+		response:   ".*missing username.*",
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddMissingPassword(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0"}`,
+		statusCode: http.StatusBadRequest,
+		response:   ".*empty password.*",
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddUsernameMissingPrefix(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"foo","password":"bar"}`,
+		statusCode: http.StatusBadRequest,
+		response:   `.*username .* should have prefix \\\"juju-metrics-\\\".*`,
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddSuccess(c *gc.C) {
+	s.state = newFakeState(nil)
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusOK,
+		response:   `.*created user \\\"juju-metrics-r0\\\".*`,
+	})
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: "controller@juju"},
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddAlreadyExists(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: "not-you"},
+	})
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusConflict,
+		response:   ".*user .* already exists.*",
+	})
+	// Nothing should have changed.
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: "not-you"},
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddDifferentPassword(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "foo", creator: userCreator},
+	})
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusConflict,
+		response:   `.*user \\\"juju-metrics-r0\\\" already exists.*`,
+	})
+	// Nothing should have changed.
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "foo", creator: userCreator},
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddAddErr(c *gc.C) {
+	s.state = newFakeState(nil)
+	s.state.addErr = fmt.Errorf("spanner in the works")
+
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*spanner in the works.*",
+	})
+	// Nothing should have changed.
+	s.assertState(c, nil)
+}
+
+func (s *handlerSuite) TestMetricsUsersAddIdempotent(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: userCreator},
+	})
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusOK, // succeed as a no-op
+		response:   `.*created user \\\"juju-metrics-r0\\\".*`,
+	})
+	// Nothing should have changed.
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: userCreator},
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersAddFailed(c *gc.C) {
+	s.state = newFakeState(nil)
+	s.state.model.err = fmt.Errorf("spanner in the works")
+
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*spanner in the works.*",
+	})
+	s.assertState(c, nil)
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveInvalidMethod(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodGet,
+		endpoint:   "/metrics-users/foo",
+		statusCode: http.StatusMethodNotAllowed,
+		ignoreBody: true,
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveUsernameMissingPrefix(c *gc.C) {
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/foo",
+		statusCode: http.StatusBadRequest,
+		response:   `.*username .* should have prefix \\\"juju-metrics-\\\".*`,
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveSuccess(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: "controller@juju"},
+	})
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/juju-metrics-r0",
+		statusCode: http.StatusOK,
+		response:   `.*deleted user \\\"juju-metrics-r0\\\".*`,
+	})
+	s.assertState(c, nil)
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveForbidden(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "foo", creator: "not-you"},
+	})
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/juju-metrics-r0",
+		statusCode: http.StatusForbidden,
+		response:   `.*cannot remove user \\\"juju-metrics-r0\\\" created by \\\"not-you\\\".*`,
+	})
+	// Nothing should have changed.
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "foo", creator: "not-you"},
+	})
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveNotFound(c *gc.C) {
+	s.state = newFakeState(nil)
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/juju-metrics-r0",
+		statusCode: http.StatusOK, // succeed as a no-op
+		response:   `.*deleted user \\\"juju-metrics-r0\\\".*`,
+	})
+	s.assertState(c, nil)
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveIdempotent(c *gc.C) {
+	s.state = newFakeState(nil)
+	s.state.userErr = stateerrors.NewDeletedUserError("juju-metrics-r0")
+
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/juju-metrics-r0",
+		statusCode: http.StatusOK, // succeed as a no-op
+		response:   `.*deleted user \\\"juju-metrics-r0\\\".*`,
+	})
+	// Nothing should have changed.
+	s.assertState(c, nil)
+}
+
+func (s *handlerSuite) TestMetricsUsersRemoveFailed(c *gc.C) {
+	s.state = newFakeState([]fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: userCreator},
+	})
+	s.state.removeErr = fmt.Errorf("spanner in the works")
+
+	s.runHandlerTest(c, handlerTest{
+		method:     http.MethodDelete,
+		endpoint:   "/metrics-users/juju-metrics-r0",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*spanner in the works.*",
+	})
+	// Nothing should have changed.
+	s.assertState(c, []fakeUser{
+		{name: "juju-metrics-r0", password: "bar", creator: userCreator},
+	})
+}
+
+type fakeState struct {
+	users map[string]fakeUser
+	model *fakeModel
+
+	userErr, addErr, removeErr error
+}
+
+func newFakeState(users []fakeUser) *fakeState {
+	s := &fakeState{
+		users: make(map[string]fakeUser, len(users)),
+	}
+	for _, user := range users {
+		s.users[user.name] = user
+	}
+	s.model = &fakeModel{nil}
+	return s
+}
+
+func (s *fakeState) User(tag names.UserTag) (user, error) {
+	if s.userErr != nil {
+		return nil, s.userErr
+	}
+
+	username := tag.Name()
+	u, ok := s.users[username]
+	if !ok {
+		return nil, errors.UserNotFoundf("user %q", username)
+	}
+	return u, nil
+}
+
+func (s *fakeState) AddUser(name, displayName, password, creator string) (user, error) {
+	if s.addErr != nil {
+		return nil, s.addErr
+	}
+
+	if _, ok := s.users[name]; ok {
+		// The real state code doesn't return the user if it already exists, it
+		// returns a typed nil value.
+		return (*fakeUser)(nil), errors.AlreadyExistsf("user %q", name)
+	}
+
+	u := fakeUser{name, displayName, password, creator}
+	s.users[name] = u
+	return u, nil
+}
+
+func (s *fakeState) RemoveUser(tag names.UserTag) error {
+	if s.removeErr != nil {
+		return s.removeErr
+	}
+
+	username := tag.Name()
+	if _, ok := s.users[username]; !ok {
+		return errors.UserNotFoundf("user %q", username)
+	}
+
+	delete(s.users, username)
+	return nil
+}
+
+func (s *fakeState) Model() (model, error) {
+	return s.model, nil
+}
+
+type fakeUser struct {
+	name, displayName, password, creator string
+}
+
+func (u fakeUser) Name() string {
+	return u.name
+}
+
+func (u fakeUser) CreatedBy() string {
+	return u.creator
+}
+
+func (u fakeUser) UserTag() names.UserTag {
+	return names.NewUserTag(u.name)
+}
+
+func (u fakeUser) PasswordValid(s string) bool {
+	return s == u.password
+}
+
+type fakeModel struct {
+	err error
+}
+
+func (m *fakeModel) AddUser(_ state.UserAccessSpec) (permission.UserAccess, error) {
+	return permission.UserAccess{}, m.err
+}
+
+// Return an *http.Client with custom transport that allows it to connect to
+// the given Unix socket.
+func client(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Dial: func(_, _ string) (conn net.Conn, err error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+}

--- a/worker/controlsocket/manifold.go
+++ b/worker/controlsocket/manifold.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/common"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// ManifoldConfig describes the dependencies required by the controlsocket worker.
+type ManifoldConfig struct {
+	StateName  string
+	Logger     Logger
+	NewWorker  func(Config) (worker.Worker, error)
+	SocketName string
+}
+
+// Manifold returns a Manifold that encapsulates the controlsocket worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start: config.start,
+	}
+}
+
+// Validate is called by start to check for bad configuration.
+func (cfg ManifoldConfig) Validate() error {
+	if cfg.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if cfg.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if cfg.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker func")
+	}
+	if cfg.SocketName == "" {
+		return errors.NotValidf("empty SocketName")
+	}
+	return nil
+}
+
+// start is a StartFunc for a Worker manifold.
+func (cfg ManifoldConfig) start(context dependency.Context) (_ worker.Worker, err error) {
+	if err = cfg.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err = context.Get(cfg.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var statePool *state.StatePool
+	statePool, err = stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// Make sure we clean up state objects if an error occurs.
+	defer func() {
+		if err != nil {
+			_ = stTracker.Done()
+		}
+	}()
+
+	var st *state.State
+	st, err = statePool.SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var w worker.Worker
+	w, err = cfg.NewWorker(Config{
+		State:      stateShim{st},
+		Logger:     cfg.Logger,
+		SocketName: cfg.SocketName,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
+}

--- a/worker/controlsocket/package_test.go
+++ b/worker/controlsocket/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/controlsocket/shim.go
+++ b/worker/controlsocket/shim.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/state"
+)
+
+// State defines the state methods that the controlsocket worker needs.
+type State interface {
+	User(tag names.UserTag) (user, error)
+	AddUser(name string, displayName string, password string, creator string) (user, error)
+	RemoveUser(tag names.UserTag) error
+	Model() (model, error)
+}
+
+// stateShim allows the real state to implement State.
+type stateShim struct {
+	st *state.State
+}
+
+func (s stateShim) User(tag names.UserTag) (user, error) {
+	u, err := s.st.User(tag)
+	return u, errors.Trace(err)
+}
+
+func (s stateShim) AddUser(name, displayName, password, creator string) (user, error) {
+	u, err := s.st.AddUser(name, displayName, password, creator)
+	return u, errors.Trace(err)
+}
+
+func (s stateShim) Model() (model, error) {
+	m, err := s.st.Model()
+	return m, errors.Trace(err)
+}
+
+func (s stateShim) RemoveUser(tag names.UserTag) error {
+	return errors.Trace(s.st.RemoveUser(tag))
+}
+
+// model defines the model methods that the controlsocket worker needs.
+type model interface {
+	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
+}
+
+// user defines the user methods that the controlsocket worker needs.
+type user interface {
+	Name() string
+	CreatedBy() string
+	UserTag() names.UserTag
+	PasswordValid(string) bool
+}

--- a/worker/controlsocket/worker.go
+++ b/worker/controlsocket/worker.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build linux
+
+package controlsocket
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/juju/sockets"
+)
+
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead use the one passed as manifold config.
+type logger any
+
+var _ logger = struct{}{}
+
+// Logger represents the methods used by the worker to log information.
+type Logger interface {
+	Errorf(string, ...any)
+	Warningf(string, ...any)
+	Infof(string, ...any)
+	Debugf(string, ...any)
+	Tracef(string, ...any)
+}
+
+// Config represents configuration for the controlsocket worker.
+type Config struct {
+	State      State
+	Logger     Logger
+	SocketName string
+}
+
+// Validate returns an error if config cannot drive the Worker.
+func (config Config) Validate() error {
+	if config.State == nil {
+		return errors.NotValidf("nil State")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.SocketName == "" {
+		return errors.NotValidf("empty SocketName")
+	}
+	return nil
+}
+
+// Worker is a controlsocket worker.
+type Worker struct {
+	config   Config
+	tomb     tomb.Tomb
+	listener net.Listener
+}
+
+// NewWorker returns a controlsocket worker with the given config.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	l, err := sockets.Listen(sockets.Socket{
+		Address: config.SocketName,
+		Network: "unix",
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to listen on unix socket")
+	}
+	config.Logger.Debugf("controlsocket worker listening on socket %q", config.SocketName)
+
+	w := &Worker{
+		config:   config,
+		listener: l,
+	}
+	w.tomb.Go(w.run)
+	return w, nil
+}
+
+func (w *Worker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *Worker) Wait() error {
+	return w.tomb.Wait()
+}
+
+// run listens on the control socket and handles requests.
+func (w *Worker) run() error {
+	router := mux.NewRouter()
+	w.registerHandlers(router)
+
+	srv := http.Server{Handler: router}
+	defer func() {
+		err := srv.Close()
+		if err != nil {
+			w.config.Logger.Warningf("error closing HTTP server: %v", err)
+		}
+	}()
+
+	go func() {
+		// Wait for the tomb to start dying and then shut the server down.
+		<-w.tomb.Dying()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			w.config.Logger.Warningf("error shutting down HTTP server: %v", err)
+		}
+	}()
+
+	w.config.Logger.Debugf("controlsocket worker now serving")
+	defer w.config.Logger.Debugf("controlsocket worker serving finished")
+	if err := srv.Serve(w.listener); err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}

--- a/worker/controlsocket/worker_test.go
+++ b/worker/controlsocket/worker_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type workerSuite struct {
+	logger *fakeLogger
+}
+
+var _ = gc.Suite(&workerSuite{})
+
+func (s *workerSuite) SetUpTest(c *gc.C) {
+	s.logger = &fakeLogger{}
+}
+
+func (s *workerSuite) TestStartStopWorker(c *gc.C) {
+	tmpDir := c.MkDir()
+	socket := path.Join(tmpDir, "test.socket")
+
+	worker, err := NewWorker(Config{
+		State:      &fakeState{},
+		Logger:     s.logger,
+		SocketName: socket,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check socket is created with correct permissions
+	fi, err := os.Stat(socket)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fi.Mode(), gc.Equals, fs.ModeSocket|0700)
+
+	// Check server is up
+	cl := client(socket)
+	resp, err := cl.Get("http://a/foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
+
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check server has stopped
+	resp, err = cl.Get("http://a/foo")
+	c.Assert(err, gc.ErrorMatches, ".*connection refused")
+
+	// No warnings/errors should have been logged
+	for _, entry := range s.logger.entries {
+		if entry.level == "ERROR" || entry.level == "WARNING" {
+			c.Errorf("%s: %s", entry.level, entry.msg)
+		}
+	}
+}
+
+type fakeLogger struct {
+	entries []logEntry
+}
+
+type logEntry struct{ level, msg string }
+
+func (f *fakeLogger) write(level string, format string, args ...any) {
+	f.entries = append(f.entries, logEntry{level, fmt.Sprintf(format, args...)})
+}
+
+func (f *fakeLogger) Errorf(format string, args ...any) {
+	f.write("ERROR", format, args...)
+}
+
+func (f *fakeLogger) Warningf(format string, args ...any) {
+	f.write("WARNING", format, args...)
+}
+
+func (f *fakeLogger) Infof(format string, args ...any) {
+	f.write("INFO", format, args...)
+}
+
+func (f *fakeLogger) Debugf(format string, args ...any) {
+	f.write("DEBUG", format, args...)
+}
+
+func (f *fakeLogger) Tracef(format string, args ...any) {
+	f.write("TRACE", format, args...)
+}


### PR DESCRIPTION
This PR adds a `controlsocket` worker, which will become the canonical way for the controller charm to communicate with the Juju controller. This worker serves an HTTP API over a Unix socket, which is exposed to the machine/container where the controller charm is running. The worker depends on state, and can interact directly with state when it receives a request.

I've added "add metrics user" and "remove metrics user" handlers, which will be used to integrate `prometheus-k8s` with the controller charm. The API is fully compliant with JSON REST:

```
POST /metrics-users
{"username":"juju-metrics-r0","password":"bar"}
```
```
DELETE /metrics-users/{username}
```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Manual

Check the worker is starting and the socket is being created:
```shell
make [k8s]-operator-update
juju bootstrap [cloud] c
juju switch controller
juju ssh controller/0
stat /var/lib/juju/control.socket
```

Manually curl the socket:
```bash
curl -X POST http://a/metrics-users \
  -d '{"username":"juju-metrics-test","password":"bar"}' \
  --unix-socket /var/lib/juju/control.socket
# {"message":"created user \"juju-metrics-test\""}
```
```bash
curl -X DELETE http://a/metrics-users/juju-metrics-test \
  --unix-socket /var/lib/juju/control.socket
# {"message":"deleted user \"juju-metrics-test\""}
```

### Integration

Integration with Prometheus (using the modified controller charm from juju/juju-controller#28):
```shell
juju bootstrap [k8s] c \
  --controller-charm-path=barrettj12-cc \
  --controller-charm-channel=latest/stable

juju switch controller
juju deploy prometheus-k8s p --trust
juju relate p controller

juju users # should include `juju-metrics-r0`
```

See also: #16388

## Links

**Jira card:** JUJU-4649

Rejected PRs:
- #15319
- #16263
- #16285