### PR TITLE
Watch for api address changes for k8s model operator and sidecar charms.

### DIFF
--- a/api/controller/caasmodeloperator/client.go
+++ b/api/controller/caasmodeloperator/client.go
@@ -8,7 +8,9 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/rpc/params"
 )
@@ -86,4 +88,17 @@ func (c *Client) SetPassword(password string) error {
 		return errors.Trace(err)
 	}
 	return result.OneError()
+}
+
+// WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the
+// information returned by ModelOperatorProvisioningInfo.
+func (c *Client) WatchModelOperatorProvisioningInfo() (watcher.NotifyWatcher, error) {
+	var result params.NotifyWatchResult
+	if err := c.facade.FacadeCall("WatchModelOperatorProvisioningInfo", nil, &result); err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -38,12 +38,13 @@ type mockState struct {
 	testing.Stub
 
 	common.APIAddressAccessor
-	model                   *mockModel
-	applicationWatcher      *mockStringsWatcher
-	app                     *mockApplication
-	resource                *mockResources
-	operatorRepo            string
-	controllerConfigWatcher *statetesting.MockNotifyWatcher
+	model                        *mockModel
+	applicationWatcher           *mockStringsWatcher
+	app                          *mockApplication
+	resource                     *mockResources
+	operatorRepo                 string
+	controllerConfigWatcher      *statetesting.MockNotifyWatcher
+	apiHostPortsForAgentsWatcher *statetesting.MockNotifyWatcher
 }
 
 func newMockState() *mockState {
@@ -119,6 +120,11 @@ func (st *mockState) ResolveConstraints(cons constraints.Value) (constraints.Val
 func (st *mockState) Resources() caasapplicationprovisioner.Resources {
 	st.MethodCall(st, "Resources")
 	return st.resource
+}
+
+func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	st.MethodCall(st, "WatchAPIHostPortsForAgents")
+	return st.apiHostPortsForAgentsWatcher
 }
 
 type mockResources struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -237,11 +237,12 @@ func (a *API) watchProvisioningInfo(appName names.ApplicationTag) (params.Notify
 		return result, errors.Trace(err)
 	}
 
-	modelConfigWatcher := model.WatchForModelConfigChanges()
 	appWatcher := app.Watch()
 	controllerConfigWatcher := a.ctrlSt.WatchControllerConfig()
+	controllerAPIHostPortsWatcher := a.ctrlSt.WatchAPIHostPortsForAgents()
+	modelConfigWatcher := model.WatchForModelConfigChanges()
 
-	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, modelConfigWatcher)
+	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, controllerAPIHostPortsWatcher, modelConfigWatcher)
 
 	if _, ok := <-multiWatcher.Changes(); ok {
 		result.NotifyWatcherId = a.resources.Register(multiWatcher)

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -124,6 +124,44 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	})
 }
 
+func (s *CAASApplicationProvisionerSuite) TestWatchProvisioningInfo(c *gc.C) {
+	appChanged := make(chan struct{}, 1)
+	portsChanged := make(chan struct{}, 1)
+	modelConfigChanged := make(chan struct{}, 1)
+	controllerConfigChanged := make(chan struct{}, 1)
+	s.st.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(portsChanged)
+	s.st.model.state.controllerConfigWatcher = statetesting.NewMockNotifyWatcher(controllerConfigChanged)
+	s.st.model.modelConfigChanges = statetesting.NewMockNotifyWatcher(modelConfigChanged)
+	s.st.app = &mockApplication{
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
+		watcher: statetesting.NewMockNotifyWatcher(appChanged),
+	}
+	appChanged <- struct{}{}
+	portsChanged <- struct{}{}
+	modelConfigChanged <- struct{}{}
+	controllerConfigChanged <- struct{}{}
+
+	results, err := s.api.WatchProvisioningInfo(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "application-gitlab"},
+		},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	res := s.resources.Get("1")
+	c.Assert(res, gc.FitsTypeOf, (*common.MultiNotifyWatcher)(nil))
+}
+
 func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 	s.st.app = &mockApplication{
 		life: state.Alive,

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -17,14 +17,17 @@ import (
 )
 
 type mockModel struct {
-	password string
-	tag      names.Tag
+	password           string
+	tag                names.Tag
+	modelConfigChanged state.NotifyWatcher
 }
 
 type mockState struct {
 	common.APIAddressAccessor
-	operatorRepo string
-	model        *mockModel
+	operatorRepo                 string
+	model                        *mockModel
+	controllerConfigWatcher      state.NotifyWatcher
+	apiHostPortsForAgentsWatcher state.NotifyWatcher
 }
 
 func newMockState() *mockState {
@@ -60,6 +63,14 @@ func (st *mockState) Model() (caasmodeloperator.Model, error) {
 	return st.model, nil
 }
 
+func (m *mockState) WatchControllerConfig() state.NotifyWatcher {
+	return m.controllerConfigWatcher
+}
+
+func (m *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	return m.apiHostPortsForAgentsWatcher
+}
+
 func (m *mockModel) Tag() names.Tag {
 	return m.tag
 }
@@ -78,4 +89,8 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	attrs["operator-storage"] = "k8s-storage"
 	attrs["agent-version"] = "2.6-beta3"
 	return config.New(config.UseDefaults, attrs)
+}
+
+func (m *mockModel) WatchForModelConfigChanges() state.NotifyWatcher {
+	return m.modelConfigChanged
 }

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state/watcher"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasmodeloperator")
@@ -30,6 +31,8 @@ type API struct {
 	auth      facade.Authorizer
 	ctrlState CAASControllerState
 	state     CAASModelOperatorState
+
+	resources facade.Resources
 }
 
 // NewAPI is alternative means of constructing a controller model facade.
@@ -49,7 +52,33 @@ func NewAPI(
 		PasswordChanger: common.NewPasswordChanger(st, common.AuthFuncForTagKind(names.ModelTagKind)),
 		ctrlState:       ctrlSt,
 		state:           st,
+		resources:       resources,
 	}, nil
+}
+
+// WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the
+// information returned by ModelOperatorProvisioningInfo.
+func (a *API) WatchModelOperatorProvisioningInfo() (params.NotifyWatchResult, error) {
+	result := params.NotifyWatchResult{}
+
+	model, err := a.state.Model()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	controllerConfigWatcher := a.ctrlState.WatchControllerConfig()
+	controllerAPIHostPortsWatcher := a.ctrlState.WatchAPIHostPortsForAgents()
+	modelConfigWatcher := model.WatchForModelConfigChanges()
+
+	multiWatcher := common.NewMultiNotifyWatcher(controllerConfigWatcher, controllerAPIHostPortsWatcher, modelConfigWatcher)
+
+	if _, ok := <-multiWatcher.Changes(); ok {
+		result.NotifyWatcherId = a.resources.Register(multiWatcher)
+	} else {
+		return result, watcher.EnsureErr(multiWatcher)
+	}
+
+	return result, nil
 }
 
 // ModelOperatorProvisioningInfo returns the information needed for provisioning

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasmodeloperator"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloudconfig/podcfg"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -76,4 +77,23 @@ func (m *ModelOperatorSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 
 	c.Assert(vers, jc.DeepEquals, info.Version)
+}
+
+func (m *ModelOperatorSuite) TestWatchProvisioningInfo(c *gc.C) {
+	controllerConfigChanged := make(chan struct{}, 1)
+	modelConfigChanged := make(chan struct{}, 1)
+	apiHostPortsForAgentsChanged := make(chan struct{}, 1)
+	m.state.controllerConfigWatcher = statetesting.NewMockNotifyWatcher(controllerConfigChanged)
+	m.state.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(apiHostPortsForAgentsChanged)
+	m.state.model.modelConfigChanged = statetesting.NewMockNotifyWatcher(modelConfigChanged)
+
+	controllerConfigChanged <- struct{}{}
+	apiHostPortsForAgentsChanged <- struct{}{}
+	modelConfigChanged <- struct{}{}
+
+	results, err := m.api.WatchModelOperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Error, gc.IsNil)
+	res := m.resources.Get("1")
+	c.Assert(res, gc.FitsTypeOf, (*common.MultiNotifyWatcher)(nil))
 }

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -25,10 +25,12 @@ type CAASModelOperatorState interface {
 type CAASControllerState interface {
 	common.APIAddressAccessor
 	ControllerConfig() (controller.Config, error)
+	WatchControllerConfig() state.NotifyWatcher
 }
 
 type Model interface {
 	ModelConfig() (*config.Config, error)
+	WatchForModelConfigChanges() state.NotifyWatcher
 }
 
 type stateShim struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10700,6 +10700,15 @@
                         }
                     },
                     "description": "WatchAPIHostPorts watches the API server addresses."
+                },
+                "WatchModelOperatorProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    },
+                    "description": "WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the\ninformation returned by ModelOperatorProvisioningInfo."
                 }
             },
             "definitions": {

--- a/worker/caasmodeloperator/modeloperator_test.go
+++ b/worker/caasmodeloperator/modeloperator_test.go
@@ -4,20 +4,25 @@
 package caasmodeloperator_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	modeloperatorapi "github.com/juju/juju/api/controller/caasmodeloperator"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/worker/caasmodeloperator"
 )
 
 type dummyAPI struct {
-	provInfo    func() (modeloperatorapi.ModelOperatorProvisioningInfo, error)
-	setPassword func(password string) error
+	provInfo      func() (modeloperatorapi.ModelOperatorProvisioningInfo, error)
+	setPassword   func(password string) error
+	watchProvInfo func() (watcher.NotifyWatcher, error)
 }
 
 type dummyBroker struct {
@@ -58,6 +63,13 @@ func (a *dummyAPI) ModelOperatorProvisioningInfo() (modeloperatorapi.ModelOperat
 	return a.provInfo()
 }
 
+func (a *dummyAPI) WatchModelOperatorProvisioningInfo() (watcher.NotifyWatcher, error) {
+	if a.watchProvInfo == nil {
+		return watcher.NewMultiNotifyWatcher(), nil
+	}
+	return a.watchProvInfo()
+}
+
 func (a *dummyAPI) SetPassword(p string) error {
 	if a.setPassword == nil {
 		return nil
@@ -65,32 +77,68 @@ func (a *dummyAPI) SetPassword(p string) error {
 	return a.setPassword(p)
 }
 
-func (m *ModelOperatorManagerSuite) TestModelOperatorManagerConstruction(c *gc.C) {
+func (m *ModelOperatorManagerSuite) TestModelOperatorManagerApplying(c *gc.C) {
+	const n = 3
 	var (
-		apiAddresses = []string{"fe80:abcd::1"}
-		apiCalled    = false
-		brokerCalled = false
-		imagePath    = "juju/jujud:1"
+		iteration = 0 // ... n
+
+		apiAddresses = [n][]string{{"fe80:abcd::1"}, {"fe80:abcd::2"}, {"fe80:abcd::3"}}
+		imagePath    = [n]string{"juju/jujud:1", "juju/jujud:2", "juju/jujud:3"}
 		modelUUID    = "deadbeef-0bad-400d-8000-4b1d0d06f00d"
-		ver          = version.MustParse("2.8.2")
+		ver          = [n]version.Number{version.MustParse("2.8.2"), version.MustParse("2.9.1"), version.MustParse("2.9.99")}
+
+		password   = ""
+		lastConfig = (*caas.ModelOperatorConfig)(nil)
 	)
 
+	changed := make(chan struct{})
 	api := &dummyAPI{
 		provInfo: func() (modeloperatorapi.ModelOperatorProvisioningInfo, error) {
-			apiCalled = true
 			return modeloperatorapi.ModelOperatorProvisioningInfo{
-				APIAddresses: apiAddresses,
-				ImageDetails: resources.DockerImageDetails{RegistryPath: imagePath},
-				Version:      ver,
+				APIAddresses: apiAddresses[iteration],
+				ImageDetails: resources.DockerImageDetails{RegistryPath: imagePath[iteration]},
+				Version:      ver[iteration],
 			}, nil
+		},
+		watchProvInfo: func() (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(changed), nil
 		},
 	}
 
 	broker := &dummyBroker{
 		ensureModelOperator: func(_, _ string, conf *caas.ModelOperatorConfig) error {
-			c.Assert(conf.ImageDetails.RegistryPath, gc.Equals, imagePath)
-			brokerCalled = true
+			defer func() {
+				iteration++
+			}()
+			lastConfig = conf
+
+			c.Check(conf.ImageDetails.RegistryPath, gc.Equals, imagePath[iteration])
+
+			ac, err := agent.ParseConfigData(conf.AgentConf)
+			c.Check(err, jc.ErrorIsNil)
+			if err != nil {
+				return err
+			}
+			addresses, _ := ac.APIAddresses()
+			c.Check(addresses, gc.DeepEquals, apiAddresses[iteration])
+			c.Check(ac.UpgradedToVersion(), gc.Equals, ver[iteration])
+
+			if password == "" {
+				password = ac.OldPassword()
+			}
+			c.Check(ac.OldPassword(), gc.Equals, password)
+			c.Check(ac.OldPassword(), gc.HasLen, 24)
+
 			return nil
+		},
+		modelOperatorExists: func() (bool, error) {
+			return iteration > 0, nil
+		},
+		modelOperator: func() (*caas.ModelOperatorConfig, error) {
+			if iteration == 0 {
+				return nil, errors.NotFoundf("model operator")
+			}
+			return lastConfig, nil
 		},
 	}
 
@@ -98,10 +146,13 @@ func (m *ModelOperatorManagerSuite) TestModelOperatorManagerConstruction(c *gc.C
 		api, broker, modelUUID, &mockAgentConfig{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	for i := 0; i < n; i++ {
+		changed <- struct{}{}
+	}
+
 	worker.Kill()
 	err = worker.Wait()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(apiCalled, gc.Equals, true)
-	c.Assert(brokerCalled, gc.Equals, true)
+	c.Assert(iteration, gc.Equals, n)
 }


### PR DESCRIPTION
The caasmodeloperator (aka the caasmodeloperator provisioner) was a single fire worker that would only run once. This changes the worker to watch the relevant inputs to the ModelOperatorProvisioningInfo for changes and re-ensure the model operator as required.

For the sidecar charms, we just need to add in the api hosts watcher in the WatchProvisioningInfo facade call.

## QA steps

- Bootstrap controller.
- Add k8s model.
- Deploy snappass-test.
- Then somehow add a new ip address to the controller.
- Check model operator configmap is updated with new api addresses in the agent config.
- Check the snappass-test secret is updated with the new api addresses.

## Documentation changes

N/A

## Links

https://bugs.launchpad.net/juju/+bug/2036849
