### PR TITLE
Inject controller config from agent bootstrap

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -186,6 +186,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 
 	adminUser := names.NewLocalUserTag("agent-admin")
 	ctlr, err := agentbootstrap.InitializeState(
+		stdcontext.Background(),
 		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 		jujujujutesting.InsertDummyCloudType,
 	)
@@ -379,7 +380,10 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	args := agentbootstrap.InitializeStateParams{}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, err = agentbootstrap.InitializeState(&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), nil)
+	_, err = agentbootstrap.InitializeState(
+		stdcontext.Background(),
+		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), nil,
+	)
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -442,6 +446,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, err := agentbootstrap.InitializeState(
+		stdcontext.Background(),
 		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 		jujujujutesting.InsertDummyCloudType,
 	)
@@ -449,6 +454,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	_ = st.Close()
 
 	st, err = agentbootstrap.InitializeState(
+		stdcontext.Background(),
 		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 	)
 	if err == nil {

--- a/agent/agentbootstrap/service.go
+++ b/agent/agentbootstrap/service.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agentbootstrap
+
+import (
+	stdcontext "context"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/database"
+	controllerconfigservice "github.com/juju/juju/domain/controllerconfig/service"
+	controllerconfigstate "github.com/juju/juju/domain/controllerconfig/state"
+)
+
+// ControllerConfigService is used to obtain the controller config.
+type ControllerConfigService interface {
+	ControllerConfig(stdcontext.Context) (controller.Config, error)
+}
+
+// newControllerConfigService returns a new ControllerConfigService.
+// Note: this side steps the need to use the full service factory. We don't
+// have all the dependencies required to build one at the time we require the
+// controller config. It is not recommended to use this pattern elsewhere.
+func newControllerConfigService(runner database.TxnRunner) ControllerConfigService {
+	return controllerconfigservice.NewService(
+		controllerconfigstate.NewState(constTxnRunnerFactory(runner)),
+		nil,
+	)
+}
+
+// constTxnRunnerFactory always returns a TxnRunnerFactory that never fails.
+func constTxnRunnerFactory[T database.TxnRunner](r T) database.TxnRunnerFactory {
+	return func() (database.TxnRunner, error) {
+		return r, nil
+	}
+}

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -230,13 +230,14 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	conf := s.WriteStateAgentConfig(c, tag, password, vers, s.ControllerModel(c).ModelTag(), apiPort)
 	s.primeAPIHostPorts(c)
 
-	err = database.BootstrapDqlite(
+	runner, err := database.BootstrapDqlite(
 		context.Background(),
 		database.NewNodeManager(conf, logger, coredatabase.NoopSlowQueryLogger{}),
 		logger,
 		true,
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	defer runner.Close()
 
 	return conf, agentTools
 }

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -379,6 +379,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 
 		adminTag := names.NewLocalUserTag(adminUserName)
 		controller, stateErr = agentInitializeState(
+			ctx,
 			env,
 			adminTag,
 			agentConfig,

--- a/database/bootstrap_test.go
+++ b/database/bootstrap_test.go
@@ -57,8 +57,9 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 		})
 	}
 
-	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, true, check)
+	runner, err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, true, check)
 	c.Assert(err, jc.ErrorIsNil)
+	defer runner.Close()
 }
 
 type testNodeManager struct {


### PR DESCRIPTION
The following injects the controller config into the agentbootstrap removing the reliance on state package. Unfortunately, we have to return a txn runner from bootstrap dqlite. This ensures that the right values are correctly returned that is consistent with what is within the db. This does mean that bootstrap isn't as pure as we'd like, but it does solve the problem of ensuring what is in the database is the source of truth.

There will become more of a requirement for this to happen in the future with later requests to the underlying db. We might have to create a full-service factory, but it becomes harder to do as we don't have a change stream that the service factory requires. We might have our modeling off slightly here.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-3795
