### PR TITLE
Fix unit tests baserefreshsuite

### DIFF
--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -858,7 +858,6 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 			`series:`,
 			`    - trusty`,
 			`    - wily`,
-			`    - bionic`,
 		},
 		"\n",
 	)

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -101,8 +101,10 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 	cookieFile := filepath.Join(c.MkDir(), "cookies")
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookieFile)
 
-	s.testPlatform = corecharm.MustParsePlatform("amd64/ubuntu/22.04")
-	s.testBase = corebase.MakeDefaultBase("ubuntu", "22.04")
+	var err error
+	s.testBase, err = corebase.GetBaseFromSeries(currentCharmURL.Series)
+	c.Assert(err, jc.ErrorIsNil)
+	s.testPlatform = corecharm.MustParsePlatform(fmt.Sprintf("%s/%s/%s", arch.DefaultArchitecture, s.testBase.OS, s.testBase.Channel))
 
 	s.deployResources = func(
 		applicationID string,


### PR DESCRIPTION
Update to #16254 unit test change for the refresh command. Which the initial change worked, it was not correct as it overrode the operating system defined by the caller of setup. This became an issue with the merge into Main. 

Also fixed, TestForcedSeriesUpgrade, which didn't actually test what it was named to Test.

## QA steps

Successful unit tests in the PR GitHub actions.

## Links

JUJU-4641