### PR TITLE
Agent bootstrap controller config

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -74,7 +74,28 @@ type bootstrapController interface {
 	SetMongoPassword(password string) error
 }
 
-// InitializeState should be called with the bootstrap machine's agent
+// DqliteInitializerFunc is a function that initializes the dqlite database
+// for the controller.
+type DqliteInitializerFunc func(
+	ctx stdcontext.Context,
+	mgr database.BootstrapNodeManager,
+	logger database.Logger,
+	preferLoopback bool,
+	ops ...database.BootstrapOpt,
+) error
+
+// AgentInitializer is used to initialize the state database.
+type AgentInitializerConfig struct {
+	BootstrapEnviron      environs.BootstrapEnviron
+	AdminUser             names.UserTag
+	AgentConfig           agent.ConfigSetter
+	InitializeStateParams InitializeStateParams
+	MongoDialOpts         mongo.DialOpts
+	StateNewPolicy        state.NewPolicyFunc
+	BootrapDqlite         DqliteInitializerFunc
+}
+
+// InitializeAgent should be called with the bootstrap machine's agent
 // configuration. It uses that information to create the controller, dial the
 // controller, and initialize it. It also generates a new password for the
 // bootstrap machine and calls Write to save the configuration.
@@ -85,53 +106,49 @@ type bootstrapController interface {
 // constraints. The connection to the controller will respect the
 // given timeout parameter.
 //
-// InitializeState returns the newly initialized state and bootstrap machine.
+// InitializeAgent returns the newly initialized state and bootstrap machine.
 // If it fails, the state may well be irredeemably compromised.
-func InitializeState(
-	env environs.BootstrapEnviron,
-	adminUser names.UserTag,
-	c agent.ConfigSetter,
-	args InitializeStateParams,
-	dialOpts mongo.DialOpts,
-	newPolicy state.NewPolicyFunc,
-) (_ *state.Controller, resultErr error) {
-	if c.Tag().Id() != agent.BootstrapControllerId || !coreagent.IsAllowedControllerTag(c.Tag().Kind()) {
+func InitializeAgent(ctx stdcontext.Context, cfg AgentInitializerConfig) (_ *state.Controller, resultErr error) {
+	agentConfig := cfg.AgentConfig
+	if agentConfig.Tag().Id() != agent.BootstrapControllerId || !coreagent.IsAllowedControllerTag(agentConfig.Tag().Kind()) {
 		return nil, errors.Errorf("InitializeState not called with bootstrap controller's configuration")
 	}
-	servingInfo, ok := c.StateServingInfo()
+	servingInfo, ok := agentConfig.StateServingInfo()
 	if !ok {
 		return nil, errors.Errorf("state serving information not available")
 	}
 	// N.B. no users are set up when we're initializing the state,
 	// so don't use any tag or password when opening it.
-	info, ok := c.MongoInfo()
+	info, ok := agentConfig.MongoInfo()
 	if !ok {
 		return nil, errors.Errorf("state info not available")
 	}
 	info.Tag = nil
-	info.Password = c.OldPassword()
+	info.Password = agentConfig.OldPassword()
+
+	stateParams := cfg.InitializeStateParams
 
 	// Add the controller model cloud and credential to the database.
-	cloudCred, cloudCredTag, err := getCloudCredential(adminUser, args)
+	cloudCred, cloudCredTag, err := getCloudCredential(cfg.AdminUser, stateParams)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting cloud credentials from args")
 	}
-	ctrlCloud := args.ControllerCloud
+	ctrlCloud := cfg.InitializeStateParams.ControllerCloud
 	ctrlCloud.IsControllerCloud = true
 
-	if err := database.BootstrapDqlite(
-		stdcontext.TODO(),
-		database.NewNodeManager(c, logger, coredatabase.NoopSlowQueryLogger{}),
+	if err := cfg.BootrapDqlite(
+		ctx,
+		database.NewNodeManager(cfg.AgentConfig, logger, coredatabase.NoopSlowQueryLogger{}),
 		logger,
 		false,
-		ccbootstrap.InsertInitialControllerConfig(args.ControllerConfig),
+		ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 		cloudbootstrap.InsertInitialControllerCloud(ctrlCloud),
 		credbootstrap.InsertInitialControllerCredentials(cloudCredTag, cloudCred),
 	); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	session, err := initMongo(info.Info, dialOpts, info.Password)
+	session, err := initMongo(info.Info, cfg.MongoDialOpts, info.Password)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to initialize mongo")
 	}
@@ -139,7 +156,7 @@ func InitializeState(
 
 	logger.Debugf("initializing address %v", info.Addrs)
 
-	isCAAS := cloud.CloudIsCAAS(args.ControllerCloud)
+	isCAAS := cloud.CloudIsCAAS(stateParams.ControllerCloud)
 	modelType := state.ModelTypeIAAS
 	if isCAAS {
 		modelType = state.ModelTypeCAAS
@@ -148,23 +165,23 @@ func InitializeState(
 		Clock: clock.WallClock,
 		ControllerModelArgs: state.ModelArgs{
 			Type:                    modelType,
-			Owner:                   adminUser,
-			Config:                  args.ControllerModelConfig,
-			Constraints:             args.ModelConstraints,
-			CloudName:               args.ControllerCloud.Name,
-			CloudRegion:             args.ControllerCloudRegion,
+			Owner:                   cfg.AdminUser,
+			Config:                  stateParams.ControllerModelConfig,
+			Constraints:             stateParams.ModelConstraints,
+			CloudName:               stateParams.ControllerCloud.Name,
+			CloudRegion:             stateParams.ControllerCloudRegion,
 			CloudCredential:         cloudCredTag,
-			StorageProviderRegistry: args.StorageProviderRegistry,
-			EnvironVersion:          args.ControllerModelEnvironVersion,
+			StorageProviderRegistry: stateParams.StorageProviderRegistry,
+			EnvironVersion:          stateParams.ControllerModelEnvironVersion,
 		},
-		StoragePools:              args.StoragePools,
-		CloudName:                 args.ControllerCloud.Name,
-		ControllerConfig:          args.ControllerConfig,
-		ControllerInheritedConfig: args.ControllerInheritedConfig,
-		RegionInheritedConfig:     args.RegionInheritedConfig,
+		StoragePools:              stateParams.StoragePools,
+		CloudName:                 stateParams.ControllerCloud.Name,
+		ControllerConfig:          stateParams.ControllerConfig,
+		ControllerInheritedConfig: stateParams.ControllerInheritedConfig,
+		RegionInheritedConfig:     stateParams.RegionInheritedConfig,
 		MongoSession:              session,
 		AdminPassword:             info.Password,
-		NewPolicy:                 newPolicy,
+		NewPolicy:                 cfg.StateNewPolicy,
 	})
 	if err != nil {
 		return nil, errors.Errorf("failed to initialize state: %v", err)
@@ -175,11 +192,11 @@ func InitializeState(
 			_ = ctrl.Close()
 		}
 	}()
-	servingInfo.SharedSecret = args.SharedSecret
-	c.SetStateServingInfo(servingInfo)
+	servingInfo.SharedSecret = stateParams.SharedSecret
+	cfg.AgentConfig.SetStateServingInfo(servingInfo)
 
 	// Filter out any LXC or LXD bridge addresses from the machine addresses.
-	args.BootstrapMachineAddresses = network.FilterBridgeAddresses(args.BootstrapMachineAddresses)
+	stateParams.BootstrapMachineAddresses = network.FilterBridgeAddresses(stateParams.BootstrapMachineAddresses)
 
 	st, err := ctrl.SystemState()
 	if err != nil {
@@ -190,8 +207,8 @@ func InitializeState(
 	// We need to do this before setting the API host-ports,
 	// because any space names in the bootstrap machine addresses must be
 	// reconcilable with space IDs at that point.
-	ctx := context.CallContext(st)
-	if err = space.ReloadSpaces(ctx, space.NewState(st), env); err != nil {
+	callContext := context.CallContext(st)
+	if err = space.ReloadSpaces(callContext, space.NewState(st), cfg.BootstrapEnviron); err != nil {
 		if errors.Is(err, errors.NotSupported) {
 			logger.Debugf("Not performing spaces load on a non-networking environment")
 		} else {
@@ -209,8 +226,8 @@ func InitializeState(
 	// to space ID decorated addresses.
 	if err = initAPIHostPorts(
 		st,
-		args.ControllerConfig,
-		args.BootstrapMachineAddresses,
+		stateParams.ControllerConfig,
+		stateParams.BootstrapMachineAddresses,
 		servingInfo.APIPort,
 	); err != nil {
 		return nil, err
@@ -220,30 +237,30 @@ func InitializeState(
 	}
 
 	cloudSpec, err := environscloudspec.MakeCloudSpec(
-		args.ControllerCloud,
-		args.ControllerCloudRegion,
-		args.ControllerCloudCredential,
+		stateParams.ControllerCloud,
+		stateParams.ControllerCloudRegion,
+		stateParams.ControllerCloudCredential,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	cloudSpec.IsControllerCloud = true
 
-	provider, err := args.Provider(cloudSpec.Type)
+	provider, err := stateParams.Provider(cloudSpec.Type)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting environ provider")
 	}
 
 	var controllerNode bootstrapController
 	if isCAAS {
-		if controllerNode, err = initBootstrapNode(st, args); err != nil {
+		if controllerNode, err = initBootstrapNode(st, stateParams); err != nil {
 			return nil, errors.Annotate(err, "cannot initialize bootstrap controller")
 		}
-		if err := initControllerCloudService(cloudSpec, provider, st, args); err != nil {
+		if err := initControllerCloudService(cloudSpec, provider, st, stateParams); err != nil {
 			return nil, errors.Annotate(err, "cannot initialize cloud service")
 		}
 	} else {
-		if controllerNode, err = initBootstrapMachine(st, args); err != nil {
+		if controllerNode, err = initBootstrapMachine(st, stateParams); err != nil {
 			return nil, errors.Annotate(err, "cannot initialize bootstrap machine")
 		}
 	}
@@ -268,9 +285,9 @@ func InitializeState(
 	if err := controllerNode.SetMongoPassword(newPassword); err != nil {
 		return nil, err
 	}
-	c.SetPassword(newPassword)
+	cfg.AgentConfig.SetPassword(newPassword)
 
-	if err := ensureInitialModel(cloudSpec, provider, args, st, ctrl, adminUser, cloudCredTag); err != nil {
+	if err := ensureInitialModel(cloudSpec, provider, stateParams, st, ctrl, cfg.AdminUser, cloudCredTag); err != nil {
 		return nil, errors.Annotate(err, "ensuring initial model")
 	}
 	return ctrl, nil

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
 	"github.com/juju/juju/internal/storage/provider"
-	jujujujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -186,8 +185,12 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 
 	adminUser := names.NewLocalUserTag("agent-admin")
 	ctlr, err := agentbootstrap.InitializeState(
-		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
-		jujujujutesting.InsertDummyCloudType,
+		&fakeEnviron{},
+		adminUser,
+		cfg,
+		args,
+		mongotest.DialOpts(),
+		state.NewPolicyFunc(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = ctlr.Close() }()
@@ -443,7 +446,6 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, err := agentbootstrap.InitializeState(
 		&fakeEnviron{}, adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
-		jujujujutesting.InsertDummyCloudType,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	_ = st.Close()

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	coreos "github.com/juju/juju/core/os"
+	"github.com/juju/juju/database"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -56,13 +57,16 @@ import (
 )
 
 var (
-	initiateMongoServer  = peergrouper.InitiateMongoServer
-	agentInitializeState = agentbootstrap.InitializeState
-	sshGenerateKey       = ssh.GenerateKey
-	minSocketTimeout     = 1 * time.Minute
+	initiateMongoServer = peergrouper.InitiateMongoServer
+	sshGenerateKey      = ssh.GenerateKey
+	minSocketTimeout    = 1 * time.Minute
 )
 
 const adminUserName = "admin"
+
+// InitializeAgentFunc is a function that initializes an agent. This can
+// be defined as a variable so that it can be overridden in tests.
+type InitializeAgentFunc func(stdcontext.Context, agentbootstrap.AgentInitializerConfig) (*state.Controller, error)
 
 // BootstrapCommand represents a jujud bootstrap command.
 type BootstrapCommand struct {
@@ -70,12 +74,14 @@ type BootstrapCommand struct {
 	agentconf.AgentConf
 	BootstrapParamsFile string
 	Timeout             time.Duration
+	InitializeAgent     InitializeAgentFunc
 }
 
 // NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
 func NewBootstrapCommand() *BootstrapCommand {
 	return &BootstrapCommand{
-		AgentConf: agentconf.NewAgentConf(""),
+		AgentConf:       agentconf.NewAgentConf(""),
+		InitializeAgent: agentbootstrap.InitializeAgent,
 	}
 }
 
@@ -376,22 +382,27 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		dialOpts.Direct = true
 
 		adminTag := names.NewLocalUserTag(adminUserName)
-		controller, stateErr = agentInitializeState(
-			env,
-			adminTag,
-			agentConfig,
-			agentbootstrap.InitializeStateParams{
-				StateInitializationParams: args,
-				BootstrapMachineAddresses: addrs,
-				BootstrapMachineJobs:      agentConfig.Jobs(),
-				SharedSecret:              info.SharedSecret,
-				Provider:                  environs.Provider,
-				StorageProviderRegistry:   stateenvirons.NewStorageProviderRegistry(env),
+		controller, stateErr = c.InitializeAgent(
+			ctx,
+			agentbootstrap.AgentInitializerConfig{
+				AgentConfig:      agentConfig,
+				BootstrapEnviron: env,
+				AdminUser:        adminTag,
+				InitializeStateParams: agentbootstrap.InitializeStateParams{
+					StateInitializationParams: args,
+					BootstrapMachineAddresses: addrs,
+					BootstrapMachineJobs:      agentConfig.Jobs(),
+					SharedSecret:              info.SharedSecret,
+					Provider:                  environs.Provider,
+					StorageProviderRegistry:   stateenvirons.NewStorageProviderRegistry(env),
+				},
+				MongoDialOpts: dialOpts,
+				StateNewPolicy: stateenvirons.GetNewPolicyFunc(
+					cloudGetter{cloud: &args.ControllerCloud},
+					credentialGetter{cred: args.ControllerCloudCredential},
+				),
+				BootrapDqlite: database.BootstrapDqlite,
 			},
-			dialOpts,
-			stateenvirons.GetNewPolicyFunc(
-				cloudGetter{cloud: &args.ControllerCloud},
-				credentialGetter{cred: args.ControllerCloudCredential}),
 		)
 		return stateErr
 	})

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	coreos "github.com/juju/juju/core/os"
-	"github.com/juju/juju/database"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -59,7 +58,6 @@ import (
 var (
 	initiateMongoServer  = peergrouper.InitiateMongoServer
 	agentInitializeState = agentbootstrap.InitializeState
-	extraBootstrapOpts   []database.BootstrapOpt
 	sshGenerateKey       = ssh.GenerateKey
 	minSocketTimeout     = 1 * time.Minute
 )
@@ -394,7 +392,6 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 			stateenvirons.GetNewPolicyFunc(
 				cloudGetter{cloud: &args.ControllerCloud},
 				credentialGetter{cred: args.ControllerCloudCredential}),
-			extraBootstrapOpts...,
 		)
 		return stateErr
 	})

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 )
 
-type bootstrapNodeManager interface {
+type BootstrapNodeManager interface {
 	// EnsureDataDir ensures that a directory for Dqlite data exists at
 	// a path determined by the agent config, then returns that path.
 	EnsureDataDir() (string, error)
@@ -78,7 +78,7 @@ type BootstrapOpt func(context.Context, coredatabase.TxnRunner) error
 // to the loopback binding.
 func BootstrapDqlite(
 	ctx context.Context,
-	mgr bootstrapNodeManager,
+	mgr BootstrapNodeManager,
 	logger Logger,
 	preferLoopback bool,
 	ops ...BootstrapOpt,

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -26,7 +27,10 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	err := cloudbootstrap.InsertInitialControllerCloud(cld)(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
-	err = InsertInitialControllerCredentials("foo", "cirrus", "fred", cred)(ctx, s.TxnRunner())
+
+	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
+
+	err = InsertInitialControllerCredentials(tag, cred)(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var owner, cloudName string

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -598,8 +598,8 @@ func SeedCloudCredentials(c *gc.C, runner coredatabase.TxnRunner) {
 	err := cloudbootstrap.InsertInitialControllerCloud(DefaultCloud)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = credentialbootstrap.InsertInitialControllerCredentials(
-		DefaultCredentialTag.Name(), DefaultCloud.Name, AdminUser.Id(), defaultCredential)(context.Background(), runner)
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", DefaultCloud.Name, AdminUser.Name(), DefaultCredentialTag.Name()))
+	err = credentialbootstrap.InsertInitialControllerCredentials(tag, defaultCredential)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
The following supersedes #16305, which didn't fix the underlying problem we've been running into. How do we pass the dqlite dependency initialization function all the way through the stack. Prior to this change, we had global variables pointing to internal state, which then allowed sideloading. We've also had different ways of loading in new db changes via additional optional args in the InitialiseState function. This was the old way of doing it. We don't want to keep the old way. The new way is to know your dependencies.

Most of the code change is threading through the right functions at the right places. In addition, passing a config type into InitializeAgent (there is no state anymore) cleans up the overloading of the function.

The whole point of this is so we can be sure that just passing the controller config into the HostAPI ports function is actually the same controller config that will be in the database.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-3795
