### PR TITLE
Agent bootstrap type

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -187,12 +187,13 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 			BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
 			SharedSecret:              "abc123",
 			StorageProviderRegistry:   registry,
+			BootstrapDqlite:           bootstrapDqliteWithDummyCloudType,
+			Provider: func(t string) (environs.EnvironProvider, error) {
+				c.Assert(t, gc.Equals, "dummy")
+				return &envProvider, nil
+			},
+			Logger: testing.NewCheckLogger(c),
 		},
-		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
-		agentbootstrap.WithProvider(func(t string) (environs.EnvironProvider, error) {
-			c.Assert(t, gc.Equals, "dummy")
-			return &envProvider, nil
-		}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -396,8 +397,9 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 			StateNewPolicy:            nil,
 			SharedSecret:              "abc123",
 			StorageProviderRegistry:   provider.CommonStorageProviders(),
+			BootstrapDqlite:           bootstrapDqliteWithDummyCloudType,
+			Logger:                    testing.NewCheckLogger(c),
 		},
-		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = bootstrap.Initialize(stdcontext.Background())
@@ -466,11 +468,12 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 			BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
 			SharedSecret:              "abc123",
 			StorageProviderRegistry:   provider.CommonStorageProviders(),
+			BootstrapDqlite:           bootstrapDqliteWithDummyCloudType,
+			Provider: func(t string) (environs.EnvironProvider, error) {
+				return &fakeProvider{}, nil
+			},
+			Logger: testing.NewCheckLogger(c),
 		},
-		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
-		agentbootstrap.WithProvider(func(t string) (environs.EnvironProvider, error) {
-			return &fakeProvider{}, nil
-		}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	st, err := bootstrap.Initialize(stdcontext.Background())
@@ -487,6 +490,8 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 			StateNewPolicy:            state.NewPolicyFunc(nil),
 			SharedSecret:              "baz",
 			StorageProviderRegistry:   provider.CommonStorageProviders(),
+			BootstrapDqlite:           database.BootstrapDqlite,
+			Logger:                    testing.NewCheckLogger(c),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -148,53 +148,55 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	}
 	registry := provider.CommonStorageProviders()
 	var envProvider fakeProvider
-	args := agentbootstrap.InitializeStateParams{
-		StateInitializationParams: instancecfg.StateInitializationParams{
-			BootstrapMachineConstraints:             expectBootstrapConstraints,
-			BootstrapMachineInstanceId:              "i-bootstrap",
-			BootstrapMachineDisplayName:             "test-display-name",
-			BootstrapMachineHardwareCharacteristics: &expectHW,
-			ControllerCloud: cloud.Cloud{
-				Name:         "dummy",
-				Type:         "dummy",
-				AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
-				Regions:      []cloud.Region{{Name: "dummy-region"}},
-				RegionConfig: regionConfig,
-			},
-			ControllerCloudRegion:         "dummy-region",
-			ControllerConfig:              controllerCfg,
-			ControllerModelConfig:         modelCfg,
-			ControllerModelEnvironVersion: 666,
-			ModelConstraints:              expectModelConstraints,
-			ControllerInheritedConfig:     controllerInheritedConfig,
-			InitialModelConfig:            InitialModelConfigAttrs,
-			StoragePools: map[string]storage.Attrs{
-				"spool": {
-					"type": "loop",
-					"foo":  "bar",
-				},
+	stateInitParams := instancecfg.StateInitializationParams{
+		BootstrapMachineConstraints:             expectBootstrapConstraints,
+		BootstrapMachineInstanceId:              "i-bootstrap",
+		BootstrapMachineDisplayName:             "test-display-name",
+		BootstrapMachineHardwareCharacteristics: &expectHW,
+		ControllerCloud: cloud.Cloud{
+			Name:         "dummy",
+			Type:         "dummy",
+			AuthTypes:    []cloud.AuthType{cloud.EmptyAuthType},
+			Regions:      []cloud.Region{{Name: "dummy-region"}},
+			RegionConfig: regionConfig,
+		},
+		ControllerCloudRegion:         "dummy-region",
+		ControllerConfig:              controllerCfg,
+		ControllerModelConfig:         modelCfg,
+		ControllerModelEnvironVersion: 666,
+		ModelConstraints:              expectModelConstraints,
+		ControllerInheritedConfig:     controllerInheritedConfig,
+		InitialModelConfig:            InitialModelConfigAttrs,
+		StoragePools: map[string]storage.Attrs{
+			"spool": {
+				"type": "loop",
+				"foo":  "bar",
 			},
 		},
-		BootstrapMachineAddresses: initialAddrs,
-		BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
-		SharedSecret:              "abc123",
-		Provider: func(t string) (environs.EnvironProvider, error) {
+	}
+	adminUser := names.NewLocalUserTag("agent-admin")
+	bootstrap, err := agentbootstrap.NewAgentBootstrap(
+		agentbootstrap.AgentBootstrapArgs{
+			AgentConfig:               cfg,
+			BootstrapEnviron:          &fakeEnviron{},
+			AdminUser:                 adminUser,
+			StateInitializationParams: stateInitParams,
+			MongoDialOpts:             mongotest.DialOpts(),
+			StateNewPolicy:            state.NewPolicyFunc(nil),
+			BootstrapMachineAddresses: initialAddrs,
+			BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
+			SharedSecret:              "abc123",
+			StorageProviderRegistry:   registry,
+		},
+		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
+		agentbootstrap.WithProvider(func(t string) (environs.EnvironProvider, error) {
 			c.Assert(t, gc.Equals, "dummy")
 			return &envProvider, nil
-		},
-		StorageProviderRegistry: registry,
-	}
+		}),
+	)
+	c.Assert(err, jc.ErrorIsNil)
 
-	adminUser := names.NewLocalUserTag("agent-admin")
-	ctlr, err := agentbootstrap.InitializeAgent(stdcontext.Background(), agentbootstrap.AgentInitializerConfig{
-		AgentConfig:           cfg,
-		BootstrapEnviron:      &fakeEnviron{},
-		AdminUser:             adminUser,
-		InitializeStateParams: args,
-		MongoDialOpts:         mongotest.DialOpts(),
-		StateNewPolicy:        state.NewPolicyFunc(nil),
-		BootrapDqlite:         bootstrapDqliteWithDummyCloudType,
-	})
+	ctlr, err := bootstrap.Initialize(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = ctlr.Close() }()
 
@@ -382,19 +384,23 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	_, available := cfg.StateServingInfo()
 	c.Assert(available, jc.IsFalse)
 
-	args := agentbootstrap.InitializeStateParams{}
-
 	adminUser := names.NewLocalUserTag("agent-admin")
 
-	_, err = agentbootstrap.InitializeAgent(stdcontext.Background(), agentbootstrap.AgentInitializerConfig{
-		AgentConfig:           cfg,
-		BootstrapEnviron:      &fakeEnviron{},
-		AdminUser:             adminUser,
-		InitializeStateParams: args,
-		MongoDialOpts:         mongotest.DialOpts(),
-		StateNewPolicy:        nil,
-		BootrapDqlite:         bootstrapDqliteWithDummyCloudType,
-	})
+	bootstrap, err := agentbootstrap.NewAgentBootstrap(
+		agentbootstrap.AgentBootstrapArgs{
+			AgentConfig:               cfg,
+			BootstrapEnviron:          &fakeEnviron{},
+			AdminUser:                 adminUser,
+			StateInitializationParams: instancecfg.StateInitializationParams{},
+			MongoDialOpts:             mongotest.DialOpts(),
+			StateNewPolicy:            nil,
+			SharedSecret:              "abc123",
+			StorageProviderRegistry:   provider.CommonStorageProviders(),
+		},
+		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = bootstrap.Initialize(stdcontext.Background())
 
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
@@ -435,49 +441,56 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		"uuid": utils.MustNewUUID().String(),
 	}
 
-	args := agentbootstrap.InitializeStateParams{
-		StateInitializationParams: instancecfg.StateInitializationParams{
-			BootstrapMachineInstanceId:  "i-bootstrap",
-			BootstrapMachineDisplayName: "test-display-name",
-			ControllerCloud: cloud.Cloud{
-				Name:      "dummy",
-				Type:      "dummy",
-				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
-			},
-			ControllerConfig:      testing.FakeControllerConfig(),
-			ControllerModelConfig: modelCfg,
-			InitialModelConfig:    InitialModelConfigAttrs,
+	args := instancecfg.StateInitializationParams{
+		BootstrapMachineInstanceId:  "i-bootstrap",
+		BootstrapMachineDisplayName: "test-display-name",
+		ControllerCloud: cloud.Cloud{
+			Name:      "dummy",
+			Type:      "dummy",
+			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 		},
-		BootstrapMachineJobs: []model.MachineJob{model.JobManageModel},
-		SharedSecret:         "abc123",
-		Provider: func(t string) (environs.EnvironProvider, error) {
-			return &fakeProvider{}, nil
-		},
-		StorageProviderRegistry: provider.CommonStorageProviders(),
+		ControllerConfig:      testing.FakeControllerConfig(),
+		ControllerModelConfig: modelCfg,
+		InitialModelConfig:    InitialModelConfigAttrs,
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, err := agentbootstrap.InitializeAgent(stdcontext.Background(), agentbootstrap.AgentInitializerConfig{
-		AgentConfig:           cfg,
-		BootstrapEnviron:      &fakeEnviron{},
-		AdminUser:             adminUser,
-		InitializeStateParams: args,
-		MongoDialOpts:         mongotest.DialOpts(),
-		StateNewPolicy:        state.NewPolicyFunc(nil),
-		BootrapDqlite:         bootstrapDqliteWithDummyCloudType,
-	})
+	bootstrap, err := agentbootstrap.NewAgentBootstrap(
+		agentbootstrap.AgentBootstrapArgs{
+			AgentConfig:               cfg,
+			BootstrapEnviron:          &fakeEnviron{},
+			AdminUser:                 adminUser,
+			StateInitializationParams: args,
+			MongoDialOpts:             mongotest.DialOpts(),
+			StateNewPolicy:            state.NewPolicyFunc(nil),
+			BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
+			SharedSecret:              "abc123",
+			StorageProviderRegistry:   provider.CommonStorageProviders(),
+		},
+		agentbootstrap.WithBootstrapDqlite(bootstrapDqliteWithDummyCloudType),
+		agentbootstrap.WithProvider(func(t string) (environs.EnvironProvider, error) {
+			return &fakeProvider{}, nil
+		}),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	st, err := bootstrap.Initialize(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	_ = st.Close()
 
-	st, err = agentbootstrap.InitializeAgent(stdcontext.Background(), agentbootstrap.AgentInitializerConfig{
-		AgentConfig:           cfg,
-		BootstrapEnviron:      &fakeEnviron{},
-		AdminUser:             adminUser,
-		InitializeStateParams: args,
-		MongoDialOpts:         mongotest.DialOpts(),
-		StateNewPolicy:        state.NewPolicyFunc(nil),
-		BootrapDqlite:         database.BootstrapDqlite,
-	})
+	bootstrap, err = agentbootstrap.NewAgentBootstrap(
+		agentbootstrap.AgentBootstrapArgs{
+			AgentConfig:               cfg,
+			BootstrapEnviron:          &fakeEnviron{},
+			AdminUser:                 adminUser,
+			StateInitializationParams: args,
+			MongoDialOpts:             mongotest.DialOpts(),
+			StateNewPolicy:            state.NewPolicyFunc(nil),
+			SharedSecret:              "baz",
+			StorageProviderRegistry:   provider.CommonStorageProviders(),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	st, err = bootstrap.Initialize(stdcontext.Background())
 	if err == nil {
 		_ = st.Close()
 	}

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3/ssh"
 	"github.com/juju/version/v2"
@@ -62,7 +63,7 @@ var (
 	minSocketTimeout    = 1 * time.Minute
 )
 
-type BootstrapAgentFunc func(agentbootstrap.AgentBootstrapArgs, ...agentbootstrap.Option) (*agentbootstrap.AgentBootstrap, error)
+type BootstrapAgentFunc func(agentbootstrap.AgentBootstrapArgs) (*agentbootstrap.AgentBootstrap, error)
 
 const adminUserName = "admin"
 
@@ -396,7 +397,10 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 				cloudGetter{cloud: &args.ControllerCloud},
 				credentialGetter{cred: args.ControllerCloudCredential},
 			),
-		}, agentbootstrap.WithBootstrapDqlite(c.DqliteInitializer))
+			BootstrapDqlite: c.DqliteInitializer,
+			Provider:        environs.Provider,
+			Logger:          loggo.GetLogger("juju.agent.bootstrap"),
+		})
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -627,7 +627,7 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	s.bootstrapAgentFunc = func(args agentbootstrap.AgentBootstrapArgs, opts ...agentbootstrap.Option) (*agentbootstrap.AgentBootstrap, error) {
+	s.bootstrapAgentFunc = func(args agentbootstrap.AgentBootstrapArgs) (*agentbootstrap.AgentBootstrap, error) {
 		called++
 		c.Assert(args.MongoDialOpts.Direct, jc.IsTrue)
 		c.Assert(args.MongoDialOpts.Timeout, gc.Equals, 30*time.Second)
@@ -648,7 +648,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	s.bootstrapAgentFunc = func(args agentbootstrap.AgentBootstrapArgs, opts ...agentbootstrap.Option) (*agentbootstrap.AgentBootstrap, error) {
+	s.bootstrapAgentFunc = func(args agentbootstrap.AgentBootstrapArgs) (*agentbootstrap.AgentBootstrap, error) {
 		called++
 		c.Assert(args.MongoDialOpts.Direct, jc.IsTrue)
 		c.Assert(args.MongoDialOpts.SocketTimeout, gc.Equals, 1*time.Minute)


### PR DESCRIPTION
Following on from #16313 this introduces a type for agent bootstrap.
It removes the need to compose the init state args and just flattens
it to what you actually require. 

Also, the initialize function is still huge, but we can tackle that
another day. For now, this should make it simpler to organize things.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
````

## Links

 - Jira card: JUJU-3795