### PR TITLE
WIP: resolve juju 3 todo regarding charm origin in state

### DIFF
--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
+	corearch "github.com/juju/juju/core/arch"
 	coreconfig "github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
@@ -235,7 +236,11 @@ var getTests = []struct {
 	},
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Revision: intPtr(7),
+		Channel: &state.Channel{
+			Risk: "stable",
+		},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{
@@ -294,7 +299,11 @@ var getTests = []struct {
 	},
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Revision: intPtr(7),
+		Channel: &state.Channel{
+			Risk: "stable",
+		},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{
@@ -349,7 +358,11 @@ var getTests = []struct {
 	charm: "logging",
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Revision: intPtr(7),
+		Channel: &state.Channel{
+			Risk: "stable",
+		},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{},
@@ -374,12 +387,13 @@ var getTests = []struct {
 	about: "charmhub subordinate application",
 	charm: "logging",
 	origin: &state.CharmOrigin{
-		Source: "charm-hub",
+		Source:   "charm-hub",
+		Revision: intPtr(7),
 		Channel: &state.Channel{
 			Risk:   "stable",
 			Branch: "foo",
 		},
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{},
@@ -402,6 +416,10 @@ var getTests = []struct {
 		Channel: "stable/foo",
 	},
 }}
+
+func intPtr(val int) *int {
+	return &val
+}
 
 func (s *getSuite) TestApplicationGet(c *gc.C) {
 	for i, t := range getTests {

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	apitesting "github.com/juju/juju/apiserver/testing"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -125,9 +126,12 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	mysqlCh, err := s.State.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
-		Name:        "mysql",
-		Charm:       mysqlCh,
-		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"}},
+		Name:  "mysql",
+		Charm: mysqlCh,
+		CharmOrigin: &state.CharmOrigin{
+			Source:   "local",
+			Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -145,10 +149,12 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{
-		Name:        "dummy",
-		Charm:       dummyCh,
-		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"}},
-	})
+		Name:  "dummy",
+		Charm: dummyCh,
+		CharmOrigin: &state.CharmOrigin{
+			Source:   "local",
+			Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: corearch.DefaultArchitecture},
+		}})
 	c.Assert(err, jc.ErrorIsNil)
 	offer2, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
 		OfferName:       "notfound-remote-app-offer",

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
+	corearch "github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
@@ -852,10 +853,15 @@ func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Ch
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name: name, Charm: ch,
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
+			Source:   "charm-hub",
+			Revision: intPtr(ch.Revision()),
+			Channel: &state.Channel{
+				Risk: "stable",
+			},
 			Platform: &state.Platform{
-				OS:      base.OS,
-				Channel: base.Channel.String(),
+				OS:           base.OS,
+				Channel:      base.Channel.String(),
+				Architecture: corearch.DefaultArchitecture,
 			}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -880,7 +886,11 @@ func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *
 		Name:  name,
 		Charm: ch,
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
+			Source:   "charm-hub",
+			Revision: intPtr(ch.Revision()),
+			Channel: &state.Channel{
+				Risk: "stable",
+			},
 			Platform: &state.Platform{
 				Architecture: arch,
 				OS:           base.OS,
@@ -899,15 +909,24 @@ func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, c
 		Name:  name,
 		Charm: ch,
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
+			Source:   "charm-hub",
+			Revision: intPtr(ch.Revision()),
+			Channel: &state.Channel{
+				Risk: "stable",
+			},
 			Platform: &state.Platform{
-				OS:      base.OS,
-				Channel: base.Channel.String(),
+				OS:           base.OS,
+				Channel:      base.Channel.String(),
+				Architecture: corearch.DefaultArchitecture,
 			}},
 		Storage: storage,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
+}
+
+func intPtr(val int) *int {
+	return &val
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, ch *state.Charm, bindings map[string]string) *state.Application {
@@ -917,10 +936,15 @@ func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, 
 		Name:  name,
 		Charm: ch,
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
+			Source:   "charm-hub",
+			Revision: intPtr(ch.Revision()),
+			Channel: &state.Channel{
+				Risk: "stable",
+			},
 			Platform: &state.Platform{
-				OS:      base.OS,
-				Channel: base.Channel.String(),
+				OS:           base.OS,
+				Channel:      base.Channel.String(),
+				Architecture: corearch.DefaultArchitecture,
 			}},
 		EndpointBindings: bindings,
 	})

--- a/state/charmorigin_test.go
+++ b/state/charmorigin_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/arch"
+	corecharm "github.com/juju/juju/core/charm"
+)
+
+type CharmOriginSuite struct {
+}
+
+var _ = gc.Suite(&CharmOriginSuite{})
+
+func (s *CharmOriginSuite) TestValidateLocal(c *gc.C) {
+	origin := successfulLocalOrigin()
+	err := origin.validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *CharmOriginSuite) TestValidateLocalFailChannel(c *gc.C) {
+	origin := successfulLocalOrigin()
+	origin.Channel = &Channel{Risk: "stable"}
+	err := origin.validate()
+	c.Assert(err, gc.NotNil)
+}
+
+func (s *CharmOriginSuite) TestValidateCharmhub(c *gc.C) {
+	origin := successfulCharmHubOrigin()
+	err := origin.validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func successfulCharmHubOrigin() CharmOrigin {
+	return CharmOrigin{
+		Source:   corecharm.CharmHub.String(),
+		Type:     "charm",
+		Revision: intPtr(7),
+		Channel: &Channel{
+			Risk: "stable",
+		},
+		Platform: &Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}
+}
+
+func successfulLocalOrigin() CharmOrigin {
+	return CharmOrigin{
+		Source: corecharm.Local.String(),
+		Platform: &Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1164,17 +1164,8 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	if args.CharmOrigin == nil {
 		return nil, errors.Errorf("charm origin is nil")
 	}
-	if args.CharmOrigin.Platform == nil {
-		return nil, errors.Errorf("charm origin platform is nil")
-	}
-
-	// If either the charm origin ID or Hash is set before a charm is
-	// downloaded, charm download will fail for charms with a forced series.
-	// The logic (refreshConfig) in sending the correct request to charmhub
-	// will break.
-	if (args.CharmOrigin.ID != "" && args.CharmOrigin.Hash == "") ||
-		(args.CharmOrigin.ID == "" && args.CharmOrigin.Hash != "") {
-		return nil, errors.BadRequestf("programming error, AddApplication, neither CharmOrigin ID nor Hash can be set before a charm is downloaded. See CharmHubRepository GetDownloadURL.")
+	if err := args.CharmOrigin.validate(); err != nil {
+		return nil, errors.Annotatef(err, "charm origin validation")
 	}
 
 	model, err := st.Model()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -504,18 +504,25 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		c.Assert(err, jc.ErrorIsNil)
 		var channel *state.Channel
 		var source string
+		var revision *int
 		// local charms cannot have a channel
 		if charm.CharmHub.Matches(curl.Schema) {
 			channel = &state.Channel{Risk: "stable"}
 			source = "charm-hub"
+			revision = &curl.Revision
 		} else if charm.Local.Matches(curl.Schema) {
 			source = "local"
 		}
+		architecture := params.Charm.URL().Architecture
+		if architecture == "" {
+			architecture = arch.AMD64
+		}
 		params.CharmOrigin = &state.CharmOrigin{
-			Channel: channel,
-			Source:  source,
+			Channel:  channel,
+			Source:   source,
+			Revision: revision,
 			Platform: &state.Platform{
-				Architecture: params.Charm.URL().Architecture,
+				Architecture: architecture,
 				OS:           base.OS,
 				Channel:      base.Channel.String(),
 			}}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1019,6 +1019,22 @@ func (s addAction) step(c *gc.C, ctx *testContext) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func intPtr(val int) *int {
+	return &val
+}
+
+func defaultCharmOrigin(curl *corecharm.URL) *state.CharmOrigin {
+	return &state.CharmOrigin{
+		Source:   "",
+		Type:     "charm",
+		ID:       "test",
+		Hash:     "test",
+		Revision: intPtr(curl.Revision),
+		Channel:  nil,
+		Platform: nil,
+	}
+}
+
 type upgradeCharm struct {
 	revision int
 	forced   bool
@@ -1029,8 +1045,9 @@ func (s upgradeCharm) step(c *gc.C, ctx *testContext) {
 	sch, err := ctx.st.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := state.SetCharmConfig{
-		Charm:      sch,
-		ForceUnits: s.forced,
+		Charm:       sch,
+		CharmOrigin: defaultCharmOrigin(curl),
+		ForceUnits:  s.forced,
 	}
 	// Make sure we upload the charm before changing it in the DB.
 	serveCharm{}.step(c, ctx)


### PR DESCRIPTION
Remove a todo for juju 3. All applications in state must now have a charm origin. Compatibility with juju 2.9.latest client is possible, as it creates charm origin's also.

Improve the validation of args when putting a charm origin into state, as well as for SetCharm in general. This helps to improve readability. The validity for the state charm origin, can serve as a template for the core/charm origin.

The charm origin validation method will return with everything checked, rather than fail on the first not valid found.
## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
(cd tests && ./main.sh -v refresh)
(cd tests && ./main.sh -v deploy)
```

## Links

JUJU-4161