### PR TITLE
Inject controller config machiner

### DIFF
--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -46,6 +46,7 @@ func (s *machinerSuite) SetUpTest(c *gc.C) {
 	machiner, err := machine.NewMachinerAPIForState(
 		st,
 		st,
+		s.ControllerServiceFactory(c).ControllerConfig(),
 		apiservertesting.ConstCloudGetter(&testing.DefaultCloud),
 		s.resources,
 		s.authorizer,
@@ -61,6 +62,7 @@ func (s *machinerSuite) TestMachinerFailsWithNonMachineAgentUser(c *gc.C) {
 	aMachiner, err := machine.NewMachinerAPIForState(
 		st,
 		st,
+		s.ControllerServiceFactory(c).ControllerConfig(),
 		nil,
 		s.resources, anAuthorizer)
 	c.Assert(err, gc.NotNil)

--- a/apiserver/facades/agent/machine/register.go
+++ b/apiserver/facades/agent/machine/register.go
@@ -24,10 +24,12 @@ func newMachinerAPI(ctx facade.Context) (*MachinerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	serviceFactory := ctx.ServiceFactory()
 	return NewMachinerAPIForState(
 		systemState,
 		ctx.State(),
-		ctx.ServiceFactory().Cloud(),
+		serviceFactory.ControllerConfig(),
+		serviceFactory.Cloud(),
 		ctx.Resources(),
 		ctx.Auth(),
 	)


### PR DESCRIPTION
The following injects controller config into machiner api facade.
It builds off the apiserver common PR changes (#16295), which does
a lot of the heavy lifting.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju enable-ha
$ juju deploy ubuntu
$ juju add-machine -n 1
```
## Links

**Jira card:** JUJU-4327
