### PR TITLE
Inject controller config provisioner

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
@@ -37,6 +38,12 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
+// ControllerConfigService is the interface that the provisioner facade
+// uses to get the controller config.
+type ControllerConfigService interface {
+	ControllerConfig(stdcontext.Context) (controller.Config, error)
+}
+
 // ProvisionerAPI provides access to the Provisioner API facade.
 type ProvisionerAPI struct {
 	*common.ControllerConfigAPI
@@ -55,6 +62,7 @@ type ProvisionerAPI struct {
 
 	st                      *state.State
 	m                       *state.Model
+	controllerConfigService ControllerConfigService
 	resources               facade.Resources
 	authorizer              facade.Authorizer
 	storageProviderRegistry storage.ProviderRegistry
@@ -65,6 +73,10 @@ type ProvisionerAPI struct {
 	providerCallContext     context.ProviderCallContext
 	toolsFinder             common.ToolsFinder
 	logger                  loggo.Logger
+
+	// Hold on to the controller UUID, as we'll reuse it for a lot of
+	// calls.
+	controllerUUID string
 
 	// Used for MaybeWriteLXDProfile()
 	mu sync.Mutex
@@ -115,13 +127,17 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	serviceFactory := ctx.ServiceFactory()
 	configGetter := stateenvirons.EnvironConfigGetter{
-		Model: model, CloudService: ctx.ServiceFactory().Cloud(), CredentialService: ctx.ServiceFactory().Credential()}
+		Model:             model,
+		CloudService:      serviceFactory.Cloud(),
+		CredentialService: serviceFactory.Credential(),
+	}
 	isCaasModel := model.Type() == state.ModelTypeCAAS
 
 	var env storage.ProviderRegistry
 	if isCaasModel {
-		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential())
+		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, serviceFactory.Cloud(), serviceFactory.Credential())
 	} else {
 		env, err = environs.GetEnviron(stdcontext.Background(), configGetter, environs.New)
 	}
@@ -131,13 +147,10 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(env)
 
 	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(
-		stdcontext.Background(), st, ctx.ServiceFactory().Cloud(), getCanModify)
+		stdcontext.Background(), st, serviceFactory.Cloud(), getCanModify)
 	if err != nil {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}
-
-	serviceFactory := ctx.ServiceFactory()
-
 	systemState, err := ctx.StatePool().SystemState()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -163,6 +176,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		NetworkConfigAPI:        netConfigAPI,
 		st:                      st,
 		m:                       model,
+		controllerConfigService: serviceFactory.ControllerConfig(),
 		resources:               resources,
 		authorizer:              authorizer,
 		configGetter:            configGetter,
@@ -1306,8 +1320,8 @@ func (api *ProvisionerAPI) SetHostMachineNetworkConfig(ctx stdcontext.Context, a
 }
 
 // CACert returns the certificate used to validate the state connection.
-func (api *ProvisionerAPI) CACert() (params.BytesResult, error) {
-	cfg, err := api.st.ControllerConfig()
+func (api *ProvisionerAPI) CACert(ctx stdcontext.Context) (params.BytesResult, error) {
+	cfg, err := api.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return params.BytesResult{}, errors.Trace(err)
 	}
@@ -1348,7 +1362,7 @@ func (api *ProvisionerAPI) ModelUUID(ctx stdcontext.Context) params.StringResult
 
 // APIHostPorts returns the API server addresses.
 func (api *ProvisionerAPI) APIHostPorts(ctx stdcontext.Context) (result params.APIHostPortsResult, err error) {
-	controllerConfig, err := api.st.ControllerConfig()
+	controllerConfig, err := api.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -1358,7 +1372,7 @@ func (api *ProvisionerAPI) APIHostPorts(ctx stdcontext.Context) (result params.A
 
 // APIAddresses returns the list of addresses used to connect to the API.
 func (api *ProvisionerAPI) APIAddresses(ctx stdcontext.Context) (result params.StringsResult, err error) {
-	controllerConfig, err := api.st.ControllerConfig()
+	controllerConfig, err := api.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -128,6 +128,14 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 	serviceFactory := ctx.ServiceFactory()
+
+	// Get the controller config early, so we can use it to cache the
+	// controller UUID.
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(stdcontext.TODO())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	configGetter := stateenvirons.EnvironConfigGetter{
 		Model:             model,
 		CloudService:      serviceFactory.Cloud(),
@@ -185,6 +193,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		getAuthFunc:             getAuthFunc,
 		getCanModify:            getCanModify,
 		providerCallContext:     callCtx,
+		controllerUUID:          controllerCfg.ControllerUUID(),
 		logger:                  ctx.Logger().Child("provisioner"),
 	}
 	if isCaasModel {

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -67,7 +67,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withController bool) {
 	if s.ApiServerSuite.ControllerModelConfigAttrs == nil {
-		s.ApiServerSuite.ControllerModelConfigAttrs = make(map[string]interface{})
+		s.ApiServerSuite.ControllerModelConfigAttrs = make(map[string]any)
 	}
 	s.ApiServerSuite.ControllerModelConfigAttrs["image-stream"] = "daily"
 	s.ApiServerSuite.SetUpTest(c)
@@ -382,7 +382,7 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: s.machines[0].Tag().String(), Status: status.Error.String(), Info: "not really",
-				Data: map[string]interface{}{"foo": "bar"}},
+				Data: map[string]any{"foo": "bar"}},
 			{Tag: s.machines[1].Tag().String(), Status: status.Stopped.String(), Info: "foobar"},
 			{Tag: s.machines[2].Tag().String(), Status: status.Started.String(), Info: "again"},
 			{Tag: "machine-42", Status: status.Started.String(), Info: "blah"},
@@ -403,9 +403,9 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 	})
 
 	// Verify the changes.
-	s.assertStatus(c, 0, status.Error, "not really", map[string]interface{}{"foo": "bar"})
-	s.assertStatus(c, 1, status.Stopped, "foobar", map[string]interface{}{})
-	s.assertStatus(c, 2, status.Started, "again", map[string]interface{}{})
+	s.assertStatus(c, 0, status.Error, "not really", map[string]any{"foo": "bar"})
+	s.assertStatus(c, 1, status.Stopped, "foobar", map[string]any{})
+	s.assertStatus(c, 2, status.Started, "again", map[string]any{})
 }
 
 func (s *withoutControllerSuite) TestSetInstanceStatus(c *gc.C) {
@@ -435,7 +435,7 @@ func (s *withoutControllerSuite) TestSetInstanceStatus(c *gc.C) {
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: s.machines[0].Tag().String(), Status: status.Provisioning.String(), Info: "not really",
-				Data: map[string]interface{}{"foo": "bar"}},
+				Data: map[string]any{"foo": "bar"}},
 			{Tag: s.machines[1].Tag().String(), Status: status.Running.String(), Info: "foobar"},
 			{Tag: s.machines[2].Tag().String(), Status: status.ProvisioningError.String(), Info: "again"},
 			{Tag: "machine-42", Status: status.Provisioning.String(), Info: "blah"},
@@ -456,11 +456,11 @@ func (s *withoutControllerSuite) TestSetInstanceStatus(c *gc.C) {
 	})
 
 	// Verify the changes.
-	s.assertInstanceStatus(c, 0, status.Provisioning, "not really", map[string]interface{}{"foo": "bar"})
-	s.assertInstanceStatus(c, 1, status.Running, "foobar", map[string]interface{}{})
-	s.assertInstanceStatus(c, 2, status.ProvisioningError, "again", map[string]interface{}{})
+	s.assertInstanceStatus(c, 0, status.Provisioning, "not really", map[string]any{"foo": "bar"})
+	s.assertInstanceStatus(c, 1, status.Running, "foobar", map[string]any{})
+	s.assertInstanceStatus(c, 2, status.ProvisioningError, "again", map[string]any{})
 	// ProvisioningError also has a special case which is to set the machine to Error
-	s.assertStatus(c, 2, status.Error, "again", map[string]interface{}{})
+	s.assertStatus(c, 2, status.Error, "again", map[string]any{})
 }
 
 func (s *withoutControllerSuite) TestSetModificationStatus(c *gc.C) {
@@ -490,7 +490,7 @@ func (s *withoutControllerSuite) TestSetModificationStatus(c *gc.C) {
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: s.machines[0].Tag().String(), Status: status.Pending.String(), Info: "not really",
-				Data: map[string]interface{}{"foo": "bar"}},
+				Data: map[string]any{"foo": "bar"}},
 			{Tag: s.machines[1].Tag().String(), Status: status.Applied.String(), Info: "foobar"},
 			{Tag: s.machines[2].Tag().String(), Status: status.Error.String(), Info: "again"},
 			{Tag: "machine-42", Status: status.Pending.String(), Info: "blah"},
@@ -511,9 +511,9 @@ func (s *withoutControllerSuite) TestSetModificationStatus(c *gc.C) {
 	})
 
 	// Verify the changes.
-	s.assertModificationStatus(c, 0, status.Pending, "not really", map[string]interface{}{"foo": "bar"})
-	s.assertModificationStatus(c, 1, status.Applied, "foobar", map[string]interface{}{})
-	s.assertModificationStatus(c, 2, status.Error, "again", map[string]interface{}{})
+	s.assertModificationStatus(c, 0, status.Pending, "not really", map[string]any{"foo": "bar"})
+	s.assertModificationStatus(c, 1, status.Applied, "foobar", map[string]any{})
+	s.assertModificationStatus(c, 2, status.Error, "again", map[string]any{})
 }
 
 func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
@@ -528,7 +528,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	sInfo = status.StatusInfo{
 		Status:  status.ProvisioningError,
 		Message: "transient error",
-		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Data:    map[string]any{"transient": true, "foo": "bar"},
 		Since:   &now,
 	}
 	err = s.machines[1].SetInstanceStatus(sInfo)
@@ -536,7 +536,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	sInfo = status.StatusInfo{
 		Status:  status.ProvisioningError,
 		Message: "error",
-		Data:    map[string]interface{}{"transient": false},
+		Data:    map[string]any{"transient": false},
 		Since:   &now,
 	}
 	err = s.machines[2].SetInstanceStatus(sInfo)
@@ -552,7 +552,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	sInfo = status.StatusInfo{
 		Status:  status.Error,
 		Message: "transient error",
-		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Data:    map[string]any{"transient": true, "foo": "bar"},
 		Since:   &now,
 	}
 	err = s.machines[4].SetInstanceStatus(sInfo)
@@ -566,7 +566,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Id: "1", Life: "alive", Status: "provisioning error", Info: "transient error",
-				Data: map[string]interface{}{"transient": true, "foo": "bar"}},
+				Data: map[string]any{"transient": true, "foo": "bar"}},
 		},
 	})
 }
@@ -596,7 +596,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	sInfo = status.StatusInfo{
 		Status:  status.ProvisioningError,
 		Message: "transient error",
-		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Data:    map[string]any{"transient": true, "foo": "bar"},
 		Since:   &now,
 	}
 	err = s.machines[1].SetInstanceStatus(sInfo)
@@ -604,7 +604,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	sInfo = status.StatusInfo{
 		Status:  status.ProvisioningError,
 		Message: "error",
-		Data:    map[string]interface{}{"transient": false},
+		Data:    map[string]any{"transient": false},
 		Since:   &now,
 	}
 	err = s.machines[2].SetInstanceStatus(sInfo)
@@ -623,7 +623,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 		Results: []params.StatusResult{{
 			Id: "1", Life: "alive", Status: "provisioning error",
 			Info: "transient error",
-			Data: map[string]interface{}{"transient": true, "foo": "bar"},
+			Data: map[string]any{"transient": true, "foo": "bar"},
 		},
 		},
 	})
@@ -670,7 +670,7 @@ func (s *withoutControllerSuite) assertLife(c *gc.C, index int, expectLife state
 }
 
 func (s *withoutControllerSuite) assertStatus(c *gc.C, index int, expectStatus status.Status, expectInfo string,
-	expectData map[string]interface{}) {
+	expectData map[string]any) {
 
 	statusInfo, err := s.machines[index].Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -680,7 +680,7 @@ func (s *withoutControllerSuite) assertStatus(c *gc.C, index int, expectStatus s
 }
 
 func (s *withoutControllerSuite) assertInstanceStatus(c *gc.C, index int, expectStatus status.Status, expectInfo string,
-	expectData map[string]interface{}) {
+	expectData map[string]any) {
 
 	statusInfo, err := s.machines[index].InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -690,7 +690,7 @@ func (s *withoutControllerSuite) assertInstanceStatus(c *gc.C, index int, expect
 }
 
 func (s *withoutControllerSuite) assertModificationStatus(c *gc.C, index int, expectStatus status.Status, expectInfo string,
-	expectData map[string]interface{}) {
+	expectData map[string]any) {
 
 	statusInfo, err := s.machines[index].ModificationStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -809,7 +809,7 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	sInfo = status.StatusInfo{
 		Status:  status.Error,
 		Message: "not really",
-		Data:    map[string]interface{}{"foo": "bar"},
+		Data:    map[string]any{"foo": "bar"},
 		Since:   &now,
 	}
 	err = s.machines[2].SetStatus(sInfo)
@@ -836,9 +836,9 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: status.Started.String(), Info: "blah", Data: map[string]interface{}{}},
-			{Status: status.Stopped.String(), Info: "foo", Data: map[string]interface{}{}},
-			{Status: status.Error.String(), Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: status.Started.String(), Info: "blah", Data: map[string]any{}},
+			{Status: status.Stopped.String(), Info: "foo", Data: map[string]any{}},
+			{Status: status.Error.String(), Info: "not really", Data: map[string]any{"foo": "bar"}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -865,7 +865,7 @@ func (s *withoutControllerSuite) TestInstanceStatus(c *gc.C) {
 	sInfo = status.StatusInfo{
 		Status:  status.ProvisioningError,
 		Message: "not really",
-		Data:    map[string]interface{}{"foo": "bar"},
+		Data:    map[string]any{"foo": "bar"},
 		Since:   &now,
 	}
 	err = s.machines[2].SetInstanceStatus(sInfo)
@@ -892,9 +892,9 @@ func (s *withoutControllerSuite) TestInstanceStatus(c *gc.C) {
 	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: status.Provisioning.String(), Info: "blah", Data: map[string]interface{}{}},
-			{Status: status.Running.String(), Info: "foo", Data: map[string]interface{}{}},
-			{Status: status.ProvisioningError.String(), Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: status.Provisioning.String(), Info: "blah", Data: map[string]any{}},
+			{Status: status.Running.String(), Info: "foo", Data: map[string]any{}},
+			{Status: status.ProvisioningError.String(), Info: "not really", Data: map[string]any{"foo": "bar"}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1279,9 +1279,9 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	})
-	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
+	_, err := pm.Create("static-pool", "static", map[string]any{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{
+	err = s.ControllerModel(c).UpdateModelConfig(map[string]any{
 		"storage-default-block-source": "static-pool",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1550,7 +1550,7 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"juju-http-proxy":              "http://proxy.example.com:9000",
 		"apt-https-proxy":              "https://proxy.example.com:9000",
 		"allow-lxd-loop-mounts":        true,
@@ -1593,16 +1593,16 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.SnapProxy, gc.DeepEquals, expectedSnapProxy)
 	c.Check(results.SnapStoreAssertions, gc.Equals, "BLOB")
 	c.Check(results.SnapStoreProxyID, gc.Equals, "b4dc0ffee")
-	c.Check(results.CloudInitUserData, gc.DeepEquals, map[string]interface{}{
-		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
-		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
-		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+	c.Check(results.CloudInitUserData, gc.DeepEquals, map[string]any{
+		"packages":        []any{"python-keystoneclient", "python-glanceclient"},
+		"preruncmd":       []any{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []any{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false})
 	c.Check(results.ContainerInheritProperties, gc.DeepEquals, "ca-certs,apt-primary")
 }
 
 func (s *withoutControllerSuite) TestContainerConfigLegacy(c *gc.C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"http-proxy":                   "http://proxy.example.com:9000",
 		"apt-https-proxy":              "https://proxy.example.com:9000",
 		"allow-lxd-loop-mounts":        true,
@@ -1635,10 +1635,10 @@ func (s *withoutControllerSuite) TestContainerConfigLegacy(c *gc.C) {
 	c.Check(results.JujuProxy.HasProxySet(), jc.IsFalse)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedAPTProxy)
 	c.Check(results.AptMirror, gc.DeepEquals, "http://example.mirror.com")
-	c.Check(results.CloudInitUserData, gc.DeepEquals, map[string]interface{}{
-		"packages":        []interface{}{"python-keystoneclient", "python-glanceclient"},
-		"preruncmd":       []interface{}{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
-		"postruncmd":      []interface{}{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
+	c.Check(results.CloudInitUserData, gc.DeepEquals, map[string]any{
+		"packages":        []any{"python-keystoneclient", "python-glanceclient"},
+		"preruncmd":       []any{"mkdir /tmp/preruncmd", "mkdir /tmp/preruncmd2"},
+		"postruncmd":      []any{"mkdir /tmp/postruncmd", "mkdir /tmp/postruncmd2"},
 		"package_upgrade": false})
 	c.Check(results.ContainerInheritProperties, gc.DeepEquals, "ca-certs,apt-primary")
 }
@@ -1806,9 +1806,10 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 		network.NewSpaceHostPorts(1234, "0.1.2.3"),
 	}
 	st := s.ControllerModel(c).State()
-	controllerConfig, err := st.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.SetAPIHostPorts(controllerConfig, hostPorts)
+
+	controllerCfg := coretesting.FakeControllerConfig()
+
+	err := st.SetAPIHostPorts(controllerCfg, hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.provisioner.APIAddresses(context.Background())
@@ -1819,7 +1820,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 }
 
 func (s *withControllerSuite) TestCACert(c *gc.C) {
-	result, err := s.provisioner.CACert()
+	result, err := s.provisioner.CACert(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BytesResult{
 		Result: []byte(coretesting.CACert),
@@ -1833,7 +1834,7 @@ type withImageMetadataSuite struct {
 var _ = gc.Suite(&withImageMetadataSuite{})
 
 func (s *withImageMetadataSuite) SetUpTest(c *gc.C) {
-	s.ControllerModelConfigAttrs = map[string]interface{}{
+	s.ControllerModelConfigAttrs = map[string]any{
 		config.ContainerImageStreamKey:      "daily",
 		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org/",
 	}

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -149,7 +149,7 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 		return result, errors.Annotate(err, "cannot get available image metadata")
 	}
 
-	if result.ControllerConfig, err = api.st.ControllerConfig(); err != nil {
+	if result.ControllerConfig, err = api.controllerConfigService.ControllerConfig(ctx); err != nil {
 		return result, errors.Annotate(err, "cannot get controller configuration")
 	}
 
@@ -191,7 +191,10 @@ func (api *ProvisionerAPI) machineVolumeParams(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	controllerCfg, err := api.st.ControllerConfig()
+
+	// TODO (stickupkid): This call for the controller UUID could just be
+	// cached in the provisioner API constructor.
+	controllerCfg, err := api.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -286,7 +289,9 @@ func (api *ProvisionerAPI) machineTags(ctx context.Context, m *state.Machine, is
 		return nil, errors.Trace(err)
 	}
 
-	controllerCfg, err := api.st.ControllerConfig()
+	// TODO (stickupkid): This call for the controller UUID could just be
+	// cached in the provisioner API constructor.
+	controllerCfg, err := api.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -192,12 +192,6 @@ func (api *ProvisionerAPI) machineVolumeParams(
 		return nil, nil, errors.Trace(err)
 	}
 
-	// TODO (stickupkid): This call for the controller UUID could just be
-	// cached in the provisioner API constructor.
-	controllerCfg, err := api.controllerConfigService.ControllerConfig(ctx)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
 	allVolumeParams := make([]params.VolumeParams, 0, len(volumeAttachments))
 	var allVolumeAttachmentParams []params.VolumeAttachmentParams
 	for _, volumeAttachment := range volumeAttachments {
@@ -213,7 +207,7 @@ func (api *ProvisionerAPI) machineVolumeParams(
 			return nil, nil, errors.Annotatef(err, "getting volume %q storage instance", volumeTag.Id())
 		}
 		volumeParams, err := storagecommon.VolumeParams(
-			volume, storageInstance, modelConfig.UUID(), controllerCfg.ControllerUUID(),
+			volume, storageInstance, modelConfig.UUID(), api.controllerUUID,
 			modelConfig, api.storagePoolManager, api.storageProviderRegistry,
 		)
 		if err != nil {
@@ -289,14 +283,7 @@ func (api *ProvisionerAPI) machineTags(ctx context.Context, m *state.Machine, is
 		return nil, errors.Trace(err)
 	}
 
-	// TODO (stickupkid): This call for the controller UUID could just be
-	// cached in the provisioner API constructor.
-	controllerCfg, err := api.controllerConfigService.ControllerConfig(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	machineTags := instancecfg.InstanceTags(cfg.UUID(), controllerCfg.ControllerUUID(), cfg, isController)
+	machineTags := instancecfg.InstanceTags(cfg.UUID(), api.controllerUUID, cfg, isController)
 	if len(unitNames) > 0 {
 		machineTags[tags.JujuUnitsDeployed] = strings.Join(unitNames, " ")
 	}

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -59,7 +59,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.ProvisioningInfoResults{
@@ -182,7 +183,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithMultiplePositiveSpaceCo
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
 
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := &params.ProvisioningInfo{
@@ -265,7 +267,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	result, err := s.provisioner.ProvisioningInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.ProvisioningInfoResults{
@@ -497,7 +500,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	mod, err := st.Model()
@@ -546,8 +550,10 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(result, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
@@ -678,6 +684,8 @@ package_upgrade: false
 `[1:]
 
 func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
+	serviceFactory := s.ControllerServiceFactory(c)
+
 	// Login as a machine agent for machine 0.
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
@@ -687,7 +695,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
 		Resources_:      s.resources,
-		ServiceFactory_: s.ControllerServiceFactory(c),
+		ServiceFactory_: serviceFactory,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(aProvisioner, gc.NotNil)
@@ -703,8 +711,10 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 	// Only machine 0 and containers therein can be accessed.
 	results, err := aProvisioner.ProvisioningInfo(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
-	controllerCfg, err := s.ControllerModel(c).State().ControllerConfig()
+
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(results, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{


### PR DESCRIPTION
The following injects the controller config into the provisioner.
We lean heavily on the service factory from PR #16295, which affords
us the ability to query in a nice way the controller config during
a test.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju enable-ha
$ juju deploy ubuntu
```

## Links

**Jira card:** JUJU-4329
