### PR TITLE
Update risk in setup origin for tests

### DIFF
--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -149,6 +149,12 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 			Meta: &charm.Meta{},
 		},
 	}
+	risk := "stable"
+	if charm.Local.Matches(currentCharmURL.Schema) {
+		// A local charm must never have a track, risk,
+		// nor branch.
+		risk = ""
+	}
 	s.charmAPIClient = mockCharmRefreshClient{
 		charmURL: currentCharmURL,
 		bindings: map[string]string{
@@ -156,7 +162,7 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 		},
 		charmOrigin: commoncharm.Origin{
 			Source: schemaToOriginScource(currentCharmURL.Schema),
-			Risk:   "stable",
+			Risk:   risk,
 		},
 	}
 	s.modelConfigGetter = newMockModelConfigGetter()


### PR DESCRIPTION
Our mocked tests should be more accurate. Otherwise it leads to false beliefs about normal code paths. A local charm must not have a channel, track/risk/branch, in its charm origin. Channels are not a concept that local charms understand.

This will have more impact in these tests in the 3.3 branch as the charm origin is validated in tests more.
## QA steps

This is a change to unit tests only, the GitHub action should succeed.
