### PR TITLE
Refactor service factory model getter

### DIFF
--- a/core/changestream/eventsource.go
+++ b/core/changestream/eventsource.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
-	"github.com/juju/juju/domain/model"
 )
 
 // EventSource describes the ability to subscribe
@@ -48,33 +47,11 @@ func NewTxnRunnerFactory(f WatchableDBFactory) database.TxnRunnerFactory {
 // an error.
 type WatchableDBFactory = func() (WatchableDB, error)
 
-// WatchableModelDBFactory provides an interface for getting a
-// database.TxnRunner or error that is scoped to a specific model.
-type WatchableModelDBFactory struct {
-	WatchableDBFactory
-	ModelUUID model.UUID
-}
-
 // NewWatchableDBFactoryForNamespace returns a WatchableDBFactory
 // for the input namespaced factory function and namespace.
-func NewWatchableDBFactoryForNamespace[T WatchableDB](
-	ns string,
-	f func(string) (T, error),
-) WatchableDBFactory {
+func NewWatchableDBFactoryForNamespace[T WatchableDB](f func(string) (T, error), ns string) WatchableDBFactory {
 	return func() (WatchableDB, error) {
 		r, err := f(ns)
 		return r, errors.Trace(err)
-	}
-}
-
-// NewWatchableModelDBFactory returns a WatchableModelDBFactory for model that
-// is used as the namespace for the factory.
-func NewWatchableModelDBFactory[T WatchableDB](
-	modelUUID model.UUID,
-	f func(string) (T, error),
-) WatchableModelDBFactory {
-	return WatchableModelDBFactory{
-		WatchableDBFactory: NewWatchableDBFactoryForNamespace(modelUUID.String(), f),
-		ModelUUID:          modelUUID,
 	}
 }

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -42,7 +42,6 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/status",
 		"core/watcher",
-		"domain/model",
 		"internal/docker",
 	})
 

--- a/domain/servicefactory/model.go
+++ b/domain/servicefactory/model.go
@@ -5,19 +5,18 @@ package servicefactory
 
 import (
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/domain/model"
 )
 
 // ModelFactory provides access to the services required by the apiserver.
 type ModelFactory struct {
 	logger  Logger
-	modelDB changestream.WatchableModelDBFactory
+	modelDB changestream.WatchableDBFactory
 }
 
 // NewModelFactory returns a new registry which uses the provided modelDB
 // function to obtain a model database.
 func NewModelFactory(
-	modelDB changestream.WatchableModelDBFactory,
+	modelDB changestream.WatchableDBFactory,
 	logger Logger,
 ) *ModelFactory {
 	return &ModelFactory{
@@ -26,7 +25,7 @@ func NewModelFactory(
 	}
 }
 
-// ModelUUID is the current UUID for the model.
-func (f *ModelFactory) ModelUUID() model.UUID {
-	return f.modelDB.ModelUUID
-}
+// TODO we need a method here because if we don't have a type here, then
+// anything satisfies the ModelFactory. Once we have model methods here, we
+// can remove this method.
+func (f *ModelFactory) TODO() {}

--- a/domain/servicefactory/service.go
+++ b/domain/servicefactory/service.go
@@ -18,7 +18,7 @@ type ServiceFactory struct {
 // get new services from.
 func NewServiceFactory(
 	controllerDB changestream.WatchableDBFactory,
-	modelDB changestream.WatchableModelDBFactory,
+	modelDB changestream.WatchableDBFactory,
 	deleterDB database.DBDeleter,
 	logger Logger,
 ) *ServiceFactory {

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -10,7 +10,6 @@ import (
 	controllernodeservice "github.com/juju/juju/domain/controllernode/service"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
-	"github.com/juju/juju/domain/model"
 	modelservice "github.com/juju/juju/domain/model/service"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 )
@@ -49,11 +48,6 @@ func (s *TestingServiceFactory) ModelManager() *modelmanagerservice.Service {
 	return nil
 }
 
-// ModelUUID is the current UUID for the model.
-func (s *TestingServiceFactory) ModelUUID() model.UUID {
-	return model.UUID("")
-}
-
 // ExternalController returns the external controller service.
 func (s *TestingServiceFactory) ExternalController() *externalcontrollerservice.Service {
 	return nil
@@ -69,6 +63,7 @@ func (s *TestingServiceFactory) Cloud() *cloudservice.Service {
 	return nil
 }
 
-func (s *TestingServiceFactory) Name() string {
-	return "TestingServiceFactory"
-}
+// TODO we need a method here because if we don't have a type here, then
+// anything satisfies the ModelFactory. Once we have model methods here, we
+// can remove this method.
+func (s *TestingServiceFactory) TODO() {}

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -66,11 +66,11 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 
 // ServiceFactoryGetter provides an implementation of the ServiceFactoryGetter
 // interface to use in tests.
-func (s *ServiceFactorySuite) ServiceFactoryGetter(c *gc.C) servicefactory.ServiceFactoryGetterFunc {
+func (s *ServiceFactorySuite) ServiceFactoryGetter(c *gc.C) ServiceFactoryGetterFunc {
 	return func(modelUUID string) servicefactory.ServiceFactory {
 		return domainservicefactory.NewServiceFactory(
 			databasetesting.ConstFactory(s.TxnRunner()),
-			databasetesting.ConstModelFactory(model.UUID(modelUUID), s.ModelTxnRunner(c, modelUUID)),
+			databasetesting.ConstFactory(s.ModelTxnRunner(c, modelUUID)),
 			stubDBDeleter{DB: s.DB()},
 			NewCheckLogger(c),
 		)
@@ -88,4 +88,13 @@ func (s *ServiceFactorySuite) SetUpTest(c *gc.C) {
 		s.DefaultModelUUID = modeltesting.GenModelUUID(c)
 	}
 	s.SeedModelDatabases(c)
+}
+
+// ServiceFactoryGetterFunc is a convenience type for translating a getter
+// function into the ServiceFactoryGetter interface.
+type ServiceFactoryGetterFunc func(string) servicefactory.ServiceFactory
+
+// FactoryForModel implements the ServiceFactoryGetter interface.
+func (s ServiceFactoryGetterFunc) FactoryForModel(modelUUID string) servicefactory.ServiceFactory {
+	return s(modelUUID)
 }

--- a/internal/database/testing/runner.go
+++ b/internal/database/testing/runner.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
-	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/internal/database/txn"
 )
 
@@ -68,15 +67,6 @@ func ConstFactory(runner coredatabase.TxnRunner) func() (changestream.WatchableD
 		return constWatchableDB{
 			TxnRunner: runner,
 		}, nil
-	}
-}
-
-// ConstModelFactory returns a changestream.WatchableModelDBFactory from just a
-// model.UUID and a database.TxnRunner.
-func ConstModelFactory(modelUUID model.UUID, runner coredatabase.TxnRunner) changestream.WatchableModelDBFactory {
-	return changestream.WatchableModelDBFactory{
-		WatchableDBFactory: ConstFactory(runner),
-		ModelUUID:          modelUUID,
 	}
 }
 

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -10,7 +10,6 @@ import (
 	controllernodeservice "github.com/juju/juju/domain/controllernode/service"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
-	"github.com/juju/juju/domain/model"
 	modelservice "github.com/juju/juju/domain/model/service"
 	modelmanagerservice "github.com/juju/juju/domain/modelmanager/service"
 )
@@ -39,8 +38,10 @@ type ControllerServiceFactory interface {
 // ModelServiceFactory provides access to the services required by the
 // apiserver for a given model.
 type ModelServiceFactory interface {
-	// ModelUUID returns the model UUID for the current model.
-	ModelUUID() model.UUID
+	// TODO we need a method here because if we don't have a type here, then
+	// anything satisfies the ModelFactory. Once we have model methods here, we
+	// can remove this method.
+	TODO()
 }
 
 // ServiceFactory provides access to the services required by the apiserver.
@@ -54,13 +55,4 @@ type ServiceFactory interface {
 type ServiceFactoryGetter interface {
 	// FactoryForModel returns a ServiceFactory for the given model.
 	FactoryForModel(modelUUID string) ServiceFactory
-}
-
-// ServiceFactoryGetterFunc is a convenience type for translating a getter
-// function into the ServiceFactoryGetter interface.
-type ServiceFactoryGetterFunc func(string) ServiceFactory
-
-// FactoryForModel implements the ServiceFactoryGetter interface.
-func (s ServiceFactoryGetterFunc) FactoryForModel(modelUUID string) ServiceFactory {
-	return s(modelUUID)
 }

--- a/worker/servicefactory/manifold.go
+++ b/worker/servicefactory/manifold.go
@@ -154,7 +154,7 @@ func NewControllerServiceFactory(
 	logger Logger,
 ) servicefactory.ControllerServiceFactory {
 	return domainservicefactory.NewControllerFactory(
-		changestream.NewWatchableDBFactoryForNamespace(coredatabase.ControllerNS, dbGetter.GetWatchableDB),
+		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		dbDeleter,
 		serviceFactoryLogger{
 			Logger: logger,
@@ -169,7 +169,7 @@ func NewModelServiceFactory(
 	logger Logger,
 ) servicefactory.ModelServiceFactory {
 	return domainservicefactory.NewModelFactory(
-		changestream.NewWatchableModelDBFactory(modelUUID, dbGetter.GetWatchableDB),
+		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, string(modelUUID)),
 		serviceFactoryLogger{
 			Logger: logger,
 		},

--- a/worker/servicefactory/servicefactory_mock_test.go
+++ b/worker/servicefactory/servicefactory_mock_test.go
@@ -13,7 +13,6 @@ import (
 	service2 "github.com/juju/juju/domain/controllernode/service"
 	service3 "github.com/juju/juju/domain/credential/service"
 	service4 "github.com/juju/juju/domain/externalcontroller/service"
-	model "github.com/juju/juju/domain/model"
 	service5 "github.com/juju/juju/domain/model/service"
 	service6 "github.com/juju/juju/domain/modelmanager/service"
 	servicefactory "github.com/juju/juju/internal/servicefactory"
@@ -178,18 +177,16 @@ func (m *MockModelServiceFactory) EXPECT() *MockModelServiceFactoryMockRecorder 
 	return m.recorder
 }
 
-// ModelUUID mocks base method.
-func (m *MockModelServiceFactory) ModelUUID() model.UUID {
+// TODO mocks base method.
+func (m *MockModelServiceFactory) TODO() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelUUID")
-	ret0, _ := ret[0].(model.UUID)
-	return ret0
+	m.ctrl.Call(m, "TODO")
 }
 
-// ModelUUID indicates an expected call of ModelUUID.
-func (mr *MockModelServiceFactoryMockRecorder) ModelUUID() *gomock.Call {
+// TODO indicates an expected call of TODO.
+func (mr *MockModelServiceFactoryMockRecorder) TODO() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockModelServiceFactory)(nil).ModelUUID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TODO", reflect.TypeOf((*MockModelServiceFactory)(nil).TODO))
 }
 
 // MockServiceFactory is a mock of ServiceFactory interface.
@@ -327,18 +324,16 @@ func (mr *MockServiceFactoryMockRecorder) ModelManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelManager", reflect.TypeOf((*MockServiceFactory)(nil).ModelManager))
 }
 
-// ModelUUID mocks base method.
-func (m *MockServiceFactory) ModelUUID() model.UUID {
+// TODO mocks base method.
+func (m *MockServiceFactory) TODO() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelUUID")
-	ret0, _ := ret[0].(model.UUID)
-	return ret0
+	m.ctrl.Call(m, "TODO")
 }
 
-// ModelUUID indicates an expected call of ModelUUID.
-func (mr *MockServiceFactoryMockRecorder) ModelUUID() *gomock.Call {
+// TODO indicates an expected call of TODO.
+func (mr *MockServiceFactoryMockRecorder) TODO() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockServiceFactory)(nil).ModelUUID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TODO", reflect.TypeOf((*MockServiceFactory)(nil).TODO))
 }
 
 // MockServiceFactoryGetter is a mock of ServiceFactoryGetter interface.


### PR DESCRIPTION
We already have a way to get a watchable db from a namespace. The namespace here can either be the "controller" namespace or a model uuid. Removal of the watchable db for model factory isn't required if we already know the model uuid.

I've also gone and removed the ModelUUID method from the model factory. We need a method on the model factory to ensure that the ModelFactory interface doesn't satisfy against every type. Instead of ModelUUID I've added a TODO() method. This will be removed once we add methods to the interface.

The ServiceFactoryGetterFunc was also lifted out of the service factory interfaces package and into the domain/servicefactory/testing suite. We don't want people to depend on this and hiding it away in the testing suite should cover the use case it was designed for.

----

It should be noted that if we do need ModelUUID then there is a problem with the modeling. I suspect most of the ModelUUID code is either at the apiserver root, which is required for getting the model the first time around, or in state. If it's the latter, that will not be required as you're already acting upon the existing model.

Anything outside of that is incorrect and will need to be solved in some other way.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps


```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
```

## Links

**Jira card:** JUJU-4698
