### PR TITLE
Move testing type for ServiceFactory to testing package.

### DIFF
--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -35,6 +35,15 @@ type ServiceFactorySuite struct {
 	DefaultModelUUID model.UUID
 }
 
+// ServiceFactoryGetterFunc is a convenience type for translating a getter
+// function into the ServiceFactoryGetter interface.
+type ServiceFactoryGetterFunc func(string) servicefactory.ServiceFactory
+
+// FactoryForModel implements the ServiceFactoryGetter interface.
+func (s ServiceFactoryGetterFunc) FactoryForModel(modelUUID string) servicefactory.ServiceFactory {
+	return s(modelUUID)
+}
+
 type stubDBDeleter struct {
 	DB *sql.DB
 }
@@ -66,7 +75,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 
 // ServiceFactoryGetter provides an implementation of the ServiceFactoryGetter
 // interface to use in tests.
-func (s *ServiceFactorySuite) ServiceFactoryGetter(c *gc.C) servicefactory.ServiceFactoryGetterFunc {
+func (s *ServiceFactorySuite) ServiceFactoryGetter(c *gc.C) ServiceFactoryGetterFunc {
 	return func(modelUUID string) servicefactory.ServiceFactory {
 		return domainservicefactory.NewServiceFactory(
 			databasetesting.ConstFactory(s.TxnRunner()),

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -55,12 +55,3 @@ type ServiceFactoryGetter interface {
 	// FactoryForModel returns a ServiceFactory for the given model.
 	FactoryForModel(modelUUID string) ServiceFactory
 }
-
-// ServiceFactoryGetterFunc is a convenience type for translating a getter
-// function into the ServiceFactoryGetter interface.
-type ServiceFactoryGetterFunc func(string) ServiceFactory
-
-// FactoryForModel implements the ServiceFactoryGetter interface.
-func (s ServiceFactoryGetterFunc) FactoryForModel(modelUUID string) ServiceFactory {
-	return s(modelUUID)
-}


### PR DESCRIPTION
We have the concept of a ServiceFactoryGetter that is responsible for building a ServiceFactory. A convenience type was introduced to make a function of this interface. This type is only used in tests so the commit moves the type into our testing package for the ServiceFactory.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

N/A

## Links

This PR is to supplement feedback from #16228

**Jira card:** JUJU-4594