### PR TITLE
Preserve agent.conf when restarting containeragent unit

### DIFF
--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -4,6 +4,7 @@
 package unit
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"path"
@@ -116,34 +117,6 @@ func (c *containerUnitAgent) CharmModifiedVersion() int {
 	return c.charmModifiedVersion
 }
 
-func (c *containerUnitAgent) ensureAgentConf(dataDir string) error {
-	templateConfigPath := path.Join(dataDir, k8sconstants.TemplateFileNameAgentConf)
-	logger.Debugf("template config path %s", templateConfigPath)
-	config, err := agent.ReadConfig(templateConfigPath)
-	if err != nil {
-		return errors.Annotate(err, "reading template agent config file")
-	}
-	unitTag := config.Tag()
-	configPath := agent.ConfigPath(dataDir, unitTag)
-	logger.Debugf("config path %s", configPath)
-	configDir := path.Dir(configPath)
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return errors.Annotatef(err, "making agent directory %q", configDir)
-	}
-	configBytes, err := config.Render()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
-		return errors.Annotate(err, "writing agent config file")
-	}
-
-	if err := c.ReadConfig(unitTag.String()); err != nil {
-		return errors.Annotate(err, "reading agent config file")
-	}
-	return nil
-}
-
 // Init initializes the command for running.
 func (c *containerUnitAgent) Init(args []string) error {
 	if err := c.AgentConf.CheckArgs(args); err != nil {
@@ -183,9 +156,7 @@ func (c *containerUnitAgent) Init(args []string) error {
 		Logger:        logger,
 	})
 
-	dataDir := c.DataDir()
-
-	if err := c.ensureAgentConf(dataDir); err != nil {
+	if err := ensureAgentConf(c.AgentConf); err != nil {
 		return errors.Annotate(err, "ensuring agent conf file")
 	}
 
@@ -195,7 +166,7 @@ func (c *containerUnitAgent) Init(args []string) error {
 	}
 
 	srcDir := path.Dir(os.Args[0])
-	if err := c.ensureToolSymlinks(srcDir, dataDir, unitTag); err != nil {
+	if err := c.ensureToolSymlinks(srcDir, c.DataDir(), unitTag); err != nil {
 		return errors.Annotate(err, "ensuring agent tool symlinks")
 	}
 	containerNames := c.environment.Getenv("JUJU_CONTAINER_NAMES")
@@ -424,4 +395,42 @@ func AgentDone(logger loggo.Logger, err error) error {
 		logger.Infof("agent restarting")
 	}
 	return err
+}
+
+func ensureAgentConf(ac agentconf.AgentConf) error {
+	templateConfigPath := path.Join(ac.DataDir(), k8sconstants.TemplateFileNameAgentConf)
+	logger.Debugf("template config path %s", templateConfigPath)
+	config, err := agent.ReadConfig(templateConfigPath)
+	if err != nil {
+		return errors.Annotate(err, "reading template agent config file")
+	}
+
+	unitTag := config.Tag()
+	configPath := agent.ConfigPath(ac.DataDir(), unitTag)
+	logger.Debugf("config path %s", configPath)
+	// if the rendered configuration already exists, use that copy
+	// as it likely has updated api addresses or could have a newer password,
+	// otherwise we need to copy the template.
+	if _, err := os.Stat(configPath); err == nil {
+		return ac.ReadConfig(unitTag.String())
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("cannot stat current config %s: %w", configPath, err)
+	}
+
+	configDir := path.Dir(configPath)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return errors.Annotatef(err, "making agent directory %q", configDir)
+	}
+	configBytes, err := config.Render()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
+		return errors.Annotate(err, "writing agent config file")
+	}
+
+	if err := ac.ReadConfig(unitTag.String()); err != nil {
+		return errors.Annotate(err, "reading agent config file")
+	}
+	return nil
 }

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -26,7 +27,9 @@ import (
 	utilsmocks "github.com/juju/juju/cmd/containeragent/utils/mocks"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	jnames "github.com/juju/juju/juju/names"
+	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 )
 
@@ -203,6 +206,55 @@ func (s *containerUnitAgentSuite) TestChangeConfig(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for config changed signal")
 	}
+}
+
+func (s *containerUnitAgentSuite) TestEnsureAgentConf(c *gc.C) {
+	dataDir := c.MkDir()
+	params := agent.AgentConfigParams{
+		Paths: agent.Paths{
+			DataDir: dataDir,
+		},
+		Tag:                    names.NewUnitTag("app/0"),
+		UpgradedToVersion:      jujuversion.Current,
+		Password:               "password",
+		CACert:                 "cacert",
+		APIAddresses:           []string{"localhost:1235"},
+		Nonce:                  "nonce",
+		Controller:             testing.ControllerTag,
+		Model:                  testing.ModelTag,
+		AgentLogfileMaxSizeMB:  150,
+		AgentLogfileMaxBackups: 4,
+	}
+	templateConfig, err := agent.NewAgentConfig(params)
+	c.Assert(err, jc.ErrorIsNil)
+	templateBytes, err := templateConfig.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	err = os.WriteFile(path.Join(dataDir, "template-agent.conf"), templateBytes, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ac := agentconf.NewAgentConf(dataDir)
+	err = unit.EnsureAgentConf(ac)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the agent.conf was seeded from the template-agent.conf.
+	agentConfBytes, err := os.ReadFile(path.Join(dataDir, "agents", "unit-app-0", "agent.conf"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(agentConfBytes), gc.Equals, string(templateBytes))
+
+	// Change the agent.conf to be different than the template-agent.conf
+	c.Assert(ac.CurrentConfig().OldPassword(), gc.Equals, "password")
+	err = ac.ChangeConfig(func(cs agent.ConfigSetter) error {
+		cs.SetOldPassword("password2")
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ac.CurrentConfig().OldPassword(), gc.Equals, "password2")
+
+	// Start a new "agent" and make sure it has password2.
+	ac2 := agentconf.NewAgentConf(dataDir)
+	err = unit.EnsureAgentConf(ac2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ac2.CurrentConfig().OldPassword(), gc.Equals, "password2")
 }
 
 type FakeConfig struct {

--- a/cmd/containeragent/unit/export_test.go
+++ b/cmd/containeragent/unit/export_test.go
@@ -61,3 +61,7 @@ func (c *containerUnitAgent) GetContainerNames() []string {
 func (c *containerUnitAgent) DataDir() string {
 	return c.AgentConf.DataDir()
 }
+
+func EnsureAgentConf(ac agentconf.AgentConf) error {
+	return ensureAgentConf(ac)
+}

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -78,7 +78,7 @@ var allowedCalls = map[string]set.Strings{
 }
 
 var ignoredPackages = set.NewStrings(
-	"jujuc", "jujud", "ks8agent", "juju-bridge", "service")
+	"jujuc", "jujud", "containeragent", "juju-bridge", "service")
 
 type OSCallTest struct{}
 


### PR DESCRIPTION
When the k8s containeragent unit starts up it would overwrite the agent.conf file even if a previous file existed.
This would cause issues due to the template being out of date with the current controller api addresses (it is only updated on pod init).

This change preserves the agent.conf file if it already exists, preserving the up to date values for controller uuid, controller api addresses, password, etc.

## QA steps

- `make install`
- `JUJU_BUILD_NUMBER=1 make <microk8s|minikube>-operator-update`
- `juju bootstrap localhost`
- add k8s to controller (e.g. `juju add-k8s ... --controller ...`)
- add model using k8s to the lxd controller (e.g. `juju add-model a my-k8s-cloud`)
- `juju deploy snappass-test`
- check snappass-test is healthy.
- capture agent.conf and agent-template
- `juju ssh snappass-test/0 cat /var/lib/juju/template-agent.conf`
- `juju ssh snappass-test/0 cat /var/lib/juju/agents/unit-snappass-test-0/agent.conf > first-agent.conf`
- enable ha on lxd controller
- check agent conf has new ha controller addresses
- `juju ssh snappass-test/0 cat /var/lib/juju/agents/unit-snappass-test-0/agent.conf > second-agent.conf`
- stop controller-0 in lxd
- kill charm pebble and force charm container restart (but keeping the pod and its fs)
- check agent conf has all controller addresses and is alive
- `juju ssh snappass-test/0 cat /var/lib/juju/agents/unit-snappass-test-0/agent.conf > third-agent.conf`
- double check the template config file still only has the controller-0 address (so it wouldn't work if the agent config was reinitialised from the template)
- `juju ssh snappass-test/0 cat /var/lib/juju/template-agent.conf`

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2037478

**Jira card:** JUJU-4691