### PR TITLE
Supply Watcher Next() with context.Context

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -203,7 +203,7 @@ func (c *Client) WatchAll(ctx stdcontext.Context) (params.AllWatcherId, error) {
 	modelUUID := c.api.stateAccessor.ModelUUID()
 	w := c.api.multiwatcherFactory.WatchModel(modelUUID)
 	if !isAdmin {
-		w = &stripApplicationOffers{w}
+		w = &stripApplicationOffers{Watcher: w}
 	}
 	return params.AllWatcherId{
 		AllWatcherId: c.api.resources.Register(w),
@@ -214,12 +214,12 @@ type stripApplicationOffers struct {
 	multiwatcher.Watcher
 }
 
-func (s *stripApplicationOffers) Next() ([]multiwatcher.Delta, error) {
+func (s *stripApplicationOffers) Next(ctx stdcontext.Context) ([]multiwatcher.Delta, error) {
 	var result []multiwatcher.Delta
 	// We don't want to return a list on nothing. Next normally blocks until there
 	// is something to return.
 	for len(result) == 0 {
-		deltas, err := s.Watcher.Next()
+		deltas, err := s.Watcher.Next(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -429,7 +429,7 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 			case <-done:
 				return
 			default:
-				result, err := watcherAPI.Next()
+				result, err := watcherAPI.Next(context.Background())
 				if err != nil {
 					c.Assert(err, jc.Satisfies, coremultiwatcher.IsErrStopped)
 					return
@@ -1092,7 +1092,7 @@ func (s *controllerSuite) TestWatchAllModelSummariesByAdmin(c *gc.C) {
 
 	resultC := make(chan params.SummaryWatcherNextResults)
 	go func() {
-		result, err := watcherAPI.Next()
+		result, err := watcherAPI.Next(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 		resultC <- result
 	}()
@@ -1161,7 +1161,7 @@ func (s *controllerSuite) TestWatchModelSummariesByNonAdmin(c *gc.C) {
 
 	resultC := make(chan params.SummaryWatcherNextResults)
 	go func() {
-		result, err := watcherAPI.Next()
+		result, err := watcherAPI.Next(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 		resultC <- result
 	}()

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -4,6 +4,8 @@
 package apiserver
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/kr/pretty"
@@ -113,8 +115,8 @@ func NewAllWatcher(context facade.Context) (facade.Facade, error) {
 
 // Next will return the current state of everything on the first call
 // and subsequent calls will
-func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
-	deltas, err := aw.watcher.Next()
+func (aw *SrvAllWatcher) Next(ctx context.Context) (params.AllWatcherNextResults, error) {
+	deltas, err := aw.watcher.Next(ctx)
 	return params.AllWatcherNextResults{
 		Deltas: translate(aw.deltaTranslater, deltas),
 	}, err
@@ -603,7 +605,7 @@ type srvNotifyWatcher struct {
 // Next returns when a change has occurred to the
 // entity being watched since the most recent call to Next
 // or the Watch call that created the NotifyWatcher.
-func (w *srvNotifyWatcher) Next() error {
+func (w *srvNotifyWatcher) Next(ctx context.Context) error {
 	_, err := internal.FirstResult[struct{}](w.watcher)
 	return errors.Trace(err)
 }
@@ -641,7 +643,7 @@ func newStringsWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvStringsWatcher.
-func (w *srvStringsWatcher) Next() (params.StringsWatchResult, error) {
+func (w *srvStringsWatcher) Next(ctx context.Context) (params.StringsWatchResult, error) {
 	changes, err := internal.FirstResult[[]string](w.watcher)
 	if err != nil {
 		return params.StringsWatchResult{}, errors.Trace(err)
@@ -683,7 +685,7 @@ func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvRelationUnitsWatcher.
-func (w *srvRelationUnitsWatcher) Next() (params.RelationUnitsWatchResult, error) {
+func (w *srvRelationUnitsWatcher) Next(ctx context.Context) (params.RelationUnitsWatchResult, error) {
 	changes, err := internal.FirstResult[params.RelationUnitsChange](w.watcher)
 	if err != nil {
 		return params.RelationUnitsWatchResult{}, errors.Trace(err)
@@ -725,7 +727,7 @@ func newRemoteRelationWatcher(context facade.Context) (facade.Facade, error) {
 	}, nil
 }
 
-func (w *srvRemoteRelationWatcher) Next() (params.RemoteRelationWatchResult, error) {
+func (w *srvRemoteRelationWatcher) Next(ctx context.Context) (params.RemoteRelationWatchResult, error) {
 	changes, err := internal.FirstResult[params.RelationUnitsChange](w.watcher)
 	if err != nil {
 		return params.RemoteRelationWatchResult{}, errors.Trace(err)
@@ -779,7 +781,7 @@ func newRelationStatusWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvRelationStatusWatcher.
-func (w *srvRelationStatusWatcher) Next() (params.RelationLifeSuspendedStatusWatchResult, error) {
+func (w *srvRelationStatusWatcher) Next(ctx context.Context) (params.RelationLifeSuspendedStatusWatchResult, error) {
 	changes, err := internal.FirstResult[[]string](w.watcher)
 	if err != nil {
 		return params.RelationLifeSuspendedStatusWatchResult{}, errors.Trace(err)
@@ -835,7 +837,7 @@ func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvOfferStatusWatcher.
-func (w *srvOfferStatusWatcher) Next() (params.OfferStatusWatchResult, error) {
+func (w *srvOfferStatusWatcher) Next(ctx context.Context) (params.OfferStatusWatchResult, error) {
 	_, err := internal.FirstResult[struct{}](w.watcher)
 	if err != nil {
 		return params.OfferStatusWatchResult{}, errors.Trace(err)
@@ -921,7 +923,7 @@ func newMachineStorageIdsWatcher(
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvMachineStorageIdsWatcher.
-func (w *srvMachineStorageIdsWatcher) Next() (params.MachineStorageIdsWatchResult, error) {
+func (w *srvMachineStorageIdsWatcher) Next(ctx context.Context) (params.MachineStorageIdsWatchResult, error) {
 	stringChanges, err := internal.FirstResult[[]string](w.watcher)
 	if err != nil {
 		return params.MachineStorageIdsWatchResult{}, errors.Trace(err)
@@ -982,7 +984,7 @@ func newEntitiesWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvEntitiesWatcher.
-func (w *srvEntitiesWatcher) Next() (params.EntitiesWatchResult, error) {
+func (w *srvEntitiesWatcher) Next(ctx context.Context) (params.EntitiesWatchResult, error) {
 	changes, err := internal.FirstResult[[]string](w.watcher)
 	if err != nil {
 		return params.EntitiesWatchResult{}, errors.Trace(err)
@@ -1056,7 +1058,7 @@ type srvMigrationStatusWatcher struct {
 // Next returns when the status for a model migration for the
 // associated model changes. The current details for the active
 // migration are returned.
-func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
+func (w *srvMigrationStatusWatcher) Next(ctx context.Context) (params.MigrationStatus, error) {
 	_, err := internal.FirstResult[struct{}](w.watcher)
 	if err != nil {
 		return params.MigrationStatus{}, errors.Trace(err)
@@ -1189,7 +1191,7 @@ type SrvModelSummaryWatcher struct {
 // Next will return the current state of everything on the first call
 // and subsequent calls will return just those model summaries that have
 // changed.
-func (w *SrvModelSummaryWatcher) Next() (params.SummaryWatcherNextResults, error) {
+func (w *SrvModelSummaryWatcher) Next(ctx context.Context) (params.SummaryWatcherNextResults, error) {
 	changes, err := internal.FirstResult[[]corewatcher.ModelSummary](w.watcher)
 	if err != nil {
 		return params.SummaryWatcherNextResults{}, errors.Trace(err)
@@ -1279,7 +1281,7 @@ func newSecretsTriggerWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvSecretRotationWatcher.
-func (w *srvSecretTriggerWatcher) Next() (params.SecretTriggerWatchResult, error) {
+func (w *srvSecretTriggerWatcher) Next(ctx context.Context) (params.SecretTriggerWatchResult, error) {
 	changes, err := internal.FirstResult[[]corewatcher.SecretTriggerChange](w.watcher)
 	if err != nil {
 		return params.SecretTriggerWatchResult{}, errors.Trace(err)
@@ -1332,7 +1334,7 @@ func newSecretBackendsRotateWatcher(context facade.Context) (facade.Facade, erro
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvSecretRotationWatcher.
-func (w *srvSecretBackendsRotateWatcher) Next() (params.SecretBackendRotateWatchResult, error) {
+func (w *srvSecretBackendsRotateWatcher) Next(ctx context.Context) (params.SecretBackendRotateWatchResult, error) {
 	changes, err := internal.FirstResult[[]corewatcher.SecretBackendRotateChange](w.watcher)
 	if err != nil {
 		return params.SecretBackendRotateWatchResult{}, errors.Trace(err)
@@ -1391,7 +1393,7 @@ func newSecretsRevisionWatcher(context facade.Context) (facade.Facade, error) {
 // Next returns when a change has occurred to an entity of the
 // collection being watched since the most recent call to Next
 // or the Watch call that created the srvSecretRotationWatcher.
-func (w *srvSecretsRevisionWatcher) Next() (params.SecretRevisionWatchResult, error) {
+func (w *srvSecretsRevisionWatcher) Next(ctx context.Context) (params.SecretRevisionWatchResult, error) {
 	changes, err := internal.FirstResult[[]string](w.watcher)
 	if err != nil {
 		return params.SecretRevisionWatchResult{}, errors.Trace(err)

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -4,6 +4,8 @@
 package apiserver_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -86,7 +88,7 @@ func (s *watcherSuite) TestVolumeAttachmentsWatcher(c *gc.C) {
 
 	ch <- []string{"0:1", "1:2"}
 	facade := s.getFacade(c, "VolumeAttachmentsWatcher", 2, id, nopDispose).(machineStorageIdsWatcher)
-	result, err := facade.Next()
+	result, err := facade.Next(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result, jc.DeepEquals, params.MachineStorageIdsWatchResult{
@@ -104,7 +106,7 @@ func (s *watcherSuite) TestFilesystemAttachmentsWatcher(c *gc.C) {
 
 	ch <- []string{"0:1", "1:2"}
 	facade := s.getFacade(c, "FilesystemAttachmentsWatcher", 2, id, nopDispose).(machineStorageIdsWatcher)
-	result, err := facade.Next()
+	result, err := facade.Next(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result, jc.DeepEquals, params.MachineStorageIdsWatchResult{
@@ -124,7 +126,7 @@ func (s *watcherSuite) TestMigrationStatusWatcher(c *gc.C) {
 
 	facade := s.getFacade(c, "MigrationStatusWatcher", 1, id, nopDispose).(migrationStatusWatcher)
 	defer c.Check(facade.Stop(), jc.ErrorIsNil)
-	result, err := facade.Next()
+	result, err := facade.Next(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
 		MigrationId:    "id",
@@ -146,7 +148,7 @@ func (s *watcherSuite) TestMigrationStatusWatcherNoMigration(c *gc.C) {
 
 	facade := s.getFacade(c, "MigrationStatusWatcher", 1, id, nopDispose).(migrationStatusWatcher)
 	defer c.Check(facade.Stop(), jc.ErrorIsNil)
-	result, err := facade.Next()
+	result, err := facade.Next(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
 		Phase: "NONE",
@@ -168,7 +170,7 @@ func (s *watcherSuite) TestMigrationStatusWatcherNotAgent(c *gc.C) {
 }
 
 type machineStorageIdsWatcher interface {
-	Next() (params.MachineStorageIdsWatchResult, error)
+	Next(context.Context) (params.MachineStorageIdsWatchResult, error)
 }
 
 type fakeStringsWatcher struct {
@@ -243,7 +245,7 @@ func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {
 }
 
 type migrationStatusWatcher interface {
-	Next() (params.MigrationStatus, error)
+	Next(context.Context) (params.MigrationStatus, error)
 	Stop() error
 }
 

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -4,6 +4,7 @@
 package multiwatcher
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/worker/v3"
@@ -44,7 +45,7 @@ type Factory interface {
 // on one or more models.
 type Watcher interface {
 	worker.Worker
-	Next() ([]Delta, error)
+	Next(context.Context) ([]Delta, error)
 }
 
 // EntityInfo is implemented by all entity Info types.

--- a/worker/multiwatcher/watcher.go
+++ b/worker/multiwatcher/watcher.go
@@ -4,6 +4,8 @@
 package multiwatcher
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/multiwatcher"
@@ -62,7 +64,7 @@ func (w *Watcher) Kill() {
 // return the deltas that represent the model's complete state at that
 // moment, even when the model is empty. In that empty model case an
 // empty set of deltas is returned.
-func (w *Watcher) Next() ([]multiwatcher.Delta, error) {
+func (w *Watcher) Next(ctx context.Context) ([]multiwatcher.Delta, error) {
 	// In order to be able to apply the filter, yet not signal the caller when
 	// all deltas were filtered out, we need an outer loop.
 	var changes []multiwatcher.Delta

--- a/worker/multiwatcher/watcher_test.go
+++ b/worker/multiwatcher/watcher_test.go
@@ -4,6 +4,7 @@
 package multiwatcher_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -187,7 +188,7 @@ func (s *watcherSuite) TestWatcherErrorWhenWorkerStopped(c *gc.C) {
 
 	b.UpdateEntity(&multiwatcher.MachineInfo{ID: "1"})
 
-	d, err := w.Next()
+	d, err := w.Next(context.Background())
 	c.Assert(err, gc.ErrorMatches, "shared state watcher was stopped")
 	c.Assert(err, jc.Satisfies, multiwatcher.IsErrStopped)
 	c.Assert(d, gc.HasLen, 0)
@@ -198,7 +199,7 @@ func getNext(c *gc.C, w multiwatcher.Watcher, timeout time.Duration) ([]multiwat
 	var err error
 	ch := make(chan struct{}, 1)
 	go func() {
-		deltas, err = w.Next()
+		deltas, err = w.Next(context.Background())
 		ch <- struct{}{}
 	}()
 	select {
@@ -264,7 +265,7 @@ func watchWatcher(c *gc.C, w multiwatcher.Watcher) *watcher {
 
 func (w *watcher) loop() {
 	for true {
-		deltas, err := w.inner.Next()
+		deltas, err := w.inner.Next(context.Background())
 		if err != nil {
 			w.err <- err
 			return


### PR DESCRIPTION
The watcher next method is also a facade call. Thus can be supplied with a context.Context. The motivation is three fold.

 1. Ability to trace all facade calls through the stack.
 2. Ability to cancel a request efficently.
 3. Remove as much reflection code in the APIServer. In theory, we have enough information about every method, that we don't actually need reflection. This is a lofty goal, but would clean up the maintainability, as we can then use compile checks instead of runtime ones.

The following just ensures that these Next calls have a context.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-4692
