### PR TITLE
Rephrase warning message for strictly confined snap

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -147,7 +147,7 @@ func (m jujuMain) Run(args []string) int {
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		cmd.WriteError(ctx.Stderr, err)
 		if errors.Is(err, errors.NotFound) {
-			ctx.Warningf("Installing juju from a snap, the .local/share directory should be manually created as it is strictly confined.")
+			ctx.Warningf("Installing Juju in a strictly confined Snap. To ensure correct operation, create the .local/share directory manually.")
 		}
 		return 2
 	}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -147,7 +147,7 @@ func (m jujuMain) Run(args []string) int {
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		cmd.WriteError(ctx.Stderr, err)
 		if errors.Is(err, errors.NotFound) {
-			ctx.Warningf("Installing Juju in a strictly confined Snap. To ensure correct operation, create the .local/share directory manually.")
+			ctx.Warningf("Installing Juju in a strictly confined Snap. To ensure correct operation, create the ~/.local/share/juju directory manually.")
 		}
 		return 2
 	}


### PR DESCRIPTION
This PR rephrases a warning message if you install juju in a strictly confined Snap.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
// Nothing
```


## Links

**Jira card:** [JUJU-[4693]](https://warthogs.atlassian.net/browse/JUJU-4693)
