### PR TITLE
A poor attempt to allow nested virtualization per machine constraint

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -839,6 +839,9 @@ func (c *Client) buildConfigSpec(
 			Reservation: &cpuPower,
 		}
 	}
+	if args.Constraints.HasNestedVirtualization() {
+		spec.NestedHVEnabled = types.NewBool(args.Constraints.CpuPower)
+	}
 
 	spec.Flags = &types.VirtualMachineFlagInfo{
 		DiskUuidEnabled: types.NewBool(args.EnableDiskUUID),


### PR DESCRIPTION
My expectation is that one would want to add machines in a model, some with this enabled, and others without. This would facilitate something like Charmed Kubernetes with kubevirt enabled. The worker machines in the model could be started with a constraint like `nested-virtualization=true` which would allow `/dev/kvm` from the metal to be passed through and used to start VMs inside the workers without adding `/dev/kvm` the machines that host kubernetes-control-plane, etcd, vault, kubeapi-load-balancer and other Charmed Kubernetes machines

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

*Commands to run to verify that the change works.*
```shell
juju deploy ubuntu --constraints="nested-virtualization=true" 
juju-wait
juju ssh ubuntu/0 -- ls /dev/kvm
```


```sh
QA steps here
```

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

If accepted, this would require new docs rendered to explain the new constraint


## Links

**Launchpad bug:** https://pad.lv/2037566
