### PR TITLE
Drop json codec v0 support

### DIFF
--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -5,7 +5,6 @@ package rpc_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -82,12 +82,12 @@ func websocketHandler(f func(*websocket.Conn)) http.Handler {
 
 func (s *dispatchSuite) TestWSWithoutParamsV0(c *gc.C) {
 	err := s.requestV0(c, `{"RequestId":1,"Type": "DispatchDummy","Id": "without","Request":"DoSomething"}`)
-	c.Assert(errors.Is(err, jsoncodec.ErrVersion0NotSupported), jc.IsTrue)
+	c.Assert(errors.Is(err, errors.NotSupported), jc.IsTrue)
 }
 
 func (s *dispatchSuite) TestWSWithParamsV0(c *gc.C) {
 	err := s.requestV0(c, `{"RequestId":2,"Type": "DispatchDummy","Id": "with","Request":"DoSomething", "Params": {}}`)
-	c.Assert(errors.Is(err, jsoncodec.ErrVersion0NotSupported), jc.IsTrue)
+	c.Assert(errors.Is(err, errors.NotSupported), jc.IsTrue)
 }
 
 func (s *dispatchSuite) TestWSWithoutParamsV1(c *gc.C) {

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -5,9 +5,12 @@ package rpc_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/juju/loggo"
@@ -24,13 +27,20 @@ type dispatchSuite struct {
 
 	server     *httptest.Server
 	serverAddr string
-	ready      chan struct{}
+
+	dead   chan error
+	unique int64
 }
 
 var _ = gc.Suite(&dispatchSuite{})
 
-func (s *dispatchSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
+func (s *dispatchSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	loggo.GetLogger("juju.rpc").SetLogLevel(loggo.TRACE)
+
+	s.dead = make(chan error)
+
 	rpcServer := func(ws *websocket.Conn) {
 		codec := jsoncodec.NewWebsocket(ws)
 		conn := rpc.NewConn(codec, nil)
@@ -39,12 +49,18 @@ func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 		conn.Start(context.Background())
 
 		<-conn.Dead()
+		s.dead <- conn.Close()
 	}
-	http.Handle("/rpc", websocketHandler(rpcServer))
+
+	unique := atomic.AddInt64(&s.unique, 1)
+
+	http.Handle(fmt.Sprintf("/rpc%d", unique), websocketHandler(rpcServer))
+
 	s.server = httptest.NewServer(nil)
 	s.serverAddr = s.server.Listener.Addr().String()
-	s.ready = make(chan struct{}, 1)
+
 	s.AddCleanup(func(*gc.C) {
+		close(s.dead)
 		s.server.Close()
 	})
 }
@@ -64,54 +80,106 @@ func websocketHandler(f func(*websocket.Conn)) http.Handler {
 	})
 }
 
-func (s *dispatchSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	loggo.GetLogger("juju.rpc").SetLogLevel(loggo.TRACE)
-}
-
 func (s *dispatchSuite) TestWSWithoutParamsV0(c *gc.C) {
-	resp := s.request(c, `{"RequestId":1,"Type": "DispatchDummy","Id": "without","Request":"DoSomething"}`)
-	s.assertResponse(c, resp, `{"RequestId":1,"Response":{}}`)
+	err := s.requestV0(c, `{"RequestId":1,"Type": "DispatchDummy","Id": "without","Request":"DoSomething"}`)
+	c.Assert(errors.Is(err, jsoncodec.ErrVersion0NotSupported), jc.IsTrue)
 }
 
 func (s *dispatchSuite) TestWSWithParamsV0(c *gc.C) {
-	resp := s.request(c, `{"RequestId":2,"Type": "DispatchDummy","Id": "with","Request":"DoSomething", "Params": {}}`)
-	s.assertResponse(c, resp, `{"RequestId":2,"Response":{}}`)
+	err := s.requestV0(c, `{"RequestId":2,"Type": "DispatchDummy","Id": "with","Request":"DoSomething", "Params": {}}`)
+	c.Assert(errors.Is(err, jsoncodec.ErrVersion0NotSupported), jc.IsTrue)
 }
 
 func (s *dispatchSuite) TestWSWithoutParamsV1(c *gc.C) {
-	resp := s.request(c, `{"request-id":1,"type": "DispatchDummy","id": "without","request":"DoSomething"}`)
+	resp := s.requestV1(c, `{"request-id":1,"type": "DispatchDummy","id": "without","request":"DoSomething"}`)
 	s.assertResponse(c, resp, `{"request-id":1,"response":{}}`)
+	s.ensureFinish(c)
 }
 
 func (s *dispatchSuite) TestWSWithParamsV1(c *gc.C) {
-	resp := s.request(c, `{"request-id":2,"type": "DispatchDummy","id": "with","request":"DoSomething", "params": {}}`)
+	resp := s.requestV1(c, `{"request-id":2,"type": "DispatchDummy","id": "with","request":"DoSomething", "params": {}}`)
 	s.assertResponse(c, resp, `{"request-id":2,"response":{}}`)
+	s.ensureFinish(c)
 }
 
 func (s *dispatchSuite) assertResponse(c *gc.C, obtained, expected string) {
 	c.Assert(obtained, gc.Equals, expected+"\n")
 }
 
+func (s *dispatchSuite) ensureFinish(c *gc.C) {
+	// Ensure the test is finished, before starting another one. This is to
+	// prevent a data race on the dead channel in SetupTest.
+	select {
+	case <-s.dead:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timeout waiting for response")
+	}
+}
+
 // request performs one request to the test server via websockets.
-func (s *dispatchSuite) request(c *gc.C, req string) string {
-	url := fmt.Sprintf("ws://%s/rpc", s.serverAddr)
+func (s *dispatchSuite) requestV0(c *gc.C, req string) error {
+	ws := s.request(c, req)
+
+	result := make(chan struct{})
+
+	go func() {
+		_, _, err := ws.ReadMessage()
+		c.Check(err, gc.NotNil)
+
+		close(result)
+	}()
+
+	select {
+	case err := <-s.dead:
+		return err
+	case <-result:
+		return nil
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timeout waiting for response")
+		return nil
+	}
+}
+
+// request performs one request to the test server via websockets.
+func (s *dispatchSuite) requestV1(c *gc.C, req string) string {
+	ws := s.request(c, req)
+
+	result := make(chan string)
+
+	go func() {
+		_, resp, err := ws.ReadMessage()
+		c.Check(err, jc.ErrorIsNil)
+
+		err = ws.Close()
+		c.Assert(err, jc.ErrorIsNil)
+
+		result <- string(resp)
+	}()
+
+	select {
+	case err := <-s.dead:
+		c.Assert(err, jc.ErrorIsNil)
+		return ""
+	case resp := <-result:
+		return resp
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timeout waiting for response")
+		return ""
+	}
+}
+
+func (s *dispatchSuite) request(c *gc.C, req string) *websocket.Conn {
+	url := fmt.Sprintf("ws://%s/rpc%d", s.serverAddr, atomic.LoadInt64(&s.unique))
 	ws, _, err := websocket.DefaultDialer.Dial(url, http.Header{
 		"Origin": {"http://localhost"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	reqdata := []byte(req)
-	err = ws.WriteMessage(websocket.TextMessage, reqdata)
+	reqData := []byte(req)
+	err = ws.WriteMessage(websocket.TextMessage, reqData)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, resp, err := ws.ReadMessage()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = ws.Close()
-	c.Assert(err, jc.ErrorIsNil)
-
-	return string(resp)
+	return ws
 }
 
 // DispatchRoot simulates the root for the test.

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -15,6 +15,12 @@ import (
 	"github.com/juju/juju/rpc"
 )
 
+var (
+	// ErrVersion0NotSupported reports that version 0 of messaging is not
+	// supported. Instead version 1 or higher should be used.
+	ErrVersion0NotSupported = errors.ConstError("version 0 not supported")
+)
+
 var logger = loggo.GetLogger("juju.rpc.jsoncodec")
 
 // JSONConn sends and receives messages to an underlying connection
@@ -48,17 +54,6 @@ func New(conn JSONConn) *Codec {
 // inMsg holds an incoming message.  We don't know the type of the
 // parameters or response yet, so we delay parsing by storing them
 // in a RawMessage.
-type inMsgV0 struct {
-	RequestId uint64
-	Type      string
-	Version   int
-	Id        string
-	Request   string
-	Params    json.RawMessage
-	Error     string
-	ErrorCode string
-	Response  json.RawMessage
-}
 
 type inMsgV1 struct {
 	RequestId uint64                 `json:"request-id"`
@@ -71,19 +66,6 @@ type inMsgV1 struct {
 	ErrorCode string                 `json:"error-code"`
 	ErrorInfo map[string]interface{} `json:"error-info"`
 	Response  json.RawMessage        `json:"response"`
-}
-
-// outMsg holds an outgoing message.
-type outMsgV0 struct {
-	RequestId uint64
-	Type      string      `json:",omitempty"`
-	Version   int         `json:",omitempty"`
-	Id        string      `json:",omitempty"`
-	Request   string      `json:",omitempty"`
-	Params    interface{} `json:",omitempty"`
-	Error     string      `json:",omitempty"`
-	ErrorCode string      `json:",omitempty"`
-	Response  interface{} `json:",omitempty"`
 }
 
 type outMsgV1 struct {
@@ -114,15 +96,11 @@ func (c *Codec) isClosing() bool {
 
 func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	var m json.RawMessage
-	var version int
-	err := c.conn.Receive(&m)
-	if err == nil {
-		logger.Tracef("<- %s", m)
-		c.msg, version, err = c.readMessage(m)
-	} else {
-		logger.Tracef("<- error: %v (closing %v)", err, c.isClosing())
-	}
-	if err != nil {
+	if err := c.conn.Receive(&m); err != nil {
+		if logger.IsTraceEnabled() {
+			logger.Tracef("<- error: %v (closing %v)", err, c.isClosing())
+		}
+
 		// If we've closed the connection, we may get a spurious error,
 		// so ignore it.
 		if c.isClosing() || err == io.EOF {
@@ -130,6 +108,16 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 		}
 		return errors.Annotate(err, "error receiving message")
 	}
+
+	if logger.IsTraceEnabled() {
+		logger.Tracef("<- %s", m)
+	}
+	var err error
+	c.msg, err = c.readMessage(m)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	hdr.RequestId = c.msg.RequestId
 	hdr.Request = rpc.Request{
 		Type:    c.msg.Type,
@@ -140,41 +128,19 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	hdr.Error = c.msg.Error
 	hdr.ErrorCode = c.msg.ErrorCode
 	hdr.ErrorInfo = c.msg.ErrorInfo
-	hdr.Version = version
+	hdr.Version = 1
 	return nil
 }
 
-func (c *Codec) readMessage(m json.RawMessage) (inMsgV1, int, error) {
+func (c *Codec) readMessage(m json.RawMessage) (inMsgV1, error) {
 	var msg inMsgV1
 	if err := json.Unmarshal(m, &msg); err != nil {
-		return msg, -1, errors.Trace(err)
+		return msg, errors.Trace(err)
 	}
-	// In order to support both new style tags (lowercase) and the old style tags (camelcase)
-	// we look at the request id. The request id is always greater than one. If the value is
-	// zero, it means that there wasn't a match for the "request-id" tag. This most likely
-	// means that it was "RequestId" which was from the old style.
 	if msg.RequestId == 0 {
-		return c.readV0Message(m)
+		return msg, ErrVersion0NotSupported
 	}
-	return msg, 1, nil
-}
-
-func (c *Codec) readV0Message(m json.RawMessage) (inMsgV1, int, error) {
-	var msg inMsgV0
-	if err := json.Unmarshal(m, &msg); err != nil {
-		return inMsgV1{}, -1, errors.Trace(err)
-	}
-	return inMsgV1{
-		RequestId: msg.RequestId,
-		Type:      msg.Type,
-		Version:   msg.Version,
-		Id:        msg.Id,
-		Request:   msg.Request,
-		Params:    msg.Params,
-		Error:     msg.Error,
-		ErrorCode: msg.ErrorCode,
-		Response:  msg.Response,
-	}, 0, nil
+	return msg, nil
 }
 
 func (c *Codec) ReadBody(body interface{}, isRequest bool) error {
@@ -231,32 +197,12 @@ func (c *Codec) WriteMessage(hdr *rpc.Header, body interface{}) error {
 func response(hdr *rpc.Header, body interface{}) (interface{}, error) {
 	switch hdr.Version {
 	case 0:
-		return newOutMsgV0(hdr, body), nil
+		return nil, ErrVersion0NotSupported
 	case 1:
 		return newOutMsgV1(hdr, body), nil
 	default:
 		return nil, errors.Errorf("unsupported version %d", hdr.Version)
 	}
-}
-
-// newOutMsgV0 fills out a outMsgV0 with information from the given
-// header and body.
-func newOutMsgV0(hdr *rpc.Header, body interface{}) outMsgV0 {
-	result := outMsgV0{
-		RequestId: hdr.RequestId,
-		Type:      hdr.Request.Type,
-		Version:   hdr.Request.Version,
-		Id:        hdr.Request.Id,
-		Request:   hdr.Request.Action,
-		Error:     hdr.Error,
-		ErrorCode: hdr.ErrorCode,
-	}
-	if hdr.IsRequest() {
-		result.Params = body
-	} else {
-		result.Response = body
-	}
-	return result
 }
 
 // newOutMsgV1 fills out a outMsgV1 with information from the given header and

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -6,7 +6,6 @@ package jsoncodec_test
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"reflect"
 	stdtesting "testing"
@@ -49,7 +48,7 @@ func (*suite) TestRead(c *gc.C) {
 				Action: "frob",
 			},
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `reading message: version 0 not supported`,
 	}, {
 		msg: `{"RequestId": 2, "Error": "an error", "ErrorCode": "a code"}`,
 		expectHdr: rpc.Header{
@@ -57,13 +56,13 @@ func (*suite) TestRead(c *gc.C) {
 			Error:     "an error",
 			ErrorCode: "a code",
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `reading message: version 0 not supported`,
 	}, {
 		msg: `{"RequestId": 3, "Response": {"X": "result"}}`,
 		expectHdr: rpc.Header{
 			RequestId: 3,
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `reading message: version 0 not supported`,
 	}, {
 		msg: `{"RequestId": 4, "Type": "foo", "Version": 2, "Id": "id", "Request": "frob", "Params": {"X": "param"}}`,
 		expectHdr: rpc.Header{
@@ -75,7 +74,7 @@ func (*suite) TestRead(c *gc.C) {
 				Action:  "frob",
 			},
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `reading message: version 0 not supported`,
 	}, {
 		msg: `{"request-id": 1, "type": "foo", "id": "id", "request": "frob", "params": {"X": "param"}}`,
 		expectHdr: rpc.Header{
@@ -163,7 +162,7 @@ func (*suite) TestErrorAfterClose(c *gc.C) {
 	codec := jsoncodec.New(conn)
 	var hdr rpc.Header
 	err := codec.ReadHeader(&hdr)
-	c.Assert(err, gc.ErrorMatches, "error receiving message: some error")
+	c.Assert(err, gc.ErrorMatches, "receiving message: some error")
 
 	err = codec.Close()
 	c.Assert(err, jc.ErrorIsNil)
@@ -190,14 +189,14 @@ func (*suite) TestWrite(c *gc.C) {
 			},
 		},
 		body:      &value{X: "param"},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `writing message: version 0 not supported`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 2,
 			Error:     "an error",
 			ErrorCode: "a code",
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `writing message: version 0 not supported`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 2,
@@ -207,13 +206,13 @@ func (*suite) TestWrite(c *gc.C) {
 				"ignored": "for version0",
 			},
 		},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `writing message: version 0 not supported`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 3,
 		},
 		body:      &value{X: "result"},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `writing message: version 0 not supported`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 4,
@@ -225,7 +224,7 @@ func (*suite) TestWrite(c *gc.C) {
 			},
 		},
 		body:      &value{X: "param"},
-		expectErr: jsoncodec.ErrVersion0NotSupported.Error(),
+		expectErr: `writing message: version 0 not supported`,
 	}, {
 		hdr: &rpc.Header{
 			RequestId: 1,
@@ -309,31 +308,31 @@ func (*suite) TestDumpRequest(c *gc.C) {
 			},
 		},
 		body:   struct{ Arg string }{Arg: "an arg"},
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 2,
 		},
 		body:   struct{ Ret string }{Ret: "return value"},
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 3,
 		},
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 4,
 			Error:     "an error",
 			ErrorCode: "an error code",
 		},
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 5,
 		},
 		body:   make(chan int),
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 1,
@@ -345,7 +344,7 @@ func (*suite) TestDumpRequest(c *gc.C) {
 			},
 		},
 		body:   struct{ Arg string }{Arg: "an arg"},
-		expect: fmt.Sprintf("%q", jsoncodec.ErrVersion0NotSupported.Error()),
+		expect: `"version 0 not supported"`,
 	}, {
 		hdr: rpc.Header{
 			RequestId: 1,


### PR DESCRIPTION
The following drops v0 json codec support. This is ongoing work to support tracing between client and server requests. I don't believe we should be supporting v0 anymore with the next major release (v4), so before I add a TraceID I thought it prudent to clean up the code.

We would need to ensure that pylibjuju also sends a Version via the header (Version=1), so we don't break compatibility.

Also for v0 messages, we were double unmarshalling to detect the version, via the RequestId. If it was 0, it was assumed that it was incorrect and would attempt to unmarshall again. Although, good for backward compatibility, not great for efficiency.

----

*EDIT:* I've checked pylibjuju and it does conform to the v1 and not the v0 message type.

https://github.com/juju/python-libjuju/blob/f3905cd0a60d3757ef86166637300ccd96abf778/juju/client/connection.py#L640-L645

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-[XXXX]
