### PR TITLE
Merge 2.9 to 3.1

### DIFF
--- a/api/controller/caasmodeloperator/client.go
+++ b/api/controller/caasmodeloperator/client.go
@@ -8,7 +8,9 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/rpc/params"
 )
@@ -86,4 +88,17 @@ func (c *Client) SetPassword(password string) error {
 		return errors.Trace(err)
 	}
 	return result.OneError()
+}
+
+// WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the
+// information returned by ModelOperatorProvisioningInfo.
+func (c *Client) WatchModelOperatorProvisioningInfo() (watcher.NotifyWatcher, error) {
+	var result params.NotifyWatchResult
+	if err := c.facade.FacadeCall("WatchModelOperatorProvisioningInfo", nil, &result); err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -37,13 +37,14 @@ type mockState struct {
 	testing.Stub
 
 	common.APIAddressAccessor
-	model                   *mockModel
-	applicationWatcher      *mockStringsWatcher
-	app                     *mockApplication
-	resource                *mockResources
-	operatorRepo            string
-	controllerConfigWatcher *statetesting.MockNotifyWatcher
-	isController            bool
+	model                        *mockModel
+	applicationWatcher           *mockStringsWatcher
+	app                          *mockApplication
+	resource                     *mockResources
+	operatorRepo                 string
+	controllerConfigWatcher      *statetesting.MockNotifyWatcher
+	apiHostPortsForAgentsWatcher *statetesting.MockNotifyWatcher
+	isController                 bool
 }
 
 func newMockState() *mockState {
@@ -124,6 +125,11 @@ func (st *mockState) Resources() caasapplicationprovisioner.Resources {
 func (st *mockState) IsController() bool {
 	st.MethodCall(st, "IsController")
 	return st.isController
+}
+
+func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	st.MethodCall(st, "WatchAPIHostPortsForAgents")
+	return st.apiHostPortsForAgentsWatcher
 }
 
 type mockResources struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -236,11 +236,12 @@ func (a *API) watchProvisioningInfo(appName names.ApplicationTag) (params.Notify
 		return result, errors.Trace(err)
 	}
 
-	modelConfigWatcher := model.WatchForModelConfigChanges()
 	appWatcher := app.Watch()
 	controllerConfigWatcher := a.ctrlSt.WatchControllerConfig()
+	controllerAPIHostPortsWatcher := a.ctrlSt.WatchAPIHostPortsForAgents()
+	modelConfigWatcher := model.WatchForModelConfigChanges()
 
-	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, modelConfigWatcher)
+	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, controllerAPIHostPortsWatcher, modelConfigWatcher)
 
 	if _, ok := <-multiWatcher.Changes(); ok {
 		result.NotifyWatcherId = a.resources.Register(multiWatcher)

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -142,6 +142,44 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoPendingCharmError(
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, `charm "ch:gitlab" pending not provisioned`)
 }
 
+func (s *CAASApplicationProvisionerSuite) TestWatchProvisioningInfo(c *gc.C) {
+	appChanged := make(chan struct{}, 1)
+	portsChanged := make(chan struct{}, 1)
+	modelConfigChanged := make(chan struct{}, 1)
+	controllerConfigChanged := make(chan struct{}, 1)
+	s.st.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(portsChanged)
+	s.st.model.state.controllerConfigWatcher = statetesting.NewMockNotifyWatcher(controllerConfigChanged)
+	s.st.model.modelConfigChanges = statetesting.NewMockNotifyWatcher(modelConfigChanged)
+	s.st.app = &mockApplication{
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
+		watcher: statetesting.NewMockNotifyWatcher(appChanged),
+	}
+	appChanged <- struct{}{}
+	portsChanged <- struct{}{}
+	modelConfigChanged <- struct{}{}
+	controllerConfigChanged <- struct{}{}
+
+	results, err := s.api.WatchProvisioningInfo(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "application-gitlab"},
+		},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	res := s.resources.Get("1")
+	c.Assert(res, gc.FitsTypeOf, (*common.MultiNotifyWatcher)(nil))
+}
+
 func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 	s.st.app = &mockApplication{
 		life: state.Alive,

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -17,14 +17,17 @@ import (
 )
 
 type mockModel struct {
-	password string
-	tag      names.Tag
+	password           string
+	tag                names.Tag
+	modelConfigChanged state.NotifyWatcher
 }
 
 type mockState struct {
 	common.APIAddressAccessor
-	operatorRepo string
-	model        *mockModel
+	operatorRepo                 string
+	model                        *mockModel
+	controllerConfigWatcher      state.NotifyWatcher
+	apiHostPortsForAgentsWatcher state.NotifyWatcher
 }
 
 func newMockState() *mockState {
@@ -60,6 +63,14 @@ func (st *mockState) Model() (caasmodeloperator.Model, error) {
 	return st.model, nil
 }
 
+func (m *mockState) WatchControllerConfig() state.NotifyWatcher {
+	return m.controllerConfigWatcher
+}
+
+func (m *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
+	return m.apiHostPortsForAgentsWatcher
+}
+
 func (m *mockModel) Tag() names.Tag {
 	return m.tag
 }
@@ -78,4 +89,8 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	attrs["operator-storage"] = "k8s-storage"
 	attrs["agent-version"] = "2.6-beta3"
 	return config.New(config.UseDefaults, attrs)
+}
+
+func (m *mockModel) WatchForModelConfigChanges() state.NotifyWatcher {
+	return m.modelConfigChanged
 }

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state/watcher"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasmodeloperator")
@@ -30,6 +31,8 @@ type API struct {
 	auth      facade.Authorizer
 	ctrlState CAASControllerState
 	state     CAASModelOperatorState
+
+	resources facade.Resources
 }
 
 // NewAPI is alternative means of constructing a controller model facade.
@@ -49,7 +52,33 @@ func NewAPI(
 		PasswordChanger: common.NewPasswordChanger(st, common.AuthFuncForTagKind(names.ModelTagKind)),
 		ctrlState:       ctrlSt,
 		state:           st,
+		resources:       resources,
 	}, nil
+}
+
+// WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the
+// information returned by ModelOperatorProvisioningInfo.
+func (a *API) WatchModelOperatorProvisioningInfo() (params.NotifyWatchResult, error) {
+	result := params.NotifyWatchResult{}
+
+	model, err := a.state.Model()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	controllerConfigWatcher := a.ctrlState.WatchControllerConfig()
+	controllerAPIHostPortsWatcher := a.ctrlState.WatchAPIHostPortsForAgents()
+	modelConfigWatcher := model.WatchForModelConfigChanges()
+
+	multiWatcher := common.NewMultiNotifyWatcher(controllerConfigWatcher, controllerAPIHostPortsWatcher, modelConfigWatcher)
+
+	if _, ok := <-multiWatcher.Changes(); ok {
+		result.NotifyWatcherId = a.resources.Register(multiWatcher)
+	} else {
+		return result, watcher.EnsureErr(multiWatcher)
+	}
+
+	return result, nil
 }
 
 // ModelOperatorProvisioningInfo returns the information needed for provisioning

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasmodeloperator"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloudconfig/podcfg"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -76,4 +77,23 @@ func (m *ModelOperatorSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 
 	c.Assert(vers, jc.DeepEquals, info.Version)
+}
+
+func (m *ModelOperatorSuite) TestWatchProvisioningInfo(c *gc.C) {
+	controllerConfigChanged := make(chan struct{}, 1)
+	modelConfigChanged := make(chan struct{}, 1)
+	apiHostPortsForAgentsChanged := make(chan struct{}, 1)
+	m.state.controllerConfigWatcher = statetesting.NewMockNotifyWatcher(controllerConfigChanged)
+	m.state.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(apiHostPortsForAgentsChanged)
+	m.state.model.modelConfigChanged = statetesting.NewMockNotifyWatcher(modelConfigChanged)
+
+	controllerConfigChanged <- struct{}{}
+	apiHostPortsForAgentsChanged <- struct{}{}
+	modelConfigChanged <- struct{}{}
+
+	results, err := m.api.WatchModelOperatorProvisioningInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Error, gc.IsNil)
+	res := m.resources.Get("1")
+	c.Assert(res, gc.FitsTypeOf, (*common.MultiNotifyWatcher)(nil))
 }

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -25,10 +25,12 @@ type CAASModelOperatorState interface {
 type CAASControllerState interface {
 	common.APIAddressAccessor
 	ControllerConfig() (controller.Config, error)
+	WatchControllerConfig() state.NotifyWatcher
 }
 
 type Model interface {
 	ModelConfig() (*config.Config, error)
+	WatchForModelConfigChanges() state.NotifyWatcher
 }
 
 type stateShim struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10365,6 +10365,15 @@
                         }
                     },
                     "description": "WatchAPIHostPorts watches the API server addresses."
+                },
+                "WatchModelOperatorProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    },
+                    "description": "WatchModelOperatorProvisioningInfo provides a watcher for changes that affect the\ninformation returned by ModelOperatorProvisioningInfo."
                 }
             },
             "definitions": {

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -6,6 +6,7 @@ package unit_test
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -22,7 +23,9 @@ import (
 	utilsmocks "github.com/juju/juju/cmd/containeragent/utils/mocks"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	jnames "github.com/juju/juju/juju/names"
+	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 )
 
@@ -199,6 +202,55 @@ func (s *containerUnitAgentSuite) TestChangeConfig(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for config changed signal")
 	}
+}
+
+func (s *containerUnitAgentSuite) TestEnsureAgentConf(c *gc.C) {
+	dataDir := c.MkDir()
+	params := agent.AgentConfigParams{
+		Paths: agent.Paths{
+			DataDir: dataDir,
+		},
+		Tag:                    names.NewUnitTag("app/0"),
+		UpgradedToVersion:      jujuversion.Current,
+		Password:               "password",
+		CACert:                 "cacert",
+		APIAddresses:           []string{"localhost:1235"},
+		Nonce:                  "nonce",
+		Controller:             testing.ControllerTag,
+		Model:                  testing.ModelTag,
+		AgentLogfileMaxSizeMB:  150,
+		AgentLogfileMaxBackups: 4,
+	}
+	templateConfig, err := agent.NewAgentConfig(params)
+	c.Assert(err, jc.ErrorIsNil)
+	templateBytes, err := templateConfig.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	err = os.WriteFile(path.Join(dataDir, "template-agent.conf"), templateBytes, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ac := agentconf.NewAgentConf(dataDir)
+	err = unit.EnsureAgentConf(ac)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the agent.conf was seeded from the template-agent.conf.
+	agentConfBytes, err := os.ReadFile(path.Join(dataDir, "agents", "unit-app-0", "agent.conf"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(agentConfBytes), gc.Equals, string(templateBytes))
+
+	// Change the agent.conf to be different than the template-agent.conf
+	c.Assert(ac.CurrentConfig().OldPassword(), gc.Equals, "password")
+	err = ac.ChangeConfig(func(cs agent.ConfigSetter) error {
+		cs.SetOldPassword("password2")
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ac.CurrentConfig().OldPassword(), gc.Equals, "password2")
+
+	// Start a new "agent" and make sure it has password2.
+	ac2 := agentconf.NewAgentConf(dataDir)
+	err = unit.EnsureAgentConf(ac2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ac2.CurrentConfig().OldPassword(), gc.Equals, "password2")
 }
 
 type FakeConfig struct {

--- a/cmd/containeragent/unit/export_test.go
+++ b/cmd/containeragent/unit/export_test.go
@@ -58,3 +58,7 @@ func (c *containerUnitAgent) GetContainerNames() []string {
 func (c *containerUnitAgent) DataDir() string {
 	return c.AgentConf.DataDir()
 }
+
+func EnsureAgentConf(ac agentconf.AgentConf) error {
+	return ensureAgentConf(ac)
+}

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -75,7 +75,7 @@ var allowedCalls = map[string]set.Strings{
 }
 
 var ignoredPackages = set.NewStrings(
-	"jujuc", "jujud", "ks8agent", "juju-bridge", "service")
+	"jujuc", "jujud", "containeragent", "juju-bridge", "service")
 
 type OSCallTest struct{}
 

--- a/worker/caasmodeloperator/modeloperator_test.go
+++ b/worker/caasmodeloperator/modeloperator_test.go
@@ -4,20 +4,25 @@
 package caasmodeloperator_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	modeloperatorapi "github.com/juju/juju/api/controller/caasmodeloperator"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/worker/caasmodeloperator"
 )
 
 type dummyAPI struct {
-	provInfo    func() (modeloperatorapi.ModelOperatorProvisioningInfo, error)
-	setPassword func(password string) error
+	provInfo      func() (modeloperatorapi.ModelOperatorProvisioningInfo, error)
+	setPassword   func(password string) error
+	watchProvInfo func() (watcher.NotifyWatcher, error)
 }
 
 type dummyBroker struct {
@@ -58,6 +63,13 @@ func (a *dummyAPI) ModelOperatorProvisioningInfo() (modeloperatorapi.ModelOperat
 	return a.provInfo()
 }
 
+func (a *dummyAPI) WatchModelOperatorProvisioningInfo() (watcher.NotifyWatcher, error) {
+	if a.watchProvInfo == nil {
+		return watcher.NewMultiNotifyWatcher(), nil
+	}
+	return a.watchProvInfo()
+}
+
 func (a *dummyAPI) SetPassword(p string) error {
 	if a.setPassword == nil {
 		return nil
@@ -65,32 +77,68 @@ func (a *dummyAPI) SetPassword(p string) error {
 	return a.setPassword(p)
 }
 
-func (m *ModelOperatorManagerSuite) TestModelOperatorManagerConstruction(c *gc.C) {
+func (m *ModelOperatorManagerSuite) TestModelOperatorManagerApplying(c *gc.C) {
+	const n = 3
 	var (
-		apiAddresses = []string{"fe80:abcd::1"}
-		apiCalled    = false
-		brokerCalled = false
-		imagePath    = "juju/jujud:1"
+		iteration = 0 // ... n
+
+		apiAddresses = [n][]string{{"fe80:abcd::1"}, {"fe80:abcd::2"}, {"fe80:abcd::3"}}
+		imagePath    = [n]string{"juju/jujud:1", "juju/jujud:2", "juju/jujud:3"}
 		modelUUID    = "deadbeef-0bad-400d-8000-4b1d0d06f00d"
-		ver          = version.MustParse("2.8.2")
+		ver          = [n]version.Number{version.MustParse("2.8.2"), version.MustParse("2.9.1"), version.MustParse("2.9.99")}
+
+		password   = ""
+		lastConfig = (*caas.ModelOperatorConfig)(nil)
 	)
 
+	changed := make(chan struct{})
 	api := &dummyAPI{
 		provInfo: func() (modeloperatorapi.ModelOperatorProvisioningInfo, error) {
-			apiCalled = true
 			return modeloperatorapi.ModelOperatorProvisioningInfo{
-				APIAddresses: apiAddresses,
-				ImageDetails: resources.DockerImageDetails{RegistryPath: imagePath},
-				Version:      ver,
+				APIAddresses: apiAddresses[iteration],
+				ImageDetails: resources.DockerImageDetails{RegistryPath: imagePath[iteration]},
+				Version:      ver[iteration],
 			}, nil
+		},
+		watchProvInfo: func() (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(changed), nil
 		},
 	}
 
 	broker := &dummyBroker{
 		ensureModelOperator: func(_, _ string, conf *caas.ModelOperatorConfig) error {
-			c.Assert(conf.ImageDetails.RegistryPath, gc.Equals, imagePath)
-			brokerCalled = true
+			defer func() {
+				iteration++
+			}()
+			lastConfig = conf
+
+			c.Check(conf.ImageDetails.RegistryPath, gc.Equals, imagePath[iteration])
+
+			ac, err := agent.ParseConfigData(conf.AgentConf)
+			c.Check(err, jc.ErrorIsNil)
+			if err != nil {
+				return err
+			}
+			addresses, _ := ac.APIAddresses()
+			c.Check(addresses, gc.DeepEquals, apiAddresses[iteration])
+			c.Check(ac.UpgradedToVersion(), gc.Equals, ver[iteration])
+
+			if password == "" {
+				password = ac.OldPassword()
+			}
+			c.Check(ac.OldPassword(), gc.Equals, password)
+			c.Check(ac.OldPassword(), gc.HasLen, 24)
+
 			return nil
+		},
+		modelOperatorExists: func() (bool, error) {
+			return iteration > 0, nil
+		},
+		modelOperator: func() (*caas.ModelOperatorConfig, error) {
+			if iteration == 0 {
+				return nil, errors.NotFoundf("model operator")
+			}
+			return lastConfig, nil
 		},
 	}
 
@@ -98,10 +146,13 @@ func (m *ModelOperatorManagerSuite) TestModelOperatorManagerConstruction(c *gc.C
 		api, broker, modelUUID, &mockAgentConfig{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	for i := 0; i < n; i++ {
+		changed <- struct{}{}
+	}
+
 	worker.Kill()
 	err = worker.Wait()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(apiCalled, gc.Equals, true)
-	c.Assert(brokerCalled, gc.Equals, true)
+	c.Assert(iteration, gc.Equals, n)
 }


### PR DESCRIPTION
Forward ports:
- #16302
- #16325 

Conflicts:
- apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
- apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go