### PR TITLE
Use `sudo` in `make k3s-operator-update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -536,7 +536,7 @@ microk8s-operator-update: host-install operator-image
 .PHONY: k3s-operator-update
 k3s-operator-update: host-install operator-image
 ## k3s-operator-update: Push up the newly built operator image for use with k3s
-	docker save "$(shell ${OPERATOR_IMAGE_PATH})" | k3s ctr images import -
+	docker save "$(shell ${OPERATOR_IMAGE_PATH})" | sudo k3s ctr images import -
 
 .PHONY: check-k8s-model
 check-k8s-model:


### PR DESCRIPTION
Root is needed to access the containerd socket for k3s.
```console
$ stat /run/k3s/containerd/containerd.sock
  File: /run/k3s/containerd/containerd.sock
  Size: 0         	Blocks: 0          IO Block: 4096   socket
Device: 19h/25d	Inode: 2216        Links: 1
Access: (0660/srw-rw----)  Uid: (    0/    root)   Gid: (    0/    root)

```