### PR TITLE
Fix deploy bundle integ test

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,4 +1,4 @@
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   influxdb:
     charm: influxdb

--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -1,4 +1,4 @@
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   influxdb:
     charm: influxdb


### PR DESCRIPTION
In this test we compare an exported bundle to a hardcoded bundle. However, we recently changed how bundles export (series -> base)

Reflect this change in these bundles

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
./main.sh -v -c aws -p ec2 deploy test_deploy_bundles
```