### PR TITLE
Fix debug-hooks/debug-code commands on k8s and fix tmux sessions.

### DIFF
--- a/.github/verify-agent-version.sh
+++ b/.github/verify-agent-version.sh
@@ -2,10 +2,16 @@
 
 set -euxo pipefail
 
-target_version="$1"
+model_type="$1"
+target_version="$2"
 attempt=0
 while true; do
-  UPDATED=$((juju show-controller --format=json || echo "") | jq -r '.c.details."agent-version"')
+  if [[ "$model_type" == "iaas" ]]; then
+    UPDATED=$( (juju ssh -mcontroller 0 sudo cat /var/lib/juju/agents/machine-0/agent.conf || echo "") | yq -r '.upgradedToVersion' )
+  elif [[ "$model_type" == "caas" ]]; then
+    UPDATED=$( (juju ssh -mcontroller --container api-server 0 cat /var/lib/juju/agents/controller-0/agent.conf || echo "") | yq -r '.upgradedToVersion' )
+  fi
+
   if [[ $UPDATED == $target_version* ]]; then
       break
   fi

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -41,6 +41,7 @@ jobs:
       shell: bash
       run: |
         (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,6 +46,7 @@ jobs:
       shell: bash
       run: |
         (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json ".insecure-registries += [\"${DOCKER_REGISTRY}\"]" | sudo tee /etc/docker/daemon.json
+          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json ".insecure-registries += [\"10.0.1.123\",\"${DOCKER_REGISTRY}\"]" | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker system info
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -278,10 +278,10 @@ jobs:
           
           # Upgrade to the latest stable.
           juju upgrade-controller --debug
-          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh iaas $CURRENT_STABLE_JUJU_TAG
           
           juju upgrade-controller --build-agent --debug
-          $GITHUB_WORKSPACE/.github/verify-agent-version.sh "${UPSTREAM_JUJU_TAG}.1"
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh iaas "${UPSTREAM_JUJU_TAG}.1"
           
           PANIC=$(juju debug-log --replay --no-tail -m controller | grep "panic" || true)
           if [ "$PANIC" != "" ]; then
@@ -303,11 +303,11 @@ jobs:
           
           # Upgrade to the latest stable.
           juju upgrade-controller --debug
-          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $CURRENT_STABLE_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh caas $CURRENT_STABLE_JUJU_TAG
           
           # Upgrade to local built version.
           juju upgrade-controller --agent-stream=develop --debug
-          $GITHUB_WORKSPACE/.github/verify-agent-version.sh $UPSTREAM_JUJU_TAG
+          $GITHUB_WORKSPACE/.github/verify-agent-version.sh caas $UPSTREAM_JUJU_TAG
           
           PANIC=$(juju debug-log --replay --no-tail -m controller | grep "panic" || true)
           if [ "$PANIC" != "" ]; then

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -230,12 +230,9 @@ func (c *debugHooksCommand) getValidHooks(ch charm.Charm) (set.Strings, error) {
 
 func (c *debugHooksCommand) decideEntryPoint(ctx *cmd.Context) string {
 	if c.modelType == model.CAAS {
-		c.provider.setArgs([]string{"which", "sudo"})
-		if err := c.sshCommand.Run(ctx); err != nil {
-			return "/bin/bash -c '%s'"
-		}
+		return "exec /bin/bash -c '%s'"
 	}
-	return "sudo /bin/bash -c '%s'"
+	return "exec sudo /bin/bash -c '%s'"
 }
 
 // commonRun is shared between debugHooks and debugCode
@@ -265,7 +262,7 @@ func (c *debugHooksCommand) commonRun(
 	debugctx := unitdebug.NewHooksContext(resolvedTargetName)
 	clientScript := unitdebug.ClientScript(debugctx, hooks, debugAt)
 	b64Script := base64.StdEncoding.EncodeToString([]byte(clientScript))
-	innercmd := fmt.Sprintf(`F=$(mktemp); echo %s | base64 -d > $F; . $F`, b64Script)
+	innercmd := fmt.Sprintf(`F=$(mktemp); echo %s | base64 -d > $F; chmod +x $F; exec $F`, b64Script)
 	args := []string{fmt.Sprintf(c.decideEntryPoint(ctx), innercmd)}
 	c.provider.setArgs(args)
 	return c.sshCommand.Run(ctx)

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -47,7 +47,7 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		args:            "ubuntu@0.public sudo /bin/bash -c 'F=$(mktemp); echo IyEvYmluL2Jhc2gKKApjbGVhbnVwX29uX2V4aXQoKSAKeyAKCWVjaG8gIkNsZWFuaW5nIHVwIHRoZSBkZWJ1ZyBzZXNzaW9uIgoJdG11eCBraWxsLXNlc3Npb24gLXQgbXlzcWwvMDsgCn0KdHJhcCBjbGVhbnVwX29uX2V4aXQgRVhJVAoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1ZyBsb2NrZmlsZS4KZmxvY2sgLW4gOCB8fCAoCgllY2hvICJGb3VuZCBleGlzdGluZyBkZWJ1ZyBzZXNzaW9ucywgYXR0ZW1wdGluZyB0byByZWNvbm5lY3QiIDI+JjEKCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCBteXNxbC8wCglleGl0ICQ/CgkpCigKIyBDbG9zZSB0aGUgaW5oZXJpdGVkIGxvY2sgRkQsIG9yIHRtdXggd2lsbCBrZWVwIGl0IG9wZW4uCmV4ZWMgOD4mLQoKIyBXcml0ZSBvdXQgdGhlIGRlYnVnLWhvb2tzIGFyZ3MuCmVjaG8gImUzMEsiIHwgYmFzZTY0IC1kID4gL3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1Zy1leGl0IGxvY2tmaWxlLgpmbG9jayAtbiA5IHx8IGV4aXQgMQoKIyBXYWl0IGZvciB0bXV4IHRvIGJlIGluc3RhbGxlZC4Kd2hpbGUgWyAhIC1mIC91c3IvYmluL3RtdXggXTsgZG8KICAgIHNsZWVwIDEKZG9uZQoKaWYgWyAhIC1mIH4vLnRtdXguY29uZiBdOyB0aGVuCiAgICAgICAgaWYgWyAtZiAvdXNyL3NoYXJlL2J5b2J1L3Byb2ZpbGVzL3RtdXggXTsgdGhlbgogICAgICAgICAgICAgICAgIyBVc2UgYnlvYnUvdG11eCBwcm9maWxlIGZvciBmYW1pbGlhciBrZXliaW5kaW5ncyBhbmQgYnJhbmRpbmcKICAgICAgICAgICAgICAgIGVjaG8gInNvdXJjZS1maWxlIC91c3Ivc2hhcmUvYnlvYnUvcHJvZmlsZXMvdG11eCIgPiB+Ly50bXV4LmNvbmYKICAgICAgICBlbHNlCiAgICAgICAgICAgICAgICAjIE90aGVyd2lzZSwgdXNlIHRoZSBsZWdhY3kganVqdS90bXV4IGNvbmZpZ3VyYXRpb24KICAgICAgICAgICAgICAgIGNhdCA+IH4vLnRtdXguY29uZiA8PEVORAogICAgICAgICAgICAgICAgCiMgU3RhdHVzIGJhcgpzZXQtb3B0aW9uIC1nIHN0YXR1cy1iZyBibGFjawpzZXQtb3B0aW9uIC1nIHN0YXR1cy1mZyB3aGl0ZQoKc2V0LXdpbmRvdy1vcHRpb24gLWcgd2luZG93LXN0YXR1cy1jdXJyZW50LWJnIHJlZApzZXQtd2luZG93LW9wdGlvbiAtZyB3aW5kb3ctc3RhdHVzLWN1cnJlbnQtYXR0ciBicmlnaHQKCnNldC1vcHRpb24gLWcgc3RhdHVzLXJpZ2h0ICcnCgojIFBhbmVzCnNldC1vcHRpb24gLWcgcGFuZS1ib3JkZXItZmcgd2hpdGUKc2V0LW9wdGlvbiAtZyBwYW5lLWFjdGl2ZS1ib3JkZXItZmcgd2hpdGUKCiMgTW9uaXRvciBhY3Rpdml0eSBvbiB3aW5kb3dzCnNldC13aW5kb3ctb3B0aW9uIC1nIG1vbml0b3ItYWN0aXZpdHkgb24KCiMgU2NyZWVuIGJpbmRpbmdzLCBzaW5jZSBwZW9wbGUgYXJlIG1vcmUgZmFtaWxpYXIgd2l0aCB0aGF0LgpzZXQtb3B0aW9uIC1nIHByZWZpeCBDLWEKYmluZCBDLWEgbGFzdC13aW5kb3cKYmluZCBhIHNlbmQta2V5IEMtYQoKYmluZCB8IHNwbGl0LXdpbmRvdyAtaApiaW5kIC0gc3BsaXQtd2luZG93IC12CgojIEZpeCBDVFJMLVBHVVAvUEdET1dOIGZvciB2aW0Kc2V0LXdpbmRvdy1vcHRpb24gLWcgeHRlcm0ta2V5cyBvbgoKIyBQcmV2ZW50IEVTQyBrZXkgZnJvbSBhZGRpbmcgZGVsYXkgYW5kIGJyZWFraW5nIFZpbSdzIEVTQyA+IGFycm93IGtleQpzZXQtb3B0aW9uIC1zIGVzY2FwZS10aW1lIDAKCkVORAogICAgICAgIGZpCmZpCgooCiAgICAjIENsb3NlIHRoZSBpbmhlcml0ZWQgbG9jayBGRCwgb3IgdG11eCB3aWxsIGtlZXAgaXQgb3Blbi4KICAgIGV4ZWMgOT4mLQogICAgaWYgISB0bXV4IGhhcy1zZXNzaW9uIC10IG15c3FsLzA7IHRoZW4KCQl0bXV4IG5ldy1zZXNzaW9uIC1kIC1zIG15c3FsLzAKCWZpCgljbGllbnRfY291bnQ9JCh0bXV4IGxpc3QtY2xpZW50cyB8IHdjIC1sKQoJaWYgWyAkY2xpZW50X2NvdW50IC1nZSAxIF07IHRoZW4KCQlzZXNzaW9uX25hbWU9bXlzcWwvMCItIiRjbGllbnRfY250CgkJZXhlYyB0bXV4IG5ldy1zZXNzaW9uIC1kIC10IG15c3FsLzAgLXMgJHNlc3Npb25fbmFtZQoJCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCAkc2Vzc2lvbl9uYW1lIFw7IHNldC1vcHRpb24gZGVzdHJveS11bmF0dGFjaGVkCgllbHNlCgkgICAgZXhlYyB0bXV4IGF0dGFjaC1zZXNzaW9uIC10IG15c3FsLzAKCWZpCikKKSA5Pi90bXAvanVqdS11bml0LW15c3FsLTAtZGVidWctaG9va3MtZXhpdAopIDg+L3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwpleGl0ICQ/Cg== | base64 -d > $F; . $F'",
+		args:            "ubuntu@0.public exec sudo /bin/bash -c 'F=$(mktemp); echo IyEvYmluL2Jhc2gKKApjbGVhbnVwX29uX2V4aXQoKSAKeyAKCWVjaG8gIkNsZWFuaW5nIHVwIHRoZSBkZWJ1ZyBzZXNzaW9uIgoJdG11eCBraWxsLXNlc3Npb24gLXQgbXlzcWwvMDsgCn0KdHJhcCBjbGVhbnVwX29uX2V4aXQgRVhJVAoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1ZyBsb2NrZmlsZS4KZmxvY2sgLW4gOCB8fCAoCgllY2hvICJGb3VuZCBleGlzdGluZyBkZWJ1ZyBzZXNzaW9ucywgYXR0ZW1wdGluZyB0byByZWNvbm5lY3QiIDI+JjEKCWV4ZWMgdG11eCBhdHRhY2gtc2Vzc2lvbiAtdCBteXNxbC8wCglleGl0ICQ/CgkpCigKIyBDbG9zZSB0aGUgaW5oZXJpdGVkIGxvY2sgRkQsIG9yIHRtdXggd2lsbCBrZWVwIGl0IG9wZW4uCmV4ZWMgOD4mLQoKIyBXcml0ZSBvdXQgdGhlIGRlYnVnLWhvb2tzIGFyZ3MuCmVjaG8gImUzMEsiIHwgYmFzZTY0IC1kID4gL3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcwoKIyBMb2NrIHRoZSBqdWp1LTx1bml0Pi1kZWJ1Zy1leGl0IGxvY2tmaWxlLgpmbG9jayAtbiA5IHx8IGV4aXQgMQoKIyBXYWl0IGZvciB0bXV4IHRvIGJlIGluc3RhbGxlZC4Kd2hpbGUgWyAhIC1mIC91c3IvYmluL3RtdXggXTsgZG8KICAgIHNsZWVwIDEKZG9uZQoKaWYgWyAhIC1mIH4vLnRtdXguY29uZiBdOyB0aGVuCglpZiBbIC1mIC91c3Ivc2hhcmUvYnlvYnUvcHJvZmlsZXMvdG11eCBdOyB0aGVuCgkJIyBVc2UgYnlvYnUvdG11eCBwcm9maWxlIGZvciBmYW1pbGlhciBrZXliaW5kaW5ncyBhbmQgYnJhbmRpbmcKCQllY2hvICJzb3VyY2UtZmlsZSAvdXNyL3NoYXJlL2J5b2J1L3Byb2ZpbGVzL3RtdXgiID4gfi8udG11eC5jb25mCgllbHNlCgkJIyBPdGhlcndpc2UsIHVzZSB0aGUgbGVnYWN5IGp1anUvdG11eCBjb25maWd1cmF0aW9uCgkJY2F0ID4gfi8udG11eC5jb25mIDw8RU5ECgojIFN0YXR1cyBiYXIKc2V0LW9wdGlvbiAtZyBzdGF0dXMtYmcgYmxhY2sKc2V0LW9wdGlvbiAtZyBzdGF0dXMtZmcgd2hpdGUKCnNldC13aW5kb3ctb3B0aW9uIC1nIHdpbmRvdy1zdGF0dXMtY3VycmVudC1iZyByZWQKc2V0LXdpbmRvdy1vcHRpb24gLWcgd2luZG93LXN0YXR1cy1jdXJyZW50LWF0dHIgYnJpZ2h0CgpzZXQtb3B0aW9uIC1nIHN0YXR1cy1yaWdodCAnJwoKIyBQYW5lcwpzZXQtb3B0aW9uIC1nIHBhbmUtYm9yZGVyLWZnIHdoaXRlCnNldC1vcHRpb24gLWcgcGFuZS1hY3RpdmUtYm9yZGVyLWZnIHdoaXRlCgojIE1vbml0b3IgYWN0aXZpdHkgb24gd2luZG93cwpzZXQtd2luZG93LW9wdGlvbiAtZyBtb25pdG9yLWFjdGl2aXR5IG9uCgojIFNjcmVlbiBiaW5kaW5ncywgc2luY2UgcGVvcGxlIGFyZSBtb3JlIGZhbWlsaWFyIHdpdGggdGhhdC4Kc2V0LW9wdGlvbiAtZyBwcmVmaXggQy1hCmJpbmQgQy1hIGxhc3Qtd2luZG93CmJpbmQgYSBzZW5kLWtleSBDLWEKCmJpbmQgfCBzcGxpdC13aW5kb3cgLWgKYmluZCAtIHNwbGl0LXdpbmRvdyAtdgoKIyBGaXggQ1RSTC1QR1VQL1BHRE9XTiBmb3IgdmltCnNldC13aW5kb3ctb3B0aW9uIC1nIHh0ZXJtLWtleXMgb24KCiMgUHJldmVudCBFU0Mga2V5IGZyb20gYWRkaW5nIGRlbGF5IGFuZCBicmVha2luZyBWaW0ncyBFU0MgPiBhcnJvdyBrZXkKc2V0LW9wdGlvbiAtcyBlc2NhcGUtdGltZSAwCgpFTkQKCWZpCmZpCgooCiAgICAjIENsb3NlIHRoZSBpbmhlcml0ZWQgbG9jayBGRCwgb3IgdG11eCB3aWxsIGtlZXAgaXQgb3Blbi4KICAgIGV4ZWMgOT4mLQoJIyBTaW5jZSB3ZSBqdXN0IHVzZSBieW9idSB0bXV4IGNvbmZpZ3Mgd2l0aG91dCBieW9idS10bXV4LCB3ZSBuZWVkCgkjIHRvIGV4cG9ydCB0aGlzIHRvIHByZXZlbnQgdGhlIFRFUk0gYmVpbmcgc2V0IHRvIGVtcHR5IHN0cmluZy4KCWV4cG9ydCBCWU9CVV9URVJNPSRURVJNCiAgICBpZiAhIHRtdXggaGFzLXNlc3Npb24gLXQgbXlzcWwvMDsgdGhlbgoJCXRtdXggbmV3LXNlc3Npb24gLWQgLXMgbXlzcWwvMAoJZmkKCWNsaWVudF9jb3VudD0kKHRtdXggbGlzdC1jbGllbnRzIHwgd2MgLWwpCglpZiBbICRjbGllbnRfY291bnQgLWdlIDEgXTsgdGhlbgoJCXNlc3Npb25fbmFtZT1teXNxbC8wIi0iJGNsaWVudF9jb3VudAoJCXRtdXggbmV3LXNlc3Npb24gLWQgLXQgbXlzcWwvMCAtcyAkc2Vzc2lvbl9uYW1lCgkJZXhlYyB0bXV4IGF0dGFjaC1zZXNzaW9uIC10ICRzZXNzaW9uX25hbWUgXDsgc2V0LW9wdGlvbiBkZXN0cm95LXVuYXR0YWNoZWQKCWVsc2UKCSAgICBleGVjIHRtdXggYXR0YWNoLXNlc3Npb24gLXQgbXlzcWwvMAoJZmkKKQopIDk+L3RtcC9qdWp1LXVuaXQtbXlzcWwtMC1kZWJ1Zy1ob29rcy1leGl0CikgOD4vdG1wL2p1anUtdW5pdC1teXNxbC0wLWRlYnVnLWhvb2tzCmV4aXQgJD8K | base64 -d > $F; chmod +x $F; exec $F'",
 	},
 }, {
 	info:        "unit name without hook (api v1)",
@@ -57,7 +57,7 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		argsMatch:       `ubuntu@0\.public sudo /bin/bash .+`,
+		argsMatch:       `ubuntu@0\.public exec sudo /bin/bash .+`,
 	},
 }, {
 	info:        "unit name without hook (api v2)",
@@ -67,7 +67,7 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
-		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
 	info:        "proxy (api v1)",
@@ -78,7 +78,7 @@ var debugHooksTests = []struct {
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
 		withProxy:       true,
-		argsMatch:       `ubuntu@0\.private sudo /bin/bash .+`,
+		argsMatch:       `ubuntu@0\.private exec sudo /bin/bash .+`,
 	},
 }, {
 	info:        "proxy (api v2)",
@@ -89,7 +89,7 @@ var debugHooksTests = []struct {
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
 		withProxy:       true,
-		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
 	info:        "pty enabled",
@@ -100,7 +100,7 @@ var debugHooksTests = []struct {
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
 		enablePty:       true,
-		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) sudo .+`, // can be any of the 3
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
 	info:        `"*" is a valid hook name: it means hook everything`,

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -361,10 +361,16 @@ type Context interface {
 func (c *sshContainer) ssh(ctx Context, enablePty bool, target *resolvedTarget) (err error) {
 	args := c.args
 	if len(args) == 0 {
-		args = []string{"sh"}
+		args = []string{"exec", "sh"}
 	}
 	cancel, stop := getInterruptAbortChan(ctx)
 	defer stop()
+	var env []string
+	if enablePty {
+		if term := os.Getenv("TERM"); term != "" {
+			env = append(env, "TERM="+term)
+		}
+	}
 	return c.execClient.Exec(
 		k8sexec.ExecParams{
 			PodName:       target.entity,
@@ -374,6 +380,7 @@ func (c *sshContainer) ssh(ctx Context, enablePty bool, target *resolvedTarget) 
 			Stderr:        ctx.GetStderr(),
 			Stdin:         ctx.GetStdin(),
 			TTY:           enablePty,
+			Env:           env,
 		},
 		cancel,
 	)

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -508,15 +508,20 @@ func (s *sshContainerSuite) TestSSHNoContainerSpecified(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(k8sexec.ExecParams{
-			PodName:  "mariadb-k8s-0",
-			Commands: []string{"bash"},
-			TTY:      true,
-			Stdout:   buffer,
-			Stderr:   buffer,
-			Stdin:    buffer,
-		}, gomock.Any()).
-			Return(nil),
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+				mc := jc.NewMultiChecker()
+				mc.AddExpr(`_.Env`, jc.Ignore)
+				c.Check(arg, mc, k8sexec.ExecParams{
+					PodName:  "mariadb-k8s-0",
+					Commands: []string{"bash"},
+					TTY:      true,
+					Stdout:   buffer,
+					Stderr:   buffer,
+					Stdin:    buffer,
+				})
+				return nil
+			}),
 		ctx.EXPECT().StopInterruptNotify(gomock.Any()),
 	)
 
@@ -540,16 +545,21 @@ func (s *sshContainerSuite) TestSSHWithContainerSpecified(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(k8sexec.ExecParams{
-			PodName:       "mariadb-k8s-0",
-			ContainerName: "container1",
-			Commands:      []string{"bash"},
-			TTY:           true,
-			Stdout:        buffer,
-			Stderr:        buffer,
-			Stdin:         buffer,
-		}, gomock.Any()).
-			Return(nil),
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+				mc := jc.NewMultiChecker()
+				mc.AddExpr(`_.Env`, jc.Ignore)
+				c.Check(arg, mc, k8sexec.ExecParams{
+					PodName:       "mariadb-k8s-0",
+					ContainerName: "container1",
+					Commands:      []string{"bash"},
+					TTY:           true,
+					Stdout:        buffer,
+					Stderr:        buffer,
+					Stdin:         buffer,
+				})
+				return nil
+			}),
 		ctx.EXPECT().StopInterruptNotify(gomock.Any()),
 	)
 
@@ -577,15 +587,18 @@ func (s *sshContainerSuite) TestSSHCancelled(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(k8sexec.ExecParams{
-			PodName:  "mariadb-k8s-0",
-			Commands: []string{"bash"},
-			TTY:      true,
-			Stdout:   buffer,
-			Stderr:   buffer,
-			Stdin:    buffer,
-		}, gomock.Any()).DoAndReturn(
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+				mc := jc.NewMultiChecker()
+				mc.AddExpr(`_.Env`, jc.Ignore)
+				c.Check(arg, mc, k8sexec.ExecParams{
+					PodName:  "mariadb-k8s-0",
+					Commands: []string{"bash"},
+					TTY:      true,
+					Stdout:   buffer,
+					Stderr:   buffer,
+					Stdin:    buffer,
+				})
 				select {
 				case <-cancel:
 					return errors.New("cancelled")
@@ -843,4 +856,96 @@ func (s *sshContainerSuite) TestNamespaceControllerModel(c *gc.C) {
 	err := s.sshC.InitRun(mc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.sshC.Namespace(), gc.Equals, "controller-foobar")
+}
+
+func (s *sshContainerSuite) TestSSHWithTerm(c *gc.C) {
+	ctrl := s.setUpController(c, false, "")
+	ctx := mocks.NewMockContext(ctrl)
+	defer ctrl.Finish()
+
+	prevTerm, prevTermSet := os.LookupEnv("TERM")
+	os.Setenv("TERM", "foobar-256color")
+	s.AddCleanup(func(c *gc.C) {
+		if prevTermSet {
+			os.Setenv("TERM", prevTerm)
+		} else {
+			os.Unsetenv("TERM")
+		}
+	})
+
+	s.sshC.SetArgs([]string{"bash"})
+
+	buffer := bytes.NewBuffer(nil)
+
+	gomock.InOrder(
+		ctx.EXPECT().InterruptNotify(gomock.Any()),
+		ctx.EXPECT().GetStdout().Return(buffer),
+		ctx.EXPECT().GetStderr().Return(buffer),
+		ctx.EXPECT().GetStdin().Return(buffer),
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+				c.Check(arg, jc.DeepEquals, k8sexec.ExecParams{
+					PodName:  "mariadb-k8s-0",
+					Env:      []string{"TERM=foobar-256color"},
+					Commands: []string{"bash"},
+					TTY:      true,
+					Stdout:   buffer,
+					Stderr:   buffer,
+					Stdin:    buffer,
+				})
+				return nil
+			}),
+		ctx.EXPECT().StopInterruptNotify(gomock.Any()),
+	)
+
+	target := &commands.ResolvedTarget{}
+	target.SetEntity("mariadb-k8s-0")
+	err := s.sshC.SSH(ctx, true, target)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *sshContainerSuite) TestSSHWithTermNoTTY(c *gc.C) {
+	ctrl := s.setUpController(c, false, "")
+	ctx := mocks.NewMockContext(ctrl)
+	defer ctrl.Finish()
+
+	prevTerm, prevTermSet := os.LookupEnv("TERM")
+	os.Setenv("TERM", "foobar-256color")
+	s.AddCleanup(func(c *gc.C) {
+		if prevTermSet {
+			os.Setenv("TERM", prevTerm)
+		} else {
+			os.Unsetenv("TERM")
+		}
+	})
+
+	s.sshC.SetArgs([]string{"bash"})
+
+	buffer := bytes.NewBuffer(nil)
+
+	gomock.InOrder(
+		ctx.EXPECT().InterruptNotify(gomock.Any()),
+		ctx.EXPECT().GetStdout().Return(buffer),
+		ctx.EXPECT().GetStderr().Return(buffer),
+		ctx.EXPECT().GetStdin().Return(buffer),
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+				c.Check(arg, jc.DeepEquals, k8sexec.ExecParams{
+					PodName:  "mariadb-k8s-0",
+					Env:      nil,
+					Commands: []string{"bash"},
+					TTY:      false,
+					Stdout:   buffer,
+					Stderr:   buffer,
+					Stdin:    buffer,
+				})
+				return nil
+			}),
+		ctx.EXPECT().StopInterruptNotify(gomock.Any()),
+	)
+
+	target := &commands.ResolvedTarget{}
+	target.SetEntity("mariadb-k8s-0")
+	err := s.sshC.SSH(ctx, false, target)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -172,6 +172,9 @@ if [ -z "$JUJU_HOOK_NAME" ] ; then
 else
   window_name="$JUJU_HOOK_NAME"
 fi
+# Since we just use byobu tmux configs without byobu-tmux, we need
+# to export this to prevent the TERM being set to empty string.
+export BYOBU_TERM=$TERM
 tmux new-window -t $JUJU_UNIT_NAME -n $window_name "$JUJU_DEBUG/hook.sh"
 
 # If we exit for whatever reason, kill the hook shell.


### PR DESCRIPTION
Fixes ERROR EOF bug when using `juju debug-hooks` or `juju debug-code` by not trying to select for sudo on k8s since we don't need it.

Fixes `juju ssh` on k8s to correctly plumb through TERM from the client when using a pty. This is the same behaviour as openssh.

Fixes `juju debug-code` and `juju debug-hook` by correctly using TERM with tmux. Since byobu tmux was meant to be run via the `byobu-tmux`, it was expecting a `BYOBU_TERM` env variable, which was used to override tmux's term handling, it was being set to empty string causing a whole load of issues with some terminals. We need to re-asses the usage of byobu in the future, either we use it fully, or we go back to using our own tmux config.

Also includes a few test fixes:
- Fix docker buildx sometimes connecting to self-hosted runner oci proxy with https.
- Fix upgrade actions to wait between controller upgrades for the previous upgrade to finish.

## QA steps

Test both k8s and lxd
- Bootstrap
- Add model
- Deploy charm
- Run `juju debug-hooks mycharm/0`
- Try out `juju debug-code` too if the charm supports it.

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1988334

**Jira card:** JUJU-4695