### PR TITLE
Export revision -1 if revision is nil

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -2220,7 +2220,8 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 	origin := doc.CharmOrigin
 
 	// If the channel is empty, then we fall back to the Revision.
-	var revision int
+	// Default to -1 since that is used to commonly denote no revision.
+	revision := -1
 	if rev := origin.Revision; rev != nil {
 		revision = *rev
 	}


### PR DESCRIPTION
Previously when exporting a charm origin without a revision, we would default it's value to 0.

However, 0 is a valid charm revision. This means we can no longer tell the difference between a charm origin without a revision, and an origin with revision 0

Instead, default to revision -1, which across our codebase is used as another way to denote no revision

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made~
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the migration integration tests
```
./main.sh -v model test_model_migration
./main.sh -v model test_model_migration_version
./main.sh -v model test_model_migration_saas_common
./main.sh -v model test_model_migration_saas_external
```

bootstrap 2 controllers
```
juju bootstrap lxd lxd
juju bootstrap lxd lxd2
```

add a model with a local charm
```
juju add-model m
juju deploy ./charms/ubuntu
```
verify charm revision in mongo
```
juju mongo
db.applications.find()
...
{ "_id" : "a8588514-4286-4417-8461-308326964b21:ubu", "name" : "ubu", "model-uuid" : "a8588514-4286-4417-8461-308326964b21", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" } }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : 2, "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```
migrate
```
juju migrate m lxd2
```
verify in mongo again
```
juju mongo
db.applications.find()
...
{ "_id" : "a8588514-4286-4417-8461-308326964b21:ubu", "name" : "ubu", "model-uuid" : "a8588514-4286-4417-8461-308326964b21", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "type" : "charm", "id" : "", "hash" : "", "revision" : -1, "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" } }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : 2, "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```
note that the charm origin's revision in the migrated model is -1
