### PR TITLE
RPC requests with trace id and span id

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -59,7 +59,7 @@ const modelRoot = "/model/"
 var logger = loggo.GetLogger("juju.api")
 
 type rpcConnection interface {
-	Call(req rpc.Request, params, response interface{}) error
+	Call(ctx context.Context, req rpc.Request, params, response interface{}) error
 	Dead() <-chan struct{}
 	Close() error
 }
@@ -1247,7 +1247,7 @@ func isX509Error(err error) bool {
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (c *conn) APICall(facade string, vers int, id, method string, args, response interface{}) error {
-	err := c.client.Call(rpc.Request{
+	err := c.client.Call(context.TODO(), rpc.Request{
 		Type:    facade,
 		Version: vers,
 		Id:      id,

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1516,7 +1516,7 @@ func (f *fakeRPCConnection) Close() error {
 	return nil
 }
 
-func (f *fakeRPCConnection) Call(req rpc.Request, params, response interface{}) error {
+func (f *fakeRPCConnection) Call(ctx context.Context, req rpc.Request, params, response interface{}) error {
 	f.stub.AddCall(req.Type+"."+req.Action, req.Version, params)
 	if f.response != nil {
 		rv := reflect.ValueOf(response)

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc
+
+import "context"
+
+type contextKey string
+
+const (
+	tracingKey contextKey = "tracing"
+)
+
+// WithTracing returns a context with the given traceID and spanID.
+func WithTracing(ctx context.Context, traceID, spanID string) context.Context {
+	return context.WithValue(ctx, tracingKey, &trace{
+		traceID: traceID,
+		spanID:  spanID,
+	})
+}
+
+// TracingFromContext returns the traceID and spanID from the context.
+func TracingFromContext(ctx context.Context) (string, string) {
+	val := ctx.Value(tracingKey)
+	if val == nil {
+		return "", ""
+	}
+	t, ok := val.(*trace)
+	if !ok {
+		return "", ""
+	}
+	return t.traceID, t.spanID
+}
+
+type trace struct {
+	traceID string
+	spanID  string
+}

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -1,0 +1,26 @@
+// Copyright 2023, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc_test
+
+import (
+	"context"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/rpc"
+)
+
+type contextSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&contextSuite{})
+
+func (s *contextSuite) TestWithTracing(c *gc.C) {
+	ctx := rpc.WithTracing(context.Background(), "trace", "span")
+	traceID, spanID := rpc.TracingFromContext(ctx)
+	c.Assert(traceID, gc.Equals, "trace")
+	c.Assert(spanID, gc.Equals, "span")
+}


### PR DESCRIPTION
The following implements the w3c tracing context document[1] for both trace-id[2] and span-id[3]. Sometimes span-id is called parent-id, but for out setup we're going to be explicit and call it span-id like the document allows.

Currently, there is no validation of the values of a trace-id or a span-id. At the moment, I'm thinking we can ignore that and force the OTEL (open telemetry) clients force that validation. Most likely, they'll be the ones seeding that information.

As tracing is optional, I don't want to bring down Juju for a bad trace and span id.

 1. https://www.w3.org/TR/2021/REC-trace-context-1-20211123/
 2. https://www.w3.org/TR/2021/REC-trace-context-1-20211123/#trace-id
 3. https://www.w3.org/TR/2021/REC-trace-context-1-20211123/#parent-id

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

There should be no breakages, as this isn't fully wired up, there will be no difference.

```sh
$ juju bootstrap lxd test --build-agent
```


## Links

**Jira card:** JUJU-[XXXX]
