### PR TITLE
Inject controller-config into storage provisioner

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -30,8 +30,9 @@ func newFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	serviceFactory := ctx.ServiceFactory()
 	registry, err := stateenvirons.NewStorageProviderRegistryForModel(
-		model, ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential(),
+		model, serviceFactory.Cloud(), serviceFactory.Credential(),
 		stateenvirons.GetNewEnvironFunc(environs.New),
 		stateenvirons.GetNewCAASBrokerFunc(caas.New),
 	)
@@ -44,5 +45,14 @@ func newFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewStorageProvisionerAPIv4(backend, storageBackend, ctx.Resources(), ctx.Auth(), registry, pm, ctx.Logger().Child("storageprovisioner"))
+	return NewStorageProvisionerAPIv4(
+		backend,
+		storageBackend,
+		serviceFactory.ControllerConfig(),
+		ctx.Resources(),
+		ctx.Auth(),
+		registry,
+		pm,
+		ctx.Logger().Child("storageprovisioner"),
+	)
 }

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/state"
 )
@@ -23,7 +22,6 @@ type Backend interface {
 	state.EntityFinder
 	state.ModelAccessor
 
-	ControllerConfig() (controller.Config, error)
 	MachineInstanceId(names.MachineTag) (instance.Id, error)
 	ModelTag() names.ModelTag
 	WatchMachine(names.MachineTag) (state.NotifyWatcher, error)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -67,7 +67,16 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm, loggo.GetLogger("juju.apiserver.storageprovisioner"))
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		backend,
+		storageBackend,
+		s.ControllerServiceFactory(c).ControllerConfig(),
+		s.resources,
+		s.authorizer,
+		registry,
+		pm,
+		loggo.GetLogger("juju.apiserver.storageprovisioner"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
@@ -62,7 +62,16 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm, loggo.GetLogger("juju.apiserver.storageprovisioner"))
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		backend,
+		storageBackend,
+		s.ControllerServiceFactory(c).ControllerConfig(),
+		s.resources,
+		s.authorizer,
+		registry,
+		pm,
+		loggo.GetLogger("juju.apiserver.storageprovisioner"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -40,7 +40,15 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, common.NewResources(), authorizer, nil, nil, loggo.GetLogger("juju.apiserver.storageprovisioner"))
+	_, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		backend,
+		storageBackend,
+		s.ControllerServiceFactory(c).ControllerConfig(),
+		common.NewResources(),
+		authorizer,
+		nil, nil,
+		loggo.GetLogger("juju.apiserver.storageprovisioner"),
+	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 


### PR DESCRIPTION
The following in the series of updates to inject the controller config into the facades. This one tackles the storage provisioner. Like others before this one, we store the controller UUID on the facade as we request the controller config multiple times for a readonly property.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Wait for the storage to be provisioned.

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju create-storage-pool rooty rootfs size=1G
$ juju list-storage-pools --format json | jq '.rooty | .provider'
$ juju deploy ./testcharms/charms/dummy-storage-fs --base ubuntu@22.04 --storage data=rootfs,1G
```

## Links

**Jira card:** JUJU-4331
