### PR TITLE
Inject controller config into caas application

### DIFF
--- a/apiserver/facades/agent/caasapplication/register.go
+++ b/apiserver/facades/agent/caasapplication/register.go
@@ -29,7 +29,10 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential())
+
+	serviceFactory := ctx.ServiceFactory()
+
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, serviceFactory.Cloud(), serviceFactory.Credential())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}
@@ -37,10 +40,14 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewFacade(resources, authorizer,
+	return NewFacade(
+		resources,
+		authorizer,
 		systemState,
-		&stateShim{st},
+		&stateShim{State: st},
+		serviceFactory.ControllerConfig(),
 		broker,
 		ctx.StatePool().Clock(),
-		ctx.Logger().Child("caasapplication"))
+		ctx.Logger().Child("caasapplication"),
+	)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6418,7 +6418,7 @@
     },
     {
         "Name": "CAASApplication",
-        "Description": "",
+        "Description": "Facade defines the API methods on the CAASApplication facade.",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",


### PR DESCRIPTION
The following injects the controller config into caas application.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Bootstrap k8s.

```sh
$ juju deploy redis-k8s
$ juju scale-application 3
```

## Links

**Jira card:** JUJU-4325
