### PR TITLE
Use existing controller config from args

### DIFF
--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -443,7 +443,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Deploy and set up the controller charm and application.
-	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmPath, args.ControllerCharmChannel, isCAAS, controllerUnitPassword); err != nil {
+	if err := c.deployControllerCharm(st, args.ControllerConfig, args.BootstrapMachineConstraints, args.ControllerCharmPath, args.ControllerCharmChannel, isCAAS, controllerUnitPassword); err != nil {
 		return errors.Annotate(err, "cannot deploy controller application")
 	}
 


### PR DESCRIPTION
To deploy the controller charm we need controller config, which we already have, so there is no need to call it again from state. This is a waste. I believe we could easily do this for all the other things, we do during bootstrap. We just need to use the minimum information and not the maximum.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ watch juju status -m controller
```

## Links

**Jira card:** JUJU-4697
