### PR TITLE
Enable upgrade action. Fix --build-agent juju root finding.

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -23,7 +23,7 @@ jobs:
   Upgrade:
     name: Upgrade
     runs-on: [self-hosted, linux, x64, aws, xlarge]
-    if: false && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- Re-enabling the upgrade action for 3.2 to ensure upgrades work from 3.2/stable to current HEAD.
- Fix build-agent to find the juju go root via `go list -json`. This is required for running juju commands that take --build-agent in a subdirectory of the juju root (e.g. running shell tests in the tests directory.)

## QA steps

- Wait for upgrade actions to pass.
- Test using build agent with tests:
```sh
$ cd tests
$ BUILD_AGENT=true BOOTSTRAP_CLOUD=lxd BOOTSTRAP_PROVIDER=lxd ./main.sh -v -s '"test_metrics,test_mongo_memory_profile,test_query_tracing"' controller test_enable_ha
```

## Documentation changes

N/A

## Links

N/A