### PR TITLE
Removes ControllerConfig calls from state tests

### DIFF
--- a/apiserver/facades/controller/crosscontroller/crosscontroller.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller.go
@@ -14,7 +14,7 @@ import (
 )
 
 type localControllerInfoFunc func(context.Context) ([]string, string, error)
-type publicDNSAddressFunc func() (string, error)
+type publicDNSAddressFunc func(context.Context) (string, error)
 type watchLocalControllerInfoFunc func() state.NotifyWatcher
 
 // CrossControllerAPI provides access to the CrossModelRelations API facade.
@@ -65,7 +65,7 @@ func (api *CrossControllerAPI) ControllerInfo(ctx context.Context) (params.Contr
 		results.Results[0].Error = apiservererrors.ServerError(err)
 		return results, nil
 	}
-	publicDNSAddress, err := api.publicDNSAddress()
+	publicDNSAddress, err := api.publicDNSAddress(ctx)
 	if err != nil {
 		results.Results[0].Error = apiservererrors.ServerError(err)
 		return results, nil

--- a/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
@@ -44,7 +44,7 @@ func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
 	api, err := crosscontroller.NewCrossControllerAPI(
 		s.resources,
 		func(context.Context) ([]string, string, error) { return s.localControllerInfo() },
-		func() (string, error) { return s.publicDnsAddress, nil },
+		func(context.Context) (string, error) { return s.publicDnsAddress, nil },
 		func() state.NotifyWatcher { return s.watchLocalControllerInfo() },
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -30,8 +30,9 @@ func newStateCrossControllerAPI(ctx facade.Context) (*CrossControllerAPI, error)
 		func(ctx context.Context) ([]string, string, error) {
 			return common.ControllerAPIInfo(ctx, st, serviceFactory.ControllerConfig())
 		},
-		func() (string, error) {
-			config, err := st.ControllerConfig()
+		func(ctx context.Context) (string, error) {
+			controllerConfig := serviceFactory.ControllerConfig()
+			config, err := controllerConfig.ControllerConfig(ctx)
 			if err != nil {
 				return "", errors.Trace(err)
 			}

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -89,11 +90,13 @@ func (s *serverSuite) TestStop(c *gc.C) {
 }
 
 func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
-	st := s.ControllerModel(c).State()
-	cfg, err := st.ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerConfig, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.SetAPIHostPorts(cfg, nil)
+	st := s.ControllerModel(c).State()
+
+	err = st.SetAPIHostPorts(controllerConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -303,9 +303,11 @@ func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
 	hostPorts := network.SpaceHostPorts{
 		{SpaceAddress: network.SpaceAddress{MachineAddress: mHP.MachineAddress}, NetPort: mHP.NetPort}}
 
-	st := s.ControllerModel(c).State()
-	controllerConfig, err := st.ControllerConfig()
+	serviceFactory := s.ControllerServiceFactory(c)
+	controllerConfig, err := serviceFactory.ControllerConfig().ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
+
+	st := s.ControllerModel(c).State()
 
 	err = st.SetAPIHostPorts(controllerConfig, []network.SpaceHostPorts{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -349,11 +349,11 @@ func (s *MachineSuite) TestMachineAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 	updatedServers := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1234, "localhost"),
 	}
-	st := s.ControllerModel(c).State()
-	controllerConfig, err := st.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.SetAPIHostPorts(controllerConfig, updatedServers)
+	controllerConfig := coretesting.FakeControllerConfig()
+
+	st := s.ControllerModel(c).State()
+	err := st.SetAPIHostPorts(controllerConfig, updatedServers)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for config to be updated.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -281,11 +281,10 @@ func (s *commonMachineSuite) newBufferedLogWriter() *logsender.BufferedLogWriter
 }
 
 func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Machine) {
-	controllerConfig, err := s.ControllerModel(c).State().ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	addrs := network.NewSpaceAddresses("0.1.2.3")
-	err = machine.SetProviderAddresses(controllerConfig, addrs...)
+	err := machine.SetProviderAddresses(controllerConfig, addrs...)
 	c.Assert(err, jc.ErrorIsNil)
 	// Set the addresses in the environ instance as well so that if the instance poller
 	// runs it won't overwrite them.

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -69,7 +69,7 @@ func (s *ControllerAddressesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -115,7 +115,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	hostPorts := []network.SpaceHostPorts{{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
@@ -157,7 +157,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	hostPorts0 := []network.SpaceHostPort{{
 		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
@@ -213,7 +213,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 	cfg[controller.JujuManagementSpace] = "mgmt01"
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
@@ -258,7 +258,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -287,7 +287,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.
 }
 
 func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	addrs, err := s.State.APIHostPortsForClients(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -316,7 +316,7 @@ func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) 
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 
 	w := s.State.WatchAPIHostPortsForClients()
 	defer workertest.CleanKill(c, w)
@@ -358,7 +358,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		NetPort: 2,
 	}
 
-	cfg := s.controllerConfig(c)
+	cfg := testing.FakeControllerConfig()
 	cfg[controller.JujuManagementSpace] = "mgmt01"
 
 	err = s.State.SetAPIHostPorts(cfg, []network.SpaceHostPorts{{mgmtHP}})
@@ -380,11 +380,6 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 	// Stop, check closed.
 	workertest.CleanKill(c, w)
 	wc.AssertClosed()
-}
-
-func (s *ControllerAddressesSuite) controllerConfig(c *gc.C) controller.Config {
-	cfg := testing.FakeControllerConfig()
-	return cfg
 }
 
 type CAASAddressesSuite struct {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -70,11 +70,6 @@ func (s *allWatcherBaseSuite) SetUpTest(c *gc.C) {
 	loggo.GetLogger("juju.state.allwatcher").SetLogLevel(loggo.TRACE)
 }
 
-func (s *allWatcherBaseSuite) controllerConfig(c *gc.C) controller.Config {
-	cfg := testing.FakeControllerConfig()
-	return cfg
-}
-
 // setUpScenario adds some entities to the state so that
 // we can check that they all get pulled in by
 // all(Model)WatcherStateBacking.GetAll.
@@ -147,9 +142,8 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	providerAddr := network.NewSpaceAddress("example.com")
 	providerAddr.SpaceID = space.Id()
 
-	controllerConfig := s.controllerConfig(c)
-
-	err = m.SetProviderAddresses(controllerConfig, providerAddr)
+	cfg := testing.FakeControllerConfig()
+	err = m.SetProviderAddresses(cfg, providerAddr)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var addresses []network.ProviderAddress
@@ -831,7 +825,8 @@ func (s *allWatcherStateSuite) TestChangeUnits(c *gc.C) {
 }
 
 func (s *allWatcherStateSuite) TestChangeUnitsNonNilPorts(c *gc.C) {
-	testChangeUnitsNonNilPorts(c, s.owner, s.controllerConfig(c), s.performChangeTestCases)
+	cfg := testing.FakeControllerConfig()
+	testChangeUnitsNonNilPorts(c, s.owner, cfg, s.performChangeTestCases)
 }
 
 func (s *allWatcherStateSuite) TestChangeRemoteApplications(c *gc.C) {
@@ -1202,7 +1197,8 @@ func (s *allModelWatcherStateSuite) TestChangeUnits(c *gc.C) {
 }
 
 func (s *allModelWatcherStateSuite) TestChangeUnitsNonNilPorts(c *gc.C) {
-	testChangeUnitsNonNilPorts(c, s.owner, s.controllerConfig(c), s.performChangeTestCases)
+	cfg := testing.FakeControllerConfig()
+	testChangeUnitsNonNilPorts(c, s.owner, cfg, s.performChangeTestCases)
 }
 
 func (s *allModelWatcherStateSuite) TestChangeRemoteApplications(c *gc.C) {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1823,8 +1823,7 @@ func (s *MachineSuite) TestSetProviderAddresses(c *gc.C) {
 			SpaceID: "1",
 		},
 	}
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	err = machine.SetProviderAddresses(controllerConfig, addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
@@ -1839,8 +1838,7 @@ func (s *MachineSuite) TestSetProviderAddressesWithContainers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	// When setting all addresses the subnet addresses have to be
 	// filtered out.
@@ -1870,8 +1868,7 @@ func (s *MachineSuite) TestSetProviderAddressesOnContainer(c *gc.C) {
 	container, err := s.State.AddMachineInsideMachine(template, machine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	// When setting all addresses the subnet address has to accepted.
 	addresses := network.NewSpaceAddresses("127.0.0.1")
 	err = container.SetProviderAddresses(controllerConfig, addresses...)
@@ -1888,8 +1885,7 @@ func (s *MachineSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	addresses := network.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetMachineAddresses(controllerConfig, addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1905,8 +1901,7 @@ func (s *MachineSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	// Add some machine addresses initially to make sure they're removed.
 	addresses := network.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetMachineAddresses(controllerConfig, addresses...)
@@ -1928,8 +1923,7 @@ func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	providerAddresses := network.NewSpaceAddresses(
 		"127.0.0.2",
 		"8.8.8.8",
@@ -1986,8 +1980,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeDifferent(c *gc.C
 	addr0 := network.NewSpaceAddress("127.0.0.1")
 	addr1 := network.NewSpaceAddress("8.8.8.8")
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		machine, err := s.State.Machine(machine.Id())
@@ -2012,8 +2005,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 	addr0 := network.NewSpaceAddress("127.0.0.1")
 	addr1 := network.NewSpaceAddress("8.8.8.8")
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	var revno1 int64
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -2045,8 +2037,7 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	addr0 := network.NewSpaceAddress("127.0.0.1")
 	addr1 := network.NewSpaceAddress("8.8.8.8")
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	// Set addresses to [addr0] initially. We'll get a separate Machine
 	// object to update addresses, to ensure that the in-memory cache of
@@ -2123,8 +2114,7 @@ func (s *MachineSuite) TestPublicAddress(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2138,8 +2128,7 @@ func (s *MachineSuite) TestPrivateAddress(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2153,8 +2142,7 @@ func (s *MachineSuite) TestPublicAddressBetterMatch(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2175,8 +2163,7 @@ func (s *MachineSuite) TestPrivateAddressBetterMatch(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2197,8 +2184,7 @@ func (s *MachineSuite) TestPublicAddressChanges(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2219,8 +2205,7 @@ func (s *MachineSuite) TestPrivateAddressChanges(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2241,8 +2226,7 @@ func (s *MachineSuite) TestAddressesDeadMachine(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.2"), network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2272,8 +2256,7 @@ func (s *MachineSuite) TestStablePrivateAddress(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2297,8 +2280,7 @@ func (s *MachineSuite) TestStablePublicAddress(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2322,8 +2304,7 @@ func (s *MachineSuite) TestAddressesRaceMachineFirst(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	changeAddresses := jujutxn.TestHook{
 		Before: func() {
@@ -2356,8 +2337,7 @@ func (s *MachineSuite) TestAddressesRaceProviderFirst(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	changeAddresses := jujutxn.TestHook{
 		Before: func() {
@@ -2390,8 +2370,7 @@ func (s *MachineSuite) TestPrivateAddressPrefersProvider(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2418,8 +2397,7 @@ func (s *MachineSuite) TestPublicAddressPrefersProvider(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2446,8 +2424,7 @@ func (s *MachineSuite) TestAddressesPrefersProviderBoth(c *gc.C) {
 	machine, err := s.State.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -2885,8 +2862,7 @@ func (s *MachineSuite) TestWatchAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	// Set machine addresses: reported.
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("abc"))

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -66,12 +67,16 @@ func (s *MigrationImportSuite) checkStatusHistory(c *gc.C, exported, imported st
 	}
 }
 
+func (s *MigrationImportSuite) controllerConfig(c *gc.C) controller.Config {
+	cfg := coretesting.FakeControllerConfig()
+	return cfg
+}
+
 func (s *MigrationImportSuite) TestExisting(c *gc.C) {
 	out, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	_, _, err = s.Controller.Import(out, ctrlCfg)
 	c.Assert(err, jc.ErrorIs, errors.AlreadyExists)
@@ -115,8 +120,7 @@ func (s *MigrationImportSuite) importModelDescription(
 	uuid := utils.MustNewUUID().String()
 	in := newModel(desc, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -161,8 +165,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -959,8 +962,7 @@ func (s *MigrationImportSuite) TestCharmRevSequencesNotImported(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1032,8 +1034,7 @@ func (s *MigrationImportSuite) TestApplicationsSubordinatesAfter(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2564,8 +2565,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	if err == nil {
@@ -2637,8 +2637,7 @@ func (s *MigrationImportSuite) TestRemoteApplicationsConsumerProxy(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	if err == nil {
@@ -2837,8 +2836,7 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
@@ -2875,8 +2873,7 @@ func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, tool
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
@@ -3218,8 +3215,7 @@ func (s *MigrationImportSuite) TestSecretsMissingBackend(c *gc.C) {
 	err = backendStore.DeleteSecretBackend("foo", true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
@@ -3231,8 +3227,7 @@ func (s *MigrationImportSuite) TestDefaultSecretBackend(c *gc.C) {
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	ctrlCfg := s.controllerConfig(c)
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -23,7 +23,6 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -67,16 +66,11 @@ func (s *MigrationImportSuite) checkStatusHistory(c *gc.C, exported, imported st
 	}
 }
 
-func (s *MigrationImportSuite) controllerConfig(c *gc.C) controller.Config {
-	cfg := coretesting.FakeControllerConfig()
-	return cfg
-}
-
 func (s *MigrationImportSuite) TestExisting(c *gc.C) {
 	out, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	_, _, err = s.Controller.Import(out, ctrlCfg)
 	c.Assert(err, jc.ErrorIs, errors.AlreadyExists)
@@ -120,7 +114,7 @@ func (s *MigrationImportSuite) importModelDescription(
 	uuid := utils.MustNewUUID().String()
 	in := newModel(desc, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -165,7 +159,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -962,7 +956,7 @@ func (s *MigrationImportSuite) TestCharmRevSequencesNotImported(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1034,7 +1028,7 @@ func (s *MigrationImportSuite) TestApplicationsSubordinatesAfter(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2565,7 +2559,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	if err == nil {
@@ -2637,7 +2631,7 @@ func (s *MigrationImportSuite) TestRemoteApplicationsConsumerProxy(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	_, newSt, err := s.Controller.Import(in, ctrlCfg)
 	if err == nil {
@@ -2836,7 +2830,7 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
@@ -2873,7 +2867,7 @@ func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, tool
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
@@ -3215,7 +3209,7 @@ func (s *MigrationImportSuite) TestSecretsMissingBackend(c *gc.C) {
 	err = backendStore.DeleteSecretBackend("foo", true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	uuid := utils.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
@@ -3227,7 +3221,7 @@ func (s *MigrationImportSuite) TestDefaultSecretBackend(c *gc.C) {
 	testModel, err := s.State.Export(map[string]string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctrlCfg := s.controllerConfig(c)
+	ctrlCfg := coretesting.FakeControllerConfig()
 
 	newConfig := testModel.Config()
 	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1204,8 +1204,7 @@ func (s *WatchRelationUnitsSuite) TestPeer(c *gc.C) {
 			fmt.Sprintf("riak%d.example.com", i),
 			network.WithScope(network.ScopeCloudLocal),
 		)
-		controllerConfig, err := s.State.ControllerConfig()
-		c.Assert(err, jc.ErrorIsNil)
+		controllerConfig := coretesting.FakeControllerConfig()
 		err = machine.SetProviderAddresses(controllerConfig, privateAddr)
 		c.Assert(err, jc.ErrorIsNil)
 		ru, err := rel.Unit(unit)

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -800,8 +800,7 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 	err = machine.SetProviderAddresses(
 		controllerConfig,
 		network.NewSpaceAddress("private.address.example.com", network.WithScope(network.ScopeCloudLocal)),
@@ -839,8 +838,7 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
 	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -856,8 +854,7 @@ func (s *UnitSuite) TestStablePrivateAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetMachineAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -879,8 +876,7 @@ func (s *UnitSuite) TestStablePublicAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -906,8 +902,7 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	privateProvider := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 	privateMachine := network.NewSpaceAddress("127.0.0.2")
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
@@ -946,8 +941,7 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
 	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = machine.SetProviderAddresses(controllerConfig, public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2921,8 +2915,7 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	controllerConfig, err := s.State.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
+	controllerConfig := coretesting.FakeControllerConfig()
 
 	err = m1.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("10.0.0.100"))
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
To help find the wood from the trees, the number of calls to ControllerConfig in tests are quite large. By removing the calls sites, we can actually see what is calling ControllerConfig. The next set of commits/PRs will hopefully just reduce state calls to the PeerGrouper and APIServer workers. We can't remove those because of the chicking and egg problem. In that we don't have a db yet (at least not in HA) and attempting to get the controller config isn't yet possible.

I removed a few tests:

 1. Watching controller config test is replaced via the domain package.
 2. Tests to get and update controller config are covered by the domain package.

All the tests can rely on the FakeControllerConfig with the addition of the management space.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

## Links

**Jira card:** JUJU-4700
