### PR TITLE
Agent controller config subscription

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -330,6 +330,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// Controller agent config manifold watches the controller
 		// agent config and bounces if it changes.
 		controllerAgentConfigName: ifController(controlleragentconfig.Manifold(controlleragentconfig.ManifoldConfig{
+			Clock:  config.Clock,
 			Logger: loggo.GetLogger("juju.worker.controlleragentconfig"),
 		})),
 

--- a/go.mod
+++ b/go.mod
@@ -324,3 +324,5 @@ require (
 replace google.golang.org/grpc/naming => google.golang.org/grpc v1.29.1
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
+
+replace github.com/juju/worker/v3 => /home/simon/go/src/github.com/juju/worker

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0
-	github.com/juju/worker/v3 v3.4.0
+	github.com/juju/worker/v3 v3.5.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.11
@@ -324,5 +324,3 @@ require (
 replace google.golang.org/grpc/naming => google.golang.org/grpc v1.29.1
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
-
-replace github.com/juju/worker/v3 => /home/simon/go/src/github.com/juju/worker

--- a/go.sum
+++ b/go.sum
@@ -922,6 +922,8 @@ github.com/juju/viddy v0.0.0-beta5/go.mod h1:5Yvv+opdIEDt15Tt0++8YvccVykcGJeVXxq
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
+github.com/juju/worker/v3 v3.5.0 h1:pbccjj102IkvdxgCcz0DtQHA5tGZK4PGwm5dUMyRtAc=
+github.com/juju/worker/v3 v3.5.0/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/go.sum
+++ b/go.sum
@@ -922,8 +922,6 @@ github.com/juju/viddy v0.0.0-beta5/go.mod h1:5Yvv+opdIEDt15Tt0++8YvccVykcGJeVXxq
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v3 v3.4.0 h1:dMpZJ0RAOFNYKEvKSNA9U/CkWufP/Z3zK4z7QfYzIDI=
-github.com/juju/worker/v3 v3.4.0/go.mod h1:ieql+6Kl+Z3akRxgVctilGNF1sc/5Xm2a/inVY0pe4I=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/worker/controlleragentconfig/doc.go
+++ b/worker/controlleragentconfig/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controlleragentconfig is a worker that listens for SIGHUP signals
+// and reloads the agent configuration when one is received.
+package controlleragentconfig

--- a/worker/controlleragentconfig/manifold.go
+++ b/worker/controlleragentconfig/manifold.go
@@ -64,6 +64,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 func configOutput(in worker.Worker, out any) error {
+	w, ok := in.(*configWorker)
+	if !ok {
+		return errors.Errorf("expected configWorker, got %T", in)
+	}
+	switch out := out.(type) {
+	case *ConfigWatcher:
+		target, err := w.Watcher()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		*out = target
+	default:
+		return errors.Errorf("unsupported output of *ConfigWatcher type, got %T", out)
+	}
 	return nil
 }
 

--- a/worker/controlleragentconfig/manifold.go
+++ b/worker/controlleragentconfig/manifold.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -25,12 +26,16 @@ type Logger interface {
 // manifold.
 type ManifoldConfig struct {
 	Logger Logger
+	Clock  clock.Clock
 }
 
 // Validate validates the manifold configuration.
 func (cfg ManifoldConfig) Validate() error {
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if cfg.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	return nil
 }
@@ -47,6 +52,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			w, err := NewWorker(WorkerConfig{
 				Logger: config.Logger,
 				Notify: Notify,
+				Clock:  config.Clock,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/controlleragentconfig/manifold_test.go
+++ b/worker/controlleragentconfig/manifold_test.go
@@ -59,3 +59,16 @@ func (s *manifoldSuite) TestStart(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 }
+
+func (s *manifoldSuite) TestOutput(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	man := Manifold(s.getConfig())
+	w, err := man.Start(s.getContext())
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	var watcher ConfigWatcher
+	c.Assert(man.Output(w, &watcher), jc.ErrorIsNil)
+	c.Assert(watcher, gc.NotNil)
+}

--- a/worker/controlleragentconfig/manifold_test.go
+++ b/worker/controlleragentconfig/manifold_test.go
@@ -4,6 +4,7 @@
 package controlleragentconfig
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/dependency"
@@ -27,11 +28,16 @@ func (s *manifoldSuite) TestValidateConfig(c *gc.C) {
 	cfg = s.getConfig()
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		Logger: s.logger,
+		Clock:  clock.WallClock,
 	}
 }
 

--- a/worker/controlleragentconfig/worker.go
+++ b/worker/controlleragentconfig/worker.go
@@ -5,9 +5,14 @@ package controlleragentconfig
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync/atomic"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/catacomb"
 	"gopkg.in/tomb.v2"
 )
 
@@ -22,6 +27,7 @@ const (
 type WorkerConfig struct {
 	Logger Logger
 	Notify func(context.Context, chan os.Signal)
+	Clock  clock.Clock
 }
 
 // Validate ensures that the config values are valid.
@@ -32,13 +38,23 @@ func (c *WorkerConfig) Validate() error {
 	if c.Notify == nil {
 		return errors.NotValidf("nil Notify")
 	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
 	return nil
+}
+
+type Watcher interface {
+	Changes() <-chan struct{}
+	Unsubscribe()
 }
 
 type configWorker struct {
 	internalStates chan string
 	cfg            WorkerConfig
-	tomb           tomb.Tomb
+	catacomb       catacomb.Catacomb
+	runner         *worker.Runner
+	unique         int64
 }
 
 // NewWorker creates a new tracer worker.
@@ -55,48 +71,164 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*configWorker, err
 	w := &configWorker{
 		internalStates: internalStates,
 		cfg:            cfg,
+		runner: worker.NewRunner(worker.RunnerParams{
+			Clock: cfg.Clock,
+			IsFatal: func(err error) bool {
+				return false
+			},
+			ShouldRestart: func(err error) bool {
+				return false
+			},
+			Logger: cfg.Logger,
+		}),
 	}
 
-	w.tomb.Go(w.loop)
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{
+			w.runner,
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	return w, nil
 }
 
 // Kill is part of the worker.Worker interface.
 func (w *configWorker) Kill() {
-	w.tomb.Kill(nil)
+	w.catacomb.Kill(nil)
 }
 
 // Wait is part of the worker.Worker interface.
 func (w *configWorker) Wait() error {
-	return w.tomb.Wait()
+	return w.catacomb.Wait()
+}
+
+// Watcher returns a Watcher for watching for changes to the agent
+// controller config.
+func (w *configWorker) Watcher() (Watcher, error) {
+	unique := atomic.AddInt64(&w.unique, 1)
+	namespace := fmt.Sprintf("watcher-%d", unique)
+	err := w.runner.StartWorker(namespace, func() (worker.Worker, error) {
+		return newSubscription(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	watcher, err := w.runner.Worker(namespace, w.catacomb.Dying())
+	if err != nil {
+		return nil, err
+	}
+	return watcher.(Watcher), nil
 }
 
 func (w *configWorker) loop() error {
 	// We must use a buffered channel or risk missing the signal
 	// if we're not ready to receive when the signal is sent.
 	ch := make(chan os.Signal, 1)
-	w.cfg.Notify(w.tomb.Context(context.Background()), ch)
+	w.cfg.Notify(w.catacomb.Context(context.Background()), ch)
 
 	// Report the initial started state.
 	w.reportInternalState(stateStarted)
 
 	for {
 		select {
-		case <-w.tomb.Dying():
-			return tomb.ErrDying
+		case <-w.catacomb.Dying():
+			return w.catacomb.Err()
 		case <-ch:
 			w.reportInternalState(stateReload)
 
 			w.cfg.Logger.Infof("SIGHUP received, reloading config")
+
+			for _, name := range w.runner.WorkerNames() {
+				runnerWorker, err := w.runner.Worker(name, w.catacomb.Dying())
+				if err != nil {
+					if errors.Is(err, errors.NotFound) {
+						continue
+					}
+					// If the runner is dead, we should stop.
+					if errors.Is(err, worker.ErrDead) {
+						return nil
+					}
+					return errors.Trace(err)
+				}
+
+				// This should ALWAYS be a subscription.
+				sub := runnerWorker.(*subscription)
+				sub.dispatch()
+			}
 		}
 	}
 }
 
 func (w *configWorker) reportInternalState(state string) {
 	select {
-	case <-w.tomb.Dying():
+	case <-w.catacomb.Dying():
 	case w.internalStates <- state:
 	default:
+	}
+}
+
+type subscription struct {
+	tomb tomb.Tomb
+	in   chan struct{}
+	out  chan struct{}
+}
+
+func newSubscription() *subscription {
+	w := &subscription{
+		in:  make(chan struct{}),
+		out: make(chan struct{}),
+	}
+	w.tomb.Go(w.loop)
+	return w
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *subscription) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *subscription) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Changes returns a channel that will be closed when the agent
+func (w *subscription) Changes() <-chan struct{} {
+	return w.out
+}
+
+// Unsubscribe stops the subscription from sending changes.
+func (w *subscription) Unsubscribe() {
+	w.tomb.Kill(nil)
+}
+
+func (w *subscription) loop() error {
+	defer close(w.out)
+
+	var out chan<- struct{}
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.in:
+			out = w.out
+		case out <- struct{}{}:
+			out = nil
+		}
+	}
+}
+
+// Dispatch sends a change notification to the subscription, but doesn't block
+// on the subscription being killed.
+func (w *subscription) dispatch() {
+	select {
+	case <-w.tomb.Dying():
+		return
+	case w.in <- struct{}{}:
 	}
 }

--- a/worker/controlleragentconfig/worker.go
+++ b/worker/controlleragentconfig/worker.go
@@ -47,8 +47,10 @@ func (c *WorkerConfig) Validate() error {
 // ConfigWatcher is an interface that can be used to watch for changes to the
 // agent controller config.
 type ConfigWatcher interface {
-	// Changes returns a channel that will be closed when the agent
+	// Changes returns a channel that will dispatch changes when the agent
 	// controller config changes.
+	// The channel will be closed when the subscription is terminated or
+	// the underlying worker is killed.
 	Changes() <-chan struct{}
 	// Done returns a channel that will be closed when the subscription is
 	// closed.

--- a/worker/controlleragentconfig/worker.go
+++ b/worker/controlleragentconfig/worker.go
@@ -157,6 +157,7 @@ func (w *configWorker) loop() error {
 				runnerWorker, err := w.runner.Worker(name, w.catacomb.Dying())
 				if err != nil {
 					if errors.Is(err, errors.NotFound) {
+						w.cfg.Logger.Debugf("worker %q not found, skipping", name)
 						continue
 					}
 					// If the runner is dead, we should stop.

--- a/worker/controlleragentconfig/worker_test.go
+++ b/worker/controlleragentconfig/worker_test.go
@@ -6,11 +6,13 @@ package controlleragentconfig
 import (
 	"context"
 	"os"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
+	"github.com/juju/clock"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -85,18 +87,232 @@ func (s *workerSuite) TestSighupAfterDeath(c *gc.C) {
 	}
 }
 
+func (s *workerSuite) TestWatchWithNoChange(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, _, states := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watcher, err := w.Watcher()
+	c.Assert(err, jc.ErrorIsNil)
+	defer watcher.Unsubscribe()
+
+	changes := watcher.Changes()
+	select {
+	case <-changes:
+		c.Fatal("should not have received a change")
+	case <-time.After(testing.ShortWait * 10):
+	}
+}
+
+func (s *workerSuite) TestWatchWithSubscribe(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, notify, states := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watcher, err := w.Watcher()
+	c.Assert(err, jc.ErrorIsNil)
+	defer watcher.Unsubscribe()
+
+	s.sendSignal(c, notify)
+	s.ensureReload(c, states)
+
+	changes := watcher.Changes()
+
+	var count int
+	select {
+	case <-changes:
+		count++
+	case <-time.After(testing.ShortWait):
+		c.Fatal("should have received a change")
+	}
+
+	c.Assert(count, gc.Equals, 1)
+}
+
+func (s *workerSuite) TestWatchAfterUnsubscribe(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, notify, states := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watcher, err := w.Watcher()
+	c.Assert(err, jc.ErrorIsNil)
+	defer watcher.Unsubscribe()
+
+	s.sendSignal(c, notify)
+	s.ensureReload(c, states)
+
+	watcher.Unsubscribe()
+
+	changes := watcher.Changes()
+
+	// The channel should be closed.
+	select {
+	case _, ok := <-changes:
+		c.Assert(ok, jc.IsFalse)
+	case <-time.After(testing.ShortWait * 10):
+	}
+}
+
+func (s *workerSuite) TestWatchWithKilledWorker(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, _, states := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watcher, err := w.Watcher()
+	c.Assert(err, jc.ErrorIsNil)
+	defer watcher.Unsubscribe()
+
+	workertest.CleanKill(c, w)
+
+	changes := watcher.Changes()
+
+	select {
+	case _, ok := <-changes:
+		c.Assert(ok, jc.IsFalse)
+	case <-time.After(testing.ShortWait * 10):
+	}
+}
+
+func (s *workerSuite) TestWatchMultiple(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, notify, states := s.newWorker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watchers := make([]Watcher, 10)
+	for i := range watchers {
+		watcher, err := w.Watcher()
+		c.Assert(err, jc.ErrorIsNil)
+		defer watcher.Unsubscribe()
+		watchers[i] = watcher
+	}
+
+	s.sendSignal(c, notify)
+	s.ensureReload(c, states)
+
+	var wg sync.WaitGroup
+	wg.Add(len(watchers))
+
+	var count int64
+	for i := 0; i < len(watchers); i++ {
+		go func(w Watcher) {
+			defer wg.Done()
+
+			changes := w.Changes()
+			select {
+			case _, ok := <-changes:
+				atomic.AddInt64(&count, 1)
+				c.Assert(ok, jc.IsTrue)
+			case <-time.After(testing.ShortWait * 10):
+				c.Fatal("should have received a change")
+			}
+		}(watchers[i])
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for changes to finish")
+	}
+
+	c.Assert(atomic.LoadInt64(&count), gc.Equals, int64(len(watchers)))
+}
+
+func (s *workerSuite) TestWatchMultipleWithUnsubscribe(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	w, notify, states := s.newWorker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.ensureStartup(c, states)
+
+	watchers := make([]Watcher, 10)
+	for i := range watchers {
+		watcher, err := w.Watcher()
+		c.Assert(err, jc.ErrorIsNil)
+		watchers[i] = watcher
+	}
+
+	s.sendSignal(c, notify)
+	s.ensureReload(c, states)
+
+	var wg sync.WaitGroup
+	wg.Add(len(watchers))
+
+	var count int64
+	for i := 0; i < len(watchers); i++ {
+		go func(i int, w Watcher) {
+			defer wg.Done()
+
+			changes := w.Changes()
+
+			// Test to ensure that a unsubscribe doesn't block another watcher.
+			if (i % 2) == 0 {
+				w.Unsubscribe()
+				// Notice that we don't wait for the unsubscribe to complete.
+				// Which means that the worker should not block sending
+				// messages.
+				return
+			}
+
+			select {
+			case _, ok := <-changes:
+				atomic.AddInt64(&count, 1)
+				c.Assert(ok, jc.IsTrue)
+			case <-time.After(testing.ShortWait * 10):
+				c.Fatal("should have received a change")
+			}
+		}(i, watchers[i])
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for changes to finish")
+	}
+
+	c.Assert(atomic.LoadInt64(&count), gc.Equals, int64(len(watchers)/2))
+}
+
 func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 	return ctrl
 }
 
-func (s *workerSuite) newWorker(c *gc.C) (worker.Worker, chan struct{}, chan string) {
+func (s *workerSuite) newWorker(c *gc.C) (*configWorker, chan struct{}, chan string) {
 	// Buffer the channel, so we don't drop signals if we're not ready.
 	states := make(chan string, 10)
 	// Buffer the channel, so we don't miss signals if we're not ready.
 	notify := make(chan struct{}, 1)
 	w, err := newWorker(WorkerConfig{
 		Logger: s.logger,
+		Clock:  clock.WallClock,
 		Notify: func(ctx context.Context, ch chan os.Signal) {
 			go func() {
 				for {


### PR DESCRIPTION
Allow a subscription model based on a dispatched signal if a SIGHUP
is sent. The following leans heavily on the worker runner type. It
allows the lifecycle management of a subscription. If the subscription
is unsubscribed then we just kill the tomb, and the runner will manage
the cleanup.

It is expected that every downstream consumer should read off the
changes channel as quickly as possible. Any hold-up will cause
back pressure on the rest of the consumers, as new events will
not be processed.

This is similar to the change stream, but we can be a lot less complex
as we don't need to filter on patterns. If that does come as a
requirement, which I don't suspect will happen, then we should crib
off that one.

In order to provide this functionality, a new change to the
runner type is required[1]. This change allows us to see what
workers are within the runner (see PR for more details).

Note: it is expected that the consumer should check the Receive
operator[2] to see if the config worker has been closed. It is best
practice if that happens, to bounce the worker as the agent controller
config is dying. This can be ignored if the unsubscribed has been
called and returned gracefully.

Until [1] has been landed, I've hardcoded the go.mod.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

## Links


**Jira card:** JUJU-4675
