### PR TITLE
Add new uniter API version that removes unused methods

### DIFF
--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -434,35 +434,6 @@ func (st *State) OpenedPortRangesByEndpoint() (map[names.UnitTag]network.Grouped
 	return processOpenPortRangesByEndpointResults(results, st.unitTag)
 }
 
-// OpenedApplicationPortRangesByEndpoint returns all port ranges currently open for the given
-// application, grouped by application endpoint.
-func (st *State) OpenedApplicationPortRangesByEndpoint(appTag names.ApplicationTag) (network.GroupedPortRanges, error) {
-	if st.BestAPIVersion() < 18 {
-		// OpenedApplicationPortRangesByEndpoint() was introduced in UniterAPIV18.
-		return nil, errors.NotImplementedf("OpenedApplicationPortRangesByEndpoint() (need V18+)")
-	}
-	arg := params.Entity{Tag: appTag.String()}
-	var result params.ApplicationOpenedPortsResults
-	if err := st.facade.FacadeCall("OpenedApplicationPortRangesByEndpoint", arg, &result); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(result.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(result.Results))
-	}
-	res := result.Results[0]
-	if res.Error != nil {
-		err := apiservererrors.RestoreError(res.Error)
-		return nil, errors.Annotatef(err, "unable to fetch opened ports for %s", appTag)
-	}
-	out := make(network.GroupedPortRanges)
-	for _, pgs := range res.ApplicationPortRanges {
-		for _, pg := range pgs.PortRanges {
-			out[pgs.Endpoint] = append(out[pgs.Endpoint], pg.NetworkPortRange())
-		}
-	}
-	return out, nil
-}
-
 // WatchRelationUnits returns a watcher that notifies of changes to the
 // counterpart units in the relation for the given unit.
 func (st *State) WatchRelationUnits(

--- a/api/agent/uniter/uniter_test.go
+++ b/api/agent/uniter/uniter_test.go
@@ -135,55 +135,6 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 	})
 }
 
-func (s *uniterSuite) TestOpenedApplicationPortRangesByEndpoint(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(request, gc.Equals, "OpenedApplicationPortRangesByEndpoint")
-		c.Assert(arg, gc.DeepEquals, params.Entity{Tag: "application-gitlab"})
-		c.Assert(result, gc.FitsTypeOf, &params.ApplicationOpenedPortsResults{})
-		*(result.(*params.ApplicationOpenedPortsResults)) = params.ApplicationOpenedPortsResults{
-			Results: []params.ApplicationOpenedPortsResult{
-				{
-					ApplicationPortRanges: []params.ApplicationOpenedPorts{
-						{
-							Endpoint:   "",
-							PortRanges: []params.PortRange{{100, 200, "tcp"}},
-						},
-						{
-							Endpoint:   "server",
-							PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
-						},
-					},
-				},
-			},
-		}
-		return nil
-	})
-	caller := testing.BestVersionCaller{apiCaller, 18}
-	client := uniter.NewState(caller, names.NewUnitTag("gitlab/0"))
-
-	result, err := client.OpenedApplicationPortRangesByEndpoint(names.NewApplicationTag("gitlab"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, network.GroupedPortRanges{
-		"":       []network.PortRange{network.MustParsePortRange("100-200/tcp")},
-		"server": []network.PortRange{network.MustParsePortRange("3306/tcp")},
-	})
-}
-
-func (s *uniterSuite) TestOpenedApplicationPortRangesByEndpointOldAPINotSupported(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(request, gc.Equals, "OpenedApplicationPortRangesByEndpoint")
-		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-gitlab-0"}}})
-		return nil
-	})
-	caller := testing.BestVersionCaller{apiCaller, 17}
-	client := uniter.NewState(caller, names.NewUnitTag("gitlab/0"))
-
-	_, err := client.OpenedApplicationPortRangesByEndpoint(names.NewApplicationTag("gitlab"))
-	c.Assert(err, gc.ErrorMatches, `OpenedApplicationPortRangesByEndpoint\(\) \(need V18\+\) not implemented`)
-}
-
 func (s *uniterSuite) TestOpenedPortRangesByEndpointOldAPINotSupported(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -125,7 +125,7 @@ var facadeVersions = map[string][]int{
 	"Subnets":                      {5},
 	"Undertaker":                   {1},
 	"UnitAssigner":                 {1},
-	"Uniter":                       {18},
+	"Uniter":                       {18, 19},
 	"Upgrader":                     {1},
 	"UpgradeSeries":                {3},
 	"UpgradeSteps":                 {2},

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -20,8 +20,19 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Uniter", 18, func(ctx facade.Context) (facade.Facade, error) {
+		return newUniterAPIv18(ctx)
+	}, reflect.TypeOf((*UniterAPIv18)(nil)))
+	registry.MustRegister("Uniter", 19, func(ctx facade.Context) (facade.Facade, error) {
 		return newUniterAPI(ctx)
 	}, reflect.TypeOf((*UniterAPI)(nil)))
+}
+
+func newUniterAPIv18(context facade.Context) (*UniterAPIv18, error) {
+	api, err := newUniterAPI(context)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &UniterAPIv18{*api}, nil
 }
 
 // newUniterAPI creates a new instance of the core Uniter API.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -38,9 +38,6 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.uniter")
 
-// TODO (manadart 2020-10-21): Remove the ModelUUID method
-// from the next version of this facade.
-
 // UniterAPI implements the latest version (v18) of the Uniter API.
 type UniterAPI struct {
 	*common.LifeGetter
@@ -79,6 +76,13 @@ type UniterAPI struct {
 	// We do not need to use an AuthFunc, because we do not need to pass a tag.
 	accessCloudSpec func() (func() bool, error)
 	cloudSpecer     cloudspec.CloudSpecer
+}
+
+// UniterAPIv18 Implements version 18 of the uniter API, which includes methods
+// ModelUUID and OpenedApplicationPortRangesByEndpoint that were removed from
+// later versions.
+type UniterAPIv18 struct {
+	UniterAPI
 }
 
 // OpenedMachinePortRangesByEndpoint returns the port ranges opened by each
@@ -179,7 +183,7 @@ func (u *UniterAPI) OpenedPortRangesByEndpoint() (params.OpenPortRangesByEndpoin
 }
 
 // OpenedApplicationPortRangesByEndpoint returns the port ranges opened by each application.
-func (u *UniterAPI) OpenedApplicationPortRangesByEndpoint(entity params.Entity) (params.ApplicationOpenedPortsResults, error) {
+func (u *UniterAPIv18) OpenedApplicationPortRangesByEndpoint(entity params.Entity) (params.ApplicationOpenedPortsResults, error) {
 	result := params.ApplicationOpenedPortsResults{
 		Results: make([]params.ApplicationOpenedPortsResult, 1),
 	}
@@ -754,8 +758,7 @@ func (u *UniterAPI) SetWorkloadVersion(args params.EntityWorkloadVersions) (para
 // ModelUUID returns the model UUID that this unit resides in.
 // It is implemented here directly as a result of removing it from
 // embedded APIAddresser *without* bumping the facade version.
-// It should be blanked when this facade version is next incremented.
-func (u *UniterAPI) ModelUUID() params.StringResult {
+func (u *UniterAPIv18) ModelUUID() params.StringResult {
 	return params.StringResult{Result: u.m.UUID()}
 }
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3739,7 +3739,8 @@ func (s *uniterSuite) TestOpenedApplicationPortRangesByEndpoint(c *gc.C) {
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)
 
-	result, err := uniterAPI.OpenedApplicationPortRangesByEndpoint(arg)
+	api := &uniter.UniterAPIv18{UniterAPI: *uniterAPI}
+	result, err := api.OpenedApplicationPortRangesByEndpoint(arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ApplicationOpenedPortsResults{
 		Results: []params.ApplicationOpenedPortsResult{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -46479,7 +46479,7 @@
     {
         "Name": "Uniter",
         "Description": "UniterAPI implements the latest version (v18) of the Uniter API.",
-        "Version": 18,
+        "Version": 19,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -47007,15 +47007,6 @@
                     },
                     "description": "ModelConfig returns the current model's configuration."
                 },
-                "ModelUUID": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/StringResult"
-                        }
-                    },
-                    "description": "ModelUUID returns the model UUID that this unit resides in.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
-                },
                 "NetworkInfo": {
                     "type": "object",
                     "properties": {
@@ -47027,18 +47018,6 @@
                         }
                     },
                     "description": "NetworkInfo returns network interfaces/addresses for specified bindings."
-                },
-                "OpenedApplicationPortRangesByEndpoint": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entity"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ApplicationOpenedPortsResults"
-                        }
-                    },
-                    "description": "OpenedApplicationPortRangesByEndpoint returns the port ranges opened by each application."
                 },
                 "OpenedMachinePortRangesByEndpoint": {
                     "type": "object",
@@ -47937,58 +47916,6 @@
                         "value",
                         "type",
                         "scope"
-                    ]
-                },
-                "ApplicationOpenedPorts": {
-                    "type": "object",
-                    "properties": {
-                        "endpoint": {
-                            "type": "string"
-                        },
-                        "port-ranges": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/PortRange"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "endpoint",
-                        "port-ranges"
-                    ]
-                },
-                "ApplicationOpenedPortsResult": {
-                    "type": "object",
-                    "properties": {
-                        "application-port-ranges": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ApplicationOpenedPorts"
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "application-port-ranges"
-                    ]
-                },
-                "ApplicationOpenedPortsResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ApplicationOpenedPortsResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "ApplicationStatusResult": {


### PR DESCRIPTION
The uniter API version 18 has 2 unused methods that we want to remove in Juju 4.0.

In preparation, we add a version 19 without the methods, and remove any associated uniter API client methods.

On the 4.0 (main) branch, we will drop support for version 18 and the methods will be deleted altogether from version 19.

## QA steps

- Bootstrap the released version of Juju and deploy a unit.
- Upgrade to this patch version with `--build-agent` and check that the unit logs are without errors relating to version.

## Documentation changes

None.

## Links

**Jira card:** [JUJU-4674](https://warthogs.atlassian.net/browse/JUJU-4674)

[JUJU-4674]: https://warthogs.atlassian.net/browse/JUJU-4674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ