### PR TITLE
Add upgrade getter to upgrade domain

### DIFF
--- a/core/upgrade/upgrade.go
+++ b/core/upgrade/upgrade.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrade
+
+import "database/sql"
+
+type Info struct {
+	UUID            string
+	PreviousVersion string
+	TargetVersion   string
+	CreatedAt       string
+	StartedAt       sql.NullString
+	CompletedAt     sql.NullString
+}

--- a/core/upgrade/upgrade.go
+++ b/core/upgrade/upgrade.go
@@ -3,13 +3,13 @@
 
 package upgrade
 
-import "database/sql"
+import "time"
 
 type Info struct {
 	UUID            string
 	PreviousVersion string
 	TargetVersion   string
-	CreatedAt       string
-	StartedAt       sql.NullString
-	CompletedAt     sql.NullString
+	CreatedAt       time.Time
+	StartedAt       time.Time
+	CompletedAt     time.Time
 }

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -159,8 +159,8 @@ func (st *State) StartUpgrade(ctx context.Context, upgradeUUID string) error {
 		return errors.Trace(err)
 	}
 
-	getUpgradeStartedQuery := "SELECT started_at AS &Info.* FROM upgrade_info WHERE uuid = $M.info_uuid"
-	getUpgradeStartedStmt, err := sqlair.Prepare(getUpgradeStartedQuery, Info{}, sqlair.M{})
+	getUpgradeStartedQuery := "SELECT started_at AS &info.* FROM upgrade_info WHERE uuid = $M.info_uuid"
+	getUpgradeStartedStmt, err := sqlair.Prepare(getUpgradeStartedQuery, info{}, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing %q", getUpgradeStartedQuery)
 	}
@@ -172,7 +172,7 @@ func (st *State) StartUpgrade(ctx context.Context, upgradeUUID string) error {
 	}
 
 	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var node Info
+		var node info
 		err := tx.Query(ctx, getUpgradeStartedStmt, sqlair.M{"info_uuid": upgradeUUID}).Get(&node)
 		if err != nil {
 			return errors.Trace(err)
@@ -301,26 +301,26 @@ func (st *State) ActiveUpgrade(ctx context.Context) (string, error) {
 }
 
 // Upgrade returns the upgrade with the supplied uuid
-func (st *State) Upgrade(ctx context.Context, upgradeUUID string) (Info, error) {
+func (st *State) Upgrade(ctx context.Context, upgradeUUID string) (info, error) {
 	db, err := st.DB()
 	if err != nil {
-		return Info{}, errors.Trace(err)
+		return info{}, errors.Trace(err)
 	}
 
-	getUpgradeQuery := "SELECT * AS &Info.* FROM upgrade_info WHERE uuid = $M.info_uuid"
-	getUpgradeStmt, err := sqlair.Prepare(getUpgradeQuery, Info{}, sqlair.M{})
+	getUpgradeQuery := "SELECT * AS &info.* FROM upgrade_info WHERE uuid = $M.info_uuid"
+	getUpgradeStmt, err := sqlair.Prepare(getUpgradeQuery, info{}, sqlair.M{})
 	if err != nil {
-		return Info{}, errors.Annotatef(err, "preparing %q", getUpgradeQuery)
+		return info{}, errors.Annotatef(err, "preparing %q", getUpgradeQuery)
 	}
 
-	var upgrade Info
+	var upgradeInstance info
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, getUpgradeStmt, sqlair.M{"info_uuid": upgradeUUID}).Get(&upgrade)
+		err := tx.Query(ctx, getUpgradeStmt, sqlair.M{"info_uuid": upgradeUUID}).Get(&upgradeInstance)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		return nil
 	})
 
-	return upgrade, errors.Trace(err)
+	return upgradeInstance, errors.Trace(err)
 }

--- a/domain/upgrade/state/state_test.go
+++ b/domain/upgrade/state/state_test.go
@@ -44,14 +44,14 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.upgradeUUID = uuid
 }
 
-func (s *stateSuite) getUpgrade(c *gc.C, st *State, upgradeUUID string) (Info, []infoControllerNode) {
+func (s *stateSuite) getUpgrade(c *gc.C, st *State, upgradeUUID string) (info, []infoControllerNode) {
 	db, err := s.st.DB()
 	c.Assert(err, jc.ErrorIsNil)
 
 	infoQ := `
-SELECT * AS &Info.* FROM upgrade_info
+SELECT * AS &info.* FROM upgrade_info
 WHERE uuid = $M.info_uuid`
-	infoS, err := sqlair.Prepare(infoQ, Info{}, sqlair.M{})
+	infoS, err := sqlair.Prepare(infoQ, info{}, sqlair.M{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	nodeInfosQ := `
@@ -61,7 +61,7 @@ WHERE upgrade_info_uuid = $M.info_uuid`
 	c.Assert(err, jc.ErrorIsNil)
 
 	var (
-		info      Info
+		info      info
 		nodeInfos []infoControllerNode
 	)
 	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
@@ -80,7 +80,7 @@ func (s *stateSuite) TestCreateUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	upgradeInfo, nodeInfos := s.getUpgrade(c, s.st, uuid)
-	c.Check(upgradeInfo, gc.Equals, Info{
+	c.Check(upgradeInfo, gc.Equals, info{
 		UUID:            uuid,
 		PreviousVersion: "3.0.0",
 		TargetVersion:   "3.0.1",
@@ -332,7 +332,7 @@ func (s *stateSuite) TestUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	upgradeInfo, err := s.st.Upgrade(context.Background(), uuid)
-	c.Check(upgradeInfo, gc.Equals, Info{
+	c.Check(upgradeInfo, gc.Equals, info{
 		UUID:            uuid,
 		PreviousVersion: "3.0.0",
 		TargetVersion:   "3.0.1",

--- a/domain/upgrade/state/types.go
+++ b/domain/upgrade/state/types.go
@@ -5,7 +5,7 @@ package state
 
 import "database/sql"
 
-type Info struct {
+type info struct {
 	UUID            string         `db:"uuid"`
 	PreviousVersion string         `db:"previous_version"`
 	TargetVersion   string         `db:"target_version"`

--- a/domain/upgrade/state/types.go
+++ b/domain/upgrade/state/types.go
@@ -5,7 +5,7 @@ package state
 
 import "database/sql"
 
-type info struct {
+type Info struct {
 	UUID            string         `db:"uuid"`
 	PreviousVersion string         `db:"previous_version"`
 	TargetVersion   string         `db:"target_version"`

--- a/domain/upgrade/state/types.go
+++ b/domain/upgrade/state/types.go
@@ -3,7 +3,14 @@
 
 package state
 
-import "database/sql"
+import (
+	"database/sql"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/upgrade"
+)
 
 type info struct {
 	UUID            string         `db:"uuid"`
@@ -12,6 +19,30 @@ type info struct {
 	CreatedAt       string         `db:"created_at"`
 	StartedAt       sql.NullString `db:"started_at"`
 	CompletedAt     sql.NullString `db:"completed_at"`
+}
+
+// ToUpgradeInfo converts an info to an upgrade.Info.
+func (i info) ToUpgradeInfo() (upgrade.Info, error) {
+	result := upgrade.Info{
+		UUID:            i.UUID,
+		PreviousVersion: i.PreviousVersion,
+		TargetVersion:   i.TargetVersion,
+	}
+
+	var err error
+
+	if result.CreatedAt, err = time.Parse("whatever the layout is", i.CreatedAt); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	// Repeat for other nullable dates.
+	if i.StartedAt.Valid {
+		if result.StartedAt, err = time.Parse("whatever the layout is", i.StartedAt.String); err != nil {
+			return result, errors.Trace(err)
+		}
+	}
+
+	return result, nil
 }
 
 type infoControllerNode struct {


### PR DESCRIPTION
This PR adds an Upgrade getter to domain/upgrade/state. This method will be used by DBUpgradeComplete watcher.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
go test github.com/juju/juju/domain/upgrade/state/... -gocheck.v
```
