### PR TITLE
[JUJU-4688] Ensure charm origins have a revision

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -287,6 +287,16 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
+		// Fill in the charm origin revision from the charm url if it's absent
+		if arg.CharmOrigin.Revision == nil {
+			curl, err := charm.ParseURL(arg.CharmURL)
+			if err != nil {
+				result.Results[i].Error = apiservererrors.ServerError(err)
+				continue
+			}
+			rev := curl.Revision
+			arg.CharmOrigin.Revision = &rev
+		}
 		err := deployApplication(
 			api.backend,
 			api.model,

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1405,7 +1405,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
-			CharmURL:        "local:foo-0",
+			CharmURL:        "local:foo-4",
 			CharmOrigin:     &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
 			NumUnits:        1,
 		}, {
@@ -1419,7 +1419,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 			NumUnits: 1,
 		}, {
 			ApplicationName: "hub",
-			CharmURL:        "hub-0",
+			CharmURL:        "hub-7",
 			CharmOrigin: &params.CharmOrigin{
 				Source: "charm-hub",
 				Risk:   "stable",
@@ -1438,6 +1438,10 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 
 	c.Assert(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
 	c.Assert(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
+
+	// assert revision is filled in from the charm url
+	c.Assert(*s.deployParams["foo"].CharmOrigin.Revision, gc.Equals, 4)
+	c.Assert(*s.deployParams["hub"].CharmOrigin.Revision, gc.Equals, 7)
 }
 
 func createCharmOriginFromURL(curl *charm.URL) *params.CharmOrigin {
@@ -1626,13 +1630,18 @@ func (s *ApplicationSuite) TestApplicationDeploymentRemovesPendingResourcesOnFai
 	resourcesManager.EXPECT().RemovePendingAppResources("my-app", resources).Return(nil)
 	s.backend.EXPECT().Resources().Return(resourcesManager)
 
+	rev := 8
 	results, err := s.api.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
-			// CharmURL is missing to ensure deployApplication fails
-			// so that we can assert pending app resources are removed
+			// CharmURL is missing & revision included to ensure deployApplication
+			// fails sufficiently far through execution so that we can assert pending
+			// app resources are removed
 			ApplicationName: "my-app",
-			CharmOrigin:     validCharmOriginForTest(),
-			Resources:       resources,
+			CharmOrigin: &params.CharmOrigin{
+				Source:   "charm-hub",
+				Revision: &rev,
+			},
+			Resources: resources,
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -55,18 +55,16 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 		if channel.Branch != "" {
 			branch = &channel.Branch
 		}
-		var revision *int
-		if url.Revision != -1 {
-			revision = &url.Revision
-		}
 		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginCharmHub,
-			Revision:     revision,
 			Risk:         string(channel.Risk),
 			Track:        track,
 			Branch:       branch,
 			Architecture: architecture,
 		}
+	}
+	if url.Revision != -1 {
+		origin.Revision = &url.Revision
 	}
 	if platform.OS != "" && platform.Channel != "" {
 		base, err := corebase.ParseBase(platform.OS, platform.Channel)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -2220,7 +2220,11 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 	origin := doc.CharmOrigin
 
 	// If the channel is empty, then we fall back to the Revision.
-	var revision int
+	// Set default revision to -1. This is because a revision of 0 is
+	// a valid revision for local charms which we need to be able to
+	// from. On import, in the -1 case we grab the revision by parsing
+	// the charm url.
+	revision := -1
 	if rev := origin.Revision; rev != nil {
 		revision = *rev
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1419,6 +1419,17 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 
 	co := a.CharmOrigin()
 	rev := co.Revision()
+	// If revision is empty we export revision -1. In this case
+	// parse the revision from the url
+	// NOTE: We use <= 0 because some old versions of juju default
+	// revision to 0 when it's empty
+	if rev <= 0 {
+		curl, err := charm.ParseURL(a.CharmURL())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		rev = curl.Revision
+	}
 
 	var channel *Channel
 	// Only charmhub charms will have a channel. Local charms

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -697,7 +697,7 @@ func (s *MigrationImportSuite) TestApplicationsUpdateSeriesNotPlatform(c *gc.C) 
 	c.Assert(obtainedOrigin.Platform.Channel, gc.Equals, "20.04/stable")
 }
 
-func (s *MigrationImportSuite) TestApplicationCharmOriginFilledIn(c *gc.C) {
+func (s *MigrationImportSuite) TestLocalApplicationCharmOriginRevisionFilledIn(c *gc.C) {
 	platform := &state.Platform{Architecture: corearch.DefaultArchitecture, OS: "ubuntu", Channel: "12.10/stable"}
 	f := factory.NewFactory(s.State, s.StatePool)
 
@@ -706,11 +706,8 @@ func (s *MigrationImportSuite) TestApplicationCharmOriginFilledIn(c *gc.C) {
 		Charm: testCharm,
 		Name:  "mysql",
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
-			Type:   "charm",
-			Channel: &state.Channel{
-				Risk: "edge",
-			},
+			Source:   "local",
+			Type:     "charm",
 			Platform: platform,
 		},
 	})

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -697,6 +697,30 @@ func (s *MigrationImportSuite) TestApplicationsUpdateSeriesNotPlatform(c *gc.C) 
 	c.Assert(obtainedOrigin.Platform.Channel, gc.Equals, "20.04/stable")
 }
 
+func (s *MigrationImportSuite) TestApplicationCharmOriginFilledIn(c *gc.C) {
+	platform := &state.Platform{Architecture: corearch.DefaultArchitecture, OS: "ubuntu", Channel: "12.10/stable"}
+	f := factory.NewFactory(s.State, s.StatePool)
+
+	testCharm := f.MakeCharm(c, &factory.CharmParams{Revision: "8"})
+	_ = f.MakeApplication(c, &factory.ApplicationParams{
+		Charm: testCharm,
+		Name:  "mysql",
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-hub",
+			Type:   "charm",
+			Channel: &state.Channel{
+				Risk: "edge",
+			},
+			Platform: platform,
+		},
+	})
+
+	_, newSt := s.importModel(c, s.State)
+	newApp, err := newSt.Application("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*newApp.CharmOrigin().Revision, gc.Equals, 8)
+}
+
 func (s *MigrationImportSuite) TestApplicationStatus(c *gc.C) {
 	cons := constraints.MustParse("arch=amd64 mem=8G")
 	platform := &state.Platform{Architecture: corearch.DefaultArchitecture, OS: "ubuntu", Channel: "12.10/stable"}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -14,6 +14,7 @@ type StateBackend interface {
 	RemoveOrphanedSecretPermissions() error
 	MigrateApplicationOpenedPortsToUnitScope() error
 	EnsureInitalRefCountForExternalSecretBackends() error
+	EnsureApplicationCharmOriginsHaveRevisions() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -42,4 +43,8 @@ func (s stateBackend) MigrateApplicationOpenedPortsToUnitScope() error {
 
 func (s stateBackend) EnsureInitalRefCountForExternalSecretBackends() error {
 	return state.EnsureInitalRefCountForExternalSecretBackends(s.pool)
+}
+
+func (s stateBackend) EnsureApplicationCharmOriginsHaveRevisions() error {
+	return state.EnsureApplicationCharmOriginsHaveRevisions(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -21,6 +21,7 @@ var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.1.1"), stateStepsFor311()},
 		upgradeToVersion{version.MustParse("3.1.3"), stateStepsFor313()},
+		upgradeToVersion{version.MustParse("3.1.7"), stateStepsFor317()},
 	}
 	return steps
 }
@@ -32,6 +33,7 @@ var upgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.1.1"), stepsFor311()},
 		upgradeToVersion{version.MustParse("3.1.3"), stepsFor313()},
+		upgradeToVersion{version.MustParse("3.1.7"), stepsFor317()},
 	}
 	return steps
 }

--- a/upgrades/steps_317.go
+++ b/upgrades/steps_317.go
@@ -1,0 +1,20 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+func stepsFor317() []Step {
+	return []Step{}
+}
+
+func stateStepsFor317() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "ensure application charm origins have revisions",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureApplicationCharmOriginsHaveRevisions()
+			},
+		},
+	}
+}

--- a/upgrades/steps_317_test.go
+++ b/upgrades/steps_317_test.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v317 = version.MustParse("3.1.7")
+
+type steps317Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps317Suite{})
+
+func (s *steps317Suite) TestEnsureApplicationCharmOriginsHaveRevisions(c *gc.C) {
+	step := findStateStep(c, v317, "ensure application charm origins have revisions")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -31,9 +31,6 @@ func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }
 
-// Untl we add upgrade steps for 3.0, keep static analysis happy.
-var _ = findStateStep
-
 func findStateStep(c *gc.C, ver version.Number, description string) upgrades.Step {
 	for _, op := range (*upgrades.StateUpgradeOperations)() {
 		if op.TargetVersion() == ver {
@@ -599,6 +596,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.1.1",
 		"3.1.3",
+		"3.1.7",
 	})
 }
 
@@ -607,6 +605,7 @@ func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.1.1",
 		"3.1.3",
+		"3.1.7",
 	})
 }
 


### PR DESCRIPTION
This will be useful for a future change, since we will now be able to use the charm origin to get a revision, rather than being force to parse it from the charm url

The client always fills in a revision when deploying. Also the apiserver parses from the provided charm url is a revision is not provided. This is for compatibility with old clients. In future, we will likely enforce an origin is provided in validation steps

Add upgrade steps which add a revision to charm origins if it doesn't have one. Parsed from the charm url

Do the same for migration on import

As a flyby, on migrations make sure to export -1 as the revision for charm origins without a revision, because 0 is a valid revision for local charms.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

#### Deploy a local charm and verify it has a revision
```
$ juju deploy /home/jack/charms/ubuntu ubu-local
$ juju mongo
db.applications.find()
...
{ "_id" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e:ubu-local", "name" : "ubu-local", "model-uuid" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" }, "revision" : 12 }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```

#### Deploy a local charm with an old client
```
$ juju-3.1.6 deploy /home/jack/charms/ubuntu ubu-local
$ juju mongo
db.applications.find()
...
{ "_id" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e:ubu-local", "name" : "ubu-local", "model-uuid" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" }, "revision" : 12 }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```

#### Deploy a local charm with pylib-juju
```
$ cat deploy.py
async def main():
    model = Model()
    print('Connecting to model')
    # connect to current model with current user, per Juju CLI
    await model.connect()

    try:
        print('Deploying ubuntu')
        application = await model.deploy(
            '/home/jack/charms/ubuntu/',
            application_name='ubu-local',
        )

        print('Waiting for active')
        await model.wait_for_idle(status='active')

    finally:
        print('Disconnecting from model')
        await model.disconnect()


if __name__ == '__main__':
    jasyncio.run(main())

$ python ./dpeloy.py
Connecting to model
Deploying ubuntu
Waiting for active
Disconnecting from moodel
$ juju mongo
db.applications.find()
...
{ "_id" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e:ubu-local", "name" : "ubu-local", "model-uuid" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" }, "revision" : 12 }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```
 
#### Upgrade a controller to 3.1.7
```
$ juju-3.1.6 deploy /home/jack/charms/ubuntu ubu-local
$ juju upgrade-controller --build-agent
(wait)
$ juju mongo
db.applications.find()
...
{ "_id" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e:ubu-local", "name" : "ubu-local", "model-uuid" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" }, "revision" : 12 }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```

#### Forward-migrate a model t o2,1,7
```
$ juju-3.1.6 add-model m
$ juju-3.1.6 deploy /home/jack/charms/ubuntu ubu-local
$ juju migrate m ctrl-3.1.7
$ juju mongo
db.applications.find()
...
{ "_id" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e:ubu-local", "name" : "ubu-local", "model-uuid" : "9b3ffcf0-3edf-434a-8b82-29a1fa58b69e", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "id" : "", "hash" : "", "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" }, "revision" : 12 }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```

#### Try upgrading a model which has been migrated (3.1.6 - 3.1.6 -> 3.1.7)
```
juju-3.1.6 bootstrap lxd lxd
juju-3.1.6 bootstrap lxd lxd2
juju-3.1.6 switch lxd
juju-3.1.6 add-model m
juju-3.1.6 deploy  /home/jack/charms/ubuntu
juju-3.1.6 migrate m lxd2
juju-3.1.6 switch lxd2:m
juju-3.1.6 mongo
db.application.find()
...
{ "_id" : "8349d7f3-00bd-439a-84b9-3ea85e6e93f9:ubuntu", "name" : "ubuntu", "model-uuid" : "8349d7f3-00bd-439a-84b9-3ea85e6e93f9", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "type" : "charm", "id" : "", "hash" : "", "revision" : 0, "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" } }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : 2, "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```
Notice that the revision is 0
```
juju upgrade-controller --build-agent
juju mongo
db.applications.find()
...
{ "_id" : "8349d7f3-00bd-439a-84b9-3ea85e6e93f9:ubuntu", "name" : "ubuntu", "model-uuid" : "8349d7f3-00bd-439a-84b9-3ea85e6e93f9", "subordinate" : false, "charmurl" : "local:focal/ubuntu-12", "charm-origin" : { "source" : "local", "type" : "charm", "id" : "", "hash" : "", "revision" : 12, "platform" : { "architecture" : "amd64", "os" : "ubuntu", "channel" : "20.04" } }, "charmmodifiedversion" : 0, "forcecharm" : false, "life" : 0, "unitcount" : 1, "relationcount" : 0, "minunits" : 0, "txn-revno" : NumberLong(3), "metric-credentials" : BinData(0,""), "exposed" : false, "scale" : 0, "passwordhash" : "", "provisioning-state" : null }
```
Notice the revision is now 12