### PR TITLE
Allow DB accessor to be more resilient

### DIFF
--- a/worker/dbaccessor/dbopener.go
+++ b/worker/dbaccessor/dbopener.go
@@ -1,0 +1,64 @@
+package dbaccessor
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/retry"
+)
+
+// DBAppAcquirer is an interface that can be used to reacquire a DBApp.
+type DBAppAcquirer interface {
+	DBApp() DBApp
+	Acquire() error
+}
+
+type dbOpener struct {
+	acquirer DBAppAcquirer
+	mutex    sync.Mutex
+	ref      DBApp
+	clock    clock.Clock
+}
+
+// Open the dqlite database with the given name.
+func (a *dbOpener) Open(ctx context.Context, name string) (*sql.DB, error) {
+	var db *sql.DB
+	err := retry.Call(retry.CallArgs{
+		Func: func() error {
+			a.mutex.Lock()
+			ref := a.ref
+			a.mutex.Unlock()
+
+			var err error
+			db, err = ref.Open(ctx, name)
+			if err == nil {
+				return nil
+			}
+
+			if err := a.ensureRef(ctx); err != nil {
+				return errors.Annotatef(err, "failed to open %q", name)
+			}
+
+			return errors.Annotatef(err, "failed to open %q", name)
+		},
+		Clock:    a.clock,
+		Attempts: 3,
+		Delay:    time.Second * 10,
+	})
+	return db, err
+}
+
+func (a *dbOpener) ensureRef(ctx context.Context) error {
+	if err := a.acquirer.Acquire(); err != nil {
+		return errors.Trace(err)
+	}
+
+	a.mutex.Lock()
+	a.ref = a.acquirer.DBApp()
+	a.mutex.Unlock()
+	return nil
+}

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -42,7 +42,7 @@ type Hub interface {
 }
 
 // NewDBWorkerFunc creates a tracked db worker.
-type NewDBWorkerFunc func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
+type NewDBWorkerFunc func(context.Context, DBOpener, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 
 // ManifoldConfig contains:
 // - The names of other manifolds on which the DB accessor depends.

--- a/worker/dbaccessor/manifold_test.go
+++ b/worker/dbaccessor/manifold_test.go
@@ -75,7 +75,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBOpener, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return nil, nil
 		},
 		NewMetricsCollector: func() *Collector {

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -112,7 +112,7 @@ func (s *baseSuite) newWorkerWithDB(c *gc.C, db TrackedDB) worker.Worker {
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
-		NewDBWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
+		NewDBWorker: func(context.Context, DBOpener, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return db, nil
 		},
 		MetricsCollector: &Collector{},


### PR DESCRIPTION
The following is a thought experiement from the london sprint, which suggested we could be more resilient to failure to open the db. As we previously only opened the db, that might not actually be enough. We might require to re-open the db handler and try again. This attempts to do this without introducing the dbApp directly into the tracker.


## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing

## QA steps

```sh
TBA
```

## Links

**Jira card:** JUJU-[XXXX]
