### PR TITLE
Introspection: reload config via SIGHUP

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -251,6 +251,9 @@ juju_revoke_lease () {
   juju_agent --post leases/revoke model="$model" lease="$lease" ns="$ns"
 }
 
+juju_reload_config() {
+  sudo kill -SIGHUP $(pidof jujud)
+}
 
 # This asks for the command of the current pid.
 # Can't use $0 nor $SHELL due to this being wrong in various situations.
@@ -276,5 +279,6 @@ if [ "$shell" = "bash" ]; then
   export -f juju_stop_unit
   export -f juju_leases
   export -f juju_revoke_lease
+  export -f juju_reload_config
 fi
 `


### PR DESCRIPTION
The following allows sending a SIGHUP to the jujud process. This will be useful for testing and may also be used by the juju-controller charm (although I suspect we'll do that in python directly).

This will also target non-controller jujud processes, but that will be treated as a no-op. If we move to controller-jujud process, then we can grab that pid, which will be safer.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju ssh -m controller
> juju_reload_config
```

## Links

**Jira card:** JUJU-4675
