### PR TITLE
Remove stateservinginfo from peergrouper

### DIFF
--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -90,10 +90,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	mongoSession := st.MongoSession()
 	agentConfig := agent.CurrentConfig()
-	stateServingInfo, ok := agentConfig.StateServingInfo()
-	if !ok {
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
 		_ = stTracker.Done()
-		return nil, errors.New("state serving info missing from agent config")
+		return nil, errors.Trace(err)
 	}
 	model, err := st.Model()
 	if err != nil {
@@ -108,9 +108,9 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		APIHostPortsSetter:   &CachingAPIHostPortsSetter{APIHostPortsSetter: st},
 		Clock:                clock,
 		Hub:                  config.Hub,
-		MongoPort:            stateServingInfo.StatePort,
-		APIPort:              stateServingInfo.APIPort,
-		ControllerAPIPort:    stateServingInfo.ControllerAPIPort,
+		MongoPort:            controllerConfig.StatePort(),
+		APIPort:              controllerConfig.APIPort(),
+		ControllerAPIPort:    controllerConfig.ControllerAPIPort(),
 		SupportsHA:           supportsHA,
 		PrometheusRegisterer: config.PrometheusRegisterer,
 		// On machine models, the controller id is the same as the machine/agent id.

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -42,15 +42,13 @@ type ManifoldSuite struct {
 var _ = gc.Suite(&ManifoldSuite{})
 
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.ControllerConfig = map[string]any{
+		controller.APIPort: 5678,
+	}
 	s.StateSuite.SetUpTest(c)
 
 	s.clock = testclock.NewClock(time.Time{})
-	s.agent = &mockAgent{conf: mockAgentConfig{
-		info: &controller.StateServingInfo{
-			StatePort: 1234,
-			APIPort:   5678,
-		},
-	}}
+	s.agent = &mockAgent{conf: mockAgentConfig{}}
 	s.hub = &mockHub{}
 	s.registerer = &fakeRegisterer{}
 	s.stateTracker = stubStateTracker{pool: s.StatePool, state: s.State}
@@ -147,15 +145,6 @@ func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckAlive(c, w)
 	return w
-}
-
-func (s *ManifoldSuite) TestNoStateServingInfoClosesState(c *gc.C) {
-	s.agent.conf.info = nil
-
-	_, err := s.manifold.Start(s.context)
-	c.Assert(err, gc.ErrorMatches, "state serving info missing from agent config")
-
-	s.stateTracker.CheckCallNames(c, "Use", "Done")
 }
 
 type stubStateTracker struct {


### PR DESCRIPTION
This was observed when identifying what we require for the new controller agent config. As part of undertaking that work we need to remove APIPort and ControllerAPIPort (state port will follow), as it doesn't need to exist in the new world.

The peergrouper has state, so just use the controller config. If it has the controller config, it will have all the relevant information.

I've removed the check for missing state serving info, as that isn't the case anymore.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu -n 3
```

## Links

**Jira card:** JUJU-4708
