### PR TITLE
Ignore status when processing controller changes in peergrouper

### DIFF
--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -218,10 +218,9 @@ func (st *fakeState) addController(id string, wantsVote bool) *fakeController {
 		panic(fmt.Errorf("id %q already used", id))
 	}
 	doc := controllerDoc{
-		id:         id,
-		wantsVote:  wantsVote,
-		statusInfo: status.StatusInfo{Status: status.Started},
-		life:       state.Alive,
+		id:        id,
+		wantsVote: wantsVote,
+		life:      state.Alive,
 	}
 	m := &fakeController{
 		errors:  &st.errors,

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -61,13 +61,6 @@ func (*cloudServiceShim) Life() state.Life {
 	return state.Alive
 }
 
-func (*cloudServiceShim) Status() (status.StatusInfo, error) {
-	// We don't record the status of a cloud service entity.
-	return status.StatusInfo{
-		Status: status.Active,
-	}, nil
-}
-
 func (*cloudServiceShim) SetStatus(status.StatusInfo) error {
 	// We don't record the status of a cloud service entity.
 	return nil

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -560,7 +560,7 @@ func (w *pgWorker) publishAPIServerDetails(
 		} else {
 			logger.Tracef("replica-set member %q not found", id)
 		}
-		
+
 		server := apiserver.APIServer{
 			ID:              id,
 			InternalAddress: internalAddress,
@@ -707,7 +707,7 @@ func (w *pgWorker) updateVoteStatus() error {
 			}
 		}
 	}
-	logger.Debugf("controllers which are no longer in replicaset: %v", orphanedNodes.Values())
+	logger.Debugf("controllers that are no longer in replicaset: %v", orphanedNodes.Values())
 	for _, id := range orphanedNodes.Values() {
 		node := w.controllerTrackers[id]
 		nonVoting = append(nonVoting, node)

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -495,7 +495,7 @@ func (w *pgWorker) updateControllerNodes() (bool, error) {
 		w.controllerTrackers[id] = tracker
 		changed = true
 	}
-	
+
 	return changed, nil
 }
 
@@ -552,10 +552,15 @@ func (w *pgWorker) publishAPIServerDetails(
 		var internalAddress string
 		if members[id] != nil {
 			mongoAddress, _, err := net.SplitHostPort(members[id].Address)
-			if err == nil {
+			if err != nil {
+				logger.Errorf("splitting host/port for address %q: %v", members[id].Address, err)
+			} else {
 				internalAddress = net.JoinHostPort(mongoAddress, strconv.Itoa(internalPort))
 			}
+		} else {
+			logger.Tracef("replica-set member %q not found", id)
 		}
+		
 		server := apiserver.APIServer{
 			ID:              id,
 			InternalAddress: internalAddress,


### PR DESCRIPTION
In the `peergrouper` worker, we have been checking the status of machines in the controller plane, and _not_ recording them as a change unless their status is other than _pending_.

This check is not necessary, because such machines cannot be clustered until they have reported an address, which is a proxy for being provisioned anyway.

Here we just remove the status check. As soon as machines have addresses, they get clustered as desired. We now do this with a little less complexity.

Some extra logging is added that will help us diagnose clustering events as they affect Dqlite topology manipulation.

## QA steps

- Bootstrap to LXD
- `juju debug-log -m controller`
- In another terminal, `juju enable-ha`
- Watch the controller model status and observe that HA is established without the debug-log session disconnecting.

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-4437