### PR TITLE
Removes internal/docker from the API Client

### DIFF
--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/httprequest.v1"
 
 	"github.com/juju/juju/api/base"
-	coretesting "github.com/juju/juju/testing"
 )
 
 // APICallerFunc is a function type that implements APICaller.
@@ -35,7 +34,7 @@ func (APICallerFunc) BestFacadeVersion(facade string) int {
 }
 
 func (APICallerFunc) ModelTag() (names.ModelTag, bool) {
-	return coretesting.ModelTag, true
+	return names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d"), true
 }
 
 func (APICallerFunc) Context() context.Context {

--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/rpc/params"
 )
@@ -310,8 +309,8 @@ func (c *Client) ApplicationOCIResources(appName string) (map[string]resources.D
 	for k, v := range res.Result.Images {
 		images[k] = resources.DockerImageDetails{
 			RegistryPath: v.RegistryPath,
-			ImageRepoDetails: docker.ImageRepoDetails{
-				BasicAuthConfig: docker.BasicAuthConfig{
+			ImageRepoDetails: resources.ImageRepoDetails{
+				BasicAuthConfig: resources.BasicAuthConfig{
 					Username: v.Username,
 					Password: v.Password,
 				},

--- a/api/controller/caasapplicationprovisioner/client_test.go
+++ b/api/controller/caasapplicationprovisioner/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -236,8 +235,8 @@ func (s *provisionerSuite) TestApplicationOCIResources(c *gc.C) {
 	c.Assert(imageResources, jc.DeepEquals, map[string]resources.DockerImageDetails{
 		"cockroachdb-image": {
 			RegistryPath: "cockroachdb/cockroach:v20.1.4",
-			ImageRepoDetails: docker.ImageRepoDetails{
-				BasicAuthConfig: docker.BasicAuthConfig{
+			ImageRepoDetails: resources.ImageRepoDetails{
+				BasicAuthConfig: resources.BasicAuthConfig{
 					Username: "jujuqa",
 					Password: "pwd",
 				},

--- a/api/controller/caasmodeloperator/client.go
+++ b/api/controller/caasmodeloperator/client.go
@@ -11,7 +11,6 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -46,17 +45,17 @@ func (c *Client) ModelOperatorProvisioningInfo() (ModelOperatorProvisioningInfo,
 	d := result.ImageDetails
 	imageRepo := resources.DockerImageDetails{
 		RegistryPath: d.RegistryPath,
-		ImageRepoDetails: docker.ImageRepoDetails{
+		ImageRepoDetails: resources.ImageRepoDetails{
 			Repository:    d.Repository,
 			ServerAddress: d.ServerAddress,
-			BasicAuthConfig: docker.BasicAuthConfig{
+			BasicAuthConfig: resources.BasicAuthConfig{
 				Username: d.Username,
 				Password: d.Password,
-				Auth:     docker.NewToken(d.Auth),
+				Auth:     resources.NewToken(d.Auth),
 			},
-			TokenAuthConfig: docker.TokenAuthConfig{
-				IdentityToken: docker.NewToken(d.IdentityToken),
-				RegistryToken: docker.NewToken(d.RegistryToken),
+			TokenAuthConfig: resources.TokenAuthConfig{
+				IdentityToken: resources.NewToken(d.IdentityToken),
+				RegistryToken: resources.NewToken(d.RegistryToken),
 				Email:         d.Email,
 			},
 		},

--- a/api/package_test.go
+++ b/api/package_test.go
@@ -46,7 +46,6 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/status",
 		"core/watcher",
 		"environs/context",
-		"internal/docker",
 		"internal/feature",
 		"internal/proxy",
 		"internal/proxy/config",

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
 	"github.com/juju/juju/state"
@@ -135,7 +136,7 @@ func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
 
 type mockResources struct {
 	caasapplicationprovisioner.Resources
-	resource *resources.DockerImageDetails
+	resource *docker.DockerImageDetails
 }
 
 func (m *mockResources) OpenResource(applicationID string, name string) (resources.Resource, io.ReadCloser, error) {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/resource"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
@@ -365,7 +366,7 @@ func (a *API) provisioningInfo(ctx context.Context, appName names.ApplicationTag
 		Devices:              devices,
 		Constraints:          mergedCons,
 		Base:                 params.Base{Name: base.OS, Channel: base.Channel},
-		ImageRepo:            params.NewDockerImageInfo(cfg.CAASImageRepo(), imagePath),
+		ImageRepo:            params.NewDockerImageInfo(docker.ConvertToResourceImageDetails(cfg.CAASImageRepo()), imagePath),
 		CharmModifiedVersion: app.CharmModifiedVersion(),
 		CharmURL:             *charmURL,
 		Trust:                appConfig.GetBool(coreapplication.TrustConfigOptionName, false),
@@ -699,7 +700,7 @@ func readDockerImageResource(reader io.Reader) (params.DockerImageInfo, error) {
 			return params.DockerImageInfo{}, errors.Annotate(err, "file neither valid json or yaml")
 		}
 	}
-	if err := resources.ValidateDockerRegistryPath(details.RegistryPath); err != nil {
+	if err := docker.ValidateDockerRegistryPath(details.RegistryPath); err != nil {
 		return params.DockerImageInfo{}, err
 	}
 	return params.DockerImageInfo{

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -690,7 +690,7 @@ func (a *API) ApplicationOCIResources(ctx context.Context, args params.Entities)
 }
 
 func readDockerImageResource(reader io.Reader) (params.DockerImageInfo, error) {
-	var details resources.DockerImageDetails
+	var details docker.DockerImageDetails
 	contents, err := io.ReadAll(reader)
 	if err != nil {
 		return params.DockerImageInfo{}, errors.Trace(err)

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/core/resources"
 	jujuresource "github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -270,8 +269,8 @@ func (s *CAASApplicationProvisionerSuite) TestApplicationOCIResources(c *gc.C) {
 	s.st.resource = &mockResources{
 		resource: &resources.DockerImageDetails{
 			RegistryPath: "gitlab:latest",
-			ImageRepoDetails: docker.ImageRepoDetails{
-				BasicAuthConfig: docker.BasicAuthConfig{
+			ImageRepoDetails: resources.ImageRepoDetails{
+				BasicAuthConfig: resources.BasicAuthConfig{
 					Username: "jujuqa",
 					Password: "pwd",
 				},

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasapplicationprovisioner"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/config"
-	"github.com/juju/juju/core/resources"
 	jujuresource "github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -267,10 +267,10 @@ func (s *CAASApplicationProvisionerSuite) TestApplicationOCIResources(c *gc.C) {
 		},
 	}
 	s.st.resource = &mockResources{
-		resource: &resources.DockerImageDetails{
+		resource: &docker.DockerImageDetails{
 			RegistryPath: "gitlab:latest",
-			ImageRepoDetails: resources.ImageRepoDetails{
-				BasicAuthConfig: resources.BasicAuthConfig{
+			ImageRepoDetails: docker.ImageRepoDetails{
+				BasicAuthConfig: docker.BasicAuthConfig{
 					Username: "jujuqa",
 					Password: "pwd",
 				},

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -15,6 +15,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloudconfig/podcfg"
+	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
 )
@@ -121,7 +122,7 @@ func (a *API) ModelOperatorProvisioningInfo(ctx context.Context) (params.ModelOp
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	imageInfo := params.NewDockerImageInfo(controllerConf.CAASImageRepo(), registryPath)
+	imageInfo := params.NewDockerImageInfo(docker.ConvertToResourceImageDetails(controllerConf.CAASImageRepo()), registryPath)
 	a.logger.Tracef("image info %v", imageInfo)
 
 	result = params.ModelOperatorInfo{

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/core/paths"
 	coreresources "github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/testing"
 )
@@ -332,8 +331,8 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 					Name: "nginx",
 					Image: coreresources.DockerImageDetails{
 						RegistryPath: "nginx-image:latest",
-						ImageRepoDetails: docker.ImageRepoDetails{
-							BasicAuthConfig: docker.BasicAuthConfig{
+						ImageRepoDetails: coreresources.ImageRepoDetails{
+							BasicAuthConfig: coreresources.BasicAuthConfig{
 								Username: "username",
 								Password: "password",
 							},

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/core/resources"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/testing"
 )
 
@@ -56,7 +55,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		Port:         int32(5497),
 	}
 	if isPrivateImageRepo {
-		config.ImageDetails.BasicAuthConfig.Auth = docker.NewToken("xxxxxxxx===")
+		config.ImageDetails.BasicAuthConfig.Auth = resources.NewToken("xxxxxxxx===")
 	}
 	bridge := &modelOperatorBrokerBridge{
 		client: m.client,

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -19,7 +19,6 @@ import (
 
 	apiresources "github.com/juju/juju/api/client/resources"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/internal/docker"
 )
 
@@ -451,7 +450,7 @@ password: hunter2
 	data := bytes.NewBufferString(content)
 	dets, err := unMarshalDockerDetails(data)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dets, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(dets, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -471,7 +470,7 @@ password: hunter2
 	data = bytes.NewBufferString(content)
 	dets, err = unMarshalDockerDetails(data)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dets, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(dets, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -503,7 +502,7 @@ func (s DeploySuite) TestGetDockerDetailsData(c *gc.C) {
 	fs := osFilesystem{}
 	result, err := getDockerDetailsData("registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image", fs.Open)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(result, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -525,7 +524,7 @@ func (s DeploySuite) TestGetDockerDetailsData(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	result, err = getDockerDetailsData(yamlFile, fs.Open)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(result, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "mariadb/mariadb:10.2",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -575,7 +574,7 @@ func (s uploadDeps) Open(name string) (modelcmd.ReadSeekCloser, error) {
 	if err := s.stub.NextErr(); err != nil {
 		return nil, err
 	}
-	if err := resources.ValidateDockerRegistryPath(name); err == nil && !strings.HasSuffix(name, ".txt") {
+	if err := docker.ValidateDockerRegistryPath(name); err == nil && !strings.HasSuffix(name, ".txt") {
 		return nil, errors.New("invalid file")
 	}
 	return rsc{bytes.NewBuffer(s.data)}, nil

--- a/core/migration/package_test.go
+++ b/core/migration/package_test.go
@@ -29,6 +29,5 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/life",
 		"core/network",
 		"core/resources",
-		"internal/docker",
 	})
 }

--- a/core/resources/dockerresource.go
+++ b/core/resources/dockerresource.go
@@ -7,52 +7,104 @@ import (
 	// Import shas that are used for docker image validation.
 	_ "crypto/sha256"
 	_ "crypto/sha512"
-	"encoding/json"
-
-	"github.com/docker/distribution/reference"
-	"github.com/juju/errors"
-	"gopkg.in/yaml.v2"
-
-	"github.com/juju/juju/internal/docker"
+	"time"
 )
+
+// Token defines a token value with expiration time.
+type Token struct {
+	// Value is the value of the token.
+	Value string
+
+	// ExpiresAt is the unix time in seconds and milliseconds when the authorization token expires.
+	ExpiresAt *time.Time
+}
+
+// NewToken creates a Token.
+func NewToken(value string) *Token {
+	if value == "" {
+		return nil
+	}
+	return &Token{Value: value}
+}
+
+// Empty checks if the auth information is empty.
+func (t *Token) Empty() bool {
+	return t == nil || t.Value == ""
+}
+
+// Content returns the raw content of the token.
+func (t *Token) Content() string {
+	if t.Empty() {
+		return ""
+	}
+	return t.Value
+}
+
+// BasicAuthConfig contains authorization information for basic auth.
+type BasicAuthConfig struct {
+	// Auth is the base64 encoded "username:password" string.
+	Auth *Token
+
+	// Username holds the username used to gain access to a non-public image.
+	Username string
+
+	// Password holds the password used to gain access to a non-public image.
+	Password string
+}
+
+// Empty checks if the auth information is empty.
+func (ba BasicAuthConfig) Empty() bool {
+	return ba.Auth.Empty() && ba.Username == "" && ba.Password == ""
+}
+
+// TokenAuthConfig contains authorization information for token auth.
+// Juju does not support the docker credential helper because k8s does not support it either.
+// https://kubernetes.io/docs/concepts/containers/images/#configuring-nodes-to-authenticate-to-a-private-registry
+type TokenAuthConfig struct {
+	Email string
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken *Token
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken *Token
+}
+
+// Empty checks if the auth information is empty.
+func (ac TokenAuthConfig) Empty() bool {
+	return ac.RegistryToken.Empty() && ac.IdentityToken.Empty()
+}
+
+// ImageRepoDetails contains authorization information for connecting to a Registry.
+type ImageRepoDetails struct {
+	BasicAuthConfig
+	TokenAuthConfig
+
+	// Repository is the namespace of the image repo.
+	Repository string
+
+	// ServerAddress is the auth server address.
+	ServerAddress string
+
+	// Region is the cloud region.
+	Region string
+}
+
+// IsPrivate checks if the repository detail is private.
+func (rid ImageRepoDetails) IsPrivate() bool {
+	return !rid.BasicAuthConfig.Empty() || !rid.TokenAuthConfig.Empty()
+}
 
 // DockerImageDetails holds the details for a Docker resource type.
 type DockerImageDetails struct {
 	// RegistryPath holds the path of the Docker image (including host and sha256) in a docker registry.
-	RegistryPath string `json:"ImageName" yaml:"registrypath"`
+	RegistryPath string
 
-	docker.ImageRepoDetails `json:",inline" yaml:",inline"`
+	ImageRepoDetails
 }
 
 // IsPrivate shows if the image repo is private or not.
 func (did DockerImageDetails) IsPrivate() bool {
 	return did.ImageRepoDetails.IsPrivate()
-}
-
-// ValidateDockerRegistryPath ensures the registry path is valid (i.e. api.jujucharms.com@sha256:deadbeef)
-func ValidateDockerRegistryPath(path string) error {
-	_, err := reference.ParseNormalizedNamed(path)
-	if err != nil {
-		return errors.NotValidf("docker image path %q", path)
-	}
-	return nil
-}
-
-// CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name string, details DockerImageDetails) error {
-	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(details.RegistryPath)
-}
-
-// UnmarshalDockerResource unmarshals the docker resource file from data.
-func UnmarshalDockerResource(data []byte) (DockerImageDetails, error) {
-	var resourceBody DockerImageDetails
-	// Older clients sent the resources as a json string.
-	err := json.Unmarshal(data, &resourceBody)
-	if err != nil {
-		if err := yaml.Unmarshal(data, &resourceBody); err != nil {
-			return DockerImageDetails{}, errors.Annotate(err, "docker resource is neither valid json or yaml")
-		}
-	}
-	return resourceBody, nil
 }

--- a/core/testing/constants.go
+++ b/core/testing/constants.go
@@ -1,32 +1,18 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package testing
 
-import (
-	"github.com/juju/utils/v3"
-
-	coretesting "github.com/juju/juju/core/testing"
-)
+import "time"
 
 // ShortWait is a reasonable amount of time to block waiting for something that
 // shouldn't actually happen. (as in, the test suite will *actually* wait this
 // long before continuing)
-// Deprecated: use core/testing.ShortWait instead. This is so you don't bring
-// in extra dependencies from this package.
-const ShortWait = coretesting.ShortWait
+const ShortWait = 50 * time.Millisecond
 
 // LongWait is used when something should have already happened, or happens
 // quickly, but we want to make sure we just haven't missed it. As in, the test
 // suite should proceed without sleeping at all, but just in case. It is long
 // so that we don't have spurious failures without actually slowing down the
 // test suite
-// Deprecated: use core/testing.LongWait instead. This is so you don't bring
-// in extra dependencies from this package.
-const LongWait = coretesting.LongWait
-
-// TODO(katco): 2016-08-09: lp:1611427
-var LongAttempt = &utils.AttemptStrategy{
-	Total: LongWait,
-	Delay: ShortWait,
-}
+const LongWait = 10 * time.Second

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -42,7 +42,6 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/status",
 		"core/watcher",
-		"internal/docker",
 	})
 
 }

--- a/core/watcher/package_test.go
+++ b/core/watcher/package_test.go
@@ -31,8 +31,6 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/resources",
 		"core/secrets",
 		"core/status",
-		//  TODO: these have been brought in from migration and this is BAD.
-		"internal/docker",
 	})
 
 }

--- a/core/watcher/watchertest/notify.go
+++ b/core/watcher/watchertest/notify.go
@@ -10,8 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/core/testing"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/testing"
 )
 
 type MockNotifyWatcher struct {

--- a/core/watcher/watchertest/relationunits.go
+++ b/core/watcher/watchertest/relationunits.go
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/testing"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/testing"
 )
 
 // NewRelationUnitsWatcherC returns a RelationUnitsWatcherC that

--- a/core/watcher/watchertest/strings.go
+++ b/core/watcher/watchertest/strings.go
@@ -11,8 +11,8 @@ import (
 	gc "gopkg.in/check.v1"
 	tomb "gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/core/testing"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/testing"
 )
 
 type MockStringsWatcher struct {

--- a/internal/docker/auth.go
+++ b/internal/docker/auth.go
@@ -145,6 +145,14 @@ func (ba *BasicAuthConfig) init() error {
 	return nil
 }
 
+// DockerImageDetails holds the details for a Docker resource type.
+type DockerImageDetails struct {
+	// RegistryPath holds the path of the Docker image (including host and sha256) in a docker registry.
+	RegistryPath string `json:"ImageName" yaml:"registrypath"`
+
+	ImageRepoDetails `json:",inline" yaml:",inline"`
+}
+
 // ImageRepoDetails contains authorization information for connecting to a Registry.
 type ImageRepoDetails struct {
 	BasicAuthConfig `json:",inline" yaml:",inline"`

--- a/internal/docker/serialization.go
+++ b/internal/docker/serialization.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	"encoding/json"
+
+	"github.com/docker/distribution/reference"
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/juju/juju/core/resources"
+)
+
+// ValidateDockerRegistryPath ensures the registry path is valid (i.e. api.jujucharms.com@sha256:deadbeef)
+func ValidateDockerRegistryPath(path string) error {
+	_, err := reference.ParseNormalizedNamed(path)
+	if err != nil {
+		return errors.NotValidf("docker image path %q", path)
+	}
+	return nil
+}
+
+// CheckDockerDetails validates the provided resource is suitable for use.
+func CheckDockerDetails(name string, details DockerImageDetails) error {
+	// TODO (veebers): Validate the URL actually works.
+	return ValidateDockerRegistryPath(details.RegistryPath)
+}
+
+// UnmarshalDockerResource unmarshals the docker resource file from data.
+func UnmarshalDockerResource(data []byte) (DockerImageDetails, error) {
+	var resourceBody DockerImageDetails
+	// Older clients sent the resources as a json string.
+	err := json.Unmarshal(data, &resourceBody)
+	if err != nil {
+		if err := yaml.Unmarshal(data, &resourceBody); err != nil {
+			return DockerImageDetails{}, errors.Annotate(err, "docker resource is neither valid json or yaml")
+		}
+	}
+	return resourceBody, nil
+}
+
+// ConvertToResourceImageDetails converts the provided DockerImageDetails to a
+// resources.ImageRepoDetails.
+func ConvertToResourceImageDetails(imageRepo ImageRepoDetails) resources.ImageRepoDetails {
+	return resources.ImageRepoDetails{
+		BasicAuthConfig: resources.BasicAuthConfig{
+			Auth:     convertToResourceToken(imageRepo.BasicAuthConfig.Auth),
+			Username: imageRepo.BasicAuthConfig.Username,
+			Password: imageRepo.BasicAuthConfig.Password,
+		},
+
+		TokenAuthConfig: resources.TokenAuthConfig{
+			IdentityToken: convertToResourceToken(imageRepo.TokenAuthConfig.IdentityToken),
+			RegistryToken: convertToResourceToken(imageRepo.TokenAuthConfig.RegistryToken),
+		},
+		Repository:    imageRepo.Repository,
+		ServerAddress: imageRepo.ServerAddress,
+		Region:        imageRepo.Region,
+	}
+}
+
+func convertToResourceToken(t *Token) *resources.Token {
+	if t == nil {
+		return nil
+	}
+	return &resources.Token{
+		Value:     t.Value,
+		ExpiresAt: t.ExpiresAt,
+	}
+}

--- a/internal/docker/serialization_test.go
+++ b/internal/docker/serialization_test.go
@@ -1,13 +1,12 @@
-// Copyright 2018 Canonical Ltd.
+// Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package resources_test
+package docker_test
 
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/internal/docker"
 )
 
@@ -27,21 +26,21 @@ func (s *DockerResourceSuite) TestValidRegistryPath(c *gc.C) {
 	}, {
 		registryPath: "me/mygitlab:latest",
 	}} {
-		err := resources.ValidateDockerRegistryPath(registryTest.registryPath)
+		err := docker.ValidateDockerRegistryPath(registryTest.registryPath)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
 
 func (s *DockerResourceSuite) TestInvalidRegistryPath(c *gc.C) {
-	err := resources.ValidateDockerRegistryPath("blah:sha256@")
+	err := docker.ValidateDockerRegistryPath("blah:sha256@")
 	c.Assert(err, gc.ErrorMatches, "docker image path .* not valid")
 }
 
 func (s *DockerResourceSuite) TestDockerImageDetailsUnmarshalJson(c *gc.C) {
 	data := []byte(`{"ImageName":"testing@sha256:beef-deed","Username":"docker-registry","Password":"fragglerock"}`)
-	result, err := resources.UnmarshalDockerResource(data)
+	result, err := docker.UnmarshalDockerResource(data)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(result, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "testing@sha256:beef-deed",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -58,9 +57,9 @@ registrypath: testing@sha256:beef-deed
 username: docker-registry
 password: fragglerock
 `[1:])
-	result, err := resources.UnmarshalDockerResource(data)
+	result, err := docker.UnmarshalDockerResource(data)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, resources.DockerImageDetails{
+	c.Assert(result, gc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "testing@sha256:beef-deed",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{

--- a/rpc/params/caas.go
+++ b/rpc/params/caas.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/resources"
-	"github.com/juju/juju/internal/docker"
 )
 
 // CAASUnitIntroductionArgs is used by sidecar units to introduce
@@ -93,7 +92,7 @@ type DockerImageInfo struct {
 }
 
 // NewDockerImageInfo converts docker.ImageRepoDetails to DockerImageInfo.
-func NewDockerImageInfo(info docker.ImageRepoDetails, registryPath string) DockerImageInfo {
+func NewDockerImageInfo(info resources.ImageRepoDetails, registryPath string) DockerImageInfo {
 	return DockerImageInfo{
 		Username:      info.Username,
 		Password:      info.Password,
@@ -110,17 +109,17 @@ func NewDockerImageInfo(info docker.ImageRepoDetails, registryPath string) Docke
 func ConvertDockerImageInfo(info DockerImageInfo) resources.DockerImageDetails {
 	return resources.DockerImageDetails{
 		RegistryPath: info.RegistryPath,
-		ImageRepoDetails: docker.ImageRepoDetails{
+		ImageRepoDetails: resources.ImageRepoDetails{
 			Repository:    info.Repository,
 			ServerAddress: info.ServerAddress,
-			BasicAuthConfig: docker.BasicAuthConfig{
+			BasicAuthConfig: resources.BasicAuthConfig{
 				Username: info.Username,
 				Password: info.Password,
-				Auth:     docker.NewToken(info.Auth),
+				Auth:     resources.NewToken(info.Auth),
 			},
-			TokenAuthConfig: docker.TokenAuthConfig{
-				IdentityToken: docker.NewToken(info.IdentityToken),
-				RegistryToken: docker.NewToken(info.RegistryToken),
+			TokenAuthConfig: resources.TokenAuthConfig{
+				IdentityToken: resources.NewToken(info.IdentityToken),
+				RegistryToken: resources.NewToken(info.RegistryToken),
 				Email:         info.Email,
 			},
 		},

--- a/state/docker_resource.go
+++ b/state/docker_resource.go
@@ -111,7 +111,7 @@ func (dr *dockerMetadataStorage) Get(resourceID string) (io.ReadCloser, int64, e
 	if err != nil {
 		return nil, -1, errors.Trace(err)
 	}
-	details := resources.DockerImageDetails{
+	details := docker.DockerImageDetails{
 		RegistryPath: doc.RegistryPath,
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -120,6 +120,7 @@ func (dr *dockerMetadataStorage) Get(resourceID string) (io.ReadCloser, int64, e
 			},
 		},
 	}
+
 	data, err := json.Marshal(details)
 	if err != nil {
 		return nil, -1, errors.Trace(err)

--- a/state/docker_resource_test.go
+++ b/state/docker_resource_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/resources"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/state"
 )
 
@@ -91,8 +90,8 @@ func (s *dockerMetadataStorageSuite) TestGet(c *gc.C) {
 	id := "test-123"
 	resource := resources.DockerImageDetails{
 		RegistryPath: "url@sha256:abc123",
-		ImageRepoDetails: docker.ImageRepoDetails{
-			BasicAuthConfig: docker.BasicAuthConfig{
+		ImageRepoDetails: resources.ImageRepoDetails{
+			BasicAuthConfig: resources.BasicAuthConfig{
 				Username: "testuser",
 				Password: "hunter2",
 			},

--- a/state/docker_resource_test.go
+++ b/state/docker_resource_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/state"
 )
 
@@ -124,8 +125,8 @@ func (s *dockerMetadataStorageSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
-func readerToDockerDetails(c *gc.C, r io.ReadCloser) *resources.DockerImageDetails {
-	var info resources.DockerImageDetails
+func readerToDockerDetails(c *gc.C, r io.ReadCloser) *docker.DockerImageDetails {
+	var info docker.DockerImageDetails
 	respBuf := new(bytes.Buffer)
 	_, err := respBuf.ReadFrom(r)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/caasapplicationprovisioner/ops_test.go
+++ b/worker/caasapplicationprovisioner/ops_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
@@ -445,7 +444,7 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 		CharmURL: charm.MustParseURL("ch:my-app"),
 		ImageDetails: resources.DockerImageDetails{
 			RegistryPath: "test-repo/jujud-operator:2.9.99",
-			ImageRepoDetails: docker.ImageRepoDetails{
+			ImageRepoDetails: resources.ImageRepoDetails{
 				Repository:    "test-repo",
 				ServerAddress: "registry.com",
 			},

--- a/worker/uniter/runner/context/resources/resource.go
+++ b/worker/uniter/runner/context/resources/resource.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/internal/docker"
 )
 
 // OpenedResourceClient exposes the API functionality needed by OpenResource.
@@ -46,7 +47,7 @@ func OpenResource(name string, client OpenedResourceClient) (*OpenedResource, er
 		if err := reader.Close(); err != nil {
 			return nil, errors.Trace(err)
 		}
-		yamlBody, err := resources.UnmarshalDockerResource(data)
+		yamlBody, err := docker.UnmarshalDockerResource(data)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
The API client shouldn't need to be aware of docker. Everything is a resource. So let's move those types to core and marshall correctly between the two.

This should prevent bringing in the world when you just need an api client.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

## Links

**Jira card:** JUJU-XXXX
