### PR TITLE
Filter out icmpv6 when reading back ec2 security groups.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2043,6 +2043,11 @@ func (e *environ) ingressRulesInGroup(ctx context.ProviderCallContext, name stri
 			FromPort: int(aws.ToInt32(p.FromPort)),
 			ToPort:   int(aws.ToInt32(p.ToPort)),
 		}
+		if portRange.Protocol == "icmpv6" {
+			// For now we need to filter out the icmpv6 rules as they are complicated and not
+			// represented well in the juju model.
+			continue
+		}
 		rules = append(rules, firewall.NewIngressRule(portRange, sourceCIDRs...))
 	}
 	if err := rules.Validate(); err != nil {


### PR DESCRIPTION
Firewaller is crashing when trying to read rules out of the ec2 provider.
```
machine-0: 13:26:54 ERROR juju.worker.dependency "firewaller" manifold worker returned unexpected error: invalid destination for ingress rule: invalid protocol "icmpv6", expected "tcp", "udp", or "icmp"
```
This is due to #16061 adding in the minimum icmpv6 rules for proper v6 support in aws that should, until juju models this better, be hidden from the firewaller.

## QA steps

@tlm how best to test this?

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/3336/