### PR TITLE
[WIP] Fix bug where "use --force" prompt is not displayed when deploying

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -417,7 +417,7 @@ func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesHaveOverlap(c *gc.C) {
-	// Donot remove this because we want to test: series supported by the charm and series supported by Juju have overlap.
+	// Do not remove this because we want to test: series supported by the charm and series supported by Juju have overlap.
 	s.PatchValue(&deployer.SupportedJujuSeries,
 		func(time.Time, string, string) (set.Strings, error) {
 			return set.NewStrings(
@@ -428,11 +428,11 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesHaveOverlap(c *gc.C) {
 
 	path := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "multi-series")
 	err := s.runDeploy(c, path, "--base", "ubuntu@12.10")
-	c.Assert(err, gc.ErrorMatches, `series "quantal" is not supported, supported series are: focal,jammy`)
+	c.Assert(err, gc.ErrorMatches, `juju does not support series "quantal"`)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesHaveNoOverlap(c *gc.C) {
-	// Donot remove this because we want to test: series supported by the charm and series supported by Juju have NO overlap.
+	// Do not remove this because we want to test: series supported by the charm and series supported by Juju have NO overlap.
 	s.PatchValue(&deployer.SupportedJujuSeries,
 		func(time.Time, string, string) (set.Strings, error) {
 			return set.NewStrings("kinetic"), nil
@@ -441,7 +441,7 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesHaveNoOverlap(c *gc.C) 
 
 	path := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "multi-series")
 	err := s.runDeploy(c, path, "--base", "ubuntu@12.10")
-	c.Assert(err, gc.ErrorMatches, `multi-series is not available on the following series: quantal`)
+	c.Assert(err, gc.ErrorMatches, `juju does not support series "quantal"`)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {
@@ -1448,7 +1448,7 @@ func (s *DeploySuite) TestDeployLocalWithSeriesMismatchReturnsError(c *gc.C) {
 
 	_, _, err := s.runDeployWithOutput(c, charmDir.Path, "--base", "ubuntu@12.10")
 
-	c.Check(err, gc.ErrorMatches, `terms1 is not available on the following series: quantal not supported`)
+	c.Check(err, gc.ErrorMatches, `juju does not support series "quantal"`)
 }
 
 func (s *DeploySuite) TestDeployLocalWithSeriesAndForce(c *gc.C) {
@@ -1535,7 +1535,7 @@ func (s *DeploySuite) TestDeployLocalWithSupportedNonESMSeries(c *gc.C) {
 func (s *DeploySuite) TestDeployLocalWithNotSupportedNonESMSeries(c *gc.C) {
 	_, loggingPath := s.setupNonESMBase(c)
 	err := s.runDeploy(c, loggingPath, "--base", "ubuntu@17.10")
-	c.Assert(err, gc.ErrorMatches, "logging is not available on the following series: artful not supported")
+	c.Assert(err, gc.ErrorMatches, `juju does not support series "artful"`)
 }
 
 // setupConfigFile creates a configuration file for testing set

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -665,7 +665,6 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	}
 
 	selector := seriesSelector{
-		charmURLSeries:      url.Series,
 		seriesFlag:          change.Params.Series,
 		supportedSeries:     supportedSeries,
 		supportedJujuSeries: workloadSeries,
@@ -1000,7 +999,6 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 
 	selector := seriesSelector{
 		seriesFlag:          chSeries,
-		charmURLSeries:      chID.URL.Series,
 		supportedSeries:     supportedSeries,
 		supportedJujuSeries: workloadSeries,
 		conf:                h.modelConfig,
@@ -1008,7 +1006,7 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 		fromBundle:          true,
 	}
 	selectedSeries, err := selector.charmSeries()
-	return selectedSeries, charmValidationError(curl.Name, errors.Trace(err))
+	return selectedSeries, errors.Trace(err)
 }
 
 // scaleApplication updates the number of units for an application.

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -373,7 +373,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 		}
 
 		seriesName, err = seriesSelector.charmSeries()
-		if err = charmValidationError(ch.Meta().Name, errors.Trace(err)); err != nil {
+		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -46,7 +46,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: "series: wily not supported",
+			err: `juju does not support series "wily"`,
 		},
 		{
 			title: "juju deploy simple --series=precise   # default series set, no supported series",
@@ -55,7 +55,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: "series: precise not supported",
+			err: `juju does not support series "precise"`,
 		}, {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series, no supported juju series",
 			seriesSelector: seriesSelector{
@@ -68,34 +68,6 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
-				conf:                defaultBase{"ubuntu@15.10", true},
-				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
-			},
-			expectedSeries: "bionic",
-		},
-		{
-			title: "juju deploy trusty/simple   # charm series set, default series set, no supported series",
-			seriesSelector: seriesSelector{
-				charmURLSeries:      "trusty",
-				conf:                defaultBase{"ubuntu@15.10", true},
-				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
-			},
-			err: "series: trusty not supported",
-		},
-		{
-			title: "juju deploy bionic/simple   # charm series set, default series set, no supported series",
-			seriesSelector: seriesSelector{
-				charmURLSeries:      "bionic",
-				conf:                defaultBase{"ubuntu@15.10", true},
-				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
-			},
-			expectedSeries: "bionic",
-		},
-		{
-			title: "juju deploy cosmic/simple --series=bionic   # series specified, charm series set, default series set, no supported series",
-			seriesSelector: seriesSelector{
-				seriesFlag:          "bionic",
-				charmURLSeries:      "cosmic",
 				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
@@ -144,9 +116,9 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic"},
 				conf:                defaultBase{"ubuntu@15.10", true},
-				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
+				supportedJujuSeries: set.NewStrings("bionic", "cosmic", "wily"),
 			},
-			err: `series "wily" is not supported, supported series are: bionic,cosmic`,
+			err: `series "wily" not supported by charm, the charm supported series are: bionic,cosmic`,
 		},
 		{
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",
@@ -164,7 +136,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultBase{"ubuntu@19.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: "series: disco not supported",
+			err: `juju does not support series "disco"`,
 		},
 		{
 			title: "juju deploy multiseries --series=bionic   # use supported requested",
@@ -190,11 +162,11 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries --series=bionic   # unsupported requested",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
-				supportedSeries:     []string{"utopic", "vivid"},
+				supportedSeries:     []string{"utopic", "vivid", "cosmic"},
 				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: `series: bionic`,
+			err: `series "bionic" not supported by charm, the charm supported series are: cosmic`,
 		},
 		{
 			title: "juju deploy multiseries --series=bionic --force   # unsupported forced",
@@ -207,9 +179,9 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			err: "expected supported juju series to exist",
 		},
 		{
-			title: "juju deploy bionic/multiseries  # non-default but supported series",
+			title: "juju deploy multiseries --series bionic  # non-default but supported series",
 			seriesSelector: seriesSelector{
-				charmURLSeries:      "bionic",
+				seriesFlag:          "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic"},
 				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
@@ -217,19 +189,18 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			expectedSeries: "bionic",
 		},
 		{
-			title: "juju deploy bionic/multiseries  # non-default but supported series",
+			title: "juju deploy multiseries --series bionic  # non-default but supported series",
 			seriesSelector: seriesSelector{
-				charmURLSeries:  "bionic",
+				seriesFlag:      "bionic",
 				supportedSeries: []string{"utopic", "vivid", "bionic"},
 				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
 		{
-			title: "juju deploy bionic/multiseries --series=cosmic  # non-default but supported series",
+			title: "juju deploy multiseries --series=cosmic  # non-default but supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "cosmic",
-				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic", "cosmic"},
 				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
@@ -237,20 +208,19 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			expectedSeries: "cosmic",
 		},
 		{
-			title: "juju deploy bionic/multiseries --series=cosmic  # unsupported series",
-			seriesSelector: seriesSelector{
-				seriesFlag:      "cosmic",
-				charmURLSeries:  "bionic",
-				supportedSeries: []string{"bionic", "utopic", "vivid"},
-				conf:            defaultBase{},
-			},
-			err: `series: cosmic`,
-		},
-		{
-			title: "juju deploy bionic/multiseries --series=cosmic  # unsupported series",
+			title: "juju deploy multiseries --series=cosmic  # unsupported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "cosmic",
-				charmURLSeries:      "bionic",
+				supportedSeries:     []string{"bionic", "utopic", "vivid"},
+				supportedJujuSeries: set.NewStrings("bionic", "focal"),
+				conf:                defaultBase{},
+			},
+			err: `juju does not support series "cosmic"`,
+		},
+		{
+			title: "juju deploy multiseries --series=cosmic  # unsupported series",
+			seriesSelector: seriesSelector{
+				seriesFlag:          "cosmic",
 				supportedSeries:     []string{"bionic", "utopic", "vivid", "cosmic"},
 				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
@@ -258,15 +228,44 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			expectedSeries: "cosmic",
 		},
 		{
-			title: "juju deploy bionic/multiseries --series=precise --force  # unsupported series forced",
+			title: "juju deploy multiseries --series=precise --force  # unsupported series forced",
 			seriesSelector: seriesSelector{
 				seriesFlag:      "precise",
-				charmURLSeries:  "bionic",
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				force:           true,
 				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
+		},
+		{
+			title: "juju deploy multiseries --series bionic  # no overlap between charm supported and juju supported series",
+			seriesSelector: seriesSelector{
+				seriesFlag:          "focal",
+				supportedSeries:     []string{"xenial", "bionic"},
+				supportedJujuSeries: set.NewStrings("focal", "jammy"),
+				conf:                defaultBase{},
+			},
+			err: `the charm defined series "xenial, bionic" not supported`,
+		},
+		{
+			title: "juju deploy multiseries --series bionic  # no overlap between charm supported and juju supported series, force a valid series",
+			seriesSelector: seriesSelector{
+				seriesFlag:          "focal",
+				supportedSeries:     []string{"xenial", "bionic"},
+				supportedJujuSeries: set.NewStrings("focal", "jammy"),
+				conf:                defaultBase{},
+				force:               true,
+			},
+			expectedSeries: "focal",
+		},
+		{
+			title: "juju deploy multiseries  # no overlap between charm supported and juju supported series",
+			seriesSelector: seriesSelector{
+				supportedSeries:     []string{"xenial", "bionic"},
+				supportedJujuSeries: set.NewStrings("focal", "jammy"),
+				conf:                defaultBase{},
+			},
+			err: `the charm defined series "xenial, bionic" not supported`,
 		},
 	}
 


### PR DESCRIPTION
For some reason our series selector was not returning an
UnsupportedSeries error when it should have been, instead duplicating
the text of the error and returning a generic error

Return an UnsupportedSeries error when the requested series is not
supported by the charm. This can then be detected downstream.

However, if the series is not supported by Juju, then we return a normal
NotSupported error

Remove some duplicated checks. We do not need validate the output of
charmSeries, since the series selector guarentees the returned series is
supported by juju

Drop selecting from charm url as this is a charmstore only feature

We also drop charmValidationError in a few places, because all this did
was reformat the error from charmSeries. Now I have re-written these
error messages, this is not longer required

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the `deploy` integration tests

Unit tests pass

(Note that kafka only supports jammy)
```
$ juju deploy kafka --revision 123 --channel stable --base ubuntu@20.04
ERROR series "focal" not supported by charm, the charm supported series are: jammy. Use --force to deploy the charm anyway.

$ juju deploy kafka --revision 123 --channel stable --base ubuntu@18.04
ERROR juju does not support series "bionic"

$ juju deploy kafka --revision 123 --channel stable --base ubuntu@18.04 --force
ERROR juju does not support series "bionic"
```

Edit `testcharms/charm-repo/quantal/dummy/metadata.yaml` such that:
```
$ cat testcharms/charm-repo/quantal/dummy/metadata.yaml
name: dummy
summary: "That's a dummy charm."
description: |
    This is a longer description which
    potentially contains multiple lines.
minjujuversion: "1.0.0"
series:
- xenial
- bionic
```
Then:
```
$ juju deploy ./testcharms/charm-repo/quantal/dummy
ERROR the charm defined series "xenial, bionic" not supported
```