### PR TITLE
Better fetch instance support.

### DIFF
--- a/provider/ec2/client.go
+++ b/provider/ec2/client.go
@@ -60,7 +60,6 @@ type Client interface {
 	AssociateIamInstanceProfile(context.Context, *ec2.AssociateIamInstanceProfileInput, ...func(*ec2.Options)) (*ec2.AssociateIamInstanceProfileOutput, error)
 	DescribeIamInstanceProfileAssociations(context.Context, *ec2.DescribeIamInstanceProfileAssociationsInput, ...func(*ec2.Options)) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error)
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
-	DescribeInstanceTypeOfferings(context.Context, *ec2.DescribeInstanceTypeOfferingsInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
 	DescribeInstanceTypes(context.Context, *ec2.DescribeInstanceTypesInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 	DescribeSpotPriceHistory(context.Context, *ec2.DescribeSpotPriceHistoryInput, ...func(*ec2.Options)) (*ec2.DescribeSpotPriceHistoryOutput, error)
 

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -49,7 +49,11 @@ func findInstanceSpec(
 		ic.Constraints = withDefaultNonControllerConstraints(ic.Constraints)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
-	logger.Debugf("found %d suitable image(s): %s", len(suitableImages), pretty.Sprint(suitableImages))
+	logger.Debugf("found %d suitable image(s) from %d available: %s",
+		len(suitableImages),
+		len(allImageMetadata),
+		pretty.Sprint(suitableImages),
+	)
 	images := instances.ImageMetadataToImages(suitableImages)
 	return instances.FindInstanceSpec(images, ic, instanceTypes)
 }

--- a/provider/ec2/instance_test.go
+++ b/provider/ec2/instance_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	stdcontext "context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/context"
+)
+
+type fetchInstanceClientFunc func(stdcontext.Context, *ec2.DescribeInstanceTypesInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
+
+type instanceSuite struct{}
+
+var _ = gc.Suite(&instanceSuite{})
+
+func (f fetchInstanceClientFunc) DescribeInstanceTypes(
+	c stdcontext.Context,
+	i *ec2.DescribeInstanceTypesInput,
+	o ...func(*ec2.Options),
+) (*ec2.DescribeInstanceTypesOutput, error) {
+	return f(c, i, o...)
+}
+
+func (s *instanceSuite) TestFetchInstanceTypeInfoPagnation(c *gc.C) {
+	callCount := 0
+	client := func(
+		_ stdcontext.Context,
+		i *ec2.DescribeInstanceTypesInput,
+		o ...func(*ec2.Options),
+	) (*ec2.DescribeInstanceTypesOutput, error) {
+		if callCount != 0 {
+			c.Assert(*i.NextToken, gc.Equals, "next")
+		}
+		c.Assert(*i.MaxResults, gc.Equals, int32(100))
+
+		callCount++
+		nextToken := aws.String("next")
+		// Let 6 calls happen
+		if callCount == 6 {
+			nextToken = nil
+		}
+
+		return &ec2.DescribeInstanceTypesOutput{
+			InstanceTypes: make([]types.InstanceTypeInfo, 100),
+			NextToken:     nextToken,
+		}, nil
+	}
+
+	res, err := FetchInstanceTypeInfo(
+		context.NewCloudCallContext(stdcontext.Background()),
+		fetchInstanceClientFunc(client),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(res), gc.Equals, 600)
+}

--- a/provider/ec2/instancetypes.go
+++ b/provider/ec2/instancetypes.go
@@ -266,10 +266,9 @@ func (c *instanceTypeCache) populateCache(ctx context.ProviderCallContext) error
 		return nil
 	}
 
-	instTypesInfo, err := FetchInstanceTypeInfoForRegion(
+	instTypesInfo, err := FetchInstanceTypeInfo(
 		ctx,
 		c.ec2Client,
-		c.region,
 	)
 	if err != nil {
 		return fmt.Errorf("populating instance type cache for region %q: %w", c.region, err)


### PR DESCRIPTION
Juju's ec2 provider has always done a fetch of instance type names with an AZ filter and then taken those results and queried the region based on the results.

We have witnessed errors in this approach where the results from one AWS call are in conflict with DescribeInstanceTypes.

Because our AWS client is already scoped to the region of the model cloud we don't need to do this double handling. Instead we can just query the region directly for instance types.

This removes the potential for conflicting data scenarios.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests cover the majority of cases.

We also want to perform a bootstrap with several add machines and also introduce a new model on a different region and make sure that we can add machines as well.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4717