### PR TITLE
Add integration tests for controller charm & Prometheus

### DIFF
--- a/tests/ENV.md
+++ b/tests/ENV.md
@@ -2,16 +2,19 @@ The following is a list of environment variables that are used to control
 behaviour in the Bash tests. This list may not be complete, and as always, the
 definitive source is the code.
 
-| Variable name               | Description                                                                        |
-|-----------------------------|------------------------------------------------------------------------------------|
-| `BOOTSTRAP_ADDITIONAL_ARGS` | Additional arguments passed to `juju bootstrap`.                                   |
-| `BOOTSTRAP_ARCH`            | Architecture to bootstrap on - passed to `--bootstrap-constraints`.                |
-| `BOOTSTRAP_CLOUD`           | The cloud to use when bootstrapping (i.e. the first argument to `juju bootstrap`). |
-| `BOOTSTRAP_PROVIDER`        | The provider to use when bootstrapping (see the `provider` package).               |
-| `BOOTSTRAP_REUSE`           | Reuse an existing controller when asked to bootstrap (true/false).                 |
-| `BOOTSTRAP_REUSE_LOCAL`     | The name of a local controller to reuse for testing. Set using the `-l` flag.      |
-| `BOOTSTRAP_SERIES`          | Series to use for the controller. Set using the `-S` flag.                         |
-| `KILL_CONTROLLER`           | If `'true'`, controllers will be forcibly killed during teardown.                  |
-| `MODEL_ARCH`                | Will be set as a model constraint on newly added models.                           |
-| `OPERATOR_IMAGE_ACCOUNT`    | Passed as the value of `--config caas-image-repo` when bootstrapping.              |
-| `TEST_INSPECT`              | If set, pause before teardown to allow inspection of the controller.               |
+| Variable name                | Description                                                                        |
+|------------------------------|------------------------------------------------------------------------------------|
+| `BOOTSTRAP_ADDITIONAL_ARGS`  | Additional arguments passed to `juju bootstrap`.                                   |
+| `BOOTSTRAP_ARCH`             | Architecture to bootstrap on - passed to `--bootstrap-constraints`.                |
+| `BOOTSTRAP_CLOUD`            | The cloud to use when bootstrapping (i.e. the first argument to `juju bootstrap`). |
+| `BOOTSTRAP_PROVIDER`         | The provider to use when bootstrapping (see the `provider` package).               |
+| `BOOTSTRAP_REUSE`            | Reuse an existing controller when asked to bootstrap (true/false).                 |
+| `BOOTSTRAP_REUSE_LOCAL`      | The name of a local controller to reuse for testing. Set using the `-l` flag.      |
+| `BOOTSTRAP_SERIES`           | Series to use for the controller. Set using the `-S` flag.                         |
+| `CONTROLLER_CHARM_CHANNEL`   | The channel to pull the controller charm from (CaaS only).                         |
+| `CONTROLLER_CHARM_PATH_CAAS` | The Charmhub charm name to pull the controller charm from (CaaS only).             |
+| `CONTROLLER_CHARM_PATH_IAAS` | Path to a locally built controller charm to use (IaaS only).                       |
+| `KILL_CONTROLLER`            | If `'true'`, controllers will be forcibly killed during teardown.                  |
+| `MODEL_ARCH`                 | Will be set as a model constraint on newly added models.                           |
+| `OPERATOR_IMAGE_ACCOUNT`     | Passed as the value of `--config caas-image-repo` when bootstrapping.              |
+| `TEST_INSPECT`               | If set, pause before teardown to allow inspection of the controller.               |

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -302,6 +302,19 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
 	fi
 
+	if [[ ${BOOTSTRAP_PROVIDER:-} == "k8s" ]]; then
+		if [[ -n ${CONTROLLER_CHARM_PATH_CAAS:-} ]]; then
+			export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --controller-charm-path=${CONTROLLER_CHARM_PATH_CAAS}"
+		fi
+		if [[ -n ${CONTROLLER_CHARM_CHANNEL:-} ]]; then
+			export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --controller-charm-channel=${CONTROLLER_CHARM_CHANNEL}"
+		fi
+	else
+		if [[ -n ${CONTROLLER_CHARM_PATH_IAAS:-} ]]; then
+			export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --controller-charm-path=${CONTROLLER_CHARM_PATH_IAAS}"
+		fi
+	fi
+
 	echo "====> BOOTSTRAP_ADDITIONAL_ARGS: ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 

--- a/tests/includes/retry.sh
+++ b/tests/includes/retry.sh
@@ -1,0 +1,30 @@
+# Retry a command until it succeeds (returns exit code 0). The retry strategy
+# is a simple: retry after a fixed delay.
+#   usage: retry <command> [max_retries] [delay]
+#
+# Arguments:
+#   - command (required): the name of the command to retry. Usually a Bash
+#     function. The function should 'return 1' instead of 'exit 1', as calling
+#     'exit' will terminate the whole test.
+#   - max_retries (optional): the number of times to retry. Defaults to 5.
+#   - delay (optional): the amount of time to sleep after an attempt. Defaults
+#     to 5 seconds.
+retry() {
+	local command=${1}
+	local max_retries=${2:-5} # default: 5 retries
+	local delay=${3:-5}       # default delay: 5s
+
+	local attempt=1
+	while true; do
+		echo "$command: attempt $attempt"
+		$command && break # if the command succeeds, break the loop
+
+		if [[ $attempt -ge $max_retries ]]; then
+			echo "$command failed after $max_retries retries"
+			return 1
+		fi
+
+		attempt=$((attempt + 1))
+		sleep $delay
+	done
+}

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -56,6 +56,18 @@ idle_condition() {
 	echo ".applications | select(($path | .[\"juju-status\"] | .current == \"idle\") and ($path | .[\"workload-status\"] | .current != \"error\")) | keys[$app_index]"
 }
 
+active_idle_condition() {
+	local name app_index unit_index
+
+	name=${1}
+	app_index=${2:-0}
+	unit_index=${3:-0}
+
+	path=".[\"$name\"] | .units | .[\"$name/$unit_index\"]"
+
+	echo ".applications | select(($path | .[\"juju-status\"] | .current == \"idle\") and ($path | .[\"workload-status\"] | .current == \"active\")) | keys[$app_index]"
+}
+
 idle_subordinate_condition() {
 	local name parent unit_index
 

--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -1,0 +1,189 @@
+run_prometheus() {
+	echo
+
+	MODEL_NAME="test-prometheus"
+	file="${TEST_DIR}/${MODEL_NAME}.log"
+	bootstrap "${MODEL_NAME}" "${file}"
+
+	juju offer controller.controller:metrics-endpoint
+
+	juju deploy prometheus-k8s --trust
+	juju relate prometheus-k8s controller.controller
+	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
+	retry 'check_prometheus_targets prometheus-k8s 0' 15
+
+	juju remove-relation prometheus-k8s controller
+	# Check Juju controller is removed from Prometheus targets
+	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	# Check no errors in controller charm or Prometheus
+	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
+	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
+
+	juju remove-application prometheus-k8s --destroy-storage \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
+	destroy_controller "${MODEL_NAME}"
+}
+
+# Check the controller charm can handle multiple Prometheus relations.
+run_prometheus_multiple_units() {
+	echo
+
+	MODEL_NAME="test-prometheus-multi"
+	file="${TEST_DIR}/${MODEL_NAME}.log"
+	bootstrap "${MODEL_NAME}" "${file}"
+
+	juju offer controller.controller:metrics-endpoint
+
+	juju deploy prometheus-k8s p1 --trust
+	juju relate p1 controller.controller
+	wait_for "p1" "$(active_idle_condition "p1" 0 0)"
+	retry 'check_prometheus_targets p1 0' 15
+
+	juju deploy prometheus-k8s p2 --trust
+	juju relate p2 controller.controller
+	wait_for "p2" "$(active_idle_condition "p2" 1 0)"
+	retry 'check_prometheus_targets p2 0' 15
+
+	juju add-unit p1
+	wait_for "p1" "$(active_idle_condition "p1" 0 1)"
+	retry 'check_prometheus_targets p1 1' 15
+
+	juju remove-unit p1 --num-units 1
+	# Check all applications are still healthy
+	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
+	juju status --format json | jq -r "$(active_condition "p1" 0)" | check "p1"
+
+	juju remove-relation p2 controller
+	# Check Juju controller is removed from Prometheus targets
+	retry 'check_prometheus_no_target p2 0' 5
+	# Check no errors in controller charm or Prometheus
+	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
+	juju status --format json | jq -r "$(active_condition "p2" 1)" | check "p2"
+
+	juju remove-relation p1 controller
+	# Check Juju controller is removed from Prometheus targets
+	retry 'check_prometheus_no_target p1 0' 5
+	# Check no errors in controller charm or Prometheus
+	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
+	juju status --format json | jq -r "$(active_condition "p1" 0)" | check "p1"
+
+	juju remove-application p1 --destroy-storage \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
+	juju remove-application p2 --destroy-storage \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
+	destroy_controller "${MODEL_NAME}"
+}
+
+run_prometheus_cross_controller() {
+	echo
+
+	CONTROLLER_MODEL_NAME="test-prometheus-cmr-ctrlr"
+	file="${TEST_DIR}/${CONTROLLER_MODEL_NAME}.log"
+	bootstrap "${CONTROLLER_MODEL_NAME}" "${file}"
+	CONTROLLER_NAME=$(juju controllers --format json | jq -r '."current-controller"')
+
+	# Prometheus must be deployed on k8s. By default, we choose microk8s, but you
+	# can set the K8S_CLOUD environment variable to select a different cluster.
+	K8S_CLOUD=${K8S_CLOUD:-microk8s}
+	PROMETHEUS_MODEL_NAME="test-prometheus-cmr-prom"
+	file="${TEST_DIR}/${PROMETHEUS_MODEL_NAME}.log"
+	export BOOTSTRAP_ADDITIONAL_ARGS='' # TODO: remove
+	BOOTSTRAP_PROVIDER='k8s' BOOTSTRAP_CLOUD="${K8S_CLOUD}" bootstrap "${PROMETHEUS_MODEL_NAME}" "${file}"
+
+	juju offer -c "${CONTROLLER_NAME}" controller.controller:metrics-endpoint
+
+	juju deploy prometheus-k8s --trust
+	juju relate prometheus-k8s "${CONTROLLER_NAME}:controller.controller"
+	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
+	retry 'check_prometheus_targets prometheus-k8s 0' 15
+
+	juju remove-relation prometheus-k8s controller
+	# Check Juju controller is removed from Prometheus targets
+	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	# Check no errors in controller charm or Prometheus
+	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
+	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
+
+	juju remove-application prometheus-k8s --destroy-storage \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
+	destroy_controller "${PROMETHEUS_MODEL_NAME}"
+}
+
+# Check the Juju controller in the list of Prometheus targets.
+#   usage: check_prometheus_targets <app-name> <unit-number>
+check_prometheus_targets() {
+	set -uo pipefail
+	local app_name=$1
+	local unit_number=$2
+
+	TARGET=$(get_juju_target "$app_name" "$unit_number")
+	if [[ -z $TARGET ]]; then
+		echo "Juju controller not found in Prometheus targets"
+		return 1
+	fi
+
+	TARGET_STATUS=$(echo $TARGET | jq -r '.health')
+	if [[ $TARGET_STATUS != "up" ]]; then
+		echo "Controller metrics endpoint status: $TARGET_STATUS: $(echo $TARGET | jq -r '.lastError')"
+		return 1
+	fi
+
+	echo "Controller metrics endpoint is up"
+}
+
+# Check the Juju controller is not present in the list of Prometheus targets.
+#   usage: check_prometheus_targets <app-name> <unit-number>
+check_prometheus_no_target() {
+	set -uo pipefail
+	local app_name=$1
+	local unit_number=$2
+
+	TARGET=$(get_juju_target "$app_name" "$unit_number")
+	if [[ -n $TARGET ]]; then
+		echo "Whoops: Juju controller still found in Prometheus targets"
+		return 1
+	fi
+
+	echo "Success: Juju controller removed from Prometheus targets"
+}
+
+# Extract the Juju controller from the list of Prometheus targets
+#   usage: get_juju_target <app-name> <unit-number>
+get_juju_target() {
+	set -uo pipefail
+	local app_name=$1
+	local unit_number=$2
+
+	PROM_IP=$(juju status --format json |
+		jq -r ".applications.\"$app_name\".units.\"$app_name/$unit_number\".address")
+	TARGET=$(curl -sSm 2 "http://${PROM_IP}:9090/api/v1/targets" |
+		jq '.data.activeTargets[] | select(.labels.juju_application == "controller")')
+	echo "$TARGET"
+}
+
+test_prometheus() {
+	if [ "$(skip 'test_prometheus')" ]; then
+		echo "==> TEST SKIPPED: Prometheus integration"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		case "${BOOTSTRAP_PROVIDER:-}" in
+		"k8s")
+			run "run_prometheus"
+			run "run_prometheus_multiple_units"
+			;;
+		*)
+			echo "==> TEST SKIPPED: run_prometheus test runs on k8s only"
+			echo "==> TEST SKIPPED: run_prometheus_multiple_units test runs on k8s only"
+			;;
+		esac
+
+		run "run_prometheus_cross_controller"
+		# TODO: test HA
+	)
+}

--- a/tests/suites/controllercharm/task.sh
+++ b/tests/suites/controllercharm/task.sh
@@ -1,0 +1,16 @@
+test_controllercharm() {
+	if [ "$(skip 'test_controllercharm')" ]; then
+		echo "==> TEST SKIPPED: controller charm tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	# Since we are testing the controller charm here, we want to do a fresh
+	# bootstrap for every subtest.
+
+	test_prometheus
+}


### PR DESCRIPTION
This PR adds Bash tests verifying integration between `prometheus-k8s` and the controller charm in various scenarios.

For these tests to pass, we need #16301 and juju/juju-controller#28 to land.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The tests can be run on both LXD and k8s. To run them:
```bash
export CONTROLLER_CHARM_PATH_IAAS=[path/to/local/ctrl/charm]  # if testing on LXD
export CONTROLLER_CHARM_PATH_CAAS='barrettj12-cc'
export CONTROLLER_CHARM_CHANNEL='latest/stable'
cd tests
./main.sh -v -c [cloud] controllercharm
```

## Links

**Jira card:** JUJU-4720

Related PRs:
- #16301
- juju/juju-controller#28