### PR TITLE
Removes ec2:DescribeInstanceTypeOfferings from iam doc.

### DIFF
--- a/provider/ec2/iam_docs.go
+++ b/provider/ec2/iam_docs.go
@@ -42,7 +42,6 @@ const (
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeIamInstanceProfileAssociations",
         "ec2:DescribeInstances",
-        "ec2:DescribeInstanceTypeOfferings",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeNetworkInterfaces",


### PR DESCRIPTION
In commit cc657a9791cf3c5502475a390a7efb3df25c0122 we removed the use of ec2:DescribeInstanceTypeOfferings. Because of this we no longer need the IAM permission so it should be removed from our permission set.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not required as we don't have this function in our set for the ec2 client anymore.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4717