### PR TITLE
Try and ensure secret access role bindings are created before serving the config to the agent

### DIFF
--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -710,7 +710,28 @@ func (k *kubernetesClient) ensureClusterBindingForSecretAccessToken(sa *core.Ser
 	}
 	clusterRoleBinding := resources.NewClusterRoleBinding(bindingSpec.Name, bindingSpec)
 	_, err = clusterRoleBinding.Ensure(context.TODO(), k.client(), resources.ClaimJujuOwnership)
-	return errors.Trace(err)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Ensure role binding exists before we return to avoid a race where a client
+	// attempts to perform an operation before the role is allowed.
+	return errors.Trace(retry.Call(retry.CallArgs{
+		Func: func() error {
+			api := k.client().RbacV1().ClusterRoleBindings()
+			_, err := api.Get(context.TODO(), clusterRoleBinding.Name, v1.GetOptions{ResourceVersion: clusterRoleBinding.ResourceVersion})
+			if k8serrors.IsNotFound(err) {
+				return errors.NewNotFound(err, "k8s")
+			}
+			return errors.Trace(err)
+		},
+		IsFatalError: func(err error) bool {
+			return !errors.Is(err, errors.NotFound)
+		},
+		Clock:    jujuclock.WallClock,
+		Attempts: 5,
+		Delay:    time.Second,
+	}))
 }
 
 func (k *kubernetesClient) ensureBindingForSecretAccessToken(sa *core.ServiceAccount, objMeta v1.ObjectMeta, owned, read, removed []string) error {
@@ -753,7 +774,28 @@ func (k *kubernetesClient) ensureBindingForSecretAccessToken(sa *core.ServiceAcc
 	}
 	roleBinding := resources.NewRoleBinding(bindingSpec.Name, bindingSpec.Namespace, bindingSpec)
 	err = roleBinding.Apply(context.TODO(), k.client())
-	return errors.Trace(err)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Ensure role binding exists before we return to avoid a race where a client
+	// attempts to perform an operation before the role is allowed.
+	return errors.Trace(retry.Call(retry.CallArgs{
+		Func: func() error {
+			api := k.client().RbacV1().RoleBindings(k.namespace)
+			_, err := api.Get(context.TODO(), roleBinding.Name, v1.GetOptions{ResourceVersion: roleBinding.ResourceVersion})
+			if k8serrors.IsNotFound(err) {
+				return errors.NewNotFound(err, "k8s")
+			}
+			return errors.Trace(err)
+		},
+		IsFatalError: func(err error) bool {
+			return !errors.Is(err, errors.NotFound)
+		},
+		Clock:    jujuclock.WallClock,
+		Attempts: 5,
+		Delay:    time.Second,
+	}))
 }
 
 func cleanRules(existing []rbacv1.PolicyRule, shouldRemove func(string) bool) []rbacv1.PolicyRule {

--- a/caas/kubernetes/provider/rbac_test.go
+++ b/caas/kubernetes/provider/rbac_test.go
@@ -90,6 +90,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 			gomock.Any(), "unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
 		).Return(nil, s.k8sNotFoundError()),
 		s.mockRoleBindings.EXPECT().Create(gomock.Any(), roleBinding, v1.CreateOptions{FieldManager: "juju"}).Return(roleBinding, nil),
+		s.mockRoleBindings.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(roleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),
@@ -175,6 +176,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
 			gomock.Any(), "controller-k1-unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
 		).Return(nil, s.k8sNotFoundError()),
 		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), clusterroleBinding, v1.CreateOptions{FieldManager: "juju"}).Return(clusterroleBinding, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(clusterroleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),
@@ -251,6 +253,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 		s.mockRoleBindings.EXPECT().Patch(
 			gomock.Any(), "unit-gitlab-0", types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
 		).Return(roleBinding, nil),
+		s.mockRoleBindings.EXPECT().Get(gomock.Any(), "unit-gitlab-0", v1.GetOptions{}).Return(roleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),
@@ -327,6 +330,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
 		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole, v1.UpdateOptions{}).Return(clusterrole, nil),
 		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(clusterroleBinding, nil),
 		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), clusterroleBinding, v1.UpdateOptions{FieldManager: "juju"}).Return(clusterroleBinding, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "controller-k1-unit-gitlab-0", v1.GetOptions{}).Return(clusterroleBinding, nil),
 		s.mockServiceAccounts.EXPECT().CreateToken(gomock.Any(), "unit-gitlab-0", treq, v1.CreateOptions{}).Return(
 			&authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil,
 		),


### PR DESCRIPTION
When the unit agent needs to get a secret value from the k8s backend, it asks the controller for a service account token. The service account is created and necessary role bindings are used to give the SA permissions it needs. It has been seen in CI tests that randomly a permission error occurs and then a retry a short time later works. The theory is that the role binding is not set up before the get is performed (perhaps a slow runner hosting k8s etc).

This PR fetches the role binding and retries until it is found before handing back to the agent. This will hopefully mitigate the issue.

## QA steps

bootstrap k8s
add a model
deploy snappass-test

```
juju exec --unit snappass-test/0 -- 'URI=$(secret-add foo=bar); secret-get $URI'
juju secrets
juju exec --unit snappass-test/0 -- 'secret-get <insert uri>'
```
switch to controller model

```
juju exec --unit controller/0 -- 'URI=$(secret-add foo=bar); secret-get $URI'
juju secrets
juju exec --unit controller/0 -- 'secret-get <insert uri>'
```

## Links

https://bugs.launchpad.net/juju/+bug/2032686

**Jira card:** JUJU-4714

