### PR TITLE
Fix dqlite binding to ipv6 address.

### DIFF
--- a/database/node.go
+++ b/database/node.go
@@ -9,9 +9,11 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -261,7 +263,9 @@ func (m *NodeManager) WithLoopbackAddressOption() app.Option {
 // WithAddressOption returns a Dqlite application Option
 // for specifying the local address:port to use.
 func (m *NodeManager) WithAddressOption(ip string) app.Option {
-	return app.WithAddress(fmt.Sprintf("%s:%d", ip, m.port))
+	// dqlite expects an ipv6 address to be in square brackets
+	// e.g. [::1]:1234 so we need to use net.JoinHostPort.
+	return app.WithAddress(net.JoinHostPort(ip, strconv.Itoa(m.port)))
 }
 
 // WithTLSOption returns a Dqlite application Option for TLS encryption

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -282,11 +282,22 @@ func (s *nodeManagerSuite) TestSetClusterToLocalNodeSuccess(c *gc.C) {
 	c.Check(newServers, gc.DeepEquals, []dqlite.NodeInfo{servers[0]})
 }
 
-func (s *nodeManagerSuite) TestWithAddressOptionSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestWithAddressOptionIPv4Success(c *gc.C) {
 	m := NewNodeManager(nil, stubLogger{}, coredatabase.NoopSlowQueryLogger{})
 	m.port = dqlitetesting.FindTCPPort(c)
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = dqliteApp.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *nodeManagerSuite) TestWithAddressOptionIPv6Success(c *gc.C) {
+	m := NewNodeManager(nil, stubLogger{}, coredatabase.NoopSlowQueryLogger{})
+	m.port = dqlitetesting.FindTCPPort(c)
+
+	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("::1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = dqliteApp.Close()


### PR DESCRIPTION
Dqlite expects IPv6 addresses to be wrapped in square brackets, so this PR changes
the WithAddressOption on the NodeManager to now use `net.JoinHostPort`.

## QA steps

-  `make run-go-tests TEST_PACKAGES=./database TEST_FILTER=TestWithAddressOption`

## Documentation changes

N/A

## Links

[AddrParse(5)](https://github.com/canonical/dqlite/blob/d16ac97d874d719a9558332aaebb4da19dd23ffa/src/lib/addr.c#L57)