### PR TITLE
Fixes problem with default region at oracle

### DIFF
--- a/provider/oci/common/client.go
+++ b/provider/oci/common/client.go
@@ -95,11 +95,3 @@ func (j JujuConfigProvider) Validate() error {
 	}
 	return nil
 }
-
-// Config returns a new ociCommon.ConfigurationProvider instance
-func (j JujuConfigProvider) Config() (ociCommon.ConfigurationProvider, error) {
-	if err := j.Validate(); err != nil {
-		return nil, err
-	}
-	return &j, nil
-}

--- a/provider/oci/provider_integration_test.go
+++ b/provider/oci/provider_integration_test.go
@@ -68,7 +68,6 @@ func fakeCredential() cloud.Credential {
 		"pass-phrase": ocitesting.PrivateKeyPassphrase,
 		"tenancy":     "fake",
 		"user":        "fake",
-		"region":      "us-ashburn-1",
 	})
 }
 
@@ -134,14 +133,12 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 			"fingerprint": ocitesting.PrivateKeyEncryptedFingerprint,
 			"pass-phrase": ocitesting.PrivateKeyPassphrase,
 			"key":         ocitesting.PrivateKeyEncrypted,
-			"region":      "us-phoenix-1",
 		},
 	}
 	s.writeOCIConfig(c, cfg)
 	creds, err := s.provider.DetectCredentials("")
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(creds.AuthCredentials), gc.Equals, 1)
-	c.Assert(creds.DefaultRegion, gc.Equals, "us-phoenix-1")
 }
 
 func (s *credentialsSuite) TestDetectCredentialsWrongPassphrase(c *gc.C) {
@@ -150,7 +147,6 @@ func (s *credentialsSuite) TestDetectCredentialsWrongPassphrase(c *gc.C) {
 			"fingerprint": ocitesting.PrivateKeyEncryptedFingerprint,
 			"pass-phrase": "bogus",
 			"key":         ocitesting.PrivateKeyEncrypted,
-			"region":      "us-phoenix-1",
 		},
 	}
 	s.writeOCIConfig(c, cfg)
@@ -164,20 +160,17 @@ func (s *credentialsSuite) TestDetectCredentialsMultiSection(c *gc.C) {
 			"fingerprint": ocitesting.PrivateKeyEncryptedFingerprint,
 			"pass-phrase": ocitesting.PrivateKeyPassphrase,
 			"key":         ocitesting.PrivateKeyEncrypted,
-			"region":      "us-ashburn-1",
 		},
 		"SECONDARY": {
 			"fingerprint": ocitesting.PrivateKeyUnencryptedFingerprint,
 			"pass-phrase": "",
 			"key":         ocitesting.PrivateKeyUnencrypted,
-			"region":      "us-phoenix-1",
 		},
 	}
 	s.writeOCIConfig(c, cfg)
 	creds, err := s.provider.DetectCredentials("")
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(creds.AuthCredentials), gc.Equals, 2)
-	c.Assert(creds.DefaultRegion, gc.Equals, "us-ashburn-1")
 }
 
 func (s *credentialsSuite) TestDetectCredentialsMultiSectionInvalidConfig(c *gc.C) {
@@ -188,13 +181,11 @@ func (s *credentialsSuite) TestDetectCredentialsMultiSectionInvalidConfig(c *gc.
 			"fingerprint": ocitesting.PrivateKeyEncryptedFingerprint,
 			"pass-phrase": "bogus",
 			"key":         ocitesting.PrivateKeyEncrypted,
-			"region":      "us-ashburn-1",
 		},
 		"SECONDARY": {
 			"fingerprint": ocitesting.PrivateKeyUnencryptedFingerprint,
 			"pass-phrase": "",
 			"key":         ocitesting.PrivateKeyUnencrypted,
-			"region":      "us-phoenix-1",
 		},
 	}
 	s.writeOCIConfig(c, cfg)


### PR DESCRIPTION
This PR makes Juju take the default region the user selects instead of respecting only one defined in the credential.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
juju bootstrap oracle/<region-name-that-differnce-from-defined-in-credentials> orc --config...
```

## Documentation changes

## Links

**Launchpad bug:** https://pad.lv/2031613

**Jira card:** [JUJU-4653](https://warthogs.atlassian.net/browse/JUJU-4653)


[JUJU-4653]: https://warthogs.atlassian.net/browse/JUJU-4653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ