### PR TITLE
Add system identity public key to authorized_keys on new model configs

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -91,6 +91,26 @@ func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	c.Assert(validateCall.Args[1], gc.IsNil)
 }
 
+func (s *ModelConfigCreatorSuite) TestCreateModelCheckAuthorizedKeys(c *gc.C) {
+	authorizedKeys := `
+			ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLNN6YxkRJ8liYGh9qymZi23lDRlFrD3ujGfcgkjqa7vOqBHJaWklaIW4vFX0XkYuhgnDlXREi7RRK+4I0XBD051LxADobguLXyeGoOhSRlLLThYMF7Ui8nNylLxY0MYpKUIE6ejve2DHtrwGXBJBUXGJr8z5gKuIZD9J39B3ld1e7v2fpK3SqQ84H8mSZxPBbZqA0NIoq9wl+ke780fYsDxBpsAJhaZW2SjCqcrmNc3m9HgYwzeHhsXDZN2xonoyK2UVMGCsqR0vTHZNpnhME4FdGsmK6WIRMq+z5Mxrw3rSYIgbWi1uACfSsPeBMXmkWORujZrf1w1OKoy1dKeWp juju-client-key
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCwvae4M/oc+p5d3vj5TBS/4Mx+us5nVuMBgpYCQYq1Bk+QyfyefVfhQwuILAhmzehKnxUse1kGERQ0wNCtn7wU/HhvAuzQBWkxMvShyO9x7GS+4cDEGhkhMGGCu5NvBBCvp24+WdNeqsvoMDRHtBO1kFVc3FQZ01IjR+FTAICW5hE8e7ssCFK+pIDa8TI44rz41grytVJ1iACvaXc7nTyFZg95EXxSurPv0EnO82Gxfdt4bkiSXPXQqNcTLNiJ2oKRyDVYAjZNIr2Yf+UGCK9fy0VAdM7dwVZ9FOQX430blrDpDNo096+FXs2MoRB5SLzueZo2Eurya5OxcYpfIkdrzNpgAUgiL7cVURCh0+xJrIX/Ow9Axle+GvDcWAS9aZsRO+nsJ9Mry0zGWN/2IAEEZY9KVr7YO8xcCJ/yZ2gFXhyRAjD2oNBBrIfwpFNHZ35TbT5znmTX1wrJapLPyXqosGHZed8FkTDIyocCZzDlB0PpuBzUtjWp8gKwrPNsBGzTMvso3Qah3xOiznc7DTBCeSf2mqsX+6iY6p2k4YmF9LST+hepbgF4WW8Y3xgSuJ510TE3wtf/QZXDjQY+r7+yLraHSlE6CzQvL07snDyn4NHqfGw3GMAT71dpoa7WVGWW4HdcpCa8ALCtOx1GpyaydFANwNuwr1wOMQuY/9R5dw== juju-system-key
+`
+	baseConfig, err := config.New(
+		config.UseDefaults,
+		coretesting.FakeConfig().Merge(coretesting.Attrs{
+			"type":            "fake",
+			"restricted":      "area51",
+			"agent-version":   "2.0.0",
+			"authorized-keys": authorizedKeys,
+		}),
+	)
+	c.Check(err, jc.ErrorIsNil)
+	cfg, err := s.newModelConfig(coretesting.Attrs(baseConfig.AllAttrs()))
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(cfg.AuthorizedKeys(), jc.DeepEquals, authorizedKeys)
+}
+
 func (s *ModelConfigCreatorSuite) TestCreateModelSameAgentVersion(c *gc.C) {
 	cfg, err := s.newModelConfig(coretesting.Attrs(
 		s.baseConfig.AllAttrs(),


### PR DESCRIPTION
This patch aims to fix https://bugs.launchpad.net/juju/+bug/1834974 where we cannot apply iptables rules on OCI.
This happens because on OCI (and Vsphere and Equinix) we use the `SshInstanceConfigurator` which applies iptables' rules via ssh, but on the units the authorized_keys file under /home/ubuntu/.ssh is not fully populated: the system identity public key is missing and therefore the controller machine cannot ssh onto it.

We fix this by adding this missing key to the model config at model creation.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Reproduce the QA steps from this PR https://github.com/juju/juju/pull/10288:

```
juju bootstrap --config compartment-id=ocid1.compartment.oc1..aaaaaaaanvu2racnlczevenu73dlcf3nokgsjpdkbdgp4xbrz3lb2y4giyjq oci-canonical c
juju deploy ubuntu -n 2
juju deploy 'juju-qa-network-health'
juju expose network-health
juju add-relation ubuntu network-health
juju run --unit ubuntu/0 curl <public IP of machine 1>:8039
```

The last command should `pass`:

```
juju run --unit ubuntu/0 curl <public IP of machine 1>:8039
pass  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     4    0     4    0     0   2000      0 --:--:-- --:--:-- --:--:--  2000
```

also, if you ssh onto any created machine, you should see the correct authorized keys:

```
juju ssh 0
ubuntu@juju-6ddb09-0:~/.ssh$ cat authorized_keys
ssh-rsa AAAAB3NzaC1yc2... Juju:juju-client-key
ssh-ed25519 AAAAC3NzaC... Juju:nicolas@thinkpad
ssh-rsa AAAAB3NzaC1yc2... Juju:juju-system-key
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1834974

**Jira card:** JUJU-4678
