### PR TITLE
Wire up dqlite trace

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -739,6 +739,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			ClockName:      clockName,
 			DBAccessorName: dbAccessorName,
+			TraceName:      traceName,
 			Logger:         loggo.GetLogger("juju.worker.leaseexpiry"),
 			NewWorker:      leaseexpiry.NewWorker,
 			NewStore:       leaseexpiry.NewStore,
@@ -749,6 +750,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:            agentName,
 			ClockName:            clockName,
 			DBAccessorName:       dbAccessorName,
+			TraceName:            traceName,
 			Logger:               loggo.GetLogger("juju.worker.lease"),
 			LogDir:               agentConfig.LogDir(),
 			PrometheusRegisterer: config.PrometheusRegisterer,

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -756,6 +756,7 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"is-primary-controller-flag",
 		"query-logger",
 		"state-config-watcher",
+		"trace",
 	},
 
 	"lease-manager": {
@@ -765,6 +766,7 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"is-controller-flag",
 		"query-logger",
 		"state-config-watcher",
+		"trace",
 	},
 
 	"log-sender": {
@@ -1358,6 +1360,7 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"is-primary-controller-flag",
 		"query-logger",
 		"state-config-watcher",
+		"trace",
 	},
 
 	"lease-manager": {
@@ -1367,6 +1370,7 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"is-controller-flag",
 		"query-logger",
 		"state-config-watcher",
+		"trace",
 	},
 
 	"log-sender": {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.3
 	github.com/aws/smithy-go v1.14.2
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2
+	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0
 	github.com/canonical/pebble v1.4.0
 	github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.3
 	github.com/aws/smithy-go v1.14.2
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/go-dqlite v1.20.0
+	github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2
 	github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0
 	github.com/canonical/pebble v1.4.0
 	github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,6 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/canonical/go-dqlite v1.20.0 h1:pnkn0oS0hPXWeODjvjWONKGb5KYh8kK0aruDPzZLwmU=
-github.com/canonical/go-dqlite v1.20.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2 h1:nLHhm2p7vm1CIHhv2IEBmBPnxCc+ygcIyUk9L51FpN8=
 github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVyM+QKFJagiyrM91Ke5S9htoL1D470g6E=

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2 h1:nLHhm2p7vm1CIHhv2IEBmBPnxCc+ygcIyUk9L51FpN8=
-github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
+github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
+github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVyM+QKFJagiyrM91Ke5S9htoL1D470g6E=
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0 h1:1JfA4hOWjPoF18ebpKFWafOWFplCh0jvHhAethmLQFo=

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite v1.20.0 h1:pnkn0oS0hPXWeODjvjWONKGb5KYh8kK0aruDPzZLwmU=
 github.com/canonical/go-dqlite v1.20.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
+github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2 h1:nLHhm2p7vm1CIHhv2IEBmBPnxCc+ygcIyUk9L51FpN8=
+github.com/canonical/go-dqlite v1.20.1-0.20230926160226-b0bb3bf916a2/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVyM+QKFJagiyrM91Ke5S9htoL1D470g6E=
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20230712132802-8d2a42545fd0 h1:1JfA4hOWjPoF18ebpKFWafOWFplCh0jvHhAethmLQFo=

--- a/internal/database/txn/transaction.go
+++ b/internal/database/txn/transaction.go
@@ -21,14 +21,6 @@ import (
 	"github.com/juju/juju/core/trace"
 )
 
-const (
-	// rootTraceName is used to define the root trace name for all transaction
-	// traces.
-	// This is purely for optimization purposes, as we can't use the
-	// trace.NameFromFunc for all these micro traces.
-	rootTraceName = "txn.(*RetryingTxnRunner)."
-)
-
 // txn represents a transaction interface that can be used for committing
 // a transaction.
 type txn interface {
@@ -184,7 +176,7 @@ func (t *RetryingTxnRunner) Txn(ctx context.Context, db *sqlair.DB, fn func(cont
 			return errors.Trace(err)
 		}
 
-		return t.commit(ctx, tx)
+		return errors.Trace(t.commit(ctx, tx))
 	})
 }
 
@@ -210,7 +202,7 @@ func (t *RetryingTxnRunner) StdTxn(ctx context.Context, db *sql.DB, fn func(cont
 			return errors.Trace(err)
 		}
 
-		return t.commit(ctx, tx)
+		return errors.Trace(t.commit(ctx, tx))
 	})
 }
 
@@ -321,6 +313,14 @@ func (s noopSemaphore) Acquire(context.Context, int64) error {
 }
 
 func (s noopSemaphore) Release(int64) {}
+
+const (
+	// rootTraceName is used to define the root trace name for all transaction
+	// traces.
+	// This is purely for optimization purposes, as we can't use the
+	// trace.NameFromFunc for all these micro traces.
+	rootTraceName = "txn.(*RetryingTxnRunner)."
+)
 
 func traceName(name string) trace.Name {
 	return trace.Name(rootTraceName + name)

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -171,6 +171,7 @@ func leaseManager(controllerUUID string, db database.DBGetter, clock clock.Clock
 		MaxSleep:             time.Minute,
 		EntityUUID:           controllerUUID,
 		PrometheusRegisterer: noopRegisterer{},
+		Tracer:               trace.NoopTracer{},
 	})
 }
 

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/trace"
 )
 
 // Secretary is responsible for validating the sanity of lease and holder names
@@ -48,6 +49,9 @@ type ManagerConfig struct {
 	// Store is responsible for recording, retrieving, and expiring leases.
 	Store lease.Store
 
+	// Tracer is used to record tracing information as the manager runs.
+	Tracer trace.Tracer
+
 	// Logger is used to report debugging/status information as the
 	// manager runs.
 	Logger Logger
@@ -78,6 +82,9 @@ func (config ManagerConfig) Validate() error {
 	}
 	if config.Store == nil {
 		return errors.NotValidf("nil Store")
+	}
+	if config.Tracer == nil {
+		return errors.NotValidf("nil Tracer")
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")

--- a/worker/lease/fixture_test.go
+++ b/worker/lease/fixture_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/trace"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/lease"
 )
@@ -78,6 +79,7 @@ func (fix *Fixture) RunTest(c *gc.C, test func(*lease.Manager, *testclock.Clock)
 		MaxSleep:             defaultMaxSleep,
 		Logger:               loggo.GetLogger("lease_test"),
 		PrometheusRegisterer: noopRegisterer{},
+		Tracer:               trace.NoopTracer{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	var wg sync.WaitGroup

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/worker/lease"
 )
 
@@ -183,6 +184,7 @@ func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 		MaxSleep:             defaultMaxSleep,
 		Logger:               loggo.GetLogger("lease_test"),
 		PrometheusRegisterer: noopRegisterer{},
+		Tracer:               trace.NoopTracer{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/worker/lease"
 )
 
@@ -38,6 +39,7 @@ func (s *ValidationSuite) SetUpTest(c *gc.C) {
 		MaxSleep:             time.Minute,
 		Logger:               loggo.GetLogger("lease_test"),
 		PrometheusRegisterer: struct{ prometheus.Registerer }{},
+		Tracer:               trace.NoopTracer{},
 	}
 }
 
@@ -58,6 +60,14 @@ func (s *ValidationSuite) TestMissingClock(c *gc.C) {
 	s.config.Clock = nil
 	manager, err := lease.NewManager(s.config)
 	c.Check(err, gc.ErrorMatches, "nil Clock not valid")
+	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(manager, gc.IsNil)
+}
+
+func (s *ValidationSuite) TestMissingTracer(c *gc.C) {
+	s.config.Tracer = nil
+	manager, err := lease.NewManager(s.config)
+	c.Check(err, gc.ErrorMatches, "nil Tracer not valid")
 	c.Check(err, jc.ErrorIs, errors.NotValid)
 	c.Check(manager, gc.IsNil)
 }

--- a/worker/lease/manifold_test.go
+++ b/worker/lease/manifold_test.go
@@ -31,7 +31,10 @@ func (s *manifoldSuite) TestValidateConfig(c *gc.C) {
 	cfg.ClockName = ""
 	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 
-	cfg.ClockName = ""
+	cfg.DBAccessorName = ""
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg.TraceName = ""
 	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 
 	cfg.Logger = nil
@@ -52,6 +55,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		AgentName:      "agent",
 		ClockName:      "clock",
 		DBAccessorName: "dbaccessor",
+		TraceName:      "trace",
 
 		Logger:               s.logger,
 		PrometheusRegisterer: s.prometheusRegisterer,

--- a/worker/leaseexpiry/worker.go
+++ b/worker/leaseexpiry/worker.go
@@ -5,6 +5,7 @@ package leaseexpiry
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/juju/clock"
@@ -91,7 +92,9 @@ func (w *expiryWorker) loop() error {
 			if err := w.store.ExpireLeases(ctx); err != nil {
 				return errors.Trace(err)
 			}
-			timer.Reset(time.Second)
+			// Random delay between 1 and 5 seconds.
+			delay := time.Second + (time.Duration(rand.Intn(4000)) * time.Millisecond)
+			timer.Reset(delay)
 		}
 	}
 }

--- a/worker/leaseexpiry/worker_test.go
+++ b/worker/leaseexpiry/worker_test.go
@@ -67,8 +67,14 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	ch := make(chan time.Time, 1)
 	ch <- time.Now()
 	timer.EXPECT().Chan().Return(ch).MinTimes(1)
-	timer.EXPECT().Reset(time.Second).Do(func(any) {
+	timer.EXPECT().Reset(gomock.Any()).DoAndReturn(func(t time.Duration) bool {
 		defer close(done)
+
+		// Ensure it's within the expected range.
+		c.Check(t >= time.Second*1, jc.IsTrue)
+		c.Check(t <= time.Second*5, jc.IsTrue)
+
+		return true
 	})
 	timer.EXPECT().Stop().Return(true)
 

--- a/worker/leaseexpiry/worker_test.go
+++ b/worker/leaseexpiry/worker_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/trace"
 	jujujujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/leaseexpiry"
 )
@@ -33,6 +34,7 @@ func (s *workerSuite) TestConfigValidate(c *gc.C) {
 	validCfg := leaseexpiry.Config{
 		Clock:  clock.WallClock,
 		Logger: jujujujutesting.CheckLogger{Log: c},
+		Tracer: trace.NoopTracer{},
 		Store:  store,
 	}
 
@@ -73,6 +75,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	w, err := leaseexpiry.NewWorker(leaseexpiry.Config{
 		Clock:  clk,
 		Logger: jujujujutesting.CheckLogger{Log: c},
+		Tracer: trace.NoopTracer{},
 		Store:  store,
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The following injects the trace into the dqlite library via the
dqlite tracing package.

We only inject the trace if a tracer is enabled. If it's not enabled
we skip the unwanted work. In addition, the dqlite tracing has
a smaller surface area than a tracing library. The dqlite library
doesn't need to implement the whole of the OTEL library as it's
not currently tracing itself. This might change in the future,
but for now it's limited (in a good way).

With this in mind, we pool as many of the shimmed types as we're going
to be making thousands of these types.

---

To help sound this PR out, I've added tracing to the lease and
lease expiry workers. Both these workers along with the API server
are making thousands of requests.

Whilst analyzing the lease expiry worker, it runs every second causing
other writes to be blocked whilst its deleted query runs. To prevent this
from causing problems with write-heavy workloads, I've introduced a 
random jitter from 1-5 seconds. This should prevent any repeating 
stuttering. In addition to this, we check to see if there are any leases we
need to expire for running the delete (write transaction) query. These are
both in the same transaction and only if there are leases to expire do we 
upgrade the read query to a write transaction.

---

Lastly, I've pinned go-dqlite to a revision until they release a new tag.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


### Setting up tempo

It assumes that docker (docker-compose) is correctly installed:

```sh
$ git clone https://github.com/grafana/tempo.git
$ cd tempo/example/docker-compose/local
$ docker compose up -d
```

### Juju

Replace `<IP ADDRESS>` with your host machine (not localhost) address (`lxc info | yq ".environment | .addresses"` is a good place to start looking)

```sh
$ juju bootstrap lxd test --build-agent --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=<IP ADDRESS>:4317"
```

### Tempo Explore

Open the following [Tempo Explore Dashboard](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D,%22queryType%22:%22nativeSearch%22,%22serviceName%22:%22apiserver%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)

Click around and have a play.

You should see the lease workers inside of tempo.

![Screenshot from 2023-10-09 13-52-28](https://github.com/juju/juju/assets/2562584/539ce8e5-c681-436d-b87c-84d76866ef58)


## Links

**Jira card:** JUJU-XXXX
