### PR TITLE
[JUJU-4726] Fix aws_ami_creation instance_type

### DIFF
--- a/tests/includes/aws_ami_creation.sh
+++ b/tests/includes/aws_ami_creation.sh
@@ -1,15 +1,32 @@
 launch_and_wait_ec2() {
-	local instance_name instance_id_result
+	local instance_name instance_id_result instance_type
 
 	instance_name=${1}
 	instance_image_id=${2}
 	subnet_id=${3}
 	instance_id_result=${4}
 
+	arch="amd64"
+	if [[ -n ${MODEL_ARCH} ]]; then
+		arch="${MODEL_ARCH}"
+	fi
+	case "${arch}" in
+	"amd64")
+		instance_type="t3.medium"
+		;;
+	"arm64")
+		instance_type="m6g.large"
+		;;
+	*)
+		echo "Unrecognised arch ${arch}"
+		exit
+		;;
+	esac
+
 	tags="ResourceType=instance,Tags=[{Key=Name,Value=${instance_name}}]"
 	instance_id=$(aws ec2 run-instances --image-id "${instance_image_id}" \
 		--count 1 \
-		--instance-type t2.medium \
+		--instance-type ${instance_type} \
 		--associate-public-ip-address \
 		--tag-specifications "${tags}" \
 		--subnet-id "${subnet_id}" \


### PR DESCRIPTION
It turns out the instance_type t2.medium can only be used for x86_64 and i386 architectures. Perhaps this was a recent change? Has this never worked for arm64?

Add a select-case clause to select an appropriate instance_type base on the architecture. We only need amd64 and arm64 for the time being

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ . includes/aws_ami_creation.sh
$ export foo 
$ MODEL_ARCH=arm64 TEST_DIR=$(mktemp) create_ami_and_wait_available foo
$ echo $foo
bash: /tmp/tmp.YCgLMNBSng/ec2-instances: Not a directory
Created instance for ami builder: i-04834e34cf20ebe62
bash: /tmp/tmp.YCgLMNBSng/ec2-amis: Not a directory
Created ami: ami-09d6d1ba1e27e44b4
ami-09d6d1ba1e27e44b4
```
