### PR TITLE
Fix controller config key finding in md-gen tool.

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -33,6 +33,7 @@ const (
 	MongoProfDefault = "default"
 )
 
+// docs:controller-config-keys
 const (
 	// APIPort is the port used for api connections.
 	APIPort = "api-port"


### PR DESCRIPTION
Finding the const block that has all the controller config keys was flawed. This fixes it with a special comment.

```
Run go run ./scripts/md-gen/controller-config
  go run ./scripts/md-gen/controller-config
  shell: /usr/bin/bash -e {0}
  env:
    TOPIC_IDS: ./.github/discourse-topic-ids.yaml
    DOCS_DIR: /tmp/tmp.OXp0YgyPv5
    JUJU_SRC_ROOT: .
panic: interface conversion: ast.Expr is *ast.BinaryExpr, not *ast.BasicLit

goroutine 1 [running]:
main.fillFromAST(0xf1ec09?, {0x40000400ae?, 0x1b3a4c0?})
	/opt/actions-runner/_work/juju/juju/scripts/md-gen/controller-config/main.go:144 +0x8a0
main.main()
	/opt/actions-runner/_work/juju/juju/scripts/md-gen/controller-config/main.go:40 +0x94
exit status [2](https://github.com/juju/juju/actions/runs/6467385651/job/17557313619?pr=16410#step:6:2)
Error: Process completed with exit code 1.
```

## QA steps

Sync to Discourse action is green

## Documentation changes

N/A

## Links

[failed run](https://github.com/juju/juju/actions/runs/6467385651/job/17557313619?pr=16410)