### PR TITLE
Add CharmRevision method to application

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -481,7 +481,7 @@ func (api *ProvisionerAPI) machineLXDProfileNames(m *state.Machine, env environs
 			continue
 		}
 
-		pName := lxdprofile.Name(api.m.Name(), app.Name(), ch.Revision())
+		pName := lxdprofile.Name(api.m.Name(), app.Name(), *app.CharmRevision())
 		// Lock here, we get a new env for every call to ProvisioningInfo().
 		api.mu.Lock()
 		if err := profileEnv.MaybeWriteLXDProfile(pName, lxdprofile.Profile{

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -967,11 +967,11 @@ func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos net
 			}
 		}
 
+		chName := lxdprofile.Name(model.Name(), app.Name(), *app.CharmRevision())
 		ch, _, err := app.Charm()
 		if err != nil {
 			continue
 		}
-		chName := lxdprofile.Name(model.Name(), app.Name(), ch.Revision())
 		if profile := ch.LXDProfile(); profile != nil {
 			lxdProfiles[chName] = &charm.LXDProfile{
 				Description: profile.Description,
@@ -1365,7 +1365,7 @@ func (context *statusContext) processApplication(application *state.Application)
 	if lxdprofile.NotEmpty(lxdStateCharmProfiler{
 		Charm: applicationCharm,
 	}) {
-		charmProfileName = lxdprofile.Name(context.model.Name(), application.Name(), applicationCharm.Revision())
+		charmProfileName = lxdprofile.Name(context.model.Name(), application.Name(), *application.CharmRevision())
 	}
 
 	mappedExposedEndpoints, err := context.mapExposedEndpointsFromState(application.ExposedEndpoints())

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -845,6 +845,10 @@ func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Ch
 	if appSeries == "kubernetes" {
 		appSeries = corebase.LegacyKubernetesSeries()
 	}
+	rev := curl.Revision
+	if rev == -1 {
+		rev = 0
+	}
 	base, err := corebase.GetBaseFromSeries(appSeries)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
@@ -854,7 +858,9 @@ func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Ch
 			Platform: &state.Platform{
 				OS:      base.OS,
 				Channel: base.Channel.String(),
-			}},
+			},
+			Revision: &rev,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
@@ -875,6 +881,10 @@ func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *
 	curl := charm.MustParseURL(ch.URL())
 	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
+	rev := curl.Revision
+	if rev == -1 {
+		rev = 0
+	}
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,
 		Charm: ch,
@@ -884,7 +894,9 @@ func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *
 				Architecture: arch,
 				OS:           base.OS,
 				Channel:      base.Channel.String(),
-			}},
+			},
+			Revision: &rev,
+		},
 		Constraints: constraints.MustParse("arch=" + arch),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -895,6 +907,10 @@ func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, c
 	curl := charm.MustParseURL(ch.URL())
 	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
+	rev := curl.Revision
+	if rev == -1 {
+		rev = 0
+	}
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,
 		Charm: ch,
@@ -903,7 +919,9 @@ func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, c
 			Platform: &state.Platform{
 				OS:      base.OS,
 				Channel: base.Channel.String(),
-			}},
+			},
+			Revision: &rev,
+		},
 		Storage: storage,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -914,6 +932,10 @@ func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, 
 	curl := charm.MustParseURL(ch.URL())
 	base, err := corebase.GetBaseFromSeries(curl.Series)
 	c.Assert(err, jc.ErrorIsNil)
+	rev := curl.Revision
+	if rev == -1 {
+		rev = 0
+	}
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:  name,
 		Charm: ch,
@@ -922,7 +944,9 @@ func (s *JujuConnSuite) AddTestingApplicationWithBindings(c *gc.C, name string, 
 			Platform: &state.Platform{
 				OS:      base.OS,
 				Channel: base.Channel.String(),
-			}},
+			},
+			Revision: &rev,
+		},
 		EndpointBindings: bindings,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/application.go
+++ b/state/application.go
@@ -1047,6 +1047,11 @@ func (a *Application) CharmURL() (*string, bool) {
 	return a.doc.CharmURL, a.doc.ForceCharm
 }
 
+// CharmRevision returns the revision of an application's charm
+func (a *Application) CharmRevision() *int {
+	return a.CharmOrigin().Revision
+}
+
 // Endpoints returns the application's currently available relation endpoints.
 func (a *Application) Endpoints() (eps []Endpoint, err error) {
 	ch, _, err := a.Charm()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -497,6 +497,10 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		if chSeries == "kubernetes" {
 			chSeries = corebase.LegacyKubernetesSeries()
 		}
+		rev := curl.Revision
+		if rev == -1 {
+			rev = 0
+		}
 		base, err := corebase.GetBaseFromSeries(chSeries)
 		c.Assert(err, jc.ErrorIsNil)
 		var channel *state.Channel
@@ -515,7 +519,9 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 				Architecture: curl.Architecture,
 				OS:           base.OS,
 				Channel:      base.Channel.String(),
-			}}
+			},
+			Revision: &rev,
+		}
 	}
 
 	rSt := factory.st.Resources()


### PR DESCRIPTION
This method does not rely on parsing the charm url, so is preferred. Make use of it in a few places

Also, now that we guarentee charm origin revision is present, ensure that JujuConnSuite reflects this

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests all pass

```
$ juju deploy ./testcharms/charm-repo/quantal/lxd-profile
$ juju deploy ./testcharms/charm-repo/quantal/lxd-profile lxd-profile1
$ juju status --format json | jq -r '.applications[]["charm-profile"]'
juju-m-lxd-profile-0
juju-m-lxd-profile1-1
```
