### PR TITLE
Close temp files before potential errors

### DIFF
--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -61,11 +61,16 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+
 	_, err = io.Copy(f, zr)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(f.Name())
+
 	gzipSHA256 := fmt.Sprintf("%x", sha256hash.Sum(nil))
 	if tools.SHA256 != gzipSHA256 {
 		return fmt.Errorf("tarball sha256 mismatch, expected %s, got %s", tools.SHA256, gzipSHA256)

--- a/api/client/charms/client.go
+++ b/api/client/charms/client.go
@@ -188,8 +188,11 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool, agen
 		if archive, err = os.CreateTemp("", "charm"); err != nil {
 			return nil, errors.Annotate(err, "cannot create temp file")
 		}
-		defer os.Remove(archive.Name())
-		defer archive.Close()
+		defer func() {
+			_ = archive.Close()
+			_ = os.Remove(archive.Name())
+		}()
+
 		if err := ch.ArchiveTo(archive); err != nil {
 			return nil, errors.Annotate(err, "cannot repackage charm")
 		}

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -579,6 +579,7 @@ func writeCharmToTempFile(r io.Reader) (string, error) {
 		return "", errors.Annotate(err, "creating temp file")
 	}
 	defer tempFile.Close()
+
 	if _, err := io.Copy(tempFile, r); err != nil {
 		return "", errors.Annotate(err, "processing upload")
 	}

--- a/apiserver/common/charms.go
+++ b/apiserver/common/charms.go
@@ -37,10 +37,11 @@ func ReadCharmFromStorage(store storage.Storage, dataDir, storagePath string) (s
 	if err != nil {
 		return "", errors.Annotate(err, "cannot create charm archive file")
 	}
+	defer charmFile.Close()
+
 	if _, err = io.Copy(charmFile, reader); err != nil {
 		return "", errors.Annotate(err, "error processing charm archive download")
 	}
-	charmFile.Close()
 	return charmFile.Name(), nil
 }
 

--- a/core/charm/downloader/downloader.go
+++ b/core/charm/downloader/downloader.go
@@ -145,8 +145,8 @@ func (d *Downloader) DownloadAndStore(charmURL *charm.URL, requestedOrigin corec
 	if err != nil {
 		return corecharm.Origin{}, errors.Trace(err)
 	}
-	_ = tmpFile.Close()
 	defer func() {
+		_ = tmpFile.Close()
 		if err := os.Remove(tmpFile.Name()); err != nil {
 			d.logger.Warningf("unable to remove temporary charm download path %q", tmpFile.Name())
 		}

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -159,8 +159,9 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = file.Close() }()
+
 	_, err = io.CopyN(file, r, length)
-	file.Close()
 	if err != nil {
 		os.Remove(file.Name())
 		return err

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -305,8 +305,11 @@ func buildAgentTarball(
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	defer os.Remove(f.Name())
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+
 	toolsVersion, forceVersion, official, sha256Hash, err := envtools.BundleTools(build, f, getForceVersion)
 	if err != nil {
 		return nil, err

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -699,8 +699,11 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*st
 		if f, err = os.CreateTemp("", name); err != nil {
 			return nil, err
 		}
-		defer os.Remove(f.Name())
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}()
+
 		err = ch.ArchiveTo(f)
 		if err != nil {
 			return nil, fmt.Errorf("cannot bundle charm: %v", err)
@@ -713,7 +716,7 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*st
 		if f, err = os.Open(ch.Path); err != nil {
 			return nil, fmt.Errorf("cannot read charm bundle: %v", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	default:
 		return nil, fmt.Errorf("unknown charm type %T", ch)
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -196,6 +196,7 @@ func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err er
 	}
 	defer func() {
 		if err != nil {
+			_ = tempFile.Close()
 			_ = os.Remove(tempFile.Name())
 		}
 	}()

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -567,8 +567,8 @@ func hostBootstrapSSHOptions(
 		return nil, cleanup, errors.Trace(err)
 	}
 	cleanup = func() {
-		f.Close()
-		os.RemoveAll(f.Name())
+		_ = f.Close()
+		_ = os.RemoveAll(f.Name())
 	}
 	w := bufio.NewWriter(f)
 	for _, pubKey := range pubKeys {

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -286,8 +286,8 @@ func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error 
 		return errors.Trace(err)
 	}
 	defer func() {
-		newFsTab.Close()
-		os.Remove(newFsTab.Name())
+		_ = newFsTab.Close()
+		_ = os.Remove(newFsTab.Name())
 	}()
 	if err := os.Chmod(newFsTab.Name(), 0644); err != nil {
 		return errors.Trace(err)
@@ -403,8 +403,8 @@ func removeFstabEntry(etcDir string, mountPoint string) error {
 		return errors.Trace(err)
 	}
 	defer func() {
-		newFsTab.Close()
-		os.Remove(newFsTab.Name())
+		_ = newFsTab.Close()
+		_ = os.Remove(newFsTab.Name())
 	}()
 	if err := os.Chmod(newFsTab.Name(), 0644); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
The following ensures that we close files before an error is returned. This was spotted just whilst auditing some code for future estimates.

In most cases the io.Copy could return an error and in those cases, we should close the tmp file before returning. This should ensure cleanup of resources.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Tests pass.

## Links

**Jira card:** JUJU-4748
