### PR TITLE
Use fsnotify instead of inotify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
 	github.com/go-logr/logr v1.2.4
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
@@ -171,7 +172,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/worker/filenotifywatcher/watcher_linux.go
+++ b/worker/filenotifywatcher/watcher_linux.go
@@ -6,14 +6,16 @@
 
 package filenotifywatcher
 
-import "k8s.io/utils/inotify"
+import (
+	"github.com/fsnotify/fsnotify"
+)
 
 type watcher struct {
-	watcher *inotify.Watcher
+	watcher *fsnotify.Watcher
 }
 
 func newWatcher() (INotifyWatcher, error) {
-	w, err := inotify.NewWatcher()
+	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
@@ -23,15 +25,15 @@ func newWatcher() (INotifyWatcher, error) {
 }
 
 func (w *watcher) Watch(path string) error {
-	return w.watcher.Watch(path)
+	return w.watcher.Add(path)
 }
 
-func (w *watcher) Events() <-chan *inotify.Event {
-	return w.watcher.Event
+func (w *watcher) Events() <-chan fsnotify.Event {
+	return w.watcher.Events
 }
 
 func (w *watcher) Errors() <-chan error {
-	return w.watcher.Error
+	return w.watcher.Errors
 }
 
 func (w *watcher) Close() error {


### PR DESCRIPTION
It was brought up that we shouldn't depend on k8s utilities for non-k8s infrastructure if there was another solution. The other solution was fsnotify, which is almost identical to inotify. The only difference from the perspective that we want is that it has a different mask type.

The rest is nicely abstracted away because we don't leak our types, it's all self-contained in the worker.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
QA steps here
```

## Links

**Jira card:** JUJU-4750
