### PR TITLE
Allow superuser to fetch offer consuming details;

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -484,12 +484,22 @@ func (api *OffersAPI) getConsumeDetails(user names.UserTag, urls params.OfferURL
 		if !isAdmin {
 			appOffer := names.NewApplicationOfferTag(offer.OfferUUID)
 			err := api.Authorizer.EntityHasPermission(user, permission.ConsumeAccess, appOffer)
-			if err != nil {
+			if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 				results[i].Error = apiservererrors.ServerError(err)
 				continue
 			}
+			if err != nil {
+				// This logic is purely for JaaS.
+				// Jaas has already checked permissions of args.UserTag in their side, so we don't need to check it again.
+				// But as a TODO, we need to set the ConsumeOfferMacaroon's expiry time to 0 to force go to
+				// discharge flow once they got the macaroon.
+				err := api.checkControllerAdmin()
+				if err != nil {
+					results[i].Error = apiservererrors.ServerError(err)
+					continue
+				}
+			}
 		}
-
 		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(api.ctx, offerDetails, user.Id(), urls.BakeryVersion)
 		if err != nil {
 			results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
@@ -1193,31 +1194,49 @@ func (s *consumeSuite) TestConsumeDetailsNoPermission(c *gc.C) {
 }
 
 func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
-	s.assertConsumeDetailsWithPermission(c, false)
+	s.assertConsumeDetailsWithPermission(c,
+		func(authorizer *apiservertesting.FakeAuthorizer, apiUser names.UserTag) string {
+			authorizer.HasConsumeTag = apiUser
+			authorizer.Tag = apiUser
+			return ""
+		},
+	)
 }
 
-func (s *consumeSuite) TestConsumeDetailsSpecifiedUser(c *gc.C) {
-	s.assertConsumeDetailsWithPermission(c, true)
+func (s *consumeSuite) TestConsumeDetailsSpecifiedUserHasPermission(c *gc.C) {
+	s.assertConsumeDetailsWithPermission(c,
+		func(authorizer *apiservertesting.FakeAuthorizer, apiUser names.UserTag) string {
+			authorizer.HasConsumeTag = apiUser
+			controllerAdmin := names.NewUserTag("superuser-joe")
+			authorizer.Tag = controllerAdmin
+			return apiUser.String()
+		},
+	)
 }
 
-func (s *consumeSuite) assertConsumeDetailsWithPermission(c *gc.C, specifiedUser bool) {
+func (s *consumeSuite) TestConsumeDetailsSpecifiedUserHasNoPermissionButSuperUserLoggedIn(c *gc.C) {
+	s.assertConsumeDetailsWithPermission(c,
+		func(authorizer *apiservertesting.FakeAuthorizer, apiUser names.UserTag) string {
+			controllerAdmin := names.NewUserTag("superuser-joe")
+			authorizer.Tag = controllerAdmin
+			return apiUser.String()
+		},
+	)
+}
+
+func (s *consumeSuite) assertConsumeDetailsWithPermission(
+	c *gc.C, configAuthorizer func(*apiservertesting.FakeAuthorizer, names.UserTag) string,
+) {
 	s.setupOffer()
 	st := s.mockStatePool.st[testing.ModelTag.Id()]
 	st.(*mockState).users["someone"] = &mockUser{"someone"}
 	apiUser := names.NewUserTag("someone")
-	s.authorizer.HasConsumeTag = apiUser
+
+	userTag := configAuthorizer(s.authorizer, apiUser)
 	offer := names.NewApplicationOfferTag("hosted-mysql")
 	err := st.CreateOfferAccess(offer, apiUser, permission.ConsumeAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
-	userTag := ""
-	if specifiedUser {
-		controllerAdmin := names.NewUserTag("superuser-joe")
-		s.authorizer.Tag = controllerAdmin
-		userTag = apiUser.String()
-	} else {
-		s.authorizer.Tag = apiUser
-	}
 	results, err := s.api.GetConsumeDetails(params.ConsumeOfferDetailsArg{
 		UserTag: userTag,
 		OfferURLs: params.OfferURLs{


### PR DESCRIPTION
This change is to allow super users to be able to fetch offer-consuming details for any users for JaaS.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju add-model model-secrets-offer

juju deploy juju-qa-dummy-source

juju offer dummy-source:sink

juju add-model model-secrets-consume

juju deploy juju-qa-dummy-sink

juju integrate dummy-sink model-secrets-offer.dummy-source
```

**Jira card:** JUJU-4761
