### PR TITLE
bump gomaasapi to 2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0
 	github.com/juju/gojsonschema v1.0.0
-	github.com/juju/gomaasapi/v2 v2.1.0
+	github.com/juju/gomaasapi/v2 v2.2.0
 	github.com/juju/http/v2 v2.0.0
 	github.com/juju/idmclient/v2 v2.0.0
 	github.com/juju/jsonschema v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -785,8 +785,8 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v1.0.0 h1:v0hVxinRWko/SwRYCZ99fBH20Q1JtDqKtplcovXewt0=
 github.com/juju/gojsonschema v1.0.0/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
-github.com/juju/gomaasapi/v2 v2.1.0 h1:K9M4OjDVSS7UWjHGvYvdpXJWQE72uyDo4do1czDjlIA=
-github.com/juju/gomaasapi/v2 v2.1.0/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
+github.com/juju/gomaasapi/v2 v2.2.0 h1:vaYeEKr0mQXsM38/zfWqCrYDG8cYhHRkfTQMgkJGHdU=
+github.com/juju/gomaasapi/v2 v2.2.0/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
 github.com/juju/http/v2 v2.0.0 h1:xexT4KO4jY0UEkhLZPwQGaEGCfgWWjw3jBPrLRumhKI=
 github.com/juju/http/v2 v2.0.0/go.mod h1:hqjfdSwUaD23PurU7FZyY/rsqVL90RF3w4Xl0iPILRA=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=


### PR DESCRIPTION
This PR aims to bump the gomaasapi package so to include https://github.com/juju/gomaasapi/pull/104 

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Launchpad bug:** [https://bugs.launchpad.net/maas/+bug/2039105](https://bugs.launchpad.net/maas/+bug/2039105)