### PR TITLE
Watch upgrades if it's already started

### DIFF
--- a/domain/upgrade/service/service_test.go
+++ b/domain/upgrade/service/service_test.go
@@ -153,3 +153,15 @@ func (s *serviceSuite) TestWatchForUpgradeReady(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watcher, gc.NotNil)
 }
+
+func (s *serviceSuite) TestWatchForUpgradeState(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	nw := watchertest.NewMockNotifyWatcher(nil)
+
+	s.watcherFactory.EXPECT().NewValuePredicateWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
+
+	watcher, err := s.srv.WatchForUpgradeState(context.Background(), s.upgradeUUID, coreupgrade.Started)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watcher, gc.NotNil)
+}

--- a/worker/upgradedatabase/manifold.go
+++ b/worker/upgradedatabase/manifold.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/internal/servicefactory"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -88,11 +89,17 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
+			// Work out where we're upgrading from and, where we want to upgrade to.
+			fromVersion := controllerAgent.CurrentConfig().UpgradedToVersion()
+			toVersion := jujuversion.Current
+
 			return cfg.NewWorker(Config{
 				DBUpgradeCompleteLock: dbUpgradeCompleteLock,
 				Agent:                 controllerAgent,
 				UpgradeService:        serviceFactoryGetter.Upgrade(),
 				DBGetter:              dbGetter,
+				FromVersion:           fromVersion,
+				ToVersion:             toVersion,
 				Logger:                cfg.Logger,
 			})
 		},

--- a/worker/upgradedatabase/manifold_test.go
+++ b/worker/upgradedatabase/manifold_test.go
@@ -6,6 +6,7 @@ package upgradedatabase
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 	dependencytesting "github.com/juju/worker/v3/dependency/testing"
@@ -88,6 +89,9 @@ func (s *manifoldSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 
 	s.worker = NewMockWorker(ctrl)
+
+	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig).AnyTimes()
+	s.agentConfig.EXPECT().UpgradedToVersion().Return(version.MustParse("1.0.0")).AnyTimes()
 
 	s.serviceFactory.EXPECT().Upgrade().Return(&upgradeservice.Service{}).AnyTimes()
 

--- a/worker/upgradedatabase/package_test.go
+++ b/worker/upgradedatabase/package_test.go
@@ -44,6 +44,7 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.agent = NewMockAgent(ctrl)
 	s.agentConfig = NewMockConfig(ctrl)
 	s.serviceFactory = NewMockControllerServiceFactory(ctrl)
+	s.upgradeService = NewMockUpgradeService(ctrl)
 	s.dbGetter = NewMockDBGetter(ctrl)
 
 	s.logger = jujujujutesting.NewCheckLogger(c)

--- a/worker/upgradedatabase/service_mock_test.go
+++ b/worker/upgradedatabase/service_mock_test.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	upgrade "github.com/juju/juju/core/upgrade"
 	watcher "github.com/juju/juju/core/watcher"
-	upgrade "github.com/juju/juju/domain/upgrade"
+	upgrade0 "github.com/juju/juju/domain/upgrade"
 	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -37,11 +38,26 @@ func (m *MockUpgradeService) EXPECT() *MockUpgradeServiceMockRecorder {
 	return m.recorder
 }
 
+// ActiveUpgrade mocks base method.
+func (m *MockUpgradeService) ActiveUpgrade(arg0 context.Context) (upgrade0.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ActiveUpgrade", arg0)
+	ret0, _ := ret[0].(upgrade0.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ActiveUpgrade indicates an expected call of ActiveUpgrade.
+func (mr *MockUpgradeServiceMockRecorder) ActiveUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveUpgrade", reflect.TypeOf((*MockUpgradeService)(nil).ActiveUpgrade), arg0)
+}
+
 // CreateUpgrade mocks base method.
-func (m *MockUpgradeService) CreateUpgrade(arg0 context.Context, arg1, arg2 version.Number) (upgrade.UUID, error) {
+func (m *MockUpgradeService) CreateUpgrade(arg0 context.Context, arg1, arg2 version.Number) (upgrade0.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUpgrade", arg0, arg1, arg2)
-	ret0, _ := ret[0].(upgrade.UUID)
+	ret0, _ := ret[0].(upgrade0.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -53,7 +69,7 @@ func (mr *MockUpgradeServiceMockRecorder) CreateUpgrade(arg0, arg1, arg2 interfa
 }
 
 // SetControllerDone mocks base method.
-func (m *MockUpgradeService) SetControllerDone(arg0 context.Context, arg1 upgrade.UUID, arg2 string) error {
+func (m *MockUpgradeService) SetControllerDone(arg0 context.Context, arg1 upgrade0.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetControllerDone", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -67,7 +83,7 @@ func (mr *MockUpgradeServiceMockRecorder) SetControllerDone(arg0, arg1, arg2 int
 }
 
 // SetControllerReady mocks base method.
-func (m *MockUpgradeService) SetControllerReady(arg0 context.Context, arg1 upgrade.UUID, arg2 string) error {
+func (m *MockUpgradeService) SetControllerReady(arg0 context.Context, arg1 upgrade0.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetControllerReady", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -81,7 +97,7 @@ func (mr *MockUpgradeServiceMockRecorder) SetControllerReady(arg0, arg1, arg2 in
 }
 
 // SetDBUpgradeCompleted mocks base method.
-func (m *MockUpgradeService) SetDBUpgradeCompleted(arg0 context.Context, arg1 upgrade.UUID) error {
+func (m *MockUpgradeService) SetDBUpgradeCompleted(arg0 context.Context, arg1 upgrade0.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDBUpgradeCompleted", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -95,7 +111,7 @@ func (mr *MockUpgradeServiceMockRecorder) SetDBUpgradeCompleted(arg0, arg1 inter
 }
 
 // StartUpgrade mocks base method.
-func (m *MockUpgradeService) StartUpgrade(arg0 context.Context, arg1 upgrade.UUID) error {
+func (m *MockUpgradeService) StartUpgrade(arg0 context.Context, arg1 upgrade0.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartUpgrade", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -109,7 +125,7 @@ func (mr *MockUpgradeServiceMockRecorder) StartUpgrade(arg0, arg1 interface{}) *
 }
 
 // WatchForUpgradeReady mocks base method.
-func (m *MockUpgradeService) WatchForUpgradeReady(arg0 context.Context, arg1 upgrade.UUID) (watcher.Watcher[struct{}], error) {
+func (m *MockUpgradeService) WatchForUpgradeReady(arg0 context.Context, arg1 upgrade0.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchForUpgradeReady", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -121,4 +137,19 @@ func (m *MockUpgradeService) WatchForUpgradeReady(arg0 context.Context, arg1 upg
 func (mr *MockUpgradeServiceMockRecorder) WatchForUpgradeReady(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForUpgradeReady", reflect.TypeOf((*MockUpgradeService)(nil).WatchForUpgradeReady), arg0, arg1)
+}
+
+// WatchForUpgradeState mocks base method.
+func (m *MockUpgradeService) WatchForUpgradeState(arg0 context.Context, arg1 upgrade0.UUID, arg2 upgrade.State) (watcher.Watcher[struct{}], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchForUpgradeState", arg0, arg1, arg2)
+	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchForUpgradeState indicates an expected call of WatchForUpgradeState.
+func (mr *MockUpgradeServiceMockRecorder) WatchForUpgradeState(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForUpgradeState", reflect.TypeOf((*MockUpgradeService)(nil).WatchForUpgradeState), arg0, arg1, arg2)
 }

--- a/worker/upgradedatabase/worker_test.go
+++ b/worker/upgradedatabase/worker_test.go
@@ -4,12 +4,22 @@
 package upgradedatabase
 
 import (
+	"time"
+
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
+	"github.com/juju/worker/v3/dependency"
 	"github.com/juju/worker/v3/workertest"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/testing"
+	upgrade "github.com/juju/juju/core/upgrade"
+	"github.com/juju/juju/core/watcher/watchertest"
+	domainupgrade "github.com/juju/juju/domain/upgrade"
+	upgradeerrors "github.com/juju/juju/domain/upgrade/errors"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -18,6 +28,8 @@ import (
 
 type workerSuite struct {
 	baseSuite
+
+	upgradeUUID domainupgrade.UUID
 }
 
 var _ = gc.Suite(&workerSuite{})
@@ -36,7 +48,7 @@ func (s *workerSuite) TestNewLockOldVersionLocked(c *gc.C) {
 	c.Assert(NewLock(s.agentConfig).IsUnlocked(), jc.IsFalse)
 }
 
-func (s *workerSuite) TestAlreadyCompleteNoWork(c *gc.C) {
+func (s *workerSuite) TestLockAlreadyUnlocked(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.lock.EXPECT().IsUnlocked().Return(true)
@@ -44,21 +56,92 @@ func (s *workerSuite) TestAlreadyCompleteNoWork(c *gc.C) {
 	w, err := NewUpgradeDatabaseWorker(s.getConfig())
 	c.Assert(err, jc.ErrorIsNil)
 
-	workertest.CleanKill(c, w)
+	err = workertest.CheckKill(c, w)
+	c.Check(err, jc.ErrorIs, dependency.ErrUninstall)
 }
 
-func (s *workerSuite) TestAlreadyUpgradedNoWork(c *gc.C) {
+func (s *workerSuite) TestLockIsUnlockedIfMatchingVersions(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.lock.EXPECT().IsUnlocked().Return(false)
-	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
-	s.agentConfig.EXPECT().UpgradedToVersion().Return(jujuversion.Current)
 	s.lock.EXPECT().Unlock()
 
-	w, err := NewUpgradeDatabaseWorker(s.getConfig())
+	cfg := s.getConfig()
+	cfg.FromVersion = jujuversion.Current
+	cfg.ToVersion = jujuversion.Current
+
+	w, err := NewUpgradeDatabaseWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	workertest.CleanKill(c, w)
+	err = workertest.CheckKill(c, w)
+	c.Check(err, jc.ErrorIs, dependency.ErrUninstall)
+}
+
+func (s *workerSuite) TestWatchUpgradeInsteadOfPerforming(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Ensure that the update hasn't already happened.
+	s.lock.EXPECT().IsUnlocked().Return(false)
+
+	cfg := s.getConfig()
+
+	ch := make(chan struct{})
+
+	watcher := watchertest.NewMockNotifyWatcher(ch)
+	defer workertest.DirtyKill(c, watcher)
+
+	// Walk through the upgrade process:
+	//  - Create Upgrade, but it's already started.
+	//  - Get the active upgrade.
+	//  - Watch for the upgrade to complete.
+
+	srv := s.upgradeService.EXPECT()
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
+	srv.WatchForUpgradeState(gomock.Any(), s.upgradeUUID, upgrade.DBCompleted).Return(watcher, nil)
+
+	// We expect the lock to be unlocked when the upgrade completes.
+	s.lock.EXPECT().Unlock()
+
+	w, err := NewUpgradeDatabaseWorker(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case ch <- struct{}{}:
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("timed out waiting to enqueue change")
+	}
+
+	err = workertest.CheckKill(c, w)
+	c.Check(err, jc.ErrorIs, dependency.ErrUninstall)
+}
+
+func (s *workerSuite) TestWatchUpgradeError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Ensure that the update hasn't already happened.
+	s.lock.EXPECT().IsUnlocked().Return(false)
+
+	cfg := s.getConfig()
+
+	ch := make(chan struct{})
+
+	watcher := watchertest.NewMockNotifyWatcher(ch)
+	defer workertest.DirtyKill(c, watcher)
+
+	// Walk through the upgrade process:
+	//  - Create Upgrade, but it's already started.
+	//  - Get the active upgrade, but it doesn't exist.
+
+	srv := s.upgradeService.EXPECT()
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.NotFoundf("no upgrade"))
+
+	w, err := NewUpgradeDatabaseWorker(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = workertest.CheckKill(c, w)
+	c.Check(err, jc.ErrorIs, dependency.ErrBounce)
 }
 
 func (s *workerSuite) getConfig() Config {
@@ -68,10 +151,15 @@ func (s *workerSuite) getConfig() Config {
 		Logger:                s.logger,
 		UpgradeService:        s.upgradeService,
 		DBGetter:              s.dbGetter,
+		FromVersion:           version.MustParse("3.0.0"),
+		ToVersion:             version.MustParse("6.6.6"),
 	}
 }
 
 func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
+
+	s.upgradeUUID = domainupgrade.UUID(utils.MustNewUUID().String())
+
 	return ctrl
 }


### PR DESCRIPTION
If the upgrade has already started we want to watch the active upgrade. We can utilize the new predicate watcher here, by just watching for a state to change.

There is a slight complication. If we can't locate an active upgrade then we're left in limbo land. We either just missed it (not sure how, as we expect everyone to participate) or something went wrong. The only course of action is to either force the whole re-evaluation or die. I chose the former.

I also changed the return error types for the worker. As this is the upgrade worker, it should only ever be evaluated once we start up. There is never a point that we want to reconsider this worker after that. In that case, we can just uninstall ourselves and call it done. This should reduce the number of workers to consider as dependencies from the dependency graph and potential goroutines.

-----

This was originally going to be a part of a larger patch, but because of the restarting (bouncing) complexity, I've broken this part out.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
$ juju upgrade-controller --build-agent
```

## Links

**Jira card:** JUJU-4756
