### PR TITLE
rename import redirect in worker/uniter

### DIFF
--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -68,7 +68,7 @@ func (s *BundlesDirSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *BundlesDirSuite) AddCharm(c *gc.C) (charm.BundleInfo, *state.Charm) {
-	curl := corecharm.MustParseURL("ch:quantal/dummy-1")
+	curl := jujucharm.MustParseURL("ch:quantal/dummy-1")
 	bun := testcharms.Repo.CharmDir("dummy")
 	sch, err := testing.AddCharm(s.State, curl, bun, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -153,7 +153,7 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 }
 
 func assertCharm(c *gc.C, bun charm.Bundle, sch *state.Charm) {
-	actual := bun.(*corecharm.CharmArchive)
+	actual := bun.(*jujucharm.CharmArchive)
 	c.Assert(actual.Revision(), gc.Equals, sch.Revision())
 	c.Assert(actual.Meta(), gc.DeepEquals, sch.Meta())
 	c.Assert(actual.Config(), gc.DeepEquals, sch.Config())

--- a/worker/uniter/charm/charm_test.go
+++ b/worker/uniter/charm/charm_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -54,13 +54,13 @@ func (br *bundleReader) Read(info charm.BundleInfo, abort <-chan struct{}) (char
 	return bundle, nil
 }
 
-func (br *bundleReader) AddCustomBundle(c *gc.C, url *corecharm.URL, customize func(path string)) charm.BundleInfo {
+func (br *bundleReader) AddCustomBundle(c *gc.C, url *jujucharm.URL, customize func(path string)) charm.BundleInfo {
 	base := c.MkDir()
 	dirpath := testcharms.Repo.ClonedDirPath(base, "dummy")
 	if customize != nil {
 		customize(dirpath)
 	}
-	dir, err := corecharm.ReadCharmDir(dirpath)
+	dir, err := jujucharm.ReadCharmDir(dirpath)
 	c.Assert(err, jc.ErrorIsNil)
 	err = dir.SetDiskRevision(url.Revision)
 	c.Assert(err, jc.ErrorIsNil)
@@ -70,12 +70,12 @@ func (br *bundleReader) AddCustomBundle(c *gc.C, url *corecharm.URL, customize f
 	defer func() { _ = file.Close() }()
 	err = dir.ArchiveTo(file)
 	c.Assert(err, jc.ErrorIsNil)
-	bundle, err := corecharm.ReadCharmArchive(bunpath)
+	bundle, err := jujucharm.ReadCharmArchive(bunpath)
 	c.Assert(err, jc.ErrorIsNil)
 	return br.AddBundle(url, bundle)
 }
 
-func (br *bundleReader) AddBundle(url *corecharm.URL, bundle charm.Bundle) charm.BundleInfo {
+func (br *bundleReader) AddBundle(url *jujucharm.URL, bundle charm.Bundle) charm.BundleInfo {
 	if br.bundles == nil {
 		br.bundles = map[string]charm.Bundle{}
 	}
@@ -109,7 +109,7 @@ func (b mockBundle) ExpandTo(dir string) error {
 	return nil
 }
 
-func charmURL(revision int) *corecharm.URL {
-	baseURL := corecharm.MustParseURL("ch:s/c")
+func charmURL(revision int) *jujucharm.URL {
+	baseURL := jujucharm.MustParseURL("ch:s/c")
 	return baseURL.WithRevision(revision)
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -6,7 +6,7 @@ package uniter
 import (
 	"fmt"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -133,7 +133,7 @@ func (opc *operationCallbacks) ActionStatus(actionId string) (string, error) {
 
 // GetArchiveInfo is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) GetArchiveInfo(url string) (charm.BundleInfo, error) {
-	charmURL, err := corecharm.ParseURL(url)
+	charmURL, err := jujucharm.ParseURL(url)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -6,7 +6,7 @@ package uniter
 import (
 	"fmt"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/hooks"
 	"github.com/juju/errors"
 
@@ -176,7 +176,7 @@ func (s *uniterResolver) NextOp(
 			// if a wrench existed.
 			if localState.CharmURL != "" && logger.IsTraceEnabled() {
 				// If it's set, the charm url will parse.
-				curl := corecharm.MustParseURL(localState.CharmURL)
+				curl := jujucharm.MustParseURL(localState.CharmURL)
 				if curl != nil && wrench.IsActive("hooks", fmt.Sprintf("%s-%s-error", curl.Name, localState.Hook.Kind)) {
 					s.config.Logger.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)
 					return nil, errors.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -6,7 +6,7 @@ package resolver
 import (
 	"time"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/mutex/v2"
@@ -268,7 +268,7 @@ func checkCharmInstallUpgrade(logger Logger, charmDir string, remote remotestate
 		return nil
 	}
 
-	_, err := corecharm.ReadCharmDir(charmDir)
+	_, err := jujucharm.ReadCharmDir(charmDir)
 	haveCharmDir := err == nil
 	if haveCharmDir {
 		// If the unit is installed and already upgrading and the charm dir
@@ -286,7 +286,7 @@ func checkCharmInstallUpgrade(logger Logger, charmDir string, remote remotestate
 		if err != nil {
 			return errors.Trace(err)
 		}
-		curl, err := corecharm.ParseURL(remote.CharmURL)
+		curl, err := jujucharm.ParseURL(remote.CharmURL)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"sync"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -620,7 +620,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 }
 
 func (u *Uniter) verifyCharmProfile(url string) error {
-	curl, err := corecharm.ParseURL(url)
+	curl, err := jujucharm.ParseURL(url)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/charm/v11/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -1347,7 +1347,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 
 	// Create the subordinate application.
 	dir := testcharms.Repo.ClonedDir(c.MkDir(), "logging")
-	curl, err := corecharm.ParseURL("ch:quantal/logging")
+	curl, err := jujucharm.ParseURL("ch:quantal/logging")
 	c.Assert(err, jc.ErrorIsNil)
 	curl = curl.WithRevision(dir.Revision())
 	step(c, ctx, addCharm{dir, curl})

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	pebbleclient "github.com/canonical/pebble/client"
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -338,7 +338,7 @@ func (s createCharm) step(c *gc.C, ctx *testContext) {
 	if len(s.badHooks) > 0 {
 		ctx.runner.hooksWithErrors = set.NewStrings(s.badHooks...)
 	}
-	dir, err := corecharm.ReadCharmDir(base)
+	dir, err := jujucharm.ReadCharmDir(base)
 	c.Assert(err, jc.ErrorIsNil)
 	err = dir.SetDiskRevision(s.revision)
 	c.Assert(err, jc.ErrorIsNil)
@@ -346,8 +346,8 @@ func (s createCharm) step(c *gc.C, ctx *testContext) {
 }
 
 type addCharm struct {
-	dir  *corecharm.CharmDir
-	curl *corecharm.URL
+	dir  *jujucharm.CharmDir
+	curl *jujucharm.URL
 }
 
 func (s addCharm) step(c *gc.C, ctx *testContext) {
@@ -827,7 +827,7 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 				c.Logf("want unit charm %q, got nil; still waiting", curl(s.charm))
 				continue
 			}
-			url, err := corecharm.ParseURL(*urlStr)
+			url, err := jujucharm.ParseURL(*urlStr)
 			if err != nil {
 				c.Fatalf("cannot refresh unit: %v", err)
 			}
@@ -1001,7 +1001,7 @@ func (s updateStatusHookTick) step(c *gc.C, ctx *testContext) {
 type changeConfig map[string]interface{}
 
 func (s changeConfig) step(c *gc.C, ctx *testContext) {
-	err := ctx.application.UpdateCharmConfig(model.GenerationMaster, corecharm.Settings(s))
+	err := ctx.application.UpdateCharmConfig(model.GenerationMaster, jujucharm.Settings(s))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1059,7 +1059,7 @@ func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 
 	urlStr := ctx.unit.CharmURL()
 	c.Assert(urlStr, gc.NotNil)
-	url, err := corecharm.ParseURL(*urlStr)
+	url, err := jujucharm.ParseURL(*urlStr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }
@@ -1385,8 +1385,8 @@ var subordinateDying = custom{func(c *gc.C, ctx *testContext) {
 	c.Assert(ctx.subordinate.Destroy(), gc.IsNil)
 }}
 
-func curl(revision int) *corecharm.URL {
-	return corecharm.MustParseURL("ch:quantal/wordpress").WithRevision(revision)
+func curl(revision int) *jujucharm.URL {
+	return jujucharm.MustParseURL("ch:quantal/wordpress").WithRevision(revision)
 }
 
 type hookLock struct {

--- a/worker/uniter/verifycharmprofile/verifycharmprofile.go
+++ b/worker/uniter/verifycharmprofile/verifycharmprofile.go
@@ -4,7 +4,7 @@
 package verifycharmprofile
 
 import (
-	corecharm "github.com/juju/charm/v11"
+	jujucharm "github.com/juju/charm/v11"
 
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
@@ -50,7 +50,7 @@ func (r *verifyCharmProfileResolver) NextOp(
 	if err != nil {
 		return nil, err
 	}
-	curl, err := corecharm.ParseURL(remoteState.CharmURL)
+	curl, err := jujucharm.ParseURL(remoteState.CharmURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rename corecharm to jujucharm on imports for worker/uniter. corecharm should be github.com/juju/juju/core/charm to be consistent with other juju code. Very confusing to see corecharm used for githubm.com/juju/charm. The two packages are no way interchangable. Uniter has its own charm pkg.

## QA steps
Successful unit test runs.
