### PR TITLE
Soften model cache test for adding a machine

### DIFF
--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -460,14 +460,6 @@ func (s *WorkerSuite) TestAddMachine(c *gc.C) {
 	cachedMachine, err := mod.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedMachine, gc.NotNil)
-
-	change = s.nextChange(c, changes)
-	obtained, ok = change.(cache.MachineChange)
-	c.Assert(ok, jc.IsTrue)
-	c.Check(obtained.Id, gc.Equals, machine.Id())
-	c.Check(obtained.InstanceId, gc.Not(gc.Equals), "")
-
-	s.checkSuperfluousChanges(c, changes, change)
 }
 
 func (s *WorkerSuite) TestRemoveMachine(c *gc.C) {


### PR DESCRIPTION
The model cache test for adding a machine has non-deterministic behaviour, because the factory method for adding a machine is non-transactional. It separately adds the machine, sets its password, marks it provisioned, sets addresses and sets tools.

Depending on the compute power of the machine running the tests, we can get different events, including errors causing a restart of the backing multi-watcher.

The best we can do is assert that a machine we add ends up in the cache. Here we modify the test for this minimal assertion.

## QA steps

Ensure tests pass consistently.
`TEST_PACKAGES="./worker/modelcache -count=1 -race" TEST_FILTER="WorkerSuite" make run-go-tests`
