### PR TITLE
Restore checkSuperfluousChanges call to machine cache test

### DIFF
--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -460,6 +460,8 @@ func (s *WorkerSuite) TestAddMachine(c *gc.C) {
 	cachedMachine, err := mod.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedMachine, gc.NotNil)
+
+	s.checkSuperfluousChanges(c, changes, change)
 }
 
 func (s *WorkerSuite) TestRemoveMachine(c *gc.C) {


### PR DESCRIPTION
This is a follow up to #16439 to restore the post-amble consumption of watcher changes to `TestAddMachine` in the `modelcache` suite.

As explained in that patch the notifications we get are not deterministic, because adding the machine is multiple steps not run transactionally. 

## QA steps

Run the test many times in a loop:
`TEST_PACKAGES="./worker/modelcache -count=30 -race" TEST_FILTER="TestAddMachine" make run-go-tests`