### PR TITLE
Merge 3.2 into 3.3

### DIFF
--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -125,7 +125,11 @@ func (p *PermissionDelegator) SubjectPermissions(
 	// We need to make very sure that the entity the request pertains to
 	// is the same entity this function was seeded with.
 	if tokenEntity.Tag().String() != e.Tag().String() {
-		return permission.NoAccess, fmt.Errorf("%w to use token permissions for one entity on another", apiservererrors.ErrPerm)
+		err = fmt.Errorf(
+			"%w to use token permissions for one entity on another",
+			apiservererrors.ErrPerm,
+		)
+		return permission.NoAccess, errors.WithType(err, authentication.ErrorEntityMissingPermission)
 	}
 	return PermissionFromToken(p.Token, subject)
 }

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -143,6 +143,7 @@ func (s *loginTokenSuite) TestPermissionsForDifferentEntity(c *gc.C) {
 	}
 	perm, err := authInfo.Delegator.SubjectPermissions(badUser, modelTag)
 	c.Assert(errors.Is(err, apiservererrors.ErrPerm), jc.IsTrue)
+	c.Assert(errors.Is(err, authentication.ErrorEntityMissingPermission), jc.IsTrue)
 	c.Assert(perm, gc.Equals, permission.NoAccess)
 
 	badUser = jwt.TokenEntity{

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -461,13 +461,24 @@ func (s *WorkerSuite) TestAddMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedMachine, gc.NotNil)
 
-	change = s.nextChange(c, changes)
+	// We don't know how many events we will get because `MakeMachine`
+	// above runs multiple operations but is not transactional.
+	// Drain the events for a short time then assert that the machine
+	// appears as though provisioned.
+	done := time.After(testing.ShortWait)
+loop:
+	for {
+		select {
+		case change = <-changes:
+		case <-done:
+			break loop
+		}
+	}
+
 	obtained, ok = change.(cache.MachineChange)
 	c.Assert(ok, jc.IsTrue)
 	c.Check(obtained.Id, gc.Equals, machine.Id())
 	c.Check(obtained.InstanceId, gc.Not(gc.Equals), "")
-
-	s.checkSuperfluousChanges(c, changes, change)
 }
 
 func (s *WorkerSuite) TestRemoveMachine(c *gc.C) {


### PR DESCRIPTION
Zero conflict merge from 3.2 to bring forward:
- #16440 from manadart/3.2-fix-enable-ha-integration
- #16443 from manadart/3.2-cache-add-machine-test-fix
- #16439 from manadart/3.2-soften-model-cache-test
- #16431 from ycliuhw/fix-jwt-auth4jaas