### PR TITLE
Fix parsing of watch flag on status command

### DIFF
--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -6660,3 +6660,16 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 	_, _, stderr = runStatus(c, "--no-color", "cannot", "match", "me")
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filters.\n")
 }
+
+func (s *StatusSuite) TestStatusArgsWithoutWatch(c *gc.C) {
+	cmd, err := initStatusCommand()
+	c.Assert(err, jc.ErrorIsNil)
+
+	statusArgsGNUStyle := []string{"juju", "status", "--watch=1s", "--relations"}
+	expectedArgsGNUStyle := []string{"juju", "status", "--relations", "--color"}
+	c.Check(cmd.statusCommandForViddy(statusArgsGNUStyle), jc.SameContents, expectedArgsGNUStyle)
+
+	statusArgsUnixStyle := []string{"juju", "status", "--watch", "1s", "--relations"}
+	expectedArgsUnixStyle := []string{"juju", "status", "--relations", "--color"}
+	c.Check(cmd.statusCommandForViddy(statusArgsUnixStyle), jc.SameContents, expectedArgsUnixStyle)
+}


### PR DESCRIPTION
On the status command, when passing the --watch flag, we pass the entire command line arguments (including 'juju status') along with all the flags except --watch to viddy, which will run the command indefinitely with an interval.

To do this, we must remove the --watch flag along with its value from the list of OS arguments to be passed to viddy. This was incorrectly done because it only accepted unix-style flags.

The fix is to remove both unix and gnu style when passing the watch flag.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

After bootstrapping and adding a model, get the status with --watch on two different styles:
```
juju status --watch 1s --relations
juju status --watch=1s --relations  
```
also, 
```
go test github.com/juju/juju/cmd/juju/status/... -gocheck.v
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2037914

**Jira card:** JUJU-4782
