### PR TITLE
Snap dependencies update

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,7 +181,7 @@ parts:
       - musl
       - musl-compat
     source: https://github.com/libuv/libuv.git
-    source-tag: v1.44.2
+    source-tag: v1.46.0
     source-type: git
     source-depth: 1
     plugin: autotools
@@ -222,7 +222,7 @@ parts:
       - musl
       - musl-compat
     source: https://github.com/sqlite/sqlite.git
-    source-tag: version-3.40.0
+    source-tag: version-3.43.1
     source-type: git
     source-depth: 1
     plugin: autotools
@@ -294,7 +294,7 @@ parts:
       - libuv
       - liblz4
     source: https://github.com/canonical/raft.git
-    source-tag: v0.17.1
+    source-tag: v0.18.0
     source-type: git
     source-depth: 1
     plugin: autotools
@@ -340,7 +340,7 @@ parts:
       - libraft
       - libsqlite3
     source: https://github.com/canonical/dqlite.git
-    source-tag: v1.14.0
+    source-tag: v1.16.0
     source-type: git
     source-depth: 1
     plugin: autotools


### PR DESCRIPTION
The following washes through the dependency updates that @manadart pushed through, except we forgot to update the snapcraft version as well. So local development was ahead of the snap. I'm surprised the snap even worked because the go-dqlite library was depending on parts of C code that weren't available.

We probably need a job that checks the two are insync.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Snaps are built correctly.

## Links

**Jira card:** JUJU-[XXXX]
