### PR TITLE
Remove credential tags from service api calls

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -234,7 +234,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		false,
 		ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 		cloudbootstrap.InsertCloud(stateParams.ControllerCloud),
-		credbootstrap.InsertCredential(cloudCredTag, cloudCred),
+		credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 		modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
 	); err != nil {
 		return nil, errors.Trace(err)

--- a/api/package_test.go
+++ b/api/package_test.go
@@ -47,6 +47,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/status",
 		"core/trace",
 		"core/watcher",
+		"domain/credential", // Imported by environs/context.
 		"environs/context",
 		"internal/feature",
 		"internal/proxy",

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/credential"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -118,6 +119,6 @@ func MakeCloudSpecCredentialContentWatcherForModel(st *state.State, credentialSe
 		if !exists {
 			return nil, nil
 		}
-		return credentialService.WatchCredential(ctx, credentialTag)
+		return credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
 	}
 }

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -10,6 +10,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -21,8 +22,8 @@ type StateBackend interface {
 
 // CredentialService exposes State methods needed by credential manager.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
-	InvalidateCredential(ctx context.Context, tag names.CloudCredentialTag, reason string) error
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	InvalidateCredential(ctx context.Context, id credential.ID, reason string) error
 }
 
 type CredentialManagerAPI struct {
@@ -44,7 +45,7 @@ func (api *CredentialManagerAPI) InvalidateModelCredential(ctx context.Context, 
 	if !ok {
 		return params.ErrorResult{}, nil
 	}
-	err := api.credentialService.InvalidateCredential(ctx, tag, args.Reason)
+	err := api.credentialService.InvalidateCredential(ctx, credential.IdFromTag(tag), args.Reason)
 	if err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 	}

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common/credentialcommon"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -36,7 +37,7 @@ func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 	credentialService := credentialcommon.NewMockCredentialService(ctrl)
 	api := credentialcommon.NewCredentialManagerAPI(s.backend, credentialService)
 
-	credentialService.EXPECT().InvalidateCredential(gomock.Any(), s.backend.tag, "not again")
+	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.IdFromTag(s.backend.tag), "not again")
 
 	result, err := api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -53,7 +54,7 @@ func (s *CredentialSuite) TestInvalidateModelCredentialError(c *gc.C) {
 
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	credentialService.EXPECT().InvalidateCredential(gomock.Any(), s.backend.tag, "not again")
+	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.IdFromTag(s.backend.tag), "not again")
 
 	result, err := api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/credentialcommon/credentialcommon_mock.go
+++ b/apiserver/common/credentialcommon/credentialcommon_mock.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	cloud "github.com/juju/juju/cloud"
-	names "github.com/juju/names/v4"
+	credential "github.com/juju/juju/domain/credential"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -75,7 +75,7 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -90,7 +90,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredential(arg0, arg1 interfac
 }
 
 // InvalidateCredential mocks base method.
-func (m *MockCredentialService) InvalidateCredential(arg0 context.Context, arg1 names.CloudCredentialTag, arg2 string) error {
+func (m *MockCredentialService) InvalidateCredential(arg0 context.Context, arg1 credential.ID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InvalidateCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/apiserver/common/mocks/credential_mock.go
+++ b/apiserver/common/mocks/credential_mock.go
@@ -10,7 +10,7 @@ import (
 
 	cloud "github.com/juju/juju/cloud"
 	watcher "github.com/juju/juju/core/watcher"
-	names "github.com/juju/names/v4"
+	credential "github.com/juju/juju/domain/credential"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -38,7 +38,7 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -53,7 +53,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredential(arg0, arg1 interfac
 }
 
 // WatchCredential mocks base method.
-func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (watcher.Watcher[struct{}], error) {
+func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.ID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -125,8 +126,8 @@ type Model interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
-	WatchCredential(ctx context.Context, tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
 }
 
 // CloudService provides access to clouds.

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -18,6 +18,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/secrets/provider/juju"
@@ -317,7 +318,7 @@ func cloudSpecForModel(
 	if !ok {
 		return cloudspec.CloudSpec{}, errors.NotValidf("cloud credential for %s is empty", m.UUID())
 	}
-	cred, err := credentialService.CloudCredential(ctx, tag)
+	cred, err := credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
 	if err != nil {
 		return cloudspec.CloudSpec{}, errors.Trace(err)
 	}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/leadership"
 	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/internal/secrets/provider"
 	_ "github.com/juju/juju/internal/secrets/provider/all"
 	"github.com/juju/juju/internal/secrets/provider/juju"
@@ -191,7 +192,7 @@ func (s *secretsSuite) assertAdminBackendConfigInfoDefault(
 		tag := names.NewCloudCredentialTag("test/fred/default")
 		model.EXPECT().CloudCredentialTag().Return(tag, true)
 		cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{"foo": "bar"})
-		credentialService.EXPECT().CloudCredential(gomock.Any(), tag).Return(cred, nil)
+		credentialService.EXPECT().CloudCredential(gomock.Any(), credential.IdFromTag(tag)).Return(cred, nil)
 	}
 
 	backendState.EXPECT().ListSecretBackends().Return([]*coresecrets.SecretBackend{{

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -206,7 +207,7 @@ func (api *AgentAPI) WatchCredentials(ctx context.Context, args params.Entities)
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		watch, err := api.credentialService.WatchCredential(ctx, credentialTag)
+		watch, err := api.credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/credential"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -279,7 +280,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	ch <- struct{}{}
 
 	nw := watchertest.NewMockNotifyWatcher(ch)
-	credentialService.EXPECT().WatchCredential(gomock.Any(), tag).Return(nw, nil)
+	credentialService.EXPECT().WatchCredential(gomock.Any(), credential.IdFromTag(tag)).Return(nw, nil)
 	api, err := s.agentAPI(c, authorizer, credentialService)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := api.WatchCredentials(context.Background(), params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/juju/names/v4"
-
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/credential"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -22,7 +21,7 @@ func Register(registry facade.FacadeRegistry) {
 }
 
 type CredentialService interface {
-	WatchCredential(ctx context.Context, tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
+	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
 }
 
 // NewAgentAPIV3 returns an object implementing version 3 of the Agent API

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -14,6 +14,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/state"
 )
 
@@ -107,16 +108,16 @@ type testCredentialService struct {
 	*testing.Stub
 }
 
-func (c testCredentialService) InvalidateCredential(ctx context.Context, tag names.CloudCredentialTag, reason string) error {
-	c.AddCall("InvalidateCredential", tag, reason)
+func (c testCredentialService) InvalidateCredential(ctx context.Context, id credential.ID, reason string) error {
+	c.AddCall("InvalidateCredential", id, reason)
 	return c.NextErr()
 }
 
-func (c testCredentialService) CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (c testCredentialService) CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error) {
 	return cloud.NewEmptyCredential(), nil
 }
 
-func (c testCredentialService) WatchCredential(ctx context.Context, tag names.CloudCredentialTag) (watcher.NotifyWatcher, error) {
+func (c testCredentialService) WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error) {
 	return apiservertesting.NewFakeNotifyWatcher(), nil
 }
 

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -15,6 +15,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
 )
@@ -30,7 +31,7 @@ type CredentialValidatorV2 interface {
 
 type CredentialService interface {
 	common.CredentialService
-	InvalidateCredential(ctx context.Context, tag names.CloudCredentialTag, reason string) error
+	InvalidateCredential(ctx context.Context, id credential.ID, reason string) error
 }
 
 type CredentialValidatorAPI struct {
@@ -83,7 +84,7 @@ func (api *CredentialValidatorAPI) WatchCredential(ctx context.Context, tag para
 	}
 
 	result := params.NotifyWatchResult{}
-	watch, err := api.credentialService.WatchCredential(ctx, credentialTag)
+	watch, err := api.credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result, nil
@@ -139,7 +140,7 @@ func (api *CredentialValidatorAPI) modelCredential(ctx context.Context) (*ModelC
 	}
 
 	result.Credential = modelCredentialTag
-	credential, err := api.credentialService.CloudCredential(ctx, modelCredentialTag)
+	credential, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(modelCredentialTag))
 	if err != nil {
 		if !errors.Is(err, errors.NotFound) {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -16,6 +16,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/agent/credentialvalidator"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -106,7 +107,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.credentialService.CheckCalls(c, []testing.StubCall{
-		{"InvalidateCredential", []interface{}{credentialTag, "not again"}},
+		{"InvalidateCredential", []interface{}{credential.IdFromTag(credentialTag), "not again"}},
 	})
 }
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -50,8 +51,8 @@ type CloudService interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
-	WatchCredential(ctx context.Context, tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
 }
 
 // UniterAPI implements the latest version (v18) of the Uniter API.

--- a/apiserver/facades/agent/uniter/uniter_apierror_test.go
+++ b/apiserver/facades/agent/uniter/uniter_apierror_test.go
@@ -30,7 +30,7 @@ func (s *uniterAPIErrorSuite) SetupTest(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
-	serviceFactory.Credential().UpdateCloudCredential(context.Background(), testing.DefaultCredentialTag, cred)
+	serviceFactory.Credential().UpdateCloudCredential(context.Background(), testing.DefaultCredentialId, cred)
 }
 
 func (s *uniterAPIErrorSuite) TestGetStorageStateError(c *gc.C) {

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -51,7 +51,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
-	serviceFactory.Credential().UpdateCloudCredential(context.Background(), testing.DefaultCredentialTag, cred)
+	serviceFactory.Credential().UpdateCloudCredential(context.Background(), testing.DefaultCredentialId, cred)
 
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -47,7 +47,7 @@ type ModelCredentialService interface {
 // CredentialService provides access to the credential domain service.
 type CredentialService interface {
 	CloudCredential(ctx stdcontext.Context, id credential.ID) (cloud.Credential, error)
-	AllCloudCredentialsForOwner(ctx stdcontext.Context, owner string) ([]credential.CloudCredential, error)
+	AllCloudCredentialsForOwner(ctx stdcontext.Context, owner string) (map[credential.ID]cloud.Credential, error)
 	CloudCredentialsForOwner(ctx stdcontext.Context, owner, cloudName string) (map[string]cloud.Credential, error)
 	UpdateCloudCredential(ctx stdcontext.Context, id credential.ID, cred cloud.Credential) error
 	RemoveCloudCredential(ctx stdcontext.Context, id credential.ID) error

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -46,12 +46,12 @@ type ModelCredentialService interface {
 
 // CredentialService provides access to the credential domain service.
 type CredentialService interface {
-	CloudCredential(ctx stdcontext.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(ctx stdcontext.Context, id credential.ID) (cloud.Credential, error)
 	AllCloudCredentialsForOwner(ctx stdcontext.Context, owner string) ([]credential.CloudCredential, error)
 	CloudCredentialsForOwner(ctx stdcontext.Context, owner, cloudName string) (map[string]cloud.Credential, error)
-	UpdateCloudCredential(ctx stdcontext.Context, tag names.CloudCredentialTag, cred cloud.Credential) error
-	RemoveCloudCredential(ctx stdcontext.Context, tag names.CloudCredentialTag) error
-	WatchCredential(ctx stdcontext.Context, tag names.CloudCredentialTag) (watcher.NotifyWatcher, error)
+	UpdateCloudCredential(ctx stdcontext.Context, id credential.ID, cred cloud.Credential) error
+	RemoveCloudCredential(ctx stdcontext.Context, id credential.ID) error
+	WatchCredential(ctx stdcontext.Context, id credential.ID) (watcher.NotifyWatcher, error)
 	CheckAndUpdateCredential(ctx stdcontext.Context, id credential.ID, cred cloud.Credential, force bool) ([]credentialservice.UpdateCredentialModelResult, error)
 	CheckAndRevokeCredential(ctx stdcontext.Context, id credential.ID, force bool) error
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -724,12 +724,11 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 	}
 
 	// Helper to parse cloud.CloudCredential into an expected result item.
-	toParam := func(tag names.CloudCredentialTag, credential credential.CloudCredential, includeSecrets bool) params.CredentialContentResult {
-		schemas, err := credentialSchemas(credential.CloudName)
+	toParam := func(id credential.ID, cred cloud.Credential, includeSecrets bool) params.CredentialContentResult {
+		schemas, err := credentialSchemas(id.Cloud)
 		if err != nil {
 			return params.CredentialContentResult{Error: apiservererrors.ServerError(err)}
 		}
-		cred := credential.Credential
 		attrs := map[string]string{}
 		// Filter out the secrets.
 		if s, ok := schemas[cred.AuthType()]; ok {
@@ -747,7 +746,7 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 				Name:       cred.Label,
 				AuthType:   string(cred.AuthType()),
 				Attributes: attrs,
-				Cloud:      credential.CloudName,
+				Cloud:      id.Cloud,
 			},
 		}
 		if includeValidity {
@@ -756,7 +755,8 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 		}
 
 		// get models
-		models, err := api.modelCredentialService.CredentialModelsAndOwnerAccess(tag)
+		credTag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", id.Cloud, id.Owner, id.Name))
+		models, err := api.modelCredentialService.CredentialModelsAndOwnerAccess(credTag)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return params.CredentialContentResult{Error: apiservererrors.ServerError(err)}
 		}
@@ -774,37 +774,33 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 		if err != nil {
 			return params.CredentialContentResults{}, errors.Trace(err)
 		}
-		result = make([]params.CredentialContentResult, len(credentials))
-		for i, cred := range credentials {
-			tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", cred.CloudName, api.apiUser.Id(), cred.Credential.Label))
-			result[i] = toParam(tag, cred, args.IncludeSecrets)
+		for id, cred := range credentials {
+			result = append(result, toParam(id, cred, args.IncludeSecrets))
 		}
 	} else {
-		// Helper to construct credential tag from cloud and name.
-		credId := func(cloudName, credentialName string) string {
-			return fmt.Sprintf("%s/%s/%s",
-				cloudName, api.apiUser.Id(), credentialName,
-			)
+		// Helper to construct credential ID from cloud and name.
+		credId := func(cloudName, credentialName string) credential.ID {
+			return credential.ID{
+				Cloud: cloudName, Owner: api.apiUser.Id(), Name: credentialName}
 		}
 
 		result = make([]params.CredentialContentResult, len(args.Credentials))
 		for i, given := range args.Credentials {
 			id := credId(given.CloudName, given.CredentialName)
-			if !names.IsValidCloudCredential(id) {
+			if err := id.Validate(); err != nil {
 				result[i] = params.CredentialContentResult{
 					Error: apiservererrors.ServerError(errors.NotValidf("cloud credential ID %q", id)),
 				}
 				continue
 			}
-			tag := names.NewCloudCredentialTag(id)
-			cred, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
+			cred, err := api.credentialService.CloudCredential(ctx, id)
 			if err != nil {
 				result[i] = params.CredentialContentResult{
 					Error: apiservererrors.ServerError(err),
 				}
 				continue
 			}
-			result[i] = toParam(tag, credential.CloudCredential{Credential: cred, CloudName: tag.Cloud().Id()}, args.IncludeSecrets)
+			result[i] = toParam(id, cred, args.IncludeSecrets)
 		}
 	}
 	return params.CredentialContentResults{Results: result}, nil

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -416,7 +416,7 @@ func (api *CloudAPI) AddCredentials(ctx context.Context, args params.TaggedCrede
 			cloud.AuthType(arg.Credential.AuthType),
 			arg.Credential.Attributes,
 		)
-		if err := api.credentialService.UpdateCloudCredential(ctx, tag, in); err != nil {
+		if err := api.credentialService.UpdateCloudCredential(ctx, credential.IdFromTag(tag), in); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
@@ -797,7 +797,7 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 				continue
 			}
 			tag := names.NewCloudCredentialTag(id)
-			cred, err := api.credentialService.CloudCredential(ctx, tag)
+			cred, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
 			if err != nil {
 				result[i] = params.CredentialContentResult{
 					Error: apiservererrors.ServerError(err),

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -1019,9 +1019,9 @@ func (s *cloudSuite) TestCredentialContentsAllNoSecrets(c *gc.C) {
 		}})
 
 	credentialTwo.Invalid = true
-	creds := []credential.CloudCredential{
-		{Credential: credentialOne, CloudName: "meep"},
-		{Credential: credentialTwo, CloudName: "meep"},
+	creds := map[credential.ID]jujucloud.Credential{
+		{Cloud: "meep", Owner: "bruce", Name: "one"}: credentialOne,
+		{Cloud: "meep", Owner: "bruce", Name: "two"}: credentialTwo,
 	}
 	cloud := jujucloud.Cloud{
 		Name:      "dummy",

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -199,7 +199,7 @@ func (mr *MockCredentialServiceMockRecorder) CheckAndUpdateCredential(arg0, arg1
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (cloud0.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud0.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud0.Credential)
@@ -229,7 +229,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredentialsForOwner(arg0, arg1
 }
 
 // RemoveCloudCredential mocks base method.
-func (m *MockCredentialService) RemoveCloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) error {
+func (m *MockCredentialService) RemoveCloudCredential(arg0 context.Context, arg1 credential.ID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveCloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -243,7 +243,7 @@ func (mr *MockCredentialServiceMockRecorder) RemoveCloudCredential(arg0, arg1 in
 }
 
 // UpdateCloudCredential mocks base method.
-func (m *MockCredentialService) UpdateCloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag, arg2 cloud0.Credential) error {
+func (m *MockCredentialService) UpdateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud0.Credential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -257,7 +257,7 @@ func (mr *MockCredentialServiceMockRecorder) UpdateCloudCredential(arg0, arg1, a
 }
 
 // WatchCredential mocks base method.
-func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (watcher.Watcher[struct{}], error) {
+func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.ID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -155,10 +155,10 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // AllCloudCredentialsForOwner mocks base method.
-func (m *MockCredentialService) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) ([]credential.CloudCredential, error) {
+func (m *MockCredentialService) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.ID]cloud0.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllCloudCredentialsForOwner", arg0, arg1)
-	ret0, _ := ret[0].([]credential.CloudCredential)
+	ret0, _ := ret[0].(map[credential.ID]cloud0.Credential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/credentialmanager/client_integration_test.go
+++ b/apiserver/facades/client/credentialmanager/client_integration_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/client/credentialmanager"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/juju/testing"
 )
 
@@ -43,12 +44,12 @@ func (s *CredentialManagerIntegrationSuite) TestInvalidateModelCredential(c *gc.
 	c.Assert(set, jc.IsTrue)
 
 	credService := s.ControllerServiceFactory(c).Credential()
-	credential, err := credService.CloudCredential(ctx.Background(), tag)
+	cred, err := credService.CloudCredential(ctx.Background(), credential.IdFromTag(tag))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credential.Invalid, jc.IsFalse)
+	c.Assert(cred.Invalid, jc.IsFalse)
 
 	c.Assert(s.client.InvalidateModelCredential("no reason really"), jc.ErrorIsNil)
-	credential, err = credService.CloudCredential(ctx.Background(), tag)
+	cred, err = credService.CloudCredential(ctx.Background(), credential.IdFromTag(tag))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credential.Invalid, jc.IsTrue)
+	c.Assert(cred.Invalid, jc.IsTrue)
 }

--- a/apiserver/facades/client/credentialmanager/client_test.go
+++ b/apiserver/facades/client/credentialmanager/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/credentialmanager"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -117,7 +118,7 @@ type testCredentialService struct {
 	*testing.Stub
 }
 
-func (b *testCredentialService) InvalidateCredential(ctx context.Context, tag names.CloudCredentialTag, reason string) error {
-	b.AddCall("InvalidateCredential", tag, reason)
+func (b *testCredentialService) InvalidateCredential(ctx context.Context, id credential.ID, reason string) error {
+	b.AddCall("InvalidateCredential", id, reason)
 	return b.NextErr()
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -392,7 +392,7 @@ func (api *API) CheckMachines(ctx context.Context, args params.ModelArgs) (param
 		return params.ErrorResults{}, nil
 	}
 
-	storedCredential, err := api.credentialService.CloudCredential(ctx, credentialTag)
+	storedCredential, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(credentialTag))
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -466,12 +466,8 @@ func (s *Suite) TestCheckMachinesManualCloud(c *gc.C) {
 	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
 	tag := names.NewCloudCredentialTag(
 		fmt.Sprintf("manual/%s/dummy-credential", owner.Name()))
-	s.credentialService.EXPECT().CloudCredential(gomock.Any(), tag).Return(cred, nil)
-	s.credentialValidator.EXPECT().Validate(gomock.Any(), credential.ID{
-		Cloud: "manual",
-		Owner: owner.Name(),
-		Name:  "dummy-credential",
-	}, &cred, false)
+	s.credentialService.EXPECT().CloudCredential(gomock.Any(), credential.IdFromTag(tag)).Return(cred, nil)
+	s.credentialValidator.EXPECT().Validate(gomock.Any(), credential.IdFromTag(tag), &cred, false)
 
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		CloudName:       "manual",

--- a/apiserver/testing/credential.go
+++ b/apiserver/testing/credential.go
@@ -7,10 +7,10 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 )
 
 // ConstCredentialGetter returns a CredentialService which serves a fixed credential.
@@ -23,9 +23,9 @@ type credentialGetter struct {
 	cred *cloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ context.Context, tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ context.Context, id credential.ID) (cloud.Credential, error) {
 	if c.cred == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", tag)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
 	}
 	return *c.cred, nil
 }

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -71,6 +71,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/status",
 		"core/trace",
 		"core/watcher",
+		"domain/credential",
 		"environs/cloudspec",
 		"environs/config",
 		"environs/context",

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -39,6 +39,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	coreos "github.com/juju/juju/core/os"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -180,9 +181,9 @@ type credentialGetter struct {
 	cred *jujucloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ stdcontext.Context, tag names.CloudCredentialTag) (jujucloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ stdcontext.Context, id credential.ID) (jujucloud.Credential, error) {
 	if c.cred == nil {
-		return jujucloud.Credential{}, errors.NotFoundf("credential %q", tag)
+		return jujucloud.Credential{}, errors.NotFoundf("credential %q", id)
 	}
 	return *c.cred, nil
 }

--- a/domain/credential/bootstrap/bootstrap.go
+++ b/domain/credential/bootstrap/bootstrap.go
@@ -17,7 +17,7 @@ import (
 )
 
 // InsertCredential inserts  a cloud credential into dqlite.
-func InsertCredential(id credential.ID, credential cloud.Credential) func(context.Context, database.TxnRunner) error {
+func InsertCredential(id credential.ID, cred cloud.Credential) func(context.Context, database.TxnRunner) error {
 	return func(ctx context.Context, db database.TxnRunner) error {
 		if id.IsZero() {
 			return nil
@@ -28,7 +28,14 @@ func InsertCredential(id credential.ID, credential cloud.Credential) func(contex
 			return errors.Trace(err)
 		}
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), id, credential); err != nil {
+			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), id, credential.CloudCredentialInfo{
+				AuthType:      string(cred.AuthType()),
+				Attributes:    cred.Attributes(),
+				Revoked:       cred.Revoked,
+				Label:         cred.Label,
+				Invalid:       cred.Invalid,
+				InvalidReason: cred.InvalidReason,
+			}); err != nil {
 				return errors.Annotate(err, "creating bootstrap credential")
 			}
 			return nil

--- a/domain/credential/bootstrap/bootstrap.go
+++ b/domain/credential/bootstrap/bootstrap.go
@@ -8,32 +8,27 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/state"
 )
 
 // InsertCredential inserts  a cloud credential into dqlite.
-func InsertCredential(cloudCredTag names.CloudCredentialTag, credential cloud.Credential) func(context.Context, database.TxnRunner) error {
+func InsertCredential(id credential.ID, credential cloud.Credential) func(context.Context, database.TxnRunner) error {
 	return func(ctx context.Context, db database.TxnRunner) error {
-		if cloudCredTag.Id() == "" {
+		if id.IsZero() {
 			return nil
 		}
 
-		var (
-			name      = cloudCredTag.Name()
-			cloudName = cloudCredTag.Cloud().Id()
-			owner     = cloudCredTag.Owner().Id()
-		)
 		credentialUUID, err := utils.NewUUID()
 		if err != nil {
 			return errors.Trace(err)
 		}
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), name, cloudName, owner, credential); err != nil {
+			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), id, credential); err != nil {
 				return errors.Annotate(err, "creating bootstrap credential")
 			}
 			return nil

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -6,12 +6,12 @@ package bootstrap
 import (
 	"context"
 
-	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
+	"github.com/juju/juju/domain/credential"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -28,9 +28,13 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
 
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
+	id := credential.ID{
+		Cloud: "cirrus",
+		Owner: "fred",
+		Name:  "foo",
+	}
 
-	err = InsertCredential(tag, cred)(ctx, s.TxnRunner())
+	err = InsertCredential(id, cred)(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var owner, cloudName string

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -5,7 +5,6 @@ package modelmigration
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/description/v4"
 	"github.com/juju/errors"
@@ -14,6 +13,8 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/credential/state"
 )
@@ -28,7 +29,7 @@ func RegisterExport(coordinator Coordinator) {
 // ExportService provides a subset of the credential domain
 // service methods needed for credential export.
 type ExportService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
 }
 
 // exportOperation describes a way to execute a migration for
@@ -41,10 +42,13 @@ type exportOperation struct {
 
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
-	// We must not use a watcher during migration, so it's safe to pass a
-	// nil watcher factory.
+	controllerDBFactory := scope.ControllerDB()
+	controllerDB, err := controllerDBFactory()
 	e.service = service.NewService(
-		state.NewState(scope.ControllerDB()), nil, logger)
+		state.NewState(controllerDB), domain.NewWatcherFactory(
+			controllerDB,
+			logger,
+		), logger)
 	return nil
 }
 
@@ -58,16 +62,19 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 		// Not set.
 		return nil
 	}
-	tag := names.NewCloudCredentialTag(
-		fmt.Sprintf("%s/%s/%s", credInfo.Cloud(), credInfo.Owner(), credInfo.Name()))
-	cred, err := e.service.CloudCredential(ctx, tag)
+	id := credential.ID{
+		Cloud: credInfo.Cloud(),
+		Owner: credInfo.Owner(),
+		Name:  credInfo.Name(),
+	}
+	cred, err := e.service.CloudCredential(ctx, id)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	model.SetCloudCredential(description.CloudCredentialArgs{
-		Owner:      tag.Owner(),
-		Cloud:      tag.Cloud(),
-		Name:       tag.Name(),
+		Owner:      names.NewUserTag(id.Owner),
+		Cloud:      names.NewCloudTag(id.Cloud),
+		Name:       id.Name,
 		AuthType:   string(cred.AuthType()),
 		Attributes: cred.Attributes(),
 	})

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/modelmigration"
-	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/credential/state"
@@ -42,13 +41,10 @@ type exportOperation struct {
 
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
-	controllerDBFactory := scope.ControllerDB()
-	controllerDB, err := controllerDBFactory()
+	// We must not use a watcher during migration, so it's safe to pass a
+	// nil watcher factory.
 	e.service = service.NewService(
-		state.NewState(controllerDB), domain.NewWatcherFactory(
-			controllerDB,
-			logger,
-		), logger)
+		state.NewState(scope.ControllerDB()), nil, logger)
 	return nil
 }
 

--- a/domain/credential/modelmigration/export_test.go
+++ b/domain/credential/modelmigration/export_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 )
 
 type exportSuite struct {
@@ -48,9 +49,9 @@ func (s *exportSuite) TestExport(c *gc.C) {
 		Name:  "foo",
 	})
 
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
-	s.service.EXPECT().CloudCredential(gomock.Any(), tag).
+	s.service.EXPECT().CloudCredential(gomock.Any(), id).
 		Times(1).
 		Return(cred, nil)
 
@@ -72,8 +73,8 @@ func (s *exportSuite) TestExportNotFound(c *gc.C) {
 		Name:  "foo",
 	})
 
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
-	s.service.EXPECT().CloudCredential(gomock.Any(), tag).
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.Any(), id).
 		Times(1).
 		Return(cloud.Credential{}, errors.NotFound)
 

--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -5,15 +5,14 @@ package modelmigration
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/juju/description/v4"
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/credential/state"
 )
@@ -32,8 +31,8 @@ func RegisterImport(coordinator Coordinator) {
 // ImportService provides a subset of the credential domain
 // service methods needed for credential import.
 type ImportService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
-	UpdateCloudCredential(context.Context, names.CloudCredentialTag, cloud.Credential) error
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	UpdateCloudCredential(context.Context, credential.ID, cloud.Credential) error
 }
 
 type importOperation struct {
@@ -60,21 +59,22 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 	// Need to add credential or make sure an existing credential
 	// matches.
-	// TODO: there really should be a way to create a cloud credential
-	// tag in the names package from the cloud, owner and name.
-	credID := fmt.Sprintf("%s/%s/%s", cred.Cloud(), cred.Owner(), cred.Name())
-	if !names.IsValidCloudCredential(credID) {
-		return errors.NotValidf("cloud credential ID %q", credID)
+	id := credential.ID{
+		Cloud: cred.Cloud(),
+		Owner: cred.Owner(),
+		Name:  cred.Name(),
 	}
-	tag := names.NewCloudCredentialTag(credID)
+	if err := id.Validate(); err != nil {
+		return errors.Trace(err)
+	}
 
-	existing, err := i.service.CloudCredential(ctx, tag)
+	existing, err := i.service.CloudCredential(ctx, id)
 
 	if errors.Is(err, errors.NotFound) {
 		credential := cloud.NewCredential(
 			cloud.AuthType(cred.AuthType()),
 			cred.Attributes())
-		return errors.Trace(i.service.UpdateCloudCredential(ctx, tag, credential))
+		return errors.Trace(i.service.UpdateCloudCredential(ctx, id, credential))
 	} else if err != nil {
 		return errors.Trace(err)
 	}
@@ -86,7 +86,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		return errors.Errorf("credential attribute mismatch: %v != %v", existing.Attributes(), cred.Attributes())
 	}
 	if existing.Revoked {
-		return errors.Errorf("credential %q is revoked", credID)
+		return errors.Errorf("credential %q is revoked", id)
 	}
 	return nil
 }

--- a/domain/credential/modelmigration/import_test.go
+++ b/domain/credential/modelmigration/import_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 )
 
 type importSuite struct {
@@ -75,9 +76,9 @@ func (s *importSuite) TestImport(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"hello": "world"})
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
-	s.service.EXPECT().CloudCredential(gomock.All(), tag).Times(1).Return(cloud.Credential{}, errors.NotFound)
-	s.service.EXPECT().UpdateCloudCredential(gomock.Any(), tag, cred).Times(1)
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cloud.Credential{}, errors.NotFound)
+	s.service.EXPECT().UpdateCloudCredential(gomock.Any(), id, cred).Times(1)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -99,8 +100,8 @@ func (s *importSuite) TestImportExistingMatches(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"hello": "world"})
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
-	s.service.EXPECT().CloudCredential(gomock.All(), tag).Times(1).Return(cred, nil)
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -122,8 +123,8 @@ func (s *importSuite) TestImportExistingAuthTypeMisMatch(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{"hello": "world"})
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
-	s.service.EXPECT().CloudCredential(gomock.All(), tag).Times(1).Return(cred, nil)
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -145,8 +146,8 @@ func (s *importSuite) TestImportExistingAttributesMisMatch(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"goodbye": "world"})
-	tag := names.NewCloudCredentialTag("cirrus/fred/foo")
-	s.service.EXPECT().CloudCredential(gomock.All(), tag).Times(1).Return(cred, nil)
+	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)

--- a/domain/credential/modelmigration/migrations_mock_test.go
+++ b/domain/credential/modelmigration/migrations_mock_test.go
@@ -10,7 +10,7 @@ import (
 
 	cloud "github.com/juju/juju/cloud"
 	modelmigration "github.com/juju/juju/core/modelmigration"
-	names "github.com/juju/names/v4"
+	credential "github.com/juju/juju/domain/credential"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -73,7 +73,7 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockImportService) CloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (cloud.Credential, error) {
+func (m *MockImportService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -88,7 +88,7 @@ func (mr *MockImportServiceMockRecorder) CloudCredential(arg0, arg1 interface{})
 }
 
 // UpdateCloudCredential mocks base method.
-func (m *MockImportService) UpdateCloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag, arg2 cloud.Credential) error {
+func (m *MockImportService) UpdateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud.Credential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -125,7 +125,7 @@ func (m *MockExportService) EXPECT() *MockExportServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockExportService) CloudCredential(arg0 context.Context, arg1 names.CloudCredentialTag) (cloud.Credential, error) {
+func (m *MockExportService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)

--- a/domain/credential/service/service.go
+++ b/domain/credential/service/service.go
@@ -130,7 +130,7 @@ func (s *Service) WithLegacyRemover(remover func(tag names.CloudCredentialTag) e
 // CloudCredential returns the cloud credential for the given tag.
 func (s *Service) CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error) {
 	if err := id.Validate(); err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "getting cloud credential")
+		return cloud.Credential{}, errors.Annotate(err, "invalid id getting cloud credential")
 	}
 	return s.st.CloudCredential(ctx, id)
 }
@@ -158,7 +158,7 @@ func (s *Service) CloudCredentialsForOwner(ctx context.Context, owner, cloudName
 // UpdateCloudCredential adds or updates a cloud credential with the given tag.
 func (s *Service) UpdateCloudCredential(ctx context.Context, id credential.ID, cred cloud.Credential) error {
 	if err := id.Validate(); err != nil {
-		return errors.Annotatef(err, "updating cloud credential")
+		return errors.Annotatef(err, "invalid id updating cloud credential")
 	}
 	_, err := s.st.UpsertCloudCredential(ctx, id, cred)
 	return err
@@ -166,13 +166,16 @@ func (s *Service) UpdateCloudCredential(ctx context.Context, id credential.ID, c
 
 // RemoveCloudCredential removes a cloud credential with the given tag.
 func (s *Service) RemoveCloudCredential(ctx context.Context, id credential.ID) error {
+	if err := id.Validate(); err != nil {
+		return errors.Annotatef(err, "invalid id removing cloud credential")
+	}
 	return s.st.RemoveCloudCredential(ctx, id)
 }
 
 // InvalidateCredential marks the cloud credential for the given name, cloud, owner as invalid.
 func (s *Service) InvalidateCredential(ctx context.Context, id credential.ID, reason string) error {
 	if err := id.Validate(); err != nil {
-		return errors.Annotatef(err, "invalidating cloud credential")
+		return errors.Annotatef(err, "invalid id invalidating cloud credential")
 	}
 	return s.st.InvalidateCloudCredential(ctx, id, reason)
 }
@@ -180,7 +183,7 @@ func (s *Service) InvalidateCredential(ctx context.Context, id credential.ID, re
 // WatchCredential returns a watcher that observes changes to the specified credential.
 func (s *Service) WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error) {
 	if err := id.Validate(); err != nil {
-		return nil, errors.Annotatef(err, "watching cloud credential")
+		return nil, errors.Annotatef(err, "invalid id watching cloud credential")
 	}
 	if s.watcherFactory != nil {
 		return s.st.WatchCredential(ctx, s.watcherFactory.NewValueWatcher, id)
@@ -236,7 +239,7 @@ type UpdateCredentialModelResult struct {
 // but before validation can complete.
 func (s *Service) CheckAndUpdateCredential(ctx context.Context, id credential.ID, cred cloud.Credential, force bool) ([]UpdateCredentialModelResult, error) {
 	if err := id.Validate(); err != nil {
-		return nil, errors.Annotatef(err, "updating cloud credential")
+		return nil, errors.Annotatef(err, "invalid id updating cloud credential")
 	}
 
 	if s.validationContextGetter == nil {
@@ -312,7 +315,7 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, id credential.ID
 // but before validation can complete.
 func (s *Service) CheckAndRevokeCredential(ctx context.Context, id credential.ID, force bool) error {
 	if err := id.Validate(); err != nil {
-		return errors.Annotatef(err, "revoking cloud credential")
+		return errors.Annotatef(err, "invalid id revoking cloud credential")
 	}
 
 	models, err := s.modelsUsingCredential(ctx, id)

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -57,6 +57,14 @@ func (s *serviceSuite) TestUpdateCloudCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *serviceSuite) TestUpdateCloudCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().UpdateCloudCredential(context.Background(), id, cloud.Credential{})
+	c.Assert(err, gc.ErrorMatches, "invalid id updating cloud credential.*")
+}
+
 func (s *serviceSuite) TestCloudCredentials(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -87,6 +95,14 @@ func (s *serviceSuite) TestCloudCredential(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, cred)
 }
 
+func (s *serviceSuite) TestCloudCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().CloudCredential(context.Background(), id)
+	c.Assert(err, gc.ErrorMatches, "invalid id getting cloud credential.*")
+}
+
 func (s *serviceSuite) TestRemoveCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -97,6 +113,14 @@ func (s *serviceSuite) TestRemoveCloudCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *serviceSuite) TestRemoveCloudCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().RemoveCloudCredential(context.Background(), id)
+	c.Assert(err, gc.ErrorMatches, "invalid id removing cloud credential.*")
+}
+
 func (s *serviceSuite) TestInvalidateCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -105,6 +129,14 @@ func (s *serviceSuite) TestInvalidateCloudCredential(c *gc.C) {
 
 	err := s.service().InvalidateCredential(context.Background(), id, "gone bad")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestInvalidateCloudCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().InvalidateCredential(context.Background(), id, "nope")
+	c.Assert(err, gc.ErrorMatches, "invalid id invalidating cloud credential.*")
 }
 
 func (s *serviceSuite) TestAllCloudCredentials(c *gc.C) {
@@ -129,6 +161,14 @@ func (s *serviceSuite) TestWatchCredential(c *gc.C) {
 	w, err := s.service().WatchCredential(context.Background(), id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
+}
+
+func (s *serviceSuite) TestWatchCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().WatchCredential(context.Background(), id)
+	c.Assert(err, gc.ErrorMatches, "invalid id watching cloud credential.*")
 }
 
 var invalid = true
@@ -161,6 +201,14 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialsNoModelsFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 0)
 	c.Assert(legacyUpdated, jc.IsTrue)
+}
+
+func (s *serviceSuite) TestCheckAndUpdateCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().CheckAndUpdateCredential(context.Background(), id, cloud.Credential{}, false)
+	c.Assert(err, gc.ErrorMatches, "invalid id updating cloud credential.*")
 }
 
 func (s *serviceSuite) TestUpdateCredentialsModelsError(c *gc.C) {
@@ -600,4 +648,12 @@ func (s *serviceSuite) TestRevokeCredentialsHasModelsForce(c *gc.C) {
 	err := service.CheckAndRevokeCredential(context.Background(), id, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(legacyUpdated, jc.IsTrue)
+}
+
+func (s *serviceSuite) TestCheckAndRevokeCredentialInvalidID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := credential.ID{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().CheckAndRevokeCredential(context.Background(), id, false)
+	c.Assert(err, gc.ErrorMatches, "invalid id revoking cloud credential.*")
 }

--- a/domain/credential/service/state_mock_test.go
+++ b/domain/credential/service/state_mock_test.go
@@ -55,18 +55,18 @@ func (mr *MockStateMockRecorder) AllCloudCredentialsForOwner(arg0, arg1 interfac
 }
 
 // CloudCredential mocks base method.
-func (m *MockState) CloudCredential(arg0 context.Context, arg1, arg2, arg3 string) (cloud.Credential, error) {
+func (m *MockState) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloudCredential indicates an expected call of CloudCredential.
-func (mr *MockStateMockRecorder) CloudCredential(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) CloudCredential(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudCredential", reflect.TypeOf((*MockState)(nil).CloudCredential), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudCredential", reflect.TypeOf((*MockState)(nil).CloudCredential), arg0, arg1)
 }
 
 // CloudCredentialsForOwner mocks base method.
@@ -85,17 +85,17 @@ func (mr *MockStateMockRecorder) CloudCredentialsForOwner(arg0, arg1, arg2 inter
 }
 
 // InvalidateCloudCredential mocks base method.
-func (m *MockState) InvalidateCloudCredential(arg0 context.Context, arg1, arg2, arg3, arg4 string) error {
+func (m *MockState) InvalidateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InvalidateCloudCredential", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "InvalidateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InvalidateCloudCredential indicates an expected call of InvalidateCloudCredential.
-func (mr *MockStateMockRecorder) InvalidateCloudCredential(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) InvalidateCloudCredential(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCloudCredential", reflect.TypeOf((*MockState)(nil).InvalidateCloudCredential), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCloudCredential", reflect.TypeOf((*MockState)(nil).InvalidateCloudCredential), arg0, arg1, arg2)
 }
 
 // ModelsUsingCloudCredential mocks base method.
@@ -114,47 +114,47 @@ func (mr *MockStateMockRecorder) ModelsUsingCloudCredential(arg0, arg1 interface
 }
 
 // RemoveCloudCredential mocks base method.
-func (m *MockState) RemoveCloudCredential(arg0 context.Context, arg1, arg2, arg3 string) error {
+func (m *MockState) RemoveCloudCredential(arg0 context.Context, arg1 credential.ID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveCloudCredential", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RemoveCloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveCloudCredential indicates an expected call of RemoveCloudCredential.
-func (mr *MockStateMockRecorder) RemoveCloudCredential(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) RemoveCloudCredential(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCloudCredential", reflect.TypeOf((*MockState)(nil).RemoveCloudCredential), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCloudCredential", reflect.TypeOf((*MockState)(nil).RemoveCloudCredential), arg0, arg1)
 }
 
 // UpsertCloudCredential mocks base method.
-func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1, arg2, arg3 string, arg4 cloud.Credential) (*bool, error) {
+func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud.Credential) (*bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertCloudCredential", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "UpsertCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpsertCloudCredential indicates an expected call of UpsertCloudCredential.
-func (mr *MockStateMockRecorder) UpsertCloudCredential(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) UpsertCloudCredential(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertCloudCredential", reflect.TypeOf((*MockState)(nil).UpsertCloudCredential), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertCloudCredential", reflect.TypeOf((*MockState)(nil).UpsertCloudCredential), arg0, arg1, arg2)
 }
 
 // WatchCredential mocks base method.
-func (m *MockState) WatchCredential(arg0 context.Context, arg1 func(string, string, changestream.ChangeType) (watcher.Watcher[struct{}], error), arg2, arg3, arg4 string) (watcher.Watcher[struct{}], error) {
+func (m *MockState) WatchCredential(arg0 context.Context, arg1 func(string, string, changestream.ChangeType) (watcher.Watcher[struct{}], error), arg2 credential.ID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchCredential indicates an expected call of WatchCredential.
-func (mr *MockStateMockRecorder) WatchCredential(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) WatchCredential(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCredential", reflect.TypeOf((*MockState)(nil).WatchCredential), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCredential", reflect.TypeOf((*MockState)(nil).WatchCredential), arg0, arg1, arg2)
 }
 
 // MockWatcherFactory is a mock of WatcherFactory interface.

--- a/domain/credential/service/state_mock_test.go
+++ b/domain/credential/service/state_mock_test.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	cloud "github.com/juju/juju/cloud"
 	changestream "github.com/juju/juju/core/changestream"
 	watcher "github.com/juju/juju/core/watcher"
 	credential "github.com/juju/juju/domain/credential"
@@ -40,10 +39,10 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AllCloudCredentialsForOwner mocks base method.
-func (m *MockState) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) ([]credential.CloudCredential, error) {
+func (m *MockState) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.ID]credential.CloudCredentialResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllCloudCredentialsForOwner", arg0, arg1)
-	ret0, _ := ret[0].([]credential.CloudCredential)
+	ret0, _ := ret[0].(map[credential.ID]credential.CloudCredentialResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -55,10 +54,10 @@ func (mr *MockStateMockRecorder) AllCloudCredentialsForOwner(arg0, arg1 interfac
 }
 
 // CloudCredential mocks base method.
-func (m *MockState) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockState) CloudCredential(arg0 context.Context, arg1 credential.ID) (credential.CloudCredentialResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
-	ret0, _ := ret[0].(cloud.Credential)
+	ret0, _ := ret[0].(credential.CloudCredentialResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -70,10 +69,10 @@ func (mr *MockStateMockRecorder) CloudCredential(arg0, arg1 interface{}) *gomock
 }
 
 // CloudCredentialsForOwner mocks base method.
-func (m *MockState) CloudCredentialsForOwner(arg0 context.Context, arg1, arg2 string) (map[string]cloud.Credential, error) {
+func (m *MockState) CloudCredentialsForOwner(arg0 context.Context, arg1, arg2 string) (map[string]credential.CloudCredentialResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredentialsForOwner", arg0, arg1, arg2)
-	ret0, _ := ret[0].(map[string]cloud.Credential)
+	ret0, _ := ret[0].(map[string]credential.CloudCredentialResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -128,7 +127,7 @@ func (mr *MockStateMockRecorder) RemoveCloudCredential(arg0, arg1 interface{}) *
 }
 
 // UpsertCloudCredential mocks base method.
-func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud.Credential) (*bool, error) {
+func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 credential.CloudCredentialInfo) (*bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*bool)

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -70,10 +70,6 @@ AND    cloud_credential.cloud_uuid = (
 // UpsertCloudCredential adds or updates a cloud credential with the given name, cloud and owner.
 // If the credential exists already, the existing credential's Invalid value is returned.
 func (st *State) UpsertCloudCredential(ctx context.Context, id credential.ID, credential cloud.Credential) (*bool, error) {
-	if err := id.Validate(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -131,10 +127,6 @@ WHERE   cloud.name = $M.cloud_name AND cloud_credential.name = $M.credential_nam
 // CreateCredential saves the specified credential.
 // Exported for use in the related credential bootstrap package.
 func CreateCredential(ctx context.Context, tx *sqlair.TX, credentialUUID string, id credential.ID, credential cloud.Credential) error {
-	if err := id.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-
 	if err := upsertCredential(ctx, tx, credentialUUID, id, credential); err != nil {
 		return errors.Annotatef(err, "creating credential %s", credentialUUID)
 	}
@@ -294,10 +286,6 @@ WHERE  cloud.name = $Cloud.name
 
 // InvalidateCloudCredential marks a cloud credential with the given name, cloud and owner. as invalid.
 func (st *State) InvalidateCloudCredential(ctx context.Context, id credential.ID, reason string) error {
-	if err := id.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -363,10 +351,6 @@ func (st *State) CloudCredentialsForOwner(ctx context.Context, owner, cloudName 
 
 // CloudCredential returns the cloud credential for the given details.
 func (st *State) CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error) {
-	if err := id.Validate(); err != nil {
-		return cloud.Credential{}, errors.Trace(err)
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return cloud.Credential{}, errors.Trace(err)
@@ -468,10 +452,6 @@ func (st *State) AllCloudCredentialsForOwner(ctx context.Context, owner string) 
 
 // RemoveCloudCredential removes a cloud credential with the given name, cloud and owner..
 func (st *State) RemoveCloudCredential(ctx context.Context, id credential.ID) error {
-	if err := id.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -516,10 +496,6 @@ func (st *State) WatchCredential(
 	getWatcher func(string, string, changestream.ChangeType) (watcher.NotifyWatcher, error),
 	id credential.ID,
 ) (watcher.NotifyWatcher, error) {
-	if err := id.Validate(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -540,10 +516,6 @@ func (st *State) WatchCredential(
 
 // ModelsUsingCloudCredential returns a map of uuid->name for models which use the credential.
 func (st *State) ModelsUsingCloudCredential(ctx context.Context, id credential.ID) (map[model.UUID]string, error) {
-	if err := id.Validate(); err != nil {
-		return nil, errors.Annotate(err, "invalid credential querying models")
-	}
-
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -68,12 +68,13 @@ func (s *credentialSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 		"foo": "foo val",
 		"bar": "bar val",
 	}, true)
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
-	out, err := st.CloudCredential(ctx, "foobar", "stratus", "bob")
+	out, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, cred)
 }
@@ -82,12 +83,13 @@ func (s *credentialSuite) TestUpdateCloudCredentialNoValues(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	cred := cloud.NewNamedCredential("foobar", cloud.AccessKeyAuthType, map[string]string{}, true)
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
-	out, err := st.CloudCredential(ctx, "foobar", "stratus", "bob")
+	out, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, cred)
 }
@@ -100,8 +102,8 @@ func (s *credentialSuite) TestUpdateCloudCredentialMissingName(c *gc.C) {
 		"bar": "bar val",
 	})
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, "", "stratus", "bob", cred)
-	c.Assert(err, gc.ErrorMatches, "updating credential: credential name cannot be empty")
+	_, err := st.UpsertCloudCredential(ctx, credential.ID{Cloud: "stratus", Owner: "bob"}, cred)
+	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
 }
 
 func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
@@ -111,11 +113,12 @@ func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
 		"foo": "foo val",
 		"bar": "bar val",
 	})
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	// Setting of these properties should have no effect when creating a new credential.
 	cred.Invalid = true
 	cred.InvalidReason = "because am testing you"
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	_, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, gc.ErrorMatches, "adding invalid credential not supported")
 }
 
@@ -126,8 +129,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 		"foo": "foo val",
 		"bar": "bar val",
 	}, false)
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -135,12 +139,12 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 		"user":     "bob's nephew",
 		"password": "simple",
 	}, true)
-	existingInvalid, err = st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	existingInvalid, err = st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsFalse)
 
-	out, err := st.CloudCredential(ctx, "foobar", "stratus", "bob")
+	out, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, cred)
 }
@@ -152,8 +156,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
 		"foo": "foo val",
 		"bar": "bar val",
 	}, false)
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, "foobar", "stratus", "bob", cred)
+	_, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(
 		`updating credential: validating credential "foobar" owned by "bob" for cloud "stratus": supported auth-types ["access-key" "userpass"], "oauth2" not supported`))
 }
@@ -174,16 +179,16 @@ func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
 		"bar": "bar val",
 	})
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, "bobcred1", "stratus", "bob", cred1)
+	_, err := st.UpsertCloudCredential(ctx, credential.ID{Cloud: "stratus", Owner: "bob", Name: "bobcred1"}, cred1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred2 := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"baz": "baz val",
 		"qux": "qux val",
 	})
-	_, err = st.UpsertCloudCredential(ctx, "bobcred2", "stratus", "bob", cred2)
+	_, err = st.UpsertCloudCredential(ctx, credential.ID{Cloud: "stratus", Owner: "bob", Name: "bobcred2"}, cred2)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.UpsertCloudCredential(ctx, "foobar", "stratus", "mary", cred2)
+	_, err = st.UpsertCloudCredential(ctx, credential.ID{Cloud: "stratus", Owner: "mary", Name: "foobar"}, cred2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred1.Label = "bobcred1"
@@ -199,13 +204,13 @@ func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
 	}
 }
 
-func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, cloudName, userName, credentialName string) {
+func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, id credential.ID) {
 	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
 		"foo": "foo val",
 		"bar": "bar val",
 	})
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, credentialName, cloudName, userName, cred)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -215,12 +220,12 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, cloudN
 	})
 	cred.Invalid = true
 	cred.InvalidReason = "because it is really really invalid"
-	existingInvalid, err = st.UpsertCloudCredential(ctx, credentialName, cloudName, userName, cred)
+	existingInvalid, err = st.UpsertCloudCredential(ctx, id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsFalse)
 
-	out, err := st.CloudCredential(ctx, credentialName, cloudName, userName)
+	out, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	cred.Label = "foobar"
 	c.Assert(out, jc.DeepEquals, cred)
@@ -228,17 +233,17 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, cloudN
 
 func (s *credentialSuite) TestInvalidateCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
-	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
+	s.assertCredentialInvalidated(c, st, credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"})
 }
 
-func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, cloudName, userName, credentialName string, credential cloud.Credential) {
+func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, id credential.ID, credential cloud.Credential) {
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, credentialName, cloudName, userName, credential)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credential)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsTrue)
 
-	out, err := st.CloudCredential(ctx, credentialName, cloudName, userName)
+	out, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Invalid, jc.IsFalse)
 }
@@ -246,26 +251,28 @@ func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, cloudN
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidExplicitly(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	// This call will ensure that there is an invalid credential to test with.
-	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
+	s.assertCredentialInvalidated(c, st, id)
 
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"user":     "bob's nephew",
 		"password": "simple",
 	})
 	cred.Invalid = false
-	s.assertCredentialMarkedValid(c, st, "stratus", "bob", "foobar", cred)
+	s.assertCredentialMarkedValid(c, st, id, cred)
 }
 
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidImplicitly(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	// This call will ensure that there is an invalid credential to test with.
-	s.assertCredentialInvalidated(c, st, "stratus", "bob", "foobar")
+	s.assertCredentialInvalidated(c, st, id)
 
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"user":     "bob's nephew",
 		"password": "simple",
 	})
-	s.assertCredentialMarkedValid(c, st, "stratus", "bob", "foobar", cred)
+	s.assertCredentialMarkedValid(c, st, id, cred)
 }
 
 func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
@@ -275,14 +282,15 @@ func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
 		"foo": "foo val",
 		"bar": "bar val",
 	})
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "bobcred1"}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, "bobcred1", "stratus", "bob", cred1)
+	_, err := st.UpsertCloudCredential(ctx, id, cred1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.RemoveCloudCredential(ctx, "bobcred1", "stratus", "bob")
+	err = st.RemoveCloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.CloudCredential(ctx, "bobcred1", "stratus", "bob")
+	_, err = st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -294,7 +302,7 @@ func (s *credentialSuite) TestAllCloudCredentialsNotFound(c *gc.C) {
 	c.Assert(out, gc.IsNil)
 }
 
-func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, credentialName, cloudName, userName string) cloud.Credential {
+func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, id credential.ID) cloud.Credential {
 	authType := cloud.AccessKeyAuthType
 	attributes := map[string]string{
 		"foo": "foo val",
@@ -302,13 +310,13 @@ func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, credentialNa
 	}
 
 	s.addCloud(c, cloud.Cloud{
-		Name:      cloudName,
+		Name:      id.Cloud,
 		Type:      "ec2",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 
-	cred := cloud.NewNamedCredential(credentialName, authType, attributes, false)
-	_, err := st.UpsertCloudCredential(context.Background(), credentialName, cloudName, userName, cred)
+	cred := cloud.NewNamedCredential(id.Name, authType, attributes, false)
+	_, err := st.UpsertCloudCredential(context.Background(), id, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	return cred
 }
@@ -316,11 +324,11 @@ func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, credentialNa
 func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	one := s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
-	two := s.createCloudCredential(c, st, "foobar", "stratus", "bob")
+	one := s.createCloudCredential(c, st, credential.ID{Cloud: "cirrus", Owner: "bob", Name: "foobar"})
+	two := s.createCloudCredential(c, st, credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"})
 
 	// Added to make sure it is not returned.
-	s.createCloudCredential(c, st, "foobar", "cumulus", "mary")
+	s.createCloudCredential(c, st, credential.ID{Cloud: "cumulus", Owner: "mary", Name: "foobar"})
 
 	out, err := st.AllCloudCredentialsForOwner(context.Background(), "bob")
 	c.Assert(err, jc.ErrorIsNil)
@@ -330,24 +338,19 @@ func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
 	})
 }
 
-func (s *credentialSuite) TestCloudCredentialEmptyID(c *gc.C) {
-	st := NewState(s.TxnRunnerFactory())
-	_, err := st.CloudCredential(context.Background(), "", "", "")
-	c.Assert(err, gc.ErrorMatches, "empty credential ID not valid")
-}
-
 func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	one := s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
+	one := s.createCloudCredential(c, st, id)
 	c.Assert(one.Invalid, jc.IsFalse)
 
 	ctx := context.Background()
 	reason := "testing, testing 1,2,3"
-	err := st.InvalidateCloudCredential(ctx, "foobar", "cirrus", "bob", reason)
+	err := st.InvalidateCloudCredential(ctx, id, reason)
 	c.Assert(err, jc.ErrorIsNil)
 
-	updated, err := st.CloudCredential(ctx, "foobar", "cirrus", "bob")
+	updated, err := st.CloudCredential(ctx, id)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(updated.Invalid, jc.IsTrue)
 	c.Assert(updated.InvalidReason, gc.Equals, reason)
@@ -356,8 +359,9 @@ func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
 func (s *credentialSuite) TestInvalidateCloudCredentialNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	err := st.InvalidateCloudCredential(ctx, "foobar", "cirrus", "bob", "reason")
+	err := st.InvalidateCloudCredential(ctx, id, "reason")
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -386,24 +390,26 @@ func (s *credentialSuite) watcherFunc(c *gc.C, expectedChangeValue string) watch
 func (s *credentialSuite) TestWatchCredentialNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
 	ctx := context.Background()
-	_, err := st.WatchCredential(ctx, s.watcherFunc(c, ""), "foobar", "cirrus", "bob")
+	_, err := st.WatchCredential(ctx, s.watcherFunc(c, ""), id)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *credentialSuite) TestWatchCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
-	s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
+	s.createCloudCredential(c, st, id)
 
 	var uuid string
 	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		uuid, err = st.credentialUUID(ctx, tx, "foobar", "cirrus", "bob")
+		uuid, err = st.credentialUUID(ctx, tx, id)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := st.WatchCredential(context.Background(), s.watcherFunc(c, uuid), "foobar", "cirrus", "bob")
+	w, err := st.WatchCredential(context.Background(), s.watcherFunc(c, uuid), id)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, w) })
 
@@ -415,7 +421,7 @@ func (s *credentialSuite) TestWatchCredential(c *gc.C) {
 		"bar": "bar val",
 	}, true)
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, err := st.UpsertCloudCredential(ctx, "foobar", "cirrus", "bob", cred)
+		_, err := st.UpsertCloudCredential(ctx, id, cred)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -450,7 +456,8 @@ func (s *credentialSuite) TestModelsUsingCloudCredentialInValidID(c *gc.C) {
 func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	one := s.createCloudCredential(c, st, "foobar", "cirrus", "bob")
+	id := credential.ID{Cloud: "stratus", Owner: "bob", Name: "foobar"}
+	one := s.createCloudCredential(c, st, id)
 	c.Assert(one.Invalid, jc.IsFalse)
 
 	insertOne := func(ctx context.Context, tx *sql.Tx, modelUUID, name string) error {
@@ -462,7 +469,7 @@ func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO model_metadata (model_uuid, name, owner_uuid, model_type_id, cloud_uuid, cloud_credential_uuid)
 		SELECT %q, %q, "admin", 0,
-			(SELECT uuid FROM cloud WHERE cloud.name="cirrus"),
+			(SELECT uuid FROM cloud WHERE cloud.name="stratus"),
 			(SELECT uuid FROM cloud_credential cc WHERE cc.name="foobar")`, modelUUID, name),
 		)
 		if err != nil {
@@ -490,7 +497,7 @@ func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := st.ModelsUsingCloudCredential(context.Background(), credential.ID{
-		Cloud: "cirrus",
+		Cloud: "stratus",
 		Owner: "bob",
 		Name:  "foobar",
 	})

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -443,16 +443,6 @@ func (s *credentialSuite) TestNoModelsUsingCloudCredential(c *gc.C) {
 	c.Assert(result, gc.HasLen, 0)
 }
 
-func (s *credentialSuite) TestModelsUsingCloudCredentialInValidID(c *gc.C) {
-	st := NewState(s.TxnRunnerFactory())
-
-	_, err := st.ModelsUsingCloudCredential(context.Background(), credential.ID{
-		Cloud: "cirrus",
-		Name:  "foobar",
-	})
-	c.Assert(err, gc.ErrorMatches, `invalid credential querying models: not valid owner cannot be empty`)
-}
-
 func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 

--- a/domain/credential/types.go
+++ b/domain/credential/types.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-
-	"github.com/juju/juju/cloud"
 )
 
 // ID represents the id of a cloud credential.
@@ -78,8 +76,32 @@ func (i ID) Validate() error {
 	return nil
 }
 
-// CloudCredential represents a credential and the cloud it belongs to.
-type CloudCredential struct {
-	Credential cloud.Credential
-	CloudName  string
+// CloudCredentialInfo represents a credential.
+type CloudCredentialInfo struct {
+	// AuthType is the credential auth type.
+	AuthType string
+
+	// Attributes are the credential attributes.
+	Attributes map[string]string
+
+	// Revoked is true if the credential has been revoked.
+	Revoked bool
+
+	// Label is optionally set to describe the credentials to a user.
+	Label string
+
+	// Invalid is true if the credential is invalid.
+	Invalid bool
+
+	// InvalidReason contains the reason why a credential was flagged as invalid.
+	// It is expected that this string will be empty when a credential is valid.
+	InvalidReason string
+}
+
+// CloudCredentialResult represents a credential and the cloud it belongs to.
+type CloudCredentialResult struct {
+	CloudCredentialInfo
+
+	// CloudName is the cloud the credential belongs to.
+	CloudName string
 }

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -55,10 +55,11 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(),
-		"foobar",
-		"my-cloud",
-		"wallyworld",
+		context.Background(), credential.ID{
+			Cloud: "my-cloud",
+			Owner: "wallyworld",
+			Name:  "foobar",
+		},
 		cred,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -203,10 +204,11 @@ func (m *modelSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(),
-		"foobar",
-		"my-cloud2",
-		"wallyworld",
+		context.Background(), credential.ID{
+			Cloud: "my-cloud2",
+			Owner: "wallyworld",
+			Name:  "foobar",
+		},
 		cred,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -44,14 +44,14 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cred := cloud.NewNamedCredential(
-		"foobar",
-		cloud.AccessKeyAuthType,
-		map[string]string{
+	cred := credential.CloudCredentialInfo{
+		Label:    "foobar",
+		AuthType: string(cloud.AccessKeyAuthType),
+		Attributes: map[string]string{
 			"foo": "foo val",
 			"bar": "bar val",
 		},
-		false)
+	}
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
@@ -193,14 +193,14 @@ func (m *modelSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cred := cloud.NewNamedCredential(
-		"foobar",
-		cloud.AccessKeyAuthType,
-		map[string]string{
+	cred := credential.CloudCredentialInfo{
+		Label:    "foobar",
+		AuthType: string(cloud.AccessKeyAuthType),
+		Attributes: map[string]string{
 			"foo": "foo val",
 			"bar": "bar val",
 		},
-		false)
+	}
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/credential"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
@@ -39,7 +40,7 @@ type PrecheckBackend interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
 }
 
 // Pool defines the interface to a StatePool used by the migration

--- a/internal/migration/precheck.go
+++ b/internal/migration/precheck.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/upgrades/upgradevalidation"
@@ -382,7 +383,7 @@ func (ctx *precheckSource) checkModel(stdCtx context.Context) error {
 		return errors.New("model is being imported as part of another migration")
 	}
 	if credTag, found := model.CloudCredentialTag(); found {
-		creds, err := ctx.credentialService.CloudCredential(stdCtx, credTag)
+		creds, err := ctx.credentialService.CloudCredential(stdCtx, credential.IdFromTag(credTag))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -18,6 +18,7 @@ import (
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/credential"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/tools"
@@ -804,7 +805,7 @@ type fakeCredentialService struct {
 	credentialsErr error
 }
 
-func (b *fakeCredentialService) CloudCredential(_ context.Context, _ names.CloudCredentialTag) (cloud.Credential, error) {
+func (b *fakeCredentialService) CloudCredential(_ context.Context, _ credential.ID) (cloud.Credential, error) {
 	return b.credential, b.credentialsErr
 }
 

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -49,6 +49,7 @@ import (
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	cloudstate "github.com/juju/juju/domain/cloud/state"
 	controllerconfigbootstrap "github.com/juju/juju/domain/controllerconfig/bootstrap"
+	"github.com/juju/juju/domain/credential"
 	credentialbootstrap "github.com/juju/juju/domain/credential/bootstrap"
 	credentialstate "github.com/juju/juju/domain/credential/state"
 	"github.com/juju/juju/domain/model"
@@ -86,6 +87,9 @@ var (
 
 	// DefaultCredentialTag is the default credential for all models.
 	DefaultCredentialTag = names.NewCloudCredentialTag("dummy/admin/default")
+
+	// DefaultCredentialId is the default credential id for all models.
+	DefaultCredentialId = credential.IdFromTag(DefaultCredentialTag)
 
 	defaultCredential = cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"username": "dummy",
@@ -559,7 +563,11 @@ func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		return credentialstate.CreateCredential(ctx, tx, credUUID.String(), "dummy-credential", "caascloud", "admin", cred)
+		return credentialstate.CreateCredential(ctx, tx, credUUID.String(), credential.ID{
+			Cloud: "caascloud",
+			Owner: "admin",
+			Name:  "dummy-credential",
+		}, cred)
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -577,8 +585,12 @@ func SeedCloudCredentials(c *gc.C, runner database.TxnRunner) {
 	err := cloudbootstrap.InsertCloud(DefaultCloud)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 
-	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", DefaultCloud.Name, AdminUser.Name(), DefaultCredentialTag.Name()))
-	err = credentialbootstrap.InsertCredential(tag, defaultCredential)(context.Background(), runner)
+	id := credential.ID{
+		Cloud: DefaultCloud.Name,
+		Owner: AdminUser.Name(),
+		Name:  DefaultCredentialId.Name,
+	}
+	err = credentialbootstrap.InsertCredential(id, defaultCredential)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -544,10 +544,13 @@ func (s *ApiServerSuite) tearDownConn(c *gc.C) {
 }
 
 func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
-	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-		"username": "dummy",
-		"password": "secret",
-	})
+	cred := credential.CloudCredentialInfo{
+		AuthType: string(cloud.UserPassAuthType),
+		Attributes: map[string]string{
+			"username": "dummy",
+			"password": "secret",
+		},
+	}
 
 	cloudUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -34,7 +35,7 @@ type Model interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, tag names.CloudCredentialTag) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
 }
 
 // CloudService provides access to clouds.
@@ -108,14 +109,14 @@ func CloudSpecForModel(
 	if err != nil {
 		return environscloudspec.CloudSpec{}, errors.Trace(err)
 	}
-	var credential cloud.Credential
+	var cred cloud.Credential
 	if ok {
-		credential, err = credentialService.CloudCredential(ctx, tag)
+		cred, err = credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
 		if err != nil {
 			return environscloudspec.CloudSpec{}, errors.Trace(err)
 		}
 	}
-	return environscloudspec.MakeCloudSpec(*cld, regionName, &credential)
+	return environscloudspec.MakeCloudSpec(*cld, regionName, &cred)
 }
 
 // NewEnvironFunc aliases a function that, given a Model,

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/state/stateenvirons"
@@ -59,9 +60,9 @@ type credentialGetter struct {
 	cred *cloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ context.Context, tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ context.Context, id credential.ID) (cloud.Credential, error) {
 	if c.cred == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", tag)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
 	}
 	return *c.cred, nil
 }

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -7,12 +7,12 @@ import (
 	stdcontext "context"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -97,9 +97,9 @@ type MockCredentialService struct {
 	Credential *cloud.Credential
 }
 
-func (m *MockCredentialService) CloudCredential(ctx stdcontext.Context, tag names.CloudCredentialTag) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(ctx stdcontext.Context, id credential.ID) (cloud.Credential, error) {
 	if m.Credential == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", tag)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
 	}
 	return *m.Credential, nil
 }


### PR DESCRIPTION
A mechanical PR to remove the use of tags in credential service api calls - use credential ID instead.
For the credential state calls, replace name,cloud,owner args with credential ID as well.


## QA steps

bootstrap
update-credential
show-credential

## Links


**Jira card:** JUJU-[4622]

