### PR TITLE
Mechanical rearrangement for firewaller test

### DIFF
--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -195,7 +195,7 @@ func MacaroonsEqual(c *gc.C, ms1, ms2 []macaroon.Slice) error {
 func MacaroonEquals(c *gc.C, m1, m2 *macaroon.Macaroon) {
 	c.Assert(m1.Id(), jc.DeepEquals, m2.Id())
 	c.Assert(m1.Signature(), jc.DeepEquals, m2.Signature())
-	c.Assert(m1.Location(), jc.DeepEquals, m2.Location())
+	c.Assert(m1.Location(), gc.Equals, m2.Location())
 }
 
 func NewMacaroon(id string) (*macaroon.Macaroon, error) {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1038,18 +1038,16 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 			c.Check(version, gc.Equals, 0)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "WatchEgressAddressesForRelations")
-			expected := params.RemoteEntityArgs{
-				Args: []params.RemoteEntityArg{{
-					Token: relToken,
-				}},
-			}
-			// Extract macaroons so we can compare them separately
-			// (as they can't be compared using DeepEquals due to 'UnmarshaledAs')
-			rArgs := arg.(params.RemoteEntityArgs)
-			newMacs := rArgs.Args[0].Macaroons
-			rArgs.Args[0].Macaroons = nil
-			apitesting.MacaroonEquals(c, newMacs[0], mac)
-			c.Check(arg, gc.DeepEquals, expected)
+
+			rArgs := arg.(params.RemoteEntityArgs).Args
+			c.Assert(rArgs, gc.HasLen, 1)
+			c.Check(rArgs[0].Token, gc.Equals, relToken)
+
+			macs := rArgs[0].Macaroons
+			c.Assert(macs, gc.HasLen, 1)
+			c.Assert(macs[0], gc.NotNil)
+			apitesting.MacaroonEquals(c, macs[0], mac)
+
 			c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
 			*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
 				Results: []params.StringsWatchResult{{StringsWatcherId: "1"}},


### PR DESCRIPTION
A panic was observed in CI for one of the firewaller worker cross-model tests.

This patch likely doesn't address the panic, but does make diagnosis easier via simpler comparisons. 

## QA steps

`TestRemoteRelationProviderRoleConsumingSide` in _worker/firewaller_ passes consistently.