### PR TITLE
Backport changes to fix model cache tests for adding a machine

### DIFF
--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -461,7 +461,20 @@ func (s *WorkerSuite) TestAddMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedMachine, gc.NotNil)
 
-	change = s.nextChange(c, changes)
+	// We don't know how many events we will get because `MakeMachine`
+	// above runs multiple operations, but is not transactional.
+	// Drain the events for a short time then assert that the machine
+	// appears as though provisioned.
+	done := time.After(2 * testing.ShortWait)
+loop:
+	for {
+		select {
+		case change = <-changes:
+		case <-done:
+			break loop
+		}
+	}
+
 	obtained, ok = change.(cache.MachineChange)
 	c.Assert(ok, jc.IsTrue)
 	c.Check(obtained.Id, gc.Equals, machine.Id())


### PR DESCRIPTION
The model cache test for adding a machine underwent some changes to fix failures on 3.2+ branches, but now we're seeing similar failures on 3.1.

Here we accrue said changes into this back-port.

## QA steps

`TestAddMachine` in _worker/modelcache_ passes consistently.