### PR TITLE
Prevent setting the authorized-keys model config

### DIFF
--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -213,8 +213,12 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 	// Make sure the secret backend exists.
 	checkSecretBackend := c.checkSecretBackend()
 
+	// Make sure the passed config does not set authorized-keys.
+	checkAuthorizedKeys := c.checkAuthorizedKeys()
+
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
+
 	return c.backend.UpdateModelConfig(attrs,
 		nil,
 		checkAgentVersion,
@@ -223,7 +227,19 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 		checkCharmhubURL,
 		checkSecretBackend,
 		checkUpdateDefaultBase,
+		checkAuthorizedKeys,
 	)
+}
+
+// checkAuthorizedKeys checks that the passed config attributes does not
+// contain authorized-keys.
+func (c *ModelConfigAPI) checkAuthorizedKeys() state.ValidateConfigFunc {
+	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
+		if _, found := updateAttrs[config.AuthorizedKeysKey]; found {
+			return errors.New("authorized-keys cannot be set")
+		}
+		return nil
+	}
 }
 
 func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -246,21 +246,14 @@ func (s *modelconfigSuite) TestModelSetCannotChangeBothDefaultSeriesAndDefaultBa
 }
 
 func (s *modelconfigSuite) TestModelSetCannotSetAuthorizedKeys(c *gc.C) {
-	originalFingerprints := `ssh-rsa aaa Juju:juju-client-key
-ssh-ed25519 bbb Juju:foo@bar
-ssh-rsa ccc Juju:juju-system-key`
-	old, err := config.New(config.UseDefaults, dummy.SampleConfig().Merge(coretesting.Attrs{
-		"authorized-keys": originalFingerprints,
-	}))
-	c.Assert(err, jc.ErrorIsNil)
-	s.backend.old = old
+	// Try to set the authorized-keys model config.
 	args := params.ModelSet{
-		Config: map[string]interface{}{"authorized-keys": `ssh-rsa ddd Juju:juju-client-key
-ssh-ed25519 eee Juju:foo@bar
-ssh-rsa fff Juju:juju-system-key`},
+		Config: map[string]interface{}{"authorized-keys": "ssh-rsa new Juju:juju-client-key"},
 	}
-	err = s.api.ModelSet(args)
+	err := s.api.ModelSet(args)
 	c.Assert(err, gc.ErrorMatches, "authorized-keys cannot be set")
+	// Make sure the authorized-keys still contains its original value.
+	s.assertConfigValue(c, "authorized-keys", coretesting.FakeAuthKeys)
 }
 
 func (s *modelconfigSuite) TestAdminCanSetLogTrace(c *gc.C) {

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -417,11 +417,15 @@ func (c *configCommand) verifyKnownKeys(client configCommandAPI, keys []string) 
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// AuthorizedKeys is a valid key, though you aren't allowed to set it.
+	// This will be denied with a server error, but we don't want to warn
+	// about an unknown key.
+	known[envconfig.AuthorizedKeysKey] = ""
 
 	allKeys := keys[:]
 	for _, key := range allKeys {
-		// check if the key exists in the known config
-		// and warn the user if the key is not defined
+		// Check if the key exists in the known config
+		// and warn the user if the key is not defined.
 		if _, exists := known[key]; !exists {
 			logger.Warningf(
 				"key %q is not defined in the current model configuration: possible misspelling", key)

--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -49,7 +49,13 @@ func (f *fakeEnvAPI) Close() error {
 }
 
 func (f *fakeEnvAPI) ModelGet() (map[string]interface{}, error) {
-	return f.values, nil
+	// We need to deep copy f.values first, because verifyKnownKeys() will
+	// alter the returned values of ModelGet(), hence breaking the tests.
+	valuesCopy := make(map[string]interface{})
+	for k, v := range f.values {
+		valuesCopy[k] = v
+	}
+	return valuesCopy, nil
 }
 
 func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {


### PR DESCRIPTION
The model config `authorized-keys` should not be settable directly by doing $ juju model-config authorized-keys=foo.
This patch ensures that the model config set does not contain the authorized-keys key or it returns an error.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

After bootstrapping (on any cloud) and creating a model, try updating the authorized-keys using `model-config`:
```
juju model-config authorized-keys=foo

ERROR authorized-keys cannot be set
```

## Links

**Launchpad bug:**https://bugs.launchpad.net/juju/+bug/2039615

**Jira card:** JUJU-4813

*Insert other relevant links here.*