### PR TITLE
Add service-principal-Asecret auth type required by Azure

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -177,7 +177,8 @@ INSERT INTO auth_type VALUES
     (8, 'interactive'),
     (9, 'empty'),
     (10, 'certificate'),
-    (11, 'oauth2withcert');
+    (11, 'oauth2withcert'),
+    (12, 'service-principal-secret');
 
 CREATE TABLE cloud (
     uuid                TEXT PRIMARY KEY,


### PR DESCRIPTION
Azure integration tests are failing at bootstrap due to using an auth type that we do not have in our lookup table.

Her we simply add the missing type.

## QA steps

Bootstrapping to Azure works.