### PR TITLE
Wireup charmhub tracer

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -924,13 +924,13 @@ func (api *APIBase) UpdateApplicationBase(ctx context.Context, args params.Updat
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
 	for i, arg := range args.Args {
-		err := api.updateOneApplicationBase(arg)
+		err := api.updateOneApplicationBase(ctx, arg)
 		results.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return results, nil
 }
 
-func (api *APIBase) updateOneApplicationBase(arg params.UpdateChannelArg) error {
+func (api *APIBase) updateOneApplicationBase(ctx context.Context, arg params.UpdateChannelArg) error {
 	var argBase corebase.Base
 	if arg.Channel != "" {
 		appTag, err := names.ParseTag(arg.Entity.Tag)
@@ -947,7 +947,7 @@ func (api *APIBase) updateOneApplicationBase(arg params.UpdateChannelArg) error 
 			return errors.Trace(err)
 		}
 	}
-	return api.updateBase.UpdateBase(arg.Entity.Tag, argBase, arg.Force)
+	return api.updateBase.UpdateBase(ctx, arg.Entity.Tag, argBase, arg.Force)
 }
 
 // SetCharm sets the charm for a given for the application.
@@ -2932,7 +2932,7 @@ func (api *APIBase) DeployFromRepository(ctx context.Context, args params.Deploy
 
 	results := make([]params.DeployFromRepositoryResult, len(args.Args))
 	for i, entity := range args.Args {
-		info, pending, errs := api.repoDeploy.DeployFromRepository(entity)
+		info, pending, errs := api.repoDeploy.DeployFromRepository(ctx, entity)
 		if len(errs) > 0 {
 			results[i].Errors = apiservererrors.ServerErrors(errs)
 			continue

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -41,13 +41,13 @@ var deployRepoLogger = logger.Child("deployfromrepository")
 
 // DeployFromRepositoryValidator defines an deploy config validator.
 type DeployFromRepositoryValidator interface {
-	ValidateArg(params.DeployFromRepositoryArg) (deployTemplate, []error)
+	ValidateArg(context.Context, params.DeployFromRepositoryArg) (deployTemplate, []error)
 }
 
 // DeployFromRepository defines an interface for deploying a charm
 // from a repository.
 type DeployFromRepository interface {
-	DeployFromRepository(arg params.DeployFromRepositoryArg) (params.DeployFromRepositoryInfo, []*params.PendingResourceUpload, []error)
+	DeployFromRepository(context.Context, params.DeployFromRepositoryArg) (params.DeployFromRepositoryInfo, []*params.PendingResourceUpload, []error)
 }
 
 // DeployFromRepositoryState defines a common set of functions for retrieving state
@@ -87,10 +87,10 @@ func NewDeployFromRepositoryAPI(state DeployFromRepositoryState, validator Deplo
 	}
 }
 
-func (api *DeployFromRepositoryAPI) DeployFromRepository(arg params.DeployFromRepositoryArg) (params.DeployFromRepositoryInfo, []*params.PendingResourceUpload, []error) {
+func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, arg params.DeployFromRepositoryArg) (params.DeployFromRepositoryInfo, []*params.PendingResourceUpload, []error) {
 	deployRepoLogger.Tracef("deployOneFromRepository(%s)", pretty.Sprint(arg))
 	// Validate the args.
-	dt, addPendingResourceErrs := api.validator.ValidateArg(arg)
+	dt, addPendingResourceErrs := api.validator.ValidateArg(ctx, arg)
 
 	if len(addPendingResourceErrs) > 0 {
 		return params.DeployFromRepositoryInfo{}, nil, addPendingResourceErrs
@@ -165,6 +165,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(arg params.DeployFromRe
 // the DeployFromRepository returns. Errors are not terminal,
 // and will be collected and returned altogether.
 func (v *deployFromRepositoryValidator) resolveResources(
+	ctx context.Context,
 	curl *charm.URL,
 	origin corecharm.Origin,
 	deployResArg map[string]string,
@@ -201,11 +202,11 @@ func (v *deployFromRepositoryValidator) resolveResources(
 		resources = append(resources, r)
 	}
 
-	repo, err := v.getCharmRepository(origin.Source)
+	repo, err := v.getCharmRepository(ctx, origin.Source)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	resolvedResources, resolveErr := repo.ResolveResources(resources, corecharm.CharmID{URL: curl, Origin: origin})
+	resolvedResources, resolveErr := repo.ResolveResources(ctx, resources, corecharm.CharmID{URL: curl, Origin: origin})
 
 	return resolvedResources, pendingUploadIDs, resolveErr
 }
@@ -348,7 +349,7 @@ type deployFromRepositoryValidator struct {
 // arguments. Returned is a deployTemplate which contains validated
 // data necessary to deploy the application.
 // Where possible, errors will be grouped and returned as a list.
-func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
+func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	errs := make([]error, 0)
 
 	if err := checkMachinePlacement(v.state, arg.ApplicationName, arg.Placement); err != nil {
@@ -357,7 +358,7 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 
 	// get the charm data to validate against, either a previously deployed
 	// charm or the essential metadata from a charm to be async downloaded.
-	charmURL, resolvedOrigin, resolvedCharm, getCharmErr := v.getCharm(arg)
+	charmURL, resolvedOrigin, resolvedCharm, getCharmErr := v.getCharm(ctx, arg)
 	if getCharmErr != nil {
 		errs = append(errs, getCharmErr)
 		// return any errors here, there is no need to continue with
@@ -385,7 +386,7 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 		dt.endpoints = bindings.Map()
 	}
 	// resolve and validate resources
-	resources, pendingResourceUploads, resolveResErr := v.resolveResources(dt.charmURL, dt.origin, dt.resources, resolvedCharm.Meta().Resources)
+	resources, pendingResourceUploads, resolveResErr := v.resolveResources(ctx, dt.charmURL, dt.origin, dt.resources, resolvedCharm.Meta().Resources)
 	if resolveResErr != nil {
 		errs = append(errs, resolveResErr)
 	}
@@ -510,8 +511,8 @@ type caasDeployFromRepositoryValidator struct {
 //   - Check kubernetes model config values against the kubernetes cluster
 //     in use
 //   - Check the charm's min version against the caasVersion
-func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
-	dt, errs := v.validator.validate(arg)
+func (v caasDeployFromRepositoryValidator) ValidateArg(ctx context.Context, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
+	dt, errs := v.validator.validate(ctx, arg)
 
 	if charm.MetaFormat(dt.charm) == charm.FormatV1 {
 		errs = append(errs, errors.NotSupportedf("deploying format v1 charm %q", arg.CharmName))
@@ -533,8 +534,8 @@ type iaasDeployFromRepositoryValidator struct {
 // ValidateArg validates DeployFromRepositoryArg from a iaas perspective.
 // First checking the common validation, then any validation specific to
 // iaas charms.
-func (v iaasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
-	dt, errs := v.validator.validate(arg)
+func (v iaasDeployFromRepositoryValidator) ValidateArg(ctx context.Context, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
+	dt, errs := v.validator.validate(ctx, arg)
 	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
 	if len(attachStorageErrs) > 0 {
 		errs = append(errs, attachStorageErrs...)
@@ -706,8 +707,8 @@ func (v *deployFromRepositoryValidator) platformFromPlacement(placements []*inst
 	return platform, platStrings.Size() == 1, nil
 }
 
-func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedOrigin corecharm.Origin, force, usedModelDefaultBase bool, cons constraints.Value) (corecharm.ResolvedDataForDeploy, error) {
-	repo, err := v.getCharmRepository(requestedOrigin.Source)
+func (v *deployFromRepositoryValidator) resolveCharm(ctx context.Context, curl *charm.URL, requestedOrigin corecharm.Origin, force, usedModelDefaultBase bool, cons constraints.Value) (corecharm.ResolvedDataForDeploy, error) {
+	repo, err := v.getCharmRepository(ctx, requestedOrigin.Source)
 	if err != nil {
 		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
@@ -715,7 +716,7 @@ func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedO
 	// TODO (hml) 2023-05-16
 	// Use resource data found in resolvedData as part of ResolveResource.
 	// Will require a new method on the repo.
-	resolvedData, resolveErr := repo.ResolveForDeploy(corecharm.CharmID{URL: curl, Origin: requestedOrigin})
+	resolvedData, resolveErr := repo.ResolveForDeploy(ctx, corecharm.CharmID{URL: curl, Origin: requestedOrigin})
 	if charm.IsUnsupportedSeriesError(resolveErr) {
 		if !force {
 			msg := fmt.Sprintf("%v. Use --force to deploy the charm anyway.", resolveErr)
@@ -802,7 +803,7 @@ func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedO
 
 // getCharm returns the charm being deployed. Either it already has been
 // used once, and we get the data from state. Or we get the essential metadata.
-func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepositoryArg) (*charm.URL, corecharm.Origin, charm.Charm, error) {
+func (v *deployFromRepositoryValidator) getCharm(ctx context.Context, arg params.DeployFromRepositoryArg) (*charm.URL, corecharm.Origin, charm.Charm, error) {
 	initialCurl, requestedOrigin, usedModelDefaultBase, err := v.createOrigin(arg)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, errors.Trace(err)
@@ -812,7 +813,7 @@ func (v *deployFromRepositoryValidator) getCharm(arg params.DeployFromRepository
 	// Fetch the essential metadata that we require to deploy the charm
 	// without downloading the full archive. The remaining metadata will
 	// be populated once the charm gets downloaded.
-	resolvedData, err := v.resolveCharm(initialCurl, requestedOrigin, arg.Force, usedModelDefaultBase, arg.Cons)
+	resolvedData, err := v.resolveCharm(ctx, initialCurl, requestedOrigin, arg.Force, usedModelDefaultBase, arg.Cons)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, err
 	}
@@ -864,13 +865,13 @@ func (v *deployFromRepositoryValidator) appCharmSettings(appName string, trust b
 	return appConfig, charmSettings, err
 }
 
-func (v *deployFromRepositoryValidator) getCharmRepository(src corecharm.Source) (corecharm.Repository, error) {
+func (v *deployFromRepositoryValidator) getCharmRepository(ctx context.Context, src corecharm.Source) (corecharm.Repository, error) {
 	// The following is only required for testing, as we generate api new http
 	// client here for production.
 	v.mu.Lock()
 	if v.repoFactory != nil {
 		defer v.mu.Unlock()
-		return v.repoFactory.GetCharmRepository(src)
+		return v.repoFactory.GetCharmRepository(ctx, src)
 	}
 	v.mu.Unlock()
 
@@ -881,5 +882,5 @@ func (v *deployFromRepositoryValidator) getCharmRepository(src corecharm.Source)
 		ModelBackend:       v.model,
 	})
 
-	return repoFactory.GetCharmRepository(src)
+	return repoFactory.GetCharmRepository(ctx, src)
 }

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -329,18 +329,18 @@ func (m *MockDeployFromRepositoryValidator) EXPECT() *MockDeployFromRepositoryVa
 }
 
 // ValidateArg mocks base method.
-func (m *MockDeployFromRepositoryValidator) ValidateArg(arg0 params.DeployFromRepositoryArg) (deployTemplate, []error) {
+func (m *MockDeployFromRepositoryValidator) ValidateArg(arg0 context.Context, arg1 params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateArg", arg0)
+	ret := m.ctrl.Call(m, "ValidateArg", arg0, arg1)
 	ret0, _ := ret[0].(deployTemplate)
 	ret1, _ := ret[1].([]error)
 	return ret0, ret1
 }
 
 // ValidateArg indicates an expected call of ValidateArg.
-func (mr *MockDeployFromRepositoryValidatorMockRecorder) ValidateArg(arg0 interface{}) *gomock.Call {
+func (mr *MockDeployFromRepositoryValidatorMockRecorder) ValidateArg(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateArg", reflect.TypeOf((*MockDeployFromRepositoryValidator)(nil).ValidateArg), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateArg", reflect.TypeOf((*MockDeployFromRepositoryValidator)(nil).ValidateArg), arg0, arg1)
 }
 
 // MockModel is a mock of Model interface.

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/charm/v11"
@@ -57,8 +58,8 @@ func (s *validatorSuite) TestValidateSuccess(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
-	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
 
 	// getCharm
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
@@ -67,7 +68,7 @@ func (s *validatorSuite) TestValidateSuccess(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testcharm",
 	}
-	dt, errs := s.getValidator().validate(arg)
+	dt, errs := s.getValidator().validate(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0, gc.Commentf("%s", pretty.Sprint(errs)))
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
@@ -110,8 +111,8 @@ func (s *validatorSuite) testValidateIAASAttachStorage(c *gc.C, argStorage []str
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
-	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
 	// getCharm
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
 	s.state.EXPECT().Charm(gomock.Any()).Return(nil, errors.NotFoundf("charm"))
@@ -120,7 +121,7 @@ func (s *validatorSuite) testValidateIAASAttachStorage(c *gc.C, argStorage []str
 		CharmName:     "testcharm",
 		AttachStorage: argStorage,
 	}
-	dt, errs := s.iaasDeployFromRepositoryValidator().ValidateArg(arg)
+	dt, errs := s.iaasDeployFromRepositoryValidator().ValidateArg(context.Background(), arg)
 	if expectedErr == "" {
 		c.Assert(errs, gc.HasLen, 0)
 		c.Assert(dt, gc.DeepEquals, deployTemplate{
@@ -158,8 +159,8 @@ func (s *validatorSuite) TestValidatePlacementSuccess(c *gc.C) {
 	// getCharm
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
-	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
 
 	// Placement
 	s.state.EXPECT().Machine("0").Return(s.machine, nil).Times(2)
@@ -178,7 +179,7 @@ func (s *validatorSuite) TestValidatePlacementSuccess(c *gc.C) {
 		CharmName: "testcharm",
 		Placement: []*instance.Placement{{Directive: "0", Scope: instance.MachineScope}},
 	}
-	dt, errs := s.getValidator().validate(arg)
+	dt, errs := s.getValidator().validate(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
@@ -211,8 +212,8 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 	// getCharm
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
-	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
 
 	// state bindings
 	endpointMap := map[string]string{"to": "from"}
@@ -224,7 +225,7 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 		CharmName:        "testcharm",
 		EndpointBindings: endpointMap,
 	}
-	dt, errs := s.getValidator().validate(arg)
+	dt, errs := s.getValidator().validate(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
@@ -260,13 +261,13 @@ func (s *validatorSuite) TestResolveCharm(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{
 		Arch: strptr("arm64"),
 	}, nil)
 
-	obtained, err := s.getValidator().resolveCharm(curl, origin, false, false, constraints.Value{})
+	obtained, err := s.getValidator().resolveCharm(context.Background(), curl, origin, false, false, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained.URL, gc.DeepEquals, resultURL)
 	c.Assert(obtained.EssentialMetadata.ResolvedOrigin, gc.DeepEquals, resolvedOrigin)
@@ -290,11 +291,11 @@ func (s *validatorSuite) TestResolveCharmArchAll(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
 
-	obtained, err := s.getValidator().resolveCharm(curl, origin, false, false, constraints.Value{})
+	obtained, err := s.getValidator().resolveCharm(context.Background(), curl, origin, false, false, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained.URL, gc.DeepEquals, resultURL)
 	expectedOrigin := resolvedOrigin
@@ -322,11 +323,11 @@ func (s *validatorSuite) TestResolveCharmUnsupportedSeriesErrorForce(c *gc.C) {
 	newErr := charm.NewUnsupportedSeriesError("jammy", supportedSeries)
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, newErr)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, newErr)
 	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
 
-	obtained, err := s.getValidator().resolveCharm(curl, origin, true, false, constraints.Value{})
+	obtained, err := s.getValidator().resolveCharm(context.Background(), curl, origin, true, false, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained.URL, gc.DeepEquals, resultURL)
 	c.Assert(obtained.EssentialMetadata.ResolvedOrigin, gc.DeepEquals, resolvedOrigin)
@@ -343,9 +344,9 @@ func (s *validatorSuite) TestResolveCharmUnsupportedSeriesError(c *gc.C) {
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	supportedSeries := []string{"focal"}
 	newErr := charm.NewUnsupportedSeriesError("jammy", supportedSeries)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(corecharm.ResolvedDataForDeploy{}, newErr)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(corecharm.ResolvedDataForDeploy{}, newErr)
 
-	_, err := s.getValidator().resolveCharm(curl, origin, false, false, constraints.Value{})
+	_, err := s.getValidator().resolveCharm(context.Background(), curl, origin, false, false, constraints.Value{})
 	c.Assert(err, gc.ErrorMatches, `series "jammy" not supported by charm, supported series are: focal. Use --force to deploy the charm anyway.`)
 }
 
@@ -367,11 +368,11 @@ func (s *validatorSuite) TestResolveCharmExplicitBaseErrorWhenUserImageID(c *gc.
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
 
-	_, err := s.getValidator().resolveCharm(curl, origin, false, false, constraints.Value{ImageID: strptr("ubuntu-bf2")})
+	_, err := s.getValidator().resolveCharm(context.Background(), curl, origin, false, false, constraints.Value{ImageID: strptr("ubuntu-bf2")})
 	c.Assert(err, gc.ErrorMatches, `base must be explicitly provided when image-id constraint is used`)
 }
 
@@ -393,14 +394,14 @@ func (s *validatorSuite) TestResolveCharmExplicitBaseErrorWhenModelImageID(c *gc
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{
 		Arch:    strptr("arm64"),
 		ImageID: strptr("ubuntu-bf2"),
 	}, nil)
 
-	_, err := s.getValidator().resolveCharm(curl, origin, false, false, constraints.Value{})
+	_, err := s.getValidator().resolveCharm(context.Background(), curl, origin, false, false, constraints.Value{})
 	c.Assert(err, gc.ErrorMatches, `base must be explicitly provided when image-id constraint is used`)
 }
 
@@ -469,14 +470,14 @@ func (s *validatorSuite) TestGetCharm(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	s.state.EXPECT().Charm(gomock.Any()).Return(nil, errors.NotFoundf("charm"))
 	// getCharm
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testcharm",
 	}
-	obtainedURL, obtainedOrigin, obtainedCharm, err := s.getValidator().getCharm(arg)
+	obtainedURL, obtainedOrigin, obtainedCharm, err := s.getValidator().getCharm(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
 	c.Assert(obtainedCharm, gc.DeepEquals, corecharm.NewCharmInfoAdapter(resolvedData.EssentialMetadata))
@@ -505,14 +506,14 @@ func (s *validatorSuite) TestGetCharmAlreadyDeployed(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	ch := NewMockCharm(ctrl)
 	s.state.EXPECT().Charm(gomock.Any()).Return(ch, nil)
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testcharm",
 	}
-	obtainedURL, obtainedOrigin, obtainedCharm, err := s.getValidator().getCharm(arg)
+	obtainedURL, obtainedOrigin, obtainedCharm, err := s.getValidator().getCharm(context.Background(), arg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin, gc.DeepEquals, resolvedOrigin)
@@ -541,11 +542,11 @@ func (s *validatorSuite) TestGetCharmFindsBundle(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testcharm",
 	}
-	_, _, _, err := s.getValidator().getCharm(arg)
+	_, _, _, err := s.getValidator().getCharm(context.Background(), arg)
 	c.Assert(err, jc.ErrorIs, errors.BadRequest)
 }
 
@@ -571,12 +572,12 @@ func (s *validatorSuite) TestGetCharmNoJujuControllerCharm(c *gc.C) {
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
 	resolvedData.EssentialMetadata.Meta.Name = "juju-controller"
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testcharm",
 	}
-	_, _, _, err := s.getValidator().getCharm(arg)
+	_, _, _, err := s.getValidator().getCharm(context.Background(), arg)
 	c.Assert(err, jc.ErrorIs, errors.NotSupported, gc.Commentf("%+v", err))
 }
 
@@ -909,8 +910,8 @@ func (s *validatorSuite) TestResolveResourcesSuccess(c *gc.C) {
 	// First one of below is the file upload for Resource 1, the second is the revision for Resource 2e
 	deployResArg := map[string]string{"foo-file": "bar", "foo-file2": "3"}
 
-	s.repo.EXPECT().ResolveResources(resolveResourcesArgsMatcher{c: c, expected: &resArgs}, corecharm.CharmID{URL: curl, Origin: origin}).Return(resResult, nil)
-	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(curl, origin, deployResArg, resMeta)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), resolveResourcesArgsMatcher{c: c, expected: &resArgs}, corecharm.CharmID{URL: curl, Origin: origin}).Return(resResult, nil)
+	resources, pendingResourceUploads, resolveResErr := s.getValidator().resolveResources(context.Background(), curl, origin, deployResArg, resMeta)
 	pendUp := &params.PendingResourceUpload{
 		Name:     "foo-resource",
 		Type:     "file",
@@ -941,8 +942,8 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 	}
 	charmID := corecharm.CharmID{URL: curl, Origin: origin}
 	resolvedData := getResolvedData(resultURL, resolvedOrigin)
-	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
-	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any(), charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(gomock.Any(), nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
 	s.state.EXPECT().Charm(gomock.Any()).Return(nil, errors.NotFoundf("charm"))
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{
 		Arch: strptr("arm64"),
@@ -952,7 +953,7 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 		CharmName: "testcharm",
 	}
 
-	obtainedDT, errs := s.caasDeployFromRepositoryValidator(c).ValidateArg(arg)
+	obtainedDT, errs := s.caasDeployFromRepositoryValidator(c).ValidateArg(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(obtainedDT, gc.DeepEquals, deployTemplate{
 		applicationName: "test-charm",
@@ -997,7 +998,7 @@ func (s *validatorSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *validatorSuite) getValidator() *deployFromRepositoryValidator {
-	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repo, nil).AnyTimes()
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any(), gomock.Any()).Return(s.repo, nil).AnyTimes()
 	return &deployFromRepositoryValidator{
 		model:       s.model,
 		state:       s.state,
@@ -1060,7 +1061,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 		},
 		placement: []*instance.Placement{{Directive: "0", Scope: instance.MachineScope}},
 	}
-	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
+	s.validator.EXPECT().ValidateArg(gomock.Any(), arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
 		ID:    "ch:amd64/jammy/testme-5",
@@ -1097,7 +1098,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 
 	deployFromRepositoryAPI := s.getDeployFromRepositoryAPI()
 
-	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(arg)
+	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(resources, gc.HasLen, 0)
 	c.Assert(obtainedInfo, gc.DeepEquals, params.DeployFromRepositoryInfo{
@@ -1183,7 +1184,7 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 		pendingResourceUploads: []*params.PendingResourceUpload{pendUp},
 		resolvedResources:      []resource.Resource{r},
 	}
-	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
+	s.validator.EXPECT().ValidateArg(gomock.Any(), arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
 		ID:    "ch:amd64/jammy/testme-5",
@@ -1222,7 +1223,7 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 
 	deployFromRepositoryAPI := s.getDeployFromRepositoryAPI()
 
-	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(arg)
+	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(resources, gc.HasLen, 1)
 	c.Assert(obtainedInfo, gc.DeepEquals, params.DeployFromRepositoryInfo{
@@ -1274,7 +1275,7 @@ func (s *deployRepositorySuite) TestRemovePendingResourcesWhenDeployErrors(c *gc
 		pendingResourceUploads: []*params.PendingResourceUpload{pendUp},
 		resolvedResources:      []resource.Resource{r},
 	}
-	s.validator.EXPECT().ValidateArg(arg).Return(template, nil)
+	s.validator.EXPECT().ValidateArg(gomock.Any(), arg).Return(template, nil)
 	info := state.CharmInfo{
 		Charm: template.charm,
 		ID:    "ch:amd64/jammy/testme-5",
@@ -1317,7 +1318,7 @@ func (s *deployRepositorySuite) TestRemovePendingResourcesWhenDeployErrors(c *gc
 
 	deployFromRepositoryAPI := s.getDeployFromRepositoryAPI()
 
-	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(arg)
+	obtainedInfo, resources, errs := deployFromRepositoryAPI.DeployFromRepository(context.Background(), arg)
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(resources, gc.HasLen, 0)
 	c.Assert(obtainedInfo, gc.DeepEquals, params.DeployFromRepositoryInfo{})

--- a/apiserver/facades/client/application/repository_mocks_test.go
+++ b/apiserver/facades/client/application/repository_mocks_test.go
@@ -5,6 +5,7 @@
 package application
 
 import (
+	context "context"
 	url "net/url"
 	reflect "reflect"
 
@@ -38,9 +39,9 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -48,15 +49,15 @@ func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2
 }
 
 // DownloadCharm indicates an expected call of DownloadCharm.
-func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockRepository)(nil).DownloadCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockRepository)(nil).DownloadCharm), arg0, arg1, arg2, arg3)
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -64,16 +65,16 @@ func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*u
 }
 
 // GetDownloadURL indicates an expected call of GetDownloadURL.
-func (mr *MockRepositoryMockRecorder) GetDownloadURL(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockRepository)(nil).GetDownloadURL), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockRepository)(nil).GetDownloadURL), arg0, arg1, arg2)
 }
 
 // GetEssentialMetadata mocks base method.
-func (m *MockRepository) GetEssentialMetadata(arg0 ...charm0.MetadataRequest) ([]charm0.EssentialMetadata, error) {
+func (m *MockRepository) GetEssentialMetadata(arg0 context.Context, arg1 ...charm0.MetadataRequest) ([]charm0.EssentialMetadata, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range arg0 {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetEssentialMetadata", varargs...)
@@ -83,60 +84,61 @@ func (m *MockRepository) GetEssentialMetadata(arg0 ...charm0.MetadataRequest) ([
 }
 
 // GetEssentialMetadata indicates an expected call of GetEssentialMetadata.
-func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 ...interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEssentialMetadata", reflect.TypeOf((*MockRepository)(nil).GetEssentialMetadata), arg0...)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEssentialMetadata", reflect.TypeOf((*MockRepository)(nil).GetEssentialMetadata), varargs...)
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListResources indicates an expected call of ListResources.
-func (mr *MockRepositoryMockRecorder) ListResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockRepository)(nil).ListResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockRepository)(nil).ListResources), arg0, arg1, arg2)
 }
 
 // ResolveForDeploy mocks base method.
-func (m *MockRepository) ResolveForDeploy(arg0 charm0.CharmID) (charm0.ResolvedDataForDeploy, error) {
+func (m *MockRepository) ResolveForDeploy(arg0 context.Context, arg1 charm0.CharmID) (charm0.ResolvedDataForDeploy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveForDeploy", arg0)
+	ret := m.ctrl.Call(m, "ResolveForDeploy", arg0, arg1)
 	ret0, _ := ret[0].(charm0.ResolvedDataForDeploy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveForDeploy indicates an expected call of ResolveForDeploy.
-func (mr *MockRepositoryMockRecorder) ResolveForDeploy(arg0 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveForDeploy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveForDeploy", reflect.TypeOf((*MockRepository)(nil).ResolveForDeploy), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveForDeploy", reflect.TypeOf((*MockRepository)(nil).ResolveForDeploy), arg0, arg1)
 }
 
 // ResolveResources mocks base method.
-func (m *MockRepository) ResolveResources(arg0 []resource.Resource, arg1 charm0.CharmID) ([]resource.Resource, error) {
+func (m *MockRepository) ResolveResources(arg0 context.Context, arg1 []resource.Resource, arg2 charm0.CharmID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveResources indicates an expected call of ResolveResources.
-func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockRepository)(nil).ResolveResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockRepository)(nil).ResolveResources), arg0, arg1, arg2)
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].([]charm0.Platform)
@@ -145,9 +147,9 @@ func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm
 }
 
 // ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel.
-func (mr *MockRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockRepository)(nil).ResolveWithPreferredChannel), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockRepository)(nil).ResolveWithPreferredChannel), arg0, arg1, arg2)
 }
 
 // MockRepositoryFactory is a mock of RepositoryFactory interface.
@@ -174,16 +176,16 @@ func (m *MockRepositoryFactory) EXPECT() *MockRepositoryFactoryMockRecorder {
 }
 
 // GetCharmRepository mocks base method.
-func (m *MockRepositoryFactory) GetCharmRepository(arg0 charm0.Source) (charm0.Repository, error) {
+func (m *MockRepositoryFactory) GetCharmRepository(arg0 context.Context, arg1 charm0.Source) (charm0.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmRepository", arg0)
+	ret := m.ctrl.Call(m, "GetCharmRepository", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmRepository indicates an expected call of GetCharmRepository.
-func (mr *MockRepositoryFactoryMockRecorder) GetCharmRepository(arg0 interface{}) *gomock.Call {
+func (mr *MockRepositoryFactoryMockRecorder) GetCharmRepository(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).GetCharmRepository), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).GetCharmRepository), arg0, arg1)
 }

--- a/apiserver/facades/client/application/updatebase_mocks_test.go
+++ b/apiserver/facades/client/application/updatebase_mocks_test.go
@@ -717,17 +717,17 @@ func (m *MockUpdateBaseValidator) EXPECT() *MockUpdateBaseValidatorMockRecorder 
 }
 
 // ValidateApplication mocks base method.
-func (m *MockUpdateBaseValidator) ValidateApplication(arg0 Application, arg1 base.Base, arg2 bool) error {
+func (m *MockUpdateBaseValidator) ValidateApplication(arg0 context.Context, arg1 Application, arg2 base.Base, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateApplication", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ValidateApplication", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateApplication indicates an expected call of ValidateApplication.
-func (mr *MockUpdateBaseValidatorMockRecorder) ValidateApplication(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockUpdateBaseValidatorMockRecorder) ValidateApplication(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplication", reflect.TypeOf((*MockUpdateBaseValidator)(nil).ValidateApplication), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplication", reflect.TypeOf((*MockUpdateBaseValidator)(nil).ValidateApplication), arg0, arg1, arg2, arg3)
 }
 
 // MockCharmhubClient is a mock of CharmhubClient interface.

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -364,7 +364,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 	}
 
 	s.state.EXPECT().Charm(curl.String()).Return(nil, errors.NotFoundf("%q", curl))
-	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any(), gomock.Any()).Return(s.repository, nil)
 
 	expMeta := new(charm.Meta)
 	expManifest := new(charm.Manifest)
@@ -434,8 +434,8 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 	}
 
 	s.state.EXPECT().Charm(curl.String()).Return(nil, nil) // a nil error indicates that the charm doc already exists
-	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
-	s.repository.EXPECT().GetDownloadURL(curl, gomock.Any()).Return(resURL, resolvedOrigin, nil)
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any(), gomock.Any()).Return(s.repository, nil)
+	s.repository.EXPECT().GetDownloadURL(gomock.Any(), curl, gomock.Any()).Return(resURL, resolvedOrigin, nil)
 
 	api := s.api(c)
 
@@ -662,13 +662,14 @@ func (s *charmsMockSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error) {
-	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil).Times(times)
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any(), gomock.Any()).Return(s.repository, nil).Times(times)
 	s.repository.EXPECT().ResolveWithPreferredChannel(
+		gomock.Any(),
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(corecharm.Origin{}),
 	).DoAndReturn(
 		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
+		func(ctx context.Context, curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 
@@ -689,13 +690,14 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 }
 
 func (s *charmsMockSuite) expectResolveWithPreferredChannelNoSeries() {
-	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any(), gomock.Any()).Return(s.repository, nil)
 	s.repository.EXPECT().ResolveWithPreferredChannel(
+		gomock.Any(),
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(corecharm.Origin{}),
 	).DoAndReturn(
 		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []string, error) {
+		func(ctx context.Context, curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []string, error) {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -369,7 +369,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 	expMeta := new(charm.Meta)
 	expManifest := new(charm.Manifest)
 	expConfig := new(charm.Config)
-	s.repository.EXPECT().GetEssentialMetadata(corecharm.MetadataRequest{
+	s.repository.EXPECT().GetEssentialMetadata(gomock.Any(), corecharm.MetadataRequest{
 		CharmURL: curl,
 		Origin:   requestedOrigin,
 	}).Return([]corecharm.EssentialMetadata{

--- a/apiserver/facades/client/charms/interfaces/downloader.go
+++ b/apiserver/facades/client/charms/interfaces/downloader.go
@@ -13,7 +13,5 @@ import (
 
 // Downloader defines an API for downloading and storing charms.
 type Downloader interface {
-	// DownloadAndStore downloads the charm at the specified URL and stores it
-	// in the object store.
-	DownloadAndStore(context.Context, *charm.URL, corecharm.Origin, bool) (corecharm.Origin, error)
+	DownloadAndStore(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, force bool) (corecharm.Origin, error)
 }

--- a/apiserver/facades/client/charms/mocks/repository.go
+++ b/apiserver/facades/client/charms/mocks/repository.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	url "net/url"
 	reflect "reflect"
 
@@ -38,9 +39,9 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -48,15 +49,15 @@ func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2
 }
 
 // DownloadCharm indicates an expected call of DownloadCharm.
-func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockRepository)(nil).DownloadCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockRepository)(nil).DownloadCharm), arg0, arg1, arg2, arg3)
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -64,16 +65,16 @@ func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*u
 }
 
 // GetDownloadURL indicates an expected call of GetDownloadURL.
-func (mr *MockRepositoryMockRecorder) GetDownloadURL(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockRepository)(nil).GetDownloadURL), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockRepository)(nil).GetDownloadURL), arg0, arg1, arg2)
 }
 
 // GetEssentialMetadata mocks base method.
-func (m *MockRepository) GetEssentialMetadata(arg0 ...charm0.MetadataRequest) ([]charm0.EssentialMetadata, error) {
+func (m *MockRepository) GetEssentialMetadata(arg0 context.Context, arg1 ...charm0.MetadataRequest) ([]charm0.EssentialMetadata, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range arg0 {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetEssentialMetadata", varargs...)
@@ -83,60 +84,61 @@ func (m *MockRepository) GetEssentialMetadata(arg0 ...charm0.MetadataRequest) ([
 }
 
 // GetEssentialMetadata indicates an expected call of GetEssentialMetadata.
-func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 ...interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEssentialMetadata", reflect.TypeOf((*MockRepository)(nil).GetEssentialMetadata), arg0...)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEssentialMetadata", reflect.TypeOf((*MockRepository)(nil).GetEssentialMetadata), varargs...)
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListResources indicates an expected call of ListResources.
-func (mr *MockRepositoryMockRecorder) ListResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockRepository)(nil).ListResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockRepository)(nil).ListResources), arg0, arg1, arg2)
 }
 
 // ResolveForDeploy mocks base method.
-func (m *MockRepository) ResolveForDeploy(arg0 charm0.CharmID) (charm0.ResolvedDataForDeploy, error) {
+func (m *MockRepository) ResolveForDeploy(arg0 context.Context, arg1 charm0.CharmID) (charm0.ResolvedDataForDeploy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveForDeploy", arg0)
+	ret := m.ctrl.Call(m, "ResolveForDeploy", arg0, arg1)
 	ret0, _ := ret[0].(charm0.ResolvedDataForDeploy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveForDeploy indicates an expected call of ResolveForDeploy.
-func (mr *MockRepositoryMockRecorder) ResolveForDeploy(arg0 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveForDeploy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveForDeploy", reflect.TypeOf((*MockRepository)(nil).ResolveForDeploy), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveForDeploy", reflect.TypeOf((*MockRepository)(nil).ResolveForDeploy), arg0, arg1)
 }
 
 // ResolveResources mocks base method.
-func (m *MockRepository) ResolveResources(arg0 []resource.Resource, arg1 charm0.CharmID) ([]resource.Resource, error) {
+func (m *MockRepository) ResolveResources(arg0 context.Context, arg1 []resource.Resource, arg2 charm0.CharmID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveResources indicates an expected call of ResolveResources.
-func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockRepository)(nil).ResolveResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockRepository)(nil).ResolveResources), arg0, arg1, arg2)
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].([]charm0.Platform)
@@ -145,9 +147,9 @@ func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm
 }
 
 // ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel.
-func (mr *MockRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockRepository)(nil).ResolveWithPreferredChannel), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockRepository)(nil).ResolveWithPreferredChannel), arg0, arg1, arg2)
 }
 
 // MockRepositoryFactory is a mock of RepositoryFactory interface.
@@ -174,18 +176,18 @@ func (m *MockRepositoryFactory) EXPECT() *MockRepositoryFactoryMockRecorder {
 }
 
 // GetCharmRepository mocks base method.
-func (m *MockRepositoryFactory) GetCharmRepository(arg0 charm0.Source) (charm0.Repository, error) {
+func (m *MockRepositoryFactory) GetCharmRepository(arg0 context.Context, arg1 charm0.Source) (charm0.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmRepository", arg0)
+	ret := m.ctrl.Call(m, "GetCharmRepository", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmRepository indicates an expected call of GetCharmRepository.
-func (mr *MockRepositoryFactoryMockRecorder) GetCharmRepository(arg0 interface{}) *gomock.Call {
+func (mr *MockRepositoryFactoryMockRecorder) GetCharmRepository(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).GetCharmRepository), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).GetCharmRepository), arg0, arg1)
 }
 
 // MockCharmArchive is a mock of CharmArchive interface.

--- a/apiserver/facades/client/charms/services/downloader.go
+++ b/apiserver/facades/client/charms/services/downloader.go
@@ -4,6 +4,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -58,8 +60,8 @@ type repoFactoryShim struct {
 }
 
 // GetCharmRepository implements charmdownloader.RepositoryGetter.
-func (s repoFactoryShim) GetCharmRepository(src corecharm.Source) (charmdownloader.CharmRepository, error) {
-	repo, err := s.factory.GetCharmRepository(src)
+func (s repoFactoryShim) GetCharmRepository(ctx context.Context, src corecharm.Source) (charmdownloader.CharmRepository, error) {
+	repo, err := s.factory.GetCharmRepository(ctx, src)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/errors"
@@ -54,7 +55,7 @@ func NewCharmRepoFactory(cfg CharmRepoFactoryConfig) *CharmRepoFactory {
 
 // GetCharmRepository returns a suitable corecharm.Repository instance for the
 // requested source. Lookups are memoized for future requests.
-func (f *CharmRepoFactory) GetCharmRepository(src corecharm.Source) (corecharm.Repository, error) {
+func (f *CharmRepoFactory) GetCharmRepository(ctx context.Context, src corecharm.Source) (corecharm.Repository, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/apiserver/facades/client/charms/services/repofactory_test.go
+++ b/apiserver/facades/client/charms/services/repofactory_test.go
@@ -4,6 +4,8 @@
 package services_test
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -39,7 +41,7 @@ func (s *repoFactoryTestSuite) TestGetCharmHubRepository(c *gc.C) {
 
 	s.modelBackend.EXPECT().Config().Return(modelCfg, nil)
 
-	repo, err := s.repoFactory.GetCharmRepository(corecharm.CharmHub)
+	repo, err := s.repoFactory.GetCharmRepository(context.Background(), corecharm.CharmHub)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(repo, gc.FitsTypeOf, new(repository.CharmHubRepository), gc.Commentf("expected to get a CharmHubRepository instance"))
 }
@@ -56,11 +58,11 @@ func (s *repoFactoryTestSuite) TestGetCharmRepositoryMemoization(c *gc.C) {
 
 	s.modelBackend.EXPECT().Config().Return(modelCfg, nil)
 
-	repo1, err := s.repoFactory.GetCharmRepository(corecharm.CharmHub)
+	repo1, err := s.repoFactory.GetCharmRepository(context.Background(), corecharm.CharmHub)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(repo1, gc.FitsTypeOf, new(repository.CharmHubRepository), gc.Commentf("expected to get a CharmHubRepository instance"))
 
-	repo2, err := s.repoFactory.GetCharmRepository(corecharm.CharmHub)
+	repo2, err := s.repoFactory.GetCharmRepository(context.Background(), corecharm.CharmHub)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(repo2, gc.FitsTypeOf, new(repository.CharmHubRepository), gc.Commentf("expected to get a CharmHubRepository instance"))
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -666,7 +666,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesValidate(
 		}
 	}
 
-	validations, err := mm.upgradeSeriesAPI.Validate(entities)
+	validations, err := mm.upgradeSeriesAPI.Validate(ctx, entities)
 	if err != nil {
 		return params.UpgradeSeriesUnitsResults{}, apiservererrors.ServerError(err)
 	}
@@ -692,7 +692,7 @@ func (mm *MachineManagerAPI) UpgradeSeriesPrepare(ctx context.Context, arg param
 	if err := mm.check.ChangeAllowed(ctx); err != nil {
 		return params.ErrorResult{}, err
 	}
-	if err := mm.upgradeSeriesAPI.Prepare(arg.Entity.Tag, arg.Channel, arg.Force); err != nil {
+	if err := mm.upgradeSeriesAPI.Prepare(ctx, arg.Entity.Tag, arg.Channel, arg.Force); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 	}
 	return params.ErrorResult{}, nil

--- a/apiserver/facades/client/machinemanager/mocks/upgradebase_mock.go
+++ b/apiserver/facades/client/machinemanager/mocks/upgradebase_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	machinemanager "github.com/juju/juju/apiserver/facades/client/machinemanager"
@@ -115,32 +116,32 @@ func (mr *MockUpgradeSeriesMockRecorder) Complete(arg0 interface{}) *gomock.Call
 }
 
 // Prepare mocks base method.
-func (m *MockUpgradeSeries) Prepare(arg0, arg1 string, arg2 bool) error {
+func (m *MockUpgradeSeries) Prepare(arg0 context.Context, arg1, arg2 string, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prepare", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Prepare", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Prepare indicates an expected call of Prepare.
-func (mr *MockUpgradeSeriesMockRecorder) Prepare(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockUpgradeSeriesMockRecorder) Prepare(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockUpgradeSeries)(nil).Prepare), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockUpgradeSeries)(nil).Prepare), arg0, arg1, arg2, arg3)
 }
 
 // Validate mocks base method.
-func (m *MockUpgradeSeries) Validate(arg0 []machinemanager.ValidationEntity) ([]machinemanager.ValidationResult, error) {
+func (m *MockUpgradeSeries) Validate(arg0 context.Context, arg1 []machinemanager.ValidationEntity) ([]machinemanager.ValidationResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
 	ret0, _ := ret[0].([]machinemanager.ValidationResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockUpgradeSeriesMockRecorder) Validate(arg0 interface{}) *gomock.Call {
+func (mr *MockUpgradeSeriesMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockUpgradeSeries)(nil).Validate), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockUpgradeSeries)(nil).Validate), arg0, arg1)
 }
 
 // MockUpgradeSeriesState is a mock of UpgradeSeriesState interface.
@@ -220,17 +221,17 @@ func (m *MockUpgradeBaseValidator) EXPECT() *MockUpgradeBaseValidatorMockRecorde
 }
 
 // ValidateApplications mocks base method.
-func (m *MockUpgradeBaseValidator) ValidateApplications(arg0 []machinemanager.Application, arg1 base.Base, arg2 bool) error {
+func (m *MockUpgradeBaseValidator) ValidateApplications(arg0 context.Context, arg1 []machinemanager.Application, arg2 base.Base, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateApplications", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ValidateApplications", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateApplications indicates an expected call of ValidateApplications.
-func (mr *MockUpgradeBaseValidatorMockRecorder) ValidateApplications(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockUpgradeBaseValidatorMockRecorder) ValidateApplications(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplications", reflect.TypeOf((*MockUpgradeBaseValidator)(nil).ValidateApplications), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplications", reflect.TypeOf((*MockUpgradeBaseValidator)(nil).ValidateApplications), arg0, arg1, arg2, arg3)
 }
 
 // ValidateBase mocks base method.

--- a/apiserver/facades/client/machinemanager/upgradebase_test.go
+++ b/apiserver/facades/client/machinemanager/upgradebase_test.go
@@ -4,6 +4,8 @@
 package machinemanager_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -51,7 +53,7 @@ func (s *UpgradeSeriesSuiteValidate) TestValidate(c *gc.C) {
 	validator := mocks.NewMockUpgradeBaseValidator(ctrl)
 	validator.EXPECT().ValidateBase(corebase.MakeDefaultBase("ubuntu", "20.04"),
 		corebase.MakeDefaultBase("ubuntu", "18.04"), "machine-0").Return(nil)
-	validator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false).Return(nil)
+	validator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false).Return(nil)
 	validator.EXPECT().ValidateMachine(machine).Return(nil)
 	validator.EXPECT().ValidateUnits(units).Return(nil)
 
@@ -63,7 +65,7 @@ func (s *UpgradeSeriesSuiteValidate) TestValidate(c *gc.C) {
 	}
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	result, err := api.Validate(entities)
+	result, err := api.Validate(context.Background(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []machinemanager.ValidationResult{
 		{UnitNames: []string{"foo/0"}},
@@ -94,7 +96,7 @@ func (s *UpgradeSeriesSuiteValidate) TestValidateWithValidateBase(c *gc.C) {
 	}
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	result, err := api.Validate(entities)
+	result, err := api.Validate(context.Background(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result[0].Error, gc.ErrorMatches, `boom`)
 }
@@ -117,7 +119,7 @@ func (s *UpgradeSeriesSuiteValidate) TestValidateApplications(c *gc.C) {
 	validator := mocks.NewMockUpgradeBaseValidator(ctrl)
 	validator.EXPECT().ValidateBase(corebase.MakeDefaultBase("ubuntu", "20.04"),
 		corebase.MakeDefaultBase("ubuntu", "18.04"), "machine-0").Return(nil)
-	validator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false).Return(errors.New("boom"))
+	validator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false).Return(errors.New("boom"))
 	validator.EXPECT().ValidateMachine(machine).Return(nil)
 
 	authorizer := mocks.NewMockAuthorizer(ctrl)
@@ -128,7 +130,7 @@ func (s *UpgradeSeriesSuiteValidate) TestValidateApplications(c *gc.C) {
 	}
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	result, err := api.Validate(entities)
+	result, err := api.Validate(context.Background(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result[0].Error, gc.ErrorMatches, `boom`)
 }
@@ -165,13 +167,13 @@ func (s UpgradeSeriesSuitePrepare) TestPrepare(c *gc.C) {
 	validator := mocks.NewMockUpgradeBaseValidator(ctrl)
 	validator.EXPECT().ValidateBase(corebase.MakeDefaultBase("ubuntu", "20.04"),
 		corebase.MakeDefaultBase("ubuntu", "18.04"), "machine-0")
-	validator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	validator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	validator.EXPECT().ValidateMachine(machine).Return(nil)
 
 	authorizer := mocks.NewMockAuthorizer(ctrl)
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	err := api.Prepare("machine-0", "20.04", false)
+	err := api.Prepare(context.Background(), "machine-0", "20.04", false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -202,13 +204,13 @@ func (s UpgradeSeriesSuitePrepare) TestPrepareWithRollback(c *gc.C) {
 	validator := mocks.NewMockUpgradeBaseValidator(ctrl)
 	validator.EXPECT().ValidateBase(corebase.MakeDefaultBase("ubuntu", "20.04"),
 		corebase.MakeDefaultBase("ubuntu", "18.04"), "machine-0").Return(nil)
-	validator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	validator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	validator.EXPECT().ValidateMachine(machine).Return(nil)
 
 	authorizer := mocks.NewMockAuthorizer(ctrl)
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	err := api.Prepare("machine-0", "20.04", false)
+	err := api.Prepare(context.Background(), "machine-0", "20.04", false)
 	c.Assert(err, gc.ErrorMatches, `bad`)
 }
 
@@ -239,13 +241,13 @@ func (s UpgradeSeriesSuitePrepare) TestPrepareWithRollbackError(c *gc.C) {
 	validator := mocks.NewMockUpgradeBaseValidator(ctrl)
 	validator.EXPECT().ValidateBase(corebase.MakeDefaultBase("ubuntu", "20.04"),
 		corebase.MakeDefaultBase("ubuntu", "18.04"), "machine-0").Return(nil)
-	validator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	validator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	validator.EXPECT().ValidateMachine(machine).Return(nil)
 
 	authorizer := mocks.NewMockAuthorizer(ctrl)
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	err := api.Prepare("machine-0", "20.04", false)
+	err := api.Prepare(context.Background(), "machine-0", "20.04", false)
 	c.Assert(err, gc.ErrorMatches, `boom occurred while cleaning up from: bad`)
 }
 
@@ -265,7 +267,7 @@ func (s UpgradeSeriesSuitePrepare) TestPrepareValidationFailure(c *gc.C) {
 	authorizer := mocks.NewMockAuthorizer(ctrl)
 
 	api := machinemanager.NewUpgradeSeriesAPI(state, validator, authorizer)
-	err := api.Prepare("machine-0", "20.04", false)
+	err := api.Prepare(context.Background(), "machine-0", "20.04", false)
 	c.Assert(err, gc.ErrorMatches, `bad`)
 }
 
@@ -293,13 +295,13 @@ func (s ValidatorSuite) TestValidateApplications(c *gc.C) {
 	}
 
 	localValidator := mocks.NewMockUpgradeBaseValidator(ctrl)
-	localValidator.EXPECT().ValidateApplications([]machinemanager.Application{localApp}, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	localValidator.EXPECT().ValidateApplications(gomock.Any(), []machinemanager.Application{localApp}, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	remoteValidator := mocks.NewMockUpgradeBaseValidator(ctrl)
-	remoteValidator.EXPECT().ValidateApplications([]machinemanager.Application{charmhubApp}, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	remoteValidator.EXPECT().ValidateApplications(gomock.Any(), []machinemanager.Application{charmhubApp}, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 
 	validator := machinemanager.NewTestUpgradeSeriesValidator(localValidator, remoteValidator)
 
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -312,13 +314,13 @@ func (s ValidatorSuite) TestValidateApplicationsWithNoOrigin(c *gc.C) {
 	applications := []machinemanager.Application{application}
 
 	localValidator := mocks.NewMockUpgradeBaseValidator(ctrl)
-	localValidator.EXPECT().ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	localValidator.EXPECT().ValidateApplications(gomock.Any(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	remoteValidator := mocks.NewMockUpgradeBaseValidator(ctrl)
-	remoteValidator.EXPECT().ValidateApplications([]machinemanager.Application(nil), corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	remoteValidator.EXPECT().ValidateApplications(gomock.Any(), []machinemanager.Application(nil), corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 
 	validator := machinemanager.NewTestUpgradeSeriesValidator(localValidator, remoteValidator)
 
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -432,7 +434,7 @@ func (s StateValidatorSuite) TestValidateApplications(c *gc.C) {
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestStateSeriesValidator()
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -452,7 +454,7 @@ func (s StateValidatorSuite) TestValidateApplicationsWithNoBases(c *gc.C) {
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestStateSeriesValidator()
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, gc.ErrorMatches, `charm "my-charm" does not support any bases. Not valid`)
 }
 
@@ -473,7 +475,7 @@ func (s StateValidatorSuite) TestValidateApplicationsWithUnsupportedSeries(c *gc
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestStateSeriesValidator()
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, gc.ErrorMatches, `base "ubuntu@20.04" not supported by charm "my-charm", supported bases are: ubuntu@16.04, ubuntu@18.04`)
 }
 
@@ -491,7 +493,7 @@ func (s StateValidatorSuite) TestValidateApplicationsWithUnsupportedSeriesWithFo
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestStateSeriesValidator()
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), true)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), true)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -528,7 +530,7 @@ func (s CharmhubValidatorSuite) TestValidateApplications(c *gc.C) {
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestCharmhubSeriesValidator(client)
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -545,7 +547,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithNoRevision(c *gc.C) 
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestCharmhubSeriesValidator(client)
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, gc.ErrorMatches, `no revision found for application "foo"`)
 }
 
@@ -574,7 +576,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithClientRefreshError(c
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestCharmhubSeriesValidator(client)
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, gc.ErrorMatches, `bad`)
 }
 
@@ -605,7 +607,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithRefreshError(c *gc.C
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestCharmhubSeriesValidator(client)
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), false)
 	c.Assert(err, gc.ErrorMatches, `unable to locate application with base ubuntu@20.04: bad`)
 }
 
@@ -639,6 +641,6 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithRefreshErrorAndForce
 	applications := []machinemanager.Application{application}
 
 	validator := machinemanager.NewTestCharmhubSeriesValidator(client)
-	err := validator.ValidateApplications(applications, corebase.MakeDefaultBase("ubuntu", "20.04"), true)
+	err := validator.ValidateApplications(context.Background(), applications, corebase.MakeDefaultBase("ubuntu", "20.04"), true)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -163,7 +163,7 @@ func (a *API) AddPendingResources(ctx context.Context, args params.AddPendingRes
 		result.Error = apiservererrors.ServerError(err)
 		return result, nil
 	}
-	ids, err := a.addPendingResources(applicationID, args.URL, requestedOrigin, args.Resources)
+	ids, err := a.addPendingResources(ctx, applicationID, args.URL, requestedOrigin, args.Resources)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result, nil
@@ -172,7 +172,7 @@ func (a *API) AddPendingResources(ctx context.Context, args params.AddPendingRes
 	return result, nil
 }
 
-func (a *API) addPendingResources(appName, chRef string, origin corecharm.Origin, apiResources []params.CharmResource) ([]string, error) {
+func (a *API) addPendingResources(ctx context.Context, appName, chRef string, origin corecharm.Origin, apiResources []params.CharmResource) ([]string, error) {
 	var resources []charmresource.Resource
 	for _, apiRes := range apiResources {
 		res, err := apiresources.API2CharmResource(apiRes)
@@ -195,7 +195,7 @@ func (a *API) addPendingResources(appName, chRef string, origin corecharm.Origin
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		resources, err = repository.ResolveResources(resources, id)
+		resources, err = repository.ResolveResources(ctx, resources, id)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/resources/mocks/backend.go
+++ b/apiserver/facades/client/resources/mocks/backend.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	resource "github.com/juju/charm/v11/resource"
@@ -90,16 +91,16 @@ func (m *MockNewCharmRepository) EXPECT() *MockNewCharmRepositoryMockRecorder {
 }
 
 // ResolveResources mocks base method.
-func (m *MockNewCharmRepository) ResolveResources(arg0 []resource.Resource, arg1 charm.CharmID) ([]resource.Resource, error) {
+func (m *MockNewCharmRepository) ResolveResources(arg0 context.Context, arg1 []resource.Resource, arg2 charm.CharmID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveResources indicates an expected call of ResolveResources.
-func (mr *MockNewCharmRepositoryMockRecorder) ResolveResources(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNewCharmRepositoryMockRecorder) ResolveResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockNewCharmRepository)(nil).ResolveResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveResources", reflect.TypeOf((*MockNewCharmRepository)(nil).ResolveResources), arg0, arg1, arg2)
 }

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"context"
+
 	charmresource "github.com/juju/charm/v11/resource"
 
 	corecharm "github.com/juju/juju/core/charm"
@@ -12,12 +14,12 @@ import (
 // NewCharmRepository defines methods required by the resources
 // facade specific to an individual repository type.
 type NewCharmRepository interface {
-	ResolveResources(resources []charmresource.Resource, id corecharm.CharmID) ([]charmresource.Resource, error)
+	ResolveResources(ctx context.Context, resources []charmresource.Resource, id corecharm.CharmID) ([]charmresource.Resource, error)
 }
 
 type localClient struct{}
 
-func (lc *localClient) ResolveResources(resources []charmresource.Resource, _ corecharm.CharmID) ([]charmresource.Resource, error) {
+func (lc *localClient) ResolveResources(ctx context.Context, resources []charmresource.Resource, _ corecharm.CharmID) ([]charmresource.Resource, error) {
 	var resolved []charmresource.Resource
 	for _, res := range resources {
 		resolved = append(resolved, charmresource.Resource{

--- a/apiserver/facades/client/resources/server_addpending_test.go
+++ b/apiserver/facades/client/resources/server_addpending_test.go
@@ -62,7 +62,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpToDate(c *gc.C) {
 	res := []charmresource.Resource{
 		res1.Resource,
 	}
-	s.factory.EXPECT().ResolveResources(gomock.Any(), gomock.Any()).Return(res, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(res, nil)
 	facade := s.newFacade(c)
 
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
@@ -100,7 +100,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchComplete(c *gc.C) {
 		Origin: corecharm.Origin{Channel: &charm.Channel{}},
 	}
 	expected := []charmresource.Resource{res1.Resource}
-	s.factory.EXPECT().ResolveResources(expected, charmID).Return(expected, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), expected, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
@@ -151,7 +151,7 @@ func (s *AddPendingResourcesSuite) TestWithURLMismatchIncomplete(c *gc.C) {
 		URL:    curl,
 		Origin: corecharm.Origin{Channel: &charm.Channel{}},
 	}
-	s.factory.EXPECT().ResolveResources(res2, charmID).Return(expected, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), res2, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
@@ -199,7 +199,7 @@ func (s *AddPendingResourcesSuite) TestWithURLNoRevision(c *gc.C) {
 		URL:    curl,
 		Origin: corecharm.Origin{Channel: &charm.Channel{}},
 	}
-	s.factory.EXPECT().ResolveResources(resNoRev, charmID).Return(expected, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), resNoRev, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
@@ -240,7 +240,7 @@ func (s *AddPendingResourcesSuite) TestWithURLUpload(c *gc.C) {
 		URL:    curl,
 		Origin: corecharm.Origin{Channel: &charm.Channel{}},
 	}
-	s.factory.EXPECT().ResolveResources([]charmresource.Resource{res1.Resource}, charmID).Return(expected, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), []charmresource.Resource{res1.Resource}, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{
@@ -278,7 +278,7 @@ func (s *AddPendingResourcesSuite) TestUnknownResource(c *gc.C) {
 		URL:    curl,
 		Origin: corecharm.Origin{Channel: &charm.Channel{}},
 	}
-	s.factory.EXPECT().ResolveResources(expected, charmID).Return(expected, nil)
+	s.factory.EXPECT().ResolveResources(gomock.Any(), expected, charmID).Return(expected, nil)
 
 	facade := s.newFacade(c)
 	result, err := facade.AddPendingResources(context.Background(), params.AddPendingResourcesArgsV2{

--- a/apiserver/facades/controller/charmdownloader/interfaces.go
+++ b/apiserver/facades/controller/charmdownloader/interfaces.go
@@ -48,9 +48,7 @@ type Charm interface {
 
 // Downloader defines an API for downloading and storing charms.
 type Downloader interface {
-	// DownloadAndStore downloads the charm at the specified URL and stores it
-	// in the object store.
-	DownloadAndStore(context.Context, *charm.URL, corecharm.Origin, bool) (corecharm.Origin, error)
+	DownloadAndStore(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, force bool) (corecharm.Origin, error)
 }
 
 // AuthChecker provides an API for checking if the API client is a controller.

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -286,7 +286,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	storeCurl.Architecture = "amd64"
 	storeOrigin := origin
 	storeOrigin.Type = "charm"
-	repo.EXPECT().ResolveWithPreferredChannel(curl, origin).Return(&storeCurl, storeOrigin, nil, nil)
+	repo.EXPECT().ResolveWithPreferredChannel(gomock.Any(), curl, origin).Return(&storeCurl, storeOrigin, nil, nil)
 
 	downloader.EXPECT().DownloadAndStore(gomock.Any(), &storeCurl, storeOrigin, false).
 		DoAndReturn(func(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, force bool) (corecharm.Origin, error) {

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -134,7 +134,7 @@ func (c *BootstrapCommand) deployControllerCharm(ctx context.Context, objectStor
 var (
 	newCharmRepo = func(cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
 		charmRepoFactory := services.NewCharmRepoFactory(cfg)
-		return charmRepoFactory.GetCharmRepository(corecharm.CharmHub)
+		return charmRepoFactory.GetCharmRepository(context.TODO(), corecharm.CharmHub)
 	}
 	newCharmDownloader = func(cfg services.CharmDownloaderConfig) (interfaces.Downloader, error) {
 		return services.NewCharmDownloader(cfg)
@@ -190,7 +190,7 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 	// error response.
 	//
 	// The controller charm doesn't have any series specific code.
-	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(curl, origin)
+	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(context.TODO(), curl, origin)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "resolving %q", controllerCharmURL)
 	}

--- a/core/charm/downloader/export_test.go
+++ b/core/charm/downloader/export_test.go
@@ -4,6 +4,8 @@
 package downloader
 
 import (
+	"context"
+
 	"github.com/juju/charm/v11"
 
 	corecharm "github.com/juju/juju/core/charm"
@@ -17,6 +19,6 @@ func (d *Downloader) NormalizePlatform(charmURL string, platform corecharm.Platf
 	return d.normalizePlatform(charmURL, platform)
 }
 
-func (d *Downloader) DownloadAndHash(charmURL *charm.URL, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
-	return d.downloadAndHash(charmURL, requestedOrigin, repo, dstPath)
+func (d *Downloader) DownloadAndHash(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
+	return d.downloadAndHash(ctx, charmURL, requestedOrigin, repo, dstPath)
 }

--- a/core/charm/downloader/mocks/charm_archive_mocks.go
+++ b/core/charm/downloader/mocks/charm_archive_mocks.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	url "net/url"
 	reflect "reflect"
 
@@ -37,9 +38,9 @@ func (m *MockCharmRepository) EXPECT() *MockCharmRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockCharmRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockCharmRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -47,15 +48,15 @@ func (m *MockCharmRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin,
 }
 
 // DownloadCharm indicates an expected call of DownloadCharm.
-func (mr *MockCharmRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCharmRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockCharmRepository)(nil).DownloadCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockCharmRepository)(nil).DownloadCharm), arg0, arg1, arg2, arg3)
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockCharmRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockCharmRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -63,15 +64,15 @@ func (m *MockCharmRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin
 }
 
 // GetDownloadURL indicates an expected call of GetDownloadURL.
-func (mr *MockCharmRepositoryMockRecorder) GetDownloadURL(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCharmRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockCharmRepository)(nil).GetDownloadURL), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockCharmRepository)(nil).GetDownloadURL), arg0, arg1, arg2)
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].([]charm0.Platform)
@@ -80,7 +81,7 @@ func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 
 }
 
 // ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel.
-func (mr *MockCharmRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCharmRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockCharmRepository)(nil).ResolveWithPreferredChannel), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockCharmRepository)(nil).ResolveWithPreferredChannel), arg0, arg1, arg2)
 }

--- a/core/charm/downloader/mocks/repo_mocks.go
+++ b/core/charm/downloader/mocks/repo_mocks.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charm "github.com/juju/juju/core/charm"
@@ -36,16 +37,16 @@ func (m *MockRepositoryGetter) EXPECT() *MockRepositoryGetterMockRecorder {
 }
 
 // GetCharmRepository mocks base method.
-func (m *MockRepositoryGetter) GetCharmRepository(arg0 charm.Source) (downloader.CharmRepository, error) {
+func (m *MockRepositoryGetter) GetCharmRepository(arg0 context.Context, arg1 charm.Source) (downloader.CharmRepository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmRepository", arg0)
+	ret := m.ctrl.Call(m, "GetCharmRepository", arg0, arg1)
 	ret0, _ := ret[0].(downloader.CharmRepository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmRepository indicates an expected call of GetCharmRepository.
-func (mr *MockRepositoryGetterMockRecorder) GetCharmRepository(arg0 interface{}) *gomock.Call {
+func (mr *MockRepositoryGetterMockRecorder) GetCharmRepository(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryGetter)(nil).GetCharmRepository), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryGetter)(nil).GetCharmRepository), arg0, arg1)
 }

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -4,6 +4,7 @@
 package charm
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/juju/charm/v11"
@@ -16,41 +17,41 @@ type Repository interface {
 	// GetDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	GetDownloadURL(*charm.URL, Origin) (*url.URL, Origin, error)
+	GetDownloadURL(context.Context, *charm.URL, Origin) (*url.URL, Origin, error)
 
 	// DownloadCharm retrieves specified charm from the store and saves its
 	// contents to the specified path.
-	DownloadCharm(charmURL *charm.URL, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
+	DownloadCharm(ctx context.Context, charmURL *charm.URL, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
 
 	// ResolveWithPreferredChannel verified that the charm with the requested
 	// channel exists.  If no channel is specified, the latests, most stable is
 	// used. It returns a charm URL which includes the most current revision,
 	// if none was provided, a charm origin, and a slice of series supported by
 	// this charm.
-	ResolveWithPreferredChannel(*charm.URL, Origin) (*charm.URL, Origin, []Platform, error)
+	ResolveWithPreferredChannel(context.Context, *charm.URL, Origin) (*charm.URL, Origin, []Platform, error)
 
 	// GetEssentialMetadata resolves each provided MetadataRequest and
 	// returns back a slice with the results. The results include the
 	// minimum set of metadata that is required for deploying each charm.
-	GetEssentialMetadata(...MetadataRequest) ([]EssentialMetadata, error)
+	GetEssentialMetadata(context.Context, ...MetadataRequest) ([]EssentialMetadata, error)
 
 	// ListResources returns a list of resources associated with a given charm.
-	ListResources(*charm.URL, Origin) ([]charmresource.Resource, error)
+	ListResources(context.Context, *charm.URL, Origin) ([]charmresource.Resource, error)
 
 	// ResolveResources looks at the provided repository and backend (already
 	// downloaded) resources to determine which to use. Provided (uploaded) take
 	// precedence. If charmhub has a newer resource than the back end, use that.
-	ResolveResources(resources []charmresource.Resource, id CharmID) ([]charmresource.Resource, error)
+	ResolveResources(ctx context.Context, resources []charmresource.Resource, id CharmID) ([]charmresource.Resource, error)
 
 	// ResolveForDeploy does the same thing as ResolveWithPreferredChannel
 	// returning EssentialMetadata also. Resources are returned if a
 	// charm revision was not provided in the CharmID.
-	ResolveForDeploy(CharmID) (ResolvedDataForDeploy, error)
+	ResolveForDeploy(context.Context, CharmID) (ResolvedDataForDeploy, error)
 }
 
 // RepositoryFactory is a factory for charm Repositories.
 type RepositoryFactory interface {
-	GetCharmRepository(src Source) (Repository, error)
+	GetCharmRepository(ctx context.Context, src Source) (Repository, error)
 }
 
 // CharmArchive provides information about a downloaded charm archive.

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -86,7 +86,7 @@ func (s *charmHubRepositorySuite) testResolve(c *gc.C, id string) {
 		origin.InstanceKey = "instance-key"
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = rev
@@ -122,7 +122,7 @@ func (s *charmHubRepositorySuite) TestResolveWithChannel(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -156,7 +156,7 @@ func (s *charmHubRepositorySuite) TestResolveWithoutBase(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -197,7 +197,7 @@ func (s *charmHubRepositorySuite) TestResolveForDeployWithRevisionSuccess(c *gc.
 	}
 	arg := corecharm.CharmID{URL: curl, Origin: origin}
 
-	obtainedData, err := s.newClient().ResolveForDeploy(arg)
+	obtainedData, err := s.newClient().ResolveForDeploy(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = revision
@@ -230,7 +230,7 @@ func (s *charmHubRepositorySuite) TestResolveForDeploySuccessChooseBase(c *gc.C)
 	}
 	arg := corecharm.CharmID{URL: curl, Origin: origin}
 
-	obtainedData, err := s.newClient().ResolveForDeploy(arg)
+	obtainedData, err := s.newClient().ResolveForDeploy(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -263,7 +263,7 @@ func (s *charmHubRepositorySuite) TestResolveWithBundles(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 17
@@ -296,7 +296,7 @@ func (s *charmHubRepositorySuite) TestResolveInvalidPlatformError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -330,7 +330,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 		},
 	}
 
-	_, _, _, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	_, _, _, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, gc.ErrorMatches,
 		`(?m)selecting releases: charm or bundle not found for channel "", platform "amd64"
 available releases are:
@@ -352,7 +352,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -410,9 +410,9 @@ func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 	resolvedArchive := new(charm.CharmArchive)
 
 	s.expectCharmRefreshInstallOneFromChannel(c)
-	s.client.EXPECT().DownloadAndRead(context.TODO(), resolvedURL, "/tmp/foo").Return(resolvedArchive, nil)
+	s.client.EXPECT().DownloadAndRead(gomock.Any(), resolvedURL, "/tmp/foo").Return(resolvedArchive, nil)
 
-	gotArchive, gotOrigin, err := s.newClient().DownloadCharm(curl, requestedOrigin, "/tmp/foo")
+	gotArchive, gotOrigin, err := s.newClient().DownloadCharm(context.Background(), curl, requestedOrigin, "/tmp/foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotArchive, gc.Equals, resolvedArchive) // note: we are using gc.Equals to check the pointers here.
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -454,7 +454,7 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 
 	s.expectCharmRefreshInstallOneFromChannel(c)
 
-	gotURL, gotOrigin, err := s.newClient().GetDownloadURL(curl, requestedOrigin)
+	gotURL, gotOrigin, err := s.newClient().GetDownloadURL(context.Background(), curl, requestedOrigin)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotURL, gc.DeepEquals, resolvedURL)
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -480,7 +480,7 @@ func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	s.expectCharmRefreshInstallOneFromChannel(c) // resolve the origin
 	s.expectCharmRefreshInstallOneFromChannel(c) // refresh and get metadata
 
-	got, err := s.newClient().GetEssentialMetadata(corecharm.MetadataRequest{
+	got, err := s.newClient().GetEssentialMetadata(context.Background(), corecharm.MetadataRequest{
 		CharmURL: curl,
 		Origin:   requestedOrigin,
 	})
@@ -499,7 +499,7 @@ func (s *charmHubRepositorySuite) TestResolveResources(c *gc.C) {
 	s.expectRefresh(true)
 	s.expectListResourceRevisions(2)
 
-	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
+	result, err := s.newClient().ResolveResources(context.Background(), []charmresource.Resource{{
 		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginUpload,
 		Revision:    1,
@@ -535,7 +535,7 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStore(c *gc.C) {
 
 	id := charmID()
 	id.Origin.ID = ""
-	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
+	result, err := s.newClient().ResolveResources(context.Background(), []charmresource.Resource{{
 		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginStore,
 		Revision: 1,
@@ -555,7 +555,7 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision(c *gc.
 	defer s.setupMocks(c).Finish()
 	s.expectRefreshWithRevision(1, true)
 
-	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
+	result, err := s.newClient().ResolveResources(context.Background(), []charmresource.Resource{{
 		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginStore,
 		Revision: -1,
@@ -577,7 +577,7 @@ func (s *charmHubRepositorySuite) TestResolveResourcesNoMatchingRevision(c *gc.C
 	s.expectRefreshWithRevision(99, true)
 	s.expectListResourceRevisions(3)
 
-	_, err := s.newClient().ResolveResources([]charmresource.Resource{{
+	_, err := s.newClient().ResolveResources(context.Background(), []charmresource.Resource{{
 		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginStore,
 		Revision: 1,
@@ -592,7 +592,7 @@ func (s *charmHubRepositorySuite) TestResolveResourcesUpload(c *gc.C) {
 
 	id := charmID()
 	id.Origin.ID = ""
-	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
+	result, err := s.newClient().ResolveResources(context.Background(), []charmresource.Resource{{
 		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginUpload,
 		Revision: 3,
@@ -630,7 +630,7 @@ func (s *charmHubRepositorySuite) TestResourceInfo(c *gc.C) {
 		},
 	}
 
-	result, err := s.newClient().resourceInfo(curl, origin, "wal-e", 25)
+	result, err := s.newClient().resourceInfo(context.Background(), curl, origin, "wal-e", 25)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, charmresource.Resource{
 		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},

--- a/internal/charmhub/download.go
+++ b/internal/charmhub/download.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/trace"
 )
 

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -162,9 +162,6 @@ func contextMetrics(metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKe
 }
 
 func (c *refreshClient) refresh(ctx context.Context, ensure func(responses []transport.RefreshResponse) error, req transport.RefreshRequest) (_ []transport.RefreshResponse, err error) {
-	t, _ := trace.TracerFromContext(ctx)
-	loggo.GetLogger("***").Criticalf(">>>>>>>>>> %T", t)
-
 	ctx, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
 		trace.StringAttr("charmhub.request", "refresh"),
 		trace.StringAttr("charmhub.names", traceNames(req)),

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -162,6 +162,9 @@ func contextMetrics(metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKe
 }
 
 func (c *refreshClient) refresh(ctx context.Context, ensure func(responses []transport.RefreshResponse) error, req transport.RefreshRequest) (_ []transport.RefreshResponse, err error) {
+	t, _ := trace.TracerFromContext(ctx)
+	loggo.GetLogger("***").Criticalf(">>>>>>>>>> %T", t)
+
 	ctx, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
 		trace.StringAttr("charmhub.request", "refresh"),
 		trace.StringAttr("charmhub.names", traceNames(req)),


### PR DESCRIPTION
The following just simply wires up the tracing client for charmhub.
This is a really nice simple quick win. We know that charmhub can
be slow sometimes, so displaying that on the trace will help
us understand that when looking at various traces.


The code is __very__ mechanical.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setting up tempo

It assumes that docker (docker-compose) is correctly installed:

```sh
$ git clone https://github.com/grafana/tempo.git
$ cd tempo/example/docker-compose/local
$ docker compose up -d
```

### Juju

Replace `<IP ADDRESS>` with your host machine (not localhost) address (`lxc info | yq ".environment | .addresses"` is a good place to start looking)

```sh
$ juju bootstrap lxd test --build-agent --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=<IP ADDRESS>:4317"
$ juju add-model default
$ juju deploy ubuntu
```

Note: this won't work on `juju info` or `juju find` as those do not hit the server, so won't be included in the trace.

### Tempo Explore

In the following screenshot you can see that we make a call from the client through the apiserver to the txn runner.

![Screenshot from 2023-10-19 11-43-26](https://github.com/juju/juju/assets/2562584/1c9a6501-0ce1-4763-ae49-f224248173dc)


## Links

**Jira card:** JUJU-[XXXX]
