### PR TITLE
Fix WWW-Authenticate challenge handling with docker registries.

### DIFF
--- a/docker/auth.go
+++ b/docker/auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/docker/distribution/reference"
@@ -166,6 +167,7 @@ func (rid ImageRepoDetails) SecretData() ([]byte, error) {
 	if rid.BasicAuthConfig.Empty() && rid.TokenAuthConfig.Empty() {
 		return nil, nil
 	}
+	repo := strings.Split(rid.Repository, "/")[0]
 	rid.Repository = ""
 	if !rid.BasicAuthConfig.Empty() && rid.BasicAuthConfig.Auth.Empty() {
 		rid.BasicAuthConfig.Auth = NewToken(
@@ -173,7 +175,7 @@ func (rid ImageRepoDetails) SecretData() ([]byte, error) {
 	}
 	o := dockerConfigData{
 		Auths: map[string]ImageRepoDetails{
-			rid.ServerAddress: rid,
+			repo: rid,
 		},
 	}
 	return json.Marshal(o)

--- a/docker/auth_test.go
+++ b/docker/auth_test.go
@@ -113,7 +113,7 @@ func (s *authSuite) TestValidateImageRepoDetails(c *gc.C) {
 
 func (s *authSuite) TestSecretData(c *gc.C) {
 	imageRepoDetails := docker.ImageRepoDetails{
-		Repository:    "test-account",
+		Repository:    "quay.io/test-account",
 		ServerAddress: "quay.io",
 		BasicAuthConfig: docker.BasicAuthConfig{
 			Auth: docker.NewToken("xxxxx=="),

--- a/docker/registry/internal/base_client.go
+++ b/docker/registry/internal/base_client.go
@@ -113,8 +113,8 @@ func transportCommon(transport http.RoundTripper, repoDetails *docker.ImageRepoD
 			),
 		)
 	}
-	return newTokenTransport(
-		transport, repoDetails.Username, repoDetails.Password, repoDetails.Auth.Content(), "", false,
+	return newChallengeTransport(
+		transport, repoDetails.Username, repoDetails.Password, repoDetails.Auth.Content(),
 	), nil
 }
 

--- a/docker/registry/internal/package_test.go
+++ b/docker/registry/internal/package_test.go
@@ -29,6 +29,7 @@ type (
 
 var (
 	NewErrorTransport                  = newErrorTransport
+	NewChallengeTransport              = newChallengeTransport
 	NewBasicTransport                  = newBasicTransport
 	NewTokenTransport                  = newTokenTransport
 	NewElasticContainerRegistryForTest = newElasticContainerRegistryForTest

--- a/docker/registry/internal/transports_test.go
+++ b/docker/registry/internal/transports_test.go
@@ -271,3 +271,275 @@ func (s *transportSuite) TestUnwrapNetError(c *gc.C) {
 	c.Assert(unwrapedErr, jc.Satisfies, errors.IsNotFound)
 	c.Assert(unwrapedErr, gc.ErrorMatches, `Get "https://example.com": jujud-operator:2.6.6 not found`)
 }
+
+func (s *transportSuite) TestChallengeTransportTokenRefresh(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	mockRoundTripper := mocks.NewMockRoundTripper(ctrl)
+
+	url, err := url.Parse(`https://example.com`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		// 1st try failed - bearer token was missing.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// Refresh OAuth Token.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+	)
+	t := internal.NewChallengeTransport(mockRoundTripper, "", "", "dXNlcm5hbWU6cHdkMQ==")
+	_, err = t.RoundTrip(&http.Request{
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *transportSuite) TestChallengeTransportBasic(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	mockRoundTripper := mocks.NewMockRoundTripper(ctrl)
+
+	url, err := url.Parse(`https://example.com`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		// 1st try failed - bearer token was missing.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Basic realm="my realm"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+	)
+	t := internal.NewChallengeTransport(mockRoundTripper, "", "", "dXNlcm5hbWU6cHdkMQ==")
+	_, err = t.RoundTrip(&http.Request{
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	mockRoundTripper := mocks.NewMockRoundTripper(ctrl)
+
+	url, err := url.Parse(`https://example.com`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		// 1st try failed - bearer token was missing.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Basic realm="my realm"`,
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusUnauthorized, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+		// Refresh OAuth Token.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+
+		// re-use last successful
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Basic realm="my realm"`,
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// Refresh OAuth Token.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+
+		// re-use last successful
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Basic realm="my realm"`,
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// Refresh OAuth Token.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		// still bad
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       ioutil.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Basic realm="my realm"`,
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// retry with basic again.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+			},
+		),
+	)
+	t := internal.NewChallengeTransport(mockRoundTripper, "", "", "dXNlcm5hbWU6cHdkMQ==")
+	_, err = t.RoundTrip(&http.Request{
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Reuse
+	_, err = t.RoundTrip(&http.Request{
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Reauth
+	_, err = t.RoundTrip(&http.Request{
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -152,15 +152,15 @@ build_push_operator_image() {
 
 seed_repository() {
   set -x
-  docker pull "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}"
-	docker tag "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}" "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
-	docker push "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
+  "$DOCKER_BIN" pull "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}"
+	"$DOCKER_BIN" tag "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}" "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
+	"$DOCKER_BIN" push "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
 
   # copy all the lts that are available
   for (( i = 18; ; i += 2 )); do
-    if docker pull "docker.io/jujusolutions/charm-base:ubuntu-$i.04" ; then
-      docker tag "docker.io/jujusolutions/charm-base:ubuntu-$i.04" "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
-      docker push "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
+    if "$DOCKER_BIN" pull "docker.io/jujusolutions/charm-base:ubuntu-$i.04" ; then
+      "$DOCKER_BIN" tag "docker.io/jujusolutions/charm-base:ubuntu-$i.04" "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
+      "$DOCKER_BIN" push "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
     else
       break
     fi


### PR DESCRIPTION
Docker v2 registries employ a standard process for authentication by returning challenge in the WWW-Authenticate header. This change attempts to use this process for all generic repositories.

## QA steps

This has been tested with quay.io, jfrog artifactory, google cloud artifact repository and digital ocean registry.

- `export DOCKER_USERNAME=my-registry.com/juju-test`
- `make seed-repository`
- `JUJU_BUILD_NUMBER=0 make push-release-operator-image`
- `juju bootstrap minikube --config caas-image-repo='{"repository":"my-registry.com/juju-test","username":"<username>","password":"<password>"}'`

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2039727

**Jira card:** JUJU-4820