### PR TITLE
[JUJU-4822] Fix help text in model-defaults

### DIFF
--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -261,7 +261,7 @@ type defaultsCommandAPI interface {
 // Info implements part of the cmd.Command interface.
 func (c *defaultsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Args:     "[[<cloud>/]<region> ]<model-key>[<=value>] ...]",
+		Args:     "[<model-key>[<=value>] ...]",
 		Doc:      modelDefaultsHelpDoc,
 		Name:     "model-defaults",
 		Purpose:  modelDefaultsSummary,


### PR DESCRIPTION
There is a difference between 2.9 and 3.x in Usage -- in 2.9 one could pass cloud/region as an optional positional argument but in 3.x it must be passed via the --region flag.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

For example, 

```
juju model-defaults --region=aws/us-east-1 http-proxy
```

## Documentation changes

This is a documentation change.

## Links

**Launchpad bug:** [https://pad.lv/<bug-number>](https://bugs.launchpad.net/juju/+bug/2039112)

**Jira card:** JUJU-[4822]
