### PR TITLE
Export Oracle cloud models with region set from credentials

### DIFF
--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/macaroon.v2"
 
+	"github.com/juju/juju/cloud"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
@@ -218,6 +219,29 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	c.Assert(model.Blocks(), jc.DeepEquals, map[string]string{
 		"all-changes": "locked down",
 	})
+}
+
+func (s *MigrationExportSuite) TestModelRegionForOCICLoud(c *gc.C) {
+	cl, err := s.Model.Cloud()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cl.Type = "oci"
+	err = s.State.UpdateCloud(cl)
+	c.Assert(err, jc.ErrorIsNil)
+
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("%s/owner/name", cl.Name))
+	err = s.State.UpdateCloudCredential(tag, cloud.NewCredential(cloud.EmptyAuthType, map[string]string{
+		"region": "nether",
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.Model.SetCloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(model.CloudRegion(), gc.Equals, "nether")
 }
 
 func (s *MigrationExportSuite) TestModelUsers(c *gc.C) {


### PR DESCRIPTION
The Oracle provider on 2.9 uses the region from credential attributes as the model region.

This breaks when migrating models to 3.3 where this behaviour has been fixed to use region stored against the model itself.

Here we modify migrated OCI clouds to set the region from credential attributes if it exists.

## QA steps

- Bootstrap an OCI cloud with this patch and add a model.
- Bootstrap a 3.3 OCI, then migrate the model to it.

## Links

**Jira card:** [JUJU-4809](https://warthogs.atlassian.net/browse/JUJU-4809)

[JUJU-4809]: https://warthogs.atlassian.net/browse/JUJU-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ