### PR TITLE
Fix ami name when creating ami on CI tests

### DIFF
--- a/tests/includes/aws_ami_creation.sh
+++ b/tests/includes/aws_ami_creation.sh
@@ -71,7 +71,8 @@ create_ami_and_wait_available() {
 	echo "Created instance for ami builder: ${instance_id_ami_builder}"
 
 	# Create the ami from the ec2 instance_id
-	ami_id=$(aws ec2 create-image --instance-id "${instance_id_ami_builder}" --name "test_ami_constraints" --description "Test ami used for constraints tests" --output text)
+	ami_name="ami_name_${instance_id_ami_builder}"
+	ami_id=$(aws ec2 create-image --instance-id "${instance_id_ami_builder}" --name "${ami_name}" --description "Test ami used for constraints tests" --output text)
 
 	aws ec2 wait image-available --image-ids "${ami_id}"
 	echo "${ami_id}" >>"${TEST_DIR}/ec2-amis"

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -1,4 +1,4 @@
-series: focal
+default-base: ubuntu@20.04/stable
 applications:
   influxdb:
     charm: influxdb


### PR DESCRIPTION
This patch consists of two fixes on `test_deploy_bundles` CI test:
1) We were creating AMIs with the same name and this made tests fail, the fix consists on giving a uuid name on it.
2) One of the telegraf bundles still contained `series` instead of `default-base`.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Try running this test (if you have time) a few times to make sure we don't have any other flaky behaviour.
```
./main.sh -v -c aws -p ec2 deploy test_deploy_bundles
```

## Links

**Jira card:** JUJU-4823
