### PR TITLE
Model config in bootstrap

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -589,11 +589,11 @@ func (e *fakeEnviron) Provider() environs.EnvironProvider {
 	return e.provider
 }
 
-func bootstrapDqliteWithDummyCloudType(ctx context.Context, mgr database.BootstrapNodeManager, logger database.Logger, preferLoopback bool, ops ...database.BootstrapOpt) error {
+func bootstrapDqliteWithDummyCloudType(ctx context.Context, mgr database.BootstrapNodeManager, logger database.Logger, preferLoopback bool, concerns ...database.BootstrapConcern) error {
 	// The dummy cloud type needs to be inserted before the other operations.
-	ops = append([]database.BootstrapOpt{
-		jujujujutesting.InsertDummyCloudType,
-	}, ops...)
+	concerns = append([]database.BootstrapConcern{
+		database.BootstrapControllerConcern(jujujujutesting.InsertDummyCloudType),
+	}, concerns...)
 
-	return database.BootstrapDqlite(ctx, mgr, logger, preferLoopback, ops...)
+	return database.BootstrapDqlite(ctx, mgr, logger, preferLoopback, concerns...)
 }

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -847,11 +847,17 @@ func nullContext() environs.BootstrapContext {
 	return environscmd.BootstrapContext(context.Background(), ctx)
 }
 
-func bootstrapDqliteWithDummyCloudType(ctx context.Context, mgr database.BootstrapNodeManager, logger database.Logger, preferLoopback bool, ops ...database.BootstrapOpt) error {
+func bootstrapDqliteWithDummyCloudType(
+	ctx context.Context,
+	mgr database.BootstrapNodeManager,
+	logger database.Logger,
+	preferLoopback bool,
+	concerns ...database.BootstrapConcern,
+) error {
 	// The dummy cloud type needs to be inserted before the other operations.
-	ops = append([]database.BootstrapOpt{
-		jujutesting.InsertDummyCloudType,
-	}, ops...)
+	concerns = append([]database.BootstrapConcern{
+		database.BootstrapControllerConcern(jujutesting.InsertDummyCloudType),
+	}, concerns...)
 
-	return database.BootstrapDqlite(ctx, mgr, logger, preferLoopback, ops...)
+	return database.BootstrapDqlite(ctx, mgr, logger, preferLoopback, concerns...)
 }

--- a/domain/modelconfig/bootstrap/bootstrap.go
+++ b/domain/modelconfig/bootstrap/bootstrap.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/modelconfig/service"
+	"github.com/juju/juju/domain/modelconfig/state"
+	"github.com/juju/juju/environs/config"
+)
+
+// SetModelConfig will remove any existing model config for the model and
+// replace with the new config provided. The new config will not be hydrated
+// with any model default attributes that have not been set on the config.
+func SetModelConfig(
+	cfg *config.Config,
+	defaultsProvider service.ModelDefaultsProvider,
+) func(context.Context, database.TxnRunner) error {
+	return func(ctx context.Context, db database.TxnRunner) error {
+		attrs := cfg.AllAttrs()
+		defaults, err := defaultsProvider.ModelDefaults(ctx)
+		if err != nil {
+			return fmt.Errorf("getting model defaults: %w", err)
+		}
+
+		for k, v := range defaults {
+			if _, exists := attrs[k]; !exists && v.Value() != nil {
+				attrs[k] = v.Value()
+			}
+		}
+
+		// TODO (tlm): Currently the Juju client passes agent version to a
+		// bootstrap controller via model config. Yep very very very silly.
+		// This needs a bit more modelling in DQlite before to change the flow.
+		// To make it more digestible of the bootstrap code we are throwing it
+		// away here.
+		//
+		// What needs to happen:
+		// - model agent version in the model database correctly.
+		// - change any client code that is passing the value via config.
+		// - add migration logic to get rid of agent version out of config.
+		if _, exists := attrs[config.AgentVersionKey]; exists {
+			delete(attrs, config.AgentVersionKey)
+		}
+
+		cfg, err = config.New(config.NoDefaults, attrs)
+		if err != nil {
+			return fmt.Errorf("constructing new model config with model defaults: %w", err)
+		}
+
+		_, err = config.ModelValidator().Validate(cfg, nil)
+		if err != nil {
+			return fmt.Errorf("validating model config to set for model: %w", err)
+		}
+
+		rawCfg, err := service.CoerceConfigForStorage(cfg.AllAttrs())
+		if err != nil {
+			return fmt.Errorf("coercing model config for storage: %w", err)
+		}
+
+		return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			return state.SetModelConfig(ctx, rawCfg, tx)
+		})
+	}
+}

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/modeldefaults"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/environs/config"
+)
+
+type bootstrapSuite struct {
+	schematesting.ModelSuite
+}
+
+type ModelDefaultsProviderFunc func(context.Context) (modeldefaults.Defaults, error)
+
+var _ = gc.Suite(&bootstrapSuite{})
+
+func (f ModelDefaultsProviderFunc) ModelDefaults(
+	c context.Context,
+) (modeldefaults.Defaults, error) {
+	return f(c)
+}
+
+func (s *bootstrapSuite) TestSetModelConfig(c *gc.C) {
+	var defaults ModelDefaultsProviderFunc = func(_ context.Context) (modeldefaults.Defaults, error) {
+		return modeldefaults.Defaults{
+			"foo": modeldefaults.DefaultAttributeValue{
+				Controller: "bar",
+			},
+		}, nil
+	}
+
+	cfg, err := config.New(config.NoDefaults, map[string]any{
+		"name": "wallyworld",
+		"uuid": "a677bdfd-3c96-46b2-912f-38e25faceaf7",
+		"type": "sometype",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = SetModelConfig(cfg, defaults)(context.Background(), s.TxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+
+	rows, err := s.DB().Query("SELECT * FROM model_config")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	configVals := map[string]string{}
+	var k, v string
+	for rows.Next() {
+		err = rows.Scan(&k, &v)
+		c.Assert(err, jc.ErrorIsNil)
+		configVals[k] = v
+	}
+
+	c.Assert(rows.Err(), jc.ErrorIsNil)
+	c.Assert(configVals, jc.DeepEquals, map[string]string{
+		"name":           "wallyworld",
+		"uuid":           "a677bdfd-3c96-46b2-912f-38e25faceaf7",
+		"type":           "sometype",
+		"foo":            "bar",
+		"logging-config": "<root>=INFO",
+		"secret-backend": "auto",
+	})
+}

--- a/domain/modelconfig/bootstrap/package_test.go
+++ b/domain/modelconfig/bootstrap/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/modelconfig/service/coerce.go
+++ b/domain/modelconfig/service/coerce.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-// coerceConfigForStorage is responsible for taking a config object and
+// CoerceConfigForStorage is responsible for taking a config object and
 // distilling all of its attribute values down to strings for persistence. The
 // best way to have complex types go through this function is for type to
 // implement the stringer interface.
@@ -21,7 +21,7 @@ import (
 // persistence. Instead, the config should be providing translation helpers to
 // deal with this so that each attribute can be encapsulated on its own.
 // This is a leftover copy from Mongo and should be dealt with at some stage.
-func coerceConfigForStorage(attrs map[string]any) (map[string]string, error) {
+func CoerceConfigForStorage(attrs map[string]any) (map[string]string, error) {
 	coerced := make(map[string]string, len(attrs))
 
 	for attrName, attrValue := range attrs {

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -155,7 +155,7 @@ func (s *Service) SetModelConfig(
 		return fmt.Errorf("validating model config to set for model: %w", err)
 	}
 
-	rawCfg, err := coerceConfigForStorage(cfg.AllAttrs())
+	rawCfg, err := CoerceConfigForStorage(cfg.AllAttrs())
 	if err != nil {
 		return fmt.Errorf("coercing model config for storage: %w", err)
 	}
@@ -199,7 +199,7 @@ func (s *Service) UpdateModelConfig(
 		return fmt.Errorf("validating updated model configuration: %w", err)
 	}
 
-	rawCfg, err := coerceConfigForStorage(updateAttrs)
+	rawCfg, err := CoerceConfigForStorage(updateAttrs)
 	if err != nil {
 		return fmt.Errorf("coercing new configuration for persistence: %w", err)
 	}

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/juju/juju/domain/modeldefaults"
+	"github.com/juju/juju/domain/modeldefaults/service"
+)
+
+// ModelDefaultsProvider is a bootstrap helper that wraps the raw config values
+// passed in during bootstrap into a model default provider interface to be used
+// when persisting initial model config. Config passed to this func can be nil.
+func ModelDefaultsProvider(
+	configDefaults map[string]any,
+	controllerConfig map[string]any,
+	cloudRegionConfig map[string]any,
+) service.ModelDefaultsProviderFunc {
+	return func(ctx context.Context) (modeldefaults.Defaults, error) {
+		defaults := modeldefaults.Defaults{}
+
+		for k, v := range configDefaults {
+			attr := defaults[k]
+			attr.Default = v
+			defaults[k] = attr
+		}
+
+		for k, v := range controllerConfig {
+			attr := defaults[k]
+			attr.Default = v
+			defaults[k] = attr
+		}
+
+		for k, v := range cloudRegionConfig {
+			attr := defaults[k]
+			attr.Default = v
+			defaults[k] = attr
+		}
+
+		return defaults, nil
+	}
+}

--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -11,7 +11,9 @@ import (
 	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
+	coreschema "github.com/juju/juju/core/database/schema"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/pragma"
@@ -61,6 +63,64 @@ func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx)
 	return errors.Trace(StdTxn(ctx, r.db, f))
 }
 
+// BootstrapConcern is a type for describing a set of bootstrap operations to
+// perform on a dqlite application.
+type BootstrapConcern = func(ctx context.Context, logger Logger, dqlite *app.App) error
+
+// BootstrapControllerConcern is a BootstrapConcern type that will run the
+// provided BootstrapOpts on the controller database.
+func BootstrapControllerConcern(ops ...BootstrapOpt) BootstrapConcern {
+	return bootstrapDBConcern(coredatabase.ControllerNS, schema.ControllerDDL(), ops...)
+}
+
+// BootstrapModelConcern is a BootstrapConcern type that will run the
+// provided BootstrapOpts on the specified model database.
+func BootstrapModelConcern(uuid model.UUID, ops ...BootstrapOpt) BootstrapConcern {
+	return bootstrapDBConcern(uuid.String(), schema.ModelDDL(), ops...)
+}
+
+func bootstrapDBConcern(
+	namespace string,
+	namespaceSchema *coreschema.Schema,
+	ops ...BootstrapOpt,
+) BootstrapConcern {
+	return func(ctx context.Context, logger Logger, dqlite *app.App) error {
+		db, err := dqlite.Open(ctx, namespace)
+		if err != nil {
+			return errors.Annotatef(err, "opening database for namespace %q", namespace)
+		}
+
+		if err := pragma.SetPragma(ctx, db, pragma.ForeignKeysPragma, true); err != nil {
+			return errors.Annotatef(err, "setting foreign keys pragma for namespace %q", namespace)
+		}
+
+		defer func() {
+			if err := db.Close(); err != nil {
+				logger.Errorf("closing database with namespace %q: %v", namespace, err)
+			}
+		}()
+
+		runner := &txnRunner{db: db}
+
+		migration := NewDBMigration(runner, logger, namespaceSchema)
+		if err := migration.Apply(ctx); err != nil {
+			return errors.Annotatef(err, "creating database with namespace %q schema", namespace)
+		}
+
+		for i, op := range ops {
+			if err := op(ctx, runner); err != nil {
+				return errors.Annotatef(
+					err,
+					"running bootstrap operation at index %d for database with namespace %q",
+					i,
+					namespace,
+				)
+			}
+		}
+		return nil
+	}
+}
+
 // BootstrapOpt is a function run when bootstrapping a database,
 // used to insert initial data into the model.
 type BootstrapOpt func(context.Context, coredatabase.TxnRunner) error
@@ -81,7 +141,7 @@ func BootstrapDqlite(
 	mgr BootstrapNodeManager,
 	logger Logger,
 	preferLoopback bool,
-	ops ...BootstrapOpt,
+	concerns ...BootstrapConcern,
 ) error {
 	dir, err := mgr.EnsureDataDir()
 	if err != nil {
@@ -119,41 +179,9 @@ func BootstrapDqlite(
 		return errors.Annotatef(err, "waiting for Dqlite readiness")
 	}
 
-	db, err := dqlite.Open(ctx, coredatabase.ControllerNS)
-	if err != nil {
-		return errors.Annotatef(err, "opening controller database")
-	}
-
-	if err := pragma.SetPragma(ctx, db, pragma.ForeignKeysPragma, true); err != nil {
-		return errors.Annotate(err, "setting foreign keys pragma")
-	}
-
-	defer func() {
-		if err := db.Close(); err != nil {
-			logger.Errorf("closing controller database: %v", err)
-		}
-	}()
-
-	runner := &txnRunner{db: db}
-
-	if err := NewDBMigration(runner, logger, schema.ControllerDDL()).Apply(ctx); err != nil {
-		return errors.Annotate(err, "creating controller database schema")
-	}
-
-	// Insert the controller node ID.
-	if err := InsertControllerNodeID(ctx, runner, dqlite.ID()); err != nil {
-		// If the controller node ID already exists, we assume that
-		// the database has already been bootstrapped. Mask the unique
-		// constraint error with a more user-friendly error.
-		if IsErrConstraintUnique(err) {
-			return errors.AlreadyExistsf("controller node ID")
-		}
-		return errors.Annotatef(err, "inserting controller node ID")
-	}
-
-	for i, op := range ops {
-		if err := op(ctx, runner); err != nil {
-			return errors.Annotatef(err, "running bootstrap operation at index %d", i)
+	for i, concern := range concerns {
+		if err := concern(ctx, logger, dqlite); err != nil {
+			return errors.Annotatef(err, "running bootstrap concern at index %d", i)
 		}
 	}
 

--- a/internal/database/bootstrap_test.go
+++ b/internal/database/bootstrap_test.go
@@ -57,7 +57,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 		})
 	}
 
-	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, true, check)
+	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, true, BootstrapControllerConcern(check))
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
This PR adds support for bootstrapping the controllers model config into dqlite. It takes verbatim the config passed to it by the bootstrap process and persists the result to the controller models config.

- New bootstrap funcs for model defaults and model config.
- Adds support for bootstrapping of model database. This new mechanism is temporary and will be replaced with a more robust solution in time.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Unit tests
2. Bootstrap a new controller and make sure the process succeeds. We aren't going to verify the result at the moment. The next PR will allow us to verify the state and modify.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4256