### PR TITLE
Add correct watcher to catacomb

### DIFF
--- a/worker/environ/environ.go
+++ b/worker/environ/environ.go
@@ -126,7 +126,7 @@ func (t *Tracker) loop() (err error) {
 		if err != nil {
 			return errors.Annotate(err, "cannot watch environ cloud spec")
 		}
-		if err := t.catacomb.Add(environWatcher); err != nil {
+		if err := t.catacomb.Add(cloudWatcher); err != nil {
 			return errors.Trace(err)
 		}
 		cloudWatcherChanges = cloudWatcher.Changes()


### PR DESCRIPTION
Instead of adding the just created cloudWatcher to the worker catacomb, the previously created environWatcher was being added instead. One line fix for this typo.