### PR TITLE
Fix "detecing" ("detecting") typo in k8s provider

### DIFF
--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -18,7 +18,7 @@ func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 
 	localKubeConfigClouds, err := localKubeConfigClouds()
 	if err != nil {
-		return clouds, errors.Annotate(err, "detecing local kube config clouds")
+		return clouds, errors.Annotate(err, "detecting local kube config clouds")
 	}
 	clouds = append(clouds, localKubeConfigClouds...)
 
@@ -62,7 +62,7 @@ func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error)
 
 	localKubeConfigClouds, err := localKubeConfigClouds()
 	if err != nil {
-		return cloud.Cloud{}, errors.Annotatef(err, "detecing local kube config clouds for %s", name)
+		return cloud.Cloud{}, errors.Annotatef(err, "detecting local kube config clouds for %s", name)
 	}
 
 	for _, cloud := range localKubeConfigClouds {


### PR DESCRIPTION
In the user-facing output of the k8s provider, an English typo of the word _"detecting"_ is present.
It was bugging me a lot. So this commit corrects _"detecing"_ to _"detecting"_ everywhere the typo occurred.

## Checklist
- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
No QA steps are necessary apart from validating the fix of the typo through CLI.

## Documentation changes
No documentation changes are necessary.

## Links
None.