### PR TITLE
Modelconfig logic moved from facade to service

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -413,7 +413,7 @@ func (b *AgentBootstrap) verifyModelConfigDefaultSpace(st *state.State) error {
 	}
 
 	_, err = st.SpaceByName(name)
-	return errors.Annotatef(err, "cannot verify %s", config.DefaultSpace)
+	return errors.Annotatef(err, "cannot verify %s", config.DefaultSpaceKey)
 }
 
 func (b *AgentBootstrap) getCloudCredential() (cloud.Credential, names.CloudCredentialTag, error) {

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -170,8 +170,7 @@ func (c *ModelConfigAPI) ModelSet(ctx context.Context, args params.ModelSet) err
 	checkSecretBackend := c.checkSecretBackend()
 
 	// Replace any deprecated attributes with their new values.
-	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	return c.backend.UpdateModelConfig(attrs,
+	return c.backend.UpdateModelConfig(args.Config,
 		nil,
 		checkAgentVersion,
 		checkLogTrace,

--- a/domain/modelconfig/validators/package_test.go
+++ b/domain/modelconfig/validators/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package validators
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/modelconfig/validators/validators.go
+++ b/domain/modelconfig/validators/validators.go
@@ -1,0 +1,161 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package validators
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/environs/config"
+)
+
+// CharmhubURLChange returns a config validator that will check to make sure
+// the charm hub url has not changed.
+func CharmhubURLChange() config.ValidatorFunc {
+	return func(cfg, old *config.Config) (*config.Config, error) {
+		if v, has := cfg.CharmHubURL(); has {
+			oldURL, _ := old.CharmHubURL()
+			if v != oldURL {
+				return cfg, &config.ValidationError{
+					InvalidAttrs: []string{config.CharmHubURLKey},
+					Reason:       "charmhub-url cannot be changed",
+				}
+			}
+		}
+		return cfg, nil
+	}
+}
+
+// SpaceProvider is responsible for checking if a given space exists.
+type SpaceProvider interface {
+	// HasSpace checks if the supplied space exists within the controller. If
+	// during the course of checking for space existence false and an error will
+	// be returned.
+	HasSpace(string) (bool, error)
+}
+
+// SpaceChecker will validate a model config's space to see if it exists within
+// this Juju controller. Should the space not exist an error satisfying
+// config.ValidationError will be returned.
+func SpaceChecker(provider SpaceProvider) config.ValidatorFunc {
+	return func(cfg, old *config.Config) (*config.Config, error) {
+		spaceName := cfg.DefaultSpace()
+		if spaceName == "" {
+			// No need to verify if the space isn't defined
+			return cfg, nil
+		}
+
+		has, err := provider.HasSpace(spaceName)
+		if err != nil {
+			return cfg, fmt.Errorf("checking for space %q existence to validate model config: %w", spaceName, err)
+		}
+
+		if !has {
+			return cfg, &config.ValidationError{
+				InvalidAttrs: []string{config.DefaultSpaceKey},
+				Reason:       fmt.Sprintf("space %q does not exist", spaceName),
+			}
+		}
+
+		return cfg, nil
+	}
+}
+
+const (
+	// ErrorLogTracingPermission is a specific error to indicate that trace
+	// level logging cannot be enabled within model config because the user
+	// requesting the change does not have adequate permission.
+	ErrorLogTracingPermission = errors.ConstError("permission denied setting log level to tracing")
+)
+
+// LoggingTracePermissionChecker checks the logging config for both validity and
+// the existence of trace level debugging. If the logging config contains trace
+// level logging and the canTrace is set to false we error with an error that
+// satisfies both ErrorLogTracingPermission and config.ValidationError.
+func LoggingTracePermissionChecker(canTrace bool) config.ValidatorFunc {
+	return func(cfg, old *config.Config) (*config.Config, error) {
+		// If we can trace no point in checking to see if we having tracing.
+		if canTrace {
+			return cfg, nil
+		}
+
+		rawLogConf := cfg.LoggingConfig()
+		logCfg, err := loggo.ParseConfigString(rawLogConf)
+		if err != nil {
+			return cfg, &config.ValidationError{
+				InvalidAttrs: []string{config.LoggingConfigKey},
+				Reason:       fmt.Sprintf("failed to parse logging config %q: %v", rawLogConf, err),
+			}
+		}
+
+		haveTrace := false
+		for _, level := range logCfg {
+			haveTrace = level == loggo.TRACE
+			if haveTrace {
+				break
+			}
+		}
+		// No TRACE level requested, so no need to permission check.
+		if !haveTrace {
+			return cfg, nil
+		}
+
+		if !canTrace && haveTrace {
+			return cfg, fmt.Errorf(
+				"%w %w",
+				ErrorLogTracingPermission,
+				&config.ValidationError{
+					InvalidAttrs: []string{config.LoggingConfigKey},
+				},
+			)
+		}
+
+		return cfg, nil
+	}
+}
+
+// SecretBackendProvider is responsible for checking if a given secrets backend
+// exists.
+type SecretBackendProvider interface {
+	// HasSecretsBackend checks if the provided secrets backend name exists. If
+	// an error occurs during checking for the backend false and a subsequent
+	// error is returned.
+	HasSecretsBackend(string) (bool, error)
+}
+
+// SecretBackendChecker is responsible for asserting the secret backend in the
+// updated model config is a valid secret backend in the controller. If the
+// secret backend has not changed or is the default backend then no validation
+// is performed. Any validation errors will satisfy config.ValidationError.
+func SecretBackendChecker(provider SecretBackendProvider) config.ValidatorFunc {
+	return func(cfg, old *config.Config) (*config.Config, error) {
+		backendName := cfg.SecretBackend()
+		if backendName == old.SecretBackend() {
+			return cfg, nil
+		}
+		if backendName == "" {
+			return cfg, &config.ValidationError{
+				InvalidAttrs: []string{config.SecretBackendKey},
+				Reason:       "secret back cannot be empty",
+			}
+		}
+		if backendName == config.DefaultSecretBackend {
+			return cfg, nil
+		}
+
+		has, err := provider.HasSecretsBackend(backendName)
+		if err != nil {
+			return cfg, fmt.Errorf("fetching secret backend for %q to validate model config: %w", backendName, err)
+		}
+		if !has {
+			return cfg, &config.ValidationError{
+				InvalidAttrs: []string{config.SecretBackendKey},
+				Reason:       fmt.Sprintf("secret backend %q not found", backendName),
+			}
+		}
+		return cfg, nil
+	}
+}

--- a/domain/modelconfig/validators/validators_test.go
+++ b/domain/modelconfig/validators/validators_test.go
@@ -1,0 +1,299 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package validators
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/testing"
+)
+
+type dummySecretBackendProviderFunc func(string) (bool, error)
+
+type dummySpaceProviderFunc func(string) (bool, error)
+
+type validatorsSuite struct{}
+
+var _ = gc.Suite(&validatorsSuite{})
+
+func (d dummySecretBackendProviderFunc) HasSecretsBackend(s string) (bool, error) {
+	return d(s)
+}
+
+func (d dummySpaceProviderFunc) HasSpace(s string) (bool, error) {
+	return d(s)
+}
+
+func (_ *validatorsSuite) TestCharmhubURLChange(c *gc.C) {
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":         "wallyworld",
+		"uuid":         testing.ModelTag.Id(),
+		"type":         "sometype",
+		"charmhub-url": "https://charmhub.example.com",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":         "wallyworld",
+		"uuid":         testing.ModelTag.Id(),
+		"type":         "sometype",
+		"charmhub-url": "https://charmhub1.example.com",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var validationError *config.ValidationError
+	_, err = CharmhubURLChange()(newCfg, oldCfg)
+	c.Assert(errors.As(err, &validationError), jc.IsTrue)
+	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"charmhub-url"})
+}
+
+func (_ *validatorsSuite) TestCharmhubURLNoChange(c *gc.C) {
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":         "wallyworld",
+		"uuid":         testing.ModelTag.Id(),
+		"type":         "sometype",
+		"charmhub-url": "https://charmhub.example.com",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":         "wallyworld",
+		"uuid":         testing.ModelTag.Id(),
+		"type":         "sometype",
+		"charmhub-url": "https://charmhub.example.com",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = CharmhubURLChange()(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *validatorsSuite) TestSpaceCheckerFound(c *gc.C) {
+	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "foobar")
+		return true, nil
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *validatorsSuite) TestSpaceCheckerNotFound(c *gc.C) {
+	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "foobar")
+		return false, nil
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	var validationError *config.ValidationError
+	c.Assert(errors.As(err, &validationError), jc.IsTrue)
+	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"default-space"})
+}
+
+func (_ *validatorsSuite) TestSpaceCheckerError(c *gc.C) {
+	providerErr := errors.New("some error")
+	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "foobar")
+		return false, providerErr
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":          "wallyworld",
+		"uuid":          testing.ModelTag.Id(),
+		"type":          "sometype",
+		"default-space": "foobar",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIs, providerErr)
+}
+
+func (_ *validatorsSuite) TestLoggincTracePermissionNoTrace(c *gc.C) {
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name": "wallyworld",
+		"uuid": testing.ModelTag.Id(),
+		"type": "sometype",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"logging-config": "root=DEBUG",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = LoggingTracePermissionChecker(false)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *validatorsSuite) TestLoggincTracePermissionTrace(c *gc.C) {
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name": "wallyworld",
+		"uuid": testing.ModelTag.Id(),
+		"type": "sometype",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"logging-config": "root=TRACE",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = LoggingTracePermissionChecker(false)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIs, ErrorLogTracingPermission)
+
+	var validationError *config.ValidationError
+	c.Assert(errors.As(err, &validationError), jc.IsTrue)
+	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"logging-config"})
+}
+
+func (_ *validatorsSuite) TestLoggincTracePermissionTraceAllow(c *gc.C) {
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name": "wallyworld",
+		"uuid": testing.ModelTag.Id(),
+		"type": "sometype",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"logging-config": "root=TRACE",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = LoggingTracePermissionChecker(true)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *validatorsSuite) TestSecretsBackendChecker(c *gc.C) {
+	provider := dummySecretBackendProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "vault")
+		return true, nil
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "default",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "vault",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *validatorsSuite) TestSecretsBackendCheckerNoExist(c *gc.C) {
+	provider := dummySecretBackendProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "vault")
+		return false, nil
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "default",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "vault",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	var validationError *config.ValidationError
+	c.Assert(errors.As(err, &validationError), jc.IsTrue)
+	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"secret-backend"})
+}
+
+func (_ *validatorsSuite) TestSecretsBackendCheckerProviderError(c *gc.C) {
+	providerErr := errors.New("some error")
+	provider := dummySecretBackendProviderFunc(func(s string) (bool, error) {
+		c.Assert(s, gc.Equals, "vault")
+		return false, providerErr
+	})
+
+	oldCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "default",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newCfg, err := config.New(config.NoDefaults, map[string]any{
+		"name":           "wallyworld",
+		"uuid":           testing.ModelTag.Id(),
+		"type":           "sometype",
+		"secret-backend": "vault",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	c.Assert(err, jc.ErrorIs, providerErr)
+}

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -29,13 +29,13 @@ func ModelDefaultsProvider(
 
 		for k, v := range controllerConfig {
 			attr := defaults[k]
-			attr.Default = v
+			attr.Controller = v
 			defaults[k] = attr
 		}
 
 		for k, v := range cloudRegionConfig {
 			attr := defaults[k]
-			attr.Default = v
+			attr.Region = v
 			defaults[k] = attr
 		}
 

--- a/domain/modeldefaults/bootstrap/bootstrap_test.go
+++ b/domain/modeldefaults/bootstrap/bootstrap_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/modeldefaults"
+)
+
+type bootstrapSuite struct{}
+
+var _ = gc.Suite(&bootstrapSuite{})
+
+func (_ *bootstrapSuite) TestBootstrapModelDefaults(c *gc.C) {
+	provider := ModelDefaultsProvider(
+		map[string]any{
+			"foo":     "default",
+			"default": "some value",
+		},
+		map[string]any{
+			"foo":        "controller",
+			"controller": "some value",
+		},
+		map[string]any{
+			"foo":    "region",
+			"region": "some value",
+		},
+	)
+
+	defaults, err := provider.ModelDefaults(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
+		"foo": modeldefaults.DefaultAttributeValue{
+			Default:    "default",
+			Controller: "controller",
+			Region:     "region",
+		},
+		"default": modeldefaults.DefaultAttributeValue{
+			Default: "some value",
+		},
+		"controller": modeldefaults.DefaultAttributeValue{
+			Controller: "some value",
+		},
+		"region": modeldefaults.DefaultAttributeValue{
+			Region: "some value",
+		},
+	})
+}

--- a/domain/modeldefaults/bootstrap/package_test.go
+++ b/domain/modeldefaults/bootstrap/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/modeldefaults/package_test.go
+++ b/domain/modeldefaults/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modeldefaults
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/modeldefaults/service/service_test.go
+++ b/domain/modeldefaults/service/service_test.go
@@ -4,9 +4,114 @@
 package service
 
 import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/model"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	modeltesting "github.com/juju/juju/domain/model/testing"
+	"github.com/juju/juju/domain/modeldefaults"
+	"github.com/juju/juju/domain/modeldefaults/service/testing"
 )
 
 type serviceSuite struct{}
 
 var _ = gc.Suite(&serviceSuite{})
+
+func (_ *serviceSuite) TestModelDefaultsForNonExistentModel(c *gc.C) {
+	uuid := modeltesting.GenModelUUID(c)
+	svc := NewService(&testing.State{})
+
+	defaults, err := svc.ModelDefaults(context.Background(), uuid)
+	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
+	c.Assert(len(defaults), gc.Equals, 0)
+
+	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
+	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
+	c.Assert(len(defaults), gc.Equals, 0)
+}
+
+func (_ *serviceSuite) TestModelDefaultsProviderNotFound(c *gc.C) {
+	uuid := modeltesting.GenModelUUID(c)
+	svc := NewService(&testing.State{
+		Defaults: map[string]any{
+			"wallyworld": "peachy",
+		},
+		CloudDefaults: map[model.UUID]map[string]string{
+			uuid: {
+				"foo": "bar",
+			},
+		},
+	})
+
+	defaults, err := svc.ModelDefaults(context.Background(), uuid)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
+		"wallyworld": modeldefaults.DefaultAttributeValue{
+			Default: "peachy",
+		},
+		"foo": modeldefaults.DefaultAttributeValue{
+			Controller: "bar",
+		},
+	})
+
+	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
+		"wallyworld": modeldefaults.DefaultAttributeValue{
+			Default: "peachy",
+		},
+		"foo": modeldefaults.DefaultAttributeValue{
+			Controller: "bar",
+		},
+	})
+}
+
+func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
+	uuid := modeltesting.GenModelUUID(c)
+	svc := NewService(&testing.State{
+		Defaults: map[string]any{
+			"wallyworld": "peachy",
+		},
+		CloudDefaults: map[model.UUID]map[string]string{
+			uuid: {
+				"foo": "bar",
+			},
+		},
+		CloudRegionDefaults: map[model.UUID]map[string]string{
+			uuid: {
+				"bar": "foo",
+			},
+		},
+	})
+
+	defaults, err := svc.ModelDefaults(context.Background(), uuid)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
+		"wallyworld": modeldefaults.DefaultAttributeValue{
+			Default: "peachy",
+		},
+		"foo": modeldefaults.DefaultAttributeValue{
+			Controller: "bar",
+		},
+		"bar": modeldefaults.DefaultAttributeValue{
+			Region: "foo",
+		},
+	})
+
+	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
+		"wallyworld": modeldefaults.DefaultAttributeValue{
+			Default: "peachy",
+		},
+		"foo": modeldefaults.DefaultAttributeValue{
+			Controller: "bar",
+		},
+		"bar": modeldefaults.DefaultAttributeValue{
+			Region: "foo",
+		},
+	})
+}

--- a/domain/modeldefaults/service/testing/state.go
+++ b/domain/modeldefaults/service/testing/state.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/domain/model"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/environs/config"
+)
+
+// State is a testing in memory implementation of State for model defaults
+// service.
+type State struct {
+	// CloudDefaults represents the cloud defaults on a per model basis and is
+	// what is returned.
+	CloudDefaults map[model.UUID]map[string]string
+
+	// CloudRegionDefaults represents the defaults set for a models cloud region
+	// and is what is returned for ModelCloudRegionDefaults.
+	CloudRegionDefaults map[model.UUID]map[string]string
+
+	// ProviderConfigSchema represents the provider defaults returned for a given
+	// model and is what is returned in ModelProviderconfigSchema.
+	ProviderConfigSchema map[model.UUID]config.ConfigSchemaSource
+
+	// Defaults is the values returned for ConfigDefaults. If this value is nil
+	// then the defaults recorded in environs config is returned.
+	Defaults map[string]any
+}
+
+// ConfigDefaults returns the default configuration values set in Juju.
+func (s *State) ConfigDefaults(_ context.Context) map[string]any {
+	if s.Defaults == nil {
+		return config.ConfigDefaults()
+	}
+	return s.Defaults
+}
+
+// ModelCloudDefaults returns the defaults associated with the model's cloud.
+func (s *State) ModelCloudDefaults(_ context.Context, uuid model.UUID) (map[string]string, error) {
+	defaults, exists := s.CloudDefaults[uuid]
+	if !exists {
+		return map[string]string{}, fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+	}
+	return defaults, nil
+}
+
+// ModelCloudRegionDefaults returns the defaults associated with the models
+// set cloud region.
+func (s *State) ModelCloudRegionDefaults(_ context.Context, uuid model.UUID) (map[string]string, error) {
+	if defaults, exists := s.CloudRegionDefaults[uuid]; exists {
+		return defaults, nil
+	}
+	return map[string]string{}, nil
+}
+
+// ModelProviderConfigSchema returns the providers config schema source based on
+// the cloud set for the model.
+func (s *State) ModelProviderConfigSchema(_ context.Context, uuid model.UUID) (config.ConfigSchemaSource, error) {
+	if schemaSource, exists := s.ProviderConfigSchema[uuid]; exists {
+		return schemaSource, nil
+	}
+	return nil, errors.NotFound
+}

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -3,10 +3,17 @@
 
 package modeldefaults
 
+import (
+	"reflect"
+
+	"github.com/juju/juju/environs/config"
+)
+
 // DefaultAttributeValue represents a model config default attribute value and
 // the hierarchical nature of where defaults can come from within Juju.
 type DefaultAttributeValue struct {
-	// Controller represents a value that come from the controller
+	// Controller represents a value that comes from the controller,
+	// specifically the cloud.
 	Controller any
 
 	// Default represents a value that comes from Juju.
@@ -16,7 +23,32 @@ type DefaultAttributeValue struct {
 	Region any
 }
 
+// Defaults represents a set of default values for a given attribute broken down
+// based on the different sources of the value.
 type Defaults map[string]DefaultAttributeValue
+
+// Has reports if the current Value() of this default attribute is equal to the
+// value passed in and also the source of the value. If the current Value() or
+// val is nil then false and empty string is returned. If this default attribute
+// does not have val then false and empty string is returned.
+func (d DefaultAttributeValue) Has(val any) (bool, string) {
+	setVal := d.Value()
+	if setVal == nil || val == nil {
+		return false, ""
+	}
+
+	equal := false
+	switch setVal.(type) {
+	case []any:
+		equal = reflect.DeepEqual(setVal, val)
+	default:
+		equal = setVal == val
+	}
+	if equal {
+		return true, d.ValueSource()
+	}
+	return false, ""
+}
 
 // Value returns the attribute value that should be used for the default based
 // on precedence. If no suitable value can be found then nil will be returned.
@@ -31,4 +63,19 @@ func (d DefaultAttributeValue) Value() any {
 		return d.Default
 	}
 	return nil
+}
+
+// ValueSource returns source identifier for the value. If no suitable value can
+// be found then empty string will be returned.
+func (d DefaultAttributeValue) ValueSource() string {
+	if d.Region != nil {
+		return config.JujuRegionSource
+	}
+	if d.Controller != nil {
+		return config.JujuControllerSource
+	}
+	if d.Default != nil {
+		return config.JujuDefaultSource
+	}
+	return ""
 }

--- a/domain/modeldefaults/types_test.go
+++ b/domain/modeldefaults/types_test.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modeldefaults
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type typesSuite struct{}
+
+var _ = gc.Suite(&typesSuite{})
+
+func (s *typesSuite) TestZeroDefaultsValue(c *gc.C) {
+	val := DefaultAttributeValue{}
+	c.Assert(val.Value(), gc.IsNil)
+	c.Assert(val.ValueSource(), gc.Equals, "")
+
+	has, source := val.Has("someval")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+}
+
+func (s *typesSuite) TestDefaultDefaultsValue(c *gc.C) {
+	val := DefaultAttributeValue{Default: "test"}
+	c.Assert(val.Value(), gc.DeepEquals, "test")
+	c.Assert(val.ValueSource(), gc.Equals, "default")
+
+	has, source := val.Has("test")
+	c.Assert(has, jc.IsTrue)
+	c.Assert(source, gc.Equals, "default")
+
+	has, source = val.Has("noexist")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+}
+
+func (s *typesSuite) TestControllerDefaultsValue(c *gc.C) {
+	val := DefaultAttributeValue{
+		Default:    "default",
+		Controller: "test",
+	}
+	c.Assert(val.Value(), gc.DeepEquals, "test")
+	c.Assert(val.ValueSource(), gc.Equals, "controller")
+
+	has, source := val.Has("test")
+	c.Assert(has, jc.IsTrue)
+	c.Assert(source, gc.Equals, "controller")
+
+	has, source = val.Has("noexist")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+
+	has, source = val.Has("default")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+}
+
+func (s *typesSuite) TestRegionDefaultsValue(c *gc.C) {
+	val := DefaultAttributeValue{
+		Default:    "default",
+		Controller: "controller",
+		Region:     "test",
+	}
+	c.Assert(val.Value(), gc.DeepEquals, "test")
+	c.Assert(val.ValueSource(), gc.Equals, "region")
+
+	has, source := val.Has("test")
+	c.Assert(has, jc.IsTrue)
+	c.Assert(source, gc.Equals, "region")
+
+	has, source = val.Has("noexist")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+
+	has, source = val.Has("default")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+
+	has, source = val.Has("controller")
+	c.Assert(has, jc.IsFalse)
+	c.Assert(source, gc.Equals, "")
+}


### PR DESCRIPTION
This PR moves model config logic previously coded into the API facades down to the services layer. This PR is to add the new logic but not remove from the facades just yet.

- Adds and renamed config keys previously missing "Key" postfix and a const default.
- Adds configuration validators found in the apiserver facades to the services layer.
- Adds bootstrap tests for model defaults.
- Adds service tests for model defaults now the service layer can be trusted for stability.
- Adds source information to model default values.
- Adds tests for model default values.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Just unit tests for the moments. This code will be wired up in the next PR.

## Documentation changes

N/A

## Links


**Jira card:** JUJU-4853
