### PR TITLE
Remove unecessary conversion between series and base

### DIFF
--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 )
@@ -126,16 +125,12 @@ func (c *Client) RetryProvisioning(all bool, machines ...names.MachineTag) ([]pa
 // UpgradeSeriesPrepare notifies the controller that a series upgrade is taking
 // place for a given machine and as such the machine is guarded against
 // operations that would impede, fail, or interfere with the upgrade process.
-func (client *Client) UpgradeSeriesPrepare(machineName, series string, force bool) error {
-	base, err := corebase.GetBaseFromSeries(series)
-	if err != nil {
-		return errors.Trace(err)
-	}
+func (client *Client) UpgradeSeriesPrepare(machineName, channel string, force bool) error {
 	args := params.UpdateChannelArg{
 		Entity: params.Entity{
 			Tag: names.NewMachineTag(machineName).String(),
 		},
-		Channel: base.Channel.String(),
+		Channel: channel,
 		Force:   force,
 	}
 	var result params.ErrorResult
@@ -167,21 +162,17 @@ func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	return nil
 }
 
-func (client *Client) UpgradeSeriesValidate(machineName, series string) ([]string, error) {
-	base, err := corebase.GetBaseFromSeries(series)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func (client *Client) UpgradeSeriesValidate(machineName, channel string) ([]string, error) {
 	args := params.UpdateChannelArgs{
 		Args: []params.UpdateChannelArg{
 			{
 				Entity:  params.Entity{Tag: names.NewMachineTag(machineName).String()},
-				Channel: base.Channel.String(),
+				Channel: channel,
 			},
 		},
 	}
 	results := new(params.UpgradeSeriesUnitsResults)
-	err = client.facade.FacadeCall("UpgradeSeriesValidate", args, results)
+	err := client.facade.FacadeCall("UpgradeSeriesValidate", args, results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/machinemanager/machinemanagernew_test.go
+++ b/api/client/machinemanager/machinemanagernew_test.go
@@ -64,7 +64,7 @@ func (s *NewMachineManagerSuite) TestUpgradeSeriesValidate(c *gc.C) {
 	results := params.UpgradeSeriesUnitsResults{Results: []params.UpgradeSeriesUnitsResult{result}}
 	s.facade.EXPECT().FacadeCall("UpgradeSeriesValidate", args, gomock.Any()).SetArg(2, results)
 
-	unitNames, err := s.client.UpgradeSeriesValidate(s.tag.String(), "xenial")
+	unitNames, err := s.client.UpgradeSeriesValidate(s.tag.String(), "16.04/stable")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitNames, gc.DeepEquals, result.UnitNames)
 }
@@ -85,7 +85,7 @@ func (s *NewMachineManagerSuite) TestUpgradeSeriesPrepareAlreadyInProgress(c *gc
 	}
 	s.facade.EXPECT().FacadeCall("UpgradeSeriesPrepare", arg, gomock.Any()).SetArg(2, resultSource)
 
-	err := s.client.UpgradeSeriesPrepare(s.tag.Id(), "xenial", true)
+	err := s.client.UpgradeSeriesPrepare(s.tag.Id(), "16.04/stable", true)
 	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
 }
 

--- a/cmd/juju/machine/upgrademachine.go
+++ b/cmd/juju/machine/upgrademachine.go
@@ -308,11 +308,6 @@ func (c *upgradeMachineCommand) UpgradePrepare(ctx *cmd.Context) (err error) {
 		return errors.NotFoundf("units for machine %q", c.machineNumber)
 	}
 
-	s, err := corebase.GetSeriesFromBase(base)
-	if err != nil {
-		return errors.Annotatef(err, "invalid series to base conversion")
-	}
-
 	if err := c.promptConfirmation(ctx, base, units); err != nil {
 		return errors.Trace(err)
 	}
@@ -320,7 +315,7 @@ func (c *upgradeMachineCommand) UpgradePrepare(ctx *cmd.Context) (err error) {
 	close := c.trapInterrupt(ctx)
 	defer close()
 
-	if err = c.upgradeMachineClient.UpgradeSeriesPrepare(c.machineNumber, s, c.force); err != nil {
+	if err = c.upgradeMachineClient.UpgradeSeriesPrepare(c.machineNumber, base.Channel.String(), c.force); err != nil {
 		return c.displayProgressFromError(ctx, err)
 	}
 

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -83,8 +83,8 @@ const (
 	machineArg   = "1"
 	containerArg = "2/lxd/0"
 
-	seriesArg = "focal"
-	baseArg   = "ubuntu@20.04"
+	channelArg = "20.04/stable"
+	baseArg    = "ubuntu@20.04"
 )
 
 func (s *UpgradeMachineSuite) runUpgradeMachineCommand(c *gc.C, args ...string) error {
@@ -117,7 +117,7 @@ func (s *UpgradeMachineSuite) runUpgradeMachineCommandWithConfirmation(
 
 	uExp := mockUpgradeMachineAPI.EXPECT()
 	prep := s.prepareExpectation
-	uExp.UpgradeSeriesPrepare(prep.machineArg, prep.baseArg, prep.force).AnyTimes()
+	uExp.UpgradeSeriesPrepare(prep.machineArg, prep.channelArg, prep.force).AnyTimes()
 	uExp.UpgradeSeriesComplete(s.completeExpectation.machineNumber).AnyTimes()
 
 	mockStatusAPI.EXPECT().Status(gomock.Nil()).AnyTimes().Return(s.statusExpectation.status, nil)
@@ -136,13 +136,13 @@ func (s *UpgradeMachineSuite) runUpgradeMachineCommandWithConfirmation(
 }
 
 func (s *UpgradeMachineSuite) TestPrepareCommandMachines(c *gc.C) {
-	s.prepareExpectation = &upgradeMachinePrepareExpectation{machineArg, seriesArg, gomock.Eq(false)}
+	s.prepareExpectation = &upgradeMachinePrepareExpectation{machineArg, channelArg, gomock.Eq(false)}
 	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, baseArg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UpgradeMachineSuite) TestPrepareCommandContainers(c *gc.C) {
-	s.prepareExpectation = &upgradeMachinePrepareExpectation{containerArg, seriesArg, gomock.Eq(false)}
+	s.prepareExpectation = &upgradeMachinePrepareExpectation{containerArg, channelArg, gomock.Eq(false)}
 	err := s.runUpgradeMachineCommand(c, containerArg, machine.PrepareCommand, baseArg)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -153,7 +153,7 @@ func (s *UpgradeMachineSuite) TestTooFewArgs(c *gc.C) {
 }
 
 func (s *UpgradeMachineSuite) TestPrepareCommandShouldAcceptForceOption(c *gc.C) {
-	s.prepareExpectation = &upgradeMachinePrepareExpectation{machineArg, seriesArg, gomock.Eq(true)}
+	s.prepareExpectation = &upgradeMachinePrepareExpectation{machineArg, channelArg, gomock.Eq(true)}
 	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, baseArg, "--force")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -243,7 +243,7 @@ type statusExpectation struct {
 }
 
 type upgradeMachinePrepareExpectation struct {
-	machineArg, baseArg, force interface{}
+	machineArg, channelArg, force interface{}
 }
 
 type upgradeMachineCompleteExpectation struct {


### PR DESCRIPTION
It turns out our UpgradeSeries api functions take a series as param, but instantly convert this series to a base.

Everywhere we use these api methods (only 1 place it turns out) we have to convert a base into a series

Drop this pointless conversions to and from

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
./main.sh -v upgrade_series
```

```
$ juju add-model m
$ juju deploy ubuntu --base ubuntu@20.04
$ juju upgrade-machine 1 prepare ubuntu@22.04
WARNING: This command will mark machine "1" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/1

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-1 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-1 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/1 pre-series-upgrade hook running
ubuntu/1 pre-series-upgrade completed
machine-1 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 1 complete

$ juju upgrade-machine 1 complete
machine-1 complete phase started
machine-1 start units after series upgrade
ubuntu/1 post-series-upgrade hook running
ubuntu/1 post-series-upgrade completed
machine-1 series upgrade complete

Upgrade machine base "1" has successfully completed
```