### PR TITLE
Fix migration of models owned by external users

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -946,13 +946,18 @@ func getTargetControllerUsers(conn api.Connection) (userList, error) {
 }
 
 func targetToAPIInfo(ti *coremigration.TargetInfo) *api.Info {
-	return &api.Info{
+	info := &api.Info{
 		Addrs:     ti.Addrs,
 		CACert:    ti.CACert,
-		Tag:       ti.AuthTag,
 		Password:  ti.Password,
 		Macaroons: ti.Macaroons,
 	}
+	// Only local users must be added to the api info.
+	// For external users, the tag needs to be left empty.
+	if ti.AuthTag.IsLocal() {
+		info.Tag = ti.AuthTag
+	}
+	return info
 }
 
 // grantControllerCloudAccess exists for backwards compatibility since older clients

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -62,7 +62,7 @@ func (info *TargetInfo) Validate() error {
 		}
 	}
 
-	if info.AuthTag.Id() == "" {
+	if info.AuthTag.Id() == "" && len(info.Macaroons) == 0 {
 		return errors.NotValidf("empty AuthTag")
 	}
 

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -54,6 +54,7 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"AuthTag",
 		func(info *migration.TargetInfo) {
 			info.AuthTag = names.UserTag{}
+			info.Macaroons = nil
 		},
 		"empty AuthTag not valid",
 	}, {
@@ -79,6 +80,12 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"Success - empty Macaroons",
 		func(info *migration.TargetInfo) {
 			info.Macaroons = nil
+		},
+		"",
+	}, {
+		"Success - empty AuthTag with macaroons",
+		func(info *migration.TargetInfo) {
+			info.AuthTag = names.UserTag{}
 		},
 		"",
 	}, {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -917,10 +917,14 @@ func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelU
 	apiInfo := &api.Info{
 		Addrs:     targetInfo.Addrs,
 		CACert:    targetInfo.CACert,
-		Tag:       targetInfo.AuthTag,
 		Password:  targetInfo.Password,
 		ModelTag:  names.NewModelTag(modelUUID),
 		Macaroons: targetInfo.Macaroons,
+	}
+	// Only local users must be added to the api info.
+	// For external users, the tag needs to be left empty.
+	if targetInfo.AuthTag.IsLocal() {
+		apiInfo.Tag = targetInfo.AuthTag
 	}
 	return w.config.APIOpen(apiInfo, migration.ControllerDialOpts())
 }


### PR DESCRIPTION
When calling the Login() api and the user is an external user, the expectation is that the auth tag in the login request is empty and the macaroon is supplied. However, model migration api calls from the source controller always pass in the model owner tag, even for external users.

This PR fixes that issue in the source controller, and also makes the target controller more robust by inspecting the type of user in the login request and returning the correct authenticator. Previously if the user were set at all, it would always return the local user authenticator.

## QA steps

bootstrap target controller
juju grant fred@external superuser

bootstrap source controller
juju grant-cloud fred@external add-model <cloudname>
juju grant fred@external login

login as fred@external on source controller
juju add-model foo
juju deploy someapp

login as admin on source controller
juju migrate fred@external/foo targetcontroller

Also test that a stock 2.9.45 controller can migrate to a controller off this PR.

## Links

https://bugs.launchpad.net/juju/+bug/2040138

**Jira card:** JUJU-[4868]

