### PR TITLE
Fix user secret client facade

### DIFF
--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -411,3 +411,18 @@ func (mr *MockSecretsRemoveStateMockRecorder) GetSecretRevision(arg0, arg1 inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRevision", reflect.TypeOf((*MockSecretsRemoveState)(nil).GetSecretRevision), arg0, arg1)
 }
+
+// ListSecretRevisions mocks base method.
+func (m *MockSecretsRemoveState) ListSecretRevisions(arg0 *secrets0.URI) ([]*secrets0.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecretRevisions", arg0)
+	ret0, _ := ret[0].([]*secrets0.SecretRevisionMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSecretRevisions indicates an expected call of ListSecretRevisions.
+func (mr *MockSecretsRemoveStateMockRecorder) ListSecretRevisions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretRevisions", reflect.TypeOf((*MockSecretsRemoveState)(nil).ListSecretRevisions), arg0)
+}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -723,7 +723,7 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 	})
 }
 
-func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
+func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -777,7 +777,65 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 	})
 }
 
-func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
+func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	expectURI := *uri
+	removeState := mocks.NewMockSecretsRemoveState(ctrl)
+	mockprovider := mocks.NewMockSecretBackendProvider(ctrl)
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
+
+	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
+	removeState.EXPECT().ListSecretRevisions(&expectURI).Return(
+		[]*coresecrets.SecretRevisionMetadata{
+			{
+				Revision: 666,
+				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
+			},
+		},
+		nil,
+	)
+	removeState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
+		BackendID:  "backend-id",
+		RevisionID: "rev-666",
+	}}, nil)
+
+	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+		return &provider.ModelBackendConfigInfo{
+			ActiveID: "backend-id",
+			Configs: map[string]provider.ModelBackendConfig{
+				"backend-id": {
+					ControllerUUID: coretesting.ControllerTag.Id(),
+					ModelUUID:      coretesting.ModelTag.Id(),
+					ModelName:      "fred",
+					BackendConfig: provider.BackendConfig{
+						BackendType: "some-backend",
+						Config:      map[string]interface{}{"foo": "admin"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	results, err := secrets.RemoveSecretsForAgent(
+		removeState, adminConfigGetter,
+		names.NewUnitTag("mariadb/0"),
+		params.DeleteSecretArgs{
+			Args: []params.DeleteSecretArg{{
+				URI: expectURI.String(),
+			}},
+		},
+		func(*coresecrets.URI) error { return nil },
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
+func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -838,6 +896,81 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 			Args: []params.DeleteSecretArg{{
 				URI:       expectURI.String(),
 				Revisions: []int{666},
+			}},
+		},
+		func(*coresecrets.URI) error { return nil },
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
+func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	expectURI := *uri
+	removeState := mocks.NewMockSecretsRemoveState(ctrl)
+	mockprovider := mocks.NewMockSecretBackendProvider(ctrl)
+	backend := mocks.NewMockSecretsBackend(ctrl)
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
+
+	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
+	removeState.EXPECT().ListSecretRevisions(&expectURI).Return(
+		[]*coresecrets.SecretRevisionMetadata{
+			{
+				Revision: 666,
+				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
+			},
+		},
+		nil,
+	)
+	removeState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
+		BackendID:  "backend-id",
+		RevisionID: "rev-666",
+	}}, nil)
+
+	cfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "some-backend",
+			Config:      map[string]interface{}{"foo": "admin"},
+		},
+	}
+	mockprovider.EXPECT().NewBackend(cfg).Return(backend, nil)
+	backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
+	mockprovider.EXPECT().CleanupSecrets(
+		cfg, names.NewUserTag("foo"),
+		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
+	).Return(nil)
+
+	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+		return &provider.ModelBackendConfigInfo{
+			ActiveID: "backend-id",
+			Configs: map[string]provider.ModelBackendConfig{
+				"backend-id": {
+					ControllerUUID: coretesting.ControllerTag.Id(),
+					ModelUUID:      coretesting.ModelTag.Id(),
+					ModelName:      "fred",
+					BackendConfig: provider.BackendConfig{
+						BackendType: "some-backend",
+						Config:      map[string]interface{}{"foo": "admin"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	results, err := secrets.RemoveUserSecrets(
+		removeState, adminConfigGetter,
+		names.NewUserTag("foo"),
+		params.DeleteSecretArgs{
+			Args: []params.DeleteSecretArg{{
+				URI: expectURI.String(),
 			}},
 		},
 		func(*coresecrets.URI) error { return nil },

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -53,7 +53,6 @@ type SecretsState interface {
 type SecretsMetaState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
-
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
 }
 
@@ -62,6 +61,7 @@ type SecretsRemoveState interface {
 	DeleteSecret(*secrets.URI, ...int) ([]secrets.ValueRef, error)
 	GetSecret(*secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretRevision(uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error)
+	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 }
 
 // Credential represents a cloud credential.

--- a/apiserver/facades/client/secrets/package_test.go
+++ b/apiserver/facades/client/secrets/package_test.go
@@ -22,25 +22,28 @@ func TestPackage(t *testing.T) {
 }
 
 func NewTestAPI(
+	authTag names.Tag,
+	authorizer facade.Authorizer,
 	secretsState SecretsState,
 	secretsConsumer SecretsConsumer,
-	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error),
+	adminBackendConfigGetter func() (*provider.ModelBackendConfigInfo, error),
+	backendConfigGetterForUserSecretsWrite func(backendID string) (*provider.ModelBackendConfigInfo, error),
 	backendGetter func(*provider.ModelBackendConfig) (provider.SecretsBackend, error),
-	authorizer facade.Authorizer, authTag names.Tag,
 ) (*SecretsAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
 
 	return &SecretsAPI{
-		authTag:             authTag,
-		authorizer:          authorizer,
-		controllerUUID:      coretesting.ControllerTag.Id(),
-		modelUUID:           coretesting.ModelTag.Id(),
-		secretsState:        secretsState,
-		secretsConsumer:     secretsConsumer,
-		backends:            make(map[string]provider.SecretsBackend),
-		backendConfigGetter: backendConfigGetter,
-		backendGetter:       backendGetter,
+		authTag:                                authTag,
+		authorizer:                             authorizer,
+		controllerUUID:                         coretesting.ControllerTag.Id(),
+		modelUUID:                              coretesting.ModelTag.Id(),
+		secretsState:                           secretsState,
+		secretsConsumer:                        secretsConsumer,
+		backends:                               make(map[string]provider.SecretsBackend),
+		adminBackendConfigGetter:               adminBackendConfigGetter,
+		backendConfigGetterForUserSecretsWrite: backendConfigGetterForUserSecretsWrite,
+		backendGetter:                          backendGetter,
 	}, nil
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -224,22 +224,6 @@ func (s *SecretsAPI) secretContentFromBackend(uri *coresecrets.URI, rev int) (co
 	}
 }
 
-func (s *SecretsAPI) getBackend(id *string) (provider.SecretsBackend, error) {
-	if s.activeBackendID == "" {
-		if err := s.getBackendInfo(); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	if id == nil {
-		id = &s.activeBackendID
-	}
-	backend, ok := s.backends[*id]
-	if !ok {
-		return nil, errors.NotFoundf("external secret backend %q", s.activeBackendID)
-	}
-	return backend, nil
-}
-
 func (s *SecretsAPI) getBackendForUserSecretsWrite() (provider.SecretsBackend, error) {
 	if s.activeBackendID == "" {
 		if err := s.getBackendInfo(); err != nil {

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -40,8 +40,9 @@ type SecretsAPI struct {
 	secretsState    SecretsState
 	secretsConsumer SecretsConsumer
 
-	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error)
-	backendGetter       func(*provider.ModelBackendConfig) (provider.SecretsBackend, error)
+	adminBackendConfigGetter               func() (*provider.ModelBackendConfigInfo, error)
+	backendConfigGetterForUserSecretsWrite func(backendID string) (*provider.ModelBackendConfigInfo, error)
+	backendGetter                          func(*provider.ModelBackendConfig) (provider.SecretsBackend, error)
 }
 
 // SecretsAPIV1 is the backend for the Secrets facade v1.
@@ -168,7 +169,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 }
 
 func (s *SecretsAPI) getBackendInfo() error {
-	info, err := s.backendConfigGetter()
+	info, err := s.adminBackendConfigGetter()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -239,6 +240,24 @@ func (s *SecretsAPI) getBackend(id *string) (provider.SecretsBackend, error) {
 	return backend, nil
 }
 
+func (s *SecretsAPI) getBackendForUserSecretsWrite() (provider.SecretsBackend, error) {
+	if s.activeBackendID == "" {
+		if err := s.getBackendInfo(); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	cfgInfo, err := s.backendConfigGetterForUserSecretsWrite(s.activeBackendID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, ok := cfgInfo.Configs[s.activeBackendID]
+	if !ok {
+		// This should never happen.
+		return nil, errors.NotFoundf("secret backend %q", s.activeBackendID)
+	}
+	return s.backendGetter(&cfg)
+}
+
 // CreateSecrets isn't on the v1 API.
 func (s *SecretsAPIV1) CreateSecrets(_ struct{}) {}
 
@@ -250,7 +269,7 @@ func (s *SecretsAPI) CreateSecrets(args params.CreateSecretArgs) (params.StringR
 	if err := s.checkCanAdmin(); err != nil {
 		return result, errors.Trace(err)
 	}
-	backend, err := s.getBackend(nil)
+	backend, err := s.getBackendForUserSecretsWrite()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -373,7 +392,7 @@ func (s *SecretsAPI) UpdateSecrets(args params.UpdateUserSecretArgs) (params.Err
 	if err := s.checkCanAdmin(); err != nil {
 		return result, errors.Trace(err)
 	}
-	backend, err := s.getBackend(nil)
+	backend, err := s.getBackendForUserSecretsWrite()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
@@ -466,7 +485,7 @@ func (s *SecretsAPIV1) RemoveSecrets(_ struct{}) {}
 func (s *SecretsAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	// TODO(secrets): JUJU-4719.
 	return commonsecrets.RemoveUserSecrets(
-		s.secretsState, s.backendConfigGetter,
+		s.secretsState, s.adminBackendConfigGetter,
 		s.authTag, args,
 		func(uri *coresecrets.URI) error {
 			// Only admin can delete user secrets.

--- a/apiserver/facades/controller/usersecrets/mocks/state.go
+++ b/apiserver/facades/controller/usersecrets/mocks/state.go
@@ -86,6 +86,21 @@ func (mr *MockSecretsStateMockRecorder) GetSecretRevision(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRevision", reflect.TypeOf((*MockSecretsState)(nil).GetSecretRevision), arg0, arg1)
 }
 
+// ListSecretRevisions mocks base method.
+func (m *MockSecretsState) ListSecretRevisions(arg0 *secrets.URI) ([]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecretRevisions", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretRevisionMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSecretRevisions indicates an expected call of ListSecretRevisions.
+func (mr *MockSecretsStateMockRecorder) ListSecretRevisions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretRevisions", reflect.TypeOf((*MockSecretsState)(nil).ListSecretRevisions), arg0)
+}
+
 // WatchRevisionsToPrune mocks base method.
 func (m *MockSecretsState) WatchRevisionsToPrune(arg0 []names.Tag) (state.StringsWatcher, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/usersecrets/state.go
+++ b/apiserver/facades/controller/usersecrets/state.go
@@ -16,4 +16,5 @@ type SecretsState interface {
 	GetSecret(*secrets.URI) (*secrets.SecretMetadata, error)
 	WatchRevisionsToPrune(owners []names.Tag) (state.StringsWatcher, error)
 	GetSecretRevision(uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error)
+	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 }

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -27,7 +27,7 @@ type SecretsDrainAPI struct {
 	backendConfigGetter commonsecrets.BackendConfigGetter
 }
 
-// GetSecretBackendConfigs gets the config needed to create a client to secret backends.
+// GetSecretBackendConfigs gets the config needed to create a client to secret backends for the drain worker.
 func (s *SecretsDrainAPI) GetSecretBackendConfigs(arg params.SecretBackendArgs) (params.SecretBackendConfigResults, error) {
 	if len(arg.BackendIDs) > 1 {
 		return params.SecretBackendConfigResults{}, errors.Errorf("Maximumly only one backend ID can be specified for drain")

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -52726,7 +52726,7 @@
                             "$ref": "#/definitions/SecretBackendConfigResults"
                         }
                     },
-                    "description": "GetSecretBackendConfigs gets the config needed to create a client to secret backends."
+                    "description": "GetSecretBackendConfigs gets the config needed to create a client to secret backends for the drain worker."
                 },
                 "GetSecretContentInfo": {
                     "type": "object",


### PR DESCRIPTION
This PR fixes two issues:
- fix user secret client facade to use the secret owner's backend config instead of the controller's.
- `juju remove-secret $URI` now can remove all revisions from the backend for external secrets;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju model-config secret-backend -m controller
myvault

juju model-config secret-backend -m t1
auto

juju add-secret token=34ae35facd4 -m t1
secret:cksbkgfmp25c7801js4g

juju add-secret token=34ae35facd4 -m controller
secret:cksbkhnmp25c7801js50

mkubectl get secrets -l app.kubernetes.io/managed-by=juju -A
NAMESPACE       NAME                            TYPE                                  DATA   AGE
controller-k1   controller-proxy                kubernetes.io/service-account-token   3      7m7s
controller-k1   controller-secret               Opaque                                2      7m6s
controller-k1   controller-application-config   Opaque                                1      7m4s
controller-k1   model-exec                      kubernetes.io/service-account-token   3      6m39s
t1              model-exec                      kubernetes.io/service-account-token   3      2m37s
t1              cksbkgfmp25c7801js4g-1          Opaque                                1      103s

mkubectl get secrets cksbkgfmp25c7801js4g-1 -nt1 -o yaml | yq .metadata.labels
app.juju.is/created-by: 87ae5451-842a-4ddc-82a6-30ac011cd29f
app.kubernetes.io/managed-by: juju
model.juju.is/name: t1

vault kv list -format json controller-${model_uuid: -6}
[
  "cksbkhnmp25c7801js50-1"
]
```

## Documentation changes

No

## Links

https://bugs.launchpad.net/juju/+bug/2040239

`JUJU-4854`
