### PR TITLE
Merge 3.1

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -987,13 +987,18 @@ func getTargetControllerUsers(conn api.Connection) (userList, error) {
 }
 
 func targetToAPIInfo(ti *coremigration.TargetInfo) *api.Info {
-	return &api.Info{
+	info := &api.Info{
 		Addrs:     ti.Addrs,
 		CACert:    ti.CACert,
-		Tag:       ti.AuthTag,
 		Password:  ti.Password,
 		Macaroons: ti.Macaroons,
 	}
+	// Only local users must be added to the api info.
+	// For external users, the tag needs to be left empty.
+	if ti.AuthTag.IsLocal() {
+		info.Tag = ti.AuthTag
+	}
+	return info
 }
 
 func grantControllerAccess(accessor ControllerAccess, targetUserTag, apiUser names.UserTag, access permission.Access) error {

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -194,7 +194,13 @@ func (a authenticator) Authenticate(
 // authenticatorForTag returns the authenticator appropriate
 // to use for a login with the given possibly-nil tag.
 func (a authenticator) authenticatorForTag(tag names.Tag) (authentication.EntityAuthenticator, error) {
-	if tag == nil {
+	if tag == nil || tag.Kind() == names.UserTagKind {
+		// Poorly written older controllers pass in an external user
+		// when doing api calls to the target controller during migration,
+		// so we need to check the user type.
+		if tag != nil && tag.(names.UserTag).IsLocal() {
+			return a.localUserAuth(), nil
+		}
 		auth, err := a.ctxt.externalMacaroonAuth(nil)
 		if errors.Cause(err) == errMacaroonAuthNotConfigured {
 			err = errors.Trace(apiservererrors.ErrNoCreds)
@@ -208,9 +214,6 @@ func (a authenticator) authenticatorForTag(tag names.Tag) (authentication.Entity
 		if tag.Kind() == agentKind {
 			return &a.ctxt.agentAuth, nil
 		}
-	}
-	if tag.Kind() == names.UserTagKind {
-		return a.localUserAuth(), nil
 	}
 	return nil, errors.Annotatef(apiservererrors.ErrBadRequest, "unexpected login entity tag")
 }

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -62,7 +62,7 @@ func (info *TargetInfo) Validate() error {
 		}
 	}
 
-	if info.AuthTag.Id() == "" {
+	if info.AuthTag.Id() == "" && len(info.Macaroons) == 0 {
 		return errors.NotValidf("empty AuthTag")
 	}
 

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -54,6 +54,7 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"AuthTag",
 		func(info *migration.TargetInfo) {
 			info.AuthTag = names.UserTag{}
+			info.Macaroons = nil
 		},
 		"empty AuthTag not valid",
 	}, {
@@ -79,6 +80,12 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"Success - empty Macaroons",
 		func(info *migration.TargetInfo) {
 			info.Macaroons = nil
+		},
+		"",
+	}, {
+		"Success - empty AuthTag with macaroons",
+		func(info *migration.TargetInfo) {
+			info.AuthTag = names.UserTag{}
 		},
 		"",
 	}, {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -897,10 +897,14 @@ func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelU
 	apiInfo := &api.Info{
 		Addrs:     targetInfo.Addrs,
 		CACert:    targetInfo.CACert,
-		Tag:       targetInfo.AuthTag,
 		Password:  targetInfo.Password,
 		ModelTag:  names.NewModelTag(modelUUID),
 		Macaroons: targetInfo.Macaroons,
+	}
+	// Only local users must be added to the api info.
+	// For external users, the tag needs to be left empty.
+	if targetInfo.AuthTag.IsLocal() {
+		apiInfo.Tag = targetInfo.AuthTag
 	}
 	return w.config.APIOpen(apiInfo, migration.ControllerDialOpts())
 }

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -850,10 +850,11 @@ func (s *Suite) TestMinionWaitMigrationIdChanged(c *gc.C) {
 		"unexpected migration id in minion reports, got blah, expected model-uuid:2")
 }
 
-func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
+func (s *Suite) assertAPIConnectWithMacaroon(c *gc.C, authUser names.UserTag) {
 	// Use ABORT because it involves an API connection to the target
 	// and is convenient.
 	status := s.makeStatus(coremigration.ABORT)
+	status.TargetInfo.AuthTag = authUser
 
 	// Set up macaroon based auth to the target.
 	mac, err := macaroon.New([]byte("secret"), []byte("id"), "location", macaroon.LatestVersion)
@@ -865,6 +866,10 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 	s.facade.queueStatus(status)
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	var apiUser names.Tag
+	if authUser.IsLocal() {
+		apiUser = authUser
+	}
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
@@ -875,7 +880,7 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 					&api.Info{
 						Addrs:     []string{"1.2.3.4:5"},
 						CACert:    "cert",
-						Tag:       names.NewUserTag("admin"),
+						Tag:       apiUser,
 						Macaroons: macs, // <---
 					},
 					migration.ControllerDialOpts(),
@@ -886,6 +891,14 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 			{"facade.SetPhase", []interface{}{coremigration.ABORTDONE}},
 		},
 	))
+}
+
+func (s *Suite) TestAPIConnectWithMacaroonLocalUser(c *gc.C) {
+	s.assertAPIConnectWithMacaroon(c, names.NewUserTag("admin"))
+}
+
+func (s *Suite) TestAPIConnectWithMacaroonExternalUser(c *gc.C) {
+	s.assertAPIConnectWithMacaroon(c, names.NewUserTag("fred@external"))
 }
 
 func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {


### PR DESCRIPTION
Merge 3.1

https://github.com/juju/juju/pull/16491 [from wallyworld/migrate-externaluser-models](https://github.com/juju/juju/commit/d187f4851ad9a9963cc8cb8b892731ed7663a1d9)

conflict was minor.

```
# Conflicts:
#       apiserver/stateauthenticator/context.go
#
```