### PR TITLE
Add spaces sql schema

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -18,6 +18,7 @@ func ModelDDL() *schema.Schema {
 		changeLogModelNamespace,
 		modelConfig,
 		changeLogTriggersForTable("model_config", "key", tableModelConfig),
+		spacesSchema,
 	}
 
 	schema := schema.New()
@@ -42,5 +43,27 @@ CREATE TABLE model_config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+`)
+}
+
+func spacesSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE provider_spaces (
+    uuid            TEXT PRIMARY KEY,
+    name            TEXT
+);
+
+CREATE TABLE spaces (
+    uuid            TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    is_public       BOOLEAN,
+    provider_uuid   TEXT,
+    CONSTRAINT      fk_lease_pin_lease
+        FOREIGN KEY     (provider_uuid)
+        REFERENCES      provider_spaces(uuid)
+);
+
+CREATE UNIQUE INDEX idx_spaces_uuid_name
+ON spaces (uuid, name);
 `)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -108,6 +108,10 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 
 		// Model config
 		"model_config",
+
+		// Spaces
+		"spaces",
+		"provider_spaces",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This patch adds the new spaces(/subnets) schema to create the following tables:
- spaces
- spaces_life

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/schema/... -gocheck.v
```


## Links

**Jira card:** JUJU-4833
