### PR TITLE
Remove generic base worker

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -297,7 +297,7 @@ func (s *caasProvisionerSuite) TestFilesystemLife(c *gc.C) {
 	})
 }
 
-func (s caasProvisionerSuite) TestFilesystemAttachmentLife(c *gc.C) {
+func (s *caasProvisionerSuite) TestFilesystemAttachmentLife(c *gc.C) {
 	s.setupFilesystems(c)
 
 	results, err := s.api.AttachmentLife(context.Background(), params.MachineStorageIds{


### PR DESCRIPTION
The concept was to make a generic base worker that provided a tomb that you could get the kill and wait from. The problem becomes about how you can also provide the loop/run method. The problem is that passing the loop is racy and can cause problems. The fix is to not be generic here, we can solve that later if required.

Fix the concurrent write to map in dqlite test suite. This needed a mutex around the db clean ups.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ go test -v ./apiserver/facades/client/application -check.v -check.f=applicationSuite -race
$ go test -v ./apiserver/facades/client/client -check.v -race
```

## Links

**Jira card:** JUJU-4871
