### PR TITLE
Stop panic in vsphere internal client

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -812,7 +812,7 @@ func (c *Client) cloneVM(
 	}
 	info, err := taskWaiter.waitTask(ctx, task, "cloning VM")
 	if err != nil {
-		return nil, errors.Annotatef(err, "waiting for task %q", info.Name)
+		return nil, errors.Annotatef(err, "waiting for task")
 	}
 
 	vm := object.NewVirtualMachine(c.client.Client, info.Result.(types.ManagedObjectReference))


### PR DESCRIPTION
The internal vsphere client was trying to access `info.Name` from the task. There is no guarantee that the info will be there if there is an error.

In this case, just return that there was an error waiting for the task. This should prevent the panic from happening.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps


```sh
TBA
```


## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2040656

**Jira card:** JUJU-[XXXX]
