### PR TITLE
Bug when setting cloud credential with no region.

### DIFF
--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -351,9 +351,7 @@ AND cloud_credential.name = ?
 UPDATE model_metadata
 SET cloud_credential_uuid = ?
 WHERE model_uuid = ?
-AND cloud_region_uuid IN (SELECT uuid
-                          FROM cloud_region
-                          WHERE cloud_uuid = ?)
+AND cloud_uuid = ?
 `
 
 	var cloudCredUUID, cloudUUID string


### PR DESCRIPTION
We introduced a bug into creating models by where if no cloud region was set on a model we were unable to set a corresponding cloud credential. This was because we were using the cloud region to validate the cloud a model was using.

Includes regression test to assert the bug and the fix.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap to Kubernetes and confirm the bootstrap process make it all the way through.

Unit tests also confirm the bug and the fix in state.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4882