### PR TITLE
Fixes deploying controller charm on Kubernetes.

### DIFF
--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -213,6 +213,11 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	if err := args.Unmarshal(bootstrapParamsData); err != nil {
 		return errors.Trace(err)
 	}
+	// We need to set IsControllerCloud on the controller cloud from params.
+	// This is so caas environs work correctly for the moment. This SHOULD be
+	// removed with Mongo in time.
+	// Fixes: lp2040947
+	args.ControllerCloud.IsControllerCloud = true
 
 	isCAAS := args.ControllerCloud.Type == k8sconstants.CAASProviderType
 


### PR DESCRIPTION
This fix set IsControllerCloud on the cloud object established during bootstrap from params. Without this the state policy that we wire up won't be able to construct a Kubernetes environ.

This is a really ugly fix but it can go with Mongo.

Fixes lp2040947

*Why this change is needed and what it does.*

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Bootstrap to a Kubernetes cluster
2. Check the logs to make sure there are no errors constructing the provider. Specifically logs such as `Get "https://127.0.0.1:16443/api/v1/namespaces?labelSelector=model.juju.is%2Fname%3Dcontroller": dial tcp 127.0.0.1:16443: connect: connection refused`
3. Run `juju switch controller` then `juju status` to confirm that the controller charm is deployed.

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2040947

**Jira card:** JUJU-4883

*Insert other relevant links here.*