### PR TITLE
Handles space errors during bootstrap better.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -413,7 +413,12 @@ func (b *AgentBootstrap) verifyModelConfigDefaultSpace(st *state.State) error {
 	}
 
 	_, err = st.SpaceByName(name)
-	return errors.Annotatef(err, "cannot verify %s", config.DefaultSpaceKey)
+	if errors.Is(err, errors.NotFound) {
+		return fmt.Errorf("model %q default space %q %w", m.Name(), name, errors.NotFound)
+	} else if err != nil {
+		return fmt.Errorf("cannot verify default space %q for model %q: %w", name, m.Name(), err)
+	}
+	return nil
 }
 
 func (b *AgentBootstrap) getCloudCredential() (cloud.Credential, names.CloudCredentialTag, error) {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -259,8 +259,8 @@ func (st *State) Space(id string) (*Space, error) {
 }
 
 // SpaceByName returns a space from state that matches the input name.
-// An error is returned if the space does not exist or if there was a problem
-// accessing its information.
+// An error is returned that satisfied errors.NotFound if the space was not found
+// or an error static any problems fetching the given space.
 func (st *State) SpaceByName(name string) (*Space, error) {
 	spaces, closer := st.db().GetCollection(spacesC)
 	defer closer()

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -82,7 +82,6 @@ func (s *SpacesSuite) assertSpaceNotFoundForState(c *gc.C, name string, st *stat
 
 func (s *SpacesSuite) assertSpaceNotFoundError(c *gc.C, err error, name string) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("space %q not found", name))
-
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 


### PR DESCRIPTION
With this change we are analysing errors returned by SpaceByName for exact error types to construct a better error message during bootstrap.

Specifically if the user has requested a space in model config that does not exist. Previously we were just wrapping up a generic error that didn't indicate the problem very well.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

* To be advised this is a test PR for @manadart to make sure I am understanding PR feedback of #16485 correctly.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4853