### PR TITLE
Remove charm url parsing from 2 places

### DIFF
--- a/api/client/charms/downloader_test.go
+++ b/api/client/charms/downloader_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/juju/charm/v11"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -54,8 +53,7 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 
 	opener, err := charms.NewCharmOpener(mockCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("ch:mycharm")
-	reader, err := opener.OpenCharm(curl)
+	reader, err := opener.OpenCharm("ch:mycharm")
 
 	defer reader.Close()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -179,15 +179,12 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURLStr := unit.CharmURL()
-		if chURLStr == nil {
-			return errors.New("no charm url")
-		}
-		chURL, err := charm.ParseURL(*chURLStr)
+		app, err := unit.Application()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if !charm.Local.Matches(chURL.Schema) {
+		source := app.CharmOrigin().Source
+		if !charm.Local.Matches(source) {
 			return errors.New("not a local charm")
 		}
 		err = unit.SetMeterStatus(status.Code.String(), status.Info)
@@ -199,12 +196,8 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		cURL, _ := application.CharmURL()
-		curl, err := charm.ParseURL(*cURL)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !charm.Local.Matches(curl.Schema) {
+		source := application.CharmOrigin().Source
+		if !charm.Local.Matches(source) {
 			return errors.New("not a local charm")
 		}
 		units, err := application.AllUnits()

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -96,7 +96,7 @@ func ImportModel(importer StateImporter, getClaimer ClaimerFunc, bytes []byte) (
 // CharmDownloader defines a single method that is used to download a
 // charm from the source controller in a migration.
 type CharmDownloader interface {
-	OpenCharm(*charm.URL) (io.ReadCloser, error)
+	OpenCharm(string) (io.ReadCloser, error)
 }
 
 // CharmUploader defines a single method that is used to upload a
@@ -225,13 +225,7 @@ func uploadCharms(config UploadBinariesConfig) error {
 
 	for _, charmURL := range config.Charms {
 		logger.Debugf("sending charm %s to target", charmURL)
-
-		curl, err := charm.ParseURL(charmURL)
-		if err != nil {
-			return errors.Annotate(err, "bad charm URL")
-		}
-
-		reader, err := config.CharmDownloader.OpenCharm(curl)
+		reader, err := config.CharmDownloader.OpenCharm(charmURL)
 		if err != nil {
 			return errors.Annotate(err, "cannot open charm")
 		}
@@ -243,6 +237,10 @@ func uploadCharms(config UploadBinariesConfig) error {
 		}
 		defer cleanup()
 
+		curl, err := charm.ParseURL(charmURL)
+		if err != nil {
+			return errors.Annotate(err, "bad charm URL")
+		}
 		if usedCurl, err := config.CharmUploader.UploadCharm(curl, content); err != nil {
 			return errors.Annotate(err, "cannot upload charm")
 		} else if usedCurl.String() != curl.String() {

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -246,11 +246,10 @@ type fakeDownloader struct {
 	resources []string
 }
 
-func (d *fakeDownloader) OpenCharm(curl *charm.URL) (io.ReadCloser, error) {
-	urlStr := curl.String()
-	d.charms = append(d.charms, urlStr)
+func (d *fakeDownloader) OpenCharm(curl string) (io.ReadCloser, error) {
+	d.charms = append(d.charms, curl)
 	// Return the charm URL string as the fake charm content
-	return io.NopCloser(bytes.NewReader([]byte(urlStr + " content"))), nil
+	return io.NopCloser(bytes.NewReader([]byte(curl + " content"))), nil
 }
 
 func (d *fakeDownloader) OpenURI(uri string, query url.Values) (io.ReadCloser, error) {

--- a/testcharms/charms/metered/hooks/collect-metrics
+++ b/testcharms/charms/metered/hooks/collect-metrics
@@ -1,2 +1,2 @@
-i#!/bin/bash
+#!/bin/bash
 juju-log -l INFO "collect-metrics hook called."

--- a/testcharms/charms/metered/hooks/meter-status-changed
+++ b/testcharms/charms/metered/hooks/meter-status-changed
@@ -1,0 +1,2 @@
+#!/bin/bash
+juju-log -l INFO "meter status changed"


### PR DESCRIPTION
Use a string param for OpenCharm instead of a parsed url

Use the charm origin source instead of charm url schema to determine the source of charms in metrics debug

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju deploy ubuntu
$ juju deploy ./testcharms/charms/metered
(wait)
$ juju set-meter-status ubuntu RED
ERROR not a local charm
$ juju set-meter-status metered RED
$ juju debug-log
...
unit-metered-1: 13:07:10 INFO unit.unit-metered-1.juju-log meter status changed
unit-metered-1: 13:07:10 INFO juju.worker.meterstatus ran "meter-status-changed" hook (via explicit, bespoke hook script)
```

```
./main.sh -v metrics
```