### PR TITLE
Add subnet, fan and availability zone schemas

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -106,7 +106,7 @@ INSERT INTO subnet_type VALUES
 
 CREATE TABLE subnet_role_definition (
     uuid                         TEXT PRIMARY KEY,
-    name                         TEXT NOT NULL,
+    name                         TEXT NOT NULL
 );
 
 INSERT INTO subnet_role_definition VALUES

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -115,13 +115,20 @@ INSERT INTO subnet_association_type VALUES
 CREATE TABLE subnet_type_association_type (
     subject_subnet_type_uuid       TEXT PRIMARY KEY,
     associated_subnet_type_uuid    TEXT NOT NULL,
+    association_type_uuid          TEXT NOT NULL,
     CONSTRAINT                     fk_subject_subnet_type_uuid
         FOREIGN KEY                    (subject_subnet_type_uuid)
         REFERENCES                     subnet_type(uuid),
     CONSTRAINT                     fk_associated_subnet_type_uuid
         FOREIGN KEY                    (associated_subnet_type_uuid)
+        REFERENCES                     subnet_association_type(uuid),
+    CONSTRAINT                     fk_association_type_uuid
+        FOREIGN KEY                    (association_type_uuid)
         REFERENCES                     subnet_association_type(uuid)
 );
+
+INSERT INTO subnet_type_association_type VALUES
+    (1, 0, 0);    -- This reference "allowable" association means that a 'fan_overlay' subnet can only be an overlay of a 'base' subnet.
 
 CREATE TABLE subnet_association (
     subject_subnet_uuid            TEXT PRIMARY KEY,

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -53,6 +53,15 @@ CREATE TABLE model_config (
 
 func spaceSchema() schema.Patch {
 	return schema.MakePatch(`
+CREATE TABLE space (
+    uuid            TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    is_public       BOOLEAN
+);
+
+CREATE UNIQUE INDEX idx_spaces_uuid_name
+ON space (name);
+
 CREATE TABLE provider_space (
     provider_id     TEXT PRIMARY KEY,
     space_uuid      TEXT NOT NULL,
@@ -63,20 +72,26 @@ CREATE TABLE provider_space (
 
 CREATE UNIQUE INDEX idx_provider_space_space_uuid
 ON provider_space (space_uuid);
-
-CREATE TABLE space (
-    uuid            TEXT PRIMARY KEY,
-    name            TEXT NOT NULL,
-    is_public       BOOLEAN
-);
-
-CREATE UNIQUE INDEX idx_spaces_uuid_name
-ON space (name);
 `)
 }
 
 func subnetSchema() schema.Patch {
 	return schema.MakePatch(`
+CREATE TABLE subnet (
+    uuid                         TEXT PRIMARY KEY,
+    cidr                         TEXT NOT NULL,
+    vlan_tag                     INT,
+    is_public                    BOOLEAN,
+    space_uuid                   TEXT,
+    fan_uuid                     TEXT,
+    CONSTRAINT                   fk_subnets_spaces
+        FOREIGN KEY                  (space_uuid)
+        REFERENCES                   space(uuid)
+    CONSTRAINT                   fk_subnets_fan_networks
+        FOREIGN KEY                  (fan_uuid)
+        REFERENCES                   fan_network(uuid)
+);
+
 CREATE TABLE provider_subnet (
     provider_id     TEXT PRIMARY KEY,
     subnet_uuid     TEXT NOT NULL,
@@ -94,8 +109,7 @@ CREATE TABLE provider_network (
 );
 
 CREATE TABLE provider_network_subnet (
-    uuid                  TEXT PRIMARY KEY,
-    provider_network_uuid TEXT NOT NULL,
+    provider_network_uuid TEXT PRIMARY KEY,
     subnet_uuid           TEXT NOT NULL,
     CONSTRAINT            fk_provider_network_subnet_provider_network_uuid
         FOREIGN KEY           (provider_network_uuid)
@@ -137,20 +151,6 @@ CREATE TABLE fan_network (
     overlay_cidr        TEXT NOT NULL
 );
 
-CREATE TABLE subnet (
-    uuid                         TEXT PRIMARY KEY,
-    cidr                         TEXT NOT NULL,
-    vlan_tag                     INT,
-    is_public                    BOOLEAN,
-    space_uuid                   TEXT,
-    fan_uuid                     TEXT,
-    CONSTRAINT                   fk_subnets_spaces
-        FOREIGN KEY                  (space_uuid)
-        REFERENCES                   spaces(uuid)
-    CONSTRAINT                   fk_subnets_fan_networks
-        FOREIGN KEY                  (fan_uuid)
-        REFERENCES                   fan_network(uuid)
-);
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -77,6 +77,36 @@ ON provider_space (space_uuid);
 
 func subnetSchema() schema.Patch {
 	return schema.MakePatch(`
+--  subnet                                    subnet_type
+-- +-----------------------+                 +-------------------------+
+-- |*uuid              text|                 |*uuid                text|
+-- |cidr               text|1               1|name                 text|
+-- |vlan_tag            int+-----------------+is_usable         boolean|
+-- |is_public       boolean|                 |is_space_settable boolean|
+-- |space_uuid         text|                 +------------+------------+
+-- |subnet_type_uuid   text|                              |1
+-- +---------+-------------+                              |
+--           |1                                           |
+--           |                                            |
+--           |                                            |
+--           |                                            |
+--           |n                                           |n
+--  subnet_association                        subject_subnet_type_uuid
+-- +---------------------------+             +--------------------------------+
+-- |*subject_subnet_uuid   text|             |*subject_subnet_type_uuid   text|
+-- |associated_subnet_uuid text|             |associated_subnet_type_uuid text|
+-- |association_type_uuid  text|             |association_type_uuid       text|
+-- +---------+-----------------+             +------------+-------------------+
+--           |1                                           |1
+--           |                                            |
+--           |                                            |
+--           |                                            |
+--           |1                                           |
+--  subnet_association_type                               |
+-- +-----------------------+                              |
+-- |*uuid              text+------------------------------+
+-- |name               text|1
+-- +-----------------------+
 CREATE TABLE subnet (
     uuid                         TEXT PRIMARY KEY,
     cidr                         TEXT NOT NULL,

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -89,15 +89,24 @@ CREATE UNIQUE INDEX idx_provider_subnet_subnet_uuid
 ON provider_subnet (subnet_uuid);
 
 CREATE TABLE provider_network (
-    provider_network_id TEXT PRIMARY KEY,
-    subnet_uuid         TEXT NOT NULL,
-    CONSTRAINT          fk_provider_network_subnet_uuid
-        FOREIGN KEY         (subnet_uuid)
-        REFERENCES          subnet(uuid)
+    uuid                TEXT PRIMARY KEY,
+    provider_network_id TEXT
+);
+
+CREATE TABLE provider_network_subnet (
+    uuid                  TEXT PRIMARY KEY,
+    provider_network_uuid TEXT NOT NULL,
+    subnet_uuid           TEXT NOT NULL,
+    CONSTRAINT            fk_provider_network_subnet_provider_network_uuid
+        FOREIGN KEY           (provider_network_uuid)
+        REFERENCES            provider_network_uuid(uuid)
+    CONSTRAINT            fk_provider_network_subnet_uuid
+        FOREIGN KEY           (subnet_uuid)
+        REFERENCES            subnet(uuid)
 );
 
 CREATE UNIQUE INDEX idx_provider_network_subnet_uuid
-ON provider_network (subnet_uuid);
+ON provider_network_subnet (subnet_uuid);
 
 CREATE TABLE availability_zone (
     uuid            TEXT PRIMARY KEY,

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -18,11 +18,12 @@ func ModelDDL() *schema.Schema {
 		changeLogModelNamespace,
 		modelConfig,
 		changeLogTriggersForTable("model_config", "key", tableModelConfig),
-		spacesSchema,
 		objectStoreMetadataSchema,
 		applicationSchema,
 		nodeSchema,
 		unitSchema,
+		spaceSchema,
+		subnetSchema,
 	}
 
 	schema := schema.New()
@@ -50,25 +51,97 @@ CREATE TABLE model_config (
 `)
 }
 
-func spacesSchema() schema.Patch {
+func spaceSchema() schema.Patch {
 	return schema.MakePatch(`
-CREATE TABLE provider_spaces (
+CREATE TABLE provider_space (
+    provider_id     TEXT PRIMARY KEY,
+    space_uuid      TEXT NOT NULL,
+    CONSTRAINT      fk_provider_space_space_uuid
+        FOREIGN KEY     (space_uuid)
+        REFERENCES      space(uuid)
+);
+
+CREATE UNIQUE INDEX idx_provider_space_space_uuid
+ON provider_space (space_uuid);
+
+CREATE TABLE space (
+    uuid            TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    is_public       BOOLEAN
+);
+
+CREATE UNIQUE INDEX idx_spaces_uuid_name
+ON space (name);
+`)
+}
+
+func subnetSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE provider_subnet (
+    provider_id     TEXT PRIMARY KEY,
+    subnet_uuid     TEXT NOT NULL,
+    CONSTRAINT      fk_provider_subnet_subnet_uuid
+        FOREIGN KEY     (subnet_uuid)
+        REFERENCES      subnet(uuid)
+);
+
+CREATE UNIQUE INDEX idx_provider_subnet_subnet_uuid
+ON provider_subnet (subnet_uuid);
+
+CREATE TABLE provider_network (
+    provider_network_id TEXT PRIMARY KEY,
+    subnet_uuid         TEXT NOT NULL,
+    CONSTRAINT          fk_provider_network_subnet_uuid
+        FOREIGN KEY         (subnet_uuid)
+        REFERENCES          subnet(uuid)
+);
+
+CREATE UNIQUE INDEX idx_provider_network_subnet_uuid
+ON provider_network (subnet_uuid);
+
+CREATE TABLE availability_zone (
     uuid            TEXT PRIMARY KEY,
     name            TEXT
 );
 
-CREATE TABLE spaces (
-    uuid            TEXT PRIMARY KEY,
-    name            TEXT NOT NULL,
-    is_public       BOOLEAN,
-    provider_uuid   TEXT,
-    CONSTRAINT      fk_lease_pin_lease
-        FOREIGN KEY (provider_uuid)
-        REFERENCES  provider_spaces(uuid)
+CREATE TABLE availability_zone_subnet (
+    uuid                   TEXT PRIMARY KEY,
+    availability_zone_uuid TEXT NOT NULL,
+    subnet_uuid            TEXT NOT NULL,
+    CONSTRAINT             fk_availability_zone_availability_zone_uuid
+        FOREIGN KEY            (availability_zone_uuid)
+        REFERENCES             availability_zone(uuid)
+    CONSTRAINT             fk_availability_zone_subnet_uuid
+        FOREIGN KEY            (subnet_uuid)
+        REFERENCES             subnet(uuid)
 );
 
-CREATE UNIQUE INDEX idx_spaces_uuid_name
-ON spaces (uuid, name);
+CREATE INDEX idx_availability_zone_subnet_availability_zone_uuid
+ON availability_zone_subnet (uuid);
+
+CREATE INDEX idx_availability_zone_subnet_subnet_uuid
+ON availability_zone_subnet (subnet_uuid);
+
+CREATE TABLE fan_network (
+    uuid                TEXT PRIMARY KEY,
+    local_underlay_cidr TEXT NOT NULL,
+    overlay_cidr        TEXT NOT NULL
+);
+
+CREATE TABLE subnet (
+    uuid                         TEXT PRIMARY KEY,
+    cidr                         TEXT NOT NULL,
+    vlan_tag                     INT,
+    is_public                    BOOLEAN,
+    space_uuid                   TEXT,
+    fan_uuid                     TEXT,
+    CONSTRAINT                   fk_subnets_spaces
+        FOREIGN KEY                  (space_uuid)
+        REFERENCES                   spaces(uuid)
+    CONSTRAINT                   fk_subnets_fan_networks
+        FOREIGN KEY                  (fan_uuid)
+        REFERENCES                   fan_network(uuid)
+);
 `)
 }
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -140,6 +140,7 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		"subnet",
 		"provider_subnet",
 		"provider_network",
+		"provider_network_subnet",
 		"availability_zone",
 		"availability_zone_subnet",
 		"fan_network",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -138,12 +138,14 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 
 		// Subnets
 		"subnet",
+		"subnet_role_definition",
+		"subnet_type",
+		"subnet_type_role_mapping",
 		"provider_subnet",
 		"provider_network",
 		"provider_network_subnet",
 		"availability_zone",
 		"availability_zone_subnet",
-		"fan_network",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -138,9 +138,10 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 
 		// Subnets
 		"subnet",
-		"subnet_role_definition",
+		"subnet_association_type",
 		"subnet_type",
-		"subnet_type_role_mapping",
+		"subnet_type_association_type",
+		"subnet_association",
 		"provider_subnet",
 		"provider_network",
 		"provider_network_subnet",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -120,10 +120,6 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		// Model config
 		"model_config",
 
-		// Spaces
-		"spaces",
-		"provider_spaces",
-
 		// Object store metadata
 		"object_store_metadata",
 		"object_store_metadata_path",
@@ -135,6 +131,18 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		"cloud_service",
 		"cloud_container",
 		"unit",
+
+		// Spaces
+		"space",
+		"provider_space",
+
+		// Subnets
+		"subnet",
+		"provider_subnet",
+		"provider_network",
+		"availability_zone",
+		"availability_zone_subnet",
+		"fan_network",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This patch adds the last necessary tables, indexes and constraints for the spaces/subnets domain:
- subnet
- provider_subnet
- provider_network
- availability_zone
- availability_zone_subnet
- fan_network

Also, some follow-up comments from the previous PR were addressed (https://github.com/juju/juju/pull/16495#pullrequestreview-1701207302). 

_Note: please pay particular attention to the `fan` design, on our current mongo implementation we have only `FanLocalUnderlay` and `FanOverlay`, which was modelled here._

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/schema/... -gocheck.v 
```

## Links


**Jira card:** JUJU-4833
