### PR TITLE
Resolve old TODO for juju 3 RE charm origins.

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -6,6 +6,7 @@ package client_test
 import (
 	"time"
 
+	"github.com/juju/charm/v11"
 	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -26,6 +27,9 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/charmhub/transport"
+	corearch "github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
@@ -475,7 +479,8 @@ func (s *statusUnitTestSuite) TestPrincipalUpgradingFrom(c *gc.C) {
 	c.Assert(unitStatus.Charm, gc.Equals, "")
 
 	err = app.SetCharm(state.SetCharmConfig{
-		Charm: meteredCharmNew,
+		Charm:       meteredCharmNew,
+		CharmOrigin: defaultCharmOrigin(meteredCharmNew.URL()),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -485,6 +490,39 @@ func (s *statusUnitTestSuite) TestPrincipalUpgradingFrom(c *gc.C) {
 	unitStatus, ok = status.Applications[app.Name()].Units[u.Name()]
 	c.Assert(ok, gc.Equals, true)
 	c.Assert(unitStatus.Charm, gc.Equals, "ch:amd64/quantal/metered-3")
+}
+
+func defaultCharmOrigin(curl *charm.URL) *state.CharmOrigin {
+	var source string
+	var channel *state.Channel
+	if charm.CharmHub.Matches(curl.Schema) {
+		source = corecharm.CharmHub.String()
+		channel = &state.Channel{
+			Risk: "stable",
+		}
+	} else if charm.Local.Matches(curl.Schema) {
+		source = corecharm.Local.String()
+	}
+
+	b, _ := base.GetBaseFromSeries(curl.Series)
+
+	platform := &state.Platform{
+		Architecture: corearch.DefaultArchitecture,
+		OS:           b.OS,
+		Channel:      b.Channel.String(),
+	}
+
+	return &state.CharmOrigin{
+		Source:   source,
+		Type:     "charm",
+		Revision: intPtr(curl.Revision),
+		Channel:  channel,
+		Platform: platform,
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
 }
 
 func (s *statusUnitTestSuite) TestSubordinateUpgradingFrom(c *gc.C) {
@@ -527,7 +565,8 @@ func (s *statusUnitTestSuite) TestSubordinateUpgradingFrom(c *gc.C) {
 	c.Assert(unitStatus.Charm, gc.Equals, "")
 
 	err = subordApp.SetCharm(state.SetCharmConfig{
-		Charm: subordCharmNew,
+		Charm:       subordCharmNew,
+		CharmOrigin: defaultCharmOrigin(subordCharmNew.URL()),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	corearch "github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
@@ -483,12 +485,13 @@ var (
 		"exposed": true,
 	})
 	loggingCharm = M{
-		"charm":        "logging",
-		"charm-origin": "charmhub",
-		"charm-name":   "logging",
-		"charm-rev":    1,
-		"base":         M{"name": "ubuntu", "channel": "12.10"},
-		"exposed":      true,
+		"charm":         "logging",
+		"charm-origin":  "charmhub",
+		"charm-name":    "logging",
+		"charm-rev":     1,
+		"charm-channel": "stable",
+		"base":          M{"name": "ubuntu", "channel": "12.10"},
+		"exposed":       true,
 		"application-status": M{
 			"current": "error",
 			"message": "somehow lost in all those logs",
@@ -1938,12 +1941,13 @@ var statusTests = []testCase{
 						},
 					}),
 					"varnish": M{
-						"charm":        "varnish",
-						"charm-origin": "charmhub",
-						"charm-name":   "varnish",
-						"charm-rev":    1,
-						"base":         M{"name": "ubuntu", "channel": "12.10"},
-						"exposed":      true,
+						"charm":         "varnish",
+						"charm-origin":  "charmhub",
+						"charm-name":    "varnish",
+						"charm-channel": "stable",
+						"charm-rev":     1,
+						"base":          M{"name": "ubuntu", "channel": "12.10"},
+						"exposed":       true,
 						"application-status": M{
 							"current": "waiting",
 							"message": "waiting for machine",
@@ -2079,12 +2083,13 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"riak": M{
-						"charm":        "riak",
-						"charm-origin": "charmhub",
-						"charm-name":   "riak",
-						"charm-rev":    7,
-						"base":         M{"name": "ubuntu", "channel": "12.10"},
-						"exposed":      true,
+						"charm":         "riak",
+						"charm-origin":  "charmhub",
+						"charm-name":    "riak",
+						"charm-rev":     7,
+						"charm-channel": "stable",
+						"base":          M{"name": "ubuntu", "channel": "12.10"},
+						"exposed":       true,
 						"application-status": M{
 							"current": "active",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -2857,7 +2862,7 @@ var statusTests = []testCase{
 		},
 	),
 	test( // 14
-		"unit with out of date charm",
+		"unit with out of date charm, switching from repo to local",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewSpaceAddresses("10.0.0.1")},
 		startAliveMachine{"0", ""},
@@ -2884,10 +2889,8 @@ var statusTests = []testCase{
 					"1": machine1,
 				},
 				"applications": M{
-					"mysql": mysqlCharm(M{
-						"charm":        "local:quantal/mysql-1",
-						"charm-origin": "local",
-						"exposed":      true,
+					"mysql": localMysqlCharm(M{
+						"charm": "local:quantal/mysql-1",
 						"application-status": M{
 							"current": "active",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -2952,7 +2955,6 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"mysql": mysqlCharm(M{
-						"charm":          "mysql",
 						"charm-rev":      2,
 						"can-upgrade-to": "ch:mysql-23",
 						"exposed":        true,
@@ -3019,10 +3021,8 @@ var statusTests = []testCase{
 					"1": machine1,
 				},
 				"applications": M{
-					"mysql": mysqlCharm(M{
-						"charm":        "local:quantal/mysql-1",
-						"charm-origin": "local",
-						"exposed":      true,
+					"mysql": localMysqlCharm(M{
+						"charm": "local:quantal/mysql-1",
 						"application-status": M{
 							"current": "active",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -3154,7 +3154,6 @@ var statusTests = []testCase{
 							"metrics-client": network.AlphaSpaceName,
 						},
 					}),
-
 					"applicationwithmeterstatus": meteredCharm(M{
 						"application-status": M{
 							"current": "active",
@@ -3731,10 +3730,8 @@ var statusTests = []testCase{
 					},
 				},
 				"applications": M{
-					"wordpress": M{
-						"base":       M{"name": "ubuntu", "channel": "12.10"},
-						"charm-name": "wordpress",
-						"exposed":    bool(false),
+					"wordpress": wordpressCharm(M{
+						"exposed": bool(false),
 						"units": M{
 							"wordpress/0": M{
 								"public-address": "10.0.1.1",
@@ -3750,9 +3747,6 @@ var statusTests = []testCase{
 								"machine": "1",
 							},
 						},
-						"charm":        "wordpress",
-						"charm-origin": "charmhub",
-						"charm-rev":    int(3),
 						"application-status": M{
 							"current": "waiting",
 							"message": "waiting for machine",
@@ -3769,7 +3763,7 @@ var statusTests = []testCase{
 							"url":             network.AlphaSpaceName,
 							"admin-api":       network.AlphaSpaceName,
 						},
-					},
+					}),
 				},
 				"storage": M{},
 				"controller": M{
@@ -3807,10 +3801,14 @@ var statusTests = []testCase{
 					"1": machine1WithLXDProfile,
 				},
 				"applications": M{
-					"lxd-profile": lxdProfileCharm(M{
-						"charm":        "local:quantal/lxd-profile-1",
-						"charm-origin": "local",
-						"exposed":      true,
+					"lxd-profile": M{
+						"charm":         "local:quantal/lxd-profile-1",
+						"charm-origin":  "local",
+						"exposed":       true,
+						"charm-name":    "lxd-profile",
+						"charm-rev":     1,
+						"charm-profile": "juju-controller-lxd-profile-1",
+						"base":          M{"name": "ubuntu", "channel": "12.10"},
 						"application-status": M{
 							"current": "active",
 							"since":   "01 Apr 15 01:23+10:00",
@@ -3835,7 +3833,7 @@ var statusTests = []testCase{
 							"another": network.AlphaSpaceName,
 							"ubuntu":  network.AlphaSpaceName,
 						},
-					}),
+					},
 				},
 				"storage": M{},
 				"controller": M{
@@ -3879,61 +3877,64 @@ var statusTests = []testCase{
 
 func mysqlCharm(extras M) M {
 	charm := M{
-		"charm":        "mysql",
-		"charm-origin": "charmhub",
-		"charm-name":   "mysql",
-		"charm-rev":    1,
-		"base":         M{"name": "ubuntu", "channel": "12.10"},
-		"exposed":      false,
-	}
-	return composeCharms(charm, extras)
-}
-
-func lxdProfileCharm(extras M) M {
-	charm := M{
-		"charm":         "lxd-profile",
+		"charm":         "mysql",
 		"charm-origin":  "charmhub",
-		"charm-name":    "lxd-profile",
+		"charm-name":    "mysql",
 		"charm-rev":     1,
-		"charm-profile": "juju-controller-lxd-profile-1",
+		"charm-channel": "stable",
 		"base":          M{"name": "ubuntu", "channel": "12.10"},
 		"exposed":       false,
 	}
 	return composeCharms(charm, extras)
 }
 
-func meteredCharm(extras M) M {
+func localMysqlCharm(extras M) M {
 	charm := M{
-		"charm":        "metered",
-		"charm-origin": "charmhub",
-		"charm-name":   "metered",
+		"charm":        "mysql",
+		"charm-origin": "local",
+		"charm-name":   "mysql",
 		"charm-rev":    1,
 		"base":         M{"name": "ubuntu", "channel": "12.10"},
-		"exposed":      false,
+		"exposed":      true,
+	}
+	return composeCharms(charm, extras)
+}
+
+func meteredCharm(extras M) M {
+	charm := M{
+		"charm":         "metered",
+		"charm-origin":  "charmhub",
+		"charm-name":    "metered",
+		"charm-rev":     1,
+		"charm-channel": "stable",
+		"base":          M{"name": "ubuntu", "channel": "12.10"},
+		"exposed":       false,
 	}
 	return composeCharms(charm, extras)
 }
 
 func dummyCharm(extras M) M {
 	charm := M{
-		"charm":        "dummy",
-		"charm-origin": "charmhub",
-		"charm-name":   "dummy",
-		"charm-rev":    1,
-		"base":         M{"name": "ubuntu", "channel": "12.10"},
-		"exposed":      false,
+		"charm":         "dummy",
+		"charm-origin":  "charmhub",
+		"charm-name":    "dummy",
+		"charm-rev":     1,
+		"charm-channel": "stable",
+		"base":          M{"name": "ubuntu", "channel": "12.10"},
+		"exposed":       false,
 	}
 	return composeCharms(charm, extras)
 }
 
 func wordpressCharm(extras M) M {
 	charm := M{
-		"charm":        "wordpress",
-		"charm-origin": "charmhub",
-		"charm-name":   "wordpress",
-		"charm-rev":    3,
-		"base":         M{"name": "ubuntu", "channel": "12.10"},
-		"exposed":      false,
+		"charm":         "wordpress",
+		"charm-origin":  "charmhub",
+		"charm-name":    "wordpress",
+		"charm-rev":     3,
+		"charm-channel": "stable",
+		"base":          M{"name": "ubuntu", "channel": "12.10"},
+		"exposed":       false,
 	}
 	return composeCharms(charm, extras)
 }
@@ -4294,17 +4295,11 @@ func (as addApplication) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
 
-	series := ch.URL().Series
-	if series == "" {
-		series = "quantal"
-	}
-	base, err := corebase.GetBaseFromSeries(series)
-	c.Assert(err, jc.ErrorIsNil)
 	app, err := ctx.st.AddApplication(state.AddApplicationArgs{
 		Name:             as.name,
 		Charm:            ch,
 		EndpointBindings: as.binding,
-		CharmOrigin:      &state.CharmOrigin{Platform: &state.Platform{OS: base.OS, Channel: base.Channel.String()}},
+		CharmOrigin:      defaultCharmOrigin(ch.URL()),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	if app.IsPrincipal() {
@@ -4413,9 +4408,49 @@ func (ssc setApplicationCharm) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	s, err := ctx.st.Application(ssc.name)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg := state.SetCharmConfig{Charm: ch}
+
+	cfg := state.SetCharmConfig{
+		Charm:       ch,
+		CharmOrigin: defaultCharmOrigin(ch.URL()),
+	}
 	err = s.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func defaultCharmOrigin(curl *charm.URL) *state.CharmOrigin {
+	var source string
+	var channel *state.Channel
+	if charm.CharmHub.Matches(curl.Schema) {
+		source = corecharm.CharmHub.String()
+		channel = &state.Channel{
+			Risk: "stable",
+		}
+	} else if charm.Local.Matches(curl.Schema) {
+		source = corecharm.Local.String()
+	}
+	s := curl.Series
+	if s == "" {
+		s = "quantal"
+	}
+	b, _ := corebase.GetBaseFromSeries(s)
+
+	platform := &state.Platform{
+		Architecture: corearch.DefaultArchitecture,
+		OS:           b.OS,
+		Channel:      b.Channel.String(),
+	}
+
+	return &state.CharmOrigin{
+		Source:   source,
+		Type:     "charm",
+		Revision: intPtr(curl.Revision),
+		Channel:  channel,
+		Platform: platform,
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
 }
 
 type addCharmPlaceholder struct {
@@ -4862,7 +4897,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		err = format.unmarshal(out, &actual)
 		c.Assert(err, jc.ErrorIsNil)
 		pretty.Ldiff(c, actual, expected)
-		c.Assert(actual, jc.DeepEquals, expected)
+		c.Check(actual, jc.DeepEquals, expected)
 	}
 }
 
@@ -5266,9 +5301,9 @@ SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
 App        Version          Status       Scale  Charm      Channel  Rev  Exposed  Message
-logging    a bit too lo...  error            2  logging               1  yes      somehow lost in all those logs
-mysql      5.7.13           maintenance    1/2  mysql                 1  yes      installing all the things
-wordpress  4.5.3            active           1  wordpress             3  yes      
+logging    a bit too lo...  error            2  logging    stable     1  yes      somehow lost in all those logs
+mysql      5.7.13           maintenance    1/2  mysql      stable     1  yes      installing all the things
+wordpress  4.5.3            active           1  wordpress  stable     3  yes      
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things

--- a/state/application.go
+++ b/state/application.go
@@ -1648,14 +1648,21 @@ type SetCharmConfig struct {
 	RequireNoUnits bool
 }
 
-// SetCharm changes the charm for the application.
-func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
-	defer errors.DeferredAnnotatef(
-		&err, "cannot upgrade application %q to charm %q", a, cfg.Charm,
-	)
+func (a *Application) validateSetCharmConfig(cfg SetCharmConfig) error {
 	if cfg.Charm.Meta().Subordinate != a.doc.Subordinate {
 		return errors.Errorf("cannot change an application's subordinacy")
 	}
+	origin := cfg.CharmOrigin
+	if origin == nil {
+		return errors.NotValidf("nil charm origin")
+	}
+	if origin.Platform == nil {
+		return errors.BadRequestf("charm origin platform is nil")
+	}
+	if (origin.ID != "" && origin.Hash == "") || (origin.ID == "" && origin.Hash != "") {
+		return errors.BadRequestf("programming error, SetCharm, neither CharmOrigin ID nor Hash can be set before a charm is downloaded. See CharmHubRepository GetDownloadURL.")
+	}
+
 	curl, err := charm.ParseURL(*a.doc.CharmURL)
 	if err != nil {
 		return errors.Annotate(err, "parsing charm url")
@@ -1684,11 +1691,6 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		}
 	}
 
-	updatedSettings, err := cfg.Charm.Config().ValidateSettings(cfg.ConfigSettings)
-	if err != nil {
-		return errors.Annotate(err, "validating config settings")
-	}
-
 	// we don't need to check that this is a charm.LXDProfiler, as we can
 	// state that the function exists.
 	if profile := cfg.Charm.LXDProfile(); profile != nil {
@@ -1700,6 +1702,25 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		if err := profile.ValidateConfigDevices(); err != nil && !cfg.Force {
 			return errors.Annotate(err, "validating lxd profile")
 		}
+	}
+	return nil
+}
+
+// SetCharm changes the charm for the application.
+func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
+	defer errors.DeferredAnnotatef(
+		&err, "cannot upgrade application %q to charm %q", a, cfg.Charm,
+	)
+
+	// Validate the input. ValidateSettings validates and transforms
+	// leaving it here.
+	if err := a.validateSetCharmConfig(cfg); err != nil {
+		return errors.Trace(err)
+	}
+
+	updatedSettings, err := cfg.Charm.Config().ValidateSettings(cfg.ConfigSettings)
+	if err != nil {
+		return errors.Annotate(err, "validating config settings")
 	}
 
 	var newCharmModifiedVersion int
@@ -1739,15 +1760,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 			updates := bson.D{
 				{"forcecharm", cfg.ForceUnits},
 			}
-			// Local charms will not have a channel in their charm origin
-			// TODO: (hml) 2023-02-03
-			// With juju 3.0, SetCharm should always have a CharmOrigin.
-			// Compatibility with the Update application facade method
-			// is no longer necessary.
-			if cfg.CharmOrigin != nil && cfg.CharmOrigin.Channel != nil {
-				updates = append(updates, bson.DocElem{"charm-origin.channel", cfg.CharmOrigin.Channel})
-			}
-			// Charm URL already set; just update the force flag and channel.
+			// Charm URL already set; just update the force flag.
 			ops = append(ops, txn.Op{
 				C:      applicationsC,
 				Id:     a.doc.DocID,
@@ -1794,59 +1807,15 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 			newCharmModifiedVersion++
 		}
 
-		// TODO: (hml) 2023-02-03
-		// With juju 3.0, SetCharm should always have a CharmOrigin.
-		// Compatibility with the Update application facade method
-		// is no longer necessary. Modify checks appropriately.
-		if cfg.CharmOrigin != nil {
-			origin := a.doc.CharmOrigin
-			// If either the charm origin ID or Hash is set before a charm is
-			// downloaded, charm download will fail for charms with a forced series.
-			// The logic (refreshConfig) in sending the correct request to charmhub
-			// will break.
-			if (origin.ID != "" && origin.Hash == "") || (origin.ID == "" && origin.Hash != "") {
-				return nil, errors.BadRequestf("programming error, SetCharm, neither CharmOrigin ID nor Hash can be set before a charm is downloaded. See CharmHubRepository GetDownloadURL.")
-			}
-			if cfg.CharmOrigin.ID != "" {
-				origin.ID = cfg.CharmOrigin.ID
-			}
-			if cfg.CharmOrigin.Hash != "" {
-				origin.Hash = cfg.CharmOrigin.Hash
-			}
-			if cfg.CharmOrigin.Type != "" {
-				origin.Type = cfg.CharmOrigin.Type
-			}
-			if cfg.CharmOrigin.Source != "" {
-				origin.Source = cfg.CharmOrigin.Source
-			}
-			if cfg.CharmOrigin.Revision != nil {
-				origin.Revision = cfg.CharmOrigin.Revision
-			}
-			if cfg.CharmOrigin.Channel != nil {
-				origin.Channel = cfg.CharmOrigin.Channel
-			}
-			if cfg.CharmOrigin.Platform != nil {
-				if cfg.CharmOrigin.Platform.Channel != "" {
-					origin.Platform.OS = cfg.CharmOrigin.Platform.OS
-					origin.Platform.Channel = cfg.CharmOrigin.Platform.Channel
-				}
-				if cfg.CharmOrigin.Platform.Architecture != "" {
-					origin.Platform.Architecture = cfg.CharmOrigin.Platform.Architecture
-				}
-			}
-			// Update in the application facade also calls
-			// SetCharm, though it has no current user in the
-			// application api client. Just in case: do not
-			// update the CharmOrigin if nil.
-			ops = append(ops, txn.Op{
-				C:      applicationsC,
-				Id:     a.doc.DocID,
-				Assert: txn.DocExists,
-				Update: bson.D{{"$set", bson.D{
-					{"charm-origin", origin},
-				}}},
-			})
-		}
+		// Update the charm origin
+		ops = append(ops, txn.Op{
+			C:      applicationsC,
+			Id:     a.doc.DocID,
+			Assert: txn.DocExists,
+			Update: bson.D{{"$set", bson.D{
+				{"charm-origin", *cfg.CharmOrigin},
+			}}},
+		})
 
 		if cfg.RequireNoUnits {
 			if a.UnitCount()+a.GetScale() > 0 {

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -251,7 +251,7 @@ func (s *CharmSuite) TestDestroyUnitReferencedCharm(c *gc.C) {
 	info := s.dummyCharm(c, "ch:quantal/dummy-2")
 	newCh, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app.SetCharm(state.SetCharmConfig{Charm: newCh})
+	err = app.SetCharm(state.SetCharmConfig{Charm: newCh, CharmOrigin: defaultCharmOrigin(newCh.URL())})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// unit should still reference original charm until updated

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -550,7 +550,7 @@ func (s *UnitSuite) TestConfigSettingsReflectCharm(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	newCharm := s.AddConfigCharm(c, "wordpress", "options: {}", 123)
-	cfg := state.SetCharmConfig{Charm: newCharm}
+	cfg := state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err = s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -601,7 +601,7 @@ func (s *UnitSuite) TestWatchConfigSettings(c *gc.C) {
 
 	// Change application's charm; nothing detected.
 	newCharm := s.AddConfigCharm(c, "wordpress", floatConfig, 123)
-	cfg := state.SetCharmConfig{Charm: newCharm}
+	cfg := state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err = s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
@@ -621,7 +621,7 @@ func (s *UnitSuite) TestWatchConfigSettings(c *gc.C) {
 
 func (s *UnitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	newCharm := s.AddConfigCharm(c, "wordpress", sortableConfig, 123)
-	cfg := state.SetCharmConfig{Charm: newCharm}
+	cfg := state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err := s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.SetCharmURL(newCharm.URL())
@@ -675,7 +675,7 @@ func (s *UnitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 
 	// Change application's charm; nothing detected.
 	newCharm = s.AddConfigCharm(c, "wordpress", floatConfig, 125)
-	cfg = state.SetCharmConfig{Charm: newCharm}
+	cfg = state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err = s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
@@ -714,7 +714,7 @@ func (s *UnitSuite) TestConfigHashesDifferentForDifferentCharms(c *gc.C) {
 	wc1.AssertChange("2e1f49c3e8b53892b822558401af33589522094681276a98458595114e04c0c1")
 
 	newCharm := s.AddConfigCharm(c, "wordpress", wordpressConfig, 125)
-	cfg := state.SetCharmConfig{Charm: newCharm}
+	cfg := state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err = s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1339,7 +1339,7 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Set a different charm to force a retry: first on
 				// the application, so the settings are created, then on
 				// the unit.
-				cfg := state.SetCharmConfig{Charm: sch}
+				cfg := state.SetCharmConfig{Charm: sch, CharmOrigin: defaultCharmOrigin(sch.URL())}
 				err := s.application.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				err = s.unit.SetCharmURL(sch.URL())
@@ -1348,7 +1348,7 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 			After: func() {
 				// Set back the same charm on the application, so the
 				// settings refcount is correct..
-				cfg := state.SetCharmConfig{Charm: s.charm}
+				cfg := state.SetCharmConfig{Charm: s.charm, CharmOrigin: defaultCharmOrigin(s.charm.URL())}
 				err := s.application.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 			},
@@ -1406,7 +1406,7 @@ func (s *UnitSuite) TestDestroyChangeCharmRetry(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	newCharm := s.AddConfigCharm(c, "mysql", "options: {}", 99)
-	cfg := state.SetCharmConfig{Charm: newCharm}
+	cfg := state.SetCharmConfig{Charm: newCharm, CharmOrigin: defaultCharmOrigin(newCharm.URL())}
 	err = s.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2908,8 +2908,9 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	// Changing the application bindings after an upgrade should trigger a change
 	sch := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 2)
 	cfg := state.SetCharmConfig{
-		Charm:      sch,
-		ForceUnits: true,
+		Charm:       sch,
+		CharmOrigin: defaultCharmOrigin(sch.URL()),
+		ForceUnits:  true,
 		EndpointBindings: map[string]string{
 			"server": "private",
 		},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -34,6 +34,9 @@ import (
 	"github.com/juju/juju/api/agent/secretsmanager"
 	apiuniter "github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/api/client/charms"
+	corearch "github.com/juju/juju/core/arch"
+	corebase "github.com/juju/juju/core/base"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/leadership"
 	corelease "github.com/juju/juju/core/lease"
@@ -1029,13 +1032,47 @@ func (s upgradeCharm) step(c *gc.C, ctx *testContext) {
 	sch, err := ctx.st.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := state.SetCharmConfig{
-		Charm:      sch,
-		ForceUnits: s.forced,
+		Charm:       sch,
+		ForceUnits:  s.forced,
+		CharmOrigin: defaultCharmOrigin(curl),
 	}
 	// Make sure we upload the charm before changing it in the DB.
 	serveCharm{}.step(c, ctx)
 	err = ctx.application.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func defaultCharmOrigin(curl *jujucharm.URL) *state.CharmOrigin {
+	var source string
+	var channel *state.Channel
+	if jujucharm.CharmHub.Matches(curl.Schema) {
+		source = corecharm.CharmHub.String()
+		channel = &state.Channel{
+			Risk: "stable",
+		}
+	} else if jujucharm.Local.Matches(curl.Schema) {
+		source = corecharm.Local.String()
+	}
+
+	b, _ := corebase.GetBaseFromSeries(curl.Series)
+
+	platform := &state.Platform{
+		Architecture: corearch.DefaultArchitecture,
+		OS:           b.OS,
+		Channel:      b.Channel.String(),
+	}
+
+	return &state.CharmOrigin{
+		Source:   source,
+		Type:     "charm",
+		Revision: intPtr(curl.Revision),
+		Channel:  channel,
+		Platform: platform,
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
 }
 
 type verifyCharm struct {


### PR DESCRIPTION
Resolve a todo for juju 3. All applications in state must now have a charm origin. Compatibility with juju 2.9.latest client is possible, as it creates charm origin's also.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

@jack-w-shaw please test the local charm scenarios you've been working with. 

```sh
(cd tests && ./main.sh -v refresh)
(cd tests && ./main.sh -v deploy)
```

## Links

JUJU-4161