### PR TITLE
remove extra -X for debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ endef
 # Compile with debug flags if requested.
 ifeq ($(DEBUG_JUJU), 1)
     COMPILE_FLAGS = -gcflags "all=-N -l"
-    LINK_FLAGS =  "-X $(link_flags_version)"
+    LINK_FLAGS =  "$(link_flags_version)"
 	CGO_LINK_FLAGS = "-linkmode 'external' -extldflags '-static' $(link_flags_version)"
 else
     LINK_FLAGS = "-s -w -extldflags '-static' $(link_flags_version)"


### PR DESCRIPTION
The linker flags defined in the Makefile (link_flags_version) include the '-X' flag, however in the debug codepath the '-X' is included again, resulting in build error:

```
$ DEBUG_JUJU=1 make go-build
Building github.com/juju/juju/cmd/jujuc for linux/amd64
# github.com/juju/juju/cmd/jujuc
/snap/go/10389/pkg/tool/linux_amd64/link: -X flag requires argument of the form importpath.name=value
make: *** [Makefile:336: /home/rafaell/repos/juju/_build/linux_amd64/bin/jujuc] Error 1
```

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
DEBUG_JUJU=1 make go-build
```

## Links

**Launchpad bug:** https://pad.lv/2041791
