### PR TITLE
[JUJU-4779] Construct charm origin from charm url

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -235,7 +235,7 @@ func AddTestingCharmWithSeries(c *gc.C, st *State, name string, series string) *
 }
 
 func getCharmRepo(series string) *repo.CharmRepo {
-	// ALl testing charms for state are under `quantal` except `kubernetes`.
+	// All testing charms for state are under `quantal` except `kubernetes`.
 	if series == "kubernetes" {
 		return testcharms.RepoForSeries(series)
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1407,35 +1407,46 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 	return appDoc, nil
 }
 
+// makeCharmOrigin returns the charm origin for an application
+//
+// Previous versions of the Juju server and clients have treated applications charm
+// origins very loosely, particularly during `refresh -- switch`s. The server performed
+// no validation on origins received from the client, and client often mutated them
+// incorrectly. For instance, when switching from a ch charm to local, pylibjuju simply
+// send back a copy of the ch charm origin, whereas the CLI only set the source to local.
+// Both resulted in incorrect/invalidate origins.
+//
+// Calculate the origin Source and Revision from the charm url. Ensure ID, Hash and Channel
+// are dropped from local charm. Keep ID, Hash and Channel (for ch charms) and Platform (always)
+// we get from the origin. We can trust these since supported clients cannot break these
+//
+// This was fixed in pylibjuju 3.2.3.0 and juju 3.3.0. As of writing, no versions of the
+// server validate new charm origins on calls to SetCharm. Ideally, the client shouldn't
+// handle charm origins at all, being an implementation detail. But this will probably have
+// to wait until the api re-write
+//
+// https://bugs.launchpad.net/juju/+bug/2039267
+// https://github.com/juju/python-libjuju/issues/962
+//
+// TODO: Once we have confidence in charm origins, do not parse charm url and simplify
+// into a translation layer
 func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, error) {
-	curlStr := a.CharmURL()
+	sourceOrigin := a.CharmOrigin()
+	curl, err := charm.ParseURL(a.CharmURL())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	// Fix bad datasets from LP 1999060 during migration.
 	// ID and Hash missing from N-1 of N applications'
 	// charm origins when deployed using the same charm.
-	if foundOrigin, ok := i.charmOrigins[curlStr]; ok {
+	if foundOrigin, ok := i.charmOrigins[curl.String()]; ok {
 		return foundOrigin, nil
 	}
 
-	co := a.CharmOrigin()
-	rev := co.Revision()
-	// If revision is empty we export revision -1. In this case
-	// parse the revision from the url
-	// NOTE: We use <= 0 because some old versions of juju default
-	// revision to 0 when it's empty
-	if rev <= 0 {
-		curl, err := charm.ParseURL(a.CharmURL())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		rev = curl.Revision
-	}
-
 	var channel *Channel
-	// Only charmhub charms will have a channel. Local charms
-	// should not have a channel, so drop even if provided.
-	serialized := co.Channel()
-	if serialized != "" && corecharm.CharmHub.Matches(co.Source()) {
+	serialized := sourceOrigin.Channel()
+	if serialized != "" && charm.CharmHub.Matches(curl.Schema) {
 		c, err := charm.ParseChannelNormalize(serialized)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1449,11 +1460,9 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 			Risk:   string(c.Risk),
 			Branch: c.Branch,
 		}
-	} else if serialized != "" && corecharm.Local.Matches(co.Source()) {
-		i.logger.Warningf("Dropping channel: %q for application %q, should not exist", serialized, a.Name())
 	}
 
-	p, err := corecharm.ParsePlatformNormalize(co.Platform())
+	p, err := corecharm.ParsePlatformNormalize(sourceOrigin.Platform())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1464,16 +1473,33 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 	}
 
 	// We can hardcode type to charm as we never store bundles in state.
-	origin := &CharmOrigin{
-		Source:   co.Source(),
-		Type:     "charm",
-		ID:       co.ID(),
-		Hash:     co.Hash(),
-		Revision: &rev,
-		Channel:  channel,
-		Platform: platform,
+	var origin *CharmOrigin
+	if charm.Local.Matches(curl.Schema) {
+		origin = &CharmOrigin{
+			Source:   corecharm.Local.String(),
+			Type:     "charm",
+			Revision: &curl.Revision,
+			Platform: platform,
+		}
+	} else if charm.CharmHub.Matches(curl.Schema) {
+		origin = &CharmOrigin{
+			Source:   corecharm.CharmHub.String(),
+			Type:     "charm",
+			Revision: &curl.Revision,
+			ID:       sourceOrigin.ID(),
+			Hash:     sourceOrigin.Hash(),
+			Channel:  channel,
+			Platform: platform,
+		}
+	} else {
+		return nil, errors.Errorf("Unrecognised charm url schema %q", curl.Schema)
 	}
-	i.charmOrigins[curlStr] = origin
+
+	if !reflect.DeepEqual(sourceOrigin, origin) {
+		i.logger.Warningf("Source origin for application %q does not match charm url. Normalising", a.Name())
+	}
+
+	i.charmOrigins[curl.String()] = origin
 	return origin, nil
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"sort"
 
-	"github.com/juju/charm/v11"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
@@ -15,6 +14,7 @@ import (
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -372,24 +372,24 @@ func (s *upgradesSuite) TestEnsureInitalRefCountForExternalSecretBackends(c *gc.
 	s.assertUpgradedData(c, EnsureInitalRefCountForExternalSecretBackends, expectedData)
 }
 
-func (s *upgradesSuite) TestEnsureApplicationCharmOriginsHaveRevisions(c *gc.C) {
+func (s *upgradesSuite) TestEnsureApplicationCharmOriginsNormaliseLocal(c *gc.C) {
 	ch := AddTestingCharm(c, s.state, "dummy")
 	platform := Platform{OS: "ubuntu", Channel: "20.04"}
+	rev := 6
 	_ = addTestingApplication(c, addTestingApplicationParams{
 		st:   s.state,
 		name: "my-local-app",
 		ch:   ch,
 		origin: &CharmOrigin{
-			Source:   charm.Local.String(),
+			Source:   corecharm.CharmHub.String(),
 			Platform: &platform,
+			Hash:     "some-hash",
+			ID:       "some-id",
+			Revision: &rev,
+			Channel:  &Channel{Track: "20.04", Risk: "stable", Branch: "deadbeef"},
 		},
 		numUnits: 1,
 	})
-
-	apps, err := s.state.AllApplications()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apps, gc.HasLen, 1)
-	c.Assert(apps[0].CharmOrigin().Revision, gc.IsNil)
 
 	expected := bsonMById{{
 		"_id": s.state.docID("my-local-app"),
@@ -421,5 +421,58 @@ func (s *upgradesSuite) TestEnsureApplicationCharmOriginsHaveRevisions(c *gc.C) 
 	defer closer()
 
 	expectedData := upgradedData(appColl, expected)
-	s.assertUpgradedData(c, EnsureApplicationCharmOriginsHaveRevisions, expectedData)
+	s.assertUpgradedData(c, EnsureApplicationCharmOriginsNormalised, expectedData)
+}
+
+func (s *upgradesSuite) TestEnsureApplicationCharmOriginsNormaliseCH(c *gc.C) {
+	ch := AddTestingCharmhubCharmForSeries(c, s.state, "quantal", "dummy")
+	platform := Platform{OS: "ubuntu", Channel: "20.04"}
+	rev := 6
+	_ = addTestingApplication(c, addTestingApplicationParams{
+		st:   s.state,
+		name: "my-local-app",
+		ch:   ch,
+		origin: &CharmOrigin{
+			Source:   corecharm.Local.String(),
+			Platform: &platform,
+			Hash:     "some-hash",
+			ID:       "some-id",
+			Revision: &rev,
+			Channel:  &Channel{Track: "20.04", Risk: "stable", Branch: "deadbeef"},
+		},
+		numUnits: 1,
+	})
+
+	expected := bsonMById{{
+		"_id": s.state.docID("my-local-app"),
+		"charm-origin": bson.M{
+			"hash":     "some-hash",
+			"id":       "some-id",
+			"platform": bson.M{"os": "ubuntu", "channel": "20.04"},
+			"channel":  bson.M{"track": "20.04", "risk": "stable", "branch": "deadbeef"},
+			"source":   "charm-hub",
+			"revision": 1,
+		},
+		"charmmodifiedversion": 0,
+		"charmurl":             "ch:amd64/quantal/dummy-1",
+		"exposed":              false,
+		"forcecharm":           false,
+		"life":                 0,
+		"metric-credentials":   []uint8{},
+		"minunits":             0,
+		"model-uuid":           s.state.ModelUUID(),
+		"name":                 "my-local-app",
+		"passwordhash":         "",
+		"provisioning-state":   nil,
+		"relationcount":        0,
+		"scale":                0,
+		"subordinate":          false,
+		"unitcount":            1,
+	}}
+
+	appColl, closer := s.state.db().GetRawCollection(applicationsC)
+	defer closer()
+
+	expectedData := upgradedData(appColl, expected)
+	s.assertUpgradedData(c, EnsureApplicationCharmOriginsNormalised, expectedData)
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -14,7 +14,7 @@ type StateBackend interface {
 	RemoveOrphanedSecretPermissions() error
 	MigrateApplicationOpenedPortsToUnitScope() error
 	EnsureInitalRefCountForExternalSecretBackends() error
-	EnsureApplicationCharmOriginsHaveRevisions() error
+	EnsureApplicationCharmOriginsNormalised() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -45,6 +45,6 @@ func (s stateBackend) EnsureInitalRefCountForExternalSecretBackends() error {
 	return state.EnsureInitalRefCountForExternalSecretBackends(s.pool)
 }
 
-func (s stateBackend) EnsureApplicationCharmOriginsHaveRevisions() error {
-	return state.EnsureApplicationCharmOriginsHaveRevisions(s.pool)
+func (s stateBackend) EnsureApplicationCharmOriginsNormalised() error {
+	return state.EnsureApplicationCharmOriginsNormalised(s.pool)
 }

--- a/upgrades/steps_317.go
+++ b/upgrades/steps_317.go
@@ -13,7 +13,7 @@ func stateStepsFor317() []Step {
 			description: "ensure application charm origins have revisions",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
-				return context.State().EnsureApplicationCharmOriginsHaveRevisions()
+				return context.State().EnsureApplicationCharmOriginsNormalised()
 			},
 		},
 	}


### PR DESCRIPTION
Where possible, we should construct charm origin using the charm url. Some versions of the Juju client/server do not properly process/validate charm origins, meaning it's possible for get incorrect data into this field

Do this construction during upgrades and migrations

NOTE: We can simply modify the existing upgrade steps because we have not done a stable release since they were added initially

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### set up

With juju 3.1.6 installed:
```
juju bootstrap lxd lxd-3.1.6
juju add-model m
juju deploy ubuntu ubuntu
juju deploy ubuntu ubuntu-ch
```

Ensure you have python-libjuju 3.2.2 (i.e. not latest) and run the following script:
```
from juju import jasyncio
from juju.model import Model


async def main():
    model = Model()
    print('Connecting to model')
    # connect to current model with current user, per Juju CLI
    await model.connect()

    try:
        print('Get deployed application')
        app = model.applications["ubuntu"]

        print('Refresh/Upgrade Ubuntu charm with local charm')
        await app.refresh(path="/home/jack/charms/ubuntu")
    finally:
        print('Disconnecting from model')
        await model.disconnect()


if __name__ == '__main__':
    jasyncio.run(main())
```
ensuring that line 16 points to an existing local ubuntu charm

You should then notice:
```
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
...
{
	"_id" : "2ccc967d-146e-42bc-876f-27865c6c39ac:ubuntu",
	"name" : "ubuntu",
	"model-uuid" : "2ccc967d-146e-42bc-876f-27865c6c39ac",
	"subordinate" : false,
	"charmurl" : "local:focal/ubuntu-12",
	"charm-origin" : {
		"source" : "charm-hub",
		"type" : "charm",
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b",
		"revision" : 24,
		"channel" : {
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"channel" : "20.04"
		}
	},
	"charmmodifiedversion" : 1,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : NumberLong(4),
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null
}
{
	"_id" : "2ccc967d-146e-42bc-876f-27865c6c39ac:ubuntu-ch",
	"name" : "ubuntu-ch",
	"model-uuid" : "2ccc967d-146e-42bc-876f-27865c6c39ac",
	"subordinate" : false,
	"charmurl" : "ch:amd64/focal/ubuntu-24",
	"charm-origin" : {
		"source" : "charm-hub",
		"type" : "charm",
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b",
		"revision" : 24,
		"channel" : {
			"track" : "latest",
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"channel" : "20.04"
		}
	},
	"charmmodifiedversion" : 0,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : 2,
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null
}
```
paying attention to how wrong the charm origin for `ubuntu` is


### Migration
Run the set up steps above

With juju 3.1.7 installed (i.e. from this PR)
```
juju bootstrap lxd lxd-3.1.7
juju switch lxd-3.1.6
juju migrate m lxd-3.1.7
juju switch lxd-3.1.7:,m
```
Then verify the charm origin is corrected in state
```
"charmurl" : "local:focal/ubuntu-12",
"charm-origin" : {
	"source" : "local",
	"type" : "charm",
	"id" : "",
	"hash" : "",
	"revision" : 12,
	"platform" : {
		"architecture" : "amd64",
		"os" : "ubuntu",
		"channel" : "20.04"
	}
},
```

### Upgrade
Run the set up steps above

With juju 3.1.7 (i.e.from this PR) installed and loaded in your working directory:
```
juju upgrade-controller --build-agent
```
Then verify the charm origin is corrected in state
```
"charmurl" : "local:focal/ubuntu-12",
"charm-origin" : {
	"source" : "local",
	"type" : "charm",
	"id" : "",
	"hash" : "",
	"revision" : 12,
	"platform" : {
		"architecture" : "amd64",
		"os" : "ubuntu",
		"channel" : "20.04"
	}
},
```