### PR TITLE
[JUJU-4732] Get name from charm meta instead of url in 2 places

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -138,11 +138,8 @@ func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
 	charmURLs := []string{}
 	for _, aCharm := range charms {
 		if checkName {
-			charmURL, err := charm.ParseURL(aCharm.URL())
-			if err != nil {
-				return params.CharmsListResult{}, errors.Trace(err)
-			}
-			if !charmNames.Contains(charmURL.Name) {
+			name := aCharm.Meta().Name
+			if !charmNames.Contains(name) {
 				continue
 			}
 		}

--- a/state/application.go
+++ b/state/application.go
@@ -2400,11 +2400,12 @@ func (a *Application) addUnitOps(
 		// has the special juju- prefix to its name, then bypass the machineID
 		// empty check.
 		if args.machineID != "" && a.st.IsController() {
-			curl, err := charm.ParseURL(*a.doc.CharmURL)
+			ch, _, err := a.Charm()
 			if err != nil {
 				return "", nil, errors.Trace(err)
 			}
-			if !strings.HasPrefix(curl.Name, "juju-") {
+			name := ch.Meta().Name
+			if !strings.HasPrefix(name, "juju-") {
 				return "", nil, errors.NotSupportedf("non-empty machineID")
 			}
 		} else if args.machineID != "" {


### PR DESCRIPTION
This is a step towards removing charm url in general. In a few places we parse the charm url to get the name of a charm. Instead, we should bypass the charm url by getting the name directly from the charm metadata



## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Passing unit tests should be enough

It seems to me both of these bits of code are inaccessible, so passing unit tests will have to do

But anyway, you should try:
```
$ juju bootstrap lxd
$ juju add-model m
$ juju deploy ubuntu
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m      lxd         localhost/localhost  3.3-rc2.1  unsupported  12:32:42Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.121         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.121  juju-1cfce9-0  ubuntu@22.04      Running

```

