### PR TITLE
Use names when adding user secrets and include in tabular list

### DIFF
--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -38,6 +38,7 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 		Filter: params.SecretsFilter{
 			OwnerTag: filter.OwnerTag,
 			Revision: filter.Revision,
+			Label:    filter.Label,
 		},
 	}
 	if filter.URI != nil {
@@ -95,7 +96,7 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 	return result, err
 }
 
-func (c *Client) CreateSecret(label, description string, data map[string]string) (string, error) {
+func (c *Client) CreateSecret(name, description string, data map[string]string) (string, error) {
 	if c.BestAPIVersion() < 2 {
 		return "", errors.NotSupportedf("user secrets")
 	}
@@ -105,8 +106,8 @@ func (c *Client) CreateSecret(label, description string, data map[string]string)
 			Content: params.SecretContentParams{Data: data},
 		},
 	}
-	if label != "" {
-		arg.Label = &label
+	if name != "" {
+		arg.Label = &name
 	}
 	if description != "" {
 		arg.Description = &description
@@ -128,22 +129,27 @@ func (c *Client) CreateSecret(label, description string, data map[string]string)
 
 // UpdateSecret updates an existing secret.
 func (c *Client) UpdateSecret(
-	uri *secrets.URI, autoPrune *bool,
-	label, description string, data map[string]string,
+	uri *secrets.URI, name string, autoPrune *bool,
+	newName string, description string, data map[string]string,
 ) error {
 	if c.BestAPIVersion() < 2 {
 		return errors.NotSupportedf("user secrets")
 	}
 	var results params.ErrorResults
 	arg := params.UpdateUserSecretArg{
-		URI:       uri.String(),
 		AutoPrune: autoPrune,
 		UpsertSecretArg: params.UpsertSecretArg{
 			Content: params.SecretContentParams{Data: data},
 		},
 	}
-	if label != "" {
-		arg.UpsertSecretArg.Label = &label
+	if uri != nil {
+		arg.URI = uri.String()
+	}
+	if name != "" {
+		arg.ExistingLabel = name
+	}
+	if newName != "" {
+		arg.UpsertSecretArg.Label = &newName
 	}
 	if description != "" {
 		arg.UpsertSecretArg.Description = &description
@@ -162,12 +168,13 @@ func (c *Client) UpdateSecret(
 	return nil
 }
 
-func (c *Client) RemoveSecret(uri *secrets.URI, revision *int) error {
+func (c *Client) RemoveSecret(uri *secrets.URI, name string, revision *int) error {
 	if c.BestAPIVersion() < 2 {
 		return errors.NotSupportedf("user secrets")
 	}
 	arg := params.DeleteSecretArg{
-		URI: uri.String(),
+		URI:   uri.String(),
+		Label: name,
 	}
 	if revision != nil {
 		arg.Revisions = append(arg.Revisions, *revision)
@@ -189,12 +196,18 @@ func (c *Client) RemoveSecret(uri *secrets.URI, revision *int) error {
 }
 
 // GrantSecret grants access to a secret to the specified applications.
-func (c *Client) GrantSecret(uri *secrets.URI, apps []string) ([]error, error) {
+func (c *Client) GrantSecret(uri *secrets.URI, name string, apps []string) ([]error, error) {
 	if c.BestAPIVersion() < 2 {
 		return nil, errors.NotSupportedf("user secrets")
 	}
+	var uriString string
+	if uri != nil {
+		uriString = uri.String()
+	}
 	arg := params.GrantRevokeUserSecretArg{
-		URI: uri.String(), Applications: apps,
+		URI:          uriString,
+		Label:        name,
+		Applications: apps,
 	}
 
 	var results params.ErrorResults
@@ -221,12 +234,19 @@ func processErrors(results params.ErrorResults) []error {
 }
 
 // RevokeSecret revokes access to a secret from the specified applications.
-func (c *Client) RevokeSecret(uri *secrets.URI, apps []string) ([]error, error) {
+func (c *Client) RevokeSecret(uri *secrets.URI, name string, apps []string) ([]error, error) {
 	if c.BestAPIVersion() < 2 {
 		return nil, errors.NotSupportedf("user secrets")
 	}
+
+	var uriString string
+	if uri != nil {
+		uriString = uri.String()
+	}
 	arg := params.GrantRevokeUserSecretArg{
-		URI: uri.String(), Applications: apps,
+		URI:          uriString,
+		Label:        name,
+		Applications: apps,
 	}
 
 	var results params.ErrorResults

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -142,6 +142,12 @@ func (c *Client) UpdateSecret(
 			Content: params.SecretContentParams{Data: data},
 		},
 	}
+	if uri == nil && name == "" {
+		return errors.New("must specify either URI or name")
+	}
+	if uri != nil && name != "" {
+		return errors.New("must specify either URI or name but not both")
+	}
 	if uri != nil {
 		arg.URI = uri.String()
 	}

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -426,3 +426,18 @@ func (mr *MockSecretsRemoveStateMockRecorder) ListSecretRevisions(arg0 interface
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretRevisions", reflect.TypeOf((*MockSecretsRemoveState)(nil).ListSecretRevisions), arg0)
 }
+
+// ListSecrets mocks base method.
+func (m *MockSecretsRemoveState) ListSecrets(arg0 state.SecretsFilter) ([]*secrets0.SecretMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0)
+	ret0, _ := ret[0].([]*secrets0.SecretMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSecrets indicates an expected call of ListSecrets.
+func (mr *MockSecretsRemoveStateMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsRemoveState)(nil).ListSecrets), arg0)
+}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -762,7 +762,6 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 
 	results, err := secrets.RemoveSecretsForAgent(
 		removeState, adminConfigGetter,
-		names.NewUnitTag("mariadb/0"),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI:       expectURI.String(),
@@ -821,10 +820,73 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 
 	results, err := secrets.RemoveSecretsForAgent(
 		removeState, adminConfigGetter,
-		names.NewUnitTag("mariadb/0"),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI: expectURI.String(),
+			}},
+		},
+		func(*coresecrets.URI) error { return nil },
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	expectURI := *uri
+	removeState := mocks.NewMockSecretsRemoveState(ctrl)
+	mockprovider := mocks.NewMockSecretBackendProvider(ctrl)
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
+
+	removeState.EXPECT().ListSecrets(state.SecretsFilter{Label: ptr("my-secret")}).Return([]*coresecrets.SecretMetadata{{
+		URI: uri,
+	}}, nil)
+	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
+	removeState.EXPECT().ListSecretRevisions(&expectURI).Return(
+		[]*coresecrets.SecretRevisionMetadata{
+			{
+				Revision: 666,
+				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
+			},
+		},
+		nil,
+	)
+	removeState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
+		BackendID:  "backend-id",
+		RevisionID: "rev-666",
+	}}, nil)
+
+	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+		return &provider.ModelBackendConfigInfo{
+			ActiveID: "backend-id",
+			Configs: map[string]provider.ModelBackendConfig{
+				"backend-id": {
+					ControllerUUID: coretesting.ControllerTag.Id(),
+					ModelUUID:      coretesting.ModelTag.Id(),
+					ModelName:      "fred",
+					BackendConfig: provider.BackendConfig{
+						BackendType: "some-backend",
+						Config:      map[string]interface{}{"foo": "admin"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	results, err := secrets.RemoveSecretsForAgent(
+		removeState, adminConfigGetter,
+		params.DeleteSecretArgs{
+			Args: []params.DeleteSecretArg{{
+				Label: "my-secret",
 			}},
 		},
 		func(*coresecrets.URI) error { return nil },

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -768,6 +768,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 				Revisions: []int{666},
 			}},
 		},
+		coretesting.ModelTag.Id(),
 		func(*coresecrets.URI) error { return nil },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -825,6 +826,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 				URI: expectURI.String(),
 			}},
 		},
+		coretesting.ModelTag.Id(),
 		func(*coresecrets.URI) error { return nil },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -847,7 +849,10 @@ func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
 	mockprovider := mocks.NewMockSecretBackendProvider(ctrl)
 	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
 
-	removeState.EXPECT().ListSecrets(state.SecretsFilter{Label: ptr("my-secret")}).Return([]*coresecrets.SecretMetadata{{
+	removeState.EXPECT().ListSecrets(state.SecretsFilter{
+		Label:     ptr("my-secret"),
+		OwnerTags: []names.Tag{coretesting.ModelTag},
+	}).Return([]*coresecrets.SecretMetadata{{
 		URI: uri,
 	}}, nil)
 	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
@@ -889,6 +894,7 @@ func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
 				Label: "my-secret",
 			}},
 		},
+		coretesting.ModelTag.Id(),
 		func(*coresecrets.URI) error { return nil },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -960,6 +966,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 				Revisions: []int{666},
 			}},
 		},
+		coretesting.ModelTag.Id(),
 		func(*coresecrets.URI) error { return nil },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1035,6 +1042,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 				URI: expectURI.String(),
 			}},
 		},
+		coretesting.ModelTag.Id(),
 		func(*coresecrets.URI) error { return nil },
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -56,12 +56,18 @@ type SecretsMetaState interface {
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
 }
 
+// ListSecretsState instances provide secret metadata apis.
+type ListSecretsState interface {
+	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
+}
+
 // SecretsRemoveState instances provide secret removal apis.
 type SecretsRemoveState interface {
 	DeleteSecret(*secrets.URI, ...int) ([]secrets.ValueRef, error)
 	GetSecret(*secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretRevision(uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
+	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 }
 
 // Credential represents a cloud credential.

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -356,6 +356,7 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 func (s *SecretsManagerAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveSecretsForAgent(
 		s.secretsState, s.adminConfigGetter, args,
+		s.modelUUID,
 		func(uri *coresecrets.URI) error {
 			_, err := s.canManage(uri)
 			return errors.Trace(err)

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -355,8 +355,7 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 // RemoveSecrets removes the specified secrets.
 func (s *SecretsManagerAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveSecretsForAgent(
-		s.secretsState, s.adminConfigGetter,
-		s.authTag, args,
+		s.secretsState, s.adminConfigGetter, args,
 		func(uri *coresecrets.URI) error {
 			_, err := s.canManage(uri)
 			return errors.Trace(err)

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -84,7 +84,8 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 		}
 	}
 	filter := state.SecretsFilter{
-		URI: uri,
+		URI:   uri,
+		Label: arg.Filter.Label,
 	}
 	if arg.Filter.OwnerTag != nil {
 		tag, err := names.ParseTag(*arg.Filter.OwnerTag)
@@ -261,7 +262,7 @@ func (s *SecretsAPI) CreateSecrets(args params.CreateSecretArgs) (params.StringR
 		ID, err := s.createSecret(backend, arg)
 		result.Results[i].Result = ID
 		if errors.Is(err, state.LabelExists) {
-			err = errors.AlreadyExistsf("secret with label %q", *arg.Label)
+			err = errors.AlreadyExistsf("secret with name %q", *arg.Label)
 		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
@@ -383,7 +384,7 @@ func (s *SecretsAPI) UpdateSecrets(args params.UpdateUserSecretArgs) (params.Err
 	for i, arg := range args.Args {
 		err := s.updateSecret(backend, arg)
 		if errors.Is(err, state.LabelExists) {
-			err = errors.AlreadyExistsf("secret with label %q", *arg.Label)
+			err = errors.AlreadyExistsf("secret with name %q", *arg.Label)
 		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
@@ -394,7 +395,15 @@ func (s *SecretsAPI) updateSecret(backend provider.SecretsBackend, arg params.Up
 	if err := arg.Validate(); err != nil {
 		return errors.Trace(err)
 	}
-	uri, err := coresecrets.ParseURI(arg.URI)
+	var (
+		uri *coresecrets.URI
+		err error
+	)
+	if arg.URI != "" {
+		uri, err = coresecrets.ParseURI(arg.URI)
+	} else {
+		uri, err = s.getSecretURI(arg.ExistingLabel)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -506,19 +515,46 @@ func (s *SecretsAPI) RevokeSecret(arg params.GrantRevokeUserSecretArg) (params.E
 
 type grantRevokeFunc func(*coresecrets.URI, state.SecretAccessParams) error
 
+func (s *SecretsAPI) getSecretURI(label string) (*coresecrets.URI, error) {
+	results, err := s.secretsState.ListSecrets(state.SecretsFilter{Label: &label})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results) == 0 {
+		return nil, errors.NotFoundf("secret %q", label)
+	}
+	if len(results) > 1 {
+		return nil, errors.NotFoundf("more than 1 secret with label %q", label)
+	}
+	return results[0].URI, nil
+}
+
 func (s *SecretsAPI) secretsGrantRevoke(arg params.GrantRevokeUserSecretArg, op grantRevokeFunc) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(arg.Applications)),
+	}
+
+	if arg.URI == "" && arg.Label == "" {
+		return results, errors.New("must specify either URI or name")
 	}
 
 	if err := s.checkCanWrite(); err != nil {
 		return results, errors.Trace(err)
 	}
 
-	uri, err := coresecrets.ParseURI(arg.URI)
+	var (
+		uri *coresecrets.URI
+		err error
+	)
+	if arg.URI != "" {
+		uri, err = coresecrets.ParseURI(arg.URI)
+	} else {
+		uri, err = s.getSecretURI(arg.Label)
+	}
 	if err != nil {
 		return results, errors.Trace(err)
 	}
+
 	scopeTag := names.NewModelTag(s.modelUUID)
 	one := func(appName string) error {
 		subjectTag := names.NewApplicationTag(appName)

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -411,7 +411,10 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI, isInte
 	if uri == nil {
 		existingLabel = "my-secret"
 		uri = coresecrets.NewURI()
-		s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{Label: ptr("my-secret")}).Return([]*coresecrets.SecretMetadata{{
+		s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+			Label:     ptr("my-secret"),
+			OwnerTags: []names.Tag{coretesting.ModelTag},
+		}).Return([]*coresecrets.SecretMetadata{{
 			URI: uri,
 		}}, nil)
 	} else {
@@ -764,7 +767,10 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
-	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{Label: ptr("my-secret")}).Return([]*coresecrets.SecretMetadata{{
+	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		Label:     ptr("my-secret"),
+		OwnerTags: []names.Tag{coretesting.ModelTag},
+	}).Return([]*coresecrets.SecretMetadata{{
 		URI: uri,
 	}}, nil)
 	s.secretConsumer.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/apiserver/facades/controller/usersecrets/mocks/state.go
+++ b/apiserver/facades/controller/usersecrets/mocks/state.go
@@ -101,6 +101,21 @@ func (mr *MockSecretsStateMockRecorder) ListSecretRevisions(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretRevisions", reflect.TypeOf((*MockSecretsState)(nil).ListSecretRevisions), arg0)
 }
 
+// ListSecrets mocks base method.
+func (m *MockSecretsState) ListSecrets(arg0 state.SecretsFilter) ([]*secrets.SecretMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSecrets indicates an expected call of ListSecrets.
+func (mr *MockSecretsStateMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsState)(nil).ListSecrets), arg0)
+}
+
 // WatchRevisionsToPrune mocks base method.
 func (m *MockSecretsState) WatchRevisionsToPrune(arg0 []names.Tag) (state.StringsWatcher, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/usersecrets/secrets.go
+++ b/apiserver/facades/controller/usersecrets/secrets.go
@@ -52,7 +52,7 @@ func (s *UserSecretsManager) WatchRevisionsToPrune() (params.StringsWatchResult,
 func (s *UserSecretsManager) DeleteRevisions(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveUserSecrets(
 		s.secretsState, s.backendConfigGetter,
-		s.authTag, args,
+		s.authTag, args, s.modelUUID,
 		func(uri *coresecrets.URI) error {
 			md, err := s.secretsState.GetSecret(uri)
 			if err != nil {

--- a/apiserver/facades/controller/usersecrets/state.go
+++ b/apiserver/facades/controller/usersecrets/state.go
@@ -17,4 +17,5 @@ type SecretsState interface {
 	WatchRevisionsToPrune(owners []names.Tag) (state.StringsWatcher, error)
 	GetSecretRevision(uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
+	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40432,6 +40432,9 @@
                 "DeleteSecretArg": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
                         "revisions": {
                             "type": "array",
                             "items": {
@@ -40444,7 +40447,8 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "uri"
+                        "uri",
+                        "label"
                     ]
                 },
                 "DeleteSecretArgs": {
@@ -40520,6 +40524,9 @@
                                 "type": "string"
                             }
                         },
+                        "label": {
+                            "type": "string"
+                        },
                         "uri": {
                             "type": "string"
                         }
@@ -40527,6 +40534,7 @@
                     "additionalProperties": false,
                     "required": [
                         "uri",
+                        "label",
                         "applications"
                     ]
                 },
@@ -40705,6 +40713,9 @@
                 "SecretsFilter": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
                         "owner-tag": {
                             "type": "string"
                         },
@@ -40762,6 +40773,9 @@
                         "description": {
                             "type": "string"
                         },
+                        "existing-label": {
+                            "type": "string"
+                        },
                         "expire-time": {
                             "type": "string",
                             "format": "date-time"
@@ -40788,7 +40802,8 @@
                     "additionalProperties": false,
                     "required": [
                         "UpsertSecretArg",
-                        "uri"
+                        "uri",
+                        "existing-label"
                     ]
                 },
                 "UpdateUserSecretArgs": {
@@ -41420,6 +41435,9 @@
                 "DeleteSecretArg": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
                         "revisions": {
                             "type": "array",
                             "items": {
@@ -41432,7 +41450,8 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "uri"
+                        "uri",
+                        "label"
                     ]
                 },
                 "DeleteSecretArgs": {
@@ -48732,6 +48751,9 @@
                 "DeleteSecretArg": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
                         "revisions": {
                             "type": "array",
                             "items": {
@@ -48744,7 +48766,8 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "uri"
+                        "uri",
+                        "label"
                     ]
                 },
                 "DeleteSecretArgs": {
@@ -53247,6 +53270,9 @@
                 "DeleteSecretArg": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
                         "revisions": {
                             "type": "array",
                             "items": {
@@ -53259,7 +53285,8 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "uri"
+                        "uri",
+                        "label"
                     ]
                 },
                 "DeleteSecretArgs": {

--- a/cmd/juju/secrets/add_test.go
+++ b/cmd/juju/secrets/add_test.go
@@ -45,10 +45,10 @@ func (s *addSuite) TestAddDataFromArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().CreateSecret("label", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(uri.String(), nil)
+	s.secretsAPI.EXPECT().CreateSecret("my-secret", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(uri.String(), nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
-	ctx, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "foo=bar", "--label", "label", "--info", "this is a secret.")
+	ctx, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "my-secret", "foo=bar", "--info", "this is a secret.")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, uri.String()+"\n")
@@ -58,7 +58,7 @@ func (s *addSuite) TestAddDataFromFile(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().CreateSecret("label", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(uri.String(), nil)
+	s.secretsAPI.EXPECT().CreateSecret("my-secret", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(uri.String(), nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	dir := c.MkDir()
@@ -69,7 +69,7 @@ foo: bar
 	err := os.WriteFile(path, []byte(data), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "--file", path, "--label", "label", "--info", "this is a secret.")
+	ctx, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "my-secret", "--file", path, "--info", "this is a secret.")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, uri.String()+"\n")
@@ -78,6 +78,6 @@ foo: bar
 func (s *addSuite) TestAddEmptyData(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	_, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "--label", "label", "--info", "this is a secret.")
+	_, err := cmdtesting.RunCommand(c, secrets.NewAddCommandForTest(s.store, s.secretsAPI), "my-secret", "--info", "this is a secret.")
 	c.Assert(err, gc.ErrorMatches, `missing secret value or filename`)
 }

--- a/cmd/juju/secrets/common.go
+++ b/cmd/juju/secrets/common.go
@@ -14,13 +14,11 @@ import (
 type SecretUpsertContentCommand struct {
 	Data        map[string]string
 	Description string
-	Label       string
 	FileName    string
 }
 
 // SetFlags implements cmd.Command.
 func (c *SecretUpsertContentCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.Label, "label", "", "a label used to identify the secret in hooks")
 	f.StringVar(&c.Description, "info", "", "the secret description")
 	f.StringVar(&c.FileName, "file", "", "a YAML file containing secret key values")
 }

--- a/cmd/juju/secrets/grantrevoke.go
+++ b/cmd/juju/secrets/grantrevoke.go
@@ -53,7 +53,7 @@ Grant applications access to view the value of a specified secret.
 `
 	grantSecretExamples = `
     juju grant-secret my-secret ubuntu-k8s
-	juju grant-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
+    juju grant-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
 `
 )
 
@@ -143,7 +143,7 @@ Revoke applications' access to view the value of a specified secret.
 `
 	revokeSecretExamples = `
     juju revoke-secret my-secret ubuntu-k8s
-	juju revoke-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
+    juju revoke-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
 `
 )
 

--- a/cmd/juju/secrets/grantrevoke_test.go
+++ b/cmd/juju/secrets/grantrevoke_test.go
@@ -42,10 +42,20 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().GrantSecret(uri, []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
+	s.secretsAPI.EXPECT().GrantSecret(uri, "", []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewGrantCommandForTest(s.store, s.secretsAPI), uri.String(), "gitlab,mysql")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *grantSuite) TestGrantByName(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.secretsAPI.EXPECT().GrantSecret(nil, "my-secret", []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
+	s.secretsAPI.EXPECT().Close().Return(nil)
+
+	_, err := cmdtesting.RunCommand(c, secrets.NewGrantCommandForTest(s.store, s.secretsAPI), "my-secret", "gitlab,mysql")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -82,10 +92,20 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().RevokeSecret(uri, []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
+	s.secretsAPI.EXPECT().RevokeSecret(uri, "", []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewRevokeCommandForTest(s.store, s.secretsAPI), uri.String(), "gitlab,mysql")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *revokeSuite) TestRevokeByName(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.secretsAPI.EXPECT().RevokeSecret(nil, "my-secret", []string{"gitlab", "mysql"}).Return([]error{nil, nil}, nil)
+	s.secretsAPI.EXPECT().Close().Return(nil)
+
+	_, err := cmdtesting.RunCommand(c, secrets.NewRevokeCommandForTest(s.store, s.secretsAPI), "my-secret", "gitlab,mysql")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -156,7 +156,7 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 		if owner, err := names.ParseTag(m.Metadata.OwnerTag); err == nil {
 			ownerId = owner.Id()
 			if owner.Kind() == names.ModelTagKind {
-				// Model owned (user) secrets have a name, ot a label.
+				// Model owned (user) secrets have a name, not a label.
 				ownerId = "<" + owner.Kind() + ">"
 				name = m.Metadata.Label
 				label = ""

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -108,6 +108,7 @@ type secretDisplayDetails struct {
 	NextRotateTime   *time.Time              `json:"rotates,omitempty" yaml:"rotates,omitempty"`
 	Owner            string                  `json:"owner,omitempty" yaml:"owner,omitempty"`
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Name             string                  `json:"name,omitempty" yaml:"name,omitempty"`
 	Label            string                  `json:"label,omitempty" yaml:"label,omitempty"`
 	CreateTime       time.Time               `json:"created" yaml:"created"`
 	UpdateTime       time.Time               `json:"updated" yaml:"updated"`
@@ -150,8 +151,16 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 	details := make(secretDetailsByID)
 	for _, m := range secrets {
 		ownerId := ""
+		name := ""
+		label := m.Metadata.Label
 		if owner, err := names.ParseTag(m.Metadata.OwnerTag); err == nil {
 			ownerId = owner.Id()
+			if owner.Kind() == names.ModelTagKind {
+				// Model owned (user) secrets have a name, ot a label.
+				ownerId = "<" + owner.Kind() + ">"
+				name = m.Metadata.Label
+				label = ""
+			}
 		}
 		info := secretDisplayDetails{
 			URI:              m.Metadata.URI,
@@ -159,7 +168,8 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 			LatestRevision:   m.Metadata.LatestRevision,
 			LatestExpireTime: m.Metadata.LatestExpireTime,
 			Description:      m.Metadata.Description,
-			Label:            m.Metadata.Label,
+			Name:             name,
+			Label:            label,
 			RotatePolicy:     m.Metadata.RotatePolicy,
 			NextRotateTime:   m.Metadata.NextRotateTime,
 			CreateTime:       m.Metadata.CreateTime,
@@ -210,9 +220,9 @@ func formatSecretsTabular(writer io.Writer, value interface{}) error {
 
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.SetColumnAlignRight(3)
+	w.SetColumnAlignRight(4)
 
-	w.Println("ID", "Owner", "Rotation", "Revision", "Last updated")
+	w.Println("ID", "Name", "Owner", "Rotation", "Revision", "Last updated")
 	sort.Slice(secrets, func(i, j int) bool {
 		if secrets[i].Owner != secrets[j].Owner {
 			return secrets[i].Owner < secrets[j].Owner
@@ -221,8 +231,12 @@ func formatSecretsTabular(writer io.Writer, value interface{}) error {
 	})
 	now := time.Now()
 	for _, s := range secrets {
+		name := s.Name
+		if name == "" {
+			name = "-"
+		}
 		age := common.UserFriendlyDuration(s.UpdateTime, now)
-		w.Print(s.URI.ID, s.Owner, s.RotatePolicy, s.LatestRevision, age)
+		w.Print(s.URI.ID, name, s.Owner, s.RotatePolicy, s.LatestRevision, age)
 		w.Println()
 	}
 	return tw.Flush()

--- a/cmd/juju/secrets/mocks/secretsapi.go
+++ b/cmd/juju/secrets/mocks/secretsapi.go
@@ -154,33 +154,33 @@ func (mr *MockGrantRevokeSecretsAPIMockRecorder) Close() *gomock.Call {
 }
 
 // GrantSecret mocks base method.
-func (m *MockGrantRevokeSecretsAPI) GrantSecret(arg0 *secrets0.URI, arg1 []string) ([]error, error) {
+func (m *MockGrantRevokeSecretsAPI) GrantSecret(arg0 *secrets0.URI, arg1 string, arg2 []string) ([]error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GrantSecret indicates an expected call of GrantSecret.
-func (mr *MockGrantRevokeSecretsAPIMockRecorder) GrantSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockGrantRevokeSecretsAPIMockRecorder) GrantSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockGrantRevokeSecretsAPI)(nil).GrantSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockGrantRevokeSecretsAPI)(nil).GrantSecret), arg0, arg1, arg2)
 }
 
 // RevokeSecret mocks base method.
-func (m *MockGrantRevokeSecretsAPI) RevokeSecret(arg0 *secrets0.URI, arg1 []string) ([]error, error) {
+func (m *MockGrantRevokeSecretsAPI) RevokeSecret(arg0 *secrets0.URI, arg1 string, arg2 []string) ([]error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RevokeSecret indicates an expected call of RevokeSecret.
-func (mr *MockGrantRevokeSecretsAPIMockRecorder) RevokeSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockGrantRevokeSecretsAPIMockRecorder) RevokeSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockGrantRevokeSecretsAPI)(nil).RevokeSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockGrantRevokeSecretsAPI)(nil).RevokeSecret), arg0, arg1, arg2)
 }
 
 // MockUpdateSecretsAPI is a mock of UpdateSecretsAPI interface.
@@ -221,17 +221,17 @@ func (mr *MockUpdateSecretsAPIMockRecorder) Close() *gomock.Call {
 }
 
 // UpdateSecret mocks base method.
-func (m *MockUpdateSecretsAPI) UpdateSecret(arg0 *secrets0.URI, arg1 *bool, arg2, arg3 string, arg4 map[string]string) error {
+func (m *MockUpdateSecretsAPI) UpdateSecret(arg0 *secrets0.URI, arg1 string, arg2 *bool, arg3, arg4 string, arg5 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecret indicates an expected call of UpdateSecret.
-func (mr *MockUpdateSecretsAPIMockRecorder) UpdateSecret(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockUpdateSecretsAPIMockRecorder) UpdateSecret(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockUpdateSecretsAPI)(nil).UpdateSecret), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockUpdateSecretsAPI)(nil).UpdateSecret), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // MockRemoveSecretsAPI is a mock of RemoveSecretsAPI interface.
@@ -272,15 +272,15 @@ func (mr *MockRemoveSecretsAPIMockRecorder) Close() *gomock.Call {
 }
 
 // RemoveSecret mocks base method.
-func (m *MockRemoveSecretsAPI) RemoveSecret(arg0 *secrets0.URI, arg1 *int) error {
+func (m *MockRemoveSecretsAPI) RemoveSecret(arg0 *secrets0.URI, arg1 string, arg2 *int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "RemoveSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveSecret indicates an expected call of RemoveSecret.
-func (mr *MockRemoveSecretsAPIMockRecorder) RemoveSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRemoveSecretsAPIMockRecorder) RemoveSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecret", reflect.TypeOf((*MockRemoveSecretsAPI)(nil).RemoveSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecret", reflect.TypeOf((*MockRemoveSecretsAPI)(nil).RemoveSecret), arg0, arg1, arg2)
 }

--- a/cmd/juju/secrets/remove.go
+++ b/cmd/juju/secrets/remove.go
@@ -20,12 +20,13 @@ type removeSecretCommand struct {
 	secretsAPIFunc func() (RemoveSecretsAPI, error)
 
 	secretURI *secrets.URI
+	name      string
 	revision  int
 }
 
 // RemoveSecretsAPI is the secrets client API.
 type RemoveSecretsAPI interface {
-	RemoveSecret(uri *secrets.URI, revision *int) error
+	RemoveSecret(uri *secrets.URI, name string, revision *int) error
 	Close() error
 }
 
@@ -49,6 +50,7 @@ const (
 Remove all the revisions of a secret with the specified URI or remove the provided revision only.
 `
 	removeSecretExamples = `
+    juju remove-secret my-secret
     juju remove-secret secret:9m4e2mr0ui3e8a215n4g
     juju remove-secret secret:9m4e2mr0ui3e8a215n4g --revision 4
 `
@@ -58,7 +60,7 @@ Remove all the revisions of a secret with the specified URI or remove the provid
 func (c *removeSecretCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "remove-secret",
-		Args:     "<ID>",
+		Args:     "<ID>|<name>",
 		Purpose:  "Remove a existing secret.",
 		Doc:      removeSecretDoc,
 		Examples: removeSecretExamples,
@@ -77,7 +79,7 @@ func (c *removeSecretCommand) Init(args []string) error {
 	}
 	var err error
 	if c.secretURI, err = secrets.ParseURI(args[0]); err != nil {
-		return errors.Trace(err)
+		c.name = args[0]
 	}
 	return cmd.CheckEmpty(args[1:])
 }
@@ -93,5 +95,5 @@ func (c *removeSecretCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	defer secretsAPI.Close()
-	return secretsAPI.RemoveSecret(c.secretURI, rev)
+	return secretsAPI.RemoveSecret(c.secretURI, c.name, rev)
 }

--- a/cmd/juju/secrets/remove_test.go
+++ b/cmd/juju/secrets/remove_test.go
@@ -49,7 +49,7 @@ func (s *removeSuite) TestRemoveWithRevision(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().RemoveSecret(uri, ptr(4)).Return(nil)
+	s.secretsAPI.EXPECT().RemoveSecret(uri, "", ptr(4)).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewRemoveCommandForTest(s.store, s.secretsAPI), uri.String(), "--revision", "4")
@@ -60,9 +60,19 @@ func (s *removeSuite) TestRemove(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().RemoveSecret(uri, nil).Return(nil)
+	s.secretsAPI.EXPECT().RemoveSecret(uri, "", nil).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewRemoveCommandForTest(s.store, s.secretsAPI), uri.String())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *removeSuite) TestRemoveByName(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.secretsAPI.EXPECT().RemoveSecret(nil, "my-secret", nil).Return(nil)
+	s.secretsAPI.EXPECT().Close().Return(nil)
+
+	_, err := cmdtesting.RunCommand(c, secrets.NewRemoveCommandForTest(s.store, s.secretsAPI), "my-secret")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/secrets/update_test.go
+++ b/cmd/juju/secrets/update_test.go
@@ -44,7 +44,7 @@ func (s *updateSuite) setup(c *gc.C) *gomock.Controller {
 func (s *updateSuite) TestUpdateMissingArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(s.store, s.secretsAPI), "--label", "label", "--info", "this is a secret.")
+	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(s.store, s.secretsAPI), "--name", "new-name", "--info", "this is a secret.")
 	c.Assert(err, gc.ErrorMatches, `missing secret URI`)
 }
 
@@ -52,12 +52,12 @@ func (s *updateSuite) TestUpdateWithoutContent(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().UpdateSecret(uri, ptr(true), "label", "this is a secret.", map[string]string{}).Return(nil)
+	s.secretsAPI.EXPECT().UpdateSecret(uri, "", ptr(true), "new-name", "this is a secret.", map[string]string{}).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(
 		s.store, s.secretsAPI), uri.String(),
-		"--auto-prune", "--label", "label", "--info", "this is a secret.",
+		"--auto-prune", "--name", "new-name", "--info", "this is a secret.",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -66,12 +66,12 @@ func (s *updateSuite) TestUpdateFromArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().UpdateSecret(uri, ptr(true), "label", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(nil)
+	s.secretsAPI.EXPECT().UpdateSecret(uri, "", ptr(true), "new-name", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(
 		s.store, s.secretsAPI), uri.String(), "foo=bar",
-		"--auto-prune", "--label", "label", "--info", "this is a secret.",
+		"--auto-prune", "--name", "new-name", "--info", "this is a secret.",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -80,7 +80,7 @@ func (s *updateSuite) TestUpdateAutoPruneFalse(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().UpdateSecret(uri, ptr(false), "", "", map[string]string{}).Return(nil)
+	s.secretsAPI.EXPECT().UpdateSecret(uri, "", ptr(false), "", "", map[string]string{}).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(
@@ -93,7 +93,7 @@ func (s *updateSuite) TestUpdateAutoPruneNil(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().UpdateSecret(uri, nil, "", "this is a secret.", map[string]string{}).Return(nil)
+	s.secretsAPI.EXPECT().UpdateSecret(uri, "", nil, "", "this is a secret.", map[string]string{}).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	_, err := cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(
@@ -106,7 +106,7 @@ func (s *updateSuite) TestUpdateFromFile(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsAPI.EXPECT().UpdateSecret(uri, ptr(true), "label", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(nil)
+	s.secretsAPI.EXPECT().UpdateSecret(uri, "", ptr(true), "new-name", "this is a secret.", map[string]string{"foo": "YmFy"}).Return(nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	dir := c.MkDir()
@@ -118,7 +118,7 @@ foo: bar
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = cmdtesting.RunCommand(c, secrets.NewUpdateCommandForTest(
 		s.store, s.secretsAPI), uri.String(), "--file", path,
-		"--auto-prune", "--label", "label", "--info", "this is a secret.",
+		"--auto-prune", "--name", "new-name", "--info", "this is a secret.",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -223,6 +223,7 @@ type SecretRevisionInfo struct {
 // Filter is used when querying secrets.
 type Filter struct {
 	URI      *URI
+	Label    *string
 	Revision *int
 	OwnerTag *string
 }

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -121,8 +121,13 @@ type UpdateUserSecretArgs struct {
 type UpdateUserSecretArg struct {
 	UpsertSecretArg
 
+	// Either URI or ExistingLabel is required.
+
 	// URI identifies the secret to update.
 	URI string `json:"uri"`
+
+	// ExistingLabel is the label of an existing secret.
+	ExistingLabel string `json:"existing-label"`
 
 	// AutoPrune indicates whether the staled secret revisions should be pruned automatically.
 	AutoPrune *bool `json:"auto-prune,omitempty"`
@@ -132,6 +137,9 @@ type UpdateUserSecretArg struct {
 func (arg UpdateUserSecretArg) Validate() error {
 	if arg.AutoPrune == nil && arg.Description == nil && arg.Label == nil && len(arg.Content.Data) == 0 {
 		return errors.New("at least one attribute to update must be specified")
+	}
+	if arg.URI == "" && arg.ExistingLabel == "" {
+		return errors.New("must specify either URI or label")
 	}
 	return nil
 }
@@ -143,7 +151,10 @@ type DeleteSecretArgs struct {
 
 // DeleteSecretArg holds the args for deleting a secret.
 type DeleteSecretArg struct {
+	// Either URI or Label is required.
+
 	URI       string `json:"uri"`
+	Label     string `json:"label"`
 	Revisions []int  `json:"revisions,omitempty"`
 }
 
@@ -221,6 +232,7 @@ type SecretValueResult struct {
 // SecretsFilter is used when querying secrets.
 type SecretsFilter struct {
 	URI      *string `json:"uri,omitempty"`
+	Label    *string `json:"label,omitempty"`
 	Revision *int    `json:"revision,omitempty"`
 	OwnerTag *string `json:"owner-tag,omitempty"`
 }
@@ -318,8 +330,12 @@ type GrantRevokeSecretArg struct {
 
 // GrantRevokeUserSecretArg holds the args for changing access to a user secret.
 type GrantRevokeUserSecretArg struct {
+	// Either URI or Label is required.
+
 	// URI identifies the secret to grant.
 	URI string `json:"uri"`
+	// Label identifies the secret to grant.
+	Label string `json:"label"`
 
 	Applications []string `json:"applications"`
 }

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -141,6 +141,9 @@ func (arg UpdateUserSecretArg) Validate() error {
 	if arg.URI == "" && arg.ExistingLabel == "" {
 		return errors.New("must specify either URI or label")
 	}
+	if arg.URI != "" && arg.ExistingLabel != "" {
+		return errors.New("must specify either URI or label but not both")
+	}
 	return nil
 }
 

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -74,6 +74,7 @@ type ChangeSecretBackendParams struct {
 // SecretsFilter holds attributes to match when listing secrets.
 type SecretsFilter struct {
 	URI          *secrets.URI
+	Label        *string
 	OwnerTags    []names.Tag
 	ConsumerTags []names.Tag
 }
@@ -896,6 +897,9 @@ func (s *secretsStore) ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetad
 	q := bson.D{}
 	if filter.URI != nil {
 		q = append(q, bson.DocElem{"_id", filter.URI.ID})
+	}
+	if filter.Label != nil {
+		q = append(q, bson.DocElem{"label", *filter.Label})
 	}
 	if len(filter.OwnerTags) > 0 {
 		owners := make([]string, len(filter.OwnerTags))

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -86,7 +86,7 @@ run_user_secret_drain() {
 	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 	wait_for "easyrsa" "$(idle_condition "easyrsa" 0 0)"
 
-	secret_uri=$(juju --show-log add-secret owned-by="$model_name-1" --info "this is a user secret")
+	secret_uri=$(juju --show-log add-secret mysecret owned-by="$model_name-1" --info "this is a user secret")
 	secret_short_uri=${secret_uri##*:}
 
 	juju show-secret --reveal "$secret_uri"
@@ -98,7 +98,7 @@ run_user_secret_drain() {
 	# change the secret backend to internal.
 	juju model-config secret-backend=auto
 
-	another_secret_uri=$(juju --show-log add-secret owned-by="$model_name-2" --info "this is another user secret")
+	another_secret_uri=$(juju --show-log add-secret anothersecret owned-by="$model_name-2" --info "this is another user secret")
 	juju show-secret --reveal "$another_secret_uri"
 
 	# ensure the user secrets are all in internal backend, no secret in vault.
@@ -129,8 +129,8 @@ run_user_secret_drain() {
 	# ensure the application can still read the user secret.
 	check_contains "$(juju exec --unit easyrsa/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
-	juju show-secret --reveal "$secret_uri"
-	juju show-secret --reveal "$another_secret_uri"
+	juju show-secret --reveal mysecret
+	juju show-secret --reveal anothersecret
 
 	destroy_model "$model_name"
 	destroy_model "model-vault-provider"

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -12,7 +12,7 @@ run_secrets() {
 	juju --show-log trust nginx --scope=cluster
 
 	# create user secrets.
-	juju --show-log add-secret owned-by="$model_name" --label "$model_name" --info "this is a user secret"
+	juju --show-log add-secret mysecret owned-by="$model_name" --label "$model_name" --info "this is a user secret"
 
 	wait_for "active" '.applications["hello"] | ."application-status".current'
 	wait_for "hello" "$(idle_condition "hello" 0)"
@@ -109,7 +109,7 @@ run_user_secrets() {
 	juju --show-log deploy hello-kubecon
 
 	# create user secrets.
-	secret_uri=$(juju --show-log add-secret owned-by="$model_name-1" --info "this is a user secret")
+	secret_uri=$(juju --show-log add-secret mysecret owned-by="$model_name-1" --info "this is a user secret")
 	secret_short_uri=${secret_uri##*:}
 
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'this is a user secret'
@@ -239,7 +239,7 @@ run_user_secret_drain() {
 	wait_for "active" '.applications["hello"] | ."application-status".current'
 	wait_for "hello" "$(idle_condition "hello" 0)"
 
-	secret_uri=$(juju --show-log add-secret owned-by="$model_name-1" --info "this is a user secret")
+	secret_uri=$(juju --show-log add-secret mysecret owned-by="$model_name-1" --info "this is a user secret")
 	secret_short_uri=${secret_uri##*:}
 
 	juju show-secret --reveal "$secret_uri"


### PR DESCRIPTION
Introduce secret names for user secrets. The name is stored in the label metadata field, but it is exposed as "name" as far as the CLI operates. The update command does not support `--label` any more - it uses `--name` instead to update the secret name.

The add-secret command takes name as the first positional arg. Then, when running update, remove, grant etc, you can use name instead of the URI. If name is used, the URI is retrieved from the name (label).

The tabular list secrets output is also tweaked to show the name for user secrets. And the owner is "<model>" instead of the uuid.

## QA steps

`juju add-secret mysecret foo=bar`

Also add some application and user secrets.

```
$ juju secrets
ID                    Name      Owner         Rotation  Revision  Last updated
ckvrpmip0pbjmiq4jrcg  mysecret  <model>       never            1  22 hours ago  
cl01nsqp0pbiht0p5shg  -         controller    never            1  15 hours ago  
cl0aqtip0pbiht0p5si0  -         controller/0  never            1  5 hours ago  
```

Check that update,remove,grant all work with the name instead of the URI.


## Links

**Jira card:** JUJU-4824