### PR TITLE
Dqlite safe-mode

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -161,7 +161,7 @@ type ModelMetrics interface {
 	ForModel(model names.ModelTag) dependency.Metrics
 }
 
-// NewMachineAgentCommand creates a Command which handles parsing
+// NewMachineAgentCommand creates a Command that handles parsing
 // command-line arguments and instantiating and running a
 // MachineAgent.
 func NewMachineAgentCommand(

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -161,16 +161,16 @@ type ModelMetrics interface {
 	ForModel(model names.ModelTag) dependency.Metrics
 }
 
-// NewMachineAgentCmd creates a Command which handles parsing
+// NewMachineAgentCommand creates a Command which handles parsing
 // command-line arguments and instantiating and running a
 // MachineAgent.
-func NewMachineAgentCmd(
+func NewMachineAgentCommand(
 	ctx *cmd.Context,
 	machineAgentFactory machineAgentFactoryFnType,
 	agentInitializer AgentInitializer,
 	configFetcher agentconfig.AgentConfigWriter,
 ) cmd.Command {
-	return &machineAgentCmd{
+	return &machineAgentCommand{
 		ctx:                 ctx,
 		machineAgentFactory: machineAgentFactory,
 		agentInitializer:    agentInitializer,
@@ -178,7 +178,7 @@ func NewMachineAgentCmd(
 	}
 }
 
-type machineAgentCmd struct {
+type machineAgentCommand struct {
 	cmd.CommandBase
 
 	// This group of arguments is required.
@@ -201,7 +201,7 @@ type machineAgentCmd struct {
 
 // Init is called by the cmd system to initialize the structure for
 // running.
-func (a *machineAgentCmd) Init(args []string) error {
+func (a *machineAgentCommand) Init(args []string) error {
 
 	if a.machineId == "" && a.controllerId == "" {
 		return errors.New("either machine-id or controller-id must be set")
@@ -253,7 +253,7 @@ func (a *machineAgentCmd) Init(args []string) error {
 }
 
 // Run instantiates a MachineAgent and runs it.
-func (a *machineAgentCmd) Run(c *cmd.Context) error {
+func (a *machineAgentCommand) Run(c *cmd.Context) error {
 	machineAgent, err := a.machineAgentFactory(a.agentTag, a.isCaas)
 	if err != nil {
 		return errors.Trace(err)
@@ -262,7 +262,7 @@ func (a *machineAgentCmd) Run(c *cmd.Context) error {
 }
 
 // SetFlags adds the requisite flags to run this command.
-func (a *machineAgentCmd) SetFlags(f *gnuflag.FlagSet) {
+func (a *machineAgentCommand) SetFlags(f *gnuflag.FlagSet) {
 	a.agentInitializer.AddFlags(f)
 	f.StringVar(&a.machineId, "machine-id", "", "id of the machine to run")
 	f.StringVar(&a.controllerId, "controller-id", "", "id of the controller to run")
@@ -270,7 +270,7 @@ func (a *machineAgentCmd) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Info returns usage information for the command.
-func (a *machineAgentCmd) Info() *cmd.Info {
+func (a *machineAgentCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "machine",
 		Purpose: "run a juju machine agent",

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/crosscontroller"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/paths"
@@ -330,7 +331,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// Each machine agent has a flag manifold/worker which
 		// reports whether or not the agent is a controller.
-		isControllerFlagName: isControllerFlagManifold(true),
+		isControllerFlagName: util.IsControllerFlagManifold(stateConfigWatcherName, true),
 
 		// Controller agent config manifold watches the controller
 		// agent config and bounces if it changes.
@@ -1005,7 +1006,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ContainerType:                instance.LXD,
 		})),
 		// isNotControllerFlagName is only used for the stateconverter,
-		isNotControllerFlagName: isControllerFlagManifold(false),
+		isNotControllerFlagName: util.IsControllerFlagManifold(stateConfigWatcherName, false),
 		stateConverterName: ifNotController(ifNotMigrating(stateconverter.Manifold(stateconverter.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -145,17 +145,17 @@ func (s *MachineSuite) SetUpTest(c *gc.C) {
 
 func (s *MachineSuite) TestParseNonsense(c *gc.C) {
 	aCfg := agentconf.NewAgentConf(s.DataDir)
-	err := ParseAgentCommand(&machineAgentCmd{agentInitializer: aCfg}, nil)
+	err := ParseAgentCommand(&machineAgentCommand{agentInitializer: aCfg}, nil)
 	c.Assert(err, gc.ErrorMatches, "either machine-id or controller-id must be set")
-	err = ParseAgentCommand(&machineAgentCmd{agentInitializer: aCfg}, []string{"--machine-id", "-4004"})
+	err = ParseAgentCommand(&machineAgentCommand{agentInitializer: aCfg}, []string{"--machine-id", "-4004"})
 	c.Assert(err, gc.ErrorMatches, "--machine-id option must be a non-negative integer")
-	err = ParseAgentCommand(&machineAgentCmd{agentInitializer: aCfg}, []string{"--controller-id", "-4004"})
+	err = ParseAgentCommand(&machineAgentCommand{agentInitializer: aCfg}, []string{"--controller-id", "-4004"})
 	c.Assert(err, gc.ErrorMatches, "--controller-id option must be a non-negative integer")
 }
 
 func (s *MachineSuite) TestParseUnknown(c *gc.C) {
 	aCfg := agentconf.NewAgentConf(s.DataDir)
-	a := &machineAgentCmd{agentInitializer: aCfg}
+	a := &machineAgentCommand{agentInitializer: aCfg}
 	err := ParseAgentCommand(a, []string{"--machine-id", "42", "blistering barnacles"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["blistering barnacles"\]`)
 }
@@ -171,7 +171,7 @@ func (s *MachineSuite) TestParseSuccess(c *gc.C) {
 		newDBWorkerFunc := func(stdcontext.Context, dbaccessor.DBApp, string, ...dbaccessor.TrackedDBWorkerOption) (dbaccessor.TrackedDB, error) {
 			return databasetesting.NewTrackedDB(s.TxnRunnerFactory()), nil
 		}
-		a := NewMachineAgentCmd(
+		a := NewMachineAgentCommand(
 			nil,
 			NewTestMachineAgentFactory(c, aCfg, logger, newDBWorkerFunc, c.MkDir(), s.cmdRunner),
 			aCfg,
@@ -180,7 +180,7 @@ func (s *MachineSuite) TestParseSuccess(c *gc.C) {
 		return a, aCfg
 	}
 	a := CheckAgentCommand(c, s.DataDir, create, []string{"--machine-id", "42", "--log-to-stderr", "--data-dir", s.DataDir})
-	c.Assert(a.(*machineAgentCmd).machineId, gc.Equals, "42")
+	c.Assert(a.(*machineAgentCommand).machineId, gc.Equals, "42")
 }
 
 func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
@@ -194,14 +194,14 @@ func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 	newDBWorkerFunc := func(stdcontext.Context, dbaccessor.DBApp, string, ...dbaccessor.TrackedDBWorkerOption) (dbaccessor.TrackedDB, error) {
 		return databasetesting.NewTrackedDB(s.TxnRunnerFactory()), nil
 	}
-	a := NewMachineAgentCmd(
+	a := NewMachineAgentCommand(
 		ctx,
 		NewTestMachineAgentFactory(c, &agentConf, logger, newDBWorkerFunc, c.MkDir(), s.cmdRunner),
 		agentConf,
 		agentConf,
 	)
 	// little hack to set the data that Init expects to already be set
-	a.(*machineAgentCmd).machineId = "42"
+	a.(*machineAgentCommand).machineId = "42"
 
 	err := a.Init(nil)
 	c.Assert(err, gc.IsNil)
@@ -225,17 +225,17 @@ func (s *MachineSuite) TestDontUseLumberjack(c *gc.C) {
 	newDBWorkerFunc := func(stdcontext.Context, dbaccessor.DBApp, string, ...dbaccessor.TrackedDBWorkerOption) (dbaccessor.TrackedDB, error) {
 		return databasetesting.NewTrackedDB(s.TxnRunnerFactory()), nil
 	}
-	a := NewMachineAgentCmd(
+	a := NewMachineAgentCommand(
 		ctx,
 		NewTestMachineAgentFactory(c, &agentConf, logger, newDBWorkerFunc, c.MkDir(), s.cmdRunner),
 		agentConf,
 		agentConf,
 	)
 	// little hack to set the data that Init expects to already be set
-	a.(*machineAgentCmd).machineId = "42"
+	a.(*machineAgentCommand).machineId = "42"
 
 	// set the value that normally gets set by the flag parsing
-	a.(*machineAgentCmd).logToStdErr = true
+	a.(*machineAgentCommand).logToStdErr = true
 
 	err := a.Init(nil)
 	c.Assert(err, gc.IsNil)

--- a/cmd/jujud/agent/safemode.go
+++ b/cmd/jujud/agent/safemode.go
@@ -1,0 +1,361 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juju/clock"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/utils/v3/voyeur"
+	"github.com/juju/version/v2"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/agent"
+	agentconfig "github.com/juju/juju/agent/config"
+	agentengine "github.com/juju/juju/agent/engine"
+	agenterrors "github.com/juju/juju/agent/errors"
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/internal/agent/agentconf"
+	"github.com/juju/juju/cmd/jujud/agent/safemode"
+	"github.com/juju/juju/cmd/jujud/reboot"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/internal/storage/looputil"
+	"github.com/juju/juju/rpc/params"
+	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dbaccessor"
+	"github.com/juju/juju/worker/logsender"
+)
+
+// NewSafeModeAgentCommand creates a Command which handles parsing
+// command-line arguments and instantiating and running a
+// MachineAgent.
+func NewSafeModeAgentCommand(
+	ctx *cmd.Context,
+	safeModeMachineAgentFactory safeModeMachineAgentFactoryFnType,
+	agentInitializer AgentInitializer,
+	configFetcher agentconfig.AgentConfigWriter,
+) cmd.Command {
+	return &safeModeAgentCommand{
+		ctx:                         ctx,
+		safeModeMachineAgentFactory: safeModeMachineAgentFactory,
+		agentInitializer:            agentInitializer,
+		currentConfig:               configFetcher,
+	}
+}
+
+type safeModeAgentCommand struct {
+	cmd.CommandBase
+
+	// This group of arguments is required.
+	agentInitializer            AgentInitializer
+	currentConfig               agentconfig.AgentConfigWriter
+	safeModeMachineAgentFactory safeModeMachineAgentFactoryFnType
+	ctx                         *cmd.Context
+
+	isCaas   bool
+	agentTag names.Tag
+
+	// The following are set via command-line flags.
+	machineId string
+	// TODO(controlleragent) - this will be in a new controller agent command
+	controllerId string
+
+	dangerous bool
+}
+
+// Init is called by the cmd system to initialize the structure for
+// running.
+func (a *safeModeAgentCommand) Init(args []string) error {
+	if !a.dangerous {
+		return errors.New("safe mode is a dangerous operation, use --dangerous to enable")
+	}
+	if a.machineId == "" && a.controllerId == "" {
+		return errors.New("either machine-id or controller-id must be set")
+	}
+	if a.machineId != "" && !names.IsValidMachine(a.machineId) {
+		return errors.Errorf("--machine-id option must be a non-negative integer")
+	}
+	if a.controllerId != "" && !names.IsValidControllerAgent(a.controllerId) {
+		return errors.Errorf("--controller-id option must be a non-negative integer")
+	}
+	if err := a.agentInitializer.CheckArgs(args); err != nil {
+		return err
+	}
+
+	// Due to changes in the logging, and needing to care about old
+	// models that have been upgraded, we need to explicitly remove the
+	// file writer if one has been added, otherwise we will get duplicate
+	// lines of all logging in the log file.
+	_, _ = loggo.RemoveWriter("logfile")
+
+	if a.machineId != "" {
+		a.agentTag = names.NewMachineTag(a.machineId)
+	} else {
+		a.agentTag = names.NewControllerAgentTag(a.controllerId)
+	}
+	if err := agentconfig.ReadAgentConfig(a.currentConfig, a.agentTag.Id()); err != nil {
+		return errors.Errorf("cannot read agent configuration: %v", err)
+	}
+	config := a.currentConfig.CurrentConfig()
+	if err := os.MkdirAll(config.LogDir(), 0644); err != nil {
+		logger.Warningf("cannot create log dir: %v", err)
+	}
+	a.isCaas = config.Value(agent.ProviderType) == k8sconstants.CAASProviderType
+
+	return nil
+}
+
+// Run instantiates a MachineAgent and runs it.
+func (a *safeModeAgentCommand) Run(c *cmd.Context) error {
+	// Force the writing of the safemode header to os.Stderr, so it can't be
+	// bypassed with a flag (obviously, this is not a security measure, but
+	// it's better than nothing).
+	fmt.Fprintln(os.Stderr, safeModeWarningHeader)
+
+	machineAgent, err := a.safeModeMachineAgentFactory(a.agentTag, a.isCaas)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return machineAgent.Run(c)
+}
+
+// SetFlags adds the requisite flags to run this command.
+func (a *safeModeAgentCommand) SetFlags(f *gnuflag.FlagSet) {
+	a.agentInitializer.AddFlags(f)
+	f.StringVar(&a.machineId, "machine-id", "", "id of the machine to run")
+	f.StringVar(&a.controllerId, "controller-id", "", "id of the controller to run")
+	f.BoolVar(&a.dangerous, "dangerous", false, "set to true to allow running in safe mode")
+}
+
+// Info returns usage information for the command.
+func (a *safeModeAgentCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "safe-mode",
+		Purpose: "run a juju in safe mode",
+	})
+}
+
+const (
+	safeModeWarningHeader = `
+Running in safe mode. 
+---------------------
+
+This is a special mode of operation that allows you to have single node
+only access to the database. This is useful if you have a database that is
+corrupt and you want to recover data from it.
+
+This will only stand up the minimum set of services required to allow
+you to connect to the database and perform recovery operations.
+
+Use at your own risk.
+`
+)
+
+type safeModeMachineAgentFactoryFnType func(names.Tag, bool) (*SafeModeMachineAgent, error)
+
+// SafeModeMachineAgentFactoryFn returns a function which instantiates a
+// SafeModeMachineAgent given a machineId.
+func SafeModeMachineAgentFactoryFn(
+	agentConfWriter agentconfig.AgentConfigWriter,
+	bufferedLogger *logsender.BufferedLogWriter,
+	newDBWorkerFunc dbaccessor.NewDBWorkerFunc,
+	newIntrospectionSocketName func(names.Tag) string,
+	rootDir string,
+) safeModeMachineAgentFactoryFnType {
+	return func(agentTag names.Tag, isCaasAgent bool) (*SafeModeMachineAgent, error) {
+		return NewSafeModeMachineAgent(
+			agentTag,
+			agentConfWriter,
+			bufferedLogger,
+			worker.NewRunner(worker.RunnerParams{
+				IsFatal:       agenterrors.IsFatal,
+				MoreImportant: agenterrors.MoreImportant,
+				RestartDelay:  jworker.RestartDelay,
+				Logger:        logger,
+			}),
+			looputil.NewLoopDeviceManager(),
+			newDBWorkerFunc,
+			newIntrospectionSocketName,
+			rootDir,
+			isCaasAgent,
+		)
+	}
+}
+
+// NewSafeModeMachineAgent instantiates a new SafeModeMachineAgent.
+func NewSafeModeMachineAgent(
+	agentTag names.Tag,
+	agentConfWriter agentconfig.AgentConfigWriter,
+	bufferedLogger *logsender.BufferedLogWriter,
+	runner *worker.Runner,
+	loopDeviceManager looputil.LoopDeviceManager,
+	newDBWorkerFunc dbaccessor.NewDBWorkerFunc,
+	newIntrospectionSocketName func(names.Tag) string,
+	rootDir string,
+	isCaasAgent bool,
+) (*SafeModeMachineAgent, error) {
+	a := &SafeModeMachineAgent{
+		agentTag:                   agentTag,
+		AgentConfigWriter:          agentConfWriter,
+		configChangedVal:           voyeur.NewValue(true),
+		bufferedLogger:             bufferedLogger,
+		workersStarted:             make(chan struct{}),
+		dead:                       make(chan struct{}),
+		runner:                     runner,
+		rootDir:                    rootDir,
+		newDBWorkerFunc:            newDBWorkerFunc,
+		loopDeviceManager:          loopDeviceManager,
+		newIntrospectionSocketName: newIntrospectionSocketName,
+		isCaasAgent:                isCaasAgent,
+	}
+	return a, nil
+}
+
+// SafeModeMachineAgent is responsible for tying together all functionality
+// needed to orchestrate a Jujud instance which controls a machine.
+type SafeModeMachineAgent struct {
+	agentconfig.AgentConfigWriter
+
+	ctx              *cmd.Context
+	dead             chan struct{}
+	errReason        error
+	agentTag         names.Tag
+	runner           *worker.Runner
+	rootDir          string
+	bufferedLogger   *logsender.BufferedLogWriter
+	configChangedVal *voyeur.Value
+
+	workersStarted chan struct{}
+
+	newDBWorkerFunc dbaccessor.NewDBWorkerFunc
+
+	loopDeviceManager          looputil.LoopDeviceManager
+	newIntrospectionSocketName func(names.Tag) string
+
+	isCaasAgent bool
+}
+
+// Wait waits for the safe mode machine agent to finish.
+func (a *SafeModeMachineAgent) Wait() error {
+	<-a.dead
+	return a.errReason
+}
+
+// Stop stops the safe mode machine agent.
+func (a *SafeModeMachineAgent) Stop() error {
+	a.runner.Kill()
+	return a.Wait()
+}
+
+// Done signals the safe mode machine agent is finished
+func (a *SafeModeMachineAgent) Done(err error) {
+	a.errReason = err
+	close(a.dead)
+}
+
+// Run runs a safe mode machine agent.
+func (a *SafeModeMachineAgent) Run(ctx *cmd.Context) (err error) {
+	defer a.Done(err)
+	a.ctx = ctx
+
+	if err := a.ReadConfig(a.Tag().String()); err != nil {
+		return errors.Errorf("cannot read agent configuration: %v", err)
+	}
+
+	agentConfig := a.CurrentConfig()
+	agentName := a.Tag().String()
+
+	agentconf.SetupAgentLogging(loggo.DefaultContext(), agentConfig)
+
+	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion())
+	_ = a.runner.StartWorker("engine", createEngine)
+
+	// At this point, all workers will have been configured to start
+	close(a.workersStarted)
+	err = a.runner.Wait()
+	switch errors.Cause(err) {
+	case jworker.ErrRebootMachine:
+		logger.Infof("Caught reboot error")
+		err = a.executeRebootOrShutdown(params.ShouldReboot)
+	case jworker.ErrShutdownMachine:
+		logger.Infof("Caught shutdown error")
+		err = a.executeRebootOrShutdown(params.ShouldShutdown)
+	}
+	return cmdutil.AgentDone(logger, err)
+}
+
+func (a *SafeModeMachineAgent) Tag() names.Tag {
+	return a.agentTag
+}
+
+func (a *SafeModeMachineAgent) ChangeConfig(mutate agent.ConfigMutator) error {
+	err := a.AgentConfigWriter.ChangeConfig(mutate)
+	a.configChangedVal.Set(true)
+	return errors.Trace(err)
+}
+
+func (a *SafeModeMachineAgent) makeEngineCreator(
+	agentName string, previousAgentVersion version.Number,
+) func() (worker.Worker, error) {
+	return func() (worker.Worker, error) {
+		eng, err := dependency.NewEngine(agentengine.DependencyEngineConfig(
+			dependency.DefaultMetrics(),
+			loggo.GetLogger("juju.worker.dependency"),
+		))
+		if err != nil {
+			return nil, err
+		}
+
+		manifoldsCfg := safemode.ManifoldsConfig{
+			PreviousAgentVersion: previousAgentVersion,
+			AgentName:            agentName,
+			Agent:                agent.APIHostPortsSetter{Agent: a},
+			RootDir:              a.rootDir,
+			AgentConfigChanged:   a.configChangedVal,
+			NewDBWorkerFunc:      a.newDBWorkerFunc,
+			LogSource:            a.bufferedLogger.Logs(),
+			Clock:                clock.WallClock,
+			IsCaasConfig:         a.isCaasAgent,
+
+			SetupLogging: agentconf.SetupAgentLogging,
+		}
+		manifolds := safemode.IAASManifolds(manifoldsCfg)
+		if a.isCaasAgent {
+			manifolds = safemode.CAASManifolds(manifoldsCfg)
+		}
+		if err := dependency.Install(eng, manifolds); err != nil {
+			if err := worker.Stop(eng); err != nil {
+				logger.Errorf("while stopping engine with bad manifolds: %v", err)
+			}
+			return nil, err
+		}
+		return eng, err
+	}
+}
+
+func (a *SafeModeMachineAgent) executeRebootOrShutdown(action params.RebootAction) error {
+	// block until all units/containers are ready, and reboot/shutdown
+	finalize, err := reboot.NewRebootWaiter(a.CurrentConfig())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	logger.Infof("Reboot: Executing reboot")
+	err = finalize.ExecuteReboot(action)
+	if err != nil {
+		logger.Infof("Reboot: Error executing reboot: %v", err)
+		return errors.Trace(err)
+	}
+	// We return ErrRebootMachine so the agent will simply exit without error
+	// pending reboot/shutdown.
+	return jworker.ErrRebootMachine
+}

--- a/cmd/jujud/agent/safemode.go
+++ b/cmd/jujud/agent/safemode.go
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package agent
@@ -37,7 +37,7 @@ import (
 	"github.com/juju/juju/worker/logsender"
 )
 
-// NewSafeModeAgentCommand creates a Command which handles parsing
+// NewSafeModeAgentCommand creates a Command that handles parsing
 // command-line arguments and instantiating and running a
 // MachineAgent.
 func NewSafeModeAgentCommand(
@@ -70,16 +70,11 @@ type safeModeAgentCommand struct {
 	machineId string
 	// TODO(controlleragent) - this will be in a new controller agent command
 	controllerId string
-
-	dangerous bool
 }
 
 // Init is called by the cmd system to initialize the structure for
 // running.
 func (a *safeModeAgentCommand) Init(args []string) error {
-	if !a.dangerous {
-		return errors.New("safe mode is a dangerous operation, use --dangerous to enable")
-	}
 	if a.machineId == "" && a.controllerId == "" {
 		return errors.New("either machine-id or controller-id must be set")
 	}
@@ -143,7 +138,6 @@ func (a *safeModeAgentCommand) SetFlags(f *gnuflag.FlagSet) {
 	a.agentInitializer.AddFlags(f)
 	f.StringVar(&a.machineId, "machine-id", "", "id of the machine to run")
 	f.StringVar(&a.controllerId, "controller-id", "", "id of the controller to run")
-	f.BoolVar(&a.dangerous, "dangerous", false, "set to true to allow running in safe mode")
 }
 
 // Info returns usage information for the command.

--- a/cmd/jujud/agent/safemode/manifolds.go
+++ b/cmd/jujud/agent/safemode/manifolds.go
@@ -1,0 +1,252 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package safemode
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/v3/voyeur"
+	"github.com/juju/version/v2"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+	"github.com/prometheus/client_golang/prometheus"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/engine"
+	"github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/controlleragentconfig"
+	"github.com/juju/juju/worker/dbaccessor"
+	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/querylogger"
+	"github.com/juju/juju/worker/stateconfigwatcher"
+	"github.com/juju/juju/worker/syslogger"
+	"github.com/juju/juju/worker/terminationworker"
+)
+
+// ManifoldsConfig allows specialisation of the result of Manifolds.
+type ManifoldsConfig struct {
+	// AgentName is the name of the machine agent, like "machine-12".
+	// This will never change during the execution of an agent, and
+	// is used to provide this as config into a worker rather than
+	// making the worker get it from the agent worker itself.
+	AgentName string
+
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+
+	// AgentConfigChanged is set whenever the machine agent's config
+	// is updated.
+	AgentConfigChanged *voyeur.Value
+
+	// RootDir is the root directory that any worker that needs to
+	// access local filesystems should use as a base. In actual use it
+	// will be "" but it may be overridden in tests.
+	RootDir string
+
+	// PreviousAgentVersion passes through the version the machine
+	// agent was running before the current restart.
+	PreviousAgentVersion version.Number
+
+	// NewDBWorkerFunc returns a tracked db worker.
+	NewDBWorkerFunc dbaccessor.NewDBWorkerFunc
+
+	// LogSource defines the channel type used to send log message
+	// structs within the machine agent.
+	LogSource logsender.LogRecordCh
+
+	// Clock supplies timekeeping services to various workers.
+	Clock clock.Clock
+
+	// IsCaasConfig is true if this config is for a caas agent.
+	IsCaasConfig bool
+
+	// SetupLogging is used by the deployer to initialize the logging
+	// context for the unit.
+	SetupLogging func(*loggo.Context, coreagent.Config)
+}
+
+// commonManifolds returns a set of co-configured manifolds covering the
+// various responsibilities of a machine agent.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
+	agentConfig := config.Agent.CurrentConfig()
+
+	manifolds := dependency.Manifolds{
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		agentName: agent.Manifold(config.Agent),
+
+		// The termination worker returns ErrTerminateAgent if a
+		// termination signal is received by the process it's running
+		// in. It has no inputs and its only output is the error it
+		// returns. It depends on the uninstall file having been
+		// written *by the manual provider* at install time; it would
+		// be Very Wrong Indeed to use SetCanUninstall in conjunction
+		// with this code.
+		terminationName: terminationworker.Manifold(),
+
+		clockName: clockManifold(config.Clock),
+
+		// Each machine agent has a flag manifold/worker which
+		// reports whether or not the agent is a controller.
+		isControllerFlagName: util.IsControllerFlagManifold(stateConfigWatcherName, true),
+
+		// Controller agent config manifold watches the controller
+		// agent config and bounces if it changes.
+		controllerAgentConfigName: ifController(controlleragentconfig.Manifold(controlleragentconfig.ManifoldConfig{
+			Clock:  config.Clock,
+			Logger: loggo.GetLogger("juju.worker.controlleragentconfig"),
+		})),
+
+		// The stateconfigwatcher manifold watches the machine agent's
+		// configuration and reports if state serving info is
+		// present. It will bounce itself if state serving info is
+		// added or removed. It is intended as a dependency just for
+		// the state manifold.
+		stateConfigWatcherName: stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
+			AgentName:          agentName,
+			AgentConfigChanged: config.AgentConfigChanged,
+		}),
+
+		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
+			AgentName:            agentName,
+			QueryLoggerName:      queryLoggerName,
+			Clock:                config.Clock,
+			Hub:                  noopHub{},
+			Logger:               loggo.GetLogger("juju.worker.dbaccessor"),
+			LogDir:               agentConfig.LogDir(),
+			PrometheusRegisterer: noopPrometheusRegisterer{},
+			NewApp:               dbaccessor.NewApp,
+			NewDBWorker:          config.NewDBWorkerFunc,
+			NewMetricsCollector:  dbaccessor.NewMetricsCollector,
+		})),
+
+		queryLoggerName: ifController(querylogger.Manifold(querylogger.ManifoldConfig{
+			LogDir: agentConfig.LogDir(),
+			Clock:  config.Clock,
+			Logger: loggo.GetLogger("juju.worker.querylogger"),
+		})),
+	}
+
+	return manifolds
+}
+
+// IAASManifolds returns a set of co-configured manifolds covering the
+// various responsibilities of a IAAS machine agent.
+func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	manifolds := dependency.Manifolds{
+		syslogName: syslogger.Manifold(syslogger.ManifoldConfig{
+			NewWorker: syslogger.NewWorker,
+			NewLogger: syslogger.NewSyslog,
+		}),
+	}
+
+	return mergeManifolds(config, manifolds)
+}
+
+// CAASManifolds returns a set of co-configured manifolds covering the
+// various responsibilities of a CAAS machine agent.
+func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	return mergeManifolds(config, dependency.Manifolds{
+		syslogName: syslogger.Manifold(syslogger.ManifoldConfig{
+			NewWorker: syslogger.NewWorker,
+			NewLogger: syslogger.NewDiscard,
+		}),
+	})
+}
+
+func mergeManifolds(config ManifoldsConfig, manifolds dependency.Manifolds) dependency.Manifolds {
+	result := commonManifolds(config)
+	for name, manifold := range manifolds {
+		result[name] = manifold
+	}
+	return result
+}
+
+func clockManifold(clock clock.Clock) dependency.Manifold {
+	return dependency.Manifold{
+		Start: func(_ dependency.Context) (worker.Worker, error) {
+			return engine.NewValueWorker(clock)
+		},
+		Output: engine.ValueWorkerOutput,
+	}
+}
+
+var ifController = engine.Housing{
+	Flags: []string{
+		isControllerFlagName,
+	},
+}.Decorate
+
+const (
+	agentName              = "agent"
+	agentConfigUpdaterName = "agent-config-updater"
+	terminationName        = "termination-signal-handler"
+	stateConfigWatcherName = "state-config-watcher"
+	clockName              = "clock"
+
+	isControllerFlagName      = "is-controller-flag"
+	controllerAgentConfigName = "controller-agent-config"
+
+	dbAccessorName        = "db-accessor"
+	queryLoggerName       = "query-logger"
+	fileNotifyWatcherName = "file-notify-watcher"
+
+	syslogName       = "syslog"
+	caasUnitsManager = "caas-units-manager"
+)
+
+type noopPrometheusRegisterer struct{}
+
+// Register registers a new Collector to be included in metrics
+// collection. It returns an error if the descriptors provided by the
+// Collector are invalid or if they — in combination with descriptors of
+// already registered Collectors — do not fulfill the consistency and
+// uniqueness criteria described in the documentation of metric.Desc.
+//
+// If the provided Collector is equal to a Collector already registered
+// (which includes the case of re-registering the same Collector), the
+// returned error is an instance of AlreadyRegisteredError, which
+// contains the previously registered Collector.
+//
+// A Collector whose Describe method does not yield any Desc is treated
+// as unchecked. Registration will always succeed. No check for
+// re-registering (see previous paragraph) is performed. Thus, the
+// caller is responsible for not double-registering the same unchecked
+// Collector, and for providing a Collector that will not cause
+// inconsistent metrics on collection. (This would lead to scrape
+// errors.)
+func (noopPrometheusRegisterer) Register(prometheus.Collector) error { return nil }
+
+// MustRegister works like Register but registers any number of
+// Collectors and panics upon the first registration that causes an
+// error.
+func (noopPrometheusRegisterer) MustRegister(...prometheus.Collector) {}
+
+// Unregister unregisters the Collector that equals the Collector passed
+// in as an argument.  (Two Collectors are considered equal if their
+// Describe method yields the same set of descriptors.) The function
+// returns whether a Collector was unregistered. Note that an unchecked
+// Collector cannot be unregistered (as its Describe method does not
+// yield any descriptor).
+//
+// Note that even after unregistering, it will not be possible to
+// register a new Collector that is inconsistent with the unregistered
+// Collector, e.g. a Collector collecting metrics with the same name but
+// a different help string. The rationale here is that the same registry
+// instance must only collect consistent metrics throughout its
+// lifetime.
+func (noopPrometheusRegisterer) Unregister(prometheus.Collector) bool { return false }
+
+type noopHub struct{}
+
+func (noopHub) Subscribe(topic string, handler interface{}) (func(), error) {
+	return func() {}, nil
+}
+func (noopHub) Publish(topic string, data interface{}) (func(), error) {
+	return func() {}, nil
+}

--- a/cmd/jujud/agent/safemode/manifolds_test.go
+++ b/cmd/jujud/agent/safemode/manifolds_test.go
@@ -1,0 +1,292 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package safemode_test
+
+import (
+	"sort"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/dependency"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/agenttest"
+	"github.com/juju/juju/cmd/jujud/agent/safemode"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/testing"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *ManifoldsSuite) TestStartFuncsIAAS(c *gc.C) {
+	s.assertStartFuncs(c, safemode.IAASManifolds(safemode.ManifoldsConfig{
+		Agent: &mockAgent{},
+	}))
+}
+
+func (s *ManifoldsSuite) TestStartFuncsCAAS(c *gc.C) {
+	s.assertStartFuncs(c, safemode.CAASManifolds(safemode.ManifoldsConfig{
+		Agent: &mockAgent{},
+	}))
+}
+
+func (*ManifoldsSuite) assertStartFuncs(c *gc.C, manifolds dependency.Manifolds) {
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
+	s.assertManifoldNames(c,
+		safemode.IAASManifolds(safemode.ManifoldsConfig{
+			Agent: &mockAgent{},
+		}),
+		[]string{
+			"agent",
+			"clock",
+			"controller-agent-config",
+			"db-accessor",
+			"is-controller-flag",
+			"query-logger",
+			"state-config-watcher",
+			"syslog",
+			"termination-signal-handler",
+		},
+	)
+}
+
+func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
+	s.assertManifoldNames(c,
+		safemode.CAASManifolds(safemode.ManifoldsConfig{
+			Agent: &mockAgent{},
+		}),
+		[]string{
+			"agent",
+			"clock",
+			"controller-agent-config",
+			"db-accessor",
+			"is-controller-flag",
+			"query-logger",
+			"state-config-watcher",
+			"syslog",
+			"termination-signal-handler",
+		},
+	)
+}
+
+func (*ManifoldsSuite) assertManifoldNames(c *gc.C, manifolds dependency.Manifolds, expectedKeys []string) {
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	c.Assert(keys, jc.SameContents, expectedKeys)
+}
+
+func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
+	manifolds := safemode.IAASManifolds(safemode.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+
+	// Explicitly guarded by ifController.
+	controllerWorkers := set.NewStrings(
+		"controller-agent-config",
+		"db-accessor",
+		"file-notify-watcher",
+		"db-accessor",
+		"query-logger",
+		"file-notify-watcher",
+	)
+
+	// Explicitly guarded by ifPrimaryController.
+	primaryControllerWorkers := set.NewStrings()
+
+	dbUpgradedWorkers := set.NewStrings()
+
+	for name, manifold := range manifolds {
+		c.Logf(name)
+		switch {
+		case controllerWorkers.Contains(name):
+			checkContains(c, manifold.Inputs, "is-controller-flag")
+			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
+		case primaryControllerWorkers.Contains(name):
+			checkNotContains(c, manifold.Inputs, "is-controller-flag")
+			checkContains(c, manifold.Inputs, "is-primary-controller-flag")
+		case dbUpgradedWorkers.Contains(name):
+			checkNotContains(c, manifold.Inputs, "is-controller-flag")
+			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
+			checkContains(c, manifold.Inputs, "upgrade-database-flag")
+		default:
+			checkNotContains(c, manifold.Inputs, "is-controller-flag")
+			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
+		}
+	}
+}
+
+func checkContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			return
+		}
+	}
+	c.Errorf("%q not found in %v", seek, names)
+}
+
+func checkNotContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			c.Errorf("%q found in %v", seek, names)
+			return
+		}
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldsDependenciesIAAS(c *gc.C) {
+	agenttest.AssertManifoldsDependencies(c,
+		safemode.IAASManifolds(safemode.ManifoldsConfig{
+			Agent: &mockAgent{},
+		}),
+		expectedMachineManifoldsWithDependenciesIAAS,
+	)
+}
+
+func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *gc.C) {
+	agenttest.AssertManifoldsDependencies(c,
+		safemode.CAASManifolds(safemode.ManifoldsConfig{
+			Agent: &mockAgent{},
+		}),
+		expectedMachineManifoldsWithDependenciesCAAS,
+	)
+}
+
+var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
+
+	"agent": {},
+
+	"clock": {},
+
+	"controller-agent-config": {
+		"agent",
+		"is-controller-flag",
+		"state-config-watcher",
+	},
+
+	"db-accessor": {
+		"agent",
+		"is-controller-flag",
+		"query-logger",
+		"state-config-watcher",
+	},
+
+	"is-controller-flag": {"agent", "state-config-watcher"},
+
+	"query-logger": {
+		"agent",
+		"is-controller-flag",
+		"state-config-watcher",
+	},
+
+	"state-config-watcher": {"agent"},
+
+	"syslog": {},
+
+	"termination-signal-handler": {},
+}
+
+var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
+
+	"agent": {},
+
+	"clock": {},
+
+	"controller-agent-config": {
+		"agent",
+		"is-controller-flag",
+		"state-config-watcher",
+	},
+
+	"db-accessor": {
+		"agent",
+		"is-controller-flag",
+		"query-logger",
+		"state-config-watcher",
+	},
+
+	"is-controller-flag": {"agent", "state-config-watcher"},
+
+	"query-logger": {
+		"agent",
+		"is-controller-flag",
+		"state-config-watcher",
+	},
+
+	"state-config-watcher": {"agent"},
+
+	"syslog": {},
+
+	"termination-signal-handler": {},
+}
+
+type mockAgent struct {
+	agent.Agent
+	conf mockConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
+	return f(&ma.conf)
+}
+
+type mockConfig struct {
+	agent.ConfigSetter
+	tag      names.Tag
+	ssiSet   bool
+	ssi      controller.StateServingInfo
+	dataPath string
+}
+
+func (mc *mockConfig) Tag() names.Tag {
+	if mc.tag == nil {
+		return names.NewMachineTag("99")
+	}
+	return mc.tag
+}
+
+func (mc *mockConfig) Controller() names.ControllerTag {
+	return testing.ControllerTag
+}
+
+func (mc *mockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
+	return mc.ssi, mc.ssiSet
+}
+
+func (mc *mockConfig) SetStateServingInfo(info controller.StateServingInfo) {
+	mc.ssiSet = true
+	mc.ssi = info
+}
+
+func (mc *mockConfig) LogDir() string {
+	return "log-dir"
+}
+
+func (mc *mockConfig) DataDir() string {
+	if mc.dataPath != "" {
+		return mc.dataPath
+	}
+	return "data-dir"
+}

--- a/cmd/jujud/agent/safemode/package_test.go
+++ b/cmd/jujud/agent/safemode/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package safemode_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -277,7 +277,17 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		upgrades.PerformUpgradeSteps,
 		"",
 	)
-	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
+	jujud.Register(agentcmd.NewMachineAgentCommand(ctx, machineAgentFactory, agentConf, agentConf))
+
+	safeModeMachineAgentFactory := agentcmd.SafeModeMachineAgentFactoryFn(
+		agentConf,
+		bufferedLogger,
+		dbaccessor.NewTrackedDBWorker,
+		addons.DefaultIntrospectionSocketName,
+		"",
+	)
+
+	jujud.Register(agentcmd.NewSafeModeAgentCommand(ctx, safeModeMachineAgentFactory, agentConf, agentConf))
 	jujud.Register(agentcmd.NewCheckConnectionCommand(agentConf, agentcmd.ConnectAsAgent))
 
 	code = cmd.Main(jujud, ctx, args[1:])

--- a/cmd/jujud/util/stateflag.go
+++ b/cmd/jujud/util/stateflag.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package machine
+package util
 
 import (
 	"github.com/juju/worker/v3"
@@ -10,19 +10,19 @@ import (
 	"github.com/juju/juju/agent/engine"
 )
 
-// isControllerFlagManifold returns a dependency.Manifold that indicates
+// IsControllerFlagManifold returns a dependency.Manifold that indicates
 // the state config is present or not depending on the arg.
 // It returns a worker implementing engine.Flag, whose Check method returns
 // True in 2 cases:
 // 1) state config is present on the machine and arg is True
 // 2) state config is not present on the machine and arg is False.
-func isControllerFlagManifold(yes bool) dependency.Manifold {
+func IsControllerFlagManifold(inputName string, yes bool) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{stateConfigWatcherName},
+		Inputs: []string{inputName},
 		Output: engine.FlagOutput,
 		Start: func(context dependency.Context) (worker.Worker, error) {
 			var haveStateConfig bool
-			if err := context.Get(stateConfigWatcherName, &haveStateConfig); err != nil {
+			if err := context.Get(inputName, &haveStateConfig); err != nil {
 				return nil, err
 			}
 			return engine.NewStaticFlagWorker(haveStateConfig && yes || !haveStateConfig && !yes), nil


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/16500 to land first.~~

-----

Implements a non-HA safemode for viewing and editing the dqlite database without all the ancillary workers. This is purely for development at the moment. To move into HA safemode, it will require the other nodes to be coordinated.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

You need the cert and the key to make this work.

### Setup

```sh
$ juju bootstrap lxd test --build-agent
$ make repl-install
```

### Single node

This will work with the existing setup...

```sh
$ juju ssh -m controller 0
$ sudo snap install yq
# Note we need to pipe indirection because of snap confinement.
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
```

The following forces safe mode, once done, repeat the steps above.

```sh
$ juju ssh -m controller 0
$ systemctl stop jujud-machine-0.service
$ /var/lib/juju/tools/machine-0/jujud safe-mode --data-dir /var/lib/juju --machine-id 0 &
```

### HA

```sh
$ juju enable-ha
```

Per node run the following:

```sh
$ lxc exec $NAME-$ID -- bash
$ systemctl stop jujud-machine-$ID.service
$ snap install yq
$ add-apt-repository -y ppa:dqlite/dev && sudo apt install -y dqlite-tools
$ cat /var/lib/juju/agents/machine-$ID/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ cat /var/lib/juju/agents/machine-$ID/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ /var/lib/juju/tools/machine-$ID/jujud safe-mode --data-dir /var/lib/juju --machine-id $ID &
```

Login to a single node:

```sh
$ lxc exec $NAME-0 -- bash
$ dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
```

The following forces safe mode, once done, repeat the steps above.

```sh
$ juju ssh -m controller 0
$ systemctl stop jujud-machine-0.service
$ /var/lib/juju/tools/machine-0/jujud safe-mode --data-dir /var/lib/juju --machine-id 0 &
dqlite >
```

## Links


**Jira card:** JUJU-4838
