### PR TITLE
[JUJU-4732] Use charm name string instead of charm URL

### DIFF
--- a/apiserver/facades/client/application/repository_mocks_test.go
+++ b/apiserver/facades/client/application/repository_mocks_test.go
@@ -38,7 +38,7 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 string, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -54,7 +54,7 @@ func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interface{}
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 string, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
 	ret0, _ := ret[0].(*url.URL)
@@ -89,7 +89,7 @@ func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 ...interface{}) 
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 string, arg1 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -134,7 +134,7 @@ func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1 interface{}) *
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 string, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
 	ret0, _ := ret[0].(*charm.URL)

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -198,7 +198,7 @@ func (a *API) getDownloadInfo(arg params.CharmURLAndOrigin) (params.DownloadInfo
 	if err != nil {
 		return params.DownloadInfoResult{}, apiservererrors.ServerError(err)
 	}
-	url, origin, err := repo.GetDownloadURL(curl, requestedOrigin)
+	url, origin, err := repo.GetDownloadURL(curl.Name, requestedOrigin)
 	if err != nil {
 		return params.DownloadInfoResult{}, apiservererrors.ServerError(err)
 	}
@@ -315,7 +315,7 @@ func (a *API) queueAsyncCharmDownload(args params.AddCharmWithAuth) (corecharm.O
 	// to ensure that the resolved origin has the ID/Hash fields correctly
 	// populated.
 	if _, err := a.backendState.Charm(args.URL); err == nil {
-		_, resolvedOrigin, err := repo.GetDownloadURL(charmURL, requestedOrigin)
+		_, resolvedOrigin, err := repo.GetDownloadURL(charmURL.Name, requestedOrigin)
 		return resolvedOrigin, errors.Trace(err)
 	}
 
@@ -323,8 +323,8 @@ func (a *API) queueAsyncCharmDownload(args params.AddCharmWithAuth) (corecharm.O
 	// without downloading the full archive. The remaining metadata will
 	// be populated once the charm gets downloaded.
 	essentialMeta, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
-		CharmURL: charmURL,
-		Origin:   requestedOrigin,
+		CharmName: charmURL.Name,
+		Origin:    requestedOrigin,
 	})
 	if err != nil {
 		return corecharm.Origin{}, errors.Annotatef(err, "retrieving essential metadata for charm %q", charmURL)
@@ -389,7 +389,7 @@ func (a *API) resolveOneCharm(arg params.ResolveCharmWithChannel) params.Resolve
 		return result
 	}
 
-	resultURL, origin, resolvedBases, err := repo.ResolveWithPreferredChannel(curl, requestedOrigin)
+	resultURL, origin, resolvedBases, err := repo.ResolveWithPreferredChannel(curl.Name, requestedOrigin)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result
@@ -717,7 +717,7 @@ func (a *API) listOneCharmResources(arg params.CharmURLAndOrigin) ([]params.Char
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}
-	resources, err := repo.ListResources(curl, requestedOrigin)
+	resources, err := repo.ListResources(curl.Name, requestedOrigin)
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -201,7 +201,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 
 	expected := []params.ResolveCharmWithChannelResult{
 		{
-			URL:    curl,
+			URL:    seriesCurl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -209,7 +209,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 				{Name: "ubuntu", Channel: "16.04"},
 			},
 		}, {
-			URL:    curl,
+			URL:    seriesCurl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -254,7 +254,7 @@ func (s *charmsMockSuite) TestResolveCharmNoDefinedSeries(c *gc.C) {
 	s.expectResolveWithPreferredChannelNoSeries()
 	api := s.api(c)
 
-	seriesCurl := "ch:focal/testme"
+	seriesCurl := "ch:amd64/focal/testme"
 
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
@@ -318,11 +318,11 @@ func (s *charmsMockSuite) TestResolveCharmV6(c *gc.C) {
 
 	expected := []params.ResolveCharmWithChannelResultV6{
 		{
-			URL:             curl,
+			URL:             seriesCurl,
 			Origin:          stableOrigin,
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		}, {
-			URL:             curl,
+			URL:             seriesCurl,
 			Origin:          stableOrigin,
 			SupportedSeries: []string{"bionic", "focal", "xenial"},
 		},
@@ -358,8 +358,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 	// Charmhub charms are downloaded asynchronously
 	defer s.setupMocks(c).Finish()
 
-	curl, err := charm.ParseURL("chtest")
-	c.Assert(err, jc.ErrorIsNil)
+	curl := "chtest"
 
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
@@ -382,15 +381,15 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 		},
 	}
 
-	s.state.EXPECT().Charm(curl.String()).Return(nil, errors.NotFoundf("%q", curl))
+	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf("%q", curl))
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
 
 	expMeta := new(charm.Meta)
 	expManifest := new(charm.Manifest)
 	expConfig := new(charm.Config)
 	s.repository.EXPECT().GetEssentialMetadata(corecharm.MetadataRequest{
-		CharmURL: curl,
-		Origin:   requestedOrigin,
+		CharmName: curl,
+		Origin:    requestedOrigin,
 	}).Return([]corecharm.EssentialMetadata{
 		{
 			Meta:           expMeta,
@@ -402,7 +401,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 
 	s.state.EXPECT().AddCharmMetadata(gomock.Any()).DoAndReturn(
 		func(ci state.CharmInfo) (*state.Charm, error) {
-			c.Assert(ci.ID, gc.DeepEquals, curl.String())
+			c.Assert(ci.ID, gc.DeepEquals, curl)
 			// Check that the essential metadata matches what
 			// the repository returned. We use pointer checks here.
 			c.Assert(ci.Charm.Meta(), gc.Equals, expMeta)
@@ -415,7 +414,7 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 	api := s.api(c)
 
 	args := params.AddCharmWithOrigin{
-		URL: curl.String(),
+		URL: curl,
 		Origin: params.CharmOrigin{
 			Source: "charm-hub",
 			Base:   params.Base{Name: "ubuntu", Channel: "20.04/stable"},
@@ -436,9 +435,8 @@ func (s *charmsMockSuite) TestAddCharmCharmhub(c *gc.C) {
 func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlreadyDownloadedCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl, err := charm.ParseURL("chtest")
-	c.Assert(err, jc.ErrorIsNil)
-	resURL, err := url.Parse(curl.String())
+	curl := "chtest"
+	resURL, err := url.Parse(curl)
 	c.Assert(err, jc.ErrorIsNil)
 
 	resolvedOrigin := corecharm.Origin{
@@ -452,14 +450,14 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 		},
 	}
 
-	s.state.EXPECT().Charm(curl.String()).Return(nil, nil) // a nil error indicates that the charm doc already exists
+	s.state.EXPECT().Charm(curl).Return(nil, nil) // a nil error indicates that the charm doc already exists
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
 	s.repository.EXPECT().GetDownloadURL(curl, gomock.Any()).Return(resURL, resolvedOrigin, nil)
 
 	api := s.api(c)
 
 	args := params.AddCharmWithOrigin{
-		URL: curl.String(),
+		URL: curl,
 		Origin: params.CharmOrigin{
 			Source: "charm-hub",
 			Risk:   "edge",
@@ -687,11 +685,10 @@ func (s *charmsMockSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error) {
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil).Times(times)
 	s.repository.EXPECT().ResolveWithPreferredChannel(
-		gomock.AssignableToTypeOf(&charm.URL{}),
+		gomock.AssignableToTypeOf(""),
 		gomock.AssignableToTypeOf(corecharm.Origin{}),
 	).DoAndReturn(
-		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
+		func(name string, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 
@@ -707,6 +704,14 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 				{OS: "ubuntu", Channel: "20.04"},
 				{OS: "ubuntu", Channel: "16.04"},
 			}
+			// ensure the charm url returned is filled out
+			curl := &charm.URL{
+				Schema:       "ch",
+				Name:         name,
+				Series:       "focal",
+				Architecture: "amd64",
+				Revision:     -1,
+			}
 			return curl, resolvedOrigin, bases, err
 		}).Times(times)
 }
@@ -714,11 +719,10 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 func (s *charmsMockSuite) expectResolveWithPreferredChannelNoSeries() {
 	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repository, nil)
 	s.repository.EXPECT().ResolveWithPreferredChannel(
-		gomock.AssignableToTypeOf(&charm.URL{}),
+		gomock.AssignableToTypeOf(""),
 		gomock.AssignableToTypeOf(corecharm.Origin{}),
 	).DoAndReturn(
-		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []string, error) {
+		func(name string, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []string, error) {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 
@@ -729,7 +733,14 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannelNoSeries() {
 
 				resolvedOrigin.Channel.Risk = "stable"
 			}
-
+			// ensure the charm url returned is filled out
+			curl := &charm.URL{
+				Schema:       "ch",
+				Name:         name,
+				Series:       "focal",
+				Architecture: "amd64",
+				Revision:     -1,
+			}
 			return curl, resolvedOrigin, []string{}, nil
 		})
 }

--- a/apiserver/facades/client/charms/mocks/repository.go
+++ b/apiserver/facades/client/charms/mocks/repository.go
@@ -38,7 +38,7 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 string, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -54,7 +54,7 @@ func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interface{}
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 string, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
 	ret0, _ := ret[0].(*url.URL)
@@ -89,7 +89,7 @@ func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 ...interface{}) 
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 string, arg1 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -134,7 +134,7 @@ func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1 interface{}) *
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 string, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
 	ret0, _ := ret[0].(*charm.URL)

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -285,7 +285,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	storeCurl.Architecture = "amd64"
 	storeOrigin := origin
 	storeOrigin.Type = "charm"
-	repo.EXPECT().ResolveWithPreferredChannel(curl, origin).Return(&storeCurl, storeOrigin, nil, nil)
+	repo.EXPECT().ResolveWithPreferredChannel(curl.Name, origin).Return(&storeCurl, storeOrigin, nil, nil)
 
 	downloader.EXPECT().DownloadAndStore(&storeCurl, storeOrigin, false).
 		DoAndReturn(func(charmURL *charm.URL, requestedOrigin corecharm.Origin, force bool) (corecharm.Origin, error) {

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -186,7 +186,7 @@ func populateStoreControllerCharm(st *state.State, charmPath string, channel cha
 	// error response.
 	//
 	// The controller charm doesn't have any series specific code.
-	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(curl, origin)
+	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(curl.Name, origin)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "resolving %q", controllerCharmURL)
 	}

--- a/core/charm/downloader/export_test.go
+++ b/core/charm/downloader/export_test.go
@@ -4,8 +4,6 @@
 package downloader
 
 import (
-	"github.com/juju/charm/v11"
-
 	corecharm "github.com/juju/juju/core/charm"
 )
 
@@ -17,6 +15,6 @@ func (d *Downloader) NormalizePlatform(charmURL string, platform corecharm.Platf
 	return d.normalizePlatform(charmURL, platform)
 }
 
-func (d *Downloader) DownloadAndHash(charmURL *charm.URL, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
-	return d.downloadAndHash(charmURL, requestedOrigin, repo, dstPath)
+func (d *Downloader) DownloadAndHash(charmName string, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
+	return d.downloadAndHash(charmName, requestedOrigin, repo, dstPath)
 }

--- a/core/charm/downloader/mocks/charm_mocks.go
+++ b/core/charm/downloader/mocks/charm_mocks.go
@@ -172,7 +172,7 @@ func (m *MockCharmRepository) EXPECT() *MockCharmRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockCharmRepository) DownloadCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockCharmRepository) DownloadCharm(arg0 string, arg1 charm0.Origin, arg2 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -188,7 +188,7 @@ func (mr *MockCharmRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2 interf
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockCharmRepository) GetDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockCharmRepository) GetDownloadURL(arg0 string, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1)
 	ret0, _ := ret[0].(*url.URL)
@@ -204,7 +204,7 @@ func (mr *MockCharmRepositoryMockRecorder) GetDownloadURL(arg0, arg1 interface{}
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 string, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
 	ret0, _ := ret[0].(*charm.URL)

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -16,18 +16,18 @@ type Repository interface {
 	// GetDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	GetDownloadURL(*charm.URL, Origin) (*url.URL, Origin, error)
+	GetDownloadURL(string, Origin) (*url.URL, Origin, error)
 
 	// DownloadCharm retrieves specified charm from the store and saves its
 	// contents to the specified path.
-	DownloadCharm(charmURL *charm.URL, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
+	DownloadCharm(charmName string, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
 
 	// ResolveWithPreferredChannel verified that the charm with the requested
 	// channel exists.  If no channel is specified, the latests, most stable is
 	// used. It returns a charm URL which includes the most current revision,
 	// if none was provided, a charm origin, and a slice of series supported by
 	// this charm.
-	ResolveWithPreferredChannel(*charm.URL, Origin) (*charm.URL, Origin, []Platform, error)
+	ResolveWithPreferredChannel(string, Origin) (*charm.URL, Origin, []Platform, error)
 
 	// GetEssentialMetadata resolves each provided MetadataRequest and
 	// returns back a slice with the results. The results include the
@@ -35,7 +35,7 @@ type Repository interface {
 	GetEssentialMetadata(...MetadataRequest) ([]EssentialMetadata, error)
 
 	// ListResources returns a list of resources associated with a given charm.
-	ListResources(*charm.URL, Origin) ([]charmresource.Resource, error)
+	ListResources(string, Origin) ([]charmresource.Resource, error)
 
 	// ResolveResources looks at the provided repository and backend (already
 	// downloaded) resources to determine which to use. Provided (uploaded) take
@@ -64,8 +64,8 @@ type CharmArchive interface {
 // MetadataRequest encapsulates the arguments for a charm essential metadata
 // resolution request.
 type MetadataRequest struct {
-	CharmURL *charm.URL
-	Origin   Origin
+	CharmName string
+	Origin    Origin
 }
 
 // EssentialMetadata encapsulates the essential metadata required for deploying

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -42,17 +42,17 @@ func NewCharmHubRepository(logger Logger, chClient CharmHubClient) *CharmHubRepo
 	}
 }
 
-// ResolveWithPreferredChannel defines a way using the given charm URL and
+// ResolveWithPreferredChannel defines a way using the given charm name and
 // charm origin (platform and channel) to locate a matching charm against the
 // Charmhub API.
-func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, argOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
-	c.logger.Tracef("Resolving CharmHub charm %q with origin %+v", charmURL, argOrigin)
+func (c *CharmHubRepository) ResolveWithPreferredChannel(charmName string, argOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
+	c.logger.Tracef("Resolving CharmHub charm %q with origin %+v", charmName, argOrigin)
 
 	requestedOrigin, err := c.validateOrigin(argOrigin)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, err
 	}
-	resCurl, outputOrigin, resolvedBases, _, err := c.resolveWithPreferredChannel(charmURL, requestedOrigin)
+	resCurl, outputOrigin, resolvedBases, _, err := c.resolveWithPreferredChannel(charmName, requestedOrigin)
 	return resCurl, outputOrigin, resolvedBases, err
 }
 
@@ -62,12 +62,12 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, ar
 func (c *CharmHubRepository) ResolveForDeploy(arg corecharm.CharmID) (corecharm.ResolvedDataForDeploy, error) {
 	c.logger.Tracef("Resolving CharmHub charm %q with origin %+v", arg.URL, arg.Origin)
 
-	resultURL, resolvedOrigin, _, resp, resolveErr := c.resolveWithPreferredChannel(arg.URL, arg.Origin)
+	resultURL, resolvedOrigin, _, resp, resolveErr := c.resolveWithPreferredChannel(arg.URL.Name, arg.Origin)
 	if resolveErr != nil {
 		return corecharm.ResolvedDataForDeploy{}, errors.Trace(resolveErr)
 	}
 
-	essMeta, err := transformRefreshResult(resultURL, resp)
+	essMeta, err := transformRefreshResult(resultURL.Name, resp)
 	if err != nil {
 		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
@@ -109,9 +109,9 @@ func (c *CharmHubRepository) ResolveForDeploy(arg corecharm.CharmID) (corecharm.
 //  3. In theory we could just return most of this information without the
 //     re-request, but we end up with missing data and potential incorrect
 //     charm downloads later.
-func (c *CharmHubRepository) resolveWithPreferredChannel(charmURL *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, transport.RefreshResponse, error) {
+func (c *CharmHubRepository) resolveWithPreferredChannel(charmName string, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, transport.RefreshResponse, error) {
 	// First attempt to find the charm based on the only input provided.
-	response, err := c.refreshOne(charmURL, requestedOrigin)
+	response, err := c.refreshOne(charmName, requestedOrigin)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, transport.RefreshResponse{}, errors.Annotatef(err, "resolving with preferred channel")
 	}
@@ -129,7 +129,7 @@ func (c *CharmHubRepository) resolveWithPreferredChannel(charmURL *charm.URL, re
 	)
 	switch {
 	case response.Error != nil:
-		retryResult, err := c.retryResolveWithPreferredChannel(charmURL, requestedOrigin, response.Error)
+		retryResult, err := c.retryResolveWithPreferredChannel(charmName, requestedOrigin, response.Error)
 		if err != nil {
 			return nil, corecharm.Origin{}, nil, transport.RefreshResponse{}, errors.Trace(err)
 		}
@@ -174,21 +174,25 @@ func (c *CharmHubRepository) resolveWithPreferredChannel(charmURL *charm.URL, re
 	// account for the closed tracks in a given channel.
 	channel, err := charm.ParseChannelNormalize(effectiveChannel)
 	if err != nil {
-		return nil, corecharm.Origin{}, nil, transport.RefreshResponse{}, errors.Annotatef(err, "invalid channel for %q", charmURL)
+		return nil, corecharm.Origin{}, nil, transport.RefreshResponse{}, errors.Annotatef(err, "invalid channel for %q", charmName)
 	}
 
 	// Ensure we send the updated charmURL back, with all the correct segments.
 	revision := response.Entity.Revision
-	resCurl := charmURL.
-		WithArchitecture(chSuggestedOrigin.Platform.Architecture).
-		WithRevision(revision)
 	// TODO(wallyworld) - does charm url still need a series?
+	var series string
 	if chSuggestedOrigin.Platform.Channel != "" {
-		series, err := corebase.GetSeriesFromChannel(chSuggestedOrigin.Platform.OS, chSuggestedOrigin.Platform.Channel)
+		series, err = corebase.GetSeriesFromChannel(chSuggestedOrigin.Platform.OS, chSuggestedOrigin.Platform.Channel)
 		if err != nil {
 			return nil, corecharm.Origin{}, nil, transport.RefreshResponse{}, errors.Trace(err)
 		}
-		resCurl = resCurl.WithSeries(series)
+	}
+	resCurl := &charm.URL{
+		Schema:       "ch",
+		Name:         charmName,
+		Revision:     revision,
+		Series:       series,
+		Architecture: chSuggestedOrigin.Platform.Architecture,
 	}
 
 	// Create a resolved origin.  Keep the original values for ID and Hash, if
@@ -261,21 +265,21 @@ type retryResolveResult struct {
 // retryResolveWithPreferredChannel will attempt to inspect the transport
 // APIError and determine if a retry is possible with the information gathered
 // from the error.
-func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmURL *charm.URL, origin corecharm.Origin, resErr *transport.APIError) (*retryResolveResult, error) {
+func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmName string, origin corecharm.Origin, resErr *transport.APIError) (*retryResolveResult, error) {
 	var (
 		err   error
 		bases []corecharm.Platform
 	)
 	switch resErr.Code {
 	case transport.ErrorCodeInvalidCharmPlatform, transport.ErrorCodeInvalidCharmBase:
-		c.logger.Tracef("Invalid charm platform %q %v - Default Base: %v", charmURL, origin, resErr.Extra.DefaultBases)
+		c.logger.Tracef("Invalid charm platform %q %v - Default Base: %v", charmName, origin, resErr.Extra.DefaultBases)
 
 		if bases, err = c.selectNextBases(resErr.Extra.DefaultBases, origin); err != nil {
 			return nil, errors.Annotatef(err, "selecting next bases")
 		}
 
 	case transport.ErrorCodeRevisionNotFound:
-		c.logger.Tracef("Revision not found %q %v - Releases: %v", charmURL, origin, resErr.Extra.Releases)
+		c.logger.Tracef("Revision not found %q %v - Releases: %v", charmName, origin, resErr.Extra.Releases)
 
 		if bases, err = c.selectNextBasesFromReleases(resErr.Extra.Releases, origin); err != nil {
 			return nil, errors.Annotatef(err, "selecting releases")
@@ -298,11 +302,11 @@ func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmURL *charm.UR
 	origin.Platform.Channel = base.Channel
 
 	if origin.Platform.Channel == "" {
-		return nil, errors.NotValidf("channel for %s", charmURL.Name)
+		return nil, errors.NotValidf("channel for %s", charmName)
 	}
 
-	c.logger.Tracef("Refresh again with %q %v", charmURL, origin)
-	res, err := c.refreshOne(charmURL, origin)
+	c.logger.Tracef("Refresh again with %q %v", charmName, origin)
+	res, err := c.refreshOne(charmName, origin)
 	if err != nil {
 		return nil, errors.Annotatef(err, "retrying")
 	}
@@ -316,13 +320,13 @@ func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmURL *charm.UR
 	}, nil
 }
 
-func transformRefreshResult(curl *charm.URL, refreshResult transport.RefreshResponse) (corecharm.EssentialMetadata, error) {
+func transformRefreshResult(charmName string, refreshResult transport.RefreshResponse) (corecharm.EssentialMetadata, error) {
 	if refreshResult.Entity.MetadataYAML == "" {
-		return corecharm.EssentialMetadata{}, errors.NotValidf("charmhub refresh response for %q does not include the contents of metadata.yaml", curl)
+		return corecharm.EssentialMetadata{}, errors.NotValidf("charmhub refresh response for %q does not include the contents of metadata.yaml", charmName)
 	}
 	chMeta, err := charm.ReadMeta(strings.NewReader(refreshResult.Entity.MetadataYAML))
 	if err != nil {
-		return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing metadata.yaml for %q", curl)
+		return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing metadata.yaml for %q", charmName)
 	}
 
 	configYAML := refreshResult.Entity.ConfigYAML
@@ -336,7 +340,7 @@ func transformRefreshResult(curl *charm.URL, refreshResult transport.RefreshResp
 	} else {
 		chConfig, err = charm.ReadConfig(strings.NewReader(configYAML))
 		if err != nil {
-			return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing config.yaml for %q", curl)
+			return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing config.yaml for %q", charmName)
 		}
 	}
 
@@ -344,7 +348,7 @@ func transformRefreshResult(curl *charm.URL, refreshResult transport.RefreshResp
 	for _, base := range refreshResult.Entity.Bases {
 		baseCh, err := charm.ParseChannelNormalize(base.Channel)
 		if err != nil {
-			return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing base channel for %q", curl)
+			return corecharm.EssentialMetadata{}, errors.Annotatef(err, "parsing base channel for %q", charmName)
 		}
 
 		chManifest.Bases = append(chManifest.Bases, charm.Base{
@@ -358,12 +362,12 @@ func transformRefreshResult(curl *charm.URL, refreshResult transport.RefreshResp
 
 // DownloadCharm retrieves specified charm from the store and saves its
 // contents to the specified path.
-func (c *CharmHubRepository) DownloadCharm(charmURL *charm.URL, requestedOrigin corecharm.Origin, archivePath string) (corecharm.CharmArchive, corecharm.Origin, error) {
-	c.logger.Tracef("DownloadCharm %q, origin: %q", charmURL, requestedOrigin)
+func (c *CharmHubRepository) DownloadCharm(charmName string, requestedOrigin corecharm.Origin, archivePath string) (corecharm.CharmArchive, corecharm.Origin, error) {
+	c.logger.Tracef("DownloadCharm %q, origin: %q", charmName, requestedOrigin)
 
 	// Resolve charm URL to a link to the charm blob and keep track of the
 	// actual resolved origin which may be different from the requested one.
-	resURL, actualOrigin, err := c.GetDownloadURL(charmURL, requestedOrigin)
+	resURL, actualOrigin, err := c.GetDownloadURL(charmName, requestedOrigin)
 	if err != nil {
 		return nil, corecharm.Origin{}, errors.Trace(err)
 	}
@@ -377,14 +381,14 @@ func (c *CharmHubRepository) DownloadCharm(charmURL *charm.URL, requestedOrigin 
 }
 
 // GetDownloadURL returns the url from which to download the CharmHub charm/bundle
-// defined by the provided curl and charm origin.  An updated charm origin is
+// defined by the provided charm name and origin.  An updated charm origin is
 // also returned with the ID and hash for the charm to be downloaded.  If the
 // provided charm origin has no ID, it is assumed that the charm is being
 // installed, not refreshed.
-func (c *CharmHubRepository) GetDownloadURL(charmURL *charm.URL, requestedOrigin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
-	c.logger.Tracef("GetDownloadURL %q, origin: %q", charmURL, requestedOrigin)
+func (c *CharmHubRepository) GetDownloadURL(charmName string, requestedOrigin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
+	c.logger.Tracef("GetDownloadURL %q, origin: %q", charmName, requestedOrigin)
 
-	refreshRes, err := c.refreshOne(charmURL, requestedOrigin)
+	refreshRes, err := c.refreshOne(charmName, requestedOrigin)
 	if err != nil {
 		return nil, corecharm.Origin{}, errors.Trace(err)
 	}
@@ -409,16 +413,16 @@ func (c *CharmHubRepository) GetDownloadURL(charmURL *charm.URL, requestedOrigin
 }
 
 // ListResources returns the resources for a given charm and origin.
-func (c *CharmHubRepository) ListResources(charmURL *charm.URL, origin corecharm.Origin) ([]charmresource.Resource, error) {
-	c.logger.Tracef("ListResources %q", charmURL)
+func (c *CharmHubRepository) ListResources(charmName string, origin corecharm.Origin) ([]charmresource.Resource, error) {
+	c.logger.Tracef("ListResources %q", charmName)
 
-	resCurl, resOrigin, _, err := c.ResolveWithPreferredChannel(charmURL, origin)
+	resCurl, resOrigin, _, err := c.ResolveWithPreferredChannel(charmName, origin)
 	if isErrSelection(err) {
 		var channel string
 		if origin.Channel != nil {
 			channel = origin.Channel.String()
 		}
-		return nil, errors.Errorf("unable to locate charm %q with matching channel %q", charmURL.Name, channel)
+		return nil, errors.Errorf("unable to locate charm %q with matching channel %q", charmName, channel)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -429,7 +433,7 @@ func (c *CharmHubRepository) ListResources(charmURL *charm.URL, origin corecharm
 	// specified.  ListResources is used by the "charm-resources" cli cmd,
 	// therefore specific charm revisions are less important.
 	resOrigin.Revision = nil
-	resp, err := c.refreshOne(resCurl, resOrigin)
+	resp, err := c.refreshOne(resCurl.Name, resOrigin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -453,7 +457,7 @@ func (c *CharmHubRepository) ListResources(charmURL *charm.URL, origin corecharm
 // downloaded) resources to determine which to use. Provided (uploaded) take
 // precedence. If charmhub has a newer resource than the back end, use that.
 func (c *CharmHubRepository) ResolveResources(resources []charmresource.Resource, id corecharm.CharmID) ([]charmresource.Resource, error) {
-	revisionResources, err := c.listResourcesIfRevisions(resources, id.URL)
+	revisionResources, err := c.listResourcesIfRevisions(resources, id.URL.Name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -475,7 +479,7 @@ func (c *CharmHubRepository) ResolveResources(resources []charmresource.Resource
 	return resolved, nil
 }
 
-func (c *CharmHubRepository) listResourcesIfRevisions(resources []charmresource.Resource, curl *charm.URL) (map[string]charmresource.Resource, error) {
+func (c *CharmHubRepository) listResourcesIfRevisions(resources []charmresource.Resource, charmName string) (map[string]charmresource.Resource, error) {
 	results := make(map[string]charmresource.Resource, 0)
 	for _, resource := range resources {
 		// If not revision is specified, or the resource has already been
@@ -483,9 +487,9 @@ func (c *CharmHubRepository) listResourcesIfRevisions(resources []charmresource.
 		if resource.Revision == -1 || resource.Origin == charmresource.OriginUpload {
 			continue
 		}
-		refreshResp, err := c.client.ListResourceRevisions(context.TODO(), curl.Name, resource.Name)
+		refreshResp, err := c.client.ListResourceRevisions(context.TODO(), charmName, resource.Name)
 		if err != nil {
-			return nil, errors.Annotatef(err, "refreshing charm %q", curl.String())
+			return nil, errors.Annotatef(err, "refreshing charm %q", charmName)
 		}
 		if len(refreshResp) == 0 {
 			return nil, errors.Errorf("no download refresh responses received")
@@ -764,12 +768,12 @@ func (c *CharmHubRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRequ
 	for reqIdx, req := range reqs {
 		// TODO(achilleasa): We should add support for resolving origin
 		// batches and move this outside the loop.
-		_, resolvedOrigin, _, err := c.ResolveWithPreferredChannel(req.CharmURL, req.Origin)
+		_, resolvedOrigin, _, err := c.ResolveWithPreferredChannel(req.CharmName, req.Origin)
 		if err != nil {
-			return nil, errors.Annotatef(err, "resolving origin for %q", req.CharmURL)
+			return nil, errors.Annotatef(err, "resolving origin for %q", req.CharmName)
 		}
 
-		refreshCfg, err := refreshConfig(req.CharmURL, resolvedOrigin)
+		refreshCfg, err := refreshConfig(req.CharmName, resolvedOrigin)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -785,7 +789,7 @@ func (c *CharmHubRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRequ
 
 	var metaRes = make([]corecharm.EssentialMetadata, len(reqs))
 	for resIdx, refreshResult := range refreshResults {
-		essMeta, err := transformRefreshResult(reqs[resIdx].CharmURL, refreshResult)
+		essMeta, err := transformRefreshResult(reqs[resIdx].CharmName, refreshResult)
 		if err != nil {
 			return nil, err
 		}
@@ -796,8 +800,8 @@ func (c *CharmHubRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRequ
 	return metaRes, nil
 }
 
-func (c *CharmHubRepository) refreshOne(charmURL *charm.URL, origin corecharm.Origin) (transport.RefreshResponse, error) {
-	cfg, err := refreshConfig(charmURL, origin)
+func (c *CharmHubRepository) refreshOne(charmName string, origin corecharm.Origin) (transport.RefreshResponse, error) {
+	cfg, err := refreshConfig(charmName, origin)
 	if err != nil {
 		return transport.RefreshResponse{}, errors.Trace(err)
 	}
@@ -919,7 +923,7 @@ const (
 // origin have a revision number in them when called by GetDownloadURL
 // to install a charm. Potentially causing an unexpected install by revision.
 // This is okay as all of the data is ready and correct in the origin.
-func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.RefreshConfig, error) {
+func refreshConfig(charmName string, origin corecharm.Origin) (charmhub.RefreshConfig, error) {
 	// Work out the correct install method.
 	rev := -1
 	var method Method
@@ -968,11 +972,11 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 		// Install from just the name and the channel. If there is no origin ID,
 		// we haven't downloaded this charm before.
 		// Try channel first.
-		cfg, err = charmhub.InstallOneFromChannel(charmURL.Name, channel, base)
+		cfg, err = charmhub.InstallOneFromChannel(charmName, channel, base)
 	case MethodRevision:
 		// If there is a revision, install it using that. If there is no origin
 		// ID, we haven't downloaded this charm before.
-		cfg, err = charmhub.InstallOneFromRevision(charmURL.Name, rev)
+		cfg, err = charmhub.InstallOneFromRevision(charmName, rev)
 	case MethodID:
 		// This must be a charm upgrade if we have an ID.  Use the refresh
 		// action for metric keeping on the CharmHub side.

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -86,7 +86,7 @@ func (s *charmHubRepositorySuite) testResolve(c *gc.C, id string) {
 		origin.InstanceKey = "instance-key"
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = rev
@@ -122,7 +122,7 @@ func (s *charmHubRepositorySuite) TestResolveWithChannel(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -156,7 +156,7 @@ func (s *charmHubRepositorySuite) TestResolveWithoutBase(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -263,7 +263,7 @@ func (s *charmHubRepositorySuite) TestResolveWithBundles(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("core-kubernetes", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 17
@@ -296,7 +296,7 @@ func (s *charmHubRepositorySuite) TestResolveInvalidPlatformError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -322,7 +322,6 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 	defer s.setupMocks(c).Finish()
 	s.expectedRefreshRevisionNotFoundError(c)
 
-	curl := charm.MustParseURL("ch:wordpress")
 	origin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -330,7 +329,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 		},
 	}
 
-	_, _, _, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	_, _, _, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, gc.ErrorMatches,
 		`(?m)selecting releases: charm or bundle not found for channel "", platform "amd64"
 available releases are:
@@ -352,7 +351,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -377,7 +376,6 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
 func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -412,7 +410,7 @@ func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 	s.expectCharmRefreshInstallOneFromChannel(c)
 	s.client.EXPECT().DownloadAndRead(context.TODO(), resolvedURL, "/tmp/foo").Return(resolvedArchive, nil)
 
-	gotArchive, gotOrigin, err := s.newClient().DownloadCharm(curl, requestedOrigin, "/tmp/foo")
+	gotArchive, gotOrigin, err := s.newClient().DownloadCharm("wordpress", requestedOrigin, "/tmp/foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotArchive, gc.Equals, resolvedArchive) // note: we are using gc.Equals to check the pointers here.
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -421,7 +419,6 @@ func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -454,7 +451,7 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 
 	s.expectCharmRefreshInstallOneFromChannel(c)
 
-	gotURL, gotOrigin, err := s.newClient().GetDownloadURL(curl, requestedOrigin)
+	gotURL, gotOrigin, err := s.newClient().GetDownloadURL("wordpress", requestedOrigin)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotURL, gc.DeepEquals, resolvedURL)
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -463,7 +460,6 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -481,8 +477,8 @@ func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	s.expectCharmRefreshInstallOneFromChannel(c) // refresh and get metadata
 
 	got, err := s.newClient().GetEssentialMetadata(corecharm.MetadataRequest{
-		CharmURL: curl,
-		Origin:   requestedOrigin,
+		CharmName: "wordpress",
+		Origin:    requestedOrigin,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -974,7 +970,7 @@ type refreshConfigSuite struct {
 var _ = gc.Suite(&refreshConfigSuite{})
 
 func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
@@ -982,7 +978,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
@@ -994,7 +990,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
@@ -1008,7 +1004,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 }
 
 func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/latest")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
@@ -1016,7 +1012,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
@@ -1028,7 +1024,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
@@ -1043,14 +1039,14 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 
 func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 	revision := 1
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	origin := corecharm.Origin{
 		Platform: platform,
 		Revision: &revision,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
@@ -1061,7 +1057,7 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Revision:    &revision,
 		}},
 		Context: []transport.RefreshRequestContext{},
@@ -1072,7 +1068,6 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	id := "aaabbbccc"
 	revision := 1
-	curl := charm.MustParseURL("ch:wordpress")
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	channel := corecharm.MustParseChannel("stable")
 	origin := corecharm.Origin{
@@ -1084,7 +1079,7 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 		InstanceKey: "instance-key",
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)


### PR DESCRIPTION
Core repository public methods DownloadCharm, GetDownloadMetadata, ResolveWithPreferredChannel, GetEssentialMetadata and ListResources all took a charm.URL param, but only needed the name of the charm. Simplify this to only need the charm name string

This has the consequence that callers don't need to parse a URL to use these functions

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@22.04/stable
$ juju deploy ubuntu --base ubuntu@20.04 ubuntu-focal
Deployed "ubuntu-focal" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@20.04/stable
$ juju deploy postgresql
Deployed "postgresql" from charm-hub charm "postgresql", revision 336 in channel 14/stable on ubuntu@22.04/stable
```

```
$ juju add-model m2
$ juju deploy juju-qa-bundle-test
```