### PR TITLE
Cleanup with objectstore

### DIFF
--- a/apiserver/facades/controller/cleaner/cleaner.go
+++ b/apiserver/facades/controller/cleaner/cleaner.go
@@ -11,19 +11,21 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
 )
 
 // CleanerAPI implements the API used by the cleaner worker.
 type CleanerAPI struct {
-	st        StateInterface
-	resources facade.Resources
+	st          StateInterface
+	resources   facade.Resources
+	objectStore objectstore.WriteObjectStore
 }
 
 // Cleanup triggers a state cleanup
 func (api *CleanerAPI) Cleanup(ctx context.Context) error {
-	return api.st.Cleanup()
+	return api.st.Cleanup(ctx, api.objectStore)
 }
 
 // WatchCleanups watches for cleanups to be performed in state.

--- a/apiserver/facades/controller/cleaner/cleaner_test.go
+++ b/apiserver/facades/controller/cleaner/cleaner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/controller/cleaner"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -132,7 +133,7 @@ func (st *mockState) WatchCleanups() state.NotifyWatcher {
 	return w
 }
 
-func (st *mockState) Cleanup() error {
+func (st *mockState) Cleanup(context.Context, objectstore.WriteObjectStore) error {
 	st.MethodCall(st, "Cleanup")
 	return st.NextErr()
 }

--- a/apiserver/facades/controller/cleaner/register.go
+++ b/apiserver/facades/controller/cleaner/register.go
@@ -24,7 +24,8 @@ func newCleanerAPI(ctx facade.Context) (*CleanerAPI, error) {
 		return nil, apiservererrors.ErrPerm
 	}
 	return &CleanerAPI{
-		st:        getState(ctx.State()),
-		resources: ctx.Resources(),
+		st:          getState(ctx.State()),
+		resources:   ctx.Resources(),
+		objectStore: ctx.ObjectStore(),
 	}, nil
 }

--- a/apiserver/facades/controller/cleaner/state.go
+++ b/apiserver/facades/controller/cleaner/state.go
@@ -3,10 +3,15 @@
 
 package cleaner
 
-import "github.com/juju/juju/state"
+import (
+	"context"
+
+	"github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/state"
+)
 
 type StateInterface interface {
-	Cleanup() error
+	Cleanup(context.Context, objectstore.WriteObjectStore) error
 	WatchCleanups() state.NotifyWatcher
 }
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/presence"
 	containerbroker "github.com/juju/juju/internal/container/broker"
 	"github.com/juju/juju/internal/container/lxd"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	proxyconfig "github.com/juju/juju/internal/proxy/config"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/state"
@@ -801,7 +802,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			TraceName:            traceName,
 			Clock:                config.Clock,
 			Logger:               loggo.GetLogger("juju.worker.objectstore"),
-			NewObjectStoreWorker: objectstore.NewStateObjectStore,
+			NewObjectStoreWorker: internalobjectstore.NewStateObjectStore,
 		})),
 	}
 

--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -1,0 +1,10 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package objectstore
+
+import "context"
+
+// ObjectStoreWorkerFunc is the function signature for creating a new object
+// store worker.
+type ObjectStoreWorkerFunc func(context.Context, string, MongoSession, Logger) (TrackedObjectStore, error)

--- a/internal/objectstore/stateobjectstore.go
+++ b/internal/objectstore/stateobjectstore.go
@@ -7,10 +7,37 @@ import (
 	"context"
 	"io"
 
+	"github.com/juju/mgo/v3"
+	"github.com/juju/worker/v3"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/state/storage"
 )
+
+// Logger represents the logging methods called.
+type Logger interface {
+	Errorf(message string, args ...any)
+	Warningf(message string, args ...any)
+	Infof(message string, args ...any)
+	Debugf(message string, args ...any)
+	Tracef(message string, args ...any)
+
+	IsTraceEnabled() bool
+}
+
+// MongoSession is the interface that is used to get a mongo session.
+// Deprecated: is only here for backwards compatibility.
+type MongoSession interface {
+	MongoSession() *mgo.Session
+}
+
+// TrackedObjectStore is a ObjectStore that is also a worker, to ensure the
+// lifecycle of the objectStore is managed.
+type TrackedObjectStore interface {
+	worker.Worker
+	objectstore.ObjectStore
+}
 
 type stateObjectStore struct {
 	tomb      tomb.Tomb

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -60,6 +60,7 @@ import (
 	databasetesting "github.com/juju/juju/internal/database/testing"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/internal/mongo/mongotest"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/pubsub/centralhub"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
@@ -69,7 +70,6 @@ import (
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/worker/lease"
 	wmultiwatcher "github.com/juju/juju/worker/multiwatcher"
-	workerobjectstore "github.com/juju/juju/worker/objectstore"
 )
 
 const AdminSecret = "dummy-secret"
@@ -670,7 +670,7 @@ func (s *stubObjectStoreGetter) GetObjectStore(ctx context.Context, namespace st
 		return nil, err
 	}
 
-	return workerobjectstore.NewStateObjectStore(ctx, namespace, state, loggo.GetLogger("juju.worker.objectstore"))
+	return internalobjectstore.NewStateObjectStore(ctx, namespace, state, loggo.GetLogger("juju.worker.objectstore"))
 }
 
 type stubObjectStore struct{}

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,7 @@ func (s *CharmSuite) destroy(c *gc.C) {
 
 func (s *CharmSuite) remove(c *gc.C) {
 	s.destroy(c)
-	err := s.charm.Remove()
+	err := s.charm.Remove(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -171,7 +172,7 @@ func (s *CharmSuite) TestRemovedCharmNotListed(c *gc.C) {
 }
 
 func (s *CharmSuite) TestRemoveWithoutDestroy(c *gc.C) {
-	err := s.charm.Remove()
+	err := s.charm.Remove(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, gc.ErrorMatches, "still alive")
 }
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"bytes"
+	"context"
 	"sort"
 	"strconv"
 	"time"
@@ -1185,7 +1186,7 @@ func (s *CleanupSuite) assertCleanupCAASEntityWithStorage(c *gc.C, deleteOp func
 
 	assertCleanups := func(n int) {
 		for i := 0; i < 4; i++ {
-			err := st.Cleanup()
+			err := st.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		state.AssertNoCleanups(c, st)
@@ -1711,7 +1712,7 @@ func (s *CleanupSuite) TestForceDestroyRelationIncorrectUnitCount(c *gc.C) {
 }
 
 func (s *CleanupSuite) assertCleanupRuns(c *gc.C) {
-	err := s.State.Cleanup()
+	err := s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -337,7 +338,7 @@ func (s *EnableHASuite) progressControllerToDead(c *gc.C, id string) {
 	// TODO(HA) - no longer need to refresh once HasVote is moved off machine
 	c.Assert(node.Refresh(), jc.ErrorIsNil)
 	c.Assert(s.State.RemoveControllerReference(node), jc.ErrorIsNil)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	c.Assert(m.EnsureDead(), jc.ErrorIsNil)
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,16 +31,19 @@ import (
 
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/internal/mongo/utils"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testcharms/repo"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
@@ -1242,4 +1246,11 @@ func (m *Model) AllActionIDsHasActionNotifications() ([]string, error) {
 		actionIDs[i] = doc.ActionID
 	}
 	return actionIDs, nil
+}
+
+func NewObjectStore(c *gc.C, st *State) objectstore.WriteObjectStore {
+	// This will be removed when the worker object store is enabled by default.
+	store, err := internalobjectstore.NewStateObjectStore(context.Background(), st.ModelUUID(), st, coretesting.NewCheckLogger(c))
+	c.Assert(err, jc.ErrorIsNil)
+	return store
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -369,7 +369,7 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 		needsCleanup, err := s.State.NeedsCleanup()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(needsCleanup, jc.IsTrue)
-		err = s.State.Cleanup()
+		err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	needsCleanup, err := s.State.NeedsCleanup()

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -140,7 +142,7 @@ func (s *MachineSuite) TestForceMarksSeriesLockUnlocksMachineForCleanup(c *gc.C)
 	// After a forced destroy an upgrade series lock on a machine should be
 	// marked for cleanup and therefore should be cleaned up if anything
 	// should trigger a state cleanup.
-	s.State.Cleanup()
+	s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 
 	// The machine, since it was destroyed, its lock should have been
 	// cleaned up. Checking to see if the machine is not locked, that is,

--- a/state/minimumunits_test.go
+++ b/state/minimumunits_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"context"
+
 	"github.com/juju/mgo/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -330,7 +332,7 @@ func (s *MinUnitsSuite) TestEnsureMinUnitsApplicationNotAlive(c *gc.C) {
 	c.Assert(s.application.EnsureMinUnits(), gc.ErrorMatches, expectedErr)
 
 	// An error is returned if the application was removed.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.application.EnsureMinUnits(), gc.ErrorMatches, expectedErr)
 }

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -1810,7 +1811,7 @@ func (s *ModelCloudValidationSuite) initializeState(
 }
 
 func assertCleanupRuns(c *gc.C, st *state.State) {
-	err := st.Cleanup()
+	err := st.Cleanup(context.Background(), state.NewObjectStore(c, st))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/payloads_test.go
+++ b/state/payloads_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -211,7 +212,7 @@ func (s *PayloadsSuite) TestRemoveUnitUntracksPayloads(c *gc.C) {
 
 	err = fix.Unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	fix.CheckNoPayload(c)
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -1182,7 +1183,7 @@ func (s *RelationSuite) TestDestroyForceStuckRemoteUnits(c *gc.C) {
 	s.assertNeedsCleanup(c)
 
 	// But running cleanup immediately doesn't do it all.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 
@@ -1196,7 +1197,7 @@ func (s *RelationSuite) TestDestroyForceStuckRemoteUnits(c *gc.C) {
 
 	s.Clock.Advance(time.Minute)
 
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertNotInScope(c, localRelUnit)
@@ -1224,7 +1225,7 @@ func (s *RelationSuite) TestDestroyForceIsFineIfUnitsAlreadyLeft(c *gc.C) {
 	s.assertNeedsCleanup(c)
 
 	// But running cleanup immediately doesn't do it.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 	for i, ru := range relUnits {
@@ -1247,7 +1248,7 @@ func (s *RelationSuite) TestDestroyForceIsFineIfUnitsAlreadyLeft(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	s.Clock.Advance(30 * time.Second)
 
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// If the cleanup had failed because the relation had gone, it
@@ -1268,7 +1269,7 @@ func (s *RelationSuite) assertRelationCleanedUp(c *gc.C, rel *state.Relation, re
 	s.assertNeedsCleanup(c)
 
 	// But running cleanup immediately doesn't do it.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 	for i, ru := range relUnits {
@@ -1281,7 +1282,7 @@ func (s *RelationSuite) assertRelationCleanedUp(c *gc.C, rel *state.Relation, re
 
 	s.Clock.Advance(time.Minute)
 
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, ru := range relUnits {

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -458,7 +458,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 
 	// Check that unit settings for the original unit still exist, and have
 	// not yet been marked for deletion.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	assertSettings := func() {
 		settings, err := pr.ru1.ReadSettings("riak/0")
@@ -479,7 +479,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 	assertSettings()
 
 	// ...but they were scheduled for deletion.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = pr.ru1.ReadSettings("riak/0")
 	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": unit "riak/0": settings not found`)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -513,7 +513,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 			},
 			triggerEvent: func(st *state.State) {
 				loggo.GetLogger("juju.state").SetLogLevel(loggo.TRACE)
-				err := st.Cleanup()
+				err := st.Cleanup(context.Background(), state.NewObjectStore(c, st))
 				c.Assert(err, jc.ErrorIsNil)
 				loggo.GetLogger("juju.state").SetLogLevel(loggo.DEBUG)
 			},
@@ -2726,7 +2726,7 @@ func (s *StateSuite) TestWatchApplicationsBulkEvents(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = keepDying.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	wc.AssertChange(alive.Name(), dying.Name())
 	wc.AssertNoChange()
 }
@@ -2762,7 +2762,7 @@ func (s *StateSuite) TestWatchApplicationsLifecycle(c *gc.C) {
 	needs, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(needs, jc.IsTrue)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	wc.AssertChange("application")
 	wc.AssertNoChange()
 }
@@ -3856,7 +3856,7 @@ func (s *StateSuite) TestWatchCleanups(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Handle that cleanup doc and create another, check one change.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(quiescence): these two changes should be one event.
 	wc.AssertOneChange()
@@ -3865,7 +3865,7 @@ func (s *StateSuite) TestWatchCleanups(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Clean up final doc, check change.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -3910,7 +3910,7 @@ func (s *StateSuite) TestWatchCleanupsBulk(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Clean them both up, check one change.
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertAtleastOneChange()
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -1249,7 +1250,7 @@ func (s *UnitSuite) TestRemoveUnitWRelationLastUnit(c *gc.C) {
 	c.Assert(s.unit.EnsureDead(), jc.ErrorIsNil)
 	assertLife(c, s.application, state.Dying)
 	c.Assert(s.unit.Remove(), jc.ErrorIsNil)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	// Now the application should be gone
 	c.Assert(s.application.Refresh(), jc.ErrorIs, errors.NotFound)
 }
@@ -2448,7 +2449,7 @@ func (s *UnitSuite) TestRemovePathological(c *gc.C) {
 	// ...but when the unit on the other side departs the relation, the
 	// relation and the other application are cleaned up.
 	c.Assert(mysql0ru.LeaveScope(), jc.ErrorIsNil)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	c.Assert(wordpress.Refresh(), jc.ErrorIs, errors.NotFound)
 	c.Assert(rel.Refresh(), jc.ErrorIs, errors.NotFound)
 }
@@ -2490,7 +2491,7 @@ func (s *UnitSuite) TestRemovePathologicalWithBuggyUniter(c *gc.C) {
 	// removal causes the relation and the other application to be cleaned up.
 	c.Assert(mysql0.EnsureDead(), jc.ErrorIsNil)
 	c.Assert(mysql0.Remove(), jc.ErrorIsNil)
-	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
+	c.Assert(s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State)), jc.ErrorIsNil)
 	c.Assert(wordpress.Refresh(), jc.ErrorIs, errors.NotFound)
 	c.Assert(rel.Refresh(), jc.ErrorIs, errors.NotFound)
 }
@@ -2839,7 +2840,7 @@ func (s *UnitSuite) TestDestroyWithForceWorksOnDyingUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(needsCleanup, gc.Equals, true)
 
-	err = s.State.Cleanup()
+	err = s.State.Cleanup(context.Background(), state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
 	needsCleanup, err = s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/objectstore/manifold.go
+++ b/worker/objectstore/manifold.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	jujustate "github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/state"
@@ -52,10 +53,6 @@ type MongoSession interface {
 	MongoSession() *mgo.Session
 }
 
-// ObjectStoreWorkerFunc is the function signature for creating a new object
-// store worker.
-type ObjectStoreWorkerFunc func(context.Context, string, MongoSession, Logger) (TrackedObjectStore, error)
-
 // ManifoldConfig defines the configuration for the trace manifold.
 type ManifoldConfig struct {
 	AgentName string
@@ -63,7 +60,7 @@ type ManifoldConfig struct {
 
 	Clock                clock.Clock
 	Logger               Logger
-	NewObjectStoreWorker ObjectStoreWorkerFunc
+	NewObjectStoreWorker internalobjectstore.ObjectStoreWorkerFunc
 
 	// StateName is only here for backwards compatibility. Once we have
 	// the right abstractions in place, and we have a replacement, we can

--- a/worker/objectstore/manifold_test.go
+++ b/worker/objectstore/manifold_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/trace"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/state"
 )
 
@@ -51,7 +52,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		TraceName: "trace",
 		Clock:     s.clock,
 		Logger:    s.logger,
-		NewObjectStoreWorker: func(context.Context, string, MongoSession, Logger) (TrackedObjectStore, error) {
+		NewObjectStoreWorker: func(context.Context, string, internalobjectstore.MongoSession, internalobjectstore.Logger) (internalobjectstore.TrackedObjectStore, error) {
 			return nil, nil
 		},
 	}

--- a/worker/objectstore/worker.go
+++ b/worker/objectstore/worker.go
@@ -15,6 +15,7 @@ import (
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	coretrace "github.com/juju/juju/core/trace"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/worker/trace"
 )
 
@@ -36,7 +37,7 @@ type WorkerConfig struct {
 	TracerGetter         trace.TracerGetter
 	Clock                clock.Clock
 	Logger               Logger
-	NewObjectStoreWorker ObjectStoreWorkerFunc
+	NewObjectStoreWorker internalobjectstore.ObjectStoreWorkerFunc
 
 	// StatePool is only here for backwards compatibility. Once we have
 	// the right abstractions in place, and we have a replacement, we can

--- a/worker/objectstore/worker_test.go
+++ b/worker/objectstore/worker_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/testing"
 )
 
@@ -188,7 +189,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		Logger:       s.logger,
 		TracerGetter: &stubTracerGetter{},
 		StatePool:    s.statePool,
-		NewObjectStoreWorker: func(context.Context, string, MongoSession, Logger) (TrackedObjectStore, error) {
+		NewObjectStoreWorker: func(context.Context, string, internalobjectstore.MongoSession, internalobjectstore.Logger) (internalobjectstore.TrackedObjectStore, error) {
 			atomic.AddInt64(&s.called, 1)
 			return s.trackedObjectStore, nil
 		},


### PR DESCRIPTION
The following just moves the clean-up of charms using the object store. This just ensures that what we create we also use to tear down.

The next step after this is to push all blobs into the objectstore and then we can consider backing it with a different storage type (files and s3).

Note: we're beginning to move the object store into the internal package, as that's the location of all the different types of backends. This is because we'll reference the backends in bootstrap and in the worker packages. This prevents cyclic import issues.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
$ juju destroy-model default -y
```

## Links

**Jira card:** JUJU-[XXXX]
