### PR TITLE
Adds NOT NULL support to cloud type.

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -129,7 +129,7 @@ func cloudSchema() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE cloud_type (
     id   INT PRIMARY KEY,
-    type TEXT
+    type TEXT NOT NULL
 );
 
 CREATE UNIQUE INDEX idx_cloud_type_type


### PR DESCRIPTION
Up until now cloud type has allowed null types. This change adds both a constraint and a test to validate null types are not allowed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run unit tests for cloud state.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4853