### PR TITLE
User secrets permission fix

### DIFF
--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -250,7 +250,7 @@ func (s *SecretsAPI) CreateSecrets(args params.CreateSecretArgs) (params.StringR
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
-	if err := s.checkCanAdmin(); err != nil {
+	if err := s.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
 	}
 	backend, err := s.getBackendForUserSecretsWrite()
@@ -373,7 +373,7 @@ func (s *SecretsAPI) UpdateSecrets(args params.UpdateUserSecretArgs) (params.Err
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
-	if err := s.checkCanAdmin(); err != nil {
+	if err := s.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
 	}
 	backend, err := s.getBackendForUserSecretsWrite()
@@ -472,8 +472,7 @@ func (s *SecretsAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorRe
 		s.secretsState, s.adminBackendConfigGetter,
 		s.authTag, args,
 		func(uri *coresecrets.URI) error {
-			// Only admin can delete user secrets.
-			if err := s.checkCanAdmin(); err != nil {
+			if err := s.checkCanWrite(); err != nil {
 				return errors.Trace(err)
 			}
 			md, err := s.secretsState.GetSecret(uri)

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -269,9 +269,7 @@ func (s *SecretsSuite) TestCreateSecretsPermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer, nil, nil, nil)
@@ -285,9 +283,7 @@ func (s *SecretsSuite) TestCreateSecretsEmptyData(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	uriStrPtr := ptr(uri.String())
@@ -316,9 +312,7 @@ func (s *SecretsSuite) assertCreateSecrets(c *gc.C, isInternal bool, finalStepFa
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	uriStrPtr := ptr(uri.String())
@@ -409,9 +403,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, isInternal bool, finalStepFa
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
@@ -455,9 +447,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, isInternal bool, finalStepFa
 	if !finalStepFailed {
 		s.secretsState.EXPECT().ListUnusedSecretRevisions(uri).Return([]int{1, 2}, nil)
 		// Prune the unused revisions.
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-			errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-		s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+		s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 		s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{URI: uri, OwnerTag: coretesting.ModelTag.String()}, nil).Times(2)
 		s.secretsState.EXPECT().GetSecretRevision(uri, 1).Return(&coresecrets.SecretRevisionMetadata{
 			Revision: 1,
@@ -536,9 +526,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{URI: uri, OwnerTag: coretesting.ModelTag.String()}, nil).Times(2)
 	s.secretsState.EXPECT().GetSecretRevision(&expectURI, 666).Return(&coresecrets.SecretRevisionMetadata{
 		Revision: 666,
@@ -590,9 +578,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelAdmin(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(apiservererrors.ErrPerm)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(apiservererrors.ErrPerm)
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{URI: uri, OwnerTag: names.NewModelTag("1cfde5b3-663d-47bf-8799-71b84fa2df3f").String()}, nil).Times(1)
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
@@ -618,9 +604,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelOwned(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{URI: uri, OwnerTag: names.NewModelTag("1cfde5b3-663d-47bf-8799-71b84fa2df3f").String()}, nil).Times(2)
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
@@ -646,9 +630,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
-		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{URI: uri, OwnerTag: coretesting.ModelTag.String()}, nil).Times(2)
 	s.secretsState.EXPECT().GetSecretRevision(&expectURI, 666).Return(&coresecrets.SecretRevisionMetadata{
 		Revision: 666,

--- a/cmd/juju/secrets/add.go
+++ b/cmd/juju/secrets/add.go
@@ -42,9 +42,8 @@ func (c *addSecretCommand) secretsAPI() (AddSecretsAPI, error) {
 	return apisecrets.NewClient(root), nil
 }
 
-// Info implements cmd.Command.
-func (c *addSecretCommand) Info() *cmd.Info {
-	doc := `
+const (
+	addSecretDoc = `
 Add a secret with a list of key values.
 
 If a key has the '#base64' suffix, the value is already in base64 format and no
@@ -55,23 +54,28 @@ If a key has the '#file' suffix, the value is read from the corresponding file.
 
 A secret is owned by the model, meaning only the model admin
 can manage it, ie grant/revoke access, update, remove etc.
-
-Examples:
-    add-secret token=34ae35facd4
-    add-secret key#base64=AA==
-    add-secret key#file=/path/to/file another-key=s3cret
-    add-secret --label db-password \
+`
+	addSecretExamples = `
+    juju add-secret token=34ae35facd4
+    juju add-secret key#base64=AA==
+    juju add-secret key#file=/path/to/file another-key=s3cret
+    juju add-secret --label db-password \
         --info "my database password" \
         data#base64=s3cret== 
-    add-secret --label db-password \
+    juju add-secret --label db-password \
         --info "my database password" \
         --file=/path/to/file
 `
+)
+
+// Info implements cmd.Command.
+func (c *addSecretCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add-secret",
-		Args:    "[key[#base64|#file]=value...]",
-		Purpose: "Add a new secret.",
-		Doc:     doc,
+		Name:     "add-secret",
+		Args:     "[key[#base64|#file]=value...]",
+		Purpose:  "Add a new secret.",
+		Doc:      addSecretDoc,
+		Examples: addSecretExamples,
 	})
 }
 

--- a/cmd/juju/secrets/grantrevoke.go
+++ b/cmd/juju/secrets/grantrevoke.go
@@ -46,19 +46,24 @@ func (c *grantSecretCommand) secretsAPI() (GrantRevokeSecretsAPI, error) {
 	return apisecrets.NewClient(root), nil
 }
 
+const (
+	grantSecretDoc = `
+Grant applications access to view the value of a specified secret.
+`
+	grantSecretExamples = `
+    juju grant-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s
+	juju grant-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
+`
+)
+
 // Info implements cmd.Command.
 func (c *grantSecretCommand) Info() *cmd.Info {
-	doc := `
-Grant applications access to view the value of a specified secret.
-
-Examples:
-    grant-secret <secret-uri> <application>[,<application>...]
-`
 	return jujucmd.Info(&cmd.Info{
-		Name:    "grant-secret",
-		Args:    "<secret-uri> <application>[,<application>...]",
-		Purpose: "Grant access to a secret.",
-		Doc:     doc,
+		Name:     "grant-secret",
+		Args:     "<secret-uri> <application>[,<application>...]",
+		Purpose:  "Grant access to a secret.",
+		Doc:      grantSecretDoc,
+		Examples: grantSecretExamples,
 	})
 }
 
@@ -130,19 +135,24 @@ func (c *revokeSecretCommand) secretsAPI() (GrantRevokeSecretsAPI, error) {
 	return apisecrets.NewClient(root), nil
 }
 
+const (
+	revokeSecretDoc = `
+Revoke applications' access to view the value of a specified secret.
+`
+	revokeSecretExamples = `
+    juju revoke-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s
+	juju revoke-secret 9m4e2mr0ui3e8a215n4g ubuntu-k8s,prometheus-k8s
+`
+)
+
 // Info implements cmd.Command.
 func (c *revokeSecretCommand) Info() *cmd.Info {
-	doc := `
-Revoke applications' access to view the value of a specified secret.
-
-Examples:
-    revoke-secret <secret-uri> <application>[,<application>...]
-`
 	return jujucmd.Info(&cmd.Info{
-		Name:    "revoke-secret",
-		Args:    "<secret-uri> <application>[,<application>...]",
-		Purpose: "Revoke access to a secret.",
-		Doc:     doc,
+		Name:     "revoke-secret",
+		Args:     "<secret-uri> <application>[,<application>...]",
+		Purpose:  "Revoke access to a secret.",
+		Doc:      revokeSecretDoc,
+		Examples: revokeSecretExamples,
 	})
 }
 

--- a/cmd/juju/secrets/remove.go
+++ b/cmd/juju/secrets/remove.go
@@ -44,21 +44,24 @@ func (c *removeSecretCommand) secretsAPI() (RemoveSecretsAPI, error) {
 	return apisecrets.NewClient(root), nil
 }
 
+const (
+	removeSecretDoc = `
+Remove all the revisions of a secret with the specified URI or remove the provided revision only.
+`
+	removeSecretExamples = `
+    juju remove-secret secret:9m4e2mr0ui3e8a215n4g
+    juju remove-secret secret:9m4e2mr0ui3e8a215n4g --revision 4
+`
+)
+
 // Info implements cmd.Command.
 func (c *removeSecretCommand) Info() *cmd.Info {
-	doc := `
-Remove all the revisions of a secret with the specified URI or remove the provided revision only.
-
-Examples:
-    remove-secret secret:9m4e2mr0ui3e8a215n4g
-
-    remove-secret secret:9m4e2mr0ui3e8a215n4g --revision 4
-`
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove-secret",
-		Args:    "<ID>",
-		Purpose: "Remove a existing secret.",
-		Doc:     doc,
+		Name:     "remove-secret",
+		Args:     "<ID>",
+		Purpose:  "Remove a existing secret.",
+		Doc:      removeSecretDoc,
+		Examples: removeSecretExamples,
 	})
 }
 

--- a/cmd/juju/secrets/update.go
+++ b/cmd/juju/secrets/update.go
@@ -49,9 +49,8 @@ func (c *updateSecretCommand) secretsAPI() (UpdateSecretsAPI, error) {
 	return apisecrets.NewClient(root), nil
 }
 
-// Info implements cmd.Command.
-func (c *updateSecretCommand) Info() *cmd.Info {
-	doc := `
+const (
+	updateSecretDoc = `
 Update a secret with a list of key values, or info.
 If a value has the '#base64' suffix, it is already in base64 format and no
 encoding will be performed, otherwise the value will be base64 encoded
@@ -61,29 +60,30 @@ which are no longer being tracked by any observers (see Rotation and Expiry).
 This is configured per revision. This feature is opt-in because Juju 
 automatically removing secret content might result in data loss.
 
-Examples:
-    update-secret secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4
-
-    update-secret secret:9m4e2mr0ui3e8a215n4g key#base64 AA==
-
-    update-secret secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4 --auto-prune
-
-    update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
+`
+	updateSecretExamples = `
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g key#base64 AA==
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4 --auto-prune
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --info "my database password" \
         data#base64 s3cret== 
-
-    update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --info "my database password"
-
-    update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
+    juju update-secret secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --info "my database password" \
         --file=/path/to/file
 `
+)
+
+// Info implements cmd.Command.
+func (c *updateSecretCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "update-secret",
-		Args:    "<ID> [key[#base64|#file]=value...]",
-		Purpose: "Update an existing secret.",
-		Doc:     doc,
+		Name:     "update-secret",
+		Args:     "<ID> [key[#base64|#file]=value...]",
+		Purpose:  "Update an existing secret.",
+		Doc:      updateSecretDoc,
+		Examples: updateSecretExamples,
 	})
 }
 


### PR DESCRIPTION
This PR changed to require model write permission to create/update/remove user secrets, and also did some doc string fix for user secret commands as a drive-by.

