### PR TITLE
3.2 into 3.3

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -812,7 +812,7 @@ func (c *Client) cloneVM(
 	}
 	info, err := taskWaiter.waitTask(ctx, task, "cloning VM")
 	if err != nil {
-		return nil, errors.Annotatef(err, "waiting for task %q", info.Name)
+		return nil, errors.Annotatef(err, "waiting for task")
 	}
 
 	vm := object.NewVirtualMachine(c.client.Client, info.Result.(types.ManagedObjectReference))

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -235,7 +235,7 @@ func AddTestingCharmWithSeries(c *gc.C, st *State, name string, series string) *
 }
 
 func getCharmRepo(series string) *repo.CharmRepo {
-	// ALl testing charms for state are under `quantal` except `kubernetes`.
+	// All testing charms for state are under `quantal` except `kubernetes`.
 	if series == "kubernetes" {
 		return testcharms.RepoForSeries(series)
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1407,35 +1407,46 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 	return appDoc, nil
 }
 
+// makeCharmOrigin returns the charm origin for an application
+//
+// Previous versions of the Juju server and clients have treated applications charm
+// origins very loosely, particularly during `refresh -- switch`s. The server performed
+// no validation on origins received from the client, and client often mutated them
+// incorrectly. For instance, when switching from a ch charm to local, pylibjuju simply
+// send back a copy of the ch charm origin, whereas the CLI only set the source to local.
+// Both resulted in incorrect/invalidate origins.
+//
+// Calculate the origin Source and Revision from the charm url. Ensure ID, Hash and Channel
+// are dropped from local charm. Keep ID, Hash and Channel (for ch charms) and Platform (always)
+// we get from the origin. We can trust these since supported clients cannot break these
+//
+// This was fixed in pylibjuju 3.2.3.0 and juju 3.3.0. As of writing, no versions of the
+// server validate new charm origins on calls to SetCharm. Ideally, the client shouldn't
+// handle charm origins at all, being an implementation detail. But this will probably have
+// to wait until the api re-write
+//
+// https://bugs.launchpad.net/juju/+bug/2039267
+// https://github.com/juju/python-libjuju/issues/962
+//
+// TODO: Once we have confidence in charm origins, do not parse charm url and simplify
+// into a translation layer
 func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, error) {
-	curlStr := a.CharmURL()
+	sourceOrigin := a.CharmOrigin()
+	curl, err := charm.ParseURL(a.CharmURL())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	// Fix bad datasets from LP 1999060 during migration.
 	// ID and Hash missing from N-1 of N applications'
 	// charm origins when deployed using the same charm.
-	if foundOrigin, ok := i.charmOrigins[curlStr]; ok {
+	if foundOrigin, ok := i.charmOrigins[curl.String()]; ok {
 		return foundOrigin, nil
 	}
 
-	co := a.CharmOrigin()
-	rev := co.Revision()
-	// If revision is empty we export revision -1. In this case
-	// parse the revision from the url
-	// NOTE: We use <= 0 because some old versions of juju default
-	// revision to 0 when it's empty
-	if rev <= 0 {
-		curl, err := charm.ParseURL(a.CharmURL())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		rev = curl.Revision
-	}
-
 	var channel *Channel
-	// Only charmhub charms will have a channel. Local charms
-	// should not have a channel, so drop even if provided.
-	serialized := co.Channel()
-	if serialized != "" && corecharm.CharmHub.Matches(co.Source()) {
+	serialized := sourceOrigin.Channel()
+	if serialized != "" && charm.CharmHub.Matches(curl.Schema) {
 		c, err := charm.ParseChannelNormalize(serialized)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1449,11 +1460,9 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 			Risk:   string(c.Risk),
 			Branch: c.Branch,
 		}
-	} else if serialized != "" && corecharm.Local.Matches(co.Source()) {
-		i.logger.Warningf("Dropping channel: %q for application %q, should not exist", serialized, a.Name())
 	}
 
-	p, err := corecharm.ParsePlatformNormalize(co.Platform())
+	p, err := corecharm.ParsePlatformNormalize(sourceOrigin.Platform())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1464,16 +1473,33 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 	}
 
 	// We can hardcode type to charm as we never store bundles in state.
-	origin := &CharmOrigin{
-		Source:   co.Source(),
-		Type:     "charm",
-		ID:       co.ID(),
-		Hash:     co.Hash(),
-		Revision: &rev,
-		Channel:  channel,
-		Platform: platform,
+	var origin *CharmOrigin
+	if charm.Local.Matches(curl.Schema) {
+		origin = &CharmOrigin{
+			Source:   corecharm.Local.String(),
+			Type:     "charm",
+			Revision: &curl.Revision,
+			Platform: platform,
+		}
+	} else if charm.CharmHub.Matches(curl.Schema) {
+		origin = &CharmOrigin{
+			Source:   corecharm.CharmHub.String(),
+			Type:     "charm",
+			Revision: &curl.Revision,
+			ID:       sourceOrigin.ID(),
+			Hash:     sourceOrigin.Hash(),
+			Channel:  channel,
+			Platform: platform,
+		}
+	} else {
+		return nil, errors.Errorf("Unrecognised charm url schema %q", curl.Schema)
 	}
-	i.charmOrigins[curlStr] = origin
+
+	if !reflect.DeepEqual(sourceOrigin, origin) {
+		i.logger.Warningf("Source origin for application %q does not match charm url. Normalising", a.Name())
+	}
+
+	i.charmOrigins[curl.String()] = origin
 	return origin, nil
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -543,6 +543,8 @@ func (s *MigrationImportSuite) setupSourceApplications(
 			Channel: &state.Channel{
 				Risk: "edge",
 			},
+			Hash:     "some-hash",
+			ID:       "some-id",
 			Platform: platform,
 		},
 		CharmConfig: map[string]interface{}{
@@ -701,25 +703,71 @@ func (s *MigrationImportSuite) TestApplicationsUpdateSeriesNotPlatform(c *gc.C) 
 	c.Assert(obtainedOrigin.Platform.Channel, gc.Equals, "20.04/stable")
 }
 
-func (s *MigrationImportSuite) TestLocalApplicationCharmOriginRevisionFilledIn(c *gc.C) {
+func (s *MigrationImportSuite) TestCharmhubApplicationCharmOriginNormalised(c *gc.C) {
 	platform := &state.Platform{Architecture: arch.DefaultArchitecture, OS: "ubuntu", Channel: "12.10/stable"}
 	f := factory.NewFactory(s.State, s.StatePool)
 
-	testCharm := f.MakeCharm(c, &factory.CharmParams{Revision: "8"})
+	testCharm := f.MakeCharm(c, &factory.CharmParams{Revision: "8", URL: "ch:mysql-8"})
+	wrongRev := 4
 	_ = f.MakeApplication(c, &factory.ApplicationParams{
 		Charm: testCharm,
 		Name:  "mysql",
 		CharmOrigin: &state.CharmOrigin{
-			Source:   "local",
+			Source:   "charm-hub",
 			Type:     "charm",
 			Platform: platform,
+			Revision: &wrongRev,
+			Channel:  &state.Channel{Track: "20.04", Risk: "stable", Branch: "deadbeef"},
+			Hash:     "some-hash",
+			ID:       "some-id",
 		},
 	})
 
 	_, newSt := s.importModel(c, s.State)
 	newApp, err := newSt.Application("mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*newApp.CharmOrigin().Revision, gc.Equals, 8)
+	rev := 8
+	c.Assert(newApp.CharmOrigin(), gc.DeepEquals, &state.CharmOrigin{
+		Source:   "charm-hub",
+		Type:     "charm",
+		Platform: platform,
+		Revision: &rev,
+		Channel:  &state.Channel{Track: "20.04", Risk: "stable", Branch: "deadbeef"},
+		Hash:     "some-hash",
+		ID:       "some-id",
+	})
+}
+
+func (s *MigrationImportSuite) TestLocalApplicationCharmOriginNormalised(c *gc.C) {
+	platform := &state.Platform{Architecture: arch.DefaultArchitecture, OS: "ubuntu", Channel: "12.10/stable"}
+	f := factory.NewFactory(s.State, s.StatePool)
+
+	testCharm := f.MakeCharm(c, &factory.CharmParams{Revision: "8", URL: "local:mysql-8"})
+	wrongRev := 4
+	_ = f.MakeApplication(c, &factory.ApplicationParams{
+		Charm: testCharm,
+		Name:  "mysql",
+		CharmOrigin: &state.CharmOrigin{
+			Source:   "charm-hub",
+			Type:     "charm",
+			Platform: platform,
+			Revision: &wrongRev,
+			Channel:  &state.Channel{Track: "20.04", Risk: "stable", Branch: "deadbeef"},
+			Hash:     "some-hash",
+			ID:       "some-id",
+		},
+	})
+
+	_, newSt := s.importModel(c, s.State)
+	newApp, err := newSt.Application("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	rev := 8
+	c.Assert(newApp.CharmOrigin(), gc.DeepEquals, &state.CharmOrigin{
+		Source:   "local",
+		Type:     "charm",
+		Platform: platform,
+		Revision: &rev,
+	})
 }
 
 func (s *MigrationImportSuite) TestApplicationStatus(c *gc.C) {


### PR DESCRIPTION
Merges:
- https://github.com/juju/juju/pull/16501
- https://github.com/juju/juju/pull/16516
- https://github.com/juju/juju/pull/16524

Conflicts:
- state/upgrades.go
- state/upgrades_test.go
- upgrades/backend.go
- upgrades/steps_324.go

Resolved by dropping upgrade steps. We can only get to to 3.3.0 via a model migration anyway, so upgrade steps must be empty