### PR TITLE
Remove provider all in the wait-for

### DIFF
--- a/cmd/juju/waitfor/waitfor.go
+++ b/cmd/juju/waitfor/waitfor.go
@@ -5,8 +5,6 @@ package waitfor
 
 import (
 	"github.com/juju/cmd/v3"
-
-	_ "github.com/juju/juju/provider/all"
 )
 
 // Logger is the interface used by the wait-for command to log messages.


### PR DESCRIPTION
The provider all import in the wait-for command was used for some original designs of the wait-for command. This is no longer required and we can remove it.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
$ juju wait-for application ubuntu
```

## Links

**Jira card:** JUJU-[XXXX]
