### PR TITLE
[JUJU-4732] Use charm name string instead of charm URL

### DIFF
--- a/apiserver/facades/client/application/repository_mocks_test.go
+++ b/apiserver/facades/client/application/repository_mocks_test.go
@@ -39,7 +39,7 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 string, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -55,7 +55,7 @@ func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 inter
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
@@ -91,7 +91,7 @@ func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 interface{}, arg
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 context.Context, arg1 string, arg2 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -136,7 +136,7 @@ func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1, arg2 interfac
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -195,7 +195,7 @@ func (a *API) getDownloadInfo(ctx context.Context, arg params.CharmURLAndOrigin)
 	if err != nil {
 		return params.DownloadInfoResult{}, apiservererrors.ServerError(err)
 	}
-	url, origin, err := repo.GetDownloadURL(ctx, curl, requestedOrigin)
+	url, origin, err := repo.GetDownloadURL(ctx, curl.Name, requestedOrigin)
 	if err != nil {
 		return params.DownloadInfoResult{}, apiservererrors.ServerError(err)
 	}
@@ -312,7 +312,7 @@ func (a *API) queueAsyncCharmDownload(ctx context.Context, args params.AddCharmW
 	// to ensure that the resolved origin has the ID/Hash fields correctly
 	// populated.
 	if _, err := a.backendState.Charm(args.URL); err == nil {
-		_, resolvedOrigin, err := repo.GetDownloadURL(ctx, charmURL, requestedOrigin)
+		_, resolvedOrigin, err := repo.GetDownloadURL(ctx, charmURL.Name, requestedOrigin)
 		return resolvedOrigin, errors.Trace(err)
 	}
 
@@ -320,8 +320,8 @@ func (a *API) queueAsyncCharmDownload(ctx context.Context, args params.AddCharmW
 	// without downloading the full archive. The remaining metadata will
 	// be populated once the charm gets downloaded.
 	essentialMeta, err := repo.GetEssentialMetadata(ctx, corecharm.MetadataRequest{
-		CharmURL: charmURL,
-		Origin:   requestedOrigin,
+		CharmName: charmURL.Name,
+		Origin:    requestedOrigin,
 	})
 	if err != nil {
 		return corecharm.Origin{}, errors.Annotatef(err, "retrieving essential metadata for charm %q", charmURL)
@@ -386,7 +386,7 @@ func (a *API) resolveOneCharm(ctx context.Context, arg params.ResolveCharmWithCh
 		return result
 	}
 
-	resultURL, origin, resolvedBases, err := repo.ResolveWithPreferredChannel(ctx, curl, requestedOrigin)
+	resultURL, origin, resolvedBases, err := repo.ResolveWithPreferredChannel(ctx, curl.Name, requestedOrigin)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result
@@ -714,7 +714,7 @@ func (a *API) listOneCharmResources(ctx context.Context, arg params.CharmURLAndO
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}
-	resources, err := repo.ListResources(ctx, curl, requestedOrigin)
+	resources, err := repo.ListResources(ctx, curl.Name, requestedOrigin)
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/charms/mocks/repository.go
+++ b/apiserver/facades/client/charms/mocks/repository.go
@@ -39,7 +39,7 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockRepository) DownloadCharm(arg0 context.Context, arg1 string, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -55,7 +55,7 @@ func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 inter
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) GetDownloadURL(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
@@ -91,7 +91,7 @@ func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 interface{}, arg
 }
 
 // ListResources mocks base method.
-func (m *MockRepository) ListResources(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockRepository) ListResources(arg0 context.Context, arg1 string, arg2 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -136,7 +136,7 @@ func (mr *MockRepositoryMockRecorder) ResolveResources(arg0, arg1, arg2 interfac
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -286,7 +286,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	storeCurl.Architecture = "amd64"
 	storeOrigin := origin
 	storeOrigin.Type = "charm"
-	repo.EXPECT().ResolveWithPreferredChannel(gomock.Any(), curl, origin).Return(&storeCurl, storeOrigin, nil, nil)
+	repo.EXPECT().ResolveWithPreferredChannel(gomock.Any(), curl.Name, origin).Return(&storeCurl, storeOrigin, nil, nil)
 
 	downloader.EXPECT().DownloadAndStore(gomock.Any(), &storeCurl, storeOrigin, false).
 		DoAndReturn(func(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, force bool) (corecharm.Origin, error) {

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -190,7 +190,7 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 	// error response.
 	//
 	// The controller charm doesn't have any series specific code.
-	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(context.TODO(), curl, origin)
+	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(context.TODO(), curl.Name, origin)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "resolving %q", controllerCharmURL)
 	}

--- a/core/charm/downloader/downloader.go
+++ b/core/charm/downloader/downloader.go
@@ -34,9 +34,9 @@ type CharmArchive interface {
 
 // CharmRepository provides an API for downloading charms/bundles.
 type CharmRepository interface {
-	GetDownloadURL(context.Context, *charm.URL, corecharm.Origin) (*url.URL, corecharm.Origin, error)
-	ResolveWithPreferredChannel(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error)
-	DownloadCharm(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, archivePath string) (corecharm.CharmArchive, corecharm.Origin, error)
+	GetDownloadURL(context.Context, string, corecharm.Origin) (*url.URL, corecharm.Origin, error)
+	ResolveWithPreferredChannel(ctx context.Context, charmName string, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error)
+	DownloadCharm(ctx context.Context, charmName string, requestedOrigin corecharm.Origin, archivePath string) (corecharm.CharmArchive, corecharm.Origin, error)
 }
 
 // RepositoryGetter returns a suitable CharmRepository for the specified Source.
@@ -117,7 +117,7 @@ func (d *Downloader) DownloadAndStore(ctx context.Context, charmURL *charm.URL, 
 		err           error
 		channelOrigin = requestedOrigin
 	)
-	channelOrigin.Platform, err = d.normalizePlatform(charmURL.String(), requestedOrigin.Platform)
+	channelOrigin.Platform, err = d.normalizePlatform(charmURL.Name, requestedOrigin.Platform)
 	if err != nil {
 		return corecharm.Origin{}, errors.Trace(err)
 	}
@@ -134,7 +134,7 @@ func (d *Downloader) DownloadAndStore(ctx context.Context, charmURL *charm.URL, 
 			if err != nil {
 				return corecharm.Origin{}, errors.Trace(err)
 			}
-			_, resolvedOrigin, err := repo.GetDownloadURL(ctx, charmURL, requestedOrigin)
+			_, resolvedOrigin, err := repo.GetDownloadURL(ctx, charmURL.Name, requestedOrigin)
 			return resolvedOrigin, errors.Trace(err)
 		}
 
@@ -158,31 +158,31 @@ func (d *Downloader) DownloadAndStore(ctx context.Context, charmURL *charm.URL, 
 		return corecharm.Origin{}, errors.Trace(err)
 	}
 
-	downloadedCharm, actualOrigin, err := d.downloadAndHash(ctx, charmURL, channelOrigin, repo, tmpFile.Name())
+	downloadedCharm, actualOrigin, err := d.downloadAndHash(ctx, charmURL.Name, channelOrigin, repo, tmpFile.Name())
 	if err != nil {
-		return corecharm.Origin{}, errors.Annotatef(err, "downloading charm %q from origin %v", charmURL, requestedOrigin)
+		return corecharm.Origin{}, errors.Annotatef(err, "downloading charm %q from origin %v", charmURL.Name, requestedOrigin)
 	}
 
 	// Validate charm
 	if err := downloadedCharm.verify(actualOrigin, force); err != nil {
-		return corecharm.Origin{}, errors.Annotatef(err, "verifying downloaded charm %q from origin %v", charmURL, requestedOrigin)
+		return corecharm.Origin{}, errors.Annotatef(err, "verifying downloaded charm %q from origin %v", charmURL.Name, requestedOrigin)
 	}
 
 	// Store Charm
-	if err := d.storeCharm(ctx, charmURL, downloadedCharm, tmpFile.Name()); err != nil {
+	if err := d.storeCharm(ctx, charmURL.String(), downloadedCharm, tmpFile.Name()); err != nil {
 		return corecharm.Origin{}, errors.Annotatef(err, "storing charm %q from origin %v", charmURL, requestedOrigin)
 	}
 
 	return actualOrigin, nil
 }
 
-func (d *Downloader) downloadAndHash(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
-	d.logger.Debugf("downloading charm %q from requested origin %v", charmURL, requestedOrigin)
-	chArchive, actualOrigin, err := repo.DownloadCharm(ctx, charmURL, requestedOrigin, dstPath)
+func (d *Downloader) downloadAndHash(ctx context.Context, charmName string, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
+	d.logger.Debugf("downloading charm %q from requested origin %v", charmName, requestedOrigin)
+	chArchive, actualOrigin, err := repo.DownloadCharm(ctx, charmName, requestedOrigin, dstPath)
 	if err != nil {
 		return DownloadedCharm{}, corecharm.Origin{}, errors.Trace(err)
 	}
-	d.logger.Debugf("downloaded charm %q from actual origin %v", charmURL, actualOrigin)
+	d.logger.Debugf("downloaded charm %q from actual origin %v", charmName, actualOrigin)
 
 	// Calculate SHA256 for the downloaded archive
 	f, err := os.Open(dstPath)
@@ -206,7 +206,7 @@ func (d *Downloader) downloadAndHash(ctx context.Context, charmURL *charm.URL, r
 	}, actualOrigin, nil
 }
 
-func (d *Downloader) storeCharm(ctx context.Context, charmURL *charm.URL, dc DownloadedCharm, archivePath string) error {
+func (d *Downloader) storeCharm(ctx context.Context, charmURL string, dc DownloadedCharm, archivePath string) error {
 	charmArchive, err := os.Open(archivePath)
 	if err != nil {
 		return errors.Annotatef(err, "unable to open downloaded charm archive at %q", archivePath)
@@ -214,16 +214,16 @@ func (d *Downloader) storeCharm(ctx context.Context, charmURL *charm.URL, dc Dow
 	defer func() { _ = charmArchive.Close() }()
 
 	dc.CharmData = charmArchive
-	if err := d.storage.Store(ctx, charmURL.String(), dc); err != nil {
+	if err := d.storage.Store(ctx, charmURL, dc); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
 }
 
-func (d *Downloader) normalizePlatform(charmURL string, platform corecharm.Platform) (corecharm.Platform, error) {
+func (d *Downloader) normalizePlatform(charmName string, platform corecharm.Platform) (corecharm.Platform, error) {
 	arc := platform.Architecture
 	if platform.Architecture == "" || platform.Architecture == "all" {
-		d.logger.Warningf("received charm Architecture: %q, changing to %q, for charm %q", platform.Architecture, arch.DefaultArchitecture, charmURL)
+		d.logger.Warningf("received charm Architecture: %q, changing to %q, for charm %q", platform.Architecture, arch.DefaultArchitecture, charmName)
 		arc = arch.DefaultArchitecture
 	}
 

--- a/core/charm/downloader/export_test.go
+++ b/core/charm/downloader/export_test.go
@@ -6,8 +6,6 @@ package downloader
 import (
 	"context"
 
-	"github.com/juju/charm/v11"
-
 	corecharm "github.com/juju/juju/core/charm"
 )
 
@@ -19,6 +17,6 @@ func (d *Downloader) NormalizePlatform(charmURL string, platform corecharm.Platf
 	return d.normalizePlatform(charmURL, platform)
 }
 
-func (d *Downloader) DownloadAndHash(ctx context.Context, charmURL *charm.URL, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
-	return d.downloadAndHash(ctx, charmURL, requestedOrigin, repo, dstPath)
+func (d *Downloader) DownloadAndHash(ctx context.Context, charmName string, requestedOrigin corecharm.Origin, repo CharmRepository, dstPath string) (DownloadedCharm, corecharm.Origin, error) {
+	return d.downloadAndHash(ctx, charmName, requestedOrigin, repo, dstPath)
 }

--- a/core/charm/downloader/mocks/charm_archive_mocks.go
+++ b/core/charm/downloader/mocks/charm_archive_mocks.go
@@ -38,7 +38,7 @@ func (m *MockCharmRepository) EXPECT() *MockCharmRepositoryMockRecorder {
 }
 
 // DownloadCharm mocks base method.
-func (m *MockCharmRepository) DownloadCharm(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
+func (m *MockCharmRepository) DownloadCharm(arg0 context.Context, arg1 string, arg2 charm0.Origin, arg3 string) (charm0.CharmArchive, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.CharmArchive)
@@ -54,7 +54,7 @@ func (mr *MockCharmRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 
 }
 
 // GetDownloadURL mocks base method.
-func (m *MockCharmRepository) GetDownloadURL(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockCharmRepository) GetDownloadURL(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
@@ -70,7 +70,7 @@ func (mr *MockCharmRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 inter
 }
 
 // ResolveWithPreferredChannel mocks base method.
-func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
+func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 context.Context, arg1 string, arg2 charm0.Origin) (*charm.URL, charm0.Origin, []charm0.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -17,18 +17,18 @@ type Repository interface {
 	// GetDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	GetDownloadURL(context.Context, *charm.URL, Origin) (*url.URL, Origin, error)
+	GetDownloadURL(context.Context, string, Origin) (*url.URL, Origin, error)
 
 	// DownloadCharm retrieves specified charm from the store and saves its
 	// contents to the specified path.
-	DownloadCharm(ctx context.Context, charmURL *charm.URL, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
+	DownloadCharm(ctx context.Context, charmName string, requestedOrigin Origin, archivePath string) (CharmArchive, Origin, error)
 
 	// ResolveWithPreferredChannel verified that the charm with the requested
 	// channel exists.  If no channel is specified, the latests, most stable is
 	// used. It returns a charm URL which includes the most current revision,
 	// if none was provided, a charm origin, and a slice of series supported by
 	// this charm.
-	ResolveWithPreferredChannel(context.Context, *charm.URL, Origin) (*charm.URL, Origin, []Platform, error)
+	ResolveWithPreferredChannel(context.Context, string, Origin) (*charm.URL, Origin, []Platform, error)
 
 	// GetEssentialMetadata resolves each provided MetadataRequest and
 	// returns back a slice with the results. The results include the
@@ -36,7 +36,7 @@ type Repository interface {
 	GetEssentialMetadata(context.Context, ...MetadataRequest) ([]EssentialMetadata, error)
 
 	// ListResources returns a list of resources associated with a given charm.
-	ListResources(context.Context, *charm.URL, Origin) ([]charmresource.Resource, error)
+	ListResources(context.Context, string, Origin) ([]charmresource.Resource, error)
 
 	// ResolveResources looks at the provided repository and backend (already
 	// downloaded) resources to determine which to use. Provided (uploaded) take
@@ -65,8 +65,8 @@ type CharmArchive interface {
 // MetadataRequest encapsulates the arguments for a charm essential metadata
 // resolution request.
 type MetadataRequest struct {
-	CharmURL *charm.URL
-	Origin   Origin
+	CharmName string
+	Origin    Origin
 }
 
 // EssentialMetadata encapsulates the essential metadata required for deploying

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -86,7 +86,7 @@ func (s *charmHubRepositorySuite) testResolve(c *gc.C, id string) {
 		origin.InstanceKey = "instance-key"
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = rev
@@ -122,7 +122,7 @@ func (s *charmHubRepositorySuite) TestResolveWithChannel(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -156,7 +156,7 @@ func (s *charmHubRepositorySuite) TestResolveWithoutBase(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -263,7 +263,7 @@ func (s *charmHubRepositorySuite) TestResolveWithBundles(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "core-kubernetes", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 17
@@ -296,7 +296,7 @@ func (s *charmHubRepositorySuite) TestResolveInvalidPlatformError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -322,7 +322,6 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 	defer s.setupMocks(c).Finish()
 	s.expectedRefreshRevisionNotFoundError(c)
 
-	curl := charm.MustParseURL("ch:wordpress")
 	origin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -330,7 +329,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 		},
 	}
 
-	_, _, _, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	_, _, _, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, gc.ErrorMatches,
 		`(?m)selecting releases: charm or bundle not found for channel "", platform "amd64"
 available releases are:
@@ -352,7 +351,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
 		},
 	}
 
-	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), curl, origin)
+	obtainedCurl, obtainedOrigin, obtainedBases, err := s.newClient().ResolveWithPreferredChannel(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 16
@@ -377,7 +376,6 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
 func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -412,7 +410,7 @@ func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 	s.expectCharmRefreshInstallOneFromChannel(c)
 	s.client.EXPECT().DownloadAndRead(gomock.Any(), resolvedURL, "/tmp/foo").Return(resolvedArchive, nil)
 
-	gotArchive, gotOrigin, err := s.newClient().DownloadCharm(context.Background(), curl, requestedOrigin, "/tmp/foo")
+	gotArchive, gotOrigin, err := s.newClient().DownloadCharm(context.Background(), "wordpress", requestedOrigin, "/tmp/foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotArchive, gc.Equals, resolvedArchive) // note: we are using gc.Equals to check the pointers here.
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -421,7 +419,6 @@ func (s *charmHubRepositorySuite) TestDownloadCharm(c *gc.C) {
 func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -454,7 +451,7 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 
 	s.expectCharmRefreshInstallOneFromChannel(c)
 
-	gotURL, gotOrigin, err := s.newClient().GetDownloadURL(context.Background(), curl, requestedOrigin)
+	gotURL, gotOrigin, err := s.newClient().GetDownloadURL(context.Background(), "wordpress", requestedOrigin)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotURL, gc.DeepEquals, resolvedURL)
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
@@ -463,7 +460,6 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("ch:wordpress")
 	requestedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -481,8 +477,8 @@ func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	s.expectCharmRefreshInstallOneFromChannel(c) // refresh and get metadata
 
 	got, err := s.newClient().GetEssentialMetadata(context.Background(), corecharm.MetadataRequest{
-		CharmURL: curl,
-		Origin:   requestedOrigin,
+		CharmName: "wordpress",
+		Origin:    requestedOrigin,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -974,7 +970,7 @@ type refreshConfigSuite struct {
 var _ = gc.Suite(&refreshConfigSuite{})
 
 func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
@@ -982,7 +978,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
@@ -994,7 +990,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
@@ -1008,7 +1004,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 }
 
 func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/latest")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
@@ -1016,7 +1012,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
@@ -1028,7 +1024,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
@@ -1043,14 +1039,14 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 
 func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 	revision := 1
-	curl := charm.MustParseURL("ch:wordpress")
+	name := "wordpress"
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	origin := corecharm.Origin{
 		Platform: platform,
 		Revision: &revision,
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig(name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
@@ -1061,7 +1057,7 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: instanceKey,
-			Name:        &curl.Name,
+			Name:        &name,
 			Revision:    &revision,
 		}},
 		Context: []transport.RefreshRequestContext{},
@@ -1072,7 +1068,6 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	id := "aaabbbccc"
 	revision := 1
-	curl := charm.MustParseURL("ch:wordpress")
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	channel := corecharm.MustParseChannel("stable")
 	origin := corecharm.Origin{
@@ -1084,7 +1079,7 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 		InstanceKey: "instance-key",
 	}
 
-	cfg, err := refreshConfig(curl, origin)
+	cfg, err := refreshConfig("wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)


### PR DESCRIPTION
NOTE:
Cherry-pick https://github.com/juju/juju/pull/16520 onto main. https://github.com/juju/juju/pull/16520 is blocked since 3.3 is currently in feature freeze, however I would like on the main branch ASAP so I can continue with work that depends on it

There were a lot of merge conflicts. However, all of them were as a result of the addition of contexts too the signature of our core/charm methods. So they were trivial to solve

DESCRIPTION:
Core repository public methods DownloadCharm, GetDownloadMetadata, ResolveWithPreferredChannel, GetEssentialMetadata and ListResources all took a charm.URL param, but only needed the name of the charm. Simplify this to only need the charm name string

This has the consequence that callers don't need to parse a URL to use these functions

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@22.04/stable
$ juju deploy ubuntu --base ubuntu@20.04 ubuntu-focal
Deployed "ubuntu-focal" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@20.04/stable
$ juju deploy postgresql
Deployed "postgresql" from charm-hub charm "postgresql", revision 336 in channel 14/stable on ubuntu@22.04/stable
```

```
$ juju add-model m2
$ juju deploy juju-qa-bundle-test
```