### PR TITLE
Remove tools version todo

### DIFF
--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/im7mortal/kmutex"
 	"github.com/juju/errors"
@@ -22,8 +21,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/httpcontext"
-	corebase "github.com/juju/juju/core/base"
-	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
 	envtools "github.com/juju/juju/environs/tools"
@@ -162,77 +159,21 @@ func (h *toolsDownloadHandler) getToolsForRequest(r *http.Request, st *state.Sta
 		}
 	}()
 
-	// TODO(juju4) = remove this compatibility logic
-	// Looked for stored tools which are recorded for a series
-	// but which have the same os type as the wanted version.
-	// Alternatively, the request may have been for a specifc
-	// series and we need to use stored tools for the corresponding
-	// os type.
-	storageVers := vers
-	var osTypeName string
-	if vers.Number.Major == 2 && vers.Number.Minor <= 8 {
-		wantedOSType := vers.Release
-		if !coreos.IsValidOSTypeName(vers.Release) {
-			wantedOSType = corebase.DefaultOSTypeNameFromSeries(vers.Release)
-		}
-		vers.Release = wantedOSType
-
-		all, err := storage.AllMetadata()
-		if err != nil {
-			return nil, 0, errors.Trace(err)
-		}
-		var osMatchVersion *version.Binary
-		for _, m := range all {
-			metaVers, err := version.ParseBinary(m.Version)
-			if err != nil {
-				return nil, 0, errors.Annotate(err, "error parsing metadata version")
-			}
-
-			// Exact match so just use that with os type name substitution.
-			if m.Version == vers.String() {
-				osMatchVersion = &metaVers
-				break
-			}
-			if osMatchVersion != nil {
-				continue
-			}
-			metaOSType := metaVers.Release
-			if !coreos.IsValidOSTypeName(metaVers.Release) {
-				metaOSType = corebase.DefaultOSTypeNameFromSeries(metaVers.Release)
-			}
-			toCompare := metaVers
-			toCompare.Release = strings.ToLower(metaOSType)
-			if toCompare.String() == vers.String() {
-				logger.Debugf("using os based version %s for requested %s", toCompare, vers)
-				osMatchVersion = &metaVers
-				osTypeName = toCompare.Release
-			}
-		}
-		// Set the version to store to be the match we found
-		// for any compatible series.
-		if osMatchVersion != nil {
-			storageVers = *osMatchVersion
-		}
-	}
-
-	locker := h.fetchMutex.Locker(storageVers.String())
+	locker := h.fetchMutex.Locker(vers.String())
 	locker.Lock()
 	defer locker.Unlock()
 
-	md, reader, err := storage.Open(storageVers.String())
+	md, reader, err := storage.Open(vers.String())
 	if errors.Is(err, errors.NotFound) {
 		// Tools could not be found in tools storage,
 		// so look for them in simplestreams,
 		// fetch them and cache in tools storage.
 		logger.Infof("%v agent binaries not found locally, fetching", vers)
-		if osTypeName != "" {
-			storageVers.Release = osTypeName
-		}
-		err = h.fetchAndCacheTools(vers, storageVers, st, storage)
+		err = h.fetchAndCacheTools(vers, st, storage)
 		if err != nil {
 			err = errors.Annotate(err, "error fetching agent binaries")
 		} else {
-			md, reader, err = storage.Open(storageVers.String())
+			md, reader, err = storage.Open(vers.String())
 		}
 	}
 	if err != nil {
@@ -247,7 +188,6 @@ func (h *toolsDownloadHandler) getToolsForRequest(r *http.Request, st *state.Sta
 // to the caller.
 func (h *toolsDownloadHandler) fetchAndCacheTools(
 	v version.Binary,
-	storageVers version.Binary,
 	st *state.State,
 	modelStorage binarystorage.Storage,
 ) error {
@@ -327,7 +267,7 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 	}
 
 	md := binarystorage.Metadata{
-		Version: storageVers.String(),
+		Version: v.String(),
 		Size:    exactTools.Size,
 		SHA256:  exactTools.SHA256,
 	}


### PR DESCRIPTION
This seems like it was only targeting 2.8 or less, as we don't support that version, we can simplify the code and just use the version binary from the request.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju boostrap lxd test --build-agent
$ juju add-model default
$ juju upgrade-controller
$ juju add-machine
```

## Links

**Jira card:** JUJU-4890