### PR TITLE
upgrade_series test: remove -d flag from do-release-upgrade

### DIFF
--- a/tests/suites/upgrade_series/base.sh
+++ b/tests/suites/upgrade_series/base.sh
@@ -21,8 +21,7 @@ run_upgrade_base_relation() {
 	reboot_machine 0
 	echo "Upgrading machine..."
 	echo "See ${TEST_DIR}/do-release-upgrade.log for progress."
-	# TODO: remove -d flag once Ubuntu 22.04.1 is released
-	juju ssh 0 'sudo do-release-upgrade -d -f DistUpgradeViewNonInteractive' &>"${TEST_DIR}/do-release-upgrade.log" || true
+	juju ssh 0 'sudo do-release-upgrade -f DistUpgradeViewNonInteractive' &>"${TEST_DIR}/do-release-upgrade.log" || true
 	reboot_machine 0
 	juju upgrade-machine 0 complete
 


### PR DESCRIPTION
The `upgrade_series` tests are failing because the machine is not being upgraded:
```
Checking for a new Ubuntu release
There is no development version of an LTS available.
To upgrade to the latest non-LTS development release 
set Prompt=normal in /etc/update-manager/release-upgrades.
```

The problem is that, when we run the `do-release-upgrade` command to upgrade Ubuntu, we are passing in the `-d` flag. This flag indicates that we should update to a development release of Ubuntu. However, as the error message says, there is no longer a development version of an LTS available. Likely, this is due to the recent release of Ubuntu 23.10.

The fix is as written in the TODO: remove the -d flag from the `do-release-upgrade` command.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the `upgrade_series` Bash test suite.