### PR TITLE
Fuzz wait-for query and lexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,12 @@ ifeq ($(COVERAGE_CHECK), 1)
 	TEST_ARGS += -coverprofile=coverage.txt -covermode=atomic
 endif
 
+ifeq ($(FUZZ_CHECK), 1)
+	TEST_ARGS += -fuzzminimizetime=30s
+else
+	TEST_ARGS += -fuzzminimizetime=0
+endif
+
 # Enable verbose testing for reporting.
 ifeq ($(VERBOSE_CHECK), 1)
 	CHECK_ARGS = -v

--- a/cmd/juju/waitfor/query/parser_test.go
+++ b/cmd/juju/waitfor/query/parser_test.go
@@ -4,6 +4,10 @@
 package query
 
 import (
+	"bufio"
+	"os"
+	"testing"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -364,4 +368,33 @@ func (p *parserSuite) TestParserInfixLambda(c *gc.C) {
 			},
 		},
 	})
+}
+
+func Fuzz(f *testing.F) {
+	readCorpus(f)
+	f.Fuzz(func(t *testing.T, value string) {
+		lex := NewLexer(value)
+		parser := NewParser(lex)
+		_, _ = parser.Run()
+	})
+}
+
+func readCorpus(f *testing.F) {
+	file, err := os.Open("./testfiles/success")
+	if err != nil {
+		f.Fatalf("unable to read file")
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		t := scanner.Text()
+		if t == "" {
+			continue
+		}
+		f.Add(t)
+	}
+	if err := scanner.Err(); err != nil {
+		f.Fatal(err)
+	}
 }

--- a/cmd/juju/waitfor/query/parser_test.go
+++ b/cmd/juju/waitfor/query/parser_test.go
@@ -370,8 +370,9 @@ func (p *parserSuite) TestParserInfixLambda(c *gc.C) {
 	})
 }
 
-func Fuzz(f *testing.F) {
+func FuzzLexerParser(f *testing.F) {
 	readCorpus(f)
+
 	f.Fuzz(func(t *testing.T, value string) {
 		lex := NewLexer(value)
 		parser := NewParser(lex)
@@ -380,6 +381,8 @@ func Fuzz(f *testing.F) {
 }
 
 func readCorpus(f *testing.F) {
+	f.Helper()
+
 	file, err := os.Open("./testfiles/success")
 	if err != nil {
 		f.Fatalf("unable to read file")


### PR DESCRIPTION
This is a reactionary PR after a lightning talk at the engineering sprint. As the wait-for command talks a user input it is advisable to fuzz the input to prevent a panic from occuring based on the input.

Fuzzing can take quite some time we may only want to enable this in some gated infrastructure (unit gating tests).

This currently hasn't found any issues, but it may well do on repeated runs.

[Note: fuzzing will be turned on just in unit-tests on jenkins.](https://github.com/juju/juju-qa-jenkins/pull/162)


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ go test -v ./cmd/juju/waitfor/query -fuzz=Fuzz
```

## Links

**Jira card:** JUJU-[XXXX]
