### PR TITLE
GH workflows run only on push to trunk branches, not feature branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: "Build"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,6 +1,7 @@
 name: "Client Tests"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,6 +1,7 @@
 name: "Generate"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,6 +1,7 @@
 name: "Licenses"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,6 +1,7 @@
 name: "Smoke"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,7 @@
 name: "Snapcraft"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,7 @@
 name: "Static Analysis"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 #   paths:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,6 +1,7 @@
 name: "Upgrade"
 on:
   push:
+    branches: [2.9, 3.1, 3.2, 3.3, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:


### PR DESCRIPTION
#16196 disabled the GitHub Actions on `push`. The intention here was to avoid triggering workflow runs on every new commit pushed to a feature branch.

However, this also disabled the workflow runs on the "trunk" branches (`2.9`, `3.1`, etc). We still want to run the workflows here - particularly so we can tell if a PR has broken a workflow, or whether it was already broken.

This change ensures we run the full suite of Actions on the main branches.

## QA steps

GitHub Actions don't run on this branch - see [here](https://github.com/barrettj12/juju/actions?query=branch%3Aci-push).