### PR TITLE
help text: indent list of config keys

### DIFF
--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -167,5 +168,12 @@ func FormatConfigSchema(values interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return out.String(), nil
+	output := out.String()
+
+	// Indent every line by 4 spaces
+	var indented string
+	for _, line := range strings.Split(output, "\n") {
+		indented += "    " + line + "\n"
+	}
+	return indented, nil
 }


### PR DESCRIPTION
In the generated Markdown docs for `bootstrap`, the list of config keys are not formatting properly, see here: https://discourse.charmhub.io/t/command-bootstrap/10132

They need to be indented so that they are treated as a preformatted code block. This PR indents the list by 4 spaces (also for controller-config and model-config).

This is a quick hack so that the config keys display properly in Markdown, with minimal change to the CLI output. Long term, we plan to remove these keys from the CLI help text, which will make this change redundant.

Affects the help text for bootstrap, controller-config, model-config.

## QA steps

```sh
juju bootstrap --help
juju documentation --split --out=./docs
```
and look at the bootstrap.md doc.