### PR TITLE
Allow compiling Juju with `BUILD_TAGS='minimal'` (no providers)

### DIFF
--- a/provider/all/none.go
+++ b/provider/all/none.go
@@ -1,0 +1,8 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package all
+
+// This file is here so that you can compile Juju with no providers
+// (i.e. BUILD_TAGS='minimal'). Otherwise, Go will complain that the build
+// constraints exclude all Go files in this package.


### PR DESCRIPTION
Currently, you can't build the Juju client with no providers:
```
$ BUILD_TAGS=minimal make go-client-build
Building [github.com/juju/juju/cmd/juju](http://github.com/juju/juju/cmd/juju) for linux/amd64
package [github.com/juju/juju/cmd/juju](http://github.com/juju/juju/cmd/juju)
        imports [github.com/juju/juju/provider/all](http://github.com/juju/juju/provider/all): build constraints exclude all Go files in /home/jb/git/juju/juju/2.9/provider/all
make: *** [Makefile:259: /home/jb/git/juju/juju/2.9/_build/linux_amd64/bin/juju] Error 1
```

Add an empty file to the `provider/all` package, so that you can compile Juju with `BUILD_TAGS=minimal` and no providers.