### PR TITLE
Remove lxd retry logic

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -627,7 +627,7 @@ type PrecheckJujuUpgradeStep interface {
 type DefaultConstraintsChecker interface {
 	// ShouldApplyControllerConstraints returns if bootstrapping logic should
 	// use default constraints
-	ShouldApplyControllerConstraints() bool
+	ShouldApplyControllerConstraints(constraints.Value) bool
 }
 
 // HardwareCharacteristicsDetector is implemented by environments that can

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -39,7 +39,10 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 
 // ShouldApplyControllerConstraints returns if bootstrapping logic should use
 // default constraints
-func (env *environ) ShouldApplyControllerConstraints() bool {
+func (env *environ) ShouldApplyControllerConstraints(cons constraints.Value) bool {
+	if cons.HasVirtType() && *cons.VirtType == "virtual-machine" {
+		return true
+	}
 	return false
 }
 

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -238,6 +238,33 @@ func (s *environPolicySuite) TestSupportNetworks(c *gc.C) {
 	c.Check(isSupported, jc.IsFalse)
 }
 
+func (s *environPolicySuite) TestShouldApplyControllerConstraints(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cons := constraints.MustParse("")
+
+	ok := s.env.(environs.DefaultConstraintsChecker).ShouldApplyControllerConstraints(cons)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *environPolicySuite) TestShouldApplyControllerConstraintsInvalid(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cons := constraints.MustParse("virt-type=invalid")
+
+	ok := s.env.(environs.DefaultConstraintsChecker).ShouldApplyControllerConstraints(cons)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *environPolicySuite) TestShouldApplyControllerConstraintsForVirtualMachine(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cons := constraints.MustParse("virt-type=virtual-machine")
+
+	ok := s.env.(environs.DefaultConstraintsChecker).ShouldApplyControllerConstraints(cons)
+	c.Assert(ok, jc.IsTrue)
+}
+
 func (s *environPolicySuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 


### PR DESCRIPTION
The lxd retry logic was added in [1] to help with locating the vm if it didn't start up in time. This isn't required anymore as the vm correctly starts up cleanly. In addition, the retry was at level that causes retries for requests that don't expect retries to
happen. This was identified in bug[2] as a failure.

In addition bootstrapping a lxd virtual machine requires at least some CPU and memory constraints, otherwise it doesn't come up without specifying them. The solution is to allow bootstrap constraints on the lxd provider if the virt-type is a virtual-machine.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent --constraints="virt-type=virtual-machine"
```

You should see the cores=2 and mem=3.5G in the bootstrap output.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2029524

**Jira card:** JUJU-[XXXX]
