### PR TITLE
Object store metadata schema

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -46,6 +46,7 @@ func ControllerDDL() *schema.Schema {
 		changeLogTriggersForTable("upgrade_info", "uuid", tableUpgradeInfo),
 		changeLogTriggersForTable("upgrade_info_controller_node", "upgrade_info_uuid", tableUpgradeInfoControllerNode),
 		autocertCacheSchema,
+		objectStoreMetadataSchema,
 	}
 
 	schema := schema.New()

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -19,6 +19,7 @@ func ModelDDL() *schema.Schema {
 		modelConfig,
 		changeLogTriggersForTable("model_config", "key", tableModelConfig),
 		spacesSchema,
+		objectStoreMetadataSchema,
 	}
 
 	schema := schema.New()

--- a/domain/schema/objectstore.go
+++ b/domain/schema/objectstore.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import "github.com/juju/juju/core/database/schema"
+
+// objectStoreMetadataSchema provides a helper function for generating a change_log ddl
+// for a schema.
+func objectStoreMetadataSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE object_store_metadata_hash_type (
+    id          INT PRIMARY KEY,
+    hash_type   TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_object_store_metadata_hash_type_name
+ON object_store_metadata_hash_type (hash_type);
+
+INSERT INTO object_store_metadata_hash_type VALUES
+    (0, 'none'),
+    (1, 'sha-256');
+
+CREATE TABLE object_store_metadata (
+    uuid            TEXT PRIMARY KEY,
+    hash_type_id    INT NOT NULL,
+    hash            TEXT,
+    CONSTRAINT      fk_object_store_metadata_hash_type
+        FOREIGN KEY (hash_type_id)
+        REFERENCES  object_store_metadata_hash_type(id)
+);
+
+CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash);
+
+CREATE TABLE object_store_metadata_path (
+    uuid            TEXT PRIMARY KEY,
+    metadata_uuid   TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    size            INT NOT NULL,
+    CONSTRAINT      fk_object_store_metadata_metadata_uuid
+        FOREIGN KEY (metadata_uuid)
+        REFERENCES  object_store_metadata(uuid)
+);
+
+CREATE UNIQUE INDEX idx_object_store_metadata_path ON object_store_metadata_path (path);
+
+`)
+}

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -87,6 +87,11 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"upgrade_info",
 		"upgrade_info_controller_node",
 		"upgrade_state_type",
+
+		// Object store metadata
+		"object_store_metadata",
+		"object_store_metadata_path",
+		"object_store_metadata_hash_type",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }
@@ -112,6 +117,11 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		// Spaces
 		"spaces",
 		"provider_spaces",
+
+		// Object store metadata
+		"object_store_metadata",
+		"object_store_metadata_path",
+		"object_store_metadata_hash_type",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
The object store will require tracking the underlying blobs of the object store. To do this we need to keep track of the path, size and hash. This is done in two tables, the `object_store_metadata` and `object_store_metadata_resource`. The first holds the path and size, along with the foreign key to the blob reference. As there may be many blobs with the same hash, we have a one-to-many mapping. 
*Why this change is needed and what it does.*

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-4899