### PR TITLE
DDL for network node entities

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -20,6 +20,9 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("model_config", "key", tableModelConfig),
 		spacesSchema,
 		objectStoreMetadataSchema,
+		applicationSchema,
+		nodeSchema,
+		unitSchema,
 	}
 
 	schema := schema.New()
@@ -41,7 +44,7 @@ INSERT INTO change_log_namespace VALUES
 func modelConfig() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE model_config (
-    key TEXT PRIMARY KEY,
+    key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
 `)
@@ -60,11 +63,101 @@ CREATE TABLE spaces (
     is_public       BOOLEAN,
     provider_uuid   TEXT,
     CONSTRAINT      fk_lease_pin_lease
-        FOREIGN KEY     (provider_uuid)
-        REFERENCES      provider_spaces(uuid)
+        FOREIGN KEY (provider_uuid)
+        REFERENCES  provider_spaces(uuid)
 );
 
 CREATE UNIQUE INDEX idx_spaces_uuid_name
 ON spaces (uuid, name);
+`)
+}
+
+func applicationSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE application (
+    uuid TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_application_name
+ON application (name);
+`)
+}
+
+func nodeSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE net_node (
+    uuid TEXT PRIMARY KEY
+);
+
+CREATE TABLE machine (
+    uuid            TEXT PRIMARY KEY,
+    machine_id      TEXT NOT NULL,
+    net_node_uuid   TEXT NOT NULL,
+    CONSTRAINT      fk_machine_net_node
+        FOREIGN KEY (net_node_uuid)
+        REFERENCES  net_node(uuid)
+);
+
+CREATE UNIQUE INDEX idx_machine_id
+ON machine (machine_id);
+
+CREATE UNIQUE INDEX idx_machine_net_node
+ON machine (net_node_uuid);
+
+CREATE TABLE cloud_service (
+    uuid             TEXT PRIMARY KEY,
+    net_node_uuid    TEXT NOT NULL,
+    application_uuid TEXT NOT NULL,
+    CONSTRAINT       fk_cloud_service_net_node
+        FOREIGN KEY  (net_node_uuid)
+        REFERENCES   net_node(uuid),
+    CONSTRAINT       fk_cloud_application
+        FOREIGN KEY  (application_uuid)
+        REFERENCES   application(uuid)
+);
+
+CREATE UNIQUE INDEX idx_cloud_service_net_node
+ON cloud_service (net_node_uuid);
+
+CREATE UNIQUE INDEX idx_cloud_service_application
+ON cloud_service (application_uuid);
+
+CREATE TABLE cloud_container (
+    uuid            TEXT PRIMARY KEY,
+    net_node_uuid   TEXT NOT NULL,
+    CONSTRAINT      fk_cloud_container_net_node
+        FOREIGN KEY (net_node_uuid)
+        REFERENCES  net_node(uuid)
+);
+
+CREATE UNIQUE INDEX idx_cloud_container_net_node
+ON cloud_container (net_node_uuid);
+`)
+}
+
+func unitSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE unit (
+    uuid             TEXT PRIMARY KEY,
+    unit_id          TEXT NOT NULL,
+    application_uuid TEXT NOT NULL,
+    net_node_uuid    TEXT NOT NULL,
+    CONSTRAINT       fk_unit_application
+        FOREIGN KEY  (application_uuid)
+        REFERENCES   application(uuid),
+    CONSTRAINT       fk_unit_net_node
+        FOREIGN KEY  (net_node_uuid)
+        REFERENCES   net_node(uuid)
+);
+
+CREATE UNIQUE INDEX idx_unit_id
+ON unit (unit_id);
+
+CREATE INDEX idx_unit_application
+ON unit (application_uuid);
+
+CREATE UNIQUE INDEX idx_unit_net_node
+ON unit (net_node_uuid);
 `)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -122,6 +122,13 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		"object_store_metadata",
 		"object_store_metadata_path",
 		"object_store_metadata_hash_type",
+
+		"application",
+		"machine",
+		"net_node",
+		"cloud_service",
+		"cloud_container",
+		"unit",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
This adds DDL to the model schema for tables that model network entities.

It includes a `net_node` indirection that allows joins through to `machine`, `cloud_service` or `cloud_container`. This will allow us to unify working with link-layer devices and IP address across different entities and substrates.

The model instituted is illustrated below.

![Untitled-2023-11-10-1410](https://github.com/juju/juju/assets/2562584/31b4a0ed-fbda-48fc-854f-cd68a2ae8074)


## QA steps

Bootstrap somewhere.