### PR TITLE
New password types and hasing for Juju and Dqlite.

### DIFF
--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package auth provides common types and functions for aiding in authentication
+// within Juju. Currently this package provides our password logic for hashing
+// and encapsulating plain text passwords.
+//
+// When a component in Juju receives a plain text password from a user it should
+// be immediately wrapped in a Password type with NewPassword("mypassword").
+//
+// To hash a new password for Juju to persist the first step is to generate a
+// new password salt with NewSalt(). This newly created salt value must follow
+// the users password for the life of the password.
+//
+// Passwords can be hashed with HashPassword(password, salt). The resultant hash
+// is now safe for storing in Juju along with the created salt.
+package auth

--- a/internal/auth/package_test.go
+++ b/internal/auth/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auth
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -1,0 +1,145 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/juju/errors"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Password hides and protects a plain text passwords in Juju from accidentally
+// being consumed or printed to a log.
+type Password struct {
+	// password is the plain text password being protected
+	password []byte
+}
+
+const (
+	// ErrPasswordDestroyed is used when a password has been destroyed and the
+	// operation cannot be performed.
+	ErrPasswordDestroyed = errors.ConstError("password destroyed")
+
+	// ErrPasswordNotValid is used when a password has failed validation.
+	ErrPasswordNotValid = errors.ConstError("password not valid")
+
+	// saltLength is the number of bytes that we randomly generate for new
+	// salts. The pbkdf2 guidelines is to use 8 bytes for salt.
+	saltLength = 12
+
+	// pbkdf2Iterations is the number iterations to perform for pbkdf2. The
+	// more iterations performed the harder brute forcing is. Each iteration
+	// repeatedly hashes the password adding computational complexity.
+	//
+	// Warning updating this value will break already established passwords on
+	// the old value!
+	pbkdf2Iterations = 8192
+
+	// pbkdf2KeySize is the size of the produced key by pbkdf2KeySize, expressed
+	// in number of bytes.
+	//
+	// Warning updating this value will break already established passwords on
+	// the old value!
+	pbkdf2KeySize = 18
+
+	// maxPasswordSizeBytes is the maximum size of a password that we will
+	// tolerate.
+	maxPasswordSizeBytes = 1024 // 1KB is the max we are going to allow.
+)
+
+// HasPassword takes a password and corresponding salt to produce a hash of the
+// password. The resultant hash is safe for persistence and comparison.
+// If the salt provided to password hash is empty then a error satisfying
+// errors.NotValid is returned. If the password does not pass validation a error
+// satisfying ErrPasswordNotValid will be returned. If the password has been
+// destroyed a error satisfying ErrPasswordDestroyed will be returned.
+//
+// HashPassword under all circumstances will Destroy() the password provided to
+// the function rendering it unusable.
+func HashPassword(p Password, salt []byte) (string, error) {
+	defer p.Destroy()
+	if err := p.Validate(); err != nil {
+		return "", fmt.Errorf("hashing password: %w", err)
+	}
+	if len(salt) == 0 {
+		return "", fmt.Errorf(
+			"%w password salt cannot be empty for password hashing", errors.NotValid,
+		)
+	}
+	h := pbkdf2.Key(p.password, salt, pbkdf2Iterations, pbkdf2KeySize, sha512.New)
+	return base64.StdEncoding.EncodeToString(h), nil
+}
+
+// NewSalt generates a new random password salt for use with password hashing.
+func NewSalt() ([]byte, error) {
+	buf := [saltLength]byte{}
+	_, err := io.ReadFull(rand.Reader, buf[:])
+	if err != nil {
+		return nil, fmt.Errorf("generating random bytes for new password salt: %w", err)
+	}
+
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(buf)))
+	base64.StdEncoding.Encode(dst, buf[:])
+	return dst, nil
+}
+
+// NewPassword returns a Password struct wrapping the plain text password.
+func NewPassword(p string) Password {
+	return Password{[]byte(p)}
+}
+
+// String implements the stringer interface always returning an empty string and
+// never the encapsulated password.
+func (p Password) String() string {
+	return ""
+}
+
+// Format implements the Formatter interface from fmt making sure not to output
+// the encapsulated password.
+func (p Password) Format(f fmt.State, verb rune) {
+}
+
+// GoString implements the GoStringer interface from fmt making sure not to
+// output the encapsulated password.
+func (p Password) GoString() string {
+	return ""
+}
+
+// Destroy will invalidate the memory being used to store the password.
+// Destroy() can be called multiple times safely.
+func (p Password) Destroy() {
+	for i := range p.password {
+		p.password[i] = 0
+	}
+}
+
+// Validate will check the wrapped password to make sure that it meets our
+// validation requirements. Passwords must not be empty and less then 1KB in
+// size. All validation errors will satisfy ErrPasswordNotValid.
+// If the password has been destroyed a error of type ErrPasswordDestroyed
+// will be returned.
+func (p Password) Validate() error {
+	destroyed := len(p.password) > 0
+	for _, b := range p.password {
+		if b != byte(0) && destroyed {
+			destroyed = false
+		}
+	}
+	if destroyed {
+		return ErrPasswordDestroyed
+	}
+
+	if len(p.password) == 0 {
+		return fmt.Errorf("%w, size must be greater then zero", ErrPasswordNotValid)
+	}
+	if len(p.password) > maxPasswordSizeBytes {
+		return fmt.Errorf("%w, size must be less then %d bytes", ErrPasswordNotValid, maxPasswordSizeBytes)
+	}
+	return nil
+}

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -1,0 +1,230 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
+	gc "gopkg.in/check.v1"
+)
+
+type passwordSuite struct {
+}
+
+var _ = gc.Suite(&passwordSuite{})
+
+func ExampleHashPassword() {
+	userExposedPassword := "topsecret"
+
+	password := NewPassword(userExposedPassword)
+	salt, err := NewSalt()
+	if err != nil {
+		log.Fatalf("generating password salt: %v", salt)
+	}
+
+	hash, err := HashPassword(password, salt)
+	if err != nil {
+		log.Fatalf("generating password hash with salt: %v", err)
+	}
+
+	fmt.Println(hash)
+}
+
+// TestPasswordEncapsulation is asserting that a wrapped password does not leak
+// the encapsulated plain text password.
+func (_ *passwordSuite) TestPasswordEncapsulation(c *gc.C) {
+	p := NewPassword("topsecret")
+
+	c.Assert(p.String(), gc.Equals, "")
+	c.Assert(p.GoString(), gc.Equals, "")
+	c.Assert(fmt.Sprintf("%s", p), gc.Equals, "")
+	c.Assert(fmt.Sprintf("%v", p), gc.Equals, "")
+	c.Assert(fmt.Sprintf("%#v", p), gc.Equals, "")
+	c.Assert(fmt.Sprintf("%T", p), gc.Equals, "auth.Password")
+}
+
+// TestPasswordValidation exists to assert the validation rules we apply to
+// passwords. All passwords in this test are invalid and should cause a
+// ErrPasswordNotValid error.
+func (_ *passwordSuite) TestPasswordValidation(c *gc.C) {
+	tests := []string{
+		"",                        // We don't allow empty passwords
+		strings.Repeat("1", 1025), // We don't allow password over 1KB
+	}
+
+	for _, test := range tests {
+		err := NewPassword(test).Validate()
+		c.Assert(err, jc.ErrorIs, ErrPasswordNotValid,
+			gc.Commentf("expected password %q to return ErrPasswordNotValid", test),
+		)
+	}
+}
+
+// TestPasswordValidationDestroyed asserts that after destroying a password and
+// then validating the password a error that satisfies ErrPasswordDestroyed is
+// returned.
+func (_ *passwordSuite) TestPasswordValidationDestroyed(c *gc.C) {
+	p := NewPassword("topsecret")
+	p.Destroy()
+	err := p.Validate()
+	c.Assert(err, jc.ErrorIs, ErrPasswordDestroyed)
+}
+
+// TestPasswordHashing is testing some known password and their respective
+// hashes to make sure we are always getting the same hash output.
+func (_ *passwordSuite) TestPasswordHashing(c *gc.C) {
+	tests := []struct {
+		Password string
+		Salt     string
+		Hash     string
+	}{
+		{
+			Password: "topsecretpassword",
+			Salt:     "xVwuRk5pzUg",
+			Hash:     "TEJvoj03UpTREYTUVs+KmOTv",
+		},
+		{
+			Password: "テストパスワード",
+			Salt:     "xVwuRk5pzUg",
+			Hash:     "p5kmNGdEeQHSJ1fy2u7lOKOJ",
+		},
+		{
+			Password: "西蒙是最好的",
+			Salt:     "xVwuRk5pzUg",
+			Hash:     "8U1/Oj8LHmD+ejpfc8mnFWZM",
+		},
+		{
+			Password: "علی",
+			Salt:     "xVwuRk5pzUg",
+			Hash:     "YW0UnyAEFq152ukVHAjRVjDz",
+		},
+		{
+			Password: "123😱😱😱😱.testpassword",
+			Salt:     "xVwuRk5pzUg",
+			Hash:     "jm2w/Q+bC3AdjVD4kTrRT95o",
+		},
+	}
+
+	for _, test := range tests {
+		p := NewPassword(test.Password)
+		hash, err := HashPassword(p, []byte(test.Salt))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(hash, gc.Equals, test.Hash,
+			gc.Commentf("computed hash %q != expected hash %q for password %q and salt %q",
+				hash, test.Hash, test.Password, test.Salt),
+		)
+
+		// We want to assert that HashPassword destroys the password after use.
+		// Because of the way the password structure is formed we have to look
+		// inside the password slice and make sure all the values are zero.
+		for _, b := range p.password {
+			c.Assert(b, gc.Equals, byte(0),
+				gc.Commentf("checking that all bytes in the password have been set to zero"),
+			)
+		}
+	}
+}
+
+// TestPasswordHashingDestroyed tests that when hashing a destroyed password a
+// error is returned satisfying ErrPasswordDestroyed.
+func (_ *passwordSuite) TestPasswordHashingDestroyed(c *gc.C) {
+	p := NewPassword("topsecret")
+	p.Destroy()
+	_, err := HashPassword(p, []byte("secretsauce"))
+	c.Assert(err, jc.ErrorIs, ErrPasswordDestroyed)
+}
+
+// TestPasswordHashWithUtils is testing the password hashing inside of Juju with
+// that of Juju utils. This it to check that both algorithms come to the same
+// conclusion. This test will assert that moving password hashing back into Juju
+// from utils has not broken anything.
+func (_ *passwordSuite) TestPasswordHashWithUtils(c *gc.C) {
+	tests := []string{
+		"testmctestface",
+		"テストパスワード",
+		"password1234",
+		"1",
+		"😁❗️",
+		"علی",
+	}
+
+	salt := "xVwuRk5pzUg"
+
+	for _, test := range tests {
+		utilsHash := utils.UserPasswordHash(test, salt)
+		jujuHash, err := HashPassword(NewPassword(test), []byte(salt))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(utilsHash, gc.Equals, jujuHash,
+			gc.Commentf("juju/utils/v3 hash %q != internal/password hash %q for password %q",
+				utilsHash, jujuHash, test),
+		)
+	}
+}
+
+// TestNewSalt is here to check that a salt can be generated with no errors and
+// the length of the salt is equal to that of what we expect.
+func (_ *passwordSuite) TestNewSalt(c *gc.C) {
+	salt, err := NewSalt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(salt) != 0, jc.IsTrue)
+}
+
+// TestDestroyPasswordMultiple checks that we can call Destroy() on a password
+// multiple times and that no panics occur.
+func (_ *passwordSuite) TestDestroyPasswordMultiple(c *gc.C) {
+	p := NewPassword("topsecret")
+	// Three times should be plenty
+	p.Destroy()
+	p.Destroy()
+	p.Destroy()
+}
+
+// FuzzPasswordHashing is a fuzz test to both try and break our password hashing
+// inputs and to also confirm that for a wide range of inputs that utils hashing
+// is the same this implementation in internal/password.
+func FuzzPasswordHashing(f *testing.F) {
+	corpase := []string{
+		"testmctestface",
+		"テストパスワード",
+		"password1234",
+		"1",
+		"😁❗️",
+		"revving-churl-brat-femur",
+		"علی",
+	}
+
+	for _, c := range corpase {
+		f.Add(c)
+	}
+
+	salt := "xVwuRk5pzUg"
+	f.Fuzz(func(t *testing.T, password string) {
+		utilsHash := utils.UserPasswordHash(password, salt)
+		jujuHash, err := HashPassword(NewPassword(password), []byte(salt))
+		// Fuzz testing will give us a string that is all nil chars and that
+		// will cause us to think the error is destroyed. This is perfectly
+		// valid. Fuzz testing is trying to break us and assert logic paths we
+		// don't have.
+		if errors.Is(err, ErrPasswordNotValid) ||
+			errors.Is(err, ErrPasswordDestroyed) {
+			return
+		}
+
+		if err != nil {
+			t.Fatalf("expected nil error from HashPassword() but got %v", err)
+		}
+
+		if utilsHash != jujuHash {
+			t.Errorf(
+				"expected juju utils hash %q for password %q to equal HashPassword() %q",
+				utilsHash, password, jujuHash)
+		}
+	})
+}


### PR DESCRIPTION
This PR is mostly about consolidating the logic that we have in Juju around user passwords into a new common package.

We are introducing a new password type for use in the code base. Because Juju deals with plain text passwords over the wire from users we want a safe way to wrap these raw strings up into a strong type. The reason for doing this is to offer safety around working with the types. When the password has been wrapped in the password type it should be almost impossible for a developer to accidentally output the password in a log or output stream.

We are also actively moving away from having lots of external Juju libraries for offering utility like functions like password hashing. Because of this we have moved the logic previously found in juju/utils around password hashing into the core of Juju now.

Moving the code back into Juju offers us greater flexibility to changing hashing algorithms and salting methods later on if we ever need to upgrade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

These changes include fuzz testing to assert that our password hashing doesn't break or panic. We also compare the same output from the new code to that of the old code to confirm there is no difference in implementations.

Run the fuzzing tests for as long you think is needed. I haven't seen any breakages yet.

```sh
go test -fuzz .
```

## Documentation changes

No changes besides internal usage. Docs are provided in the package for usage.

## Links

**Jira card:** JUJU-4900