### PR TITLE
Trace flags: Sample ratio

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -311,6 +311,10 @@ type Config interface {
 	// for each span.
 	OpenTelemetryStackTraces() bool
 
+	// OpenTelemetrySampleRatio returns the sample ratio to use for open
+	// telemetry collection.
+	OpenTelemetrySampleRatio() float64
+
 	// DqlitePort returns the port that should be used by Dqlite. This should
 	// only be set during testing.
 	DqlitePort() (int, bool)
@@ -382,6 +386,10 @@ type configSetterOnly interface {
 	// SetOpenTelemetryStackTraces sets the debug stack traces should be
 	// enabled for each span.
 	SetOpenTelemetryStackTraces(bool)
+
+	// SetOpenTelemetrySampleRatio sets the sample ratio to use for open
+	// telemetry collection.
+	SetOpenTelemetrySampleRatio(float64)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -463,6 +471,7 @@ type configInternal struct {
 	openTelemetryEndpoint    string
 	openTelemetryInsecure    bool
 	openTelemetryStackTraces bool
+	openTelemetrySampleRatio float64
 	dqlitePort               int
 }
 
@@ -490,6 +499,7 @@ type AgentConfigParams struct {
 	OpenTelemetryEndpoint    string
 	OpenTelemetryInsecure    bool
 	OpenTelemetryStackTraces bool
+	OpenTelemetrySampleRatio float64
 	DqlitePort               int
 }
 
@@ -560,6 +570,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		openTelemetryEndpoint:    configParams.OpenTelemetryEndpoint,
 		openTelemetryInsecure:    configParams.OpenTelemetryInsecure,
 		openTelemetryStackTraces: configParams.OpenTelemetryStackTraces,
+		openTelemetrySampleRatio: configParams.OpenTelemetrySampleRatio,
 		dqlitePort:               configParams.DqlitePort,
 	}
 	if len(configParams.APIAddresses) > 0 {
@@ -938,9 +949,19 @@ func (c *configInternal) OpenTelemetryStackTraces() bool {
 	return c.openTelemetryStackTraces
 }
 
-// SetopenTelemetryStackTraces implements configSetterOnly.
+// SetOpenTelemetryStackTraces implements configSetterOnly.
 func (c *configInternal) SetOpenTelemetryStackTraces(v bool) {
 	c.openTelemetryStackTraces = v
+}
+
+// OpenTelemetrySampleRatio implements Config.
+func (c *configInternal) OpenTelemetrySampleRatio() float64 {
+	return c.openTelemetrySampleRatio
+}
+
+// SetOpenTelemetryStackTraces implements configSetterOnly.
+func (c *configInternal) SetOpenTelemetrySampleRatio(v float64) {
+	c.openTelemetrySampleRatio = v
 }
 
 var validAddr = regexp.MustCompile("^.+:[0-9]+$")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -773,3 +773,15 @@ func (*suite) TestSetOpenTelemetryStackTraces(c *gc.C) {
 	queryTracingStackTraces = conf.OpenTelemetryStackTraces()
 	c.Assert(queryTracingStackTraces, gc.Equals, true, gc.Commentf("open telemetry stack traces setting not updated"))
 }
+
+func (*suite) TestSetOpenTelemetrySampleRatio(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	queryTracingSampleRatio := conf.OpenTelemetrySampleRatio()
+	c.Assert(queryTracingSampleRatio, gc.Equals, attributeParams.OpenTelemetrySampleRatio)
+
+	conf.SetOpenTelemetrySampleRatio(.42)
+	queryTracingSampleRatio = conf.OpenTelemetrySampleRatio()
+	c.Assert(queryTracingSampleRatio, gc.Equals, .42, gc.Commentf("open telemetry sample ratio setting not updated"))
+}

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -218,7 +218,6 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		OpenTelemetryEnabled:     config.openTelemetryEnabled,
 		OpenTelemetryInsecure:    config.openTelemetryInsecure,
 		OpenTelemetryStackTraces: config.openTelemetryStackTraces,
-		OpenTelemetrySampleRatio: fmt.Sprintf("%.04f", config.openTelemetrySampleRatio),
 
 		DqlitePort: config.dqlitePort,
 	}
@@ -245,6 +244,9 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	}
 	if config.openTelemetryEndpoint != "" {
 		format.OpenTelemetryEndpoint = config.openTelemetryEndpoint
+	}
+	if config.openTelemetrySampleRatio != 0 {
+		format.OpenTelemetrySampleRatio = fmt.Sprintf("%.04f", config.openTelemetrySampleRatio)
 	}
 	return goyaml.Marshal(format)
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"time"
@@ -71,6 +72,7 @@ type format_2_0Serialization struct {
 	OpenTelemetryEndpoint    string `yaml:"opentelemetryendpoint,omitempty"`
 	OpenTelemetryInsecure    bool   `yaml:"opentelemetryinsecure,omitempty"`
 	OpenTelemetryStackTraces bool   `yaml:"opentelemetrystacktraces,omitempty"`
+	OpenTelemetrySampleRatio string `yaml:"opentelemetrysampleratio,omitempty"`
 
 	DqlitePort int `yaml:"dqlite-port,omitempty"`
 }
@@ -178,6 +180,13 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 	if format.OpenTelemetryEndpoint != "" {
 		config.openTelemetryEndpoint = format.OpenTelemetryEndpoint
 	}
+	if format.OpenTelemetrySampleRatio != "" {
+		sampleRatio, err := strconv.ParseFloat(format.OpenTelemetrySampleRatio, 64)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		config.openTelemetrySampleRatio = sampleRatio
+	}
 	return config, nil
 }
 
@@ -209,6 +218,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		OpenTelemetryEnabled:     config.openTelemetryEnabled,
 		OpenTelemetryInsecure:    config.openTelemetryInsecure,
 		OpenTelemetryStackTraces: config.openTelemetryStackTraces,
+		OpenTelemetrySampleRatio: fmt.Sprintf("%.04f", config.openTelemetrySampleRatio),
 
 		DqlitePort: config.dqlitePort,
 	}

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -185,7 +185,7 @@ func (fc facadeCaller) FacadeCall(ctx context.Context, request string, params, r
 	scope := span.Scope()
 
 	return fc.caller.APICall(
-		rpc.WithTracing(ctx, scope.TraceID(), scope.SpanID()),
+		rpc.WithTracing(ctx, scope.TraceID(), scope.SpanID(), scope.TraceFlags()),
 		fc.facadeName, fc.bestVersion, "",
 		request, params, response,
 	)

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -182,10 +182,12 @@ func (fc facadeCaller) FacadeCall(ctx context.Context, request string, params, r
 		span.End()
 	}()
 
-	scope := span.Scope()
+	if scope := span.Scope(); scope.TraceID() != "" && scope.SpanID() != "" {
+		ctx = rpc.WithTracing(ctx, scope.TraceID(), scope.SpanID(), scope.TraceFlags())
+	}
 
 	return fc.caller.APICall(
-		rpc.WithTracing(ctx, scope.TraceID(), scope.SpanID(), scope.TraceFlags()),
+		ctx,
 		fc.facadeName, fc.bestVersion, "",
 		request, params, response,
 	)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -504,6 +504,7 @@ func (cfg *InstanceConfig) AgentConfig(
 		configParams.OpenTelemetryEndpoint = cfg.ControllerConfig.OpenTelemetryEndpoint()
 		configParams.OpenTelemetryInsecure = cfg.ControllerConfig.OpenTelemetryInsecure()
 		configParams.OpenTelemetryStackTraces = cfg.ControllerConfig.OpenTelemetryStackTraces()
+		configParams.OpenTelemetrySampleRatio = cfg.ControllerConfig.OpenTelemetrySampleRatio()
 	}
 	if cfg.Bootstrap == nil {
 		return agent.NewAgentConfig(configParams)

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -115,6 +115,7 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 		OpenTelemetryEndpoint:    cfg.Controller.OpenTelemetryEndpoint(),
 		OpenTelemetryInsecure:    cfg.Controller.OpenTelemetryInsecure(),
 		OpenTelemetryStackTraces: cfg.Controller.OpenTelemetryStackTraces(),
+		OpenTelemetrySampleRatio: cfg.Controller.OpenTelemetrySampleRatio(),
 	}
 	return agent.NewStateMachineConfig(configParams, cfg.Bootstrap.StateServingInfo)
 }

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -155,6 +155,10 @@ func (c *configFromEnv) OpenTelemetryStackTraces() bool {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) OpenTelemetrySampleRatio() float64 {
+	panic("not implemented")
+}
+
 func (c *configFromEnv) DqlitePort() (int, bool) {
 	panic("not implemented")
 }

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -194,6 +194,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 			OpenTelemetryEndpoint:    "",
 			OpenTelemetryInsecure:    controller.DefaultOpenTelemetryInsecure,
 			OpenTelemetryStackTraces: controller.DefaultOpenTelemetryStackTraces,
+			OpenTelemetrySampleRatio: controller.DefaultOpenTelemetrySampleRatio,
 
 			DqlitePort: dqlitePort,
 		},
@@ -275,6 +276,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			OpenTelemetryEndpoint:    "",
 			OpenTelemetryInsecure:    controller.DefaultOpenTelemetryInsecure,
 			OpenTelemetryStackTraces: controller.DefaultOpenTelemetryStackTraces,
+			OpenTelemetrySampleRatio: controller.DefaultOpenTelemetrySampleRatio,
 
 			DqlitePort: dqlitePort,
 		},

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -343,6 +343,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		agentConfig.SetOpenTelemetryEndpoint(args.ControllerConfig.OpenTelemetryEndpoint())
 		agentConfig.SetOpenTelemetryInsecure(args.ControllerConfig.OpenTelemetryInsecure())
 		agentConfig.SetOpenTelemetryStackTraces(args.ControllerConfig.OpenTelemetryStackTraces())
+		agentConfig.SetOpenTelemetrySampleRatio(args.ControllerConfig.OpenTelemetrySampleRatio())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -382,6 +382,12 @@ var newConfigTests = []struct {
 	},
 	expectError: `open-telemetry-stack-traces: expected bool, got string\("invalid"\)`,
 }, {
+	about: "invalid open telemetry tracing sample ratio value",
+	config: controller.Config{
+		controller.OpenTelemetrySampleRatio: "invalid",
+	},
+	expectError: `open-telemetry-sample-ratio: strconv.ParseFloat: parsing "invalid": invalid syntax`,
+}, {
 	about: "invalid object store type value",
 	config: controller.Config{
 		controller.ObjectStoreType: "invalid",
@@ -979,6 +985,18 @@ func (s *ConfigSuite) TestOpenTelemetryEndpointSettingValue(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.OpenTelemetryEndpoint(), gc.Equals, mURL)
+}
+
+func (s *ConfigSuite) TestOpenTelemetrySampleRatio(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cfg.OpenTelemetrySampleRatio(), gc.Equals, controller.DefaultOpenTelemetrySampleRatio)
+
+	cfg[controller.OpenTelemetrySampleRatio] = 0.42
+	c.Assert(cfg.OpenTelemetrySampleRatio(), gc.Equals, 0.42)
 }
 
 func (s *ConfigSuite) TestObjectStoreType(c *gc.C) {

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -62,6 +62,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	OpenTelemetryEndpoint:            schema.String(),
 	OpenTelemetryInsecure:            schema.Bool(),
 	OpenTelemetryStackTraces:         schema.Bool(),
+	OpenTelemetrySampleRatio:         schema.String(),
 	ObjectStoreType:                  schema.String(),
 }, schema.Defaults{
 	AgentRateLimitMax:                schema.Omit,
@@ -114,6 +115,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	OpenTelemetryEndpoint:            schema.Omit,
 	OpenTelemetryInsecure:            DefaultOpenTelemetryInsecure,
 	OpenTelemetryStackTraces:         DefaultOpenTelemetryStackTraces,
+	OpenTelemetrySampleRatio:         fmt.Sprintf("%.02f", DefaultOpenTelemetrySampleRatio),
 	ObjectStoreType:                  schema.Omit,
 })
 
@@ -327,6 +329,10 @@ will be output if tracing is enabled.`,
 	OpenTelemetryStackTraces: {
 		Type:        environschema.Tbool,
 		Description: `Allows stack traces open telemetry tracing per span`,
+	},
+	OpenTelemetrySampleRatio: {
+		Type:        environschema.Tstring,
+		Description: `Allows defining a sample ratio open telemetry tracing`,
 	},
 	ObjectStoreType: {
 		Type:        environschema.Tstring,

--- a/core/trace/context.go
+++ b/core/trace/context.go
@@ -88,7 +88,9 @@ func WithTraceScope(ctx context.Context, traceID, spanID string, flags int) cont
 	return context.WithValue(ctx, traceIDContextKey, traceID)
 }
 
-// ScopeFromContext returns the traceID and spanID from the context.
+// ScopeFromContext returns the traceID, spanID and the flags from the context.
+// Both traceID and spanID can be in the form of a hex string or a raw
+// string.
 func ScopeFromContext(ctx context.Context) (string, string, int) {
 	traceID, _ := ctx.Value(traceIDContextKey).(string)
 	spanID, _ := ctx.Value(spanIDContextKey).(string)
@@ -150,4 +152,9 @@ func (NoopScope) SpanID() string {
 // TraceFlags returns the trace flags of the span.
 func (NoopScope) TraceFlags() int {
 	return 0
+}
+
+// IsSampled returns if the span is sampled.
+func (NoopScope) IsSampled() bool {
+	return false
 }

--- a/core/trace/context.go
+++ b/core/trace/context.go
@@ -13,8 +13,9 @@ const (
 	traceContextKey contextKey = "trace"
 	spanContextKey  contextKey = "span"
 
-	traceIDContextKey contextKey = "traceID"
-	spanIDContextKey  contextKey = "spanID"
+	traceIDContextKey    contextKey = "traceID"
+	spanIDContextKey     contextKey = "spanID"
+	traceFlagsContextKey contextKey = "traceFlags"
 )
 
 // TracerFromContext returns a tracer from the context. If no tracer is found,
@@ -81,16 +82,18 @@ func WithSpan(ctx context.Context, span Span) context.Context {
 
 // WithTraceScope returns a new context with the given trace scope (traceID and
 // spanID).
-func WithTraceScope(ctx context.Context, traceID, spanID string) context.Context {
+func WithTraceScope(ctx context.Context, traceID, spanID string, flags int) context.Context {
+	ctx = context.WithValue(ctx, traceFlagsContextKey, flags)
 	ctx = context.WithValue(ctx, spanIDContextKey, spanID)
 	return context.WithValue(ctx, traceIDContextKey, traceID)
 }
 
 // ScopeFromContext returns the traceID and spanID from the context.
-func ScopeFromContext(ctx context.Context) (string, string) {
+func ScopeFromContext(ctx context.Context) (string, string, int) {
 	traceID, _ := ctx.Value(traceIDContextKey).(string)
 	spanID, _ := ctx.Value(spanIDContextKey).(string)
-	return traceID, spanID
+	flags, _ := ctx.Value(traceFlagsContextKey).(int)
+	return traceID, spanID, flags
 }
 
 // NoopTracer is a tracer that does nothing.
@@ -142,4 +145,9 @@ func (NoopScope) TraceID() string {
 // SpanID returns the span ID of the span.
 func (NoopScope) SpanID() string {
 	return ""
+}
+
+// TraceFlags returns the trace flags of the span.
+func (NoopScope) TraceFlags() int {
+	return 0
 }

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -119,6 +119,8 @@ type Scope interface {
 	SpanID() string
 	// TraceFlags returns the trace flags of the span.
 	TraceFlags() int
+	// IsSampled returns if the span is sampled.
+	IsSampled() bool
 }
 
 // Name is the name of the span.

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -27,7 +27,7 @@ const (
 // Option are options that can be passed to the Tracer.Start() method.
 type Option func(*TracerOption)
 
-// TraceOption is an option that can be passed to the Tracer.Start() method.
+// TracerOption is an option that can be passed to the Tracer.Start() method.
 type TracerOption struct {
 	attributes []Attribute
 	stackTrace bool

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -117,6 +117,8 @@ type Scope interface {
 	TraceID() string
 	// SpanID returns the span ID of the span.
 	SpanID() string
+	// TraceFlags returns the trace flags of the span.
+	TraceFlags() int
 }
 
 // Name is the name of the span.

--- a/internal/upgrade/agent_mock_test.go
+++ b/internal/upgrade/agent_mock_test.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/internal/upgradesteps/agent_mock_test.go
+++ b/internal/upgradesteps/agent_mock_test.go
@@ -406,6 +406,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -897,6 +911,20 @@ func (mr *MockConfigSetterMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfigSetter) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -1059,6 +1087,18 @@ func (m *MockConfigSetter) SetOpenTelemetryInsecure(arg0 bool) {
 func (mr *MockConfigSetterMockRecorder) SetOpenTelemetryInsecure(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetryInsecure), arg0)
+}
+
+// SetOpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) SetOpenTelemetrySampleRatio(arg0 float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOpenTelemetrySampleRatio", arg0)
+}
+
+// SetOpenTelemetrySampleRatio indicates an expected call of SetOpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) SetOpenTelemetrySampleRatio(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetrySampleRatio), arg0)
 }
 
 // SetOpenTelemetryStackTraces mocks base method.

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -12,24 +12,25 @@ const (
 )
 
 // WithTracing returns a context with the given traceID and spanID.
-func WithTracing(ctx context.Context, traceID, spanID string) context.Context {
+func WithTracing(ctx context.Context, traceID, spanID string, flags int) context.Context {
 	return context.WithValue(ctx, tracingKey, &distributedTrace{
 		traceID: traceID,
 		spanID:  spanID,
+		flags:   flags,
 	})
 }
 
 // TracingFromContext returns the traceID and spanID from the context.
-func TracingFromContext(ctx context.Context) (string, string) {
+func TracingFromContext(ctx context.Context) (string, string, int) {
 	val := ctx.Value(tracingKey)
 	if val == nil {
-		return "", ""
+		return "", "", 0
 	}
 	t, ok := val.(*distributedTrace)
 	if !ok {
-		return "", ""
+		return "", "", 0
 	}
-	return t.traceID, t.spanID
+	return t.traceID, t.spanID, t.flags
 }
 
 // distributedTrace represents a distributed trace, that contains both
@@ -38,4 +39,5 @@ func TracingFromContext(ctx context.Context) (string, string) {
 type distributedTrace struct {
 	traceID string
 	spanID  string
+	flags   int
 }

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -19,8 +19,9 @@ type contextSuite struct {
 var _ = gc.Suite(&contextSuite{})
 
 func (s *contextSuite) TestWithTracing(c *gc.C) {
-	ctx := rpc.WithTracing(context.Background(), "trace", "span")
-	traceID, spanID := rpc.TracingFromContext(ctx)
+	ctx := rpc.WithTracing(context.Background(), "trace", "span", 1)
+	traceID, spanID, flags := rpc.TracingFromContext(ctx)
 	c.Assert(traceID, gc.Equals, "trace")
 	c.Assert(spanID, gc.Equals, "span")
+	c.Assert(flags, gc.Equals, 1)
 }

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -108,8 +108,8 @@ func (s *dispatchSuite) TestWSWithParamsV1(c *gc.C) {
 }
 
 func (s *dispatchSuite) TestWSWithParamsV1Tracing(c *gc.C) {
-	resp := s.requestV1(c, `{"request-id":2,"type": "DispatchDummy","id": "with","request":"DoSomething", "params": {}, "trace-id": "foobar", "span-id": "baz"}`)
-	s.assertResponse(c, resp, `{"request-id":2,"response":{},"trace-id":"foobar","span-id":"baz"}`)
+	resp := s.requestV1(c, `{"request-id":2,"type": "DispatchDummy","id": "with","request":"DoSomething", "params": {}, "trace-id": "foobar", "span-id": "baz", "trace-flags": 1}`)
+	s.assertResponse(c, resp, `{"request-id":2,"response":{},"trace-id":"foobar","span-id":"baz","trace-flags":1}`)
 }
 
 func (s *dispatchSuite) assertResponse(c *gc.C, obtained, expected string) {

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -50,33 +50,35 @@ func New(conn JSONConn) *Codec {
 // in a RawMessage.
 
 type inMsgV1 struct {
-	RequestId uint64                 `json:"request-id"`
-	Type      string                 `json:"type"`
-	Version   int                    `json:"version"`
-	Id        string                 `json:"id"`
-	Request   string                 `json:"request"`
-	Params    json.RawMessage        `json:"params"`
-	Error     string                 `json:"error"`
-	ErrorCode string                 `json:"error-code"`
-	ErrorInfo map[string]interface{} `json:"error-info"`
-	Response  json.RawMessage        `json:"response"`
-	TraceID   string                 `json:"trace-id"`
-	SpanID    string                 `json:"span-id"`
+	RequestId  uint64                 `json:"request-id"`
+	Type       string                 `json:"type"`
+	Version    int                    `json:"version"`
+	Id         string                 `json:"id"`
+	Request    string                 `json:"request"`
+	Params     json.RawMessage        `json:"params"`
+	Error      string                 `json:"error"`
+	ErrorCode  string                 `json:"error-code"`
+	ErrorInfo  map[string]interface{} `json:"error-info"`
+	Response   json.RawMessage        `json:"response"`
+	TraceID    string                 `json:"trace-id"`
+	SpanID     string                 `json:"span-id"`
+	TraceFlags int                    `json:"trace-flags"`
 }
 
 type outMsgV1 struct {
-	RequestId uint64                 `json:"request-id,omitempty"`
-	Type      string                 `json:"type,omitempty"`
-	Version   int                    `json:"version,omitempty"`
-	Id        string                 `json:"id,omitempty"`
-	Request   string                 `json:"request,omitempty"`
-	Params    interface{}            `json:"params,omitempty"`
-	Error     string                 `json:"error,omitempty"`
-	ErrorCode string                 `json:"error-code,omitempty"`
-	ErrorInfo map[string]interface{} `json:"error-info,omitempty"`
-	Response  interface{}            `json:"response,omitempty"`
-	TraceID   string                 `json:"trace-id,omitempty"`
-	SpanID    string                 `json:"span-id,omitempty"`
+	RequestId  uint64                 `json:"request-id,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Version    int                    `json:"version,omitempty"`
+	Id         string                 `json:"id,omitempty"`
+	Request    string                 `json:"request,omitempty"`
+	Params     interface{}            `json:"params,omitempty"`
+	Error      string                 `json:"error,omitempty"`
+	ErrorCode  string                 `json:"error-code,omitempty"`
+	ErrorInfo  map[string]interface{} `json:"error-info,omitempty"`
+	Response   interface{}            `json:"response,omitempty"`
+	TraceID    string                 `json:"trace-id,omitempty"`
+	SpanID     string                 `json:"span-id,omitempty"`
+	TraceFlags int                    `json:"trace-flags,omitempty"`
 }
 
 // Close closes the underlying connection and sets the codec to
@@ -127,6 +129,7 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	hdr.ErrorInfo = c.msg.ErrorInfo
 	hdr.TraceID = c.msg.TraceID
 	hdr.SpanID = c.msg.SpanID
+	hdr.TraceFlags = c.msg.TraceFlags
 	hdr.Version = 1
 	return nil
 }
@@ -213,16 +216,17 @@ func response(hdr *rpc.Header, body interface{}) (interface{}, error) {
 // reflect, but no.
 func newOutMsgV1(hdr *rpc.Header, body interface{}) outMsgV1 {
 	result := outMsgV1{
-		RequestId: hdr.RequestId,
-		Type:      hdr.Request.Type,
-		Version:   hdr.Request.Version,
-		Id:        hdr.Request.Id,
-		Request:   hdr.Request.Action,
-		Error:     hdr.Error,
-		ErrorCode: hdr.ErrorCode,
-		ErrorInfo: hdr.ErrorInfo,
-		TraceID:   hdr.TraceID,
-		SpanID:    hdr.SpanID,
+		RequestId:  hdr.RequestId,
+		Type:       hdr.Request.Type,
+		Version:    hdr.Request.Version,
+		Id:         hdr.Request.Id,
+		Request:    hdr.Request.Action,
+		Error:      hdr.Error,
+		ErrorCode:  hdr.ErrorCode,
+		ErrorInfo:  hdr.ErrorInfo,
+		TraceID:    hdr.TraceID,
+		SpanID:     hdr.SpanID,
+		TraceFlags: hdr.TraceFlags,
 	}
 	if hdr.IsRequest() {
 		result.Params = body

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -513,7 +513,7 @@ func (root *Root) testCall(c *gc.C, args testCallParams) {
 	root.returnErr = args.testErr
 	c.Logf("test call %s", args.request().Action)
 	var response stringVal
-	err := args.client.Call(rpc.WithTracing(context.Background(), "foobar", "baz"), args.request(), stringVal{"arg"}, &response)
+	err := args.client.Call(rpc.WithTracing(context.Background(), "foobar", "baz", 0), args.request(), stringVal{"arg"}, &response)
 	switch {
 	case args.retErr && args.testErr:
 		c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
@@ -978,7 +978,7 @@ func testBadCall(
 	requestKnown bool,
 ) {
 	serverNotifier.reset()
-	err := client.Call(rpc.WithTracing(context.Background(), "foobar", "baz"), req, nil, nil)
+	err := client.Call(rpc.WithTracing(context.Background(), "foobar", "baz", 1), req, nil, nil)
 	msg := expectedErr
 	if expectedErrCode != "" {
 		msg += " (" + expectedErrCode + ")"
@@ -994,11 +994,12 @@ func testBadCall(
 	}
 	c.Assert(serverNotifier.serverRequests[0], gc.DeepEquals, requestEvent{
 		hdr: rpc.Header{
-			RequestId: client.ClientRequestID(),
-			Request:   req,
-			Version:   1,
-			TraceID:   "foobar",
-			SpanID:    "baz",
+			RequestId:  client.ClientRequestID(),
+			Request:    req,
+			Version:    1,
+			TraceID:    "foobar",
+			SpanID:     "baz",
+			TraceFlags: 1,
 		},
 		body: expectBody,
 	})

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -513,7 +513,7 @@ func (root *Root) testCall(c *gc.C, args testCallParams) {
 	root.returnErr = args.testErr
 	c.Logf("test call %s", args.request().Action)
 	var response stringVal
-	err := args.client.Call(rpc.WithTracing(context.Background(), "foobar", "baz", 0), args.request(), stringVal{"arg"}, &response)
+	err := args.client.Call(rpc.WithTracing(context.Background(), "foobar", "baz", 1), args.request(), stringVal{"arg"}, &response)
 	switch {
 	case args.retErr && args.testErr:
 		c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
@@ -556,11 +556,12 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 	c.Assert(p.serverNotifier.serverRequests, gc.HasLen, 1)
 	serverReq := p.serverNotifier.serverRequests[0]
 	c.Assert(serverReq.hdr, gc.DeepEquals, rpc.Header{
-		RequestId: requestId,
-		Request:   p.request(),
-		Version:   1,
-		TraceID:   "foobar",
-		SpanID:    "baz",
+		RequestId:  requestId,
+		Request:    p.request(),
+		Version:    1,
+		TraceID:    "foobar",
+		SpanID:     "baz",
+		TraceFlags: 1,
 	})
 	if p.narg > 0 {
 		c.Assert(serverReq.body, gc.Equals, stringVal{"arg"})
@@ -579,18 +580,20 @@ func (root *Root) assertServerNotified(c *gc.C, p testCallParams, requestId uint
 	}
 	if p.retErr && p.testErr {
 		c.Assert(serverReply.hdr, jc.DeepEquals, rpc.Header{
-			RequestId: requestId,
-			Error:     p.errorMessage(),
-			Version:   1,
-			TraceID:   "foobar",
-			SpanID:    "baz",
+			RequestId:  requestId,
+			Error:      p.errorMessage(),
+			Version:    1,
+			TraceID:    "foobar",
+			SpanID:     "baz",
+			TraceFlags: 1,
 		})
 	} else {
 		c.Assert(serverReply.hdr, jc.DeepEquals, rpc.Header{
-			RequestId: requestId,
-			Version:   1,
-			TraceID:   "foobar",
-			SpanID:    "baz",
+			RequestId:  requestId,
+			Version:    1,
+			TraceID:    "foobar",
+			SpanID:     "baz",
+			TraceFlags: 1,
 		})
 	}
 }
@@ -1009,12 +1012,13 @@ func testBadCall(
 	serverReply := serverNotifier.serverReplies[0]
 	c.Assert(serverReply, gc.DeepEquals, replyEvent{
 		hdr: rpc.Header{
-			RequestId: client.ClientRequestID(),
-			Error:     expectedErr,
-			ErrorCode: expectedErrCode,
-			Version:   1,
-			TraceID:   "foobar",
-			SpanID:    "baz",
+			RequestId:  client.ClientRequestID(),
+			Error:      expectedErr,
+			ErrorCode:  expectedErrCode,
+			Version:    1,
+			TraceID:    "foobar",
+			SpanID:     "baz",
+			TraceFlags: 1,
 		},
 		req:  req,
 		body: struct{}{},

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -67,6 +67,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.OpenTelemetryEnabled,
 		controller.OpenTelemetryEndpoint,
 		controller.OpenTelemetryInsecure,
+		controller.OpenTelemetrySampleRatio,
 		controller.OpenTelemetryStackTraces,
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -147,6 +147,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configOpenTelemetryStackTraces := controllerConfig.OpenTelemetryStackTraces()
 			openTelemetryStackTracesChanged := agentsOpenTelemetryStackTraces != configOpenTelemetryStackTraces
 
+			agentsOpenTelemetrySampleRatio := currentConfig.OpenTelemetrySampleRatio()
+			configOpenTelemetrySampleRatio := controllerConfig.OpenTelemetrySampleRatio()
+			openTelemetrySampleRatioChanged := agentsOpenTelemetrySampleRatio != configOpenTelemetrySampleRatio
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -197,6 +201,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting open telemetry stack trace: %t => %t", agentsOpenTelemetryStackTraces, configOpenTelemetryStackTraces)
 					config.SetOpenTelemetryStackTraces(configOpenTelemetryStackTraces)
 				}
+				if openTelemetrySampleRatioChanged {
+					logger.Debugf("setting open telemetry sample ratio: %f => %f", agentsOpenTelemetrySampleRatio, configOpenTelemetrySampleRatio)
+					config.SetOpenTelemetrySampleRatio(configOpenTelemetrySampleRatio)
+				}
 
 				return nil
 			})
@@ -229,6 +237,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			} else if openTelemetryStackTracesChanged {
 				logger.Infof("restarting agent for new open telemetry stack traces")
 				return nil, jworker.ErrRestartAgent
+			} else if openTelemetrySampleRatioChanged {
+				logger.Infof("restarting agent for new open telemetry sample ratio")
+				return nil, jworker.ErrRestartAgent
 			}
 
 			// Only get the hub if we are a controller and we haven't updated
@@ -250,6 +261,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				OpenTelemetryEndpoint:    configOpenTelemetryEndpoint,
 				OpenTelemetryInsecure:    configOpenTelemetryInsecure,
 				OpenTelemetryStackTraces: configOpenTelemetryStackTraces,
+				OpenTelemetrySampleRatio: configOpenTelemetrySampleRatio,
 				Logger:                   config.Logger,
 			})
 		},

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -153,6 +153,7 @@ func (s *AgentConfigUpdaterSuite) TestCentralHubMissing(c *gc.C) {
 						controller.OpenTelemetryEnabled:     controller.DefaultOpenTelemetryEnabled,
 						controller.OpenTelemetryInsecure:    controller.DefaultOpenTelemetryInsecure,
 						controller.OpenTelemetryStackTraces: controller.DefaultOpenTelemetryStackTraces,
+						controller.OpenTelemetrySampleRatio: controller.DefaultOpenTelemetrySampleRatio,
 					},
 				}
 			default:
@@ -245,6 +246,7 @@ func (s *AgentConfigUpdaterSuite) startManifold(c *gc.C, a agent.Agent, mockAPIP
 						controller.OpenTelemetryEnabled:     controller.DefaultOpenTelemetryEnabled,
 						controller.OpenTelemetryInsecure:    controller.DefaultOpenTelemetryInsecure,
 						controller.OpenTelemetryStackTraces: controller.DefaultOpenTelemetryStackTraces,
+						controller.OpenTelemetrySampleRatio: controller.DefaultOpenTelemetrySampleRatio,
 					},
 				}
 			default:
@@ -393,6 +395,9 @@ type mockConfig struct {
 
 	openTelemetryStackTraces    bool
 	openTelemetryStackTracesSet bool
+
+	openTelemetrySampleRatio    float64
+	openTelemetrySampleRatioSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -494,6 +499,15 @@ func (mc *mockConfig) OpenTelemetryStackTraces() bool {
 func (mc *mockConfig) SetOpenTelemetryStackTraces(enabled bool) {
 	mc.openTelemetryStackTraces = enabled
 	mc.openTelemetryStackTracesSet = true
+}
+
+func (mc *mockConfig) OpenTelemetrySampleRatio() float64 {
+	return mc.openTelemetrySampleRatio
+}
+
+func (mc *mockConfig) SetOpenTelemetrySampleRatio(enabled float64) {
+	mc.openTelemetrySampleRatio = enabled
+	mc.openTelemetrySampleRatioSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -502,11 +502,14 @@ func (mc *mockConfig) SetOpenTelemetryStackTraces(enabled bool) {
 }
 
 func (mc *mockConfig) OpenTelemetrySampleRatio() float64 {
+	if mc.openTelemetrySampleRatio == 0 {
+		return controller.DefaultOpenTelemetrySampleRatio
+	}
 	return mc.openTelemetrySampleRatio
 }
 
-func (mc *mockConfig) SetOpenTelemetrySampleRatio(enabled float64) {
-	mc.openTelemetrySampleRatio = enabled
+func (mc *mockConfig) SetOpenTelemetrySampleRatio(ratio float64) {
+	mc.openTelemetrySampleRatio = ratio
 	mc.openTelemetrySampleRatioSet = true
 }
 

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/worker/objectstore/agent_mock_test.go
+++ b/worker/objectstore/agent_mock_test.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/worker/stateconverter/mocks/agent_mock.go
+++ b/worker/stateconverter/mocks/agent_mock.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/worker/trace/agent_mock_test.go
+++ b/worker/trace/agent_mock_test.go
@@ -405,6 +405,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()

--- a/worker/trace/manifold.go
+++ b/worker/trace/manifold.go
@@ -35,7 +35,7 @@ type Logger interface {
 }
 
 // TracerWorkerFunc is the function signature for creating a new tracer worker.
-type TracerWorkerFunc func(ctx context.Context, namespace coretrace.TaggedTracerNamespace, endpoint string, insecureSkipVerify bool, showStackTraces bool, logger Logger, newClient NewClientFunc) (TrackedTracer, error)
+type TracerWorkerFunc func(ctx context.Context, namespace coretrace.TaggedTracerNamespace, endpoint string, insecureSkipVerify bool, showStackTraces bool, sampleRatio float64, logger Logger, newClient NewClientFunc) (TrackedTracer, error)
 
 // ManifoldConfig defines the configuration for the trace manifold.
 type ManifoldConfig struct {
@@ -102,6 +102,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Endpoint:           endpoint,
 				InsecureSkipVerify: currentConfig.OpenTelemetryInsecure(),
 				StackTracesEnabled: currentConfig.OpenTelemetryStackTraces(),
+				SampleRatio:        currentConfig.OpenTelemetrySampleRatio(),
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/trace/manifold_test.go
+++ b/worker/trace/manifold_test.go
@@ -95,4 +95,5 @@ func (s *manifoldSuite) expectOpenTelemetry() {
 	s.config.EXPECT().OpenTelemetryEndpoint().Return("blah")
 	s.config.EXPECT().OpenTelemetryInsecure().Return(false)
 	s.config.EXPECT().OpenTelemetryStackTraces().Return(true)
+	s.config.EXPECT().OpenTelemetrySampleRatio().Return(0.5)
 }

--- a/worker/trace/manifold_test.go
+++ b/worker/trace/manifold_test.go
@@ -49,7 +49,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		AgentName: "agent",
 		Clock:     s.clock,
 		Logger:    s.logger,
-		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, Logger, NewClientFunc) (TrackedTracer, error) {
+		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, float64, Logger, NewClientFunc) (TrackedTracer, error) {
 			return nil, nil
 		},
 	}

--- a/worker/trace/tracer.go
+++ b/worker/trace/tracer.go
@@ -66,7 +66,7 @@ type ClientTracerProvider interface {
 }
 
 // NewClientFunc is the function signature for creating a new client.
-type NewClientFunc func(context.Context, coretrace.TaggedTracerNamespace, string, bool) (Client, ClientTracerProvider, ClientTracer, error)
+type NewClientFunc func(context.Context, coretrace.TaggedTracerNamespace, string, bool, float64) (Client, ClientTracerProvider, ClientTracer, error)
 
 type tracer struct {
 	tomb tomb.Tomb
@@ -86,10 +86,11 @@ func NewTracerWorker(
 	endpoint string,
 	insecureSkipVerify bool,
 	stackTracesEnabled bool,
+	sampleRatio float64,
 	logger Logger,
 	newClient NewClientFunc,
 ) (TrackedTracer, error) {
-	client, clientProvider, clientTracer, err := newClient(ctx, namespace, endpoint, insecureSkipVerify)
+	client, clientProvider, clientTracer, err := newClient(ctx, namespace, endpoint, insecureSkipVerify, sampleRatio)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -146,10 +147,8 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Optio
 
 	ctx, span = t.clientTracer.Start(ctx, name, trace.WithAttributes(attrs...))
 
-	if t.logger.IsTraceEnabled() {
-		spanContext := span.SpanContext()
-		t.logger.Tracef("SpanContext: span-id %s, trace-id %s", spanContext.SpanID(), spanContext.TraceID())
-	}
+	spanContext := span.SpanContext()
+	t.logger.Debugf("SpanContext: trace-id %s, span-id %s, sampled: %t", spanContext.TraceID(), spanContext.SpanID(), spanContext.IsSampled())
 
 	managed := &managedSpan{
 		span:               span,
@@ -209,18 +208,18 @@ func (w *tracer) scopedContext(ctx context.Context) (context.Context, context.Ca
 
 // buildRequestContext returns a context that may contain a remote span context.
 func (t *tracer) buildRequestContext(ctx context.Context) context.Context {
-	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
-	if traceID == "" || spanID == "" {
+	traceHex, spanHex, flags := coretrace.ScopeFromContext(ctx)
+	if traceHex == "" || spanHex == "" {
 		return ctx
 	}
-	traceHex, err := trace.TraceIDFromHex(traceID)
+	traceID, err := trace.TraceIDFromHex(traceHex)
 	if err != nil {
 		// There is clearly something wrong with the trace ID, so we
 		// should remove it from all future requests. That way we don't attempt
 		// to parse it again.
 		return coretrace.WithTraceScope(ctx, "", "", 0)
 	}
-	spanHex, err := trace.SpanIDFromHex(spanID)
+	spanID, err := trace.SpanIDFromHex(spanHex)
 	if err != nil {
 		// There is clearly something wrong with the span ID, so we
 		// should remove it from all future requests. That way we don't attempt
@@ -233,8 +232,8 @@ func (t *tracer) buildRequestContext(ctx context.Context) context.Context {
 
 	// It might be wise to encode more additional information into the context.
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    traceHex,
-		SpanID:     spanHex,
+		TraceID:    traceID,
+		SpanID:     spanID,
 		TraceFlags: traceFlags,
 	})
 
@@ -246,7 +245,7 @@ func (t *tracer) buildRequestContext(ctx context.Context) context.Context {
 }
 
 // NewClient returns a new tracing client.
-func NewClient(ctx context.Context, namespace coretrace.TaggedTracerNamespace, endpoint string, insecureSkipVerify bool) (Client, ClientTracerProvider, ClientTracer, error) {
+func NewClient(ctx context.Context, namespace coretrace.TaggedTracerNamespace, endpoint string, insecureSkipVerify bool, sampleRatio float64) (Client, ClientTracerProvider, ClientTracer, error) {
 	options := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(endpoint),
 	}
@@ -261,10 +260,10 @@ func NewClient(ctx context.Context, namespace coretrace.TaggedTracerNamespace, e
 	}
 
 	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(sampleRatio)),
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(newResource(namespace.ServiceName())),
 	)
-
 	return client, tp, tp.Tracer(namespace.String()), nil
 }
 
@@ -340,6 +339,11 @@ func (s managedScope) SpanID() string {
 // TraceFlags returns the trace flags of the span.
 func (s managedScope) TraceFlags() int {
 	return int(s.span.SpanContext().TraceFlags())
+}
+
+// IsSampled returns if the span is sampled.
+func (s managedScope) IsSampled() bool {
+	return s.span.SpanContext().IsSampled()
 }
 
 // limitedSpan prevents you shooting yourself in the foot by ending a span that

--- a/worker/trace/tracer.go
+++ b/worker/trace/tracer.go
@@ -147,8 +147,9 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Optio
 
 	ctx, span = t.clientTracer.Start(ctx, name, trace.WithAttributes(attrs...))
 
-	spanContext := span.SpanContext()
-	t.logger.Debugf("SpanContext: trace-id %s, span-id %s, sampled: %t", spanContext.TraceID(), spanContext.SpanID(), spanContext.IsSampled())
+	if spanContext := span.SpanContext(); spanContext.IsSampled() {
+		t.logger.Debugf("SpanContext: trace-id %s, span-id %s", spanContext.TraceID(), spanContext.SpanID())
+	}
 
 	managed := &managedSpan{
 		span:               span,

--- a/worker/trace/tracer_test.go
+++ b/worker/trace/tracer_test.go
@@ -206,10 +206,10 @@ func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
 
 func (s *tracerSuite) newTracer(c *gc.C) TrackedTracer {
 	ns := coretrace.Namespace("agent", "controller").WithTag(names.NewMachineTag("0"))
-	newClient := func(context.Context, coretrace.TaggedTracerNamespace, string, bool) (Client, ClientTracerProvider, ClientTracer, error) {
+	newClient := func(context.Context, coretrace.TaggedTracerNamespace, string, bool, float64) (Client, ClientTracerProvider, ClientTracer, error) {
 		return s.client, s.clientTracerProvider, s.clientTracer, nil
 	}
-	tracer, err := NewTracerWorker(context.Background(), ns, "http://meshuggah.com", false, false, s.logger, newClient)
+	tracer, err := NewTracerWorker(context.Background(), ns, "http://meshuggah.com", false, false, 0.42, s.logger, newClient)
 	c.Assert(err, jc.ErrorIsNil)
 	return tracer
 }

--- a/worker/trace/tracer_test.go
+++ b/worker/trace/tracer_test.go
@@ -198,7 +198,7 @@ func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
 	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
 	c.Check(traceID, gc.Equals, "")
 	c.Check(spanID, gc.Equals, "")
-	c.Check(flags, gc.Equals, 1)
+	c.Check(flags, gc.Equals, 0)
 
 	span := trace.SpanContextFromContext(ctx)
 	c.Check(span.IsRemote(), jc.IsTrue)

--- a/worker/trace/tracer_test.go
+++ b/worker/trace/tracer_test.go
@@ -138,9 +138,10 @@ func (s *tracerSuite) TestBuildRequestContextWithBackgroundContext(c *gc.C) {
 	ctx := w.(*tracer).buildRequestContext(context.Background())
 	c.Check(ctx, gc.NotNil)
 
-	traceID, spanID := coretrace.ScopeFromContext(ctx)
+	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
 	c.Check(traceID, gc.Equals, "")
 	c.Check(spanID, gc.Equals, "")
+	c.Check(flags, gc.Equals, 0)
 }
 
 func (s *tracerSuite) TestBuildRequestContextWithBrokenTraceID(c *gc.C) {
@@ -151,14 +152,15 @@ func (s *tracerSuite) TestBuildRequestContextWithBrokenTraceID(c *gc.C) {
 	w := s.newTracer(c)
 	defer workertest.CleanKill(c, w)
 
-	ctx := coretrace.WithTraceScope(context.Background(), "foo", "bar")
+	ctx := coretrace.WithTraceScope(context.Background(), "foo", "bar", 0)
 
 	ctx = w.(*tracer).buildRequestContext(ctx)
 	c.Check(ctx, gc.NotNil)
 
-	traceID, spanID := coretrace.ScopeFromContext(ctx)
+	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
 	c.Check(traceID, gc.Equals, "")
 	c.Check(spanID, gc.Equals, "")
+	c.Check(flags, gc.Equals, 0)
 }
 
 func (s *tracerSuite) TestBuildRequestContextWithBrokenSpanID(c *gc.C) {
@@ -169,14 +171,15 @@ func (s *tracerSuite) TestBuildRequestContextWithBrokenSpanID(c *gc.C) {
 	w := s.newTracer(c)
 	defer workertest.CleanKill(c, w)
 
-	ctx := coretrace.WithTraceScope(context.Background(), "80f198ee56343ba864fe8b2a57d3eff7", "bar")
+	ctx := coretrace.WithTraceScope(context.Background(), "80f198ee56343ba864fe8b2a57d3eff7", "bar", 0)
 
 	ctx = w.(*tracer).buildRequestContext(ctx)
 	c.Check(ctx, gc.NotNil)
 
-	traceID, spanID := coretrace.ScopeFromContext(ctx)
+	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
 	c.Check(traceID, gc.Equals, "")
 	c.Check(spanID, gc.Equals, "")
+	c.Check(flags, gc.Equals, 0)
 }
 
 func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
@@ -187,14 +190,15 @@ func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
 	w := s.newTracer(c)
 	defer workertest.CleanKill(c, w)
 
-	ctx := coretrace.WithTraceScope(context.Background(), "80f198ee56343ba864fe8b2a57d3eff7", "ff00000000000000")
+	ctx := coretrace.WithTraceScope(context.Background(), "80f198ee56343ba864fe8b2a57d3eff7", "ff00000000000000", 1)
 
 	ctx = w.(*tracer).buildRequestContext(ctx)
 	c.Check(ctx, gc.NotNil)
 
-	traceID, spanID := coretrace.ScopeFromContext(ctx)
+	traceID, spanID, flags := coretrace.ScopeFromContext(ctx)
 	c.Check(traceID, gc.Equals, "")
 	c.Check(spanID, gc.Equals, "")
+	c.Check(flags, gc.Equals, 1)
 
 	span := trace.SpanContextFromContext(ctx)
 	c.Check(span.IsRemote(), jc.IsTrue)

--- a/worker/trace/worker.go
+++ b/worker/trace/worker.go
@@ -45,6 +45,7 @@ type WorkerConfig struct {
 	Endpoint           string
 	InsecureSkipVerify bool
 	StackTracesEnabled bool
+	SampleRatio        float64
 }
 
 // Validate ensures that the config values are valid.
@@ -257,6 +258,7 @@ func (w *tracerWorker) initTracer(namespace coretrace.TaggedTracerNamespace) err
 			w.cfg.Endpoint,
 			w.cfg.InsecureSkipVerify,
 			w.cfg.StackTracesEnabled,
+			w.cfg.SampleRatio,
 			w.cfg.Logger,
 			NewClient,
 		)

--- a/worker/trace/worker_test.go
+++ b/worker/trace/worker_test.go
@@ -170,7 +170,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		Clock:    s.clock,
 		Logger:   s.logger,
 		Endpoint: "https://meshuggah.com",
-		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, Logger, NewClientFunc) (TrackedTracer, error) {
+		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, float64, Logger, NewClientFunc) (TrackedTracer, error) {
 			atomic.AddInt64(&s.called, 1)
 			return s.trackedTracer, nil
 		},

--- a/worker/upgradedatabase/agent_mock_test.go
+++ b/worker/upgradedatabase/agent_mock_test.go
@@ -406,6 +406,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -897,6 +911,20 @@ func (mr *MockConfigSetterMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfigSetter) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -1059,6 +1087,18 @@ func (m *MockConfigSetter) SetOpenTelemetryInsecure(arg0 bool) {
 func (mr *MockConfigSetterMockRecorder) SetOpenTelemetryInsecure(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetryInsecure), arg0)
+}
+
+// SetOpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) SetOpenTelemetrySampleRatio(arg0 float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOpenTelemetrySampleRatio", arg0)
+}
+
+// SetOpenTelemetrySampleRatio indicates an expected call of SetOpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) SetOpenTelemetrySampleRatio(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetrySampleRatio), arg0)
 }
 
 // SetOpenTelemetryStackTraces mocks base method.

--- a/worker/upgradesteps/agent_mock_test.go
+++ b/worker/upgradesteps/agent_mock_test.go
@@ -406,6 +406,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -897,6 +911,20 @@ func (mr *MockConfigSetterMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfigSetter) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -1059,6 +1087,18 @@ func (m *MockConfigSetter) SetOpenTelemetryInsecure(arg0 bool) {
 func (mr *MockConfigSetterMockRecorder) SetOpenTelemetryInsecure(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetryInsecure), arg0)
+}
+
+// SetOpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) SetOpenTelemetrySampleRatio(arg0 float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOpenTelemetrySampleRatio", arg0)
+}
+
+// SetOpenTelemetrySampleRatio indicates an expected call of SetOpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) SetOpenTelemetrySampleRatio(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetrySampleRatio), arg0)
 }
 
 // SetOpenTelemetryStackTraces mocks base method.

--- a/worker/upgradestepsmachine/agent_mock_test.go
+++ b/worker/upgradestepsmachine/agent_mock_test.go
@@ -406,6 +406,20 @@ func (mr *MockConfigMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfig)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfig) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfig)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfig) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -897,6 +911,20 @@ func (mr *MockConfigSetterMockRecorder) OpenTelemetryInsecure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetryInsecure))
 }
 
+// OpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) OpenTelemetrySampleRatio() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenTelemetrySampleRatio")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// OpenTelemetrySampleRatio indicates an expected call of OpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) OpenTelemetrySampleRatio() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).OpenTelemetrySampleRatio))
+}
+
 // OpenTelemetryStackTraces mocks base method.
 func (m *MockConfigSetter) OpenTelemetryStackTraces() bool {
 	m.ctrl.T.Helper()
@@ -1059,6 +1087,18 @@ func (m *MockConfigSetter) SetOpenTelemetryInsecure(arg0 bool) {
 func (mr *MockConfigSetterMockRecorder) SetOpenTelemetryInsecure(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetryInsecure", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetryInsecure), arg0)
+}
+
+// SetOpenTelemetrySampleRatio mocks base method.
+func (m *MockConfigSetter) SetOpenTelemetrySampleRatio(arg0 float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOpenTelemetrySampleRatio", arg0)
+}
+
+// SetOpenTelemetrySampleRatio indicates an expected call of SetOpenTelemetrySampleRatio.
+func (mr *MockConfigSetterMockRecorder) SetOpenTelemetrySampleRatio(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOpenTelemetrySampleRatio", reflect.TypeOf((*MockConfigSetter)(nil).SetOpenTelemetrySampleRatio), arg0)
 }
 
 // SetOpenTelemetryStackTraces mocks base method.


### PR DESCRIPTION
As discussed in person at the last sprint, we want to be able to
turn down the sample ratio. This is a crude float64 value at the moment.
In the long run, we should implement a type that can be decoded into
the sampling ruleset.

Luckily, we're starting to keep all the controller config values as
a string, so moving over to the new rule set would be easy.

The code just follows the existing open telemetry controller config
properties.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


### Setting up tempo

It assumes that docker (docker-compose) is correctly installed:

```sh
$ git clone https://github.com/grafana/tempo.git
$ cd tempo/example/docker-compose/local
$ docker compose up -d
```

### Juju

Replace `<IP ADDRESS>` with your host machine (not localhost) address (`lxc info | yq ".environment | .addresses"` is a good place to start looking)

```sh
$ juju bootstrap lxd test --build-agent --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=<IP ADDRESS>:4317"  --config="open-telemetry-sample-ratio=1.0"
```

### Turn sample ratio

```sh
$ juju controller-config "open-telemetry-sample-ratio=.5"
$ juju ssh -m controller 0
$ sudo cat /var/lib/juju/agents/machine-0/agents.conf
```


## Links

**Jira card:** JUJU-[XXXX]
