### PR TITLE
Add snap access to .local

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ apps:
       - ssh-keys
       - lxd
       # Needed so that juju can still use the real ~/.local/share/juju.
-      - dot-local-share-juju
+      - dot-local
       # Needed to read lxd config.
       - config-lxd
       # Needed to read ~/.kube, ~/.novarc, ~/.aws etc.
@@ -490,10 +490,10 @@ plugs:
     content: microk8s
     target: $SNAP_DATA/microk8s
 
-  dot-local-share-juju:
+  dot-local:
     interface: personal-files
     write:
-      - $HOME/.local/share/juju
+      - $HOME/.local
 
   config-lxd:
     interface: personal-files


### PR DESCRIPTION
So that a missing `~/.local/share/juju` can be created.

Closes: https://bugs.launchpad.net/juju/+bug/1988355

Installing the strictly confined snap on a new machine fails because the snap does not have access to `~/.local/share` and cannot create `~/.local/share/juju`. This change adds access.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

In a new VM, install any `>= juju-3.0`:
```console
$ juju clouds
ERROR cannot create juju home directory: mkdir /home/ubuntu/.local: permission denied
WARNING Installing Juju in a strictly confined Snap. To ensure correct operation, create the ~/.local/share/juju directory manually.
```

Installing the new snap:
```console
$ snap connections juju | grep dot-local
personal-files  juju:dot-local             -                -
$ sudo snap connect juju:dot-local
```

## Documentation changes

None

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1988355

**Jira card:** JUJU-[XXXX]

*Insert other relevant links here.*