### PR TITLE
Update deploy tests

### DIFF
--- a/tests/suites/deploy/bundles/basic-openstack.yaml
+++ b/tests/suites/deploy/bundles/basic-openstack.yaml
@@ -41,7 +41,7 @@ relations:
     - mysql:shared-db
   - - nova-cloud-controller:neutron-api
     - neutron-api:neutron-api
-series: xenial
+series: focal
 applications:
   glance:
     annotations:
@@ -50,7 +50,7 @@ applications:
     charm: cs:glance
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   keystone:
     annotations:
@@ -60,7 +60,7 @@ applications:
     num_units: 1
     options:
       admin-password: openstack
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   mysql:
     annotations:
@@ -80,7 +80,7 @@ applications:
     options:
       neutron-security-groups: true
       overlay-network-type: "gre vxlan"
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       flat-network-providers: physnet1
   neutron-gateway:
     annotations:
@@ -89,7 +89,7 @@ applications:
     charm: cs:neutron-gateway
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
       dns-servers: 10.101.0.1
   neutron-openvswitch:
@@ -106,7 +106,7 @@ applications:
     num_units: 1
     options:
       network-manager: Neutron
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   nova-compute:
     annotations:
@@ -117,7 +117,7 @@ applications:
     options:
       enable-live-migration: False
       enable-resize: False
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
   rabbitmq-server:
     annotations:
       gui-x: '500'

--- a/tests/suites/deploy/charms/lxd-profile-alt/manifest.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/manifest.yaml
@@ -1,0 +1,26 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 20.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 18.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 16.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 12.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
@@ -13,6 +13,7 @@ tags:
   - application_development
 subordinate: false
 series:
+  - jammy
   - focal
   - bionic
   - xenial

--- a/tests/suites/deploy/charms/lxd-profile/manifest.yaml
+++ b/tests/suites/deploy/charms/lxd-profile/manifest.yaml
@@ -1,0 +1,26 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 20.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 18.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 16.04/stable
+    architectures:
+      - amd64
+      - arm64
+  - name: ubuntu
+    channel: 12.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -322,11 +322,12 @@ test_deploy_bundles() {
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_profile_bundle_openstack"
-			run "run_deploy_lxd_profile_bundle"
+			echo "==> TEST SKIPPED: deploy_lxd_profile_bundle - tests for non LXD only"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_profile_bundle_openstack - tests for LXD only"
-			echo "==> TEST SKIPPED: deploy_lxd_profile_bundle - tests for LXD only"
+			run "run_deploy_lxd_profile_bundle"
+
 			;;
 		esac
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -45,7 +45,10 @@ run_deploy_lxd_profile_charm() {
 
 	ensure "test-deploy-lxd-profile" "${file}"
 
-	juju deploy juju-qa-lxd-profile-without-devices
+	# This charm deploys to Xenial by default, which doesn't
+	# always result in a machine which becomes fully deployed
+	# with the lxd provider.
+	juju deploy juju-qa-lxd-profile-without-devices --series jammy
 	wait_for "lxd-profile-without-devices" "$(idle_condition "lxd-profile-without-devices")"
 
 	juju status --format=json | jq '.machines | .["0"] | .["lxd-profiles"] | keys[0]' | check "juju-test-deploy-lxd-profile-lxd-profile"
@@ -60,7 +63,10 @@ run_deploy_lxd_profile_charm_container() {
 
 	ensure "test-deploy-lxd-profile-container" "${file}"
 
-	juju deploy juju-qa-lxd-profile-without-devices --to lxd
+	# This charm deploys to Xenial by default, which doesn't
+	# always result in a machine which becomes fully deployed
+	# with the lxd provider.
+	juju deploy juju-qa-lxd-profile-without-devices --to lxd --series jammy
 	wait_for "lxd-profile-without-devices" "$(idle_condition "lxd-profile-without-devices")"
 
 	juju status --format=json | jq '.machines | .["0"] | .containers | .["0/lxd/0"] | .["lxd-profiles"] | keys[0]' |
@@ -269,8 +275,6 @@ test_deploy_charms() {
 
 		run "run_deploy_charm"
 		run "run_deploy_specific_series"
-		run "run_deploy_lxd_to_container"
-		run "run_deploy_lxd_profile_charm_container"
 		run "run_resolve_charm"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
@@ -278,11 +282,15 @@ test_deploy_charms() {
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
 			run "run_deploy_local_lxd_profile_charm"
+			echo "==> TEST SKIPPED: deploy_lxd_to_container - tests for non LXD only"
+			echo "==> TEST SKIPPED: deploy_lxd_profile_charm_container - tests for non LXD only"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"
+			run "run_deploy_lxd_to_container"
+			run "run_deploy_lxd_profile_charm_container"
 			;;
 		esac
 	)

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -16,7 +16,6 @@ test_deploy_os() {
 			# https://wiki.centos.org/Cloud/AWS
 			#
 			run "run_deploy_centos7"
-			run "run_deploy_centos8"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_centos - tests for AWS only"
@@ -58,35 +57,4 @@ run_deploy_centos7() {
 
 	destroy_model "${name}"
 	destroy_model "test-deploy-centos-west2"
-}
-
-run_deploy_centos8() {
-	echo
-
-	echo "==> Checking for dependencies"
-	check_juju_dependencies metadata
-
-	name="test-deploy-centos8"
-	file="${TEST_DIR}/${name}.log"
-
-	ensure "${name}" "${file}"
-
-	#
-	# Images have been setup and and subscribed for juju-qa aws
-	# in us-east-1.  Take care editing the details.
-	#
-	juju metadata add-image --series centos8 ami-0d6e9a57f6259ba3a
-
-	#
-	# The disk size must be >= 10G to cover the image above.
-	# Ensure we use an instance with enough disk space.
-	#
-	juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos8 --constraints root-disk=10G
-
-	series=$(juju status --format=json | jq '.applications."dummy-sink".series')
-	echo "$series" | check "centos8"
-
-	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
-
-	destroy_model "${name}"
 }


### PR DESCRIPTION
While trying to test a bug fix change, there was frustration that the tests didn't work for easily fixed reasons:

- Charms not supporting the series the test was attempting to use
- Nested containers on lxd do not work consistently, move the provider the test runs on.
- Stopped testing centos8 deploy, it's unsupported and no longer available on aws.

None of these change the intention of what is being tested.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Please run the tests - at least one of these changes is due to neither the author nor reviewer running them. A series unsupported by the charm was specified and thus the test failed. 

```sh
$ juju bootstrap localhost testing --agent-version 2.9.45
$ (cd tests/ ; ./main.sh -l testing -v deploy)

$ juju bootstrap aws aws-testing --agent-version 2.9.45
$ (cd tests/ ; ./main.sh -l aws-testing -v deploy)
```

## Links

JUJU-4932