### PR TITLE
Drop unnecessary reference to curl Series

### DIFF
--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -238,8 +238,7 @@ func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocke
 		// TODO 6-dec-2022
 		// Update check once charm's ValidateSchema rejects charm store charms.
 		if !charm.CharmHub.Matches(curl.Schema) && !charm.Local.Matches(curl.Schema) {
-			c := curl.WithSeries("").WithArchitecture("")
-			result.Add(c.String())
+			result.Add(curl.Name)
 		}
 	}
 	if !result.IsEmpty() {


### PR DESCRIPTION
This reduces the surface area where we interact with a charm URL series, which will make replacing it easier in the future

NOTE: This validation check is slightly broken (in a safe way) in 3.4 anyway, so this code is actually inaccessible. `ParseURL` for charmstore charms before the check is even run. So in reality this code is inaccessible

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju-3.4 bootstrap lxd lxd-3.4
$ juju-2.9 bootstrap lxd lxd-2.9
$ juju-2.9 deploy cs:ubuntu --series focal
$ juju-2.9 migrate default lxd-3.4 
$ juju-2.9 status
Model    Controller  Cloud/Region         Version   SLA          Timestamp  Notes
default  lxd         localhost/localhost  2.9.46.1  unsupported  12:43:13Z  migrating: aborted, removing model from target controller: model data transfer failed, failed to import model into ta...

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/2*  active    idle   2        10.219.211.142         

Machine  State    Address         Inst id        Series  AZ  Message
2        started  10.219.211.142  juju-3f7619-2  focal       Running

$ juju-2.9 debug-log -m controller
...
machine-0: 12:39:26 ERROR juju.worker.migrationmaster.cd0164 model data transfer failed, failed to import model into target controller: applications: ubuntu: cannot parse URL "cs:ubuntu-24": schema "cs" not valid (not valid)
machine-0: 12:39:26 INFO juju.worker.migrationmaster.cd0164 setting migration phase to ABORT
...
```