### PR TITLE
Drop curl.Series check

### DIFF
--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -270,7 +270,7 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}
 	_, baseSupportedErr := corecharm.BaseForCharm(deployedBase, supportedBases)
-	if !r.forceBase && !deployedBase.Empty() && newURL.Series == "" && baseSupportedErr != nil {
+	if !r.forceBase && !deployedBase.Empty() && baseSupportedErr != nil {
 		bases := []string{"no bases"}
 		if len(supportedBases) > 0 {
 			bases = transform.Slice(supportedBases, func(in corebase.Base) string { return in.DisplayString() })


### PR DESCRIPTION
After discussions with @hmlanigan we discovered this check was a leftover remanent from when we used to support charmstore. Since we no longer do so, this part of the check is redundant and can be removed

This will act as a step towards replacing the series part of charm url with a base. Removing un-necessary references to `.Series` will make this process far easier

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
./main.sh -v refresh
```

```
$ mkdir kafka
$ cd kafka
$ juju download kafka
$ unzip kafka_r123.charm
(edit manifest.yaml such that:)
$ cat manifest.yaml
analysis:
  attributes:
  - name: language
    result: python
  - name: framework
    result: operator
bases:
- architectures:
  - amd64
  channel: '20.04'
  name: ubuntu
charmcraft-started-at: '2023-05-23T17:31:52.708211Z'
charmcraft-version: 2.3.0

$ cd ..
$ juju deploy ./kafka
Located local charm "kafka", revision 0
Deploying "kafka" from local charm "kafka", revision 0 on ubuntu@20.04/stable

$ juju refresh --switch kafka kafka --channel 3
ERROR cannot upgrade from single base "ubuntu@20.04" charm to a charm supporting ["ubuntu@22.04"]. Use --force-series to override.

$ juju refresh --switch kafka kafka --channel 3 --force-series
Added charm-hub charm "kafka", revision 123 in channel 3/stable, to the model
no change to endpoints in space "alpha": certificates, cluster, cos-agent, kafka-client, restart, trusted-ca, trusted-certificate, zookeeper
```