### PR TITLE
Wire up trace uniter

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1129,7 +1129,7 @@ func (srv *Server) serveConn(
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
 		ctx,
-		coretrace.Namespace("apiserver", modelUUID),
+		coretrace.Namespace("apiserver", resolvedModelUUID),
 	)
 	if err != nil {
 		logger.Infof("failed to get tracer for model %q: %v", modelUUID, err)

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -394,7 +394,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
-			Kind:            coretrace.UnitKind,
+			Kind:            coretrace.KindUnit,
 		}),
 
 		// The CAAS unit termination worker handles SIGTERM from the container runtime.

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -49,6 +49,7 @@ import (
 	"github.com/juju/juju/internal/worker/s3caller"
 	"github.com/juju/juju/internal/worker/secretsdrainworker"
 	"github.com/juju/juju/internal/worker/simplesignalhandler"
+	"github.com/juju/juju/internal/worker/trace"
 	"github.com/juju/juju/internal/worker/uniter"
 	"github.com/juju/juju/internal/worker/upgradestepsmachine"
 )
@@ -374,6 +375,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			ModelType:                    model.CAAS,
 			APICallerName:                apiCallerName,
 			S3CallerName:                 s3CallerName,
+			TraceName:                    traceName,
 			MachineLock:                  config.MachineLock,
 			Clock:                        config.Clock,
 			LeadershipTrackerName:        leadershipTrackerName,
@@ -385,6 +387,13 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			EnforcedCharmModifiedVersion: config.CharmModifiedVersion,
 			ContainerNames:               config.ContainerNames,
 		}))),
+
+		traceName: trace.Manifold(trace.ManifoldConfig{
+			AgentName:       agentName,
+			Clock:           config.Clock,
+			Logger:          loggo.GetLogger("juju.worker.trace"),
+			NewTracerWorker: trace.NewTracerWorker,
+		}),
 
 		// The CAAS unit termination worker handles SIGTERM from the container runtime.
 		caasUnitTerminationWorker: ifNotMigrating(ifNotDead(caasunitterminationworker.Manifold(caasunitterminationworker.ManifoldConfig{
@@ -446,6 +455,7 @@ const (
 	s3CallerName         = "s3-caller"
 	uniterName           = "uniter"
 	logSenderName        = "log-sender"
+	traceName            = "trace"
 
 	charmDirName          = "charm-dir"
 	leadershipTrackerName = "leadership-tracker"

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/observability/probe"
 	proxy "github.com/juju/juju/internal/proxy/config"
 	"github.com/juju/juju/internal/upgrades"
@@ -393,6 +394,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
+			Kind:            coretrace.UnitKind,
 		}),
 
 		// The CAAS unit termination worker handles SIGTERM from the container runtime.

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -72,6 +72,8 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"not-dead-flag",
 
 		"signal-handler",
+
+		"trace",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -120,6 +122,8 @@ func (s *ManifoldsSuite) TestManifoldNamesColocatedController(c *gc.C) {
 		"not-dead-flag",
 
 		"signal-handler",
+
+		"trace",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -153,6 +157,8 @@ func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 		"not-dead-flag",
 		"signal-handler",
 		"caas-zombie-prober",
+
+		"trace",
 	)
 	config := unit.ManifoldsConfig{}
 	manifolds := unit.Manifolds(config)
@@ -213,6 +219,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
+		"trace",
 	},
 
 	"log-sender": {
@@ -294,6 +301,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"s3-caller",
 		"uniter",
 		"not-dead-flag",
+		"trace",
 	},
 	"upgrade-steps-flag": {
 		"upgrade-steps-gate",
@@ -326,6 +334,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"s3-caller",
 		"uniter",
 		"not-dead-flag",
+		"trace",
 	},
 	"caas-units-manager": {
 		"agent",
@@ -364,5 +373,8 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"migration-fortress",
 		"migration-inactive-flag",
+	},
+	"trace": {
+		"agent",
 	},
 }

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/presence"
+	coretrace "github.com/juju/juju/core/trace"
 	containerbroker "github.com/juju/juju/internal/container/broker"
 	"github.com/juju/juju/internal/container/lxd"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
@@ -604,6 +605,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
+			Kind:            coretrace.ControllerKind,
 		}),
 
 		httpServerArgsName: httpserverargs.Manifold(httpserverargs.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -605,7 +605,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
-			Kind:            coretrace.ControllerKind,
+			Kind:            coretrace.KindController,
 		}),
 
 		httpServerArgsName: httpserverargs.Manifold(httpserverargs.ManifoldConfig{

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -182,11 +182,19 @@ func (ns TracerNamespace) ShortNamespace() string {
 	if ns.Namespace == controllerNamespace {
 		return ns.Namespace
 	}
+	// If the namespace is less than 6 characters then return the whole
+	// namespace.
+	if len(ns.Namespace) < 6 {
+		return ns.Namespace
+	}
 	return ns.Namespace[:6]
 }
 
 // String returns a short representation of the namespace.
 func (ns TracerNamespace) String() string {
+	if ns.Namespace == "" {
+		return ns.Worker
+	}
 	return fmt.Sprintf("%s:%s", ns.Worker, ns.Namespace)
 }
 

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -217,7 +217,11 @@ func (ns TaggedTracerNamespace) String() string {
 type Kind string
 
 const (
-	ControllerKind Kind = "controller"
-	UnitKind       Kind = "unit"
-	ClientKind     Kind = "client"
+	KindController Kind = "controller"
+	KindUnit       Kind = "unit"
+	KindClient     Kind = "client"
 )
+
+func (k Kind) String() string {
+	return string(k)
+}

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -190,26 +190,34 @@ func (ns TracerNamespace) String() string {
 	return fmt.Sprintf("%s:%s", ns.Worker, ns.Namespace)
 }
 
-// WithTag returns a new TaggedTracerNamespace.
-func (ns TracerNamespace) WithTag(tag names.Tag) TaggedTracerNamespace {
+// WithTagAndKind returns a new TaggedTracerNamespace.
+func (ns TracerNamespace) WithTagAndKind(tag names.Tag, kind Kind) TaggedTracerNamespace {
 	return TaggedTracerNamespace{
 		TracerNamespace: ns,
 		Tag:             tag,
+		Kind:            kind,
 	}
 }
 
 // TaggedTracerNamespace is a TracerNamespace with a tag.
 type TaggedTracerNamespace struct {
 	TracerNamespace
-	Tag names.Tag
-}
-
-func (ns TaggedTracerNamespace) ServiceName() string {
-	// TODO (stickupkid): This won't always be jujud, work out the right
-	// agent binary.
-	return fmt.Sprintf("jujud-%s", ns.ShortNamespace())
+	Tag  names.Tag
+	Kind Kind
 }
 
 func (ns TaggedTracerNamespace) String() string {
-	return fmt.Sprintf("%s:%s:%s", ns.Tag.String(), ns.Worker, ns.Namespace)
+	return fmt.Sprintf("%s:%s", ns.Kind, ns.ShortNamespace())
 }
+
+// Kind represents the source of the trace. Either the trace will come
+// from a controller, unit or client.
+// We can expand on these later, for example we can add machine or worker kinds,
+// but for now this is enough.
+type Kind string
+
+const (
+	ControllerKind Kind = "controller"
+	UnitKind       Kind = "unit"
+	ClientKind     Kind = "client"
+)

--- a/core/trace/tracer_test.go
+++ b/core/trace/tracer_test.go
@@ -4,6 +4,8 @@
 package trace
 
 import (
+	"fmt"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
@@ -23,4 +25,70 @@ func (nameSuite) TestNameFromFuncMethod(c *gc.C) {
 
 func (nameSuite) TestControllerNamespaceConstant(c *gc.C) {
 	c.Assert(controllerNamespace, gc.Equals, database.ControllerNS)
+}
+
+type namespaceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&namespaceSuite{})
+
+func (namespaceSuite) TestNamespaceShortNamespace(c *gc.C) {
+	tests := []struct {
+		workerName string
+		namespace  string
+		expected   string
+	}{{
+		workerName: "foo",
+		namespace:  "bar",
+		expected:   "bar",
+	}, {
+		workerName: "foo",
+		namespace:  "",
+		expected:   "",
+	}, {
+		workerName: "foo",
+		namespace:  "deadbeef",
+		expected:   "deadbe",
+	}, {
+		workerName: "foo",
+		namespace:  controllerNamespace,
+		expected:   controllerNamespace,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.workerName)
+
+		ns := Namespace(test.workerName, test.namespace)
+		c.Assert(ns.ShortNamespace(), gc.Equals, test.expected)
+	}
+}
+
+func (namespaceSuite) TestNamespaceString(c *gc.C) {
+	tests := []struct {
+		workerName string
+		namespace  string
+		expected   string
+	}{{
+		workerName: "foo",
+		namespace:  "bar",
+		expected:   "foo:bar",
+	}, {
+		workerName: "foo",
+		namespace:  "",
+		expected:   "foo",
+	}, {
+		workerName: "foo",
+		namespace:  "deadbeef",
+		expected:   "foo:deadbeef",
+	}, {
+		workerName: "foo",
+		namespace:  controllerNamespace,
+		expected:   fmt.Sprintf("foo:%s", controllerNamespace),
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.workerName)
+
+		ns := Namespace(test.workerName, test.namespace)
+		c.Assert(ns.String(), gc.Equals, test.expected)
+	}
 }

--- a/internal/worker/agentconfigupdater/manifold_test.go
+++ b/internal/worker/agentconfigupdater/manifold_test.go
@@ -407,6 +407,10 @@ func (mc *mockConfig) Tag() names.Tag {
 	return mc.tag
 }
 
+func (mc *mockConfig) Model() names.ModelTag {
+	return testing.ModelTag
+}
+
 func (mc *mockConfig) Controller() names.ControllerTag {
 	return testing.ControllerTag
 }

--- a/internal/worker/deployer/nested.go
+++ b/internal/worker/deployer/nested.go
@@ -491,6 +491,11 @@ func (c *nestedContext) createUnitAgentConfig(tag names.UnitTag, initialPassword
 
 			AgentLogfileMaxBackups: c.agentConfig.AgentLogfileMaxBackups(),
 			AgentLogfileMaxSizeMB:  c.agentConfig.AgentLogfileMaxSizeMB(),
+
+			OpenTelemetryEnabled:     c.agentConfig.OpenTelemetryEnabled(),
+			OpenTelemetryEndpoint:    c.agentConfig.OpenTelemetryEndpoint(),
+			OpenTelemetryInsecure:    c.agentConfig.OpenTelemetryInsecure(),
+			OpenTelemetryStackTraces: c.agentConfig.OpenTelemetryStackTraces(),
 		})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/deployer/nested.go
+++ b/internal/worker/deployer/nested.go
@@ -496,6 +496,7 @@ func (c *nestedContext) createUnitAgentConfig(tag names.UnitTag, initialPassword
 			OpenTelemetryEndpoint:    c.agentConfig.OpenTelemetryEndpoint(),
 			OpenTelemetryInsecure:    c.agentConfig.OpenTelemetryInsecure(),
 			OpenTelemetryStackTraces: c.agentConfig.OpenTelemetryStackTraces(),
+			OpenTelemetrySampleRatio: c.agentConfig.OpenTelemetrySampleRatio(),
 		})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/internal/worker/retrystrategy"
 	"github.com/juju/juju/internal/worker/s3caller"
 	"github.com/juju/juju/internal/worker/secretsdrainworker"
+	"github.com/juju/juju/internal/worker/trace"
 	"github.com/juju/juju/internal/worker/uniter"
 	"github.com/juju/juju/internal/worker/upgrader"
 )
@@ -234,6 +235,7 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			ModelType:             model.IAAS,
 			APICallerName:         apiCallerName,
 			S3CallerName:          s3CallerName,
+			TraceName:             traceName,
 			MachineLock:           config.MachineLock,
 			Clock:                 config.Clock,
 			LeadershipTrackerName: leadershipTrackerName,
@@ -242,6 +244,13 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			TranslateResolverErr:  uniter.TranslateFortressErrors,
 			Logger:                config.LoggingContext.GetLogger("juju.worker.uniter"),
 		})),
+
+		traceName: trace.Manifold(trace.ManifoldConfig{
+			AgentName:       agentName,
+			Clock:           config.Clock,
+			Logger:          loggo.GetLogger("juju.worker.trace"),
+			NewTracerWorker: trace.NewTracerWorker,
+		}),
 
 		// TODO (mattyw) should be added to machine agent.
 		metricSpoolName: ifNotMigrating(spool.Manifold(spool.ManifoldConfig{
@@ -326,6 +335,7 @@ const (
 	hookRetryStrategyName = "hook-retry-strategy"
 	uniterName            = "uniter"
 	upgraderName          = "upgrader"
+	traceName             = "trace"
 
 	metricSpoolName   = "metric-spool"
 	meterStatusName   = "meter-status"

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -251,7 +251,7 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
-			Kind:            coretrace.UnitKind,
+			Kind:            coretrace.KindUnit,
 		}),
 
 		// TODO (mattyw) should be added to machine agent.

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -20,6 +20,7 @@ import (
 	commonapi "github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/agent"
 	"github.com/juju/juju/internal/worker/apiaddressupdater"
@@ -250,6 +251,7 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			Clock:           config.Clock,
 			Logger:          loggo.GetLogger("juju.worker.trace"),
 			NewTracerWorker: trace.NewTracerWorker,
+			Kind:            coretrace.UnitKind,
 		}),
 
 		// TODO (mattyw) should be added to machine agent.

--- a/internal/worker/deployer/unit_manifolds_test.go
+++ b/internal/worker/deployer/unit_manifolds_test.go
@@ -64,6 +64,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"uniter",
 		"upgrader",
 		"secret-drain-worker",
+		"trace",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -85,6 +86,7 @@ func (s *ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",
+		"trace",
 	)
 	manifolds := deployer.UnitManifolds(s.config)
 	for name, manifold := range manifolds {
@@ -226,6 +228,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"leadership-tracker",
 		"migration-fortress",
 		"migration-inactive-flag",
+		"trace",
 	},
 
 	"upgrader": {
@@ -239,5 +242,8 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"migration-fortress",
 		"migration-inactive-flag",
+	},
+	"trace": {
+		"agent",
 	},
 }

--- a/internal/worker/lease/manifold.go
+++ b/internal/worker/lease/manifold.go
@@ -103,14 +103,16 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
-	tracer, err := tracerGetter.GetTracer(stdcontext.TODO(), coretrace.Namespace("leaseexpiry", database.ControllerNS))
+	currentConfig := agent.CurrentConfig()
+
+	tracer, err := tracerGetter.GetTracer(stdcontext.TODO(), coretrace.Namespace("leaseexpiry", currentConfig.Model().Id()))
 	if err != nil {
 		tracer = coretrace.NoopTracer{}
 	}
 
 	store := s.config.NewStore(dbGetter, s.config.Logger)
 
-	controllerUUID := agent.CurrentConfig().Controller().Id()
+	controllerUUID := currentConfig.Controller().Id()
 	w, err := s.config.NewWorker(ManagerConfig{
 		Secretary:            SecretaryFinder(controllerUUID),
 		Store:                store,

--- a/internal/worker/trace/manifold.go
+++ b/internal/worker/trace/manifold.go
@@ -43,6 +43,7 @@ type ManifoldConfig struct {
 	Clock           clock.Clock
 	Logger          Logger
 	NewTracerWorker TracerWorkerFunc
+	Kind            coretrace.Kind
 }
 
 // Validate validates the manifold configuration.
@@ -58,6 +59,9 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.NewTracerWorker == nil {
 		return errors.NotValidf("nil NewTracerWorker")
+	}
+	if cfg.Kind == "" {
+		return errors.NotValidf("empty Kind")
 	}
 	return nil
 }
@@ -99,6 +103,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Logger:             config.Logger,
 				NewTracerWorker:    config.NewTracerWorker,
 				Tag:                currentConfig.Tag(),
+				Kind:               config.Kind,
 				Endpoint:           endpoint,
 				InsecureSkipVerify: currentConfig.OpenTelemetryInsecure(),
 				StackTracesEnabled: currentConfig.OpenTelemetryStackTraces(),

--- a/internal/worker/trace/manifold_test.go
+++ b/internal/worker/trace/manifold_test.go
@@ -52,6 +52,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, float64, Logger, NewClientFunc) (TrackedTracer, error) {
 			return nil, nil
 		},
+		Kind: coretrace.ControllerKind,
 	}
 }
 

--- a/internal/worker/trace/manifold_test.go
+++ b/internal/worker/trace/manifold_test.go
@@ -56,7 +56,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewTracerWorker: func(context.Context, coretrace.TaggedTracerNamespace, string, bool, bool, float64, Logger, NewClientFunc) (TrackedTracer, error) {
 			return nil, nil
 		},
-		Kind: coretrace.ControllerKind,
+		Kind: coretrace.KindController,
 	}
 }
 

--- a/internal/worker/trace/manifold_test.go
+++ b/internal/worker/trace/manifold_test.go
@@ -42,6 +42,10 @@ func (s *manifoldSuite) TestValidateConfig(c *gc.C) {
 	cfg = s.getConfig()
 	cfg.NewTracerWorker = nil
 	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.Kind = coretrace.Kind("")
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {

--- a/internal/worker/trace/tracer.go
+++ b/internal/worker/trace/tracer.go
@@ -93,7 +93,7 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Optio
 		attribute.String("namespace", t.namespace.Namespace),
 		attribute.String("namespace.short", t.namespace.ShortNamespace()),
 		attribute.String("namespace.tag", t.namespace.Tag.String()),
-		attribute.String("namespace.worker", t.namespace.Worker),
+		attribute.String("namespace.kind", string(t.namespace.Kind)),
 	)
 
 	ctx, span = t.clientTracer.Start(ctx, name, trace.WithAttributes(attrs...))

--- a/internal/worker/trace/tracer.go
+++ b/internal/worker/trace/tracer.go
@@ -92,8 +92,8 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Optio
 	attrs = append(attrs,
 		attribute.String("namespace", t.namespace.Namespace),
 		attribute.String("namespace.short", t.namespace.ShortNamespace()),
-		attribute.String("namespace.tag", t.namespace.Tag.String()),
-		attribute.String("namespace.kind", string(t.namespace.Kind)),
+		attribute.Stringer("namespace.tag", t.namespace.Tag),
+		attribute.Stringer("namespace.kind", t.namespace.Kind),
 	)
 
 	ctx, span = t.clientTracer.Start(ctx, name, trace.WithAttributes(attrs...))

--- a/internal/worker/trace/tracer_test.go
+++ b/internal/worker/trace/tracer_test.go
@@ -205,7 +205,7 @@ func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
 }
 
 func (s *tracerSuite) newTracer(c *gc.C) TrackedTracer {
-	ns := coretrace.Namespace("agent", "controller").WithTagAndKind(names.NewMachineTag("0"), coretrace.ControllerKind)
+	ns := coretrace.Namespace("agent", "controller").WithTagAndKind(names.NewMachineTag("0"), coretrace.KindController)
 	newClient := func(context.Context, coretrace.TaggedTracerNamespace, string, bool, float64) (Client, ClientTracerProvider, ClientTracer, error) {
 		return s.client, s.clientTracerProvider, s.clientTracer, nil
 	}

--- a/internal/worker/trace/tracer_test.go
+++ b/internal/worker/trace/tracer_test.go
@@ -205,7 +205,7 @@ func (s *tracerSuite) TestBuildRequestContext(c *gc.C) {
 }
 
 func (s *tracerSuite) newTracer(c *gc.C) TrackedTracer {
-	ns := coretrace.Namespace("agent", "controller").WithTag(names.NewMachineTag("0"))
+	ns := coretrace.Namespace("agent", "controller").WithTagAndKind(names.NewMachineTag("0"), coretrace.ControllerKind)
 	newClient := func(context.Context, coretrace.TaggedTracerNamespace, string, bool, float64) (Client, ClientTracerProvider, ClientTracer, error) {
 		return s.client, s.clientTracerProvider, s.clientTracer, nil
 	}

--- a/internal/worker/trace/worker.go
+++ b/internal/worker/trace/worker.go
@@ -64,7 +64,7 @@ func (c *WorkerConfig) Validate() error {
 		return errors.NotValidf("nil Tag")
 	}
 	if c.Kind == "" {
-		return errors.NotValidf("nil Kind")
+		return errors.NotValidf("nil or empty Kind")
 	}
 	// If we are enabled, then we require an endpoint.
 	if c.Endpoint == "" {

--- a/internal/worker/trace/worker.go
+++ b/internal/worker/trace/worker.go
@@ -40,7 +40,8 @@ type WorkerConfig struct {
 	Logger          Logger
 	NewTracerWorker TracerWorkerFunc
 
-	Tag names.Tag
+	Tag  names.Tag
+	Kind coretrace.Kind
 
 	Endpoint           string
 	InsecureSkipVerify bool
@@ -61,6 +62,9 @@ func (c *WorkerConfig) Validate() error {
 	}
 	if c.Tag == nil {
 		return errors.NotValidf("nil Tag")
+	}
+	if c.Kind == "" {
+		return errors.NotValidf("nil Kind")
 	}
 	// If we are enabled, then we require an endpoint.
 	if c.Endpoint == "" {
@@ -173,7 +177,7 @@ func (w *tracerWorker) Wait() error {
 
 // GetTracer returns a tracer for the given namespace.
 func (w *tracerWorker) GetTracer(ctx context.Context, namespace coretrace.TracerNamespace) (coretrace.Tracer, error) {
-	ns := namespace.WithTag(w.cfg.Tag)
+	ns := namespace.WithTagAndKind(w.cfg.Tag, w.cfg.Kind)
 	// First check if we've already got the tracer worker already running. If
 	// we have, then return out quickly. The tracerRunner is the cache, so there
 	// is no need to have a in-memory cache here.

--- a/internal/worker/trace/worker_test.go
+++ b/internal/worker/trace/worker_test.go
@@ -175,7 +175,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 			return s.trackedTracer, nil
 		},
 		Tag:  names.NewMachineTag("0"),
-		Kind: coretrace.ControllerKind,
+		Kind: coretrace.KindController,
 	}, s.states)
 	c.Assert(err, jc.ErrorIsNil)
 	return w

--- a/internal/worker/trace/worker_test.go
+++ b/internal/worker/trace/worker_test.go
@@ -127,7 +127,7 @@ func (s *workerSuite) TestGetTracerIsNotCachedForDifferentNamespaces(c *gc.C) {
 
 	close(done)
 
-	c.Assert(atomic.LoadInt64(&s.called), gc.Equals, int64(10))
+	c.Assert(atomic.LoadInt64(&s.called), gc.Equals, int64(1))
 }
 
 func (s *workerSuite) TestGetTracerConcurrently(c *gc.C) {
@@ -160,7 +160,7 @@ func (s *workerSuite) TestGetTracerConcurrently(c *gc.C) {
 	}
 
 	assertWait(c, wg.Wait)
-	c.Assert(atomic.LoadInt64(&s.called), gc.Equals, int64(10))
+	c.Assert(atomic.LoadInt64(&s.called), gc.Equals, int64(1))
 
 	close(done)
 }
@@ -174,7 +174,8 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 			atomic.AddInt64(&s.called, 1)
 			return s.trackedTracer, nil
 		},
-		Tag: names.NewMachineTag("0"),
+		Tag:  names.NewMachineTag("0"),
+		Kind: coretrace.ControllerKind,
 	}, s.states)
 	c.Assert(err, jc.ErrorIsNil)
 	return w

--- a/internal/worker/uniter/actions/resolver.go
+++ b/internal/worker/uniter/actions/resolver.go
@@ -4,6 +4,8 @@
 package actions
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/internal/worker/common/charmrunner"
@@ -49,6 +51,7 @@ func nextAction(pendingActions []string, completedActions map[string]struct{}) (
 
 // NextOp implements the resolver.Resolver interface.
 func (r *actionsResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/actions/resolver_test.go
+++ b/internal/worker/uniter/actions/resolver_test.go
@@ -4,6 +4,8 @@
 package actions_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -32,7 +34,7 @@ func (s *actionsSuite) TestNoActions(c *gc.C) {
 	actionResolver := s.newResolver()
 	localState := resolver.LocalState{}
 	remoteState := remotestate.Snapshot{}
-	_, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 }
 
@@ -46,7 +48,7 @@ func (s *actionsSuite) TestActionStateKindContinue(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{"actionA", "actionB"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockOp("actionA"))
 }
@@ -62,7 +64,7 @@ func (s *actionsSuite) TestActionRunHook(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{"actionA", "actionB"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockOp("actionA"))
 }
@@ -78,7 +80,7 @@ func (s *actionsSuite) TestNextAction(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{"actionA", "actionB"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockOp("actionB"))
 }
@@ -95,7 +97,7 @@ func (s *actionsSuite) TestNextActionBlocked(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 		ActionsBlocked: true,
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
@@ -111,7 +113,7 @@ func (s *actionsSuite) TestNextActionNotAvailable(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{"actionA", "actionB"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{err: charmrunner.ErrActionNotAvailable})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{err: charmrunner.ErrActionNotAvailable})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
@@ -129,7 +131,7 @@ func (s *actionsSuite) TestNextActionBlockedRemoteInit(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 		ActionsBlocked: false,
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
@@ -149,7 +151,7 @@ func (s *actionsSuite) TestNextActionBlockedRemoteInitInProgress(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 		ActionsBlocked: false,
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.DeepEquals, mockFailAction("actionB"))
 }
@@ -170,7 +172,7 @@ func (s *actionsSuite) TestNextActionBlockedRemoteInitSkipHook(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 		ActionsBlocked: true,
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.DeepEquals, mockSkipHook(*localState.Hook))
 }
@@ -189,7 +191,7 @@ func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockOp(actionA))
 }
@@ -209,7 +211,7 @@ func (s *actionsSuite) TestActionStateKindRunActionSkipHook(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockSkipHook(*localState.Hook))
 }
@@ -228,7 +230,7 @@ func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{actionA, "actionB"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockFailAction(actionA))
 }
@@ -248,7 +250,7 @@ func (s *actionsSuite) TestPendingActionNotAvailable(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		ActionsPending: []string{"666"},
 	}
-	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := actionResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockFailAction(actionA))
 }

--- a/internal/worker/uniter/container/remoteinit.go
+++ b/internal/worker/uniter/container/remoteinit.go
@@ -4,6 +4,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/juju/juju/internal/worker/uniter/operation"
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
 	"github.com/juju/juju/internal/worker/uniter/resolver"
@@ -19,6 +21,7 @@ func NewRemoteContainerInitResolver() resolver.Resolver {
 
 // NextOp implements the resolver.Resolver interface.
 func (r *remoteContainerInitResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/container/remoteinit_test.go
+++ b/internal/worker/uniter/container/remoteinit_test.go
@@ -4,6 +4,7 @@
 package container_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -23,7 +24,7 @@ func (s *containerSuite) TestNoRemoteInitRequired(c *gc.C) {
 	containerResolver := container.NewRemoteContainerInitResolver()
 	localState := resolver.LocalState{}
 	remoteState := remotestate.Snapshot{}
-	_, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 }
 
@@ -33,7 +34,7 @@ func (s *containerSuite) TestRunningStatusNil(c *gc.C) {
 		OutdatedRemoteCharm: true,
 	}
 	remoteState := remotestate.Snapshot{}
-	_, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 }
 
@@ -53,7 +54,7 @@ func (s *containerSuite) TestRemoteInitRequiredContinue(c *gc.C) {
 			Running:          false,
 		},
 	}
-	op, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "remote init")
 }
@@ -75,7 +76,7 @@ func (s *containerSuite) TestRemoteInitRequiredRunHookPending(c *gc.C) {
 			Running:          false,
 		},
 	}
-	op, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "remote init")
 }
@@ -97,7 +98,7 @@ func (s *containerSuite) TestRemoteInitRequiredRunHookNotPending(c *gc.C) {
 			Running:          false,
 		},
 	}
-	_, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
 }
 
@@ -118,7 +119,7 @@ func (s *containerSuite) TestRemoteInitRequiredAndPending(c *gc.C) {
 			Running:          false,
 		},
 	}
-	op, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "remote init")
 }
@@ -140,7 +141,7 @@ func (s *containerSuite) TestRemoteInitRequiredAndDone(c *gc.C) {
 			Running:          false,
 		},
 	}
-	op, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "skip remote init")
 }
@@ -167,7 +168,7 @@ func (s *containerSuite) TestReinit(c *gc.C) {
 			Running:          false,
 		},
 	}
-	op, err := containerResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "remote init")
 }

--- a/internal/worker/uniter/container/workload.go
+++ b/internal/worker/uniter/container/workload.go
@@ -4,6 +4,7 @@
 package container
 
 import (
+	"context"
 	"strconv"
 	"sync"
 
@@ -149,6 +150,7 @@ func NewWorkloadHookResolver(logger Logger, events WorkloadEvents, eventComplete
 
 // NextOp implements the resolver.Resolver interface.
 func (r *workloadHookResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/container/workload.go
+++ b/internal/worker/uniter/container/workload.go
@@ -230,8 +230,8 @@ type errorWrappedOp struct {
 }
 
 // Prepare is part of the Operation interface.
-func (op *errorWrappedOp) Prepare(state operation.State) (*operation.State, error) {
-	newState, err := op.Operation.Prepare(state)
+func (op *errorWrappedOp) Prepare(ctx context.Context, state operation.State) (*operation.State, error) {
+	newState, err := op.Operation.Prepare(ctx, state)
 	if err != nil && err != operation.ErrSkipExecute {
 		op.handler(err)
 	}
@@ -239,8 +239,8 @@ func (op *errorWrappedOp) Prepare(state operation.State) (*operation.State, erro
 }
 
 // Execute is part of the Operation interface.
-func (op *errorWrappedOp) Execute(state operation.State) (*operation.State, error) {
-	newState, err := op.Operation.Execute(state)
+func (op *errorWrappedOp) Execute(ctx context.Context, state operation.State) (*operation.State, error) {
+	newState, err := op.Operation.Execute(ctx, state)
 	if err != nil {
 		op.handler(err)
 	}
@@ -249,8 +249,8 @@ func (op *errorWrappedOp) Execute(state operation.State) (*operation.State, erro
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
-func (op *errorWrappedOp) Commit(state operation.State) (*operation.State, error) {
-	newState, err := op.Operation.Commit(state)
+func (op *errorWrappedOp) Commit(ctx context.Context, state operation.State) (*operation.State, error) {
+	newState, err := op.Operation.Commit(ctx, state)
 	op.handler(err)
 	return newState, err
 }

--- a/internal/worker/uniter/container/workload_test.go
+++ b/internal/worker/uniter/container/workload_test.go
@@ -119,7 +119,7 @@ func (s *workloadSuite) TestWorkloadCustomNoticeHook(c *gc.C) {
 		},
 	}
 	opFactory := &mockOperations{}
-	op, err := containerResolver.NextOp(localState, remoteState, opFactory)
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.NotNil)
 	op = operation.Unwrap(op)

--- a/internal/worker/uniter/container/workload_test.go
+++ b/internal/worker/uniter/container/workload_test.go
@@ -4,6 +4,8 @@
 package container_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -77,7 +79,7 @@ func (s *workloadSuite) TestWorkloadReadyHook(c *gc.C) {
 		},
 	}
 	opFactory := &mockOperations{}
-	op, err := containerResolver.NextOp(localState, remoteState, opFactory)
+	op, err := containerResolver.NextOp(context.Background(), localState, remoteState, opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.NotNil)
 	op = operation.Unwrap(op)

--- a/internal/worker/uniter/leadership/resolver.go
+++ b/internal/worker/uniter/leadership/resolver.go
@@ -4,6 +4,8 @@
 package leadership
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 
 	"github.com/juju/juju/core/life"
@@ -35,6 +37,7 @@ func NewResolver(logger Logger) resolver.Resolver {
 
 // NextOp is defined on the Resolver interface.
 func (l *leadershipResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/leadership/resolver_test.go
+++ b/internal/worker/uniter/leadership/resolver_test.go
@@ -4,6 +4,8 @@
 package leadership_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -34,7 +36,7 @@ func (s *resolverSuite) TestNextOpNotInstalled(c *gc.C) {
 	logger := loggo.GetLogger("test")
 
 	r := leadership.NewResolver(logger)
-	_, err := r.NextOp(resolver.LocalState{}, remotestate.Snapshot{}, f)
+	_, err := r.NextOp(context.Background(), resolver.LocalState{}, remotestate.Snapshot{}, f)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -49,7 +51,7 @@ func (s *resolverSuite) TestNextOpAcceptLeader(c *gc.C) {
 	f.EXPECT().NewAcceptLeadership().Return(op, nil)
 
 	r := leadership.NewResolver(logger)
-	result, err := r.NextOp(resolver.LocalState{
+	result, err := r.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{Installed: true, Kind: operation.Continue},
 	}, remotestate.Snapshot{
 		Leader: true,
@@ -69,7 +71,7 @@ func (s *resolverSuite) TestNextOpResignLeader(c *gc.C) {
 	f.EXPECT().NewResignLeadership().Return(op, nil)
 
 	r := leadership.NewResolver(logger)
-	result, err := r.NextOp(resolver.LocalState{
+	result, err := r.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{Installed: true, Leader: true, Kind: operation.Continue},
 	}, remotestate.Snapshot{}, f)
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,7 +89,7 @@ func (s *resolverSuite) TestNextOpResignLeaderDying(c *gc.C) {
 	f.EXPECT().NewResignLeadership().Return(op, nil)
 
 	r := leadership.NewResolver(logger)
-	result, err := r.NextOp(resolver.LocalState{
+	result, err := r.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{Installed: true, Leader: true, Kind: operation.Continue},
 	}, remotestate.Snapshot{
 		Leader: true, Life: life.Dying,
@@ -107,7 +109,7 @@ func (s *resolverSuite) TestNextOpLeaderSettings(c *gc.C) {
 	f.EXPECT().NewRunHook(hook.Info{Kind: hooks.LeaderSettingsChanged}).Return(op, nil)
 
 	r := leadership.NewResolver(logger)
-	result, err := r.NextOp(resolver.LocalState{
+	result, err := r.NextOp(context.Background(), resolver.LocalState{
 		State:                 operation.State{Installed: true, Kind: operation.Continue},
 		LeaderSettingsVersion: 1,
 	}, remotestate.Snapshot{LeaderSettingsVersion: 2}, f)
@@ -123,7 +125,7 @@ func (s *resolverSuite) TestNextOpNoLeaderSettingsWhenDying(c *gc.C) {
 	logger := loggo.GetLogger("test")
 
 	r := leadership.NewResolver(logger)
-	_, err := r.NextOp(resolver.LocalState{
+	_, err := r.NextOp(context.Background(), resolver.LocalState{
 		State:                 operation.State{Installed: true, Kind: operation.Continue},
 		LeaderSettingsVersion: 1,
 	}, remotestate.Snapshot{Life: life.Dying, LeaderSettingsVersion: 2}, f)

--- a/internal/worker/uniter/mock_test.go
+++ b/internal/worker/uniter/mock_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/secrets"
@@ -36,6 +38,6 @@ func (*dummySecretsAccessor) GetConsumerSecretsRevisionInfo(string, []string) (m
 
 type nopResolver struct{}
 
-func (nopResolver) NextOp(resolver.LocalState, remotestate.Snapshot, operation.Factory) (operation.Operation, error) {
+func (nopResolver) NextOp(context.Context, resolver.LocalState, remotestate.Snapshot, operation.Factory) (operation.Operation, error) {
 	return nil, resolver.ErrNoOperation
 }

--- a/internal/worker/uniter/operation/deploy.go
+++ b/internal/worker/uniter/operation/deploy.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/charm/v12/hooks"
@@ -47,7 +48,7 @@ func (d *deploy) String() string {
 // that the unit will be using it. If the supplied state indicates that a
 // hook was pending, that hook is recorded in the returned state.
 // Prepare is part of the Operation interface.
-func (d *deploy) Prepare(state State) (*State, error) {
+func (d *deploy) Prepare(ctx context.Context, state State) (*State, error) {
 	if err := d.checkAlreadyDone(state); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -74,7 +75,7 @@ func (d *deploy) Prepare(state State) (*State, error) {
 // Execute installs or upgrades the prepared charm, and preserves any hook
 // recorded in the supplied state.
 // Execute is part of the Operation interface.
-func (d *deploy) Execute(state State) (*State, error) {
+func (d *deploy) Execute(ctx context.Context, state State) (*State, error) {
 	if err := d.deployer.Deploy(); err == charm.ErrConflict {
 		return nil, NewDeployConflictError(d.charmURL)
 	} else if err != nil {
@@ -85,7 +86,7 @@ func (d *deploy) Execute(state State) (*State, error) {
 
 // Commit restores state for any interrupted hook, or queues an install or
 // upgrade-charm hook if no hook was interrupted.
-func (d *deploy) Commit(state State) (*State, error) {
+func (d *deploy) Commit(ctx context.Context, state State) (*State, error) {
 	change := &stateChange{
 		Kind: RunHook,
 	}

--- a/internal/worker/uniter/operation/deploy_test.go
+++ b/internal/worker/uniter/operation/deploy_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -38,7 +40,7 @@ func (s *DeploySuite) testPrepareAlreadyDone(
 	})
 	op, err := newDeploy(factory, "ch:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
-	newState, err := op.Prepare(operation.State{
+	newState, err := op.Prepare(context.Background(), operation.State{
 		Kind:     kind,
 		Step:     operation.Done,
 		CharmURL: "ch:quantal/hive-23",
@@ -91,7 +93,7 @@ func (s *DeploySuite) testPrepareArchiveInfoError(c *gc.C, newDeploy newDeploy) 
 	op, err := newDeploy(factory, "ch:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(context.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "pew")
 	c.Check(callbacks.MockGetArchiveInfo.gotCharmURL, gc.Equals, "ch:quantal/hive-23")
@@ -132,7 +134,7 @@ func (s *DeploySuite) testPrepareStageError(c *gc.C, newDeploy newDeploy) {
 	op, err := newDeploy(factory, "ch:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(context.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "squish")
 	c.Check(*deployer.MockStage.gotInfo, gc.Equals, callbacks.MockGetArchiveInfo.info)
@@ -174,7 +176,7 @@ func (s *DeploySuite) testPrepareSetCharmError(c *gc.C, newDeploy newDeploy) {
 	op, err := newDeploy(factory, "ch:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(context.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "blargh")
 	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.Equals, "ch:quantal/hive-23")
@@ -211,7 +213,7 @@ func (s *DeploySuite) testPrepareSuccess(c *gc.C, newDeploy newDeploy, before, a
 	op, err := newDeploy(factory, "ch:quantal/nyancat-4")
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(before)
+	newState, err := op.Prepare(context.Background(), before)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &after)
 	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.Equals, "ch:quantal/nyancat-4")
@@ -345,10 +347,10 @@ func (s *DeploySuite) testExecuteError(c *gc.C, newDeploy newDeploy) {
 	})
 	op, err := newDeploy(factory, "ch:quantal/nyancat-4")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(context.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "rasp")
 	c.Check(deployer.MockDeploy.called, jc.IsTrue)
@@ -383,11 +385,11 @@ func (s *DeploySuite) testExecuteSuccess(
 	op, err := newDeploy(factory, "ch:quantal/lol-1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	midState, err := op.Prepare(before)
+	midState, err := op.Prepare(context.Background(), before)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
-	newState, err := op.Execute(*midState)
+	newState, err := op.Execute(context.Background(), *midState)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &after)
 	c.Check(deployer.MockDeploy.called, jc.IsTrue)
@@ -503,7 +505,7 @@ func (s *DeploySuite) TestCommitQueueInstallHook(c *gc.C) {
 	})
 	op, err := factory.NewInstall("ch:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(context.Background(), operation.State{
 		Kind:     operation.Install,
 		Step:     operation.Done,
 		CharmURL: "", // doesn't actually matter here
@@ -530,7 +532,7 @@ func (s *DeploySuite) testCommitQueueUpgradeHook(c *gc.C, newDeploy newDeploy) {
 
 	op, err := newDeploy(factory, "ch:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(context.Background(), operation.State{
 		Kind:     operation.Upgrade,
 		Step:     operation.Done,
 		CharmURL: "", // doesn't actually matter here
@@ -570,7 +572,7 @@ func (s *DeploySuite) testCommitInterruptedHook(c *gc.C, newDeploy newDeploy) {
 	op, err := newDeploy(factory, "ch:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
 	hookStep := operation.Done
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(context.Background(), operation.State{
 		Kind:     operation.Upgrade,
 		Step:     operation.Done,
 		CharmURL: "", // doesn't actually matter here

--- a/internal/worker/uniter/operation/executor.go
+++ b/internal/worker/uniter/operation/executor.go
@@ -4,10 +4,12 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
 )
 
@@ -81,7 +83,16 @@ func (x *executor) State() State {
 }
 
 // Run is part of the Executor interface.
-func (x *executor) Run(op Operation, remoteStateChange <-chan remotestate.Snapshot) error {
+func (x *executor) Run(ctx context.Context, op Operation, remoteStateChange <-chan remotestate.Snapshot) (err error) {
+	_, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
+		trace.StringAttr("executor.state", op.String()),
+		trace.StringAttr("executor.unit", x.unitName),
+	))
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
 	x.logger.Debugf("running operation %v for %s", op, x.unitName)
 
 	if op.NeedsGlobalMachineLock() {
@@ -125,7 +136,16 @@ func (x *executor) Run(op Operation, remoteStateChange <-chan remotestate.Snapsh
 }
 
 // Skip is part of the Executor interface.
-func (x *executor) Skip(op Operation) error {
+func (x *executor) Skip(ctx context.Context, op Operation) (err error) {
+	_, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
+		trace.StringAttr("executor.state", op.String()),
+		trace.StringAttr("executor.unit", x.unitName),
+	))
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
 	x.logger.Debugf("skipping operation %v for %s", op, x.unitName)
 	return x.do(op, stepCommit)
 }

--- a/internal/worker/uniter/operation/executor_test.go
+++ b/internal/worker/uniter/operation/executor_test.go
@@ -264,7 +264,7 @@ func (s *ExecutorSuite) TestSucceedWithRemoteStateChanges(c *gc.C) {
 
 	remoteStateUpdated := make(chan struct{}, 1)
 	prepare := newStep(nil, nil)
-	execute := mockStepFunc(func(state operation.State) (*operation.State, error) {
+	execute := mockStepFunc(func(ctx context.Context, state operation.State) (*operation.State, error) {
 		select {
 		case <-remoteStateUpdated:
 			return nil, nil
@@ -628,13 +628,13 @@ func (mock *mockLockFunc) newSucceedingLock() func(string, string) (func(), erro
 }
 
 type mockStepInterface interface {
-	Run(state operation.State) (*operation.State, error)
+	Run(ctx context.Context, state operation.State) (*operation.State, error)
 }
 
-type mockStepFunc func(state operation.State) (*operation.State, error)
+type mockStepFunc func(ctx context.Context, state operation.State) (*operation.State, error)
 
-func (m mockStepFunc) Run(state operation.State) (*operation.State, error) {
-	return m(state)
+func (m mockStepFunc) Run(ctx context.Context, state operation.State) (*operation.State, error) {
+	return m(ctx, state)
 }
 
 type mockStep struct {
@@ -648,7 +648,7 @@ func newStep(newState *operation.State, err error) *mockStep {
 	return &mockStep{newState: newState, err: err}
 }
 
-func (step *mockStep) Run(state operation.State) (*operation.State, error) {
+func (step *mockStep) Run(ctx context.Context, state operation.State) (*operation.State, error) {
 	step.called = true
 	step.gotState = state
 	return step.newState, step.err
@@ -674,16 +674,16 @@ func (m *mockOperation) ExecutionGroup() string {
 	return ""
 }
 
-func (op *mockOperation) Prepare(state operation.State) (*operation.State, error) {
-	return op.prepare.Run(state)
+func (op *mockOperation) Prepare(ctx context.Context, state operation.State) (*operation.State, error) {
+	return op.prepare.Run(ctx, state)
 }
 
-func (op *mockOperation) Execute(state operation.State) (*operation.State, error) {
-	return op.execute.Run(state)
+func (op *mockOperation) Execute(ctx context.Context, state operation.State) (*operation.State, error) {
+	return op.execute.Run(ctx, state)
 }
 
-func (op *mockOperation) Commit(state operation.State) (*operation.State, error) {
-	return op.commit.Run(state)
+func (op *mockOperation) Commit(ctx context.Context, state operation.State) (*operation.State, error) {
+	return op.commit.Run(ctx, state)
 }
 
 func (op *mockOperation) RemoteStateChanged(snapshot remotestate.Snapshot) {

--- a/internal/worker/uniter/operation/executor_test.go
+++ b/internal/worker/uniter/operation/executor_test.go
@@ -4,6 +4,7 @@
 package operation_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v12/hooks"
@@ -218,7 +219,7 @@ func (s *ExecutorSuite) TestSucceedNoStateChanges(c *gc.C) {
 		commit:  commit,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -246,7 +247,7 @@ func (s *ExecutorSuite) TestSucceedWithStateChanges(c *gc.C) {
 		commit:  commit,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -289,7 +290,7 @@ func (s *ExecutorSuite) TestSucceedWithRemoteStateChanges(c *gc.C) {
 	rs <- remotestate.Snapshot{
 		ConfigHash: "test",
 	}
-	err := executor.Run(op, rs)
+	err := executor.Run(context.Background(), op, rs)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -309,7 +310,7 @@ func (s *ExecutorSuite) TestErrSkipExecute(c *gc.C) {
 		commit:  commit,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -331,7 +332,7 @@ func (s *ExecutorSuite) TestValidateStateChange(c *gc.C) {
 		prepare: prepare,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: invalid operation state: missing hook info with Kind RunHook`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info with Kind RunHook")
 	c.Assert(executor.State(), gc.DeepEquals, initialState)
@@ -348,7 +349,7 @@ func (s *ExecutorSuite) TestFailPrepareNoStateChange(c *gc.C) {
 		prepare: prepare,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: pow`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "pow")
 
@@ -368,7 +369,7 @@ func (s *ExecutorSuite) TestFailPrepareWithStateChange(c *gc.C) {
 		prepare: prepare,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: blam`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "blam")
 
@@ -389,7 +390,7 @@ func (s *ExecutorSuite) TestFailExecuteNoStateChange(c *gc.C) {
 		execute: execute,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation" for test: splat`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "splat")
 
@@ -411,7 +412,7 @@ func (s *ExecutorSuite) TestFailExecuteWithStateChange(c *gc.C) {
 		execute: execute,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation" for test: kerblooie`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "kerblooie")
 
@@ -434,7 +435,7 @@ func (s *ExecutorSuite) TestFailCommitNoStateChange(c *gc.C) {
 		commit:  commit,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation" for test: whack`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "whack")
 
@@ -458,7 +459,7 @@ func (s *ExecutorSuite) TestFailCommitWithStateChange(c *gc.C) {
 		commit:  commit,
 	}
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation" for test: take that you bandit`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "take that you bandit")
 
@@ -494,7 +495,7 @@ func (s *ExecutorSuite) TestLockSucceedsStepsCalled(c *gc.C) {
 	lockFunc := mockLock.newSucceedingLock()
 	executor := s.initLockTest(c, lockFunc)
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(mockLock.calledLock, jc.IsTrue)
@@ -520,7 +521,7 @@ func (s *ExecutorSuite) TestLockFailsOpsStepsNotCalled(c *gc.C) {
 	lockFunc := mockLock.newFailingLock()
 	executor := s.initLockTest(c, lockFunc)
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 	c.Assert(err, gc.ErrorMatches, "could not acquire lock: wat")
 
 	c.Assert(mockLock.calledLock, jc.IsFalse)
@@ -537,7 +538,7 @@ func (s *ExecutorSuite) testLockUnlocksOnError(c *gc.C, op *mockOperation) (erro
 	lockFunc := mockLock.newSucceedingLock()
 	executor := s.initLockTest(c, lockFunc)
 
-	err := executor.Run(op, nil)
+	err := executor.Run(context.Background(), op, nil)
 
 	c.Assert(mockLock.calledLock, jc.IsTrue)
 	c.Assert(mockLock.calledUnlock, jc.IsTrue)

--- a/internal/worker/uniter/operation/failaction.go
+++ b/internal/worker/uniter/operation/failaction.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
@@ -21,7 +22,7 @@ func (fa *failAction) String() string {
 }
 
 // Prepare is part of the Operation interface.
-func (fa *failAction) Prepare(state State) (*State, error) {
+func (fa *failAction) Prepare(ctx context.Context, state State) (*State, error) {
 	return stateChange{
 		Kind:     RunAction,
 		Step:     Pending,
@@ -31,7 +32,7 @@ func (fa *failAction) Prepare(state State) (*State, error) {
 }
 
 // Execute is part of the Operation interface.
-func (fa *failAction) Execute(state State) (*State, error) {
+func (fa *failAction) Execute(ctx context.Context, state State) (*State, error) {
 	if err := fa.callbacks.FailAction(fa.actionId, "action terminated"); err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func (fa *failAction) Execute(state State) (*State, error) {
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
-func (fa *failAction) Commit(state State) (*State, error) {
+func (fa *failAction) Commit(ctx context.Context, state State) (*State, error) {
 	return stateChange{
 		Kind: continuationKind(state),
 		Step: Pending,

--- a/internal/worker/uniter/operation/failaction_test.go
+++ b/internal/worker/uniter/operation/failaction_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -25,7 +27,7 @@ func (s *FailActionSuite) TestPrepare(c *gc.C) {
 	op, err := factory.NewFailAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, jc.DeepEquals, &operation.State{
 		Kind:     operation.RunAction,
@@ -64,11 +66,11 @@ func (s *FailActionSuite) TestExecuteSuccess(c *gc.C) {
 		factory := newOpFactory(nil, callbacks)
 		op, err := factory.NewFailAction(someActionId)
 		c.Assert(err, jc.ErrorIsNil)
-		midState, err := op.Prepare(test.before)
+		midState, err := op.Prepare(stdcontext.Background(), test.before)
 		c.Assert(midState, gc.NotNil)
 		c.Assert(err, jc.ErrorIsNil)
 
-		newState, err := op.Execute(*midState)
+		newState, err := op.Execute(stdcontext.Background(), *midState)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(newState, jc.DeepEquals, &test.after)
 		c.Assert(*callbacks.MockFailAction.gotMessage, gc.Equals, "action terminated")
@@ -86,11 +88,11 @@ func (s *FailActionSuite) TestExecuteFail(c *gc.C) {
 	factory := newOpFactory(nil, callbacks)
 	op, err := factory.NewFailAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
-	midState, err := op.Prepare(st)
+	midState, err := op.Prepare(stdcontext.Background(), st)
 	c.Assert(midState, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Execute(*midState)
+	_, err = op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, gc.ErrorMatches, "squelch")
 }
 
@@ -143,7 +145,7 @@ func (s *FailActionSuite) TestCommit(c *gc.C) {
 		op, err := factory.NewFailAction(someActionId)
 		c.Assert(err, jc.ErrorIsNil)
 
-		newState, err := op.Commit(test.before)
+		newState, err := op.Commit(stdcontext.Background(), test.before)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(newState, jc.DeepEquals, &test.after)
 	}

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -4,6 +4,8 @@
 package operation
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	utilexec "github.com/juju/utils/v3/exec"
@@ -99,11 +101,11 @@ type Executor interface {
 	// error, the run will be aborted and an error will be returned.
 	// On remote state change, the executor will fire the operation's
 	// RemoteStateChanged method.
-	Run(Operation, <-chan remotestate.Snapshot) error
+	Run(stdcontext.Context, Operation, <-chan remotestate.Snapshot) error
 
 	// Skip will Commit the supplied operation, and write any state change
 	// indicated. If Commit returns an error, so will Skip.
-	Skip(Operation) error
+	Skip(stdcontext.Context, Operation) error
 }
 
 // Factory creates operations.

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -55,16 +55,16 @@ type Operation interface {
 	// If it returns a non-nil state, that state will be validated and recorded.
 	// If it returns ErrSkipExecute, it indicates that the operation can be
 	// committed directly.
-	Prepare(state State) (*State, error)
+	Prepare(ctx stdcontext.Context, state State) (*State, error)
 
 	// Execute carries out the operation. It must not be called without having
 	// called Prepare first. If it returns a non-nil state, that state will be
 	// validated and recorded.
-	Execute(state State) (*State, error)
+	Execute(ctx stdcontext.Context, state State) (*State, error)
 
 	// Commit ensures that the operation's completion is recorded. If it returns
 	// a non-nil state, that state will be validated and recorded.
-	Commit(state State) (*State, error)
+	Commit(ctx stdcontext.Context, state State) (*State, error)
 
 	// RemoteStateChanged is called when the remote state changed during execution
 	// of the operation.

--- a/internal/worker/uniter/operation/leader.go
+++ b/internal/worker/uniter/operation/leader.go
@@ -4,6 +4,8 @@
 package operation
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 
@@ -21,7 +23,7 @@ func (al *acceptLeadership) String() string {
 }
 
 // Prepare is part of the Operation interface.
-func (al *acceptLeadership) Prepare(state State) (*State, error) {
+func (al *acceptLeadership) Prepare(ctx context.Context, state State) (*State, error) {
 	if err := al.checkState(state); err != nil {
 		return nil, err
 	}
@@ -29,12 +31,12 @@ func (al *acceptLeadership) Prepare(state State) (*State, error) {
 }
 
 // Execute is part of the Operation interface.
-func (al *acceptLeadership) Execute(state State) (*State, error) {
+func (al *acceptLeadership) Execute(ctx context.Context, state State) (*State, error) {
 	return nil, errors.New("prepare always errors; Execute is never valid")
 }
 
 // Commit is part of the Operation interface.
-func (al *acceptLeadership) Commit(state State) (*State, error) {
+func (al *acceptLeadership) Commit(ctx context.Context, state State) (*State, error) {
 	if err := al.checkState(state); err != nil {
 		return nil, err
 	}
@@ -78,7 +80,7 @@ func (rl *resignLeadership) String() string {
 }
 
 // Prepare is part of the Operation interface.
-func (rl *resignLeadership) Prepare(state State) (*State, error) {
+func (rl *resignLeadership) Prepare(ctx context.Context, state State) (*State, error) {
 	if !state.Leader {
 		// Nothing needs to be done -- state.Leader should only be set to
 		// false when committing the leader-deposed hook. This code is not
@@ -89,7 +91,7 @@ func (rl *resignLeadership) Prepare(state State) (*State, error) {
 }
 
 // Execute is part of the Operation interface.
-func (rl *resignLeadership) Execute(state State) (*State, error) {
+func (rl *resignLeadership) Execute(ctx context.Context, state State) (*State, error) {
 	// TODO(fwereade): this hits a lot of interestingly intersecting problems.
 	//
 	// 1) we can't yet create a sufficiently dumbed-down hook context for a
@@ -125,7 +127,7 @@ func (rl *resignLeadership) Execute(state State) (*State, error) {
 }
 
 // Commit is part of the Operation interface.
-func (rl *resignLeadership) Commit(state State) (*State, error) {
+func (rl *resignLeadership) Commit(ctx context.Context, state State) (*State, error) {
 	state.Leader = false
 	return &state, nil
 }

--- a/internal/worker/uniter/operation/leader_test.go
+++ b/internal/worker/uniter/operation/leader_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -31,7 +33,7 @@ func (s *LeaderSuite) TestAcceptLeadership_Prepare_BadState(c *gc.C) {
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	// accept is only valid in Continue mode, when we're sure nothing is queued
 	// or in progress.
@@ -43,7 +45,7 @@ func (s *LeaderSuite) TestAcceptLeadership_Prepare_NotLeader(c *gc.C) {
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{Kind: operation.Continue})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{Kind: operation.Continue})
 	c.Check(newState, gc.IsNil)
 	// *execute* is currently just a no-op -- all the meat happens in commit.
 	c.Check(err, gc.Equals, operation.ErrSkipExecute)
@@ -54,7 +56,7 @@ func (s *LeaderSuite) TestAcceptLeadership_Prepare_AlreadyLeader(c *gc.C) {
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{
 		Kind:   operation.Continue,
 		Leader: true,
 	})
@@ -67,10 +69,10 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_BlankSlate(c *gc.C) 
 	factory := s.newFactory()
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{Kind: operation.Continue})
 	c.Check(err, gc.Equals, operation.ErrSkipExecute)
 
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(stdcontext.Background(), operation.State{
 		Kind: operation.Continue,
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -86,10 +88,10 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_Preserve(c *gc.C) {
 	factory := s.newFactory()
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{Kind: operation.Continue})
 	c.Check(err, gc.Equals, operation.ErrSkipExecute)
 
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(stdcontext.Background(), operation.State{
 		Kind:    operation.Continue,
 		Started: true,
 		Hook:    &hook.Info{Kind: hooks.Install},
@@ -108,10 +110,10 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_AlreadyLeader(c *gc.C) {
 	factory := s.newFactory()
 	op, err := factory.NewAcceptLeadership()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{Kind: operation.Continue})
 	c.Check(err, gc.Equals, operation.ErrSkipExecute)
 
-	newState, err := op.Commit(operation.State{
+	newState, err := op.Commit(stdcontext.Background(), operation.State{
 		Kind:   operation.Continue,
 		Leader: true,
 	})
@@ -131,7 +133,7 @@ func (s *LeaderSuite) TestResignLeadership_Prepare_Leader(c *gc.C) {
 	op, err := factory.NewResignLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{Leader: true})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{Leader: true})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -141,7 +143,7 @@ func (s *LeaderSuite) TestResignLeadership_Prepare_NotLeader(c *gc.C) {
 	op, err := factory.NewResignLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.Equals, operation.ErrSkipExecute)
 }
@@ -151,11 +153,11 @@ func (s *LeaderSuite) TestResignLeadership_Execute(c *gc.C) {
 	op, err := factory.NewResignLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{Leader: true})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{Leader: true})
 	c.Check(err, jc.ErrorIsNil)
 
 	// Execute is a no-op (which logs that we should run leader-deposed)
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -165,7 +167,7 @@ func (s *LeaderSuite) TestResignLeadership_Commit_ClearLeader(c *gc.C) {
 	op, err := factory.NewResignLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Commit(operation.State{Leader: true})
+	newState, err := op.Commit(stdcontext.Background(), operation.State{Leader: true})
 	c.Check(newState, gc.DeepEquals, &operation.State{})
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -175,7 +177,7 @@ func (s *LeaderSuite) TestResignLeadership_Commit_PreserveOthers(c *gc.C) {
 	op, err := factory.NewResignLeadership()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Commit(overwriteState)
+	newState, err := op.Commit(stdcontext.Background(), overwriteState)
 	c.Check(newState, gc.DeepEquals, &overwriteState)
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -187,7 +189,7 @@ func (s *LeaderSuite) TestResignLeadership_Commit_All(c *gc.C) {
 
 	leaderState := overwriteState
 	leaderState.Leader = true
-	newState, err := op.Commit(leaderState)
+	newState, err := op.Commit(stdcontext.Background(), leaderState)
 	c.Check(newState, gc.DeepEquals, &overwriteState)
 	c.Check(err, jc.ErrorIsNil)
 }

--- a/internal/worker/uniter/operation/mocks/interface_mock.go
+++ b/internal/worker/uniter/operation/mocks/interface_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	model "github.com/juju/juju/core/model"
@@ -17,7 +18,7 @@ import (
 	hook "github.com/juju/juju/internal/worker/uniter/hook"
 	operation "github.com/juju/juju/internal/worker/uniter/operation"
 	remotestate "github.com/juju/juju/internal/worker/uniter/remotestate"
-	context "github.com/juju/juju/internal/worker/uniter/runner/context"
+	context0 "github.com/juju/juju/internal/worker/uniter/runner/context"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,33 +46,33 @@ func (m *MockOperation) EXPECT() *MockOperationMockRecorder {
 }
 
 // Commit mocks base method.
-func (m *MockOperation) Commit(arg0 operation.State) (*operation.State, error) {
+func (m *MockOperation) Commit(arg0 context.Context, arg1 operation.State) (*operation.State, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Commit", arg0)
+	ret := m.ctrl.Call(m, "Commit", arg0, arg1)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Commit indicates an expected call of Commit.
-func (mr *MockOperationMockRecorder) Commit(arg0 any) *gomock.Call {
+func (mr *MockOperationMockRecorder) Commit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockOperation)(nil).Commit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockOperation)(nil).Commit), arg0, arg1)
 }
 
 // Execute mocks base method.
-func (m *MockOperation) Execute(arg0 operation.State) (*operation.State, error) {
+func (m *MockOperation) Execute(arg0 context.Context, arg1 operation.State) (*operation.State, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0)
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockOperationMockRecorder) Execute(arg0 any) *gomock.Call {
+func (mr *MockOperationMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockOperation)(nil).Execute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockOperation)(nil).Execute), arg0, arg1)
 }
 
 // ExecutionGroup mocks base method.
@@ -103,18 +104,18 @@ func (mr *MockOperationMockRecorder) NeedsGlobalMachineLock() *gomock.Call {
 }
 
 // Prepare mocks base method.
-func (m *MockOperation) Prepare(arg0 operation.State) (*operation.State, error) {
+func (m *MockOperation) Prepare(arg0 context.Context, arg1 operation.State) (*operation.State, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prepare", arg0)
+	ret := m.ctrl.Call(m, "Prepare", arg0, arg1)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Prepare indicates an expected call of Prepare.
-func (mr *MockOperationMockRecorder) Prepare(arg0 any) *gomock.Call {
+func (mr *MockOperationMockRecorder) Prepare(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockOperation)(nil).Prepare), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockOperation)(nil).Prepare), arg0, arg1)
 }
 
 // RemoteStateChanged mocks base method.
@@ -473,7 +474,7 @@ func (mr *MockCallbacksMockRecorder) GetArchiveInfo(arg0 any) *gomock.Call {
 }
 
 // NotifyHookCompleted mocks base method.
-func (m *MockCallbacks) NotifyHookCompleted(arg0 string, arg1 context.Context) {
+func (m *MockCallbacks) NotifyHookCompleted(arg0 string, arg1 context0.Context) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "NotifyHookCompleted", arg0, arg1)
 }
@@ -485,7 +486,7 @@ func (mr *MockCallbacksMockRecorder) NotifyHookCompleted(arg0, arg1 any) *gomock
 }
 
 // NotifyHookFailed mocks base method.
-func (m *MockCallbacks) NotifyHookFailed(arg0 string, arg1 context.Context) {
+func (m *MockCallbacks) NotifyHookFailed(arg0 string, arg1 context0.Context) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "NotifyHookFailed", arg0, arg1)
 }

--- a/internal/worker/uniter/operation/noopfinishupgradeseries.go
+++ b/internal/worker/uniter/operation/noopfinishupgradeseries.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -17,7 +18,7 @@ func (op *noOpFinishUpgradeSeries) String() string {
 }
 
 // Commit is part of the Operation interface.
-func (op *noOpFinishUpgradeSeries) Commit(state State) (*State, error) {
+func (op *noOpFinishUpgradeSeries) Commit(ctx context.Context, state State) (*State, error) {
 	// make no change to state
 	return &state, nil
 }

--- a/internal/worker/uniter/operation/remoteinit.go
+++ b/internal/worker/uniter/operation/remoteinit.go
@@ -4,6 +4,8 @@
 package operation
 
 import (
+	"context"
+
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
 )
 
@@ -29,7 +31,7 @@ func (remoteInit) ExecutionGroup() string {
 }
 
 // Prepare is part of the Operation interface.
-func (op *remoteInit) Prepare(state State) (*State, error) {
+func (op *remoteInit) Prepare(ctx context.Context, state State) (*State, error) {
 	return stateChange{
 		Kind: RemoteInit,
 		Step: Pending,
@@ -38,7 +40,7 @@ func (op *remoteInit) Prepare(state State) (*State, error) {
 }
 
 // Execute is part of the Operation interface.
-func (op *remoteInit) Execute(state State) (*State, error) {
+func (op *remoteInit) Execute(ctx context.Context, state State) (*State, error) {
 	if err := op.callbacks.RemoteInit(op.runningStatus, op.abort); err != nil {
 		return nil, err
 	}
@@ -51,7 +53,7 @@ func (op *remoteInit) Execute(state State) (*State, error) {
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
-func (op *remoteInit) Commit(state State) (*State, error) {
+func (op *remoteInit) Commit(ctx context.Context, state State) (*State, error) {
 	return stateChange{
 		Kind: continuationKind(state),
 		Step: Pending,
@@ -84,18 +86,18 @@ func (skipRemoteInit) ExecutionGroup() string {
 }
 
 // Prepare is part of the Operation interface.
-func (op *skipRemoteInit) Prepare(state State) (*State, error) {
+func (op *skipRemoteInit) Prepare(ctx context.Context, state State) (*State, error) {
 	return nil, ErrSkipExecute
 }
 
 // Execute is part of the Operation interface.
-func (op *skipRemoteInit) Execute(state State) (*State, error) {
+func (op *skipRemoteInit) Execute(ctx context.Context, state State) (*State, error) {
 	return nil, ErrSkipExecute
 }
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
-func (op *skipRemoteInit) Commit(state State) (*State, error) {
+func (op *skipRemoteInit) Commit(ctx context.Context, state State) (*State, error) {
 	kind := continuationKind(state)
 	if op.retry {
 		kind = RemoteInit

--- a/internal/worker/uniter/operation/remoteinit_test.go
+++ b/internal/worker/uniter/operation/remoteinit_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -38,7 +40,7 @@ func (s *RemoteInitSuite) TestRemoteInit(c *gc.C) {
 	op, err := factory.NewRemoteInit(runningStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RemoteInit,
@@ -47,7 +49,7 @@ func (s *RemoteInitSuite) TestRemoteInit(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(*newState)
+	newState, err = op.Execute(stdcontext.Background(), *newState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RemoteInit,
@@ -56,7 +58,7 @@ func (s *RemoteInitSuite) TestRemoteInit(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.DeepEquals, &runningStatus)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.Equals, abort)
 
-	newState, err = op.Commit(*newState)
+	newState, err = op.Commit(stdcontext.Background(), *newState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.Continue,
@@ -81,7 +83,7 @@ func (s *RemoteInitSuite) TestRemoteInitWithHook(c *gc.C) {
 	op, err := factory.NewRemoteInit(runningStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{
 		Kind: operation.RunHook,
 		Step: operation.Pending,
 		Hook: &hook.Info{
@@ -99,7 +101,7 @@ func (s *RemoteInitSuite) TestRemoteInitWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(*newState)
+	newState, err = op.Execute(stdcontext.Background(), *newState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RemoteInit,
@@ -111,7 +113,7 @@ func (s *RemoteInitSuite) TestRemoteInitWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.DeepEquals, &runningStatus)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.Equals, abort)
 
-	newState, err = op.Commit(*newState)
+	newState, err = op.Commit(stdcontext.Background(), *newState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RunHook,
@@ -139,7 +141,7 @@ func (s *RemoteInitSuite) TestRemoteInitFail(c *gc.C) {
 	op, err := factory.NewRemoteInit(runningStatus)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RemoteInit,
@@ -148,7 +150,7 @@ func (s *RemoteInitSuite) TestRemoteInitFail(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(*newState)
+	newState, err = op.Execute(stdcontext.Background(), *newState)
 	c.Assert(err, gc.ErrorMatches, "ooops")
 	c.Assert(newState, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.DeepEquals, &runningStatus)
@@ -169,19 +171,19 @@ func (s *RemoteInitSuite) TestSkipRemoteInit(c *gc.C) {
 	op, err := factory.NewSkipRemoteInit(false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(operation.State{})
+	newState, err = op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Commit(operation.State{})
+	newState, err = op.Commit(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.Continue,
@@ -203,7 +205,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitWithHook(c *gc.C) {
 	op, err := factory.NewSkipRemoteInit(false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Pending,
 		Hook: &hook.Info{
@@ -215,7 +217,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(operation.State{
+	newState, err = op.Execute(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Pending,
 		Hook: &hook.Info{
@@ -227,7 +229,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Commit(operation.State{
+	newState, err = op.Commit(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Pending,
 		Hook: &hook.Info{
@@ -258,19 +260,19 @@ func (s *RemoteInitSuite) TestSkipRemoteInitRetry(c *gc.C) {
 	op, err := factory.NewSkipRemoteInit(true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(operation.State{})
+	newState, err = op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Commit(operation.State{})
+	newState, err = op.Commit(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &operation.State{
 		Kind: operation.RemoteInit,
@@ -292,7 +294,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitRetryWithHook(c *gc.C) {
 	op, err := factory.NewSkipRemoteInit(true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Done,
 		Hook: &hook.Info{
@@ -304,7 +306,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitRetryWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Execute(operation.State{
+	newState, err = op.Execute(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Done,
 		Hook: &hook.Info{
@@ -316,7 +318,7 @@ func (s *RemoteInitSuite) TestSkipRemoteInitRetryWithHook(c *gc.C) {
 	c.Assert(callbacks.MockRemoteInit.gotRunningStatus, gc.IsNil)
 	c.Assert(callbacks.MockRemoteInit.gotAbort, gc.IsNil)
 
-	newState, err = op.Commit(operation.State{
+	newState, err = op.Commit(stdcontext.Background(), operation.State{
 		Kind: operation.RemoteInit,
 		Step: operation.Done,
 		Hook: &hook.Info{

--- a/internal/worker/uniter/operation/runaction.go
+++ b/internal/worker/uniter/operation/runaction.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -48,7 +49,7 @@ func (ra *runAction) ExecutionGroup() string {
 // will return ErrSkipExecute. It preserves any hook recorded in the supplied
 // state.
 // Prepare is part of the Operation interface.
-func (ra *runAction) Prepare(state State) (*State, error) {
+func (ra *runAction) Prepare(ctx context.Context, state State) (*State, error) {
 	ra.changed = make(chan struct{}, 1)
 	ra.cancel = make(chan struct{})
 	actionID := ra.action.ID()
@@ -84,7 +85,7 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 
 // Execute runs the action, and preserves any hook recorded in the supplied state.
 // Execute is part of the Operation interface.
-func (ra *runAction) Execute(state State) (*State, error) {
+func (ra *runAction) Execute(ctx context.Context, state State) (*State, error) {
 	message := fmt.Sprintf("running action %s", ra.name)
 	if err := ra.callbacks.SetExecutingStatus(message); err != nil {
 		return nil, err
@@ -133,7 +134,7 @@ func (ra *runAction) Execute(state State) (*State, error) {
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
-func (ra *runAction) Commit(state State) (*State, error) {
+func (ra *runAction) Commit(ctx context.Context, state State) (*State, error) {
 	return stateChange{
 		Kind: continuationKind(state),
 		Step: Pending,

--- a/internal/worker/uniter/operation/runcommands.go
+++ b/internal/worker/uniter/operation/runcommands.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -41,7 +42,7 @@ func (rc *runCommands) String() string {
 
 // Prepare ensures the commands can be run. It never returns a state change.
 // Prepare is part of the Operation interface.
-func (rc *runCommands) Prepare(state State) (*State, error) {
+func (rc *runCommands) Prepare(ctx stdcontext.Context, state State) (*State, error) {
 	rnr, err := rc.runnerFactory.NewCommandRunner(context.CommandInfo{
 		RelationId:     rc.args.RelationId,
 		RemoteUnitName: rc.args.RemoteUnitName,
@@ -63,7 +64,7 @@ func (rc *runCommands) Prepare(state State) (*State, error) {
 // Execute runs the commands and dispatches their results. It never returns a
 // state change.
 // Execute is part of the Operation interface.
-func (rc *runCommands) Execute(state State) (*State, error) {
+func (rc *runCommands) Execute(ctx stdcontext.Context, state State) (*State, error) {
 	rc.logger.Tracef("run commands: %s", rc)
 	if err := rc.callbacks.SetExecutingStatus("running commands"); err != nil {
 		return nil, errors.Trace(err)
@@ -88,7 +89,7 @@ func (rc *runCommands) Execute(state State) (*State, error) {
 
 // Commit does nothing.
 // Commit is part of the Operation interface.
-func (rc *runCommands) Commit(state State) (*State, error) {
+func (rc *runCommands) Commit(ctx stdcontext.Context, state State) (*State, error) {
 	return nil, nil
 }
 

--- a/internal/worker/uniter/operation/runcommands_test.go
+++ b/internal/worker/uniter/operation/runcommands_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -30,7 +32,7 @@ func (s *RunCommandsSuite) TestPrepareError(c *gc.C) {
 	op, err := factory.NewCommands(someCommandArgs, sendResponse)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.ErrorMatches, "blooey")
 	c.Assert(newState, gc.IsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.gotInfo, gc.Equals, context.CommandInfo{
@@ -54,7 +56,7 @@ func (s *RunCommandsSuite) TestPrepareSuccess(c *gc.C) {
 	op, err := factory.NewCommands(someCommandArgs, sendResponse)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.gotInfo, gc.Equals, context.CommandInfo{
@@ -80,7 +82,7 @@ func (s *RunCommandsSuite) TestPrepareCtxError(c *gc.C) {
 	op, err := factory.NewCommands(someCommandArgs, sendResponse)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.ErrorMatches, "ctx prepare error")
 	c.Assert(newState, gc.IsNil)
 	ctx.CheckCall(c, 0, "Prepare")
@@ -96,10 +98,10 @@ func (s *RunCommandsSuite) TestExecuteRebootErrors(c *gc.C) {
 		sendResponse := &MockSendResponse{}
 		op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
 		c.Assert(err, jc.ErrorIsNil)
-		_, err = op.Prepare(operation.State{})
+		_, err = op.Prepare(stdcontext.Background(), operation.State{})
 		c.Assert(err, jc.ErrorIsNil)
 
-		newState, err := op.Execute(operation.State{})
+		newState, err := op.Execute(stdcontext.Background(), operation.State{})
 		c.Assert(newState, gc.IsNil)
 		c.Assert(err, gc.Equals, operation.ErrNeedsReboot)
 		c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
@@ -118,10 +120,10 @@ func (s *RunCommandsSuite) TestExecuteOtherError(c *gc.C) {
 	sendResponse := &MockSendResponse{}
 	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "sneh")
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
@@ -141,10 +143,10 @@ func (s *RunCommandsSuite) TestExecuteConsumeOtherError(c *gc.C) {
 	}
 	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
@@ -162,10 +164,10 @@ func (s *RunCommandsSuite) TestExecuteSuccess(c *gc.C) {
 	sendResponse := &MockSendResponse{}
 	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
@@ -185,10 +187,10 @@ func (s *RunCommandsSuite) TestExecuteSuccessOperator(c *gc.C) {
 	commandArgs.RunLocation = runner.Operator
 	op, err := factory.NewCommands(commandArgs, sendResponse.Call)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
@@ -202,7 +204,7 @@ func (s *RunCommandsSuite) TestCommit(c *gc.C) {
 	sendResponse := func(*utilexec.ExecResponse, error) bool { panic("not expected") }
 	op, err := factory.NewCommands(someCommandArgs, sendResponse)
 	c.Assert(err, jc.ErrorIsNil)
-	newState, err := op.Commit(operation.State{})
+	newState, err := op.Commit(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/internal/worker/uniter/operation/runhook.go
+++ b/internal/worker/uniter/operation/runhook.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/charm/v12/hooks"
@@ -63,7 +64,7 @@ func (rh *runHook) String() string {
 
 // Prepare ensures the hook can be executed.
 // Prepare is part of the Operation interface.
-func (rh *runHook) Prepare(state State) (*State, error) {
+func (rh *runHook) Prepare(ctx stdcontext.Context, state State) (*State, error) {
 	name, err := rh.callbacks.PrepareHook(rh.info)
 	if err != nil {
 		return nil, err
@@ -131,7 +132,7 @@ func RunningHookMessage(hookName string, info hook.Info) string {
 
 // Execute runs the hook.
 // Execute is part of the Operation interface.
-func (rh *runHook) Execute(state State) (*State, error) {
+func (rh *runHook) Execute(ctx stdcontext.Context, state State) (*State, error) {
 	message := RunningHookMessage(rh.name, rh.info)
 	if err := rh.beforeHook(state); err != nil {
 		return nil, err
@@ -295,7 +296,7 @@ func createUpgradeSeriesStatusMessage(name string, hookFound bool) string {
 // records the impact of start and collect-metrics hooks, and queues follow-up
 // config-changed hooks to directly follow install and upgrade-charm hooks.
 // Commit is part of the Operation interface.
-func (rh *runHook) Commit(state State) (*State, error) {
+func (rh *runHook) Commit(ctx stdcontext.Context, state State) (*State, error) {
 	var err error
 	err = rh.callbacks.CommitHook(rh.info)
 	if err != nil {

--- a/internal/worker/uniter/operation/runhook_test.go
+++ b/internal/worker/uniter/operation/runhook_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -37,7 +39,7 @@ func (s *RunHookSuite) testPrepareHookError(
 	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	if expectSkip {
 		c.Check(err, gc.Equals, operation.ErrSkipExecute)
@@ -67,7 +69,7 @@ func (s *RunHookSuite) TestPrepareHookCtxCalled(c *gc.C) {
 	op, err := factory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -92,7 +94,7 @@ func (s *RunHookSuite) TestPrepareHookCtxError(c *gc.C) {
 	op, err := factory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `ctx prepare error`)
 
@@ -123,7 +125,7 @@ func (s *RunHookSuite) TestPrepareHookError_LeaderElectedNotLeader(c *gc.C) {
 	op, err := operation.Factory.NewRunHook(factory, hook.Info{Kind: hooks.LeaderElected})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 }
 
@@ -136,7 +138,7 @@ func (s *RunHookSuite) testPrepareRunnerError(c *gc.C, newHook newHook) {
 	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(operation.State{})
+	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "splat")
 	c.Check(runnerFactory.MockNewHookRunner.gotHook, gc.DeepEquals, &hook.Info{
@@ -157,7 +159,7 @@ func (s *RunHookSuite) testPrepareSuccess(
 	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Prepare(before)
+	newState, err := op.Prepare(stdcontext.Background(), before)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &after)
 }
@@ -211,10 +213,10 @@ func (s *RunHookSuite) TestExecuteMissingHookError(c *gc.C) {
 	for _, kind := range hooks.UnitHooks() {
 		c.Logf("hook %v", kind)
 		op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, kind, runErr)
-		_, err := op.Prepare(operation.State{})
+		_, err := op.Prepare(stdcontext.Background(), operation.State{})
 		c.Assert(err, jc.ErrorIsNil)
 
-		newState, err := op.Execute(operation.State{})
+		newState, err := op.Execute(stdcontext.Background(), operation.State{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		s.assertStateMatches(c, newState, operation.RunHook, operation.Done, kind)
@@ -245,10 +247,10 @@ func (s *RunHookSuite) assertStateMatches(
 func (s *RunHookSuite) TestExecuteRequeueRebootError(c *gc.C) {
 	runErr := context.ErrRequeueAndReboot
 	op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.ConfigChanged, runErr)
-	_, err := op.Prepare(operation.State{})
+	_, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrNeedsReboot)
 
 	s.assertStateMatches(c, newState, operation.RunHook, operation.Queued, hooks.ConfigChanged)
@@ -262,10 +264,10 @@ func (s *RunHookSuite) TestExecuteRequeueRebootError(c *gc.C) {
 func (s *RunHookSuite) TestExecuteRebootError(c *gc.C) {
 	runErr := context.ErrReboot
 	op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.ConfigChanged, runErr)
-	_, err := op.Prepare(operation.State{})
+	_, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrNeedsReboot)
 
 	s.assertStateMatches(c, newState, operation.RunHook, operation.Done, hooks.ConfigChanged)
@@ -279,10 +281,10 @@ func (s *RunHookSuite) TestExecuteRebootError(c *gc.C) {
 func (s *RunHookSuite) TestExecuteOtherError(c *gc.C) {
 	runErr := errors.New("graaargh")
 	op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.ConfigChanged, runErr)
-	_, err := op.Prepare(operation.State{})
+	_, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrHookFailed)
 	c.Assert(newState, gc.IsNil)
 	c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "config-changed")
@@ -294,10 +296,10 @@ func (s *RunHookSuite) TestExecuteOtherError(c *gc.C) {
 func (s *RunHookSuite) TestExecuteTerminated(c *gc.C) {
 	runErr := runner.ErrTerminated
 	op, callbacks, runnerFactory := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.ConfigChanged, runErr)
-	_, err := op.Prepare(operation.State{})
+	_, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, runner.ErrTerminated)
 
 	s.assertStateMatches(c, newState, operation.RunHook, operation.Queued, hooks.ConfigChanged)
@@ -313,11 +315,11 @@ func (s *RunHookSuite) TestInstallHookPreservesStatus(c *gc.C) {
 	st := operation.State{
 		StatusSet: true,
 	}
-	midState, err := op.Prepare(st)
+	midState, err := op.Prepare(stdcontext.Background(), st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
-	_, err = op.Execute(*midState)
+	_, err = op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callbacks.executingMessage, gc.Equals, "running install hook")
 	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
@@ -331,11 +333,11 @@ func (s *RunHookSuite) TestInstallHookWHenNoStatusSet(c *gc.C) {
 	st := operation.State{
 		StatusSet: false,
 	}
-	midState, err := op.Prepare(st)
+	midState, err := op.Prepare(stdcontext.Background(), st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
-	_, err = op.Execute(*midState)
+	_, err = op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callbacks.executingMessage, gc.Equals, "running install hook")
 	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
@@ -349,11 +351,11 @@ func (s *RunHookSuite) testExecuteSuccess(
 ) {
 	op, callbacks, f := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.ConfigChanged, nil)
 	f.MockNewHookRunner.runner.MockRunHook.setStatusCalled = setStatusCalled
-	midState, err := op.Prepare(before)
+	midState, err := op.Prepare(stdcontext.Background(), before)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
-	newState, err := op.Execute(*midState)
+	newState, err := op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertStateMatches(c, newState, after.Kind, after.Step, after.Hook.Kind)
@@ -395,14 +397,14 @@ func (s *RunHookSuite) testExecuteThenCharmStatus(
 ) {
 	op, _, f := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, kind, nil)
 	f.MockNewHookRunner.runner.MockRunHook.setStatusCalled = setStatusCalled
-	midState, err := op.Prepare(before)
+	midState, err := op.Prepare(stdcontext.Background(), before)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
 	_, err = f.MockNewHookRunner.runner.Context().UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(*midState)
+	newState, err := op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertStateMatches(c, newState, after.Kind, after.Step, after.Hook.Kind)
@@ -456,10 +458,10 @@ func (s *RunHookSuite) testBeforeHookExecute(c *gc.C, newHook newHook, kind hook
 	// overwriting the values.
 	runErr := errors.New("graaargh")
 	op, _, runnerFactory := s.getExecuteRunnerTest(c, newHook, kind, runErr)
-	_, err := op.Prepare(operation.State{})
+	_, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrHookFailed)
 	c.Assert(newState, gc.IsNil)
 
@@ -506,7 +508,7 @@ func (s *RunHookSuite) testCommitError(c *gc.C, newHook newHook) {
 	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Commit(operation.State{})
+	newState, err := op.Commit(stdcontext.Background(), operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "committing hook.*: pow")
 }
@@ -527,7 +529,7 @@ func (s *RunHookSuite) testCommitSuccess(c *gc.C, newHook newHook, hookInfo hook
 	op, err := newHook(factory, hookInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Commit(before)
+	newState, err := op.Commit(stdcontext.Background(), before)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, gc.DeepEquals, &after)
 }
@@ -631,10 +633,10 @@ func (s *RunHookSuite) assertCommitSuccess_RelationBroken_SetStatus(c *gc.C, sus
 	op, err := factory.NewRunHook(hook.Info{Kind: hooks.RelationBroken})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	newState, err := op.Execute(operation.State{})
+	newState, err := op.Execute(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	step := operation.Done
 	c.Assert(newState, gc.DeepEquals, &operation.State{
@@ -944,9 +946,9 @@ func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
 		Step: operation.Pending,
 	}
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
-	newState, err := op.Commit(operation.State{})
+	newState, err := op.Commit(stdcontext.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, jc.DeepEquals, expectState)
 	c.Assert(callbacks.rotatedSecretURI, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
@@ -977,6 +979,6 @@ func (s *RunHookSuite) assertPrepareSecretHookErrorNotLeader(c *gc.C, kind hooks
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 }

--- a/internal/worker/uniter/operation/secrets.go
+++ b/internal/worker/uniter/operation/secrets.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -21,7 +22,7 @@ func (op *noOpSecretsRemoved) String() string {
 }
 
 // Commit is part of the Operation interface.
-func (op *noOpSecretsRemoved) Commit(state State) (*State, error) {
+func (op *noOpSecretsRemoved) Commit(ctx context.Context, state State) (*State, error) {
 	if err := op.callbacks.SecretsRemoved(op.uris); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/uniter/operation/skip.go
+++ b/internal/worker/uniter/operation/skip.go
@@ -4,6 +4,7 @@
 package operation
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
@@ -24,12 +25,12 @@ func (op *skipOperation) NeedsGlobalMachineLock() bool {
 }
 
 // Prepare is part of the Operation interface.
-func (op *skipOperation) Prepare(state State) (*State, error) {
+func (op *skipOperation) Prepare(ctx context.Context, state State) (*State, error) {
 	return nil, ErrSkipExecute
 }
 
 // Execute is part of the Operation interface.
-func (op *skipOperation) Execute(state State) (*State, error) {
+func (op *skipOperation) Execute(ctx context.Context, state State) (*State, error) {
 	return nil, ErrSkipExecute
 }
 

--- a/internal/worker/uniter/reboot/resolver.go
+++ b/internal/worker/uniter/reboot/resolver.go
@@ -4,6 +4,8 @@
 package reboot
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 
@@ -35,7 +37,7 @@ func NewResolver(logger Logger, rebootDetected bool) resolver.Resolver {
 type nopResolver struct {
 }
 
-func (nopResolver) NextOp(_ resolver.LocalState, _ remotestate.Snapshot, _ operation.Factory) (operation.Operation, error) {
+func (nopResolver) NextOp(_ context.Context, _ resolver.LocalState, _ remotestate.Snapshot, _ operation.Factory) (operation.Operation, error) {
 	return nil, resolver.ErrNoOperation
 }
 
@@ -44,7 +46,7 @@ type rebootResolver struct {
 	logger         Logger
 }
 
-func (r *rebootResolver) NextOp(localState resolver.LocalState, remoteState remotestate.Snapshot, opfactory operation.Factory) (operation.Operation, error) {
+func (r *rebootResolver) NextOp(ctx context.Context, localState resolver.LocalState, remoteState remotestate.Snapshot, opfactory operation.Factory) (operation.Operation, error) {
 	// Have we already notified that a reboot occurred?
 	if !r.rebootDetected {
 		return nil, resolver.ErrNoOperation

--- a/internal/worker/uniter/relation/mock_test.go
+++ b/internal/worker/uniter/relation/mock_test.go
@@ -4,6 +4,7 @@
 package relation_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/charm/v12/hooks"
@@ -47,15 +48,15 @@ func (m *mockOperation) ExecutionGroup() string {
 	return ""
 }
 
-func (m *mockOperation) Prepare(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Prepare(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 
-func (m *mockOperation) Execute(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Execute(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 
-func (m *mockOperation) Commit(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Commit(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 

--- a/internal/worker/uniter/relation/resolver.go
+++ b/internal/worker/uniter/relation/resolver.go
@@ -4,6 +4,8 @@
 package relation
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -51,7 +53,7 @@ type relationsResolver struct {
 }
 
 // NextOp implements resolver.Resolver.
-func (r *relationsResolver) NextOp(localState resolver.LocalState, remoteState remotestate.Snapshot, opFactory operation.Factory) (_ operation.Operation, err error) {
+func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.LocalState, remoteState remotestate.Snapshot, opFactory operation.Factory) (_ operation.Operation, err error) {
 	if r.logger.IsTraceEnabled() {
 		r.logger.Tracef("relation resolver next op for new remote relations %# v", pretty.Formatter(remoteState.Relations))
 		defer func() {
@@ -336,6 +338,7 @@ type createdRelationsResolver struct {
 
 // NextOp implements resolver.Resolver.
 func (r *createdRelationsResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/relation/resolver_test.go
+++ b/internal/worker/uniter/relation/resolver_test.go
@@ -4,6 +4,7 @@
 package relation_test
 
 import (
+	stdcontext "context"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -261,7 +262,7 @@ func (s *relationResolverSuite) TestNextOpNothing(c *gc.C) {
 	}
 	remoteState := remotestate.Snapshot{}
 	relationsResolver := s.newRelationResolver(r, nil)
-	_, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -399,7 +400,7 @@ func (s *relationResolverSuite) assertHookRelationJoined(c *gc.C, numCalls *int3
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, numCalls, 11)
 	c.Assert(op.String(), gc.Equals, "run hook relation-joined on unit wordpress/0 with relation 1")
@@ -433,7 +434,7 @@ func (s *relationResolverSuite) assertHookRelationChanged(
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, numCalls, numCallsBefore)
 	c.Assert(op.String(), gc.Equals, "run hook relation-changed on unit wordpress/0 with relation 1")
@@ -535,7 +536,7 @@ func (s *relationResolverSuite) TestHookRelationChangedApplication(c *gc.C) {
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	// No new calls
 	assertNumCalls(c, &numCalls, numCallsBefore)
@@ -573,7 +574,7 @@ func (s *relationResolverSuite) TestHookRelationChangedSuspended(c *gc.C) {
 	}
 
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, &numCalls, numCallsBefore+2) // Refresh/Life calls made by the resolver prior to emitting a RelationDeparted hook
 	c.Assert(op.String(), gc.Equals, "run hook relation-departed on unit wordpress/0 with relation 1")
@@ -603,7 +604,7 @@ func (s *relationResolverSuite) assertHookRelationDeparted(c *gc.C, numCalls *in
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, numCalls, numCallsBefore+2) // Refresh/Life calls made by the resolver prior to emitting a RelationDeparted hook
 	c.Assert(op.String(), gc.Equals, "run hook relation-departed on unit wordpress/0 with relation 1")
@@ -642,7 +643,7 @@ func (s *relationResolverSuite) TestHookRelationBroken(c *gc.C) {
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, &numCalls, 16)
 	c.Assert(op.String(), gc.Equals, "run hook relation-broken with relation 1")
@@ -668,7 +669,7 @@ func (s *relationResolverSuite) TestHookRelationBrokenWhenSuspended(c *gc.C) {
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	assertNumCalls(c, &numCalls, 16)
 	c.Assert(op.String(), gc.Equals, "run hook relation-broken with relation 1")
@@ -711,7 +712,7 @@ func (s *relationResolverSuite) TestHookRelationBrokenOnlyOnce(c *gc.C) {
 	}
 	// Get RelationBroken once.
 	relationsResolver := s.newRelationResolver(r, nil)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Commit the RelationBroken, so the NextOp will do the correct thing.
@@ -721,7 +722,7 @@ func (s *relationResolverSuite) TestHookRelationBrokenOnlyOnce(c *gc.C) {
 	err = r.CommitHook(mockOp.hookInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err = relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -840,7 +841,7 @@ func (s *relationResolverSuite) TestImplicitRelationNoHooks(c *gc.C) {
 		},
 	}
 	relationsResolver := s.newRelationResolver(r, nil)
-	_, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -993,7 +994,7 @@ func (s *relationResolverSuite) TestSubSubPrincipalRelationDyingDestroysUnit(c *
 	}
 
 	relationResolver := s.newRelationResolver(r, nil)
-	_, err := relationResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we've made the destroy unit call.
@@ -1054,7 +1055,7 @@ func (s *relationResolverSuite) TestSubSubOtherRelationDyingNotDestroyed(c *gc.C
 	}
 
 	relationResolver := s.newRelationResolver(r, nil)
-	_, err := relationResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we didn't try to make a destroy call (the apiCaller
@@ -1164,7 +1165,7 @@ func (s *relationResolverSuite) TestPrincipalDyingDestroysSubordinates(c *gc.C) 
 	destroyer := mocks.NewMockSubordinateDestroyer(ctrl)
 	destroyer.EXPECT().DestroyAllSubordinates().Return(nil)
 	relationResolver := s.newRelationResolver(r, destroyer)
-	_, err := relationResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we've made the destroy unit call.
@@ -1213,7 +1214,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationResolverForRelationInS
 	)
 
 	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
-	_, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := createdRelationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation, gc.Commentf("unexpected hook from created relations resolver for already joined relation"))
 }
 
@@ -1257,7 +1258,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationResolverFordRelationNo
 	)
 
 	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
-	op, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := createdRelationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.DeepEquals, &mockOperation{
 		hookInfo: hook.Info{
@@ -1287,7 +1288,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationsResolverWithPendingHo
 	}
 
 	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
-	_, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := createdRelationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation, gc.Commentf("expected to get ErrNoOperation when a RunHook operation is pending"))
 }
 
@@ -1312,7 +1313,7 @@ func (s *mockRelationResolverSuite) TestNextOpNothing(c *gc.C) {
 	remoteState := remotestate.Snapshot{}
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	_, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -1345,7 +1346,7 @@ func (s *mockRelationResolverSuite) TestHookRelationJoined(c *gc.C) {
 	s.expectIsPeerRelationFalse(1)
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-joined on unit wordpress/0 with relation 1")
 }
@@ -1388,7 +1389,7 @@ func (s *mockRelationResolverSuite) TestHookRelationChangedApplication(c *gc.C) 
 	s.expectIsPeerRelationFalse(1)
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-changed on app wordpress with relation 1")
 }
@@ -1425,7 +1426,7 @@ func (s *mockRelationResolverSuite) TestHookRelationChangedSuspended(c *gc.C) {
 	s.expectLocalUnitAndApplicationLife()
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-departed on unit wordpress/0 with relation 1")
 }
@@ -1462,7 +1463,7 @@ func (s *mockRelationResolverSuite) TestHookRelationDeparted(c *gc.C) {
 	s.expectLocalUnitAndApplicationLife()
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-departed on unit wordpress/0 with relation 1")
 }
@@ -1496,7 +1497,7 @@ func (s *mockRelationResolverSuite) TestHookRelationBroken(c *gc.C) {
 	s.expectRemoteApplication(1, "")
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-broken with relation 1")
 }
@@ -1531,7 +1532,7 @@ func (s *mockRelationResolverSuite) TestHookRelationBrokenWhenSuspended(c *gc.C)
 	s.expectRemoteApplication(1, "")
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-broken with relation 1")
 }
@@ -1564,7 +1565,7 @@ func (s *mockRelationResolverSuite) TestHookRelationBrokenOnlyOnce(c *gc.C) {
 	s.expectStateFoundFalse(1)
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	_, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -1590,7 +1591,7 @@ func (s *mockRelationResolverSuite) TestImplicitRelationNoHooks(c *gc.C) {
 	s.expectIsImplicit(1)
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, s.mockSupDestroyer)
-	_, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	_, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -1634,7 +1635,7 @@ func (s *mockRelationResolverSuite) TestPrincipalDyingDestroysSubordinates(c *gc
 	destroyer.EXPECT().DestroyAllSubordinates().Return(nil)
 
 	relationsResolver := s.newRelationResolver(s.mockRelStTracker, destroyer)
-	op, err := relationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run hook relation-broken with relation 1")
 }

--- a/internal/worker/uniter/resolver.go
+++ b/internal/worker/uniter/resolver.go
@@ -4,6 +4,7 @@
 package uniter
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	jujucharm "github.com/juju/charm/v12"
@@ -57,6 +58,7 @@ func NewUniterResolver(cfg ResolverConfig) resolver.Resolver {
 }
 
 func (s *uniterResolver) NextOp(
+	ctx stdcontext.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
@@ -69,7 +71,7 @@ func (s *uniterResolver) NextOp(
 	// Operations for series-upgrade need to be resolved early,
 	// in particular because no other operations should be run when the unit
 	// has completed preparation and is waiting for upgrade completion.
-	op, err := s.config.UpgradeSeries.NextOp(localState, remoteState, opFactory)
+	op, err := s.config.UpgradeSeries.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		if errors.Cause(err) == resolver.ErrDoNotProceed {
 			return nil, resolver.ErrNoOperation
@@ -78,18 +80,18 @@ func (s *uniterResolver) NextOp(
 	}
 
 	// Check if we need to notify the charms because a reboot was detected.
-	op, err = s.config.Reboot.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Reboot.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
 	if localState.Kind == operation.Upgrade {
 		if localState.Conflicted {
-			return s.nextOpConflicted(localState, remoteState, opFactory)
+			return s.nextOpConflicted(ctx, localState, remoteState, opFactory)
 		}
 		// continue upgrading the charm
 		logger.Infof("resuming charm upgrade")
-		return s.newUpgradeOperation(localState, remoteState, opFactory)
+		return s.newUpgradeOperation(ctx, localState, remoteState, opFactory)
 	}
 
 	if localState.Restart {
@@ -107,39 +109,39 @@ func (s *uniterResolver) NextOp(
 		s.retryHookTimerStarted = false
 	}
 
-	op, err = s.config.CreatedRelations.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.CreatedRelations.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
-	op, err = s.config.Leadership.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Leadership.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
 	for _, r := range s.config.OptionalResolvers {
-		op, err = r.NextOp(localState, remoteState, opFactory)
+		op, err = r.NextOp(ctx, localState, remoteState, opFactory)
 		if errors.Cause(err) != resolver.ErrNoOperation {
 			return op, err
 		}
 	}
 
-	op, err = s.config.Secrets.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Secrets.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
-	op, err = s.config.Actions.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Actions.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
-	op, err = s.config.Commands.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Commands.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 
-	op, err = s.config.Storage.NextOp(localState, remoteState, opFactory)
+	op, err = s.config.Storage.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
@@ -147,7 +149,7 @@ func (s *uniterResolver) NextOp(
 	// If we are to shut down, we don't want to start running any more queued/pending hooks.
 	if remoteState.Shutdown {
 		logger.Debugf("unit agent is shutting down, will not run pending/queued hooks")
-		return s.nextOp(localState, remoteState, opFactory)
+		return s.nextOp(ctx, localState, remoteState, opFactory)
 	}
 
 	switch localState.Kind {
@@ -159,14 +161,14 @@ func (s *uniterResolver) NextOp(
 		switch step {
 		case operation.Pending:
 			logger.Infof("awaiting error resolution for %q hook", localState.Hook.Kind)
-			return s.nextOpHookError(localState, remoteState, opFactory)
+			return s.nextOpHookError(ctx, localState, remoteState, opFactory)
 
 		case operation.Queued:
 			logger.Infof("found queued %q hook", localState.Hook.Kind)
 			if localState.Hook.Kind == hooks.Install {
 				// Special case: handle install in nextOp,
 				// so we do nothing when the unit is dying.
-				return s.nextOp(localState, remoteState, opFactory)
+				return s.nextOp(ctx, localState, remoteState, opFactory)
 			}
 			return opFactory.NewRunHook(*localState.Hook)
 
@@ -192,7 +194,7 @@ func (s *uniterResolver) NextOp(
 
 	case operation.Continue:
 		logger.Debugf("no operations in progress; waiting for changes")
-		return s.nextOp(localState, remoteState, opFactory)
+		return s.nextOp(ctx, localState, remoteState, opFactory)
 
 	default:
 		return nil, errors.Errorf("unknown operation kind %v", localState.Kind)
@@ -203,6 +205,7 @@ func (s *uniterResolver) NextOp(
 // yet been resolved or reverted. When in this mode, the resolver will only
 // consider those two possibilities for progressing.
 func (s *uniterResolver) nextOpConflicted(
+	ctx stdcontext.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
@@ -212,7 +215,7 @@ func (s *uniterResolver) nextOpConflicted(
 
 	// Verify the charm profile before proceeding.  No hooks to run, if the
 	// correct one is not yet applied.
-	_, err := s.config.VerifyCharmProfile.NextOp(localState, remoteState, opFactory)
+	_, err := s.config.VerifyCharmProfile.NextOp(ctx, localState, remoteState, opFactory)
 	if e := errors.Cause(err); e == resolver.ErrDoNotProceed {
 		return nil, resolver.ErrNoOperation
 	} else if e != resolver.ErrNoOperation {
@@ -232,13 +235,14 @@ func (s *uniterResolver) nextOpConflicted(
 }
 
 func (s *uniterResolver) newUpgradeOperation(
+	ctx stdcontext.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
 	// Verify the charm profile before proceeding.  No hooks to run, if the
 	// correct one is not yet applied.
-	_, err := s.config.VerifyCharmProfile.NextOp(localState, remoteState, opFactory)
+	_, err := s.config.VerifyCharmProfile.NextOp(ctx, localState, remoteState, opFactory)
 	if e := errors.Cause(err); e == resolver.ErrDoNotProceed {
 		return nil, resolver.ErrNoOperation
 	} else if e != resolver.ErrNoOperation {
@@ -248,6 +252,7 @@ func (s *uniterResolver) newUpgradeOperation(
 }
 
 func (s *uniterResolver) nextOpHookError(
+	ctx stdcontext.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
@@ -259,7 +264,7 @@ func (s *uniterResolver) nextOpHookError(
 	}
 
 	if remoteState.ForceCharmUpgrade && s.charmModified(localState, remoteState) {
-		return s.newUpgradeOperation(localState, remoteState, opFactory)
+		return s.newUpgradeOperation(ctx, localState, remoteState, opFactory)
 	}
 
 	switch remoteState.ResolvedMode {
@@ -322,6 +327,7 @@ func (s *uniterResolver) charmModified(local resolver.LocalState, remote remotes
 }
 
 func (s *uniterResolver) nextOp(
+	ctx stdcontext.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
@@ -338,7 +344,7 @@ func (s *uniterResolver) nextOp(
 	case life.Dying:
 		// Normally we handle relations last, but if we're dying we
 		// must ensure that all relations are broken first.
-		op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
+		op, err := s.config.Relations.NextOp(ctx, localState, remoteState, opFactory)
 		if errors.Cause(err) != resolver.ErrNoOperation {
 			return op, err
 		}
@@ -370,7 +376,7 @@ func (s *uniterResolver) nextOp(
 	}
 
 	if s.charmModified(localState, remoteState) {
-		return s.newUpgradeOperation(localState, remoteState, opFactory)
+		return s.newUpgradeOperation(ctx, localState, remoteState, opFactory)
 	}
 
 	configHashChanged := localState.ConfigHash != remoteState.ConfigHash
@@ -380,7 +386,7 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 
-	op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
+	op, err := s.config.Relations.NextOp(ctx, localState, remoteState, opFactory)
 	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}

--- a/internal/worker/uniter/resolver/func.go
+++ b/internal/worker/uniter/resolver/func.go
@@ -4,20 +4,24 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/juju/juju/internal/worker/uniter/operation"
 	"github.com/juju/juju/internal/worker/uniter/remotestate"
 )
 
 type ResolverFunc func(
+	context.Context,
 	LocalState,
 	remotestate.Snapshot,
 	operation.Factory,
 ) (operation.Operation, error)
 
 func (f ResolverFunc) NextOp(
+	ctx context.Context,
 	local LocalState,
 	remote remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
-	return f(local, remote, opFactory)
+	return f(ctx, local, remote, opFactory)
 }

--- a/internal/worker/uniter/resolver/interface.go
+++ b/internal/worker/uniter/resolver/interface.go
@@ -4,6 +4,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/model"
@@ -46,6 +48,7 @@ type Resolver interface {
 	// it will never have any more operations to perform,
 	// and the caller can cease calling.
 	NextOp(
+		context.Context,
 		LocalState,
 		remotestate.Snapshot,
 		operation.Factory,

--- a/internal/worker/uniter/resolver/loop.go
+++ b/internal/worker/uniter/resolver/loop.go
@@ -4,6 +4,7 @@
 package resolver
 
 import (
+	"context"
 	"time"
 
 	jujucharm "github.com/juju/charm/v12"
@@ -72,7 +73,7 @@ type LoopConfig struct {
 //     state has changed again
 //   - if the resolver, onIdle, or executor return some other
 //     error, the loop will exit immediately
-func Loop(cfg LoopConfig, localState *LocalState) error {
+func Loop(ctx context.Context, cfg LoopConfig, localState *LocalState) error {
 	rf := &resolverOpFactory{Factory: cfg.Factory, LocalState: localState}
 
 	// Initialize charmdir availability before entering the loop in case we're recovering from a restart.
@@ -103,7 +104,7 @@ func Loop(cfg LoopConfig, localState *LocalState) error {
 			}
 		}
 
-		op, err := cfg.Resolver.NextOp(*rf.LocalState, rf.RemoteState, rf)
+		op, err := cfg.Resolver.NextOp(ctx, *rf.LocalState, rf.RemoteState, rf)
 		for err == nil {
 			// Send remote state changes to running operations.
 			remoteStateChanged := make(chan remotestate.Snapshot)
@@ -159,7 +160,7 @@ func Loop(cfg LoopConfig, localState *LocalState) error {
 				return errors.Trace(err)
 			}
 
-			op, err = cfg.Resolver.NextOp(*rf.LocalState, rf.RemoteState, rf)
+			op, err = cfg.Resolver.NextOp(ctx, *rf.LocalState, rf.RemoteState, rf)
 		}
 
 		switch errors.Cause(err) {

--- a/internal/worker/uniter/resolver/loop.go
+++ b/internal/worker/uniter/resolver/loop.go
@@ -84,7 +84,7 @@ func Loop(ctx context.Context, cfg LoopConfig, localState *LocalState) error {
 
 	// If we're restarting the loop, ensure any pending charm upgrade is run
 	// before continuing.
-	err = checkCharmInstallUpgrade(cfg.Logger, cfg.CharmDir, cfg.Watcher.Snapshot(), rf, cfg.Executor)
+	err = checkCharmInstallUpgrade(ctx, cfg.Logger, cfg.CharmDir, cfg.Watcher.Snapshot(), rf, cfg.Executor)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -131,7 +131,7 @@ func Loop(ctx context.Context, cfg LoopConfig, localState *LocalState) error {
 			}()
 
 			cfg.Logger.Tracef("running op: %v", op)
-			if err := cfg.Executor.Run(op, remoteStateChanged); err != nil {
+			if err := cfg.Executor.Run(ctx, op, remoteStateChanged); err != nil {
 				close(done)
 
 				if errors.Cause(err) == mutex.ErrCancelled {
@@ -249,7 +249,7 @@ func updateCharmDir(opState operation.State, guard fortress.Guard, abort fortres
 	}
 }
 
-func checkCharmInstallUpgrade(logger Logger, charmDir string, remote remotestate.Snapshot, rf *resolverOpFactory, ex operation.Executor) error {
+func checkCharmInstallUpgrade(ctx context.Context, logger Logger, charmDir string, remote remotestate.Snapshot, rf *resolverOpFactory, ex operation.Executor) error {
 	// If we restarted due to error with a pending charm upgrade available,
 	// do the upgrade now.  There are cases (lp:1895040) where the error was
 	// caused because not all units were upgraded before relation-created
@@ -312,7 +312,7 @@ func checkCharmInstallUpgrade(logger Logger, charmDir string, remote remotestate
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = ex.Run(op, nil); err != nil {
+	if err = ex.Run(ctx, op, nil); err != nil {
 		return errors.Trace(err)
 	}
 	if local.Restart {

--- a/internal/worker/uniter/resolver/loop_test.go
+++ b/internal/worker/uniter/resolver/loop_test.go
@@ -4,6 +4,7 @@
 package resolver_test
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -40,7 +41,7 @@ var _ = gc.Suite(&LoopSuite{})
 
 func (s *LoopSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.resolver = resolver.ResolverFunc(func(resolver.LocalState, remotestate.Snapshot, operation.Factory) (operation.Operation, error) {
+	s.resolver = resolver.ResolverFunc(func(context.Context, resolver.LocalState, remotestate.Snapshot, operation.Factory) (operation.Operation, error) {
 		return nil, resolver.ErrNoOperation
 	})
 	s.watcher = &mockRemoteStateWatcher{
@@ -56,7 +57,7 @@ func (s *LoopSuite) loop() (resolver.LocalState, error) {
 	localState := resolver.LocalState{
 		CharmURL: s.charmURL,
 	}
-	err := resolver.Loop(resolver.LoopConfig{
+	err := resolver.Loop(context.Background(), resolver.LoopConfig{
 		Resolver:      s.resolver,
 		Factory:       s.opFactory,
 		Watcher:       s.watcher,
@@ -120,6 +121,7 @@ func (s *LoopSuite) TestErrWaitingNoOnIdle(c *gc.C) {
 		return nil
 	}
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -135,6 +137,7 @@ func (s *LoopSuite) TestErrWaitingNoOnIdle(c *gc.C) {
 func (s *LoopSuite) TestInitialFinalLocalState(c *gc.C) {
 	var local resolver.LocalState
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		l resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -156,6 +159,7 @@ func (s *LoopSuite) TestLoop(c *gc.C) {
 	var resolverCalls int
 	theOp := &mockOp{}
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -195,6 +199,7 @@ func (s *LoopSuite) TestLoopWithChange(c *gc.C) {
 	var resolverCalls int
 	theOp := &mockOp{}
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -263,6 +268,7 @@ func (s *LoopSuite) TestLoopWithChange(c *gc.C) {
 func (s *LoopSuite) TestRunFails(c *gc.C) {
 	s.executor.SetErrors(errors.New("run fails"))
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -275,6 +281,7 @@ func (s *LoopSuite) TestRunFails(c *gc.C) {
 
 func (s *LoopSuite) TestNextOpFails(c *gc.C) {
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -359,6 +366,7 @@ func (s *LoopSuite) TestCheckCharmUpgradeIncorrectLXDProfile(c *gc.C) {
 
 func (s *LoopSuite) testCheckCharmUpgradeDoesNothing(c *gc.C) {
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -458,6 +466,7 @@ func (s *LoopSuite) testCheckCharmUpgradeCallsRun(c *gc.C, op string) {
 		op:      mockOp{},
 	}
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,
@@ -490,6 +499,7 @@ func (s *LoopSuite) TestCancelledLockAcquisitionCausesRestart(c *gc.C) {
 	}
 
 	s.resolver = resolver.ResolverFunc(func(
+		_ context.Context,
 		_ resolver.LocalState,
 		_ remotestate.Snapshot,
 		_ operation.Factory,

--- a/internal/worker/uniter/resolver/mock_test.go
+++ b/internal/worker/uniter/resolver/mock_test.go
@@ -105,14 +105,14 @@ type mockOp struct {
 	prepare func(operation.State) (*operation.State, error)
 }
 
-func (op mockOp) Prepare(st operation.State) (*operation.State, error) {
+func (op mockOp) Prepare(ctx context.Context, st operation.State) (*operation.State, error) {
 	if op.prepare != nil {
 		return op.prepare(st)
 	}
 	return &st, nil
 }
 
-func (op mockOp) Commit(st operation.State) (*operation.State, error) {
+func (op mockOp) Commit(ctx context.Context, st operation.State) (*operation.State, error) {
 	if op.commit != nil {
 		return op.commit(st)
 	}

--- a/internal/worker/uniter/resolver/mock_test.go
+++ b/internal/worker/uniter/resolver/mock_test.go
@@ -4,6 +4,8 @@
 package resolver_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 
 	"github.com/juju/juju/internal/worker/fortress"
@@ -89,7 +91,7 @@ func (e *mockOpExecutor) State() operation.State {
 	return e.st
 }
 
-func (e *mockOpExecutor) Run(op operation.Operation, rs <-chan remotestate.Snapshot) error {
+func (e *mockOpExecutor) Run(ctx context.Context, op operation.Operation, rs <-chan remotestate.Snapshot) error {
 	e.MethodCall(e, "Run", op, rs)
 	if e.run != nil {
 		return e.run(op, rs)

--- a/internal/worker/uniter/resolver/opfactory.go
+++ b/internal/worker/uniter/resolver/opfactory.go
@@ -4,6 +4,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 
@@ -203,8 +205,8 @@ type onCommitWrapper struct {
 	onCommit func(*operation.State)
 }
 
-func (op onCommitWrapper) Commit(state operation.State) (*operation.State, error) {
-	st, err := op.Operation.Commit(state)
+func (op onCommitWrapper) Commit(ctx context.Context, state operation.State) (*operation.State, error) {
+	st, err := op.Operation.Commit(ctx, state)
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +224,8 @@ type onPrepareWrapper struct {
 	onPrepare func()
 }
 
-func (op onPrepareWrapper) Prepare(state operation.State) (*operation.State, error) {
-	st, err := op.Operation.Prepare(state)
+func (op onPrepareWrapper) Prepare(ctx context.Context, state operation.State) (*operation.State, error) {
+	st, err := op.Operation.Prepare(ctx, state)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/worker/uniter/resolver/opfactory_test.go
+++ b/internal/worker/uniter/resolver/opfactory_test.go
@@ -4,6 +4,7 @@
 package resolver_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/charm/v12/hooks"
@@ -51,7 +52,7 @@ func (s *ResolverOpFactorySuite) testUpdateStatusChanged(
 	c.Assert(err, jc.ErrorIsNil)
 	f.RemoteState.UpdateStatusVersion = 2
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local state's UpdateStatusVersion should be set to what
@@ -75,13 +76,13 @@ func (s *ResolverOpFactorySuite) TestUpgradeSeriesStatusChanged(c *gc.C) {
 	op, err := f.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(f.LocalState.UpgradeMachineStatus, gc.Equals, model.UpgradeSeriesPrepareStarted)
 	f.RemoteState.UpgradeMachineStatus = model.UpgradeSeriesPrepareCompleted
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(f.LocalState.UpgradeMachineStatus, gc.Equals, model.UpgradeSeriesPrepareCompleted)
@@ -115,7 +116,7 @@ func (s *ResolverOpFactorySuite) testConfigChanged(
 	f.RemoteState.AddressesHash = "differenthash"
 	f.RemoteState.UpdateStatusVersion = 4
 
-	resultState, err := op.Commit(operation.State{})
+	resultState, err := op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resultState, gc.NotNil)
 
@@ -147,7 +148,7 @@ func (s *ResolverOpFactorySuite) testLeaderSettingsChanged(
 	f.RemoteState.LeaderSettingsVersion = 2
 	f.RemoteState.UpdateStatusVersion = 4
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local state's LeaderSettingsVersion should be set to what
@@ -171,7 +172,7 @@ func (s *ResolverOpFactorySuite) testUpgrade(
 	curl := "ch:trusty/mysql"
 	op, err := meth(f, curl)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.CharmURL, jc.DeepEquals, curl)
 	c.Assert(f.LocalState.Conflicted, jc.IsFalse)
@@ -182,7 +183,7 @@ func (s *ResolverOpFactorySuite) TestRemoteInit(c *gc.C) {
 	f.LocalState.OutdatedRemoteCharm = true
 	op, err := f.NewRemoteInit(remotestate.ContainerRunningStatus{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.OutdatedRemoteCharm, jc.IsFalse)
 }
@@ -192,7 +193,7 @@ func (s *ResolverOpFactorySuite) TestSkipRemoteInit(c *gc.C) {
 	f.LocalState.OutdatedRemoteCharm = true
 	op, err := f.NewSkipRemoteInit(false)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.OutdatedRemoteCharm, jc.IsTrue)
 }
@@ -221,7 +222,7 @@ func (s *ResolverOpFactorySuite) TestCommitError(c *gc.C) {
 	}
 	op, err := f.NewUpgrade("ch:trusty/mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, gc.ErrorMatches, "commit fails")
 	// Local state should not have been updated. We use the same code
 	// internally for all operations, so it suffices to test just the
@@ -235,7 +236,7 @@ func (s *ResolverOpFactorySuite) TestActionsCommit(c *gc.C) {
 	f.LocalState.CompletedActions = map[string]struct{}{}
 	op, err := f.NewAction("action 1")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
 		"action 1": {},
@@ -252,7 +253,7 @@ func (s *ResolverOpFactorySuite) TestActionsTrimming(c *gc.C) {
 	}
 	op, err := f.NewAction("d")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
 		"c": {},

--- a/internal/worker/uniter/runcommands/runcommands.go
+++ b/internal/worker/uniter/runcommands/runcommands.go
@@ -106,7 +106,7 @@ func (s *commandsResolver) NextOp(
 		s.commands.RemoveCommand(id)
 		s.commandCompleted(id)
 	}
-	return &commandCompleter{op, commandCompleted}, nil
+	return &commandCompleter{Operation: op, commandCompleted: commandCompleted}, nil
 }
 
 type commandCompleter struct {
@@ -114,8 +114,8 @@ type commandCompleter struct {
 	commandCompleted func()
 }
 
-func (c *commandCompleter) Commit(st operation.State) (*operation.State, error) {
-	result, err := c.Operation.Commit(st)
+func (c *commandCompleter) Commit(ctx context.Context, st operation.State) (*operation.State, error) {
+	result, err := c.Operation.Commit(ctx, st)
 	if err == nil {
 		c.commandCompleted()
 	}

--- a/internal/worker/uniter/runcommands/runcommands.go
+++ b/internal/worker/uniter/runcommands/runcommands.go
@@ -4,6 +4,7 @@
 package runcommands
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -88,6 +89,7 @@ func NewCommandsResolver(commands Commands, commandCompleted func(string)) resol
 
 // NextOp is part of the resolver.Resolver interface.
 func (s *commandsResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/runcommands/runcommands_test.go
+++ b/internal/worker/uniter/runcommands/runcommands_test.go
@@ -4,6 +4,8 @@
 package runcommands_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -74,7 +76,7 @@ func (s *runcommandsSuite) TestRunCommands(c *gc.C) {
 		RunLocation: runner.Operator,
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 }
@@ -104,7 +106,7 @@ func (s *runcommandsSuite) TestRunCommandsCallbacks(c *gc.C) {
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 
@@ -152,7 +154,7 @@ func (s *runcommandsSuite) TestRunCommandsCommitErrorNoCompletedCallback(c *gc.C
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 
@@ -192,7 +194,7 @@ func (s *runcommandsSuite) TestRunCommandsError(c *gc.C) {
 	})
 	s.remoteState.Commands = []string{id}
 
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 
@@ -226,7 +228,7 @@ func (s *runcommandsSuite) TestRunCommandsErrorConsumed(c *gc.C) {
 	})
 	s.remoteState.Commands = []string{id}
 
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 
@@ -252,7 +254,7 @@ func (s *runcommandsSuite) TestRunCommandsStatus(c *gc.C) {
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run commands (0)")
 	s.callbacks.CheckCalls(c, nil /* no calls */)

--- a/internal/worker/uniter/secrets/resolver.go
+++ b/internal/worker/uniter/secrets/resolver.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -46,6 +47,7 @@ func NewSecretsResolver(logger Logger, secretsTracker SecretStateTracker,
 
 // NextOp is part of the resolver.Resolver interface.
 func (s *secretsResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/secrets/resolver.go
+++ b/internal/worker/uniter/secrets/resolver.go
@@ -168,7 +168,7 @@ func (s *secretsResolver) expireOp(
 	opCompleted := func() {
 		s.expiredRevisions(revSpec)
 	}
-	return &secretCompleter{op, opCompleted}, nil
+	return &secretCompleter{Operation: op, secretCompleted: opCompleted}, nil
 }
 
 type secretCompleter struct {
@@ -176,8 +176,8 @@ type secretCompleter struct {
 	secretCompleted func()
 }
 
-func (c *secretCompleter) Commit(st operation.State) (*operation.State, error) {
-	result, err := c.Operation.Commit(st)
+func (c *secretCompleter) Commit(ctx context.Context, st operation.State) (*operation.State, error) {
+	result, err := c.Operation.Commit(ctx, st)
 	if err == nil {
 		c.secretCompleted()
 	}

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -4,6 +4,8 @@
 package secrets_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -84,7 +86,7 @@ func (s *triggerSecretsSuite) TestNextOpNotInstalled(c *gc.C) {
 		},
 	}
 	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -97,7 +99,7 @@ func (s *triggerSecretsSuite) TestNextOpNotAlive(c *gc.C) {
 	}
 	s.remoteState.Life = life.Dying
 	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -109,7 +111,7 @@ func (s *triggerSecretsSuite) TestNextOpNotReady(c *gc.C) {
 		},
 	}
 	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -124,7 +126,7 @@ func (s *triggerSecretsSuite) TestNextOpRotate(c *gc.C) {
 		},
 	}
 	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-rotate (secret:9m4e2mr0ui3e8a215n4g) hook")
 }
@@ -145,7 +147,7 @@ func (s *triggerSecretsSuite) TestRotateCommit(c *gc.C) {
 	s.rotatedSecret = func(uri string) {
 		rotatedURI = uri
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 
 	hi := hook.Info{
@@ -183,7 +185,7 @@ func (s *triggerSecretsSuite) TestNextOpExpire(c *gc.C) {
 		},
 	}
 	s.remoteState.ExpiredSecretRevisions = []string{"secret:9m4e2mr0ui3e8a215n4g/666"}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-expired (secret:9m4e2mr0ui3e8a215n4g/666) hook")
 }
@@ -204,7 +206,7 @@ func (s *triggerSecretsSuite) TestExpireCommit(c *gc.C) {
 	s.expiredRevision = func(rev string) {
 		expiredRevision = rev
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 
 	hi := hook.Info{
@@ -261,7 +263,7 @@ func (s *changeSecretsSuite) TestNextOpNotInstalled(c *gc.C) {
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
 	}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -280,7 +282,7 @@ func (s *changeSecretsSuite) TestNextOpNoneExisting(c *gc.C) {
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-changed (secret:9m4e2mr0ui3e8a215n4g) hook")
 }
@@ -300,7 +302,7 @@ func (s *changeSecretsSuite) TestNextOpUpdatedRevision(c *gc.C) {
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-changed (secret:9m4e2mr0ui3e8a215n4g) hook")
 }
@@ -320,7 +322,7 @@ func (s *changeSecretsSuite) TestNextOpNone(c *gc.C) {
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
 	}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -359,7 +361,7 @@ func (s *removeSecretSuite) TestNextOpNotInstalled(c *gc.C) {
 	s.remoteState.ObsoleteSecretRevisions = map[string][]int{
 		"secret:9m4e2mr0ui3e8a215n4g": {666, 668},
 	}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -378,7 +380,7 @@ func (s *removeSecretSuite) TestNextOpNoneExisting(c *gc.C) {
 	s.remoteState.ObsoleteSecretRevisions = map[string][]int{
 		"secret:9m4e2mr0ui3e8a215n4g": {666, 668},
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-remove (secret:9m4e2mr0ui3e8a215n4g/666) hook")
 }
@@ -398,7 +400,7 @@ func (s *removeSecretSuite) TestNextOpNextRevision(c *gc.C) {
 	s.remoteState.ObsoleteSecretRevisions = map[string][]int{
 		"secret:9m4e2mr0ui3e8a215n4g": {666, 668},
 	}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run secret-remove (secret:9m4e2mr0ui3e8a215n4g/668) hook")
 }
@@ -418,7 +420,7 @@ func (s *removeSecretSuite) TestNextOpNone(c *gc.C) {
 	s.remoteState.ObsoleteSecretRevisions = map[string][]int{
 		"secret:9m4e2mr0ui3e8a215n4g": {666, 668},
 	}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -463,7 +465,7 @@ func (s *secretDeletedSuite) TestNextOpNotInstalled(c *gc.C) {
 	}
 	s.remoteState.DeletedSecrets = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
@@ -478,7 +480,7 @@ func (s *secretDeletedSuite) TestNextOp(c *gc.C) {
 		},
 	}
 	s.remoteState.DeletedSecrets = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "process removed secrets: [secret:9m4e2mr0ui3e8a215n4g]")
 }
@@ -494,7 +496,7 @@ func (s *secretDeletedSuite) TestCommit(c *gc.C) {
 		},
 	}
 	s.remoteState.DeletedSecrets = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = op.Prepare(operation.State{})

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -163,13 +163,13 @@ func (s *triggerSecretsSuite) TestRotateCommit(c *gc.C) {
 			LatestRevision: 666,
 		},
 	}, nil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.mockCallbacks.EXPECT().CommitHook(hi).Return(nil)
 	s.mockCallbacks.EXPECT().SetSecretRotated(uri.String(), 666).Return(nil)
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rotatedURI, gc.Equals, uri.String())
 }
@@ -218,12 +218,12 @@ func (s *triggerSecretsSuite) TestExpireCommit(c *gc.C) {
 	s.mockFactory.EXPECT().NewHookRunner(hi).Return(s.mockRunner, nil)
 	s.mockRunner.EXPECT().Context().Return(s.mockContext).AnyTimes()
 	s.mockContext.EXPECT().Prepare().Return(nil)
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.mockCallbacks.EXPECT().CommitHook(hi).Return(nil)
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(expiredRevision, gc.Equals, uri.String()+"/666")
 }
@@ -499,14 +499,14 @@ func (s *secretDeletedSuite) TestCommit(c *gc.C) {
 	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = op.Prepare(operation.State{})
+	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
-	_, err = op.Execute(operation.State{})
+	_, err = op.Execute(context.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 
 	s.mockCallbacks.EXPECT().SecretsRemoved([]string{"secret:9m4e2mr0ui3e8a215n4g"}).Return(nil)
 
-	_, err = op.Commit(operation.State{})
+	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deleted, jc.DeepEquals, []string{"secret:9m4e2mr0ui3e8a215n4g"})
 }

--- a/internal/worker/uniter/storage/attachments_test.go
+++ b/internal/worker/uniter/storage/attachments_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -171,7 +173,7 @@ func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
 	}}
 	storageTag0 := names.NewStorageTag("data/0")
 	storageTag1 := names.NewStorageTag("data/1")
-	_, err = r.NextOp(localState, remotestate.Snapshot{
+	_, err = r.NextOp(context.Background(), localState, remotestate.Snapshot{
 		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag0: {
@@ -185,7 +187,7 @@ func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	for _, storageTag := range []names.StorageTag{storageTag0, storageTag1} {
-		_, err = r.NextOp(localState, remotestate.Snapshot{
+		_, err = r.NextOp(context.Background(), localState, remotestate.Snapshot{
 			Life: life.Alive,
 			Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 				storageTag: {Life: life.Dying},
@@ -232,7 +234,7 @@ func (s *attachmentsSuite) testAttachmentsStorage(c *gc.C, opState operation.Sta
 
 	// Inform the resolver of an attachment.
 	localState := resolver.LocalState{State: opState}
-	op, err := r.NextOp(localState, remotestate.Snapshot{
+	op, err := r.NextOp(context.Background(), localState, remotestate.Snapshot{
 		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
@@ -272,7 +274,7 @@ func (s *caasAttachmentsSuite) TestAttachmentsStorageNotStarted(c *gc.C) {
 		Installed: true,
 		Started:   false,
 	}}
-	_, err = r.NextOp(localState, remotestate.Snapshot{
+	_, err = r.NextOp(context.Background(), localState, remotestate.Snapshot{
 		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
@@ -313,7 +315,7 @@ func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
 	localState := resolver.LocalState{State: operation.State{
 		Kind: operation.Continue,
 	}}
-	_, err = r.NextOp(localState, remotestate.Snapshot{
+	_, err = r.NextOp(context.Background(), localState, remotestate.Snapshot{
 		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
@@ -396,7 +398,7 @@ func (s *attachmentsSuite) TestAttachmentsSetDying(c *gc.C) {
 	localState := resolver.LocalState{State: operation.State{
 		Kind: operation.Continue,
 	}}
-	_, err = r.NextOp(localState, remotestate.Snapshot{
+	_, err = r.NextOp(context.Background(), localState, remotestate.Snapshot{
 		Life: life.Dying,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
@@ -435,7 +437,7 @@ func (s *attachmentsSuite) TestAttachmentsWaitPending(c *gc.C) {
 			Installed: installed,
 			Kind:      operation.Continue,
 		}}
-		_, err := r.NextOp(localState, remotestate.Snapshot{
+		_, err := r.NextOp(context.Background(), localState, remotestate.Snapshot{
 			Life: life.Alive,
 			Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 				storageTag: {

--- a/internal/worker/uniter/storage/mock_test.go
+++ b/internal/worker/uniter/storage/mock_test.go
@@ -4,6 +4,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v5"
@@ -65,15 +66,15 @@ func (m *mockOperation) ExecutionGroup() string {
 	return ""
 }
 
-func (m *mockOperation) Prepare(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Prepare(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 
-func (m *mockOperation) Execute(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Execute(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 
-func (m *mockOperation) Commit(state operation.State) (*operation.State, error) {
+func (m *mockOperation) Commit(ctx context.Context, state operation.State) (*operation.State, error) {
 	return &state, nil
 }
 

--- a/internal/worker/uniter/storage/resolver.go
+++ b/internal/worker/uniter/storage/resolver.go
@@ -4,6 +4,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -55,6 +57,7 @@ func NewResolver(logger Logger, storage *Attachments, modelType model.ModelType)
 
 // NextOp is defined on the Resolver interface.
 func (s *storageResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,

--- a/internal/worker/uniter/uniter.go
+++ b/internal/worker/uniter/uniter.go
@@ -4,6 +4,7 @@
 package uniter
 
 import (
+	stdcontext "context"
 	"fmt"
 	"os"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	jworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/fortress"
@@ -77,6 +79,7 @@ type Uniter struct {
 	enforcedCharmModifiedVersion int
 	storage                      *storage.Attachments
 	clock                        clock.Clock
+	tracer                       coretrace.Tracer
 
 	relationStateTracker relation.RelationStateTracker
 
@@ -206,6 +209,7 @@ type UniterParams struct {
 	EnforcedCharmModifiedVersion int
 	ContainerNames               []string
 	NewPebbleClient              NewPebbleClientFunc
+	Tracer                       coretrace.Tracer
 }
 
 // NewOperationExecutorFunc is a func which returns an operations.Executor.
@@ -260,6 +264,7 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 			translateResolverErr:          translateResolverErr,
 			observer:                      uniterParams.Observer,
 			clock:                         uniterParams.Clock,
+			tracer:                        uniterParams.Tracer,
 			downloader:                    uniterParams.Downloader,
 			containerRunningStatusChannel: uniterParams.ContainerRunningStatusChannel,
 			containerRunningStatusFunc:    uniterParams.ContainerRunningStatusFunc,
@@ -293,6 +298,9 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 }
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
+	ctx, cancel := u.scopedContext()
+	defer cancel()
+
 	defer func() {
 		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
 		// the uniter main loop, but the parent operator agent needs to keep running.
@@ -536,7 +544,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		}
 
 		for err == nil {
-			err = resolver.Loop(resolver.LoopConfig{
+			err = resolver.Loop(ctx, resolver.LoopConfig{
 				Resolver:      uniterResolver,
 				Watcher:       watcher,
 				Executor:      u.operationExecutor,
@@ -1044,4 +1052,12 @@ func (u *Uniter) Report() map[string]interface{} {
 	}
 
 	return result
+}
+
+// scopedContext returns a context that is in the scope of the worker lifetime.
+// It returns a cancellable context that is cancelled when the action has
+// completed.
+func (u *Uniter) scopedContext() (stdcontext.Context, stdcontext.CancelFunc) {
+	ctx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	return u.catacomb.Context(ctx), cancel
 }

--- a/internal/worker/uniter/uniter_test.go
+++ b/internal/worker/uniter/uniter_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -1471,10 +1472,10 @@ type mockExecutor struct {
 	operation.Executor
 }
 
-func (m *mockExecutor) Run(op operation.Operation, rs <-chan remotestate.Snapshot) error {
+func (m *mockExecutor) Run(ctx context.Context, op operation.Operation, rs <-chan remotestate.Snapshot) error {
 	// want to allow charm unpacking to occur
 	if strings.HasPrefix(op.String(), "install") {
-		return m.Executor.Run(op, rs)
+		return m.Executor.Run(ctx, op, rs)
 	}
 	// but hooks should error
 	return mockExecutorErr

--- a/internal/worker/uniter/upgradeseries/resolver.go
+++ b/internal/worker/uniter/upgradeseries/resolver.go
@@ -4,6 +4,8 @@
 package upgradeseries
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 
 	"github.com/juju/juju/core/model"
@@ -28,6 +30,7 @@ func NewResolver(logger Logger) resolver.Resolver {
 
 // NextOp is defined on the Resolver interface.
 func (r *upgradeSeriesResolver) NextOp(
+	ctx context.Context,
 	localState resolver.LocalState, remoteState remotestate.Snapshot, opFactory operation.Factory,
 ) (operation.Operation, error) {
 	// If the unit is in the validate state, just sit and idle until validation

--- a/internal/worker/uniter/upgradeseries/resolver_test.go
+++ b/internal/worker/uniter/upgradeseries/resolver_test.go
@@ -4,6 +4,8 @@
 package upgradeseries_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -37,7 +39,7 @@ func (s ResolverSuite) TestNextOpWithValidationStatus(c *gc.C) {
 
 	mockFactory := mocks.NewMockFactory(ctrl)
 	res := s.NewResolver()
-	_, err := res.NextOp(resolver.LocalState{}, remotestate.Snapshot{
+	_, err := res.NextOp(context.Background(), resolver.LocalState{}, remotestate.Snapshot{
 		UpgradeMachineStatus: model.UpgradeSeriesValidate,
 	}, mockFactory)
 	c.Assert(err, gc.Equals, resolver.ErrDoNotProceed)
@@ -49,7 +51,7 @@ func (s ResolverSuite) TestNextOpWithRemoveStateCompleted(c *gc.C) {
 
 	mockFactory := mocks.NewMockFactory(ctrl)
 	res := s.NewResolver()
-	_, err := res.NextOp(resolver.LocalState{}, remotestate.Snapshot{
+	_, err := res.NextOp(context.Background(), resolver.LocalState{}, remotestate.Snapshot{
 		UpgradeMachineStatus: model.UpgradeSeriesPrepareCompleted,
 	}, mockFactory)
 	c.Assert(err, gc.Equals, resolver.ErrDoNotProceed)
@@ -65,7 +67,7 @@ func (s ResolverSuite) TestNextOpWithPreSeriesUpgrade(c *gc.C) {
 	mockFactory.EXPECT().NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade}).Return(mockOp, nil)
 
 	res := s.NewResolver()
-	op, err := res.NextOp(resolver.LocalState{
+	op, err := res.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{
 			Kind: operation.Continue,
 		},
@@ -87,7 +89,7 @@ func (s ResolverSuite) TestNextOpWithPostSeriesUpgrade(c *gc.C) {
 	mockFactory.EXPECT().NewRunHook(hook.Info{Kind: hooks.PostSeriesUpgrade}).Return(mockOp, nil)
 
 	res := s.NewResolver()
-	op, err := res.NextOp(resolver.LocalState{
+	op, err := res.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{
 			Kind: operation.Continue,
 		},
@@ -109,7 +111,7 @@ func (s ResolverSuite) TestNextOpWithFinishUpgradeSeries(c *gc.C) {
 	mockFactory.EXPECT().NewNoOpFinishUpgradeSeries().Return(mockOp, nil)
 
 	res := s.NewResolver()
-	op, err := res.NextOp(resolver.LocalState{
+	op, err := res.NextOp(context.Background(), resolver.LocalState{
 		State: operation.State{
 			Kind: operation.Continue,
 		},
@@ -128,6 +130,6 @@ func (s ResolverSuite) TestNextOpWithNoState(c *gc.C) {
 	mockFactory := mocks.NewMockFactory(ctrl)
 
 	res := s.NewResolver()
-	_, err := res.NextOp(resolver.LocalState{}, remotestate.Snapshot{}, mockFactory)
+	_, err := res.NextOp(context.Background(), resolver.LocalState{}, remotestate.Snapshot{}, mockFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }

--- a/internal/worker/uniter/verifycharmprofile/verifycharmprofile.go
+++ b/internal/worker/uniter/verifycharmprofile/verifycharmprofile.go
@@ -4,6 +4,8 @@
 package verifycharmprofile
 
 import (
+	"context"
+
 	jujucharm "github.com/juju/charm/v12"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -33,6 +35,7 @@ func NewResolver(logger Logger, modelType model.ModelType) resolver.Resolver {
 // NextOp is defined on the Resolver interface.
 // This NextOp is only meant to be called before any Upgrade operation.
 func (r *verifyCharmProfileResolver) NextOp(
+	ctx context.Context,
 	_ resolver.LocalState, remoteState remotestate.Snapshot, _ operation.Factory,
 ) (operation.Operation, error) {
 	// NOTE: this is very similar code to Uniter.verifyCharmProfile(),
@@ -67,6 +70,7 @@ type caasVerifyCharmProfileResolver struct{}
 // NextOp is defined on the Resolver interface.
 // This NextOp ensures that we never check for lxd profiles on CAAS machines.
 func (r *caasVerifyCharmProfileResolver) NextOp(
+	_ context.Context,
 	_ resolver.LocalState, _ remotestate.Snapshot, _ operation.Factory,
 ) (operation.Operation, error) {
 	return nil, resolver.ErrNoOperation

--- a/internal/worker/uniter/verifycharmprofile/verifycharmprofile_test.go
+++ b/internal/worker/uniter/verifycharmprofile/verifycharmprofile_test.go
@@ -4,6 +4,8 @@
 package verifycharmprofile_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -25,7 +27,7 @@ func (s *verifySuite) TestNextOpNotInstallNorUpgrade(c *gc.C) {
 	remote := remotestate.Snapshot{}
 	res := newVerifyCharmProfileResolver()
 
-	op, err := res.NextOp(local, remote, nil)
+	op, err := res.NextOp(context.Background(), local, remote, nil)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
@@ -39,7 +41,7 @@ func (s *verifySuite) TestNextOpInstallProfileNotRequired(c *gc.C) {
 	}
 	res := newVerifyCharmProfileResolver()
 
-	op, err := res.NextOp(local, remote, nil)
+	op, err := res.NextOp(context.Background(), local, remote, nil)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
@@ -53,7 +55,7 @@ func (s *verifySuite) TestNextOpInstallProfileRequiredEmptyName(c *gc.C) {
 	}
 	res := newVerifyCharmProfileResolver()
 
-	op, err := res.NextOp(local, remote, nil)
+	op, err := res.NextOp(context.Background(), local, remote, nil)
 	c.Assert(err, gc.Equals, resolver.ErrDoNotProceed)
 	c.Assert(op, gc.IsNil)
 }
@@ -69,7 +71,7 @@ func (s *verifySuite) TestNextOpMisMatchCharmRevisions(c *gc.C) {
 	}
 	res := newVerifyCharmProfileResolver()
 
-	op, err := res.NextOp(local, remote, nil)
+	op, err := res.NextOp(context.Background(), local, remote, nil)
 	c.Assert(err, gc.Equals, resolver.ErrDoNotProceed)
 	c.Assert(op, gc.IsNil)
 }
@@ -85,14 +87,14 @@ func (s *verifySuite) TestNextOpMatchingCharmRevisions(c *gc.C) {
 	}
 	res := newVerifyCharmProfileResolver()
 
-	op, err := res.NextOp(local, remote, nil)
+	op, err := res.NextOp(context.Background(), local, remote, nil)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 	c.Assert(op, gc.IsNil)
 }
 
 func (s *verifySuite) TestNewResolverCAAS(c *gc.C) {
 	r := verifycharmprofile.NewResolver(&fakelogger{}, model.CAAS)
-	op, err := r.NextOp(resolver.LocalState{}, remotestate.Snapshot{}, nil)
+	op, err := r.NextOp(context.Background(), resolver.LocalState{}, remotestate.Snapshot{}, nil)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 	c.Assert(op, jc.ErrorIsNil)
 }


### PR DESCRIPTION
The uniter worker is one of the most complex parts of juju. The set of mechanical changes aims to pass the context.Context through a lot of the layers and operations that the uniter undertakes. This will help better understand the various requests to the API server and to the various resolvers, executors and operations.

Currently, the only trace added to the uniter is to the executor. Attempting to add it to the resolver loop is fraught with issues. If a trace takes too long, it leaves orphaned spans in the UI and it doesn't correctly correspond them to the parent trace until after the trace has been completed (a restart or other failure). Added a trace to every operation (NextOp method call) is also _very_ chatty, so I'm not sure of the usage patterns there either.

To see these correctly sent, meant pushing the tracer into every unit. This means we now get distributed tracing on every unit, not just the controllers. Part of the change is to remove the model uuid from the service name and follow the tempo terminology. Service.Instance.ID now models the model UUID, which means it's a lot easier to search for multiple models at a time for different or similar spans (etc).

A follow-up PR will be required to watch for the open telemetry changes in the controller config and to notify that the agent config needs to be updated. This will echo what the logging changes do, so it's something we can either combine or do similarly.

Lastly, looking to the future, it should be relatively easy to send the `TraceID`, `SpanID` and `Flag` with each hook request, allowing the tracing to be sent via hooks. The ops framework could just pick up the envars, parse them, and send them to the same tracing endpoint to get a full stack trace distributed trace.
 
## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setting up tempo

It assumes that docker (docker-compose) is correctly installed:

```sh
$ git clone https://github.com/grafana/tempo.git
$ git checkout v2.2.4 # someone broke the docker compose in later releases
$ cd tempo/example/docker-compose/local
$ docker compose up -d
```

### Juju

Replace `<IP ADDRESS>` with your host machine (not localhost) address (`lxc info | yq ".environment | .addresses"` is a good place to start looking)

```sh
$ juju bootstrap lxd test --build-agent --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=<IP ADDRESS>:4317" --config="open-telemetry-sample-ratio=1.0"
```

![Screenshot from 2023-11-20 17-42-28](https://github.com/juju/juju/assets/2562584/8754a607-e596-4012-bcb2-18b45a5ef599)

