### PR TITLE
Treat owners of secrets the same as other consumers when reading secret content

### DIFF
--- a/apiserver/common/secrets/access.go
+++ b/apiserver/common/secrets/access.go
@@ -29,11 +29,6 @@ func IsSameApplication(authTag names.Tag, tag names.Tag) bool {
 	return AuthTagApp(authTag) == AuthTagApp(tag)
 }
 
-func hasRole(api SecretsConsumer, uri *coresecrets.URI, entity names.Tag, role coresecrets.SecretRole) bool {
-	hasRole, err := api.SecretAccess(uri, entity)
-	return err == nil && hasRole.Allowed(role)
-}
-
 // CanManage checks that the authenticated caller can manage the secret, and returns a
 // token to ensure leadership if that is required; ie if the request is for a secret
 // owned by an application, the entity must be the unit leader.
@@ -47,17 +42,32 @@ func CanManage(
 
 	switch authTag.(type) {
 	case names.UnitTag:
-		if hasRole(api, uri, authTag, coresecrets.RoleManage) {
+		hasRole, err := api.SecretAccess(uri, authTag)
+		if err != nil {
+			// Typically not found error.
+			return nil, errors.Trace(err)
+		}
+		if hasRole.Allowed(coresecrets.RoleManage) {
 			// owner unit.
 			return successfulToken{}, nil
 		}
-		if hasRole(api, uri, appTag, coresecrets.RoleManage) {
+		hasRole, err = api.SecretAccess(uri, appTag)
+		if err != nil {
+			// Typically not found error.
+			return nil, errors.Trace(err)
+		}
+		if hasRole.Allowed(coresecrets.RoleManage) {
 			// leader unit can manage app owned secret.
 			return LeadershipToken(authTag, leadershipChecker)
 		}
 	case names.ApplicationTag:
 		// TODO(wallyworld) - remove auth tag kind check when podspec charms are gone.
-		if hasRole(api, uri, appTag, coresecrets.RoleManage) {
+		hasRole, err := api.SecretAccess(uri, appTag)
+		if err != nil {
+			// Typically not found error.
+			return nil, errors.Trace(err)
+		}
+		if hasRole.Allowed(coresecrets.RoleManage) {
 			return successfulToken{}, nil
 		}
 	}
@@ -65,18 +75,26 @@ func CanManage(
 }
 
 // CanRead returns true if the specified entity can read the secret.
-func CanRead(api SecretsConsumer, authTag names.Tag, uri *coresecrets.URI, entity names.Tag) bool {
+func CanRead(api SecretsConsumer, authTag names.Tag, uri *coresecrets.URI, entity names.Tag) (bool, error) {
 	// First try looking up unit access.
-	hasRole, _ := api.SecretAccess(uri, entity)
+	hasRole, err := api.SecretAccess(uri, entity)
+	if err != nil {
+		// Typically not found error.
+		return false, errors.Trace(err)
+	}
 	if hasRole.Allowed(coresecrets.RoleView) {
-		return true
+		return true, nil
 	}
 
 	// 1. all units can read secrets owned by application.
 	// 2. units of podspec applications can do this as well.
 	appName := AuthTagApp(authTag)
-	hasRole, _ = api.SecretAccess(uri, names.NewApplicationTag(appName))
-	return hasRole.Allowed(coresecrets.RoleView)
+	hasRole, err = api.SecretAccess(uri, names.NewApplicationTag(appName))
+	if err != nil {
+		// Typically not found error.
+		return false, errors.Trace(err)
+	}
+	return hasRole.Allowed(coresecrets.RoleView), nil
 }
 
 // OwnerToken returns a token used to determine if the specified entity

--- a/apiserver/common/secrets/access_test.go
+++ b/apiserver/common/secrets/access_test.go
@@ -4,7 +4,6 @@
 package secrets_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -44,7 +43,7 @@ func (s *secretsSuite) TestCanManageLeaderUnitAppSecret(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	gomock.InOrder(
-		secretsConsumer.EXPECT().SecretAccess(uri, authTag).Return(coresecrets.RoleNone, errors.NotFoundf("")),
+		secretsConsumer.EXPECT().SecretAccess(uri, authTag).Return(coresecrets.RoleNone, nil),
 		secretsConsumer.EXPECT().SecretAccess(uri, names.NewApplicationTag("mariadb")).Return(coresecrets.RoleManage, nil),
 		leadershipChecker.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(token),
 		token.EXPECT().Check().Return(nil),

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -671,6 +671,14 @@ func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner, knownSe
 				return errors.Annotatef(err, "invalid consumer for secret %q", secret.Id())
 			}
 			key := src.SecretConsumerKey(uri, consumer.String())
+			currentRev := info.CurrentRevision()
+			latestRev := info.LatestRevision()
+			// Older models may have set the consumed rev info to 0 (assuming the latest revision always).
+			// So set the latest values explicitly.
+			if currentRev == 0 {
+				currentRev = secret.LatestRevision()
+				latestRev = secret.LatestRevision()
+			}
 			ops = append(ops, txn.Op{
 				C:      secretConsumersC,
 				Id:     key,
@@ -679,8 +687,8 @@ func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner, knownSe
 					DocID:           key,
 					ConsumerTag:     consumer.String(),
 					Label:           info.Label(),
-					CurrentRevision: info.CurrentRevision(),
-					LatestRevision:  info.LatestRevision(),
+					CurrentRevision: currentRev,
+					LatestRevision:  latestRev,
 				},
 			})
 		}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -3285,6 +3285,51 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	c.Assert(backendRefCount, gc.Equals, 2)
 }
 
+func (s *MigrationImportSuite) TestSecretsEnsureConsumerRevisionInfo(c *gc.C) {
+	store := state.NewSecrets(s.State)
+	owner := s.Factory.MakeApplication(c, nil)
+	uri := secrets.NewURI()
+	p := state.CreateSecretParams{
+		Version: 1,
+		Owner:   owner.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken:  &fakeToken{},
+			RotatePolicy: ptr(secrets.RotateNever),
+			Data:         map[string]string{"foo": "bar"},
+		},
+	}
+	md, err := store.CreateSecret(uri, p)
+	c.Assert(err, jc.ErrorIsNil)
+
+	consumer := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	err = s.State.SaveSecretConsumer(uri, consumer.Tag(), &secrets.SecretConsumerMetadata{
+		Label:           "consumer label",
+		CurrentRevision: 0,
+		LatestRevision:  0,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c, s.State)
+
+	store = state.NewSecrets(newSt)
+	all, err := store.ListSecrets(state.SecretsFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, 1)
+	c.Assert(all[0], jc.DeepEquals, md)
+
+	info, err := newSt.GetSecretConsumer(uri, consumer.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, &secrets.SecretConsumerMetadata{
+		Label:           "consumer label",
+		CurrentRevision: 1,
+		LatestRevision:  1,
+	})
+}
+
 func (s *MigrationImportSuite) TestSecretsMissingBackend(c *gc.C) {
 	store := state.NewSecrets(s.State)
 	owner := s.Factory.MakeApplication(c, nil)

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -15,6 +15,7 @@ type StateBackend interface {
 	MigrateApplicationOpenedPortsToUnitScope() error
 	EnsureInitalRefCountForExternalSecretBackends() error
 	EnsureApplicationCharmOriginsNormalised() error
+	FixOwnerConsumedSecretInfo() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -47,4 +48,8 @@ func (s stateBackend) EnsureInitalRefCountForExternalSecretBackends() error {
 
 func (s stateBackend) EnsureApplicationCharmOriginsNormalised() error {
 	return state.EnsureApplicationCharmOriginsNormalised(s.pool)
+}
+
+func (s stateBackend) FixOwnerConsumedSecretInfo() error {
+	return state.FixOwnerConsumedSecretInfo(s.pool)
 }

--- a/upgrades/steps_317.go
+++ b/upgrades/steps_317.go
@@ -15,6 +15,12 @@ func stateStepsFor317() []Step {
 			run: func(context Context) error {
 				return context.State().EnsureApplicationCharmOriginsNormalised()
 			},
+		}, &upgradeStep{
+			description: "fix owner consumed secret info",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().FixOwnerConsumedSecretInfo()
+			},
 		},
 	}
 }

--- a/upgrades/steps_317_test.go
+++ b/upgrades/steps_317_test.go
@@ -24,3 +24,8 @@ func (s *steps317Suite) TestEnsureApplicationCharmOriginsHaveRevisions(c *gc.C) 
 	step := findStateStep(c, v317, "ensure application charm origins have revisions")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps317Suite) TestFixOwnerConsumedSecretInfo(c *gc.C) {
+	step := findStateStep(c, v317, "fix owner consumed secret info")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
Secret owners would always read the latest secret revision. This PR removes that behaviour so that owners are treated that same as other consumers; ie the `--peek` and `--refresh` options are used to inspect latest revision content.

The main change is to remove the special case helper methods for owners - these methods would create an empty consumer record with current/latest revision initially set to 0. Latest revision would get updated but current revision would always be 0. Now the consumer record is maintained as expected. The only difference is that for secret owners, label is always empty (since the label on the secret metadata record is what's used to access the secret).

As a result of the above, upgrade and migrate tweaks are needed to ensure any secret consumer records with current revision set to 0 are updated,

Another implementation change is to eliminate extra unnecessary calls to `GetSecret()` to check for existence. This is done when the secret access checks (view, manage) are done, but the error is ignored. So the `CanRead()` and `CanManage()` methods now return an error as well as a bool; the error is NotFound if the secret doesn't exist.

The next PR will update the unit hook behaviour to account for peek and refresh being used within the same hook.

As a drive by, the error messages for `uniqueSecretLabelBaseOps` have been tweaked to provide better info when a duplicate label is used.

There  was also an issue with labels used by peer units for app owned secrets. If a non leader attempted to pass in both URI and label, no update was attempted. This should be an error that is surfaced, but only if the label would actually change. ie a non leader passing URI and label and the label is the same as the current metadata label is ok. The change was made and tests were added to cover this case.

## QA steps

bootstrap and add a model
create 3 ubuntu units
on the leader unit, add a secret
update the secret to add another revision

on the leader unit, run secret-get and see that rev 1 content is returned
on the leader unit, run secret-get --peek and see that rev 2 content is returned
on the leader unit, run secret-get and see that rev 1 content is returned
on the leader unit, run secret-get --refresh and see that rev 2 content is returned
on the leader unit, run secret-get and see that rev 2 content is returned
on a non leader unit, run secret-get and see that rev 2 content is returned
on a non leader unit, pass in both the uri and same label as currently set and see that content is returned
on a non leader unit, pass in both the uri and  different label as currently set and see that  error is returned

update the secret to add another revision

on a non leader unit, run secret-get and see that rev 2 content is returned
on the leader unit, run secret-get --peek and see that rev 3 content is returned
repeat the --peek and --refresh tests above on the non leader unit

bootstrap 3.1.6
create 3 ubuntu units
on the leader unit, add a secret
update the secret to add another revision
on the leader unit, run secret-get and see that rev 2 content is returned
on the non leader unit, run secret-get and see that rev 2 content is returned

upgrade the controller to this PR
using the mongo client, check that the secret consumer records have current revision set to 2
repeat the --peek and --refresh tests

bootstrap 3.1.6 and repeat the above checks, but instead of upgrading the controller, bootstrap a controller off this PR and migrate the 3.1.6 model across

## Documentation changes

Charm ops API docs will need to be updated.

## Links

https://bugs.launchpad.net/juju/+bug/2037120
https://bugs.launchpad.net/juju/+bug/2042594

**Jira card:** JUJU-[4978]

