### PR TITLE
Inhook secret refresh

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -1042,6 +1042,15 @@ func (b *CommitHookParamsBuilder) AddSecretUpdates(updates []SecretUpsertArg) {
 	}
 }
 
+// AddTrackLatest records the URIs for which the latest revision should be tracked.
+func (b *CommitHookParamsBuilder) AddTrackLatest(trackLatest []string) {
+	if len(trackLatest) == 0 {
+		return
+	}
+	b.arg.TrackLatest = make([]string, len(trackLatest))
+	copy(b.arg.TrackLatest, trackLatest)
+}
+
 // SecretGrantRevokeArgs holds parameters for updating a secret's access.
 type SecretGrantRevokeArgs struct {
 	URI             *secrets.URI

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2811,15 +2811,6 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 	}
 
 	// TODO - do in txn once we have support for that
-	if len(changes.SecretDeletes) > 0 {
-		result, err := u.SecretsManagerAPI.RemoveSecrets(params.DeleteSecretArgs{Args: changes.SecretDeletes})
-		if err == nil {
-			err = result.Combine()
-		}
-		if err != nil {
-			return errors.Annotate(err, "removing secrets")
-		}
-	}
 	if len(changes.SecretCreates) > 0 {
 		result, err := u.SecretsManagerAPI.CreateSecrets(params.CreateSecretArgs{Args: changes.SecretCreates})
 		if err == nil {
@@ -2846,6 +2837,15 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 			return errors.Annotate(err, "updating secrets")
 		}
 	}
+	if len(changes.TrackLatest) > 0 {
+		result, err := u.SecretsManagerAPI.UpdateTrackedRevisions(changes.TrackLatest)
+		if err == nil {
+			err = result.Combine()
+		}
+		if err != nil {
+			return errors.Annotate(err, "updating secret tracked revisions")
+		}
+	}
 	if len(changes.SecretGrants) > 0 {
 		result, err := u.SecretsManagerAPI.SecretsGrant(params.GrantRevokeSecretArgs{Args: changes.SecretGrants})
 		if err == nil {
@@ -2862,6 +2862,15 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 		if err != nil {
 			return errors.Annotate(err, "revoking secrets access")
+		}
+	}
+	if len(changes.SecretDeletes) > 0 {
+		result, err := u.SecretsManagerAPI.RemoveSecrets(params.DeleteSecretArgs{Args: changes.SecretDeletes})
+		if err == nil {
+			err = result.Combine()
+		}
+		if err != nil {
+			return errors.Annotate(err, "removing secrets")
 		}
 	}
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4731,7 +4731,11 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 		Description:  ptr("a secret"),
 		Label:        ptr("foobar"),
 		Value:        secrets.NewSecretValue(map[string]string{"foo": "bar2"}),
+	}, {
+		URI:   uri3,
+		Value: secrets.NewSecretValue(map[string]string{"foo3": "bar3"}),
 	}})
+	b.AddTrackLatest([]string{uri3.ID})
 	b.AddSecretDeletes([]apiuniter.SecretDeleteArg{{URI: uri3, Revision: ptr(1)}})
 	b.AddSecretGrants([]apiuniter.SecretGrantRevokeArgs{{
 		URI:             uri,
@@ -4757,7 +4761,7 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 	})
 
 	// Verify state
-	_, err = store.GetSecret(uri3)
+	_, _, err = store.GetSecretValue(uri3, 1)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	md, err := store.GetSecret(uri)
 	c.Assert(err, jc.ErrorIsNil)
@@ -4773,6 +4777,11 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 	access, err = s.State.SecretAccess(uri2, s.mysql.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(access, gc.Equals, secrets.RoleNone)
+
+	info, err := s.State.GetSecretConsumer(uri3, s.wordpressUnit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.CurrentRevision, gc.Equals, 2)
+	c.Assert(info.LatestRevision, gc.Equals, 2)
 }
 
 func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -47931,6 +47931,12 @@
                                 "$ref": "#/definitions/GrantRevokeSecretArg"
                             }
                         },
+                        "secret-track-latest": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "secret-updates": {
                             "type": "array",
                             "items": {

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -316,6 +316,7 @@ type CommitHookChangesArg struct {
 	SetPodSpec           *PodSpec               `json:"pod-spec,omitempty"`
 	SetRawK8sSpec        *PodSpec               `json:"set-raw-k8s-spec,omitempty"`
 	SecretCreates        []CreateSecretArg      `json:"secret-creates,omitempty"`
+	TrackLatest          []string               `json:"secret-track-latest,omitempty"`
 	SecretUpdates        []UpdateSecretArg      `json:"secret-updates,omitempty"`
 	SecretGrants         []GrantRevokeSecretArg `json:"secret-grants,omitempty"`
 	SecretRevokes        []GrantRevokeSecretArg `json:"secret-revokes,omitempty"`

--- a/state/application.go
+++ b/state/application.go
@@ -767,13 +767,13 @@ func (a *Application) removeOps(asserts bson.D, op *ForcedOperation) ([]txn.Op, 
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, secretConsumerPermissionsOps...)
-	secretLabelOps, err := a.st.removeOwnerSecretLabelOps(a.ApplicationTag())
+	secretLabelOps, err := a.st.removeOwnerSecretLabelsOps(a.ApplicationTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, secretLabelOps...)
 
-	secretLabelOps, err = a.st.removeConsumerSecretLabelOps(a.ApplicationTag())
+	secretLabelOps, err = a.st.removeConsumerSecretLabelsOps(a.ApplicationTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -3035,11 +3035,11 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
-	secretOwnerLabelOps, err := a.st.removeOwnerSecretLabelOps(u.Tag())
+	secretOwnerLabelOps, err := a.st.removeOwnerSecretLabelsOps(u.Tag())
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
-	secretConsumerLabelOps, err := a.st.removeConsumerSecretLabelOps(u.Tag())
+	secretConsumerLabelOps, err := a.st.removeConsumerSecretLabelsOps(u.Tag())
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -356,3 +356,7 @@ func (ctx *HookContext) PendingSecretGrants() map[string]uniter.SecretGrantRevok
 func (ctx *HookContext) PendingSecretRevokes() map[string]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingRevokes
 }
+
+func (ctx *HookContext) PendingSecretTrackLatest() map[string]bool {
+	return ctx.secretChanges.pendingTrackLatest
+}

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -16,21 +16,23 @@ import (
 type secretsChangeRecorder struct {
 	logger loggo.Logger
 
-	pendingCreates map[string]uniter.SecretCreateArg
-	pendingUpdates map[string]uniter.SecretUpdateArg
-	pendingDeletes map[string]uniter.SecretDeleteArg
-	pendingGrants  map[string]uniter.SecretGrantRevokeArgs
-	pendingRevokes map[string]uniter.SecretGrantRevokeArgs
+	pendingCreates     map[string]uniter.SecretCreateArg
+	pendingUpdates     map[string]uniter.SecretUpdateArg
+	pendingDeletes     map[string]uniter.SecretDeleteArg
+	pendingGrants      map[string]uniter.SecretGrantRevokeArgs
+	pendingRevokes     map[string]uniter.SecretGrantRevokeArgs
+	pendingTrackLatest map[string]bool
 }
 
 func newSecretsChangeRecorder(logger loggo.Logger) *secretsChangeRecorder {
 	return &secretsChangeRecorder{
-		logger:         logger,
-		pendingCreates: make(map[string]uniter.SecretCreateArg),
-		pendingUpdates: make(map[string]uniter.SecretUpdateArg),
-		pendingDeletes: make(map[string]uniter.SecretDeleteArg),
-		pendingGrants:  make(map[string]uniter.SecretGrantRevokeArgs),
-		pendingRevokes: make(map[string]uniter.SecretGrantRevokeArgs),
+		logger:             logger,
+		pendingCreates:     make(map[string]uniter.SecretCreateArg),
+		pendingUpdates:     make(map[string]uniter.SecretUpdateArg),
+		pendingDeletes:     make(map[string]uniter.SecretDeleteArg),
+		pendingGrants:      make(map[string]uniter.SecretGrantRevokeArgs),
+		pendingRevokes:     make(map[string]uniter.SecretGrantRevokeArgs),
+		pendingTrackLatest: make(map[string]bool),
 	}
 }
 
@@ -79,6 +81,7 @@ func (s *secretsChangeRecorder) remove(uri *secrets.URI, revision *int) {
 	delete(s.pendingUpdates, uri.ID)
 	delete(s.pendingGrants, uri.ID)
 	delete(s.pendingRevokes, uri.ID)
+	delete(s.pendingTrackLatest, uri.ID)
 	s.pendingDeletes[uri.ID] = uniter.SecretDeleteArg{URI: uri, Revision: revision}
 }
 


### PR DESCRIPTION
Follows on from https://github.com/juju/juju/pull/16598

This PR implements support for  `secret-get` `--refresh` and `--peek` for secrets created in the same hook.
The key pieces are inspecting the pending secrets and using data from there if applicable, and adding the refreshed URIs to the hook commit struct, so that any refreshed secret revisions can be tracked when the secret is saved. There's no need to bump the uniter facade since older agents simply pass an empty list of tracked revisions.

Some fixes were also made to allow secret owners to using both URI and label with secret-get; the behaviour is now consistent with how non owners can use secret-get.

Finally, a fix was done in state to allow owners to change a secret label back to a previous value - old values were not being deleted from the ref count collection when the label changed, so this fixes that.

## QA steps

Create a secret. As the owner, ensure the label can be updated to a previous value, eg

```
$ juju exec --unit controller/0 -- secret-add --label foo foo=bar
secret://7c573112-602b-4197-83f5-caf58286a766/clenauhu9nvi9vtkpvr0
$ juju exec --unit controller/0 -- secret-get clenauhu9nvi9vtkpvr0 --label foo2 
foo: bar
$ juju exec --unit controller/0 -- secret-get clenauhu9nvi9vtkpvr0 --label foo3
foo: bar
$ juju exec --unit controller/0 -- secret-get clenauhu9nvi9vtkpvr0 --label foo2
$  juju exec --unit controller/0 -- secret-get --label foo2
foo: bar
```

To test the hook behaviour, I had to create a test charm. The charm has a config attribute "secret" (string).

In the start hook
```
URI=$(secret-add --label baz foo=baz)
juju-log "Secret: $URI"
```

In the config-changed hook
```
URI=$(config-get secret)
if [[ -n "$URI" ]]; then
        juju-log "initial get $(secret-get $URI)"
        $(secret-set $URI foo=baz2)
        juju-log "get refresh $(secret-get --label baz --refresh)"
        exit 0
fi
```

Once the charm is deployed, trigger a config-changed by setting the app "secret" to the URI. Then set it to "" and then back to the URI again.
The logs will show the second trigger will read revision 2 because of the `--refresh`.

## Documentation changes

Charm api docs will need to be updated.

## Links

https://bugs.launchpad.net/juju/+bug/2037120
https://bugs.launchpad.net/juju/+bug/2042594

Jira card: JUJU-[4978]