### PR TITLE
Secret grant info

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -162,6 +162,11 @@ func (c *Client) SecretMetadata() ([]coresecrets.SecretOwnerMetadata, error) {
 			LatestExpireTime: info.LatestExpireTime,
 			NextRotateTime:   info.NextRotateTime,
 		}
+		for _, g := range info.Grants {
+			md.Grants = append(md.Grants, coresecrets.GrantInfo{
+				Target: g.Target, Scope: g.Scope, Role: g.Role,
+			})
+		}
 		revisions := make([]int, len(info.Revisions))
 		for i, r := range info.Revisions {
 			revisions[i] = r.Revision

--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -162,8 +162,8 @@ func (c *Client) SecretMetadata() ([]coresecrets.SecretOwnerMetadata, error) {
 			LatestExpireTime: info.LatestExpireTime,
 			NextRotateTime:   info.NextRotateTime,
 		}
-		for _, g := range info.Grants {
-			md.Grants = append(md.Grants, coresecrets.GrantInfo{
+		for _, g := range info.Access {
+			md.Access = append(md.Access, coresecrets.AccessInfo{
 				Target: g.Target, Scope: g.Scope, Role: g.Role,
 			})
 		}

--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -164,7 +164,7 @@ func (c *Client) SecretMetadata() ([]coresecrets.SecretOwnerMetadata, error) {
 		}
 		for _, g := range info.Access {
 			md.Access = append(md.Access, coresecrets.AccessInfo{
-				Target: g.Target, Scope: g.Scope, Role: g.Role,
+				Target: g.TargetTag, Scope: g.ScopeTag, Role: g.Role,
 			})
 		}
 		revisions := make([]int, len(info.Revisions))

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -407,7 +407,7 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 				}, {
 					Revision: 667,
 				}},
-				Grants: []params.GrantInfo{
+				Access: []params.AccessInfo{
 					{
 						Target: "application-gitlab",
 						Scope:  coretesting.ModelTag.Id(),
@@ -430,7 +430,7 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 		c.Assert(info.Metadata.LatestExpireTime, gc.Equals, &now)
 		c.Assert(info.Metadata.NextRotateTime, gc.Equals, &now)
 		c.Assert(info.Revisions, jc.DeepEquals, []int{666, 667})
-		c.Assert(info.Metadata.Grants, jc.DeepEquals, []coresecrets.GrantInfo{
+		c.Assert(info.Metadata.Access, jc.DeepEquals, []coresecrets.AccessInfo{
 			{
 				Target: "application-gitlab",
 				Scope:  coretesting.ModelTag.Id(),

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -393,7 +393,7 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			Results: []params.ListSecretResult{{
 				URI:              uri.String(),
-				OwnerTag:         "application-mariadb",
+				OwnerTag:         coretesting.ModelTag.String(),
 				Label:            "label",
 				LatestRevision:   667,
 				NextRotateTime:   &now,
@@ -407,6 +407,13 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 				}, {
 					Revision: 667,
 				}},
+				Grants: []params.GrantInfo{
+					{
+						Target: "application-gitlab",
+						Scope:  coretesting.ModelTag.Id(),
+						Role:   coresecrets.RoleView,
+					},
+				},
 			}},
 		}
 		return nil
@@ -417,12 +424,19 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 	c.Assert(result, gc.HasLen, 1)
 	for _, info := range result {
 		c.Assert(info.Metadata.URI.String(), gc.Equals, uri.String())
-		c.Assert(info.Metadata.OwnerTag, gc.Equals, "application-mariadb")
+		c.Assert(info.Metadata.OwnerTag, gc.Equals, coretesting.ModelTag.String())
 		c.Assert(info.Metadata.Label, gc.Equals, "label")
 		c.Assert(info.Metadata.LatestRevision, gc.Equals, 667)
 		c.Assert(info.Metadata.LatestExpireTime, gc.Equals, &now)
 		c.Assert(info.Metadata.NextRotateTime, gc.Equals, &now)
 		c.Assert(info.Revisions, jc.DeepEquals, []int{666, 667})
+		c.Assert(info.Metadata.Grants, jc.DeepEquals, []coresecrets.GrantInfo{
+			{
+				Target: "application-gitlab",
+				Scope:  coretesting.ModelTag.Id(),
+				Role:   coresecrets.RoleView,
+			},
+		})
 	}
 }
 

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -409,9 +409,9 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 				}},
 				Access: []params.AccessInfo{
 					{
-						Target: "application-gitlab",
-						Scope:  coretesting.ModelTag.Id(),
-						Role:   coresecrets.RoleView,
+						TargetTag: "application-gitlab",
+						ScopeTag:  coretesting.ModelTag.Id(),
+						Role:      coresecrets.RoleView,
 					},
 				},
 			}},

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -1060,6 +1060,18 @@ type SecretGrantRevokeArgs struct {
 	Role            secrets.SecretRole
 }
 
+// Equal returns true if the two SecretGrantRevokeArgs are equal.
+func (arg SecretGrantRevokeArgs) Equal(other SecretGrantRevokeArgs) bool {
+	return arg.URI.ID == other.URI.ID &&
+		arg.Role == other.Role &&
+		((arg.ApplicationName == nil && other.ApplicationName == nil) ||
+			(arg.ApplicationName != nil && other.ApplicationName != nil && *arg.ApplicationName == *other.ApplicationName)) &&
+		((arg.UnitName == nil && other.UnitName == nil) ||
+			(arg.UnitName != nil && other.UnitName != nil && *arg.UnitName == *other.UnitName)) &&
+		((arg.RelationKey == nil && other.RelationKey == nil) ||
+			(arg.RelationKey != nil && other.RelationKey != nil && *arg.RelationKey == *other.RelationKey))
+}
+
 // AddSecretGrants records requests to grant secret access.
 func (b *CommitHookParamsBuilder) AddSecretGrants(grants []SecretGrantRevokeArgs) {
 	if len(grants) == 0 {

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -1067,7 +1067,7 @@ func (b *CommitHookParamsBuilder) AddSecretGrants(grants []SecretGrantRevokeArgs
 	}
 	b.arg.SecretGrants = make([]params.GrantRevokeSecretArg, len(grants))
 	for i, g := range grants {
-		b.arg.SecretGrants[i] = grantRevokeArgsToParams(&g)
+		b.arg.SecretGrants[i] = g.ToParams()
 	}
 }
 
@@ -1078,28 +1078,29 @@ func (b *CommitHookParamsBuilder) AddSecretRevokes(revokes []SecretGrantRevokeAr
 	}
 	b.arg.SecretRevokes = make([]params.GrantRevokeSecretArg, len(revokes))
 	for i, g := range revokes {
-		b.arg.SecretRevokes[i] = grantRevokeArgsToParams(&g)
+		b.arg.SecretRevokes[i] = g.ToParams()
 	}
 }
 
-func grantRevokeArgsToParams(p *SecretGrantRevokeArgs) params.GrantRevokeSecretArg {
+// ToParams converts a SecretGrantRevokeArgs to a params.GrantRevokeSecretArg.
+func (arg SecretGrantRevokeArgs) ToParams() params.GrantRevokeSecretArg {
 	var subjectTag, scopeTag string
-	if p.ApplicationName != nil {
-		subjectTag = names.NewApplicationTag(*p.ApplicationName).String()
+	if arg.ApplicationName != nil {
+		subjectTag = names.NewApplicationTag(*arg.ApplicationName).String()
 	}
-	if p.UnitName != nil {
-		subjectTag = names.NewUnitTag(*p.UnitName).String()
+	if arg.UnitName != nil {
+		subjectTag = names.NewUnitTag(*arg.UnitName).String()
 	}
-	if p.RelationKey != nil {
-		scopeTag = names.NewRelationTag(*p.RelationKey).String()
+	if arg.RelationKey != nil {
+		scopeTag = names.NewRelationTag(*arg.RelationKey).String()
 	} else {
 		scopeTag = subjectTag
 	}
 	return params.GrantRevokeSecretArg{
-		URI:         p.URI.String(),
+		URI:         arg.URI.String(),
 		ScopeTag:    scopeTag,
 		SubjectTags: []string{subjectTag},
-		Role:        string(p.Role),
+		Role:        string(arg.Role),
 	}
 }
 

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -36,8 +36,8 @@ func toGrantInfo(grants []params.AccessInfo) []secrets.AccessInfo {
 	result := make([]secrets.AccessInfo, len(grants))
 	for i, g := range grants {
 		result[i] = secrets.AccessInfo{
-			Target: g.Target,
-			Scope:  g.Scope,
+			Target: g.TargetTag,
+			Scope:  g.ScopeTag,
 			Role:   g.Role,
 		}
 	}

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -26,16 +26,16 @@ func NewClient(caller base.APICallCloser) *Client {
 // SecretDetails holds a secret metadata and value.
 type SecretDetails struct {
 	Metadata  secrets.SecretMetadata
-	Grants    []secrets.GrantInfo
+	Access    []secrets.AccessInfo
 	Revisions []secrets.SecretRevisionMetadata
 	Value     secrets.SecretValue
 	Error     string
 }
 
-func toGrantInfo(grants []params.GrantInfo) []secrets.GrantInfo {
-	result := make([]secrets.GrantInfo, len(grants))
+func toGrantInfo(grants []params.AccessInfo) []secrets.AccessInfo {
+	result := make([]secrets.AccessInfo, len(grants))
 	for i, g := range grants {
-		result[i] = secrets.GrantInfo{
+		result[i] = secrets.AccessInfo{
 			Target: g.Target,
 			Scope:  g.Scope,
 			Role:   g.Role,
@@ -78,7 +78,7 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 				CreateTime:       r.CreateTime,
 				UpdateTime:       r.UpdateTime,
 			},
-			Grants: toGrantInfo(r.Grants),
+			Access: toGrantInfo(r.Access),
 		}
 		uri, err := secrets.ParseURI(r.URI)
 		if err == nil {

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -26,9 +26,22 @@ func NewClient(caller base.APICallCloser) *Client {
 // SecretDetails holds a secret metadata and value.
 type SecretDetails struct {
 	Metadata  secrets.SecretMetadata
+	Grants    []secrets.GrantInfo
 	Revisions []secrets.SecretRevisionMetadata
 	Value     secrets.SecretValue
 	Error     string
+}
+
+func toGrantInfo(grants []params.GrantInfo) []secrets.GrantInfo {
+	result := make([]secrets.GrantInfo, len(grants))
+	for i, g := range grants {
+		result[i] = secrets.GrantInfo{
+			Target: g.Target,
+			Scope:  g.Scope,
+			Role:   g.Role,
+		}
+	}
+	return result
 }
 
 // ListSecrets lists the available secrets.
@@ -65,6 +78,7 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 				CreateTime:       r.CreateTime,
 				UpdateTime:       r.UpdateTime,
 			},
+			Grants: toGrantInfo(r.Grants),
 		}
 		uri, err := secrets.ParseURI(r.URI)
 		if err == nil {

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -78,6 +78,13 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 					BackendName: ptr("some backend"),
 				}},
 				Value: &params.SecretValueResult{Data: data},
+				Grants: []params.GrantInfo{
+					{
+						Target: "application-gitlab",
+						Scope:  "relation-key",
+						Role:   "view",
+					},
+				},
 			}},
 		}
 		return nil
@@ -113,6 +120,13 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 			ExpireTime:  ptr(now.Add(time.Hour)),
 		}},
 		Value: secrets.NewSecretValue(data),
+		Grants: []secrets.GrantInfo{
+			{
+				Target: "application-gitlab",
+				Scope:  "relation-key",
+				Role:   secrets.RoleView,
+			},
+		},
 	}})
 }
 

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -78,7 +78,7 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 					BackendName: ptr("some backend"),
 				}},
 				Value: &params.SecretValueResult{Data: data},
-				Grants: []params.GrantInfo{
+				Access: []params.AccessInfo{
 					{
 						Target: "application-gitlab",
 						Scope:  "relation-key",
@@ -120,7 +120,7 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 			ExpireTime:  ptr(now.Add(time.Hour)),
 		}},
 		Value: secrets.NewSecretValue(data),
-		Grants: []secrets.GrantInfo{
+		Access: []secrets.AccessInfo{
 			{
 				Target: "application-gitlab",
 				Scope:  "relation-key",

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -80,9 +80,9 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 				Value: &params.SecretValueResult{Data: data},
 				Access: []params.AccessInfo{
 					{
-						Target: "application-gitlab",
-						Scope:  "relation-key",
-						Role:   "view",
+						TargetTag: "application-gitlab",
+						ScopeTag:  "relation-key",
+						Role:      "view",
 					},
 				},
 			}},

--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -140,7 +140,7 @@ func (s *secretsDrainSuite) assertGetSecretsToDrain(
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	s.secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{}, nil)
+	s.secretsMetaState.EXPECT().SecretGrants(uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{}, nil)
 	s.secretsMetaState.EXPECT().ListSecretRevisions(uri).Return([]*coresecrets.SecretRevisionMetadata{
 		{
 			// External backend.

--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -140,6 +140,7 @@ func (s *secretsDrainSuite) assertGetSecretsToDrain(
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
+	s.secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{}, nil)
 	s.secretsMetaState.EXPECT().ListSecretRevisions(uri).Return([]*coresecrets.SecretRevisionMetadata{
 		{
 			// External backend.

--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -140,7 +140,7 @@ func (s *secretsDrainSuite) assertGetSecretsToDrain(
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	s.secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{}, nil)
+	s.secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{}, nil)
 	s.secretsMetaState.EXPECT().ListSecretRevisions(uri).Return([]*coresecrets.SecretRevisionMetadata{
 		{
 			// External backend.

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -340,10 +340,10 @@ func (mr *MockSecretsMetaStateMockRecorder) ListSecrets(arg0 interface{}) *gomoc
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsMetaState) SecretGrants(arg0 *secrets0.URI) ([]secrets0.GrantInfo, error) {
+func (m *MockSecretsMetaState) SecretGrants(arg0 *secrets0.URI) ([]secrets0.AccessInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretGrants", arg0)
-	ret0, _ := ret[0].([]secrets0.GrantInfo)
+	ret0, _ := ret[0].([]secrets0.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -340,18 +340,18 @@ func (mr *MockSecretsMetaStateMockRecorder) ListSecrets(arg0 interface{}) *gomoc
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsMetaState) SecretGrants(arg0 *secrets0.URI) ([]secrets0.AccessInfo, error) {
+func (m *MockSecretsMetaState) SecretGrants(arg0 *secrets0.URI, arg1 secrets0.SecretRole) ([]secrets0.AccessInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret := m.ctrl.Call(m, "SecretGrants", arg0, arg1)
 	ret0, _ := ret[0].([]secrets0.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretGrants indicates an expected call of SecretGrants.
-func (mr *MockSecretsMetaStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsMetaStateMockRecorder) SecretGrants(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsMetaState)(nil).SecretGrants), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsMetaState)(nil).SecretGrants), arg0, arg1)
 }
 
 // MockSecretsRemoveState is a mock of SecretsRemoveState interface.

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -339,6 +339,21 @@ func (mr *MockSecretsMetaStateMockRecorder) ListSecrets(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsMetaState)(nil).ListSecrets), arg0)
 }
 
+// SecretGrants mocks base method.
+func (m *MockSecretsMetaState) SecretGrants(arg0 *secrets0.URI) ([]secrets0.GrantInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret0, _ := ret[0].([]secrets0.GrantInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretGrants indicates an expected call of SecretGrants.
+func (mr *MockSecretsMetaStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsMetaState)(nil).SecretGrants), arg0)
+}
+
 // MockSecretsRemoveState is a mock of SecretsRemoveState interface.
 type MockSecretsRemoveState struct {
 	ctrl     *gomock.Controller

--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -194,18 +194,18 @@ func (mr *MockSecretsStoreMockRecorder) ListUnusedSecretRevisions(arg0 interface
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsStore) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
+func (m *MockSecretsStore) SecretGrants(arg0 *secrets.URI, arg1 secrets.SecretRole) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret := m.ctrl.Call(m, "SecretGrants", arg0, arg1)
 	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretGrants indicates an expected call of SecretGrants.
-func (mr *MockSecretsStoreMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsStoreMockRecorder) SecretGrants(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsStore)(nil).SecretGrants), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsStore)(nil).SecretGrants), arg0, arg1)
 }
 
 // UpdateSecret mocks base method.

--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -193,6 +193,21 @@ func (mr *MockSecretsStoreMockRecorder) ListUnusedSecretRevisions(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUnusedSecretRevisions", reflect.TypeOf((*MockSecretsStore)(nil).ListUnusedSecretRevisions), arg0)
 }
 
+// SecretGrants mocks base method.
+func (m *MockSecretsStore) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretGrants indicates an expected call of SecretGrants.
+func (mr *MockSecretsStoreMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsStore)(nil).SecretGrants), arg0)
+}
+
 // UpdateSecret mocks base method.
 func (m *MockSecretsStore) UpdateSecret(arg0 *secrets.URI, arg1 state.UpdateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -194,10 +194,10 @@ func (mr *MockSecretsStoreMockRecorder) ListUnusedSecretRevisions(arg0 interface
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsStore) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+func (m *MockSecretsStore) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretGrants", arg0)
-	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -518,7 +518,7 @@ func GetSecretMetadata(
 			return result, errors.Trace(err)
 		}
 		for _, g := range grants {
-			secretResult.Grants = append(secretResult.Grants, params.GrantInfo{
+			secretResult.Access = append(secretResult.Access, params.AccessInfo{
 				Target: g.Target, Scope: g.Scope, Role: g.Role,
 			})
 		}

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -513,7 +513,7 @@ func GetSecretMetadata(
 			CreateTime:       md.CreateTime,
 			UpdateTime:       md.UpdateTime,
 		}
-		grants, err := secretsState.SecretGrants(md.URI)
+		grants, err := secretsState.SecretGrants(md.URI, coresecrets.RoleView)
 		if err != nil {
 			return result, errors.Trace(err)
 		}

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -513,9 +513,19 @@ func GetSecretMetadata(
 			CreateTime:       md.CreateTime,
 			UpdateTime:       md.UpdateTime,
 		}
+		grants, err := secretsState.SecretGrants(md.URI)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		for _, g := range grants {
+			secretResult.Grants = append(secretResult.Grants, params.GrantInfo{
+				Target: g.Target, Scope: g.Scope, Role: g.Role,
+			})
+		}
+
 		revs, err := secretsState.ListSecretRevisions(md.URI)
 		if err != nil {
-			return params.ListSecretResults{}, errors.Trace(err)
+			return result, errors.Trace(err)
 		}
 		for _, r := range revs {
 			if filter != nil && !filter(md, r) {

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -519,7 +519,7 @@ func GetSecretMetadata(
 		}
 		for _, g := range grants {
 			secretResult.Access = append(secretResult.Access, params.AccessInfo{
-				Target: g.Target, Scope: g.Scope, Role: g.Role,
+				TargetTag: g.Target, ScopeTag: g.Scope, Role: g.Role,
 			})
 		}
 

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -688,7 +688,7 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+	secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",
@@ -726,7 +726,7 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 			}, {
 				Revision: 667,
 			}},
-			Grants: []params.GrantInfo{
+			Access: []params.AccessInfo{
 				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
 			},
 		}},

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -727,7 +727,7 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 				Revision: 667,
 			}},
 			Access: []params.AccessInfo{
-				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+				{TargetTag: "application-gitlab", ScopeTag: "relation-key", Role: "view"},
 			},
 		}},
 	})

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -688,6 +688,13 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
+	secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+		{
+			Target: "application-gitlab",
+			Scope:  "relation-key",
+			Role:   coresecrets.RoleView,
+		},
+	}, nil)
 	secretsMetaState.EXPECT().ListSecretRevisions(uri).Return([]*coresecrets.SecretRevisionMetadata{{
 		Revision: 666,
 		ValueRef: &coresecrets.ValueRef{
@@ -719,6 +726,9 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 			}, {
 				Revision: 667,
 			}},
+			Grants: []params.GrantInfo{
+				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+			},
 		}},
 	})
 }

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -688,7 +688,7 @@ func (s *secretsSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	secretsMetaState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
+	secretsMetaState.EXPECT().SecretGrants(uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -53,6 +53,7 @@ type SecretsState interface {
 type SecretsMetaState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
 }
 

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -53,7 +53,7 @@ type SecretsState interface {
 type SecretsMetaState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
-	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
+	SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
 }
 

--- a/apiserver/common/secrets/state.go
+++ b/apiserver/common/secrets/state.go
@@ -53,7 +53,7 @@ type SecretsState interface {
 type SecretsMetaState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
-	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
 }
 

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
@@ -162,10 +162,10 @@ func (mr *MockSecretsStateMockRecorder) ListSecrets(arg0 interface{}) *gomock.Ca
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretGrants", arg0)
-	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
@@ -162,18 +162,18 @@ func (mr *MockSecretsStateMockRecorder) ListSecrets(arg0 interface{}) *gomock.Ca
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI, arg1 secrets.SecretRole) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret := m.ctrl.Call(m, "SecretGrants", arg0, arg1)
 	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretGrants indicates an expected call of SecretGrants.
-func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0, arg1)
 }
 
 // UpdateSecret mocks base method.

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsstate.go
@@ -161,6 +161,21 @@ func (mr *MockSecretsStateMockRecorder) ListSecrets(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsState)(nil).ListSecrets), arg0)
 }
 
+// SecretGrants mocks base method.
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretGrants indicates an expected call of SecretGrants.
+func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0)
+}
+
 // UpdateSecret mocks base method.
 func (m *MockSecretsState) UpdateSecret(arg0 *secrets.URI, arg1 state.UpdateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -658,7 +658,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
+	s.secretsState.EXPECT().SecretGrants(uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -697,7 +697,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 				Revision: 667,
 			}},
 			Access: []params.AccessInfo{
-				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+				{TargetTag: "application-gitlab", ScopeTag: "relation-key", Role: "view"},
 			},
 		}},
 	})

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -658,7 +658,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
-	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",
@@ -696,7 +696,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 			}, {
 				Revision: 667,
 			}},
-			Grants: []params.GrantInfo{
+			Access: []params.AccessInfo{
 				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
 			},
 		}},

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -658,6 +658,13 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 		LatestExpireTime: &now,
 		NextRotateTime:   &now,
 	}}, nil)
+	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+		{
+			Target: "application-gitlab",
+			Scope:  "relation-key",
+			Role:   coresecrets.RoleView,
+		},
+	}, nil)
 	s.secretsState.EXPECT().ListSecretRevisions(uri).Return([]*coresecrets.SecretRevisionMetadata{{
 		Revision: 666,
 		ValueRef: &coresecrets.ValueRef{
@@ -689,6 +696,9 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 			}, {
 				Revision: 667,
 			}},
+			Grants: []params.GrantInfo{
+				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+			},
 		}},
 	})
 }

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -42,7 +42,7 @@ type SecretsState interface {
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	WatchObsolete(owners []names.Tag) (state.StringsWatcher, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
-	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
+	SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
 }
 
 type CrossModelState interface {

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -42,6 +42,7 @@ type SecretsState interface {
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	WatchObsolete(owners []names.Tag) (state.StringsWatcher, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
+	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
 }
 
 type CrossModelState interface {

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -42,7 +42,7 @@ type SecretsState interface {
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	WatchObsolete(owners []names.Tag) (state.StringsWatcher, error)
 	ChangeSecretBackend(state.ChangeSecretBackendParams) error
-	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
 }
 
 type CrossModelState interface {

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -163,18 +163,18 @@ func (mr *MockSecretsStateMockRecorder) ListUnusedSecretRevisions(arg0 interface
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI, arg1 secrets.SecretRole) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret := m.ctrl.Call(m, "SecretGrants", arg0, arg1)
 	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretGrants indicates an expected call of SecretGrants.
-func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0, arg1)
 }
 
 // UpdateSecret mocks base method.

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -163,10 +163,10 @@ func (mr *MockSecretsStateMockRecorder) ListUnusedSecretRevisions(arg0 interface
 }
 
 // SecretGrants mocks base method.
-func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.AccessInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretGrants", arg0)
-	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret0, _ := ret[0].([]secrets.AccessInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -162,6 +162,21 @@ func (mr *MockSecretsStateMockRecorder) ListUnusedSecretRevisions(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUnusedSecretRevisions", reflect.TypeOf((*MockSecretsState)(nil).ListUnusedSecretRevisions), arg0)
 }
 
+// SecretGrants mocks base method.
+func (m *MockSecretsState) SecretGrants(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretGrants", arg0)
+	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretGrants indicates an expected call of SecretGrants.
+func (mr *MockSecretsStateMockRecorder) SecretGrants(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretGrants", reflect.TypeOf((*MockSecretsState)(nil).SecretGrants), arg0)
+}
+
 // UpdateSecret mocks base method.
 func (m *MockSecretsState) UpdateSecret(arg0 *secrets.URI, arg1 state.UpdateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -129,7 +129,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			CreateTime:       m.CreateTime,
 			UpdateTime:       m.UpdateTime,
 		}
-		grants, err := s.secretsState.SecretGrants(m.URI)
+		grants, err := s.secretsState.SecretGrants(m.URI, coresecrets.RoleView)
 		if err != nil {
 			return result, errors.Trace(err)
 		}

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -135,7 +135,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 		}
 		for _, g := range grants {
 			secretResult.Access = append(secretResult.Access, params.AccessInfo{
-				Target: g.Target, Scope: g.Scope, Role: g.Role,
+				TargetTag: g.Target, ScopeTag: g.Scope, Role: g.Role,
 			})
 		}
 		for _, r := range revisionMetadata[m.URI.ID] {

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -129,6 +129,15 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			CreateTime:       m.CreateTime,
 			UpdateTime:       m.UpdateTime,
 		}
+		grants, err := s.secretsState.SecretGrants(m.URI)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		for _, g := range grants {
+			secretResult.Grants = append(secretResult.Grants, params.GrantInfo{
+				Target: g.Target, Scope: g.Scope, Role: g.Role,
+			})
+		}
 		for _, r := range revisionMetadata[m.URI.ID] {
 			backendName := r.BackendName
 			if backendName == nil {

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -134,7 +134,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			return result, errors.Trace(err)
 		}
 		for _, g := range grants {
-			secretResult.Grants = append(secretResult.Grants, params.GrantInfo{
+			secretResult.Access = append(secretResult.Access, params.AccessInfo{
 				Target: g.Target, Scope: g.Scope, Role: g.Role,
 			})
 		}

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -176,7 +176,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{}).Return(
 		metadata, nil,
 	)
-	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
+	s.secretsState.EXPECT().SecretGrants(uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -176,7 +176,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{}).Return(
 		metadata, nil,
 	)
-	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.AccessInfo{
 		{
 			Target: "application-gitlab",
 			Scope:  "relation-key",
@@ -238,7 +238,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 				UpdateTime:  now.Add(2 * time.Second),
 				ExpireTime:  ptr(now.Add(2 * time.Hour)),
 			}},
-			Grants: []params.GrantInfo{
+			Access: []params.AccessInfo{
 				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
 			},
 		}},

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -239,7 +239,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 				ExpireTime:  ptr(now.Add(2 * time.Hour)),
 			}},
 			Access: []params.AccessInfo{
-				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+				{TargetTag: "application-gitlab", ScopeTag: "relation-key", Role: "view"},
 			},
 		}},
 	})

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -176,6 +176,13 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 	s.secretsState.EXPECT().ListSecrets(state.SecretsFilter{}).Return(
 		metadata, nil,
 	)
+	s.secretsState.EXPECT().SecretGrants(uri).Return([]coresecrets.GrantInfo{
+		{
+			Target: "application-gitlab",
+			Scope:  "relation-key",
+			Role:   coresecrets.RoleView,
+		},
+	}, nil)
 	s.secretsState.EXPECT().ListSecretRevisions(uri).Return(
 		revisions, nil,
 	)
@@ -231,6 +238,9 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 				UpdateTime:  now.Add(2 * time.Second),
 				ExpireTime:  ptr(now.Add(2 * time.Hour)),
 			}},
+			Grants: []params.GrantInfo{
+				{Target: "application-gitlab", Scope: "relation-key", Role: "view"},
+			},
 		}},
 	})
 }

--- a/apiserver/facades/client/secrets/state.go
+++ b/apiserver/facades/client/secrets/state.go
@@ -21,6 +21,7 @@ type SecretsState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	ListUnusedSecretRevisions(uri *secrets.URI) ([]int, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
 }
 
 // SecretsConsumer instances provide secret consumer apis.

--- a/apiserver/facades/client/secrets/state.go
+++ b/apiserver/facades/client/secrets/state.go
@@ -21,7 +21,7 @@ type SecretsState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	ListUnusedSecretRevisions(uri *secrets.URI) ([]int, error)
-	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
+	SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
 }
 
 // SecretsConsumer instances provide secret consumer apis.

--- a/apiserver/facades/client/secrets/state.go
+++ b/apiserver/facades/client/secrets/state.go
@@ -21,7 +21,7 @@ type SecretsState interface {
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
 	ListUnusedSecretRevisions(uri *secrets.URI) ([]int, error)
-	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
 }
 
 // SecretsConsumer instances provide secret consumer apis.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40537,6 +40537,26 @@
                         "results"
                     ]
                 },
+                "GrantInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "GrantRevokeUserSecretArg": {
                     "type": "object",
                     "properties": {
@@ -40569,6 +40589,12 @@
                         },
                         "description": {
                             "type": "string"
+                        },
+                        "grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantInfo"
+                            }
                         },
                         "label": {
                             "type": "string"
@@ -41005,6 +41031,26 @@
                         "results"
                     ]
                 },
+                "GrantInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
@@ -41014,6 +41060,12 @@
                         },
                         "description": {
                             "type": "string"
+                        },
+                        "grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantInfo"
+                            }
                         },
                         "label": {
                             "type": "string"
@@ -41622,6 +41674,26 @@
                         "args"
                     ]
                 },
+                "GrantInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "GrantRevokeSecretArg": {
                     "type": "object",
                     "properties": {
@@ -41673,6 +41745,12 @@
                         },
                         "description": {
                             "type": "string"
+                        },
+                        "grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantInfo"
+                            }
                         },
                         "label": {
                             "type": "string"
@@ -49210,6 +49288,26 @@
                         "since"
                     ]
                 },
+                "GrantInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "GrantRevokeSecretArg": {
                     "type": "object",
                     "properties": {
@@ -49384,6 +49482,12 @@
                         },
                         "description": {
                             "type": "string"
+                        },
+                        "grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantInfo"
+                            }
                         },
                         "label": {
                             "type": "string"
@@ -52942,6 +53046,26 @@
                         "args"
                     ]
                 },
+                "GrantInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
@@ -52951,6 +53075,12 @@
                         },
                         "description": {
                             "type": "string"
+                        },
+                        "grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantInfo"
+                            }
                         },
                         "label": {
                             "type": "string"

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40392,6 +40392,26 @@
                 }
             },
             "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "CreateSecretArg": {
                     "type": "object",
                     "properties": {
@@ -40537,26 +40557,6 @@
                         "results"
                     ]
                 },
-                "GrantInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target",
-                        "scope",
-                        "role"
-                    ]
-                },
                 "GrantRevokeUserSecretArg": {
                     "type": "object",
                     "properties": {
@@ -40583,18 +40583,18 @@
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
                         },
                         "description": {
                             "type": "string"
-                        },
-                        "grants": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/GrantInfo"
-                            }
                         },
                         "label": {
                             "type": "string"
@@ -40948,6 +40948,26 @@
                 }
             },
             "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "ChangeSecretBackendArg": {
                     "type": "object",
                     "properties": {
@@ -41031,41 +41051,21 @@
                         "results"
                     ]
                 },
-                "GrantInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target",
-                        "scope",
-                        "role"
-                    ]
-                },
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
                         },
                         "description": {
                             "type": "string"
-                        },
-                        "grants": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/GrantInfo"
-                            }
                         },
                         "label": {
                             "type": "string"
@@ -41435,6 +41435,26 @@
                 }
             },
             "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "CreateSecretArg": {
                     "type": "object",
                     "properties": {
@@ -41674,26 +41694,6 @@
                         "args"
                     ]
                 },
-                "GrantInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target",
-                        "scope",
-                        "role"
-                    ]
-                },
                 "GrantRevokeSecretArg": {
                     "type": "object",
                     "properties": {
@@ -41739,18 +41739,18 @@
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
                         },
                         "description": {
                             "type": "string"
-                        },
-                        "grants": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/GrantInfo"
-                            }
                         },
                         "label": {
                             "type": "string"
@@ -48239,6 +48239,26 @@
                         "servers"
                     ]
                 },
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "Action": {
                     "type": "object",
                     "properties": {
@@ -49288,26 +49308,6 @@
                         "since"
                     ]
                 },
-                "GrantInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target",
-                        "scope",
-                        "role"
-                    ]
-                },
                 "GrantRevokeSecretArg": {
                     "type": "object",
                     "properties": {
@@ -49476,18 +49476,18 @@
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
                         },
                         "description": {
                             "type": "string"
-                        },
-                        "grants": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/GrantInfo"
-                            }
                         },
                         "label": {
                             "type": "string"
@@ -52927,6 +52927,26 @@
                 }
             },
             "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target",
+                        "scope",
+                        "role"
+                    ]
+                },
                 "ChangeSecretBackendArg": {
                     "type": "object",
                     "properties": {
@@ -53046,41 +53066,21 @@
                         "args"
                     ]
                 },
-                "GrantInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target",
-                        "scope",
-                        "role"
-                    ]
-                },
                 "ListSecretResult": {
                     "type": "object",
                     "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
                         },
                         "description": {
                             "type": "string"
-                        },
-                        "grants": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/GrantInfo"
-                            }
                         },
                         "label": {
                             "type": "string"

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40398,17 +40398,17 @@
                         "role": {
                             "type": "string"
                         },
-                        "scope": {
+                        "scope-tag": {
                             "type": "string"
                         },
-                        "target": {
+                        "target-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "target",
-                        "scope",
+                        "target-tag",
+                        "scope-tag",
                         "role"
                     ]
                 },
@@ -40954,17 +40954,17 @@
                         "role": {
                             "type": "string"
                         },
-                        "scope": {
+                        "scope-tag": {
                             "type": "string"
                         },
-                        "target": {
+                        "target-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "target",
-                        "scope",
+                        "target-tag",
+                        "scope-tag",
                         "role"
                     ]
                 },
@@ -41441,17 +41441,17 @@
                         "role": {
                             "type": "string"
                         },
-                        "scope": {
+                        "scope-tag": {
                             "type": "string"
                         },
-                        "target": {
+                        "target-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "target",
-                        "scope",
+                        "target-tag",
+                        "scope-tag",
                         "role"
                     ]
                 },
@@ -48245,17 +48245,17 @@
                         "role": {
                             "type": "string"
                         },
-                        "scope": {
+                        "scope-tag": {
                             "type": "string"
                         },
-                        "target": {
+                        "target-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "target",
-                        "scope",
+                        "target-tag",
+                        "scope-tag",
                         "role"
                     ]
                 },
@@ -52933,17 +52933,17 @@
                         "role": {
                             "type": "string"
                         },
-                        "scope": {
+                        "scope-tag": {
                             "type": "string"
                         },
-                        "target": {
+                        "target-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "target",
-                        "scope",
+                        "target-tag",
+                        "scope-tag",
                         "role"
                     ]
                 },

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -115,20 +115,20 @@ type secretDisplayDetails struct {
 	Error            string                  `json:"error,omitempty" yaml:"error,omitempty"`
 	Value            *secretValueDetails     `json:"content,omitempty" yaml:"content,omitempty"`
 	Revisions        []secretRevisionDetails `json:"revisions,omitempty" yaml:"revisions,omitempty"`
-	Grants           []GrantInfo             `yaml:"grants,omitempty" json:"grants,omitempty"`
+	Access           []AccessInfo            `yaml:"access,omitempty" json:"access,omitempty"`
 }
 
-// GrantInfo holds info about a secret grant.
-type GrantInfo struct {
-	Target string             `json:"target"`
+// AccessInfo holds info about a secret access information.
+type AccessInfo struct {
+	Target string             `json:"target" yaml:"target"`
 	Scope  string             `json:"scope"`
 	Role   secrets.SecretRole `json:"role"`
 }
 
-func toGrantInfo(grants []secrets.GrantInfo) []GrantInfo {
-	result := make([]GrantInfo, len(grants))
+func toGrantInfo(grants []secrets.AccessInfo) []AccessInfo {
+	result := make([]AccessInfo, len(grants))
 	for i, grant := range grants {
-		result[i] = GrantInfo{
+		result[i] = AccessInfo{
 			Target: grant.Target,
 			Scope:  grant.Scope,
 			Role:   grant.Role,
@@ -199,7 +199,7 @@ func gatherSecretInfo(
 			Error:            m.Error,
 		}
 		if includeGrants {
-			info.Grants = toGrantInfo(m.Grants)
+			info.Access = toGrantInfo(m.Access)
 		}
 		if includeRevisions {
 			info.Revisions = make([]secretRevisionDetails, len(m.Revisions))

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -121,8 +121,8 @@ type secretDisplayDetails struct {
 // AccessInfo holds info about a secret access information.
 type AccessInfo struct {
 	Target string             `json:"target" yaml:"target"`
-	Scope  string             `json:"scope"`
-	Role   secrets.SecretRole `json:"role"`
+	Scope  string             `json:"scope" yaml:"scope"`
+	Role   secrets.SecretRole `json:"role" yaml:"role"`
 }
 
 func toGrantInfo(grants []secrets.AccessInfo) []AccessInfo {

--- a/cmd/juju/secrets/show.go
+++ b/cmd/juju/secrets/show.go
@@ -135,7 +135,7 @@ func (c *showSecretsCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	details := gatherSecretInfo(result, c.revealSecrets, c.revisions)
+	details := gatherSecretInfo(result, c.revealSecrets, c.revisions, true)
 	if len(details) == 0 {
 		if c.uri != nil {
 			return errors.NotFoundf("secret %q", c.uri.ID)

--- a/cmd/juju/secrets/show_test.go
+++ b/cmd/juju/secrets/show_test.go
@@ -76,7 +76,7 @@ func (s *ShowSuite) TestShow(c *gc.C) {
 				LatestExpireTime: &expire,
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "application-gitlab",
 					Scope:  "relation-key",
@@ -99,7 +99,7 @@ func (s *ShowSuite) TestShow(c *gc.C) {
   label: foobar
   created: 0001-01-01T00:00:00Z
   updated: 0001-01-01T00:00:00Z
-  grants:
+  access:
   - target: application-gitlab
     scope: relation-key
     role: view

--- a/cmd/juju/secrets/show_test.go
+++ b/cmd/juju/secrets/show_test.go
@@ -76,6 +76,13 @@ func (s *ShowSuite) TestShow(c *gc.C) {
 				LatestExpireTime: &expire,
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
+			Grants: []coresecrets.GrantInfo{
+				{
+					Target: "application-gitlab",
+					Scope:  "relation-key",
+					Role:   coresecrets.RoleView,
+				},
+			},
 		}}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
@@ -92,6 +99,10 @@ func (s *ShowSuite) TestShow(c *gc.C) {
   label: foobar
   created: 0001-01-01T00:00:00Z
   updated: 0001-01-01T00:00:00Z
+  grants:
+  - target: application-gitlab
+    scope: relation-key
+    role: view
 `[1:], uri.ID))
 }
 

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -178,12 +178,12 @@ type SecretMetadata struct {
 	// AutoPrune is true if the secret revisions should be pruned when it's not been used.
 	AutoPrune bool
 
-	// Grants is a list of grant information for this secret.
-	Grants []GrantInfo
+	// Access is a list of access information for this secret.
+	Access []AccessInfo
 }
 
-// GrantInfo holds info about a secret grant.
-type GrantInfo struct {
+// AccessInfo holds info about a secret access information.
+type AccessInfo struct {
 	Target string
 	Scope  string
 	Role   SecretRole

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -177,6 +177,16 @@ type SecretMetadata struct {
 
 	// AutoPrune is true if the secret revisions should be pruned when it's not been used.
 	AutoPrune bool
+
+	// Grants is a list of grant information for this secret.
+	Grants []GrantInfo
+}
+
+// GrantInfo holds info about a secret grant.
+type GrantInfo struct {
+	Target string
+	Scope  string
+	Role   SecretRole
 }
 
 // SecretRevisionMetadata holds metadata about a secret revision.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -288,8 +288,8 @@ type ListSecretResult struct {
 
 // AccessInfo holds info about a secret access information.
 type AccessInfo struct {
-	Target string             `json:"target"`
-	Scope  string             `json:"scope"`
+	Target string             `json:"target-tag"`
+	Scope  string             `json:"scope-tag"`
 	Role   secrets.SecretRole `json:"role"`
 }
 

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -283,11 +283,11 @@ type ListSecretResult struct {
 	UpdateTime       time.Time          `json:"update-time"`
 	Revisions        []SecretRevision   `json:"revisions"`
 	Value            *SecretValueResult `json:"value,omitempty"`
-	Grants           []GrantInfo        `json:"grants,omitempty"`
+	Access           []AccessInfo       `json:"access,omitempty"`
 }
 
-// GrantInfo holds info about a secret grant.
-type GrantInfo struct {
+// AccessInfo holds info about a secret access information.
+type AccessInfo struct {
 	Target string             `json:"target"`
 	Scope  string             `json:"scope"`
 	Role   secrets.SecretRole `json:"role"`

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -283,6 +283,14 @@ type ListSecretResult struct {
 	UpdateTime       time.Time          `json:"update-time"`
 	Revisions        []SecretRevision   `json:"revisions"`
 	Value            *SecretValueResult `json:"value,omitempty"`
+	Grants           []GrantInfo        `json:"grants,omitempty"`
+}
+
+// GrantInfo holds info about a secret grant.
+type GrantInfo struct {
+	Target string             `json:"target"`
+	Scope  string             `json:"scope"`
+	Role   secrets.SecretRole `json:"role"`
 }
 
 // SecretTriggerChange describes a change to a secret trigger.
@@ -311,6 +319,29 @@ type SecretRotatedArg struct {
 	Skip             bool   `json:"skip"`
 }
 
+// SecretGrantInfoArgs holds args for getting secret grant information.
+type SecretGrantInfoArgs struct {
+	Args []SecretGrantInfoArg `json:"args"`
+}
+
+// SecretGrantInfoArg holds the args for getting secret grant information.
+type SecretGrantInfoArg struct {
+	// URI identifies the secret.
+	URI string `json:"uri"`
+}
+
+// SecretGrantInfoResult holds the result of an API call to retrieve secret grant info.
+type SecretGrantInfoResult struct {
+	URI         string   `json:"uri"`
+	SubjectTags []string `json:"subject-tags"`
+	Error       *Error   `json:"error,omitempty"`
+}
+
+// SecretGrantInfoResults holds the result of an API call to retrieve details of multiple secret grant info.
+type SecretGrantInfoResults struct {
+	Results []SecretGrantInfoResult `json:"results,omitempty"`
+}
+
 // GrantRevokeSecretArgs holds args for changing access to secrets.
 type GrantRevokeSecretArgs struct {
 	Args []GrantRevokeSecretArg `json:"args"`
@@ -324,7 +355,8 @@ type GrantRevokeSecretArg struct {
 	// ScopeTag is defines the entity to which the access is scoped.
 	ScopeTag string `json:"scope-tag"`
 
-	// OwnerTag is the owner of the secret.
+	// SubjectTags are the target tag of the secret grant/revoke request.
+	// TODO: rename this field to TargetTags and bump facade version.
 	SubjectTags []string `json:"subject-tags"`
 
 	// Role is the role being granted.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -288,9 +288,9 @@ type ListSecretResult struct {
 
 // AccessInfo holds info about a secret access information.
 type AccessInfo struct {
-	Target string             `json:"target-tag"`
-	Scope  string             `json:"scope-tag"`
-	Role   secrets.SecretRole `json:"role"`
+	TargetTag string             `json:"target-tag"`
+	ScopeTag  string             `json:"scope-tag"`
+	Role      secrets.SecretRole `json:"role"`
 }
 
 // SecretTriggerChange describes a change to a secret trigger.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -319,29 +319,6 @@ type SecretRotatedArg struct {
 	Skip             bool   `json:"skip"`
 }
 
-// SecretGrantInfoArgs holds args for getting secret grant information.
-type SecretGrantInfoArgs struct {
-	Args []SecretGrantInfoArg `json:"args"`
-}
-
-// SecretGrantInfoArg holds the args for getting secret grant information.
-type SecretGrantInfoArg struct {
-	// URI identifies the secret.
-	URI string `json:"uri"`
-}
-
-// SecretGrantInfoResult holds the result of an API call to retrieve secret grant info.
-type SecretGrantInfoResult struct {
-	URI         string   `json:"uri"`
-	SubjectTags []string `json:"subject-tags"`
-	Error       *Error   `json:"error,omitempty"`
-}
-
-// SecretGrantInfoResults holds the result of an API call to retrieve details of multiple secret grant info.
-type SecretGrantInfoResults struct {
-	Results []SecretGrantInfoResult `json:"results,omitempty"`
-}
-
 // GrantRevokeSecretArgs holds args for changing access to secrets.
 type GrantRevokeSecretArgs struct {
 	Args []GrantRevokeSecretArg `json:"args"`

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -94,7 +94,7 @@ type SecretsStore interface {
 	WatchObsolete(owners []names.Tag) (StringsWatcher, error)
 	WatchRevisionsToPrune(ownerTags []names.Tag) (StringsWatcher, error)
 	ChangeSecretBackend(ChangeSecretBackendParams) error
-	SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error)
+	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
 }
 
 // NewSecrets creates a new mongo backed secrets store.
@@ -868,8 +868,8 @@ func (s *secretsStore) ChangeSecretBackend(arg ChangeSecretBackendParams) error 
 	return errors.Trace(err)
 }
 
-// SecretGrants returns the list of grant information of the secret.
-func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, error) {
+// SecretGrants returns the list of access information of the secret.
+func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error) {
 	secretPermissionsCollection, closer := s.st.db().GetCollection(secretPermissionsC)
 	defer closer()
 
@@ -890,9 +890,9 @@ func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, erro
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot retrieve secret permissions for %s", uri.String())
 	}
-	var results []secrets.GrantInfo
+	var results []secrets.AccessInfo
 	for _, doc := range docs {
-		results = append(results, secrets.GrantInfo{
+		results = append(results, secrets.AccessInfo{
 			Target: doc.Subject,
 			Scope:  doc.Scope,
 			Role:   secrets.SecretRole(doc.Role),

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -888,7 +888,7 @@ func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.GrantInfo, erro
 		},
 	).All(&docs)
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannnot retrieve secret permissions for %s", uri.String())
+		return nil, errors.Annotatef(err, "cannot retrieve secret permissions for %s", uri.String())
 	}
 	var results []secrets.GrantInfo
 	for _, doc := range docs {

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -94,7 +94,7 @@ type SecretsStore interface {
 	WatchObsolete(owners []names.Tag) (StringsWatcher, error)
 	WatchRevisionsToPrune(ownerTags []names.Tag) (StringsWatcher, error)
 	ChangeSecretBackend(ChangeSecretBackendParams) error
-	SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error)
+	SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
 }
 
 // NewSecrets creates a new mongo backed secrets store.
@@ -869,7 +869,7 @@ func (s *secretsStore) ChangeSecretBackend(arg ChangeSecretBackendParams) error 
 }
 
 // SecretGrants returns the list of access information of the secret.
-func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, error) {
+func (s *secretsStore) SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error) {
 	secretPermissionsCollection, closer := s.st.db().GetCollection(secretPermissionsC)
 	defer closer()
 
@@ -883,8 +883,7 @@ func (s *secretsStore) SecretGrants(uri *secrets.URI) ([]secrets.AccessInfo, err
 			"_id": bson.M{
 				"$regex": fmt.Sprintf("%s#.*", uri.ID),
 			},
-			// We just want the manually granted record but not the auto-granted for owners.
-			"role": secrets.RoleView,
+			"role": role,
 		},
 	).All(&docs)
 	if err != nil {

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -868,7 +868,7 @@ func (s *secretsStore) ChangeSecretBackend(arg ChangeSecretBackendParams) error 
 	return errors.Trace(err)
 }
 
-// SecretGrants returns the list of access information of the secret.
+// SecretGrants returns the list of access information of the secret for the specified role.
 func (s *secretsStore) SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error) {
 	secretPermissionsCollection, closer := s.st.db().GetCollection(secretPermissionsC)
 	defer closer()

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -1306,6 +1306,46 @@ func (s *SecretsSuite) TestChangeSecretBackendExternalToInternal(c *gc.C) {
 	c.Assert(valRef, gc.IsNil)
 }
 
+func (s *SecretsSuite) TestSecretGrants(c *gc.C) {
+	uri := secrets.NewURI()
+
+	now := s.Clock.Now().Round(time.Second).UTC()
+	next := now.Add(time.Minute).Round(time.Second).UTC()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.owner.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			Label:          strPtr("label-1"),
+			LeaderToken:    &fakeToken{},
+			RotatePolicy:   ptr(secrets.RotateDaily),
+			NextRotateTime: ptr(next),
+			Data:           map[string]string{"foo": "bar"},
+		},
+	}
+	md, err := s.store.CreateSecret(uri, cp)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(md.URI, jc.DeepEquals, uri)
+
+	subject := names.NewApplicationTag("wordpress")
+	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
+		LeaderToken: &fakeToken{},
+		Scope:       s.relation.Tag(),
+		Subject:     subject,
+		Role:        secrets.RoleView,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	access, err := s.store.SecretGrants(uri, secrets.RoleView)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(access, jc.DeepEquals, []secrets.AccessInfo{
+		{
+			Target: subject.String(),
+			Scope:  "relation-wordpress.db#mysql.server",
+			Role:   secrets.RoleView,
+		},
+	})
+}
+
 func (s *SecretsSuite) TestGetSecret(c *gc.C) {
 	uri := secrets.NewURI()
 

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1657,9 +1657,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	}
 
 	for _, revokes := range ctx.secretChanges.pendingRevokes {
-		for _, r := range revokes {
-			pendingRevokes = append(pendingRevokes, r)
-		}
+		pendingRevokes = append(pendingRevokes, revokes...)
 	}
 
 	for uri := range ctx.secretChanges.pendingTrackLatest {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1084,7 +1084,7 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 	}
 	params := uniterArg.ToParams()
 	if len(params.SubjectTags) != 1 {
-		return errors.NotValidf("subject tags")
+		return errors.NotValidf("subject tags %v", params.SubjectTags)
 	}
 	subjectTag, err := names.ParseTag(params.SubjectTags[0])
 	if err != nil {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1049,7 +1049,7 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 	for k, v := range result {
 		uri := &coresecrets.URI{ID: k}
 		var err error
-		if v.Grants, err = ctx.secretChanges.secretGrantInfo(uri, v.Grants...); err != nil {
+		if v.Access, err = ctx.secretChanges.secretGrantInfo(uri, v.Access...); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -1090,7 +1090,7 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, g := range md.Grants {
+	for _, g := range md.Access {
 		if params.ScopeTag != g.Scope || params.Role != string(g.Role) {
 			continue
 		}

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1084,7 +1084,7 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 	}
 	params := uniterArg.ToParams()
 	if len(params.SubjectTags) != 1 {
-		return errors.NotValidf("subject tags %v", params.SubjectTags)
+		return errors.NewNotValid(nil, fmt.Sprintf("expected only 1 subject, got %d", len(params.SubjectTags)))
 	}
 	subjectTag, err := names.ParseTag(params.SubjectTags[0])
 	if err != nil {
@@ -1107,7 +1107,7 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 			return nil
 		}
 		if subjectTag.Kind() == names.ApplicationTagKind {
-			return errors.NewNotValid(nil, "to grant in application level, all unit level grants should be revoked first")
+			return errors.NewNotValid(nil, "any unit level grants need to be revoked before granting access to the corresponding application")
 		}
 	}
 	ctx.secretChanges.grant(uniterArg)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1046,6 +1046,13 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 		}
 		result[id] = v
 	}
+	for k, v := range result {
+		uri := &coresecrets.URI{ID: k}
+		var err error
+		if v.Grants, err = ctx.secretChanges.secretGrantInfo(uri, v.Grants...); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	return result, nil
 }
 
@@ -1607,12 +1614,16 @@ func (ctx *HookContext) doFlush(process string) error {
 		}
 	}
 
-	for _, g := range ctx.secretChanges.pendingGrants {
-		pendingGrants = append(pendingGrants, g)
+	for _, grants := range ctx.secretChanges.pendingGrants {
+		for _, g := range grants {
+			pendingGrants = append(pendingGrants, g)
+		}
 	}
 
-	for _, r := range ctx.secretChanges.pendingRevokes {
-		pendingRevokes = append(pendingRevokes, r)
+	for _, revokes := range ctx.secretChanges.pendingRevokes {
+		for _, r := range revokes {
+			pendingRevokes = append(pendingRevokes, r)
+		}
 	}
 
 	for uri := range ctx.secretChanges.pendingTrackLatest {

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -563,7 +563,7 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "description",
 			RotatePolicy: coresecrets.RotateHourly,
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "unit-gitlab-0",
 					Scope:  "relation-mariadb.db#gitlab.db",
@@ -585,7 +585,7 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "description",
 			RotatePolicy: coresecrets.RotateHourly,
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "unit-gitlab-0",
 					Scope:  "relation-mariadb.db#gitlab.db",
@@ -625,7 +625,7 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "another",
 			RotatePolicy: coresecrets.RotateHourly,
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{Target: "unit-gitlab-0", Scope: "relation-mariadb.db#gitlab.db", Role: "view"},
 			},
 		},
@@ -1709,7 +1709,7 @@ func (s *mockHookContextSuite) TestSecretGrantNoOPSBecauseofExactSameApp(c *gc.C
 			Description:    "a secret",
 			LatestRevision: 666,
 			Owner:          names.NewApplicationTag("mariadb"),
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "application-gitlab",
 					Role:   coresecrets.RoleView,
@@ -1741,7 +1741,7 @@ func (s *mockHookContextSuite) TestSecretGrantNoOPSBecauseofExactSameUnit(c *gc.
 			Description:    "a secret",
 			LatestRevision: 666,
 			Owner:          names.NewApplicationTag("mariadb"),
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "unit-gitlab-0",
 					Role:   coresecrets.RoleView,
@@ -1773,7 +1773,7 @@ func (s *mockHookContextSuite) TestSecretGrantNoOPSBecauseApplicationLevelGrante
 			Description:    "a secret",
 			LatestRevision: 666,
 			Owner:          names.NewApplicationTag("mariadb"),
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "application-gitlab",
 					Role:   coresecrets.RoleView,
@@ -1805,7 +1805,7 @@ func (s *mockHookContextSuite) TestSecretGrantFailedRevokeExistingRecordRequired
 			Description:    "a secret",
 			LatestRevision: 666,
 			Owner:          names.NewApplicationTag("mariadb"),
-			Grants: []coresecrets.GrantInfo{
+			Access: []coresecrets.AccessInfo{
 				{
 					Target: "unit-gitlab-0",
 					Role:   coresecrets.RoleView,

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -563,6 +563,13 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "description",
 			RotatePolicy: coresecrets.RotateHourly,
+			Grants: []coresecrets.GrantInfo{
+				{
+					Target: "unit-gitlab-0",
+					Scope:  "mariadb:db gitlab:db",
+					Role:   coresecrets.RoleView,
+				},
+			},
 		},
 		uri2.ID: {
 			Owner:       names.NewApplicationTag("mariadb"),
@@ -578,6 +585,13 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "description",
 			RotatePolicy: coresecrets.RotateHourly,
+			Grants: []coresecrets.GrantInfo{
+				{
+					Target: "unit-gitlab-0",
+					Scope:  "mariadb:db gitlab:db",
+					Role:   coresecrets.RoleView,
+				},
+			},
 		},
 		uri2.ID: {
 			Owner:       names.NewApplicationTag("mariadb"),
@@ -595,6 +609,11 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 		Description: ptr("another"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	ctx.GrantSecret(uri, &jujuc.SecretGrantRevokeArgs{
+		UnitName:    ptr("gitlab/1"),
+		RelationKey: ptr("mariadb:db gitlab:db"),
+		Role:        ptr(coresecrets.RoleView),
+	})
 
 	err = ctx.RemoveSecret(uri2, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -606,6 +625,9 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "another",
 			RotatePolicy: coresecrets.RotateHourly,
+			Grants: []coresecrets.GrantInfo{
+				{Target: "unit-gitlab-0", Scope: "mariadb:db gitlab:db", Role: "view"},
+			},
 		},
 		uri3.ID: {
 			Owner:          names.NewApplicationTag("foo"),
@@ -1624,18 +1646,22 @@ func (s *mockHookContextSuite) TestSecretGrant(c *gc.C) {
 		RelationKey:     &relationKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hookContext.PendingSecretGrants(), jc.DeepEquals, map[string]uniter.SecretGrantRevokeArgs{
+	c.Assert(hookContext.PendingSecretGrants(), jc.DeepEquals, map[string]map[string]uniter.SecretGrantRevokeArgs{
 		uri.ID: {
-			URI:             uri,
-			ApplicationName: &app,
-			RelationKey:     &relationKey,
-			Role:            coresecrets.RoleView,
+			relationKey: {
+				URI:             uri,
+				ApplicationName: &app,
+				RelationKey:     &relationKey,
+				Role:            coresecrets.RoleView,
+			},
 		},
 		uri2.ID: {
-			URI:             uri2,
-			ApplicationName: &app,
-			RelationKey:     &relationKey,
-			Role:            coresecrets.RoleView,
+			relationKey: {
+				URI:             uri2,
+				ApplicationName: &app,
+				RelationKey:     &relationKey,
+				Role:            coresecrets.RoleView,
+			},
 		}})
 }
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -1823,7 +1823,7 @@ func (s *mockHookContextSuite) TestSecretGrantFailedRevokeExistingRecordRequired
 		RelationKey:     &relationKey,
 		Role:            ptr(coresecrets.RoleView),
 	})
-	c.Assert(err, gc.ErrorMatches, `to grant in application level, all unit level grants should be revoked first`)
+	c.Assert(err, gc.ErrorMatches, `any unit level grants need to be revoked before granting access to the corresponding application`)
 }
 
 func (s *mockHookContextSuite) TestSecretRevoke(c *gc.C) {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -444,7 +444,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 			LatestExpireTime: md.LatestExpireTime,
 			NextRotateTime:   md.NextRotateTime,
 			Revisions:        v.Revisions,
-			Grants:           md.Grants,
+			Access:           md.Access,
 		}
 	}
 

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -444,6 +444,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 			LatestExpireTime: md.LatestExpireTime,
 			NextRotateTime:   md.NextRotateTime,
 			Revisions:        v.Revisions,
+			Grants:           md.Grants,
 		}
 	}
 

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -349,11 +349,11 @@ func (ctx *HookContext) SetPendingSecretUpdates(in map[string]uniter.SecretUpdat
 	ctx.secretChanges.pendingUpdates = in
 }
 
-func (ctx *HookContext) PendingSecretGrants() map[string]uniter.SecretGrantRevokeArgs {
+func (ctx *HookContext) PendingSecretGrants() map[string]map[string]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingGrants
 }
 
-func (ctx *HookContext) PendingSecretRevokes() map[string]uniter.SecretGrantRevokeArgs {
+func (ctx *HookContext) PendingSecretRevokes() map[string]map[string]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingRevokes
 }
 

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -353,7 +353,7 @@ func (ctx *HookContext) PendingSecretGrants() map[string]map[string]uniter.Secre
 	return ctx.secretChanges.pendingGrants
 }
 
-func (ctx *HookContext) PendingSecretRevokes() map[string]map[string]uniter.SecretGrantRevokeArgs {
+func (ctx *HookContext) PendingSecretRevokes() map[string][]uniter.SecretGrantRevokeArgs {
 	return ctx.secretChanges.pendingRevokes
 }
 

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -17,10 +17,14 @@ import (
 type secretsChangeRecorder struct {
 	logger loggo.Logger
 
-	pendingCreates     map[string]uniter.SecretCreateArg
-	pendingUpdates     map[string]uniter.SecretUpdateArg
-	pendingDeletes     map[string]uniter.SecretDeleteArg
-	pendingGrants      map[string]map[string]uniter.SecretGrantRevokeArgs
+	pendingCreates map[string]uniter.SecretCreateArg
+	pendingUpdates map[string]uniter.SecretUpdateArg
+	pendingDeletes map[string]uniter.SecretDeleteArg
+	// pendingGrants maps secret URI to a map of relation key to grant args.
+	// Because we need to track the grant args per relation key per secret URI.
+	pendingGrants map[string]map[string]uniter.SecretGrantRevokeArgs
+	// pendingRevokes maps secret URI to a list of revoke args.
+	// For revoke, we only need to know the target URI and target entity(unit/application).
 	pendingRevokes     map[string][]uniter.SecretGrantRevokeArgs
 	pendingTrackLatest map[string]bool
 }

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -113,7 +113,7 @@ func (s *secretsChangeRecorder) revoke(arg uniter.SecretGrantRevokeArgs) {
 	s.pendingRevokes[arg.URI.ID] = append(s.pendingRevokes[arg.URI.ID], arg)
 }
 
-func (s *secretsChangeRecorder) secretGrantInfo(uri *secrets.URI, applied ...secrets.GrantInfo) ([]secrets.GrantInfo, error) {
+func (s *secretsChangeRecorder) secretGrantInfo(uri *secrets.URI, applied ...secrets.AccessInfo) ([]secrets.AccessInfo, error) {
 	mergePendingGrants := func() {
 		grants, ok := s.pendingGrants[uri.ID]
 		if !ok {
@@ -126,7 +126,7 @@ func (s *secretsChangeRecorder) secretGrantInfo(uri *secrets.URI, applied ...sec
 				s.logger.Warningf("missing SubjectTags: %+v", params)
 				continue
 			}
-			applied = append(applied, secrets.GrantInfo{
+			applied = append(applied, secrets.AccessInfo{
 				Target: params.SubjectTags[0],
 				Scope:  params.ScopeTag,
 				Role:   secrets.SecretRole(params.Role),

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -205,6 +205,7 @@ type SecretMetadata struct {
 	LatestExpireTime *time.Time
 	NextRotateTime   *time.Time
 	Revisions        []int
+	Grants           []secrets.GrantInfo
 }
 
 // ContextSecrets is the part of a hook context related to secrets.

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -205,7 +205,7 @@ type SecretMetadata struct {
 	LatestExpireTime *time.Time
 	NextRotateTime   *time.Time
 	Revisions        []int
-	Grants           []secrets.GrantInfo
+	Access           []secrets.AccessInfo
 }
 
 // ContextSecrets is the part of a hook context related to secrets.

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -15,6 +15,7 @@ type ContextSecrets struct {
 	contextBase
 
 	SecretValue secrets.SecretValue
+	Access      []secrets.AccessInfo
 }
 
 // GetSecret implements jujuc.ContextSecrets.
@@ -52,6 +53,7 @@ func (c *ContextSecrets) SecretMetadata() (map[string]jujuc.SecretMetadata, erro
 			Owner:          names.NewApplicationTag("mariadb"),
 			Description:    "description",
 			RotatePolicy:   secrets.RotateHourly,
+			Access:         c.Access,
 		},
 	}, nil
 }

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -336,21 +336,6 @@ func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3)
 }
 
-// GetSecretGrant mocks base method.
-func (m *MockContext) GetSecretGrant(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretGrant", arg0)
-	ret0, _ := ret[0].([]secrets.GrantInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSecretGrant indicates an expected call of GetSecretGrant.
-func (mr *MockContextMockRecorder) GetSecretGrant(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretGrant", reflect.TypeOf((*MockContext)(nil).GetSecretGrant), arg0)
-}
-
 // GoalState mocks base method.
 func (m *MockContext) GoalState() (*application.GoalState, error) {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -336,6 +336,21 @@ func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3)
 }
 
+// GetSecretGrant mocks base method.
+func (m *MockContext) GetSecretGrant(arg0 *secrets.URI) ([]secrets.GrantInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretGrant", arg0)
+	ret0, _ := ret[0].([]secrets.GrantInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretGrant indicates an expected call of GetSecretGrant.
+func (mr *MockContextMockRecorder) GetSecretGrant(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretGrant", reflect.TypeOf((*MockContext)(nil).GetSecretGrant), arg0)
+}
+
 // GoalState mocks base method.
 func (m *MockContext) GoalState() (*application.GoalState, error) {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/secret-grant.go
+++ b/worker/uniter/runner/jujuc/secret-grant.go
@@ -48,7 +48,7 @@ By default, all units of the related application are granted access.
 Optionally specify a unit name to limit access to just that unit.
 
 Examples:
-    secret-grant secret:9m4e2mr0ui3e8a215n4g --unit mediawiki/6 -r 0
+    secret-grant secret:9m4e2mr0ui3e8a215n4g -r 0 --unit mediawiki/6
     secret-grant secret:9m4e2mr0ui3e8a215n4g --relation db:2
 `
 	return jujucmd.Info(&cmd.Info{

--- a/worker/uniter/runner/jujuc/secret-grant.go
+++ b/worker/uniter/runner/jujuc/secret-grant.go
@@ -48,7 +48,7 @@ By default, all units of the related application are granted access.
 Optionally specify a unit name to limit access to just that unit.
 
 Examples:
-    secret-grant secret:9m4e2mr0ui3e8a215n4g --unit mediawiki/6 
+    secret-grant secret:9m4e2mr0ui3e8a215n4g --unit mediawiki/6 -r 0
     secret-grant secret:9m4e2mr0ui3e8a215n4g --relation db:2
 `
 	return jujucmd.Info(&cmd.Info{

--- a/worker/uniter/runner/jujuc/secret-info-get.go
+++ b/worker/uniter/runner/jujuc/secret-info-get.go
@@ -82,20 +82,20 @@ type metadataDisplay struct {
 	RotatePolicy     secrets.RotatePolicy `yaml:"rotation,omitempty" json:"rotation,omitempty"`
 	LatestExpireTime *time.Time           `yaml:"expiry,omitempty" json:"expiry,omitempty"`
 	NextRotateTime   *time.Time           `yaml:"rotates,omitempty" json:"rotates,omitempty"`
-	Grants           []GrantInfo          `yaml:"grants,omitempty" json:"grants,omitempty"`
+	Access           []AccessInfo         `yaml:"access,omitempty" json:"access,omitempty"`
 }
 
-// GrantInfo holds info about a secret grant.
-type GrantInfo struct {
+// AccessInfo holds info about a secret access information.
+type AccessInfo struct {
 	Target string             `json:"target"`
 	Scope  string             `json:"scope"`
 	Role   secrets.SecretRole `json:"role"`
 }
 
-func toGrantInfo(grants []secrets.GrantInfo) []GrantInfo {
-	result := make([]GrantInfo, len(grants))
+func toAccessInfo(grants []secrets.AccessInfo) []AccessInfo {
+	result := make([]AccessInfo, len(grants))
 	for i, grant := range grants {
-		result[i] = GrantInfo{
+		result[i] = AccessInfo{
 			Target: grant.Target,
 			Scope:  grant.Scope,
 			Role:   grant.Role,
@@ -120,7 +120,7 @@ func (c *secretInfoGetCommand) Run(ctx *cmd.Context) error {
 				RotatePolicy:     md.RotatePolicy,
 				LatestExpireTime: md.LatestExpireTime,
 				NextRotateTime:   md.NextRotateTime,
-				Grants:           toGrantInfo(md.Grants),
+				Access:           toAccessInfo(md.Access),
 			}})
 	}
 	var want string

--- a/worker/uniter/runner/jujuc/secret-info-get.go
+++ b/worker/uniter/runner/jujuc/secret-info-get.go
@@ -82,20 +82,20 @@ type metadataDisplay struct {
 	RotatePolicy     secrets.RotatePolicy `yaml:"rotation,omitempty" json:"rotation,omitempty"`
 	LatestExpireTime *time.Time           `yaml:"expiry,omitempty" json:"expiry,omitempty"`
 	NextRotateTime   *time.Time           `yaml:"rotates,omitempty" json:"rotates,omitempty"`
-	Access           []AccessInfo         `yaml:"access,omitempty" json:"access,omitempty"`
+	Access           []accessInfo         `yaml:"access,omitempty" json:"access,omitempty"`
 }
 
-// AccessInfo holds info about a secret access information.
-type AccessInfo struct {
-	Target string             `json:"target"`
-	Scope  string             `json:"scope"`
-	Role   secrets.SecretRole `json:"role"`
+// accessInfo holds info about a secret access information.
+type accessInfo struct {
+	Target string             `yaml:"target" json:"target"`
+	Scope  string             `yaml:"scope" json:"scope"`
+	Role   secrets.SecretRole `yaml:"role" json:"role"`
 }
 
-func toAccessInfo(grants []secrets.AccessInfo) []AccessInfo {
-	result := make([]AccessInfo, len(grants))
+func toAccessInfo(grants []secrets.AccessInfo) []accessInfo {
+	result := make([]accessInfo, len(grants))
 	for i, grant := range grants {
-		result[i] = AccessInfo{
+		result[i] = accessInfo{
 			Target: grant.Target,
 			Scope:  grant.Scope,
 			Role:   grant.Role,

--- a/worker/uniter/runner/jujuc/secret-info-get.go
+++ b/worker/uniter/runner/jujuc/secret-info-get.go
@@ -82,6 +82,26 @@ type metadataDisplay struct {
 	RotatePolicy     secrets.RotatePolicy `yaml:"rotation,omitempty" json:"rotation,omitempty"`
 	LatestExpireTime *time.Time           `yaml:"expiry,omitempty" json:"expiry,omitempty"`
 	NextRotateTime   *time.Time           `yaml:"rotates,omitempty" json:"rotates,omitempty"`
+	Grants           []GrantInfo          `yaml:"grants,omitempty" json:"grants,omitempty"`
+}
+
+// GrantInfo holds info about a secret grant.
+type GrantInfo struct {
+	Target string             `json:"target"`
+	Scope  string             `json:"scope"`
+	Role   secrets.SecretRole `json:"role"`
+}
+
+func toGrantInfo(grants []secrets.GrantInfo) []GrantInfo {
+	result := make([]GrantInfo, len(grants))
+	for i, grant := range grants {
+		result[i] = GrantInfo{
+			Target: grant.Target,
+			Scope:  grant.Scope,
+			Role:   grant.Role,
+		}
+	}
+	return result
 }
 
 // Run implements cmd.Command.
@@ -100,6 +120,7 @@ func (c *secretInfoGetCommand) Run(ctx *cmd.Context) error {
 				RotatePolicy:     md.RotatePolicy,
 				LatestExpireTime: md.LatestExpireTime,
 				NextRotateTime:   md.NextRotateTime,
+				Grants:           toGrantInfo(md.Grants),
 			}})
 	}
 	var want string

--- a/worker/uniter/runner/jujuc/secret-info-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-info-get_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -57,6 +58,37 @@ func (s *SecretInfoGetSuite) TestSecretInfoGetURI(c *gc.C) {
   owner: application
   description: description
   rotation: hourly
+`[1:])
+}
+
+func (s *SecretInfoGetSuite) TestSecretInfoGetWithGrants(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.Access = []secrets.AccessInfo{
+		{
+			Target: "application-gitlab",
+			Scope:  "relation-key",
+			Role:   secrets.RoleView,
+		},
+	}
+
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
+	c.Assert(code, gc.Equals, 0)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+9m4e2mr0ui3e8a215n4g:
+  revision: 666
+  label: label
+  owner: application
+  description: description
+  rotation: hourly
+  access:
+  - target: application-gitlab
+    scope: relation-key
+    role: view
 `[1:])
 }
 


### PR DESCRIPTION
This PR includes secrets grant information for the `show-secret` client command and the `secret-info-get` hook command.

It also fixed bugs on `secret-grant`:
- currently, if we run multiple grants in the same hook context, the latter one could overwrite the previous one. (
for example, `grant $URI -r 1` can overwrite `grant $URI -r 0` in the uniter cache layer which means the secret will not be granted to the relation `0`.)
- added validation for `secret-grant` to prevent unexpected result;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju add-secret foo token=34ae35facd4
secret:cli5dkfmp25c79oiqbrg

juju grant-secret foo hello

juju grant-secret foo nginx-ingress-integrator

juju show-secret foo --revisions
cli5dkfmp25c79oiqbrg:
  revision: 1
  owner: <model>
  name: foo
  created: 2023-11-27T08:44:01Z
  updated: 2023-11-27T08:44:01Z
  revisions:
  - revision: 1
    backend: t1-local
    created: 2023-11-27T08:44:01Z
    updated: 2023-11-27T08:44:01Z
  access:
  - target: application-hello
    scope: model-e1b431e9-c002-476f-8491-945afbb4d404
    role: view
  - target: application-nginx-ingress-integrator
    scope: model-e1b431e9-c002-476f-8491-945afbb4d404
    role: view

juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0
secret://e1b431e9-c002-476f-8491-945afbb4d404/cli5elnmp25c79oiqbs0

juju exec --unit hello/0 -- secret-grant cli5elnmp25c79oiqbs0 -r 0 --unit nginx-ingress-integrator/0

juju exec --unit hello/0 -- secret-info-get cli5elnmp25c79oiqbs0
cli5elnmp25c79oiqbs0:
  revision: 1
  label: ""
  owner: unit
  rotation: never
  access:
  - target: unit-nginx-ingress-integrator-0
    scope: relation-hello.ingress#nginx-ingress-integrator.ingress
    role: view

juju exec --unit hello/0 -- secret-grant cli5elnmp25c79oiqbs0 -r 0
ERROR to grant in application level, all unit level grants should be revoked first
ERROR the following task failed:
 - id "10" with return code 1

use 'juju show-task' to inspect the failure

juju exec --unit hello/0 -- secret-revoke cli5elnmp25c79oiqbs0 -r 0 --unit nginx-ingress-integrator/0

juju exec --unit hello/0 -- secret-grant cli5elnmp25c79oiqbs0 -r 0

# no ops.
juju exec --unit hello/0 -- secret-grant cli5elnmp25c79oiqbs0 -r 0 --unit nginx-ingress-integrator/0

juju exec --unit hello/0 -- secret-info-get cli5elnmp25c79oiqbs0
cli5elnmp25c79oiqbs0:
  revision: 1
  label: ""
  owner: unit
  rotation: never
  access:
  - target: application-nginx-ingress-integrator
    scope: relation-hello.ingress#nginx-ingress-integrator.ingress
    role: view
```

## Documentation changes

Yes

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2035290

**Jira card:** JUJU-4901 JUJU-5040