### PR TITLE
Remove unused charms endpoint

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -990,16 +990,6 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		// for discharge required errors to be handled correctly.
 		unauthenticated: true,
 	}, {
-		// GET /charms has no authorizer
-		pattern: "/charms",
-		methods: []string{"GET"},
-		handler: modelCharmsHTTPHandler,
-	}, {
-		pattern:    "/charms",
-		methods:    []string{"POST"},
-		handler:    modelCharmsHTTPHandler,
-		authorizer: modelCharmsUploadAuthorizer,
-	}, {
 		pattern: charmsObjectsRoutePrefix,
 		methods: []string{"GET"},
 		handler: modelObjectsCharmsHTTPHandler,

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -258,17 +258,6 @@ func (s *charmsSuite) TestUploadWithMultiSeriesCharm(c *gc.C) {
 	s.assertUploadResponse(c, resp, expectedURL)
 }
 
-func (s *charmsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	// Backwards compatibility check, that we can upload charms to
-	// https://host:port/charms
-	url := s.charmsURL("series=quantal")
-	url.Path = "/charms"
-	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-}
-
 func (s *charmsSuite) TestUploadAllowsModelUUIDPath(c *gc.C) {
 	// Check that we can upload charms to https://host:port/ModelUUID/charms
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
@@ -747,17 +736,6 @@ func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 	uri := s.charmsURI("?url=local:quantal/dummy-1&file=*")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 	s.assertGetFileResponse(c, resp, string(data), "application/zip")
-}
-
-func (s *charmsSuite) TestGetAllowsTopLevelPath(c *gc.C) {
-	// Backwards compatibility check, that we can GET from charms at
-	// https://host:port/charms
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
-	url := s.charmsURL("url=local:quantal/dummy-1&file=revision")
-	url.Path = "/charms"
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: url.String()})
-	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
 
 func (s *charmsSuite) TestGetAllowsModelUUIDPath(c *gc.C) {


### PR DESCRIPTION
Remove our two `/charms` handlers on the apiserver

These are identical to the model-scoped `/model/:model-uuid/charms` endpoints, which should be used instead.

Everywhere in the Juju and python-libjuju codebases we use the correct endpoint. Since 4.0 is a breaking change, we can just remove it

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap two controllers
```sh
$ juju bootstrap lxd lxd
$ juju bootstrap lxd lxd-dst
```

Ensure all the following commands are successful

```sh
$ juju switch lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu ubu-local
$ juju deploy ubuntu
$ juju migrate m lxd-dst
```
