### PR TITLE
Better ModelDefaults values.

### DIFF
--- a/domain/modelconfig/bootstrap/bootstrap.go
+++ b/domain/modelconfig/bootstrap/bootstrap.go
@@ -29,8 +29,9 @@ func SetModelConfig(
 		}
 
 		for k, v := range defaults {
-			if _, exists := attrs[k]; !exists && v.Value() != nil {
-				attrs[k] = v.Value()
+			attrVal := v.ApplyStrategy(attrs[k])
+			if attrVal != nil {
+				attrs[k] = attrVal
 			}
 		}
 

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -33,7 +33,7 @@ func (s *bootstrapSuite) TestSetModelConfig(c *gc.C) {
 		return modeldefaults.Defaults{
 			"foo": modeldefaults.DefaultAttributeValue{
 				Source: config.JujuControllerSource,
-				V:      "bar",
+				Value:  "bar",
 			},
 		}, nil
 	}

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -32,7 +32,8 @@ func (s *bootstrapSuite) TestSetModelConfig(c *gc.C) {
 	var defaults ModelDefaultsProviderFunc = func(_ context.Context) (modeldefaults.Defaults, error) {
 		return modeldefaults.Defaults{
 			"foo": modeldefaults.DefaultAttributeValue{
-				Controller: "bar",
+				Source: config.JujuControllerSource,
+				V:      "bar",
 			},
 		}, nil
 	}

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -106,7 +106,7 @@ func (s *Service) ModelConfigValues(
 	if len(allAtrs) == 0 {
 		allAtrs = map[string]any{}
 		for k, v := range defaults {
-			allAtrs[k] = v.Value()
+			allAtrs[k] = v.V
 		}
 	}
 
@@ -135,7 +135,7 @@ func (s *Service) buildUpdatedModelConfig(
 ) (*config.Config, *config.Config, error) {
 	current, err := s.ModelConfig(ctx)
 	if err != nil {
-		return nil, current, errors.Trace(err)
+		return nil, current, err
 	}
 
 	newConf, err := current.Remove(removeAttrs)
@@ -174,7 +174,7 @@ func (s *Service) reconcileRemovedAttributes(
 	}
 
 	for _, attr := range hasAttrs {
-		if val := defaults[attr].Value(); val != nil {
+		if val := defaults[attr].V; val != nil {
 			updates[attr] = val
 		}
 	}
@@ -196,8 +196,9 @@ func (s *Service) SetModelConfig(
 	}
 
 	for k, v := range defaults {
-		if _, exists := attrs[k]; !exists && v.Value() != nil {
-			attrs[k] = v.Value()
+		applyVal := v.ApplyStrategy(attrs[k])
+		if applyVal != nil {
+			attrs[k] = applyVal
 		}
 	}
 

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -106,7 +106,7 @@ func (s *Service) ModelConfigValues(
 	if len(allAtrs) == 0 {
 		allAtrs = map[string]any{}
 		for k, v := range defaults {
-			allAtrs[k] = v.V
+			allAtrs[k] = v.Value
 		}
 	}
 
@@ -174,7 +174,7 @@ func (s *Service) reconcileRemovedAttributes(
 	}
 
 	for _, attr := range hasAttrs {
-		if val := defaults[attr].V; val != nil {
+		if val := defaults[attr].Value; val != nil {
 			updates[attr] = val
 		}
 	}

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -33,7 +33,8 @@ func (s *serviceSuite) TestSetModelConfig(c *gc.C) {
 	var defaults ModelDefaultsProviderFunc = func(_ context.Context) (modeldefaults.Defaults, error) {
 		return modeldefaults.Defaults{
 			"foo": modeldefaults.DefaultAttributeValue{
-				Controller: "bar",
+				Source: config.JujuControllerSource,
+				V:      "bar",
 			},
 		}, nil
 	}

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -34,7 +34,7 @@ func (s *serviceSuite) TestSetModelConfig(c *gc.C) {
 		return modeldefaults.Defaults{
 			"foo": modeldefaults.DefaultAttributeValue{
 				Source: config.JujuControllerSource,
-				V:      "bar",
+				Value:  "bar",
 			},
 		}, nil
 	}

--- a/domain/modelconfig/service/testing/service.go
+++ b/domain/modelconfig/service/testing/service.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+
+	"github.com/juju/juju/domain/modeldefaults"
+)
+
+type modelDefaultsProviderFunc func(context.Context) (modeldefaults.Defaults, error)
+
+func (m modelDefaultsProviderFunc) ModelDefaults(c context.Context) (modeldefaults.Defaults, error) {
+	return m(c)
+}
+
+// ModelDefaultsProvider is a testing func that returns a
+// service.ModelDefaultsProvider statically returning the defaults supplied to
+// this func with no errors. It is also safe to pass a nil defaults to this func.
+func ModelDefaultsProvider(defaults modeldefaults.Defaults) modelDefaultsProviderFunc {
+	return func(_ context.Context) (modeldefaults.Defaults, error) {
+		return defaults, nil
+	}
+}

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/domain/modeldefaults/service"
+	"github.com/juju/juju/environs/config"
 )
 
 // ModelDefaultsProvider is a bootstrap helper that wraps the raw config values
@@ -22,21 +23,24 @@ func ModelDefaultsProvider(
 		defaults := modeldefaults.Defaults{}
 
 		for k, v := range configDefaults {
-			attr := defaults[k]
-			attr.Default = v
-			defaults[k] = attr
+			defaults[k] = modeldefaults.DefaultAttributeValue{
+				Source: config.JujuDefaultSource,
+				V:      v,
+			}
 		}
 
 		for k, v := range controllerConfig {
-			attr := defaults[k]
-			attr.Controller = v
-			defaults[k] = attr
+			defaults[k] = modeldefaults.DefaultAttributeValue{
+				Source: config.JujuControllerSource,
+				V:      v,
+			}
 		}
 
 		for k, v := range cloudRegionConfig {
-			attr := defaults[k]
-			attr.Region = v
-			defaults[k] = attr
+			defaults[k] = modeldefaults.DefaultAttributeValue{
+				Source: config.JujuRegionSource,
+				V:      v,
+			}
 		}
 
 		return defaults, nil

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -25,21 +25,21 @@ func ModelDefaultsProvider(
 		for k, v := range configDefaults {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
 				Source: config.JujuDefaultSource,
-				V:      v,
+				Value:  v,
 			}
 		}
 
 		for k, v := range controllerConfig {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
 				Source: config.JujuControllerSource,
-				V:      v,
+				Value:  v,
 			}
 		}
 
 		for k, v := range cloudRegionConfig {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
 				Source: config.JujuRegionSource,
-				V:      v,
+				Value:  v,
 			}
 		}
 

--- a/domain/modeldefaults/bootstrap/bootstrap_test.go
+++ b/domain/modeldefaults/bootstrap/bootstrap_test.go
@@ -32,12 +32,12 @@ func (_ *bootstrapSuite) TestBootstrapModelDefaults(c *gc.C) {
 
 	defaults, err := provider.ModelDefaults(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults["foo"].V, gc.Equals, "region")
+	c.Assert(defaults["foo"].Value, gc.Equals, "region")
 	c.Assert(defaults["foo"].Source, gc.Equals, "region")
-	c.Assert(defaults["default"].V, gc.Equals, "some value")
+	c.Assert(defaults["default"].Value, gc.Equals, "some value")
 	c.Assert(defaults["default"].Source, gc.Equals, "default")
-	c.Assert(defaults["controller"].V, gc.Equals, "some value")
+	c.Assert(defaults["controller"].Value, gc.Equals, "some value")
 	c.Assert(defaults["controller"].Source, gc.Equals, "controller")
-	c.Assert(defaults["region"].V, gc.Equals, "some value")
+	c.Assert(defaults["region"].Value, gc.Equals, "some value")
 	c.Assert(defaults["region"].Source, gc.Equals, "region")
 }

--- a/domain/modeldefaults/bootstrap/bootstrap_test.go
+++ b/domain/modeldefaults/bootstrap/bootstrap_test.go
@@ -8,8 +8,6 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/domain/modeldefaults"
 )
 
 type bootstrapSuite struct{}
@@ -34,20 +32,12 @@ func (_ *bootstrapSuite) TestBootstrapModelDefaults(c *gc.C) {
 
 	defaults, err := provider.ModelDefaults(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
-		"foo": modeldefaults.DefaultAttributeValue{
-			Default:    "default",
-			Controller: "controller",
-			Region:     "region",
-		},
-		"default": modeldefaults.DefaultAttributeValue{
-			Default: "some value",
-		},
-		"controller": modeldefaults.DefaultAttributeValue{
-			Controller: "some value",
-		},
-		"region": modeldefaults.DefaultAttributeValue{
-			Region: "some value",
-		},
-	})
+	c.Assert(defaults["foo"].V, gc.Equals, "region")
+	c.Assert(defaults["foo"].Source, gc.Equals, "region")
+	c.Assert(defaults["default"].V, gc.Equals, "some value")
+	c.Assert(defaults["default"].Source, gc.Equals, "default")
+	c.Assert(defaults["controller"].V, gc.Equals, "some value")
+	c.Assert(defaults["controller"].Source, gc.Equals, "controller")
+	c.Assert(defaults["region"].V, gc.Equals, "some value")
+	c.Assert(defaults["region"].Source, gc.Equals, "region")
 }

--- a/domain/modeldefaults/service/service.go
+++ b/domain/modeldefaults/service/service.go
@@ -16,10 +16,6 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-// applyStrategyFunc is a utility type that implements the
-// [modeldefaults.ApplyStrategy] interface as a func type.
-type applyStrategyFunc func(any, any) any
-
 // ModelDefaultsProvider represents a provider that will provide model defaults
 // values for a single model. Interfaces of this type are expected to be
 // scoped to a predetermined model already.
@@ -56,11 +52,6 @@ type Service struct {
 	st State
 }
 
-// Apply implements [modeldefaults.ApplyStrategy] for [applyStrategyFunc]
-func (f applyStrategyFunc) Apply(d, s any) any {
-	return f(d, s)
-}
-
 // ModelDefaults implements ModelDefaultsProvider
 func (f ModelDefaultsProviderFunc) ModelDefaults(
 	ctx context.Context,
@@ -84,9 +75,8 @@ func (s *Service) ModelDefaults(
 	jujuDefaults := s.st.ConfigDefaults(ctx)
 	for k, v := range jujuDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
-			Strategy: preferSetStrategy(),
-			Source:   config.JujuDefaultSource,
-			V:        v,
+			Source: config.JujuDefaultSource,
+			V:      v,
 		}
 	}
 
@@ -102,9 +92,8 @@ func (s *Service) ModelDefaults(
 
 		for k, v := range coercedAttrs.(map[string]interface{}) {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
-				Strategy: preferSetStrategy(),
-				Source:   config.JujuDefaultSource,
-				V:        v,
+				Source: config.JujuDefaultSource,
+				V:      v,
 			}
 		}
 	}
@@ -116,9 +105,8 @@ func (s *Service) ModelDefaults(
 
 	for k, v := range cloudDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
-			Strategy: preferSetStrategy(),
-			Source:   config.JujuControllerSource,
-			V:        v,
+			Source: config.JujuControllerSource,
+			V:      v,
 		}
 	}
 
@@ -129,9 +117,8 @@ func (s *Service) ModelDefaults(
 
 	for k, v := range cloudRegionDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
-			Strategy: preferSetStrategy(),
-			Source:   config.JujuRegionSource,
-			V:        v,
+			Source: config.JujuRegionSource,
+			V:      v,
 		}
 	}
 
@@ -156,17 +143,5 @@ func (s *Service) ModelDefaultsProvider(
 func NewService(st State) *Service {
 	return &Service{
 		st: st,
-	}
-}
-
-// preferSetStrategy is a [modeldefaults.ApplyStrategy] that will always prefer
-// using the set value in model config over that of the default value. The
-// default value will only ever be chosen when the set value is nil.
-func preferSetStrategy() applyStrategyFunc {
-	return func(defaultVal, setVal any) any {
-		if setVal != nil {
-			return setVal
-		}
-		return defaultVal
 	}
 }

--- a/domain/modeldefaults/service/service.go
+++ b/domain/modeldefaults/service/service.go
@@ -76,7 +76,7 @@ func (s *Service) ModelDefaults(
 	for k, v := range jujuDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
 			Source: config.JujuDefaultSource,
-			V:      v,
+			Value:  v,
 		}
 	}
 
@@ -93,7 +93,7 @@ func (s *Service) ModelDefaults(
 		for k, v := range coercedAttrs.(map[string]interface{}) {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
 				Source: config.JujuDefaultSource,
-				V:      v,
+				Value:  v,
 			}
 		}
 	}
@@ -106,7 +106,7 @@ func (s *Service) ModelDefaults(
 	for k, v := range cloudDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
 			Source: config.JujuControllerSource,
-			V:      v,
+			Value:  v,
 		}
 	}
 
@@ -118,7 +118,7 @@ func (s *Service) ModelDefaults(
 	for k, v := range cloudRegionDefaults {
 		defaults[k] = modeldefaults.DefaultAttributeValue{
 			Source: config.JujuRegionSource,
-			V:      v,
+			Value:  v,
 		}
 	}
 

--- a/domain/modeldefaults/service/service_test.go
+++ b/domain/modeldefaults/service/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	modeltesting "github.com/juju/juju/domain/model/testing"
-	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/domain/modeldefaults/service/testing"
 )
 
@@ -20,6 +19,9 @@ type serviceSuite struct{}
 
 var _ = gc.Suite(&serviceSuite{})
 
+// TestModelDefaultsForNonExistentModel is here to establish that when we ask
+// for model defaults for a model that does not exist we get back a error that
+// satisfies [modelerrors.NotFound].
 func (_ *serviceSuite) TestModelDefaultsForNonExistentModel(c *gc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	svc := NewService(&testing.State{})
@@ -33,6 +35,11 @@ func (_ *serviceSuite) TestModelDefaultsForNonExistentModel(c *gc.C) {
 	c.Assert(len(defaults), gc.Equals, 0)
 }
 
+// TestModelDefaultsProviderNotFound is testing the fact that if we can not find
+// provider defaults for the models cloud that we handle the error gracefully
+// internally and the service still returns defaults but just without any
+// provider defaults. i.e we want a NotFound error from the provider to be
+// transparent.
 func (_ *serviceSuite) TestModelDefaultsProviderNotFound(c *gc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	svc := NewService(&testing.State{
@@ -48,25 +55,17 @@ func (_ *serviceSuite) TestModelDefaultsProviderNotFound(c *gc.C) {
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
-		"wallyworld": modeldefaults.DefaultAttributeValue{
-			Default: "peachy",
-		},
-		"foo": modeldefaults.DefaultAttributeValue{
-			Controller: "bar",
-		},
-	})
+	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
+	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 
 	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
-		"wallyworld": modeldefaults.DefaultAttributeValue{
-			Default: "peachy",
-		},
-		"foo": modeldefaults.DefaultAttributeValue{
-			Controller: "bar",
-		},
-	})
+	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
+	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 }
 
 func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
@@ -89,29 +88,19 @@ func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
-		"wallyworld": modeldefaults.DefaultAttributeValue{
-			Default: "peachy",
-		},
-		"foo": modeldefaults.DefaultAttributeValue{
-			Controller: "bar",
-		},
-		"bar": modeldefaults.DefaultAttributeValue{
-			Region: "foo",
-		},
-	})
+	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
+	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Source, gc.Equals, "controller")
+	c.Check(defaults["bar"].V, gc.Equals, "foo")
+	c.Check(defaults["bar"].Source, gc.Equals, "region")
 
 	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults, jc.DeepEquals, modeldefaults.Defaults{
-		"wallyworld": modeldefaults.DefaultAttributeValue{
-			Default: "peachy",
-		},
-		"foo": modeldefaults.DefaultAttributeValue{
-			Controller: "bar",
-		},
-		"bar": modeldefaults.DefaultAttributeValue{
-			Region: "foo",
-		},
-	})
+	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
+	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Source, gc.Equals, "controller")
+	c.Check(defaults["bar"].V, gc.Equals, "foo")
+	c.Check(defaults["bar"].Source, gc.Equals, "region")
 }

--- a/domain/modeldefaults/service/service_test.go
+++ b/domain/modeldefaults/service/service_test.go
@@ -55,16 +55,16 @@ func (_ *serviceSuite) TestModelDefaultsProviderNotFound(c *gc.C) {
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Value, gc.Equals, "peachy")
 	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
-	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Value, gc.Equals, "bar")
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 
 	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Value, gc.Equals, "peachy")
 	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
-	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Value, gc.Equals, "bar")
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 }
 
@@ -88,19 +88,19 @@ func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Value, gc.Equals, "peachy")
 	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
-	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Value, gc.Equals, "bar")
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
-	c.Check(defaults["bar"].V, gc.Equals, "foo")
+	c.Check(defaults["bar"].Value, gc.Equals, "foo")
 	c.Check(defaults["bar"].Source, gc.Equals, "region")
 
 	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(defaults["wallyworld"].V, gc.Equals, "peachy")
+	c.Check(defaults["wallyworld"].Value, gc.Equals, "peachy")
 	c.Check(defaults["wallyworld"].Source, gc.Equals, "default")
-	c.Check(defaults["foo"].V, gc.Equals, "bar")
+	c.Check(defaults["foo"].Value, gc.Equals, "bar")
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
-	c.Check(defaults["bar"].V, gc.Equals, "foo")
+	c.Check(defaults["bar"].Value, gc.Equals, "foo")
 	c.Check(defaults["bar"].Source, gc.Equals, "region")
 }

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -57,8 +57,8 @@ type PreferSetApplyStrategy struct{}
 // [PreferSetApplyStrategy].
 func (d DefaultAttributeValue) ApplyStrategy(setVal any) any {
 	if d.Strategy == nil {
-		strat := PreferSetApplyStrategy{}
-		return strat.Apply(d.Value, setVal)
+		strategy := PreferSetApplyStrategy{}
+		return strategy.Apply(d.Value, setVal)
 	}
 	return d.Strategy.Apply(d.Value, setVal)
 }

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -5,34 +5,69 @@ package modeldefaults
 
 import (
 	"reflect"
-
-	"github.com/juju/juju/environs/config"
 )
+
+// ApplyStrategy describes a strategy for how default values should be
+// applied to model config.
+type ApplyStrategy interface {
+	// Apply evaluates both the model config default value and that of the
+	// already set value on model config and returns the resultant value that
+	// should be set on model config.
+	Apply(defaultVal, setVal any) any
+}
 
 // DefaultAttributeValue represents a model config default attribute value and
 // the hierarchical nature of where defaults can come from within Juju.
+//
+// Because model defaults and the respective sources from which defaults come
+// from all have their own opinions on how the default will get applied to model
+// config and the ultimate say in what the value is DefaultAttributeValue
+// provides the mechanism for sources to place their opinions in one place and
+// for the consuming side (model config) to have a one size fits all approach
+// for taking on the defaults.
 type DefaultAttributeValue struct {
-	// Controller represents a value that comes from the controller,
-	// specifically the cloud.
-	Controller any
+	// Source describes the source of the default value.
+	Source string
 
-	// Default represents a value that comes from Juju.
-	Default any
+	// Strategy is the ApplyStrategy that should be used when deciding how to
+	// integrate this default value.
+	Strategy ApplyStrategy
 
-	// Region represents a value that come from a model's set cloud region.
-	Region any
+	// V is the default value.
+	V any
 }
 
-// Defaults represents a set of default values for a given attribute broken down
-// based on the different sources of the value.
+// Defaults represents a set of default values for a given attribute. Defaults
+// should be used to describe the full set of defaults that a model should
+// consider for it's config.
 type Defaults map[string]DefaultAttributeValue
 
-// Has reports if the current Value() of this default attribute is equal to the
-// value passed in and also the source of the value. If the current Value() or
-// val is nil then false and empty string is returned. If this default attribute
-// does not have val then false and empty string is returned.
+// ApplyStrategy runs the ApplyStrategy attached to this default value. The
+// returned value is the result of what the ApplyStrategy has deemed is the
+// value that should be set on the model config. If this DefaultAttributeValue
+// has no ApplyStrategy set then the setVal passed to this function is returned.
+func (d DefaultAttributeValue) ApplyStrategy(setVal any) any {
+	if d.Strategy == nil {
+		return setVal
+	}
+	return d.Strategy.Apply(d.V, setVal)
+}
+
+// Has reports if the current V of this default attribute is equal to the
+// value passed in. The source of the default value is also returned when the
+// values are equal. If the current value of V or val is nil then false and
+// empty string is returned.
+//
+// For legacy reasons in Juju's life we have have worked with types of "any" for
+// model config values and trying to apply comparison logic over these types is
+// hard to get right. For this purpose this function only considers values to be
+// equal if their types are comparable via == and or the type of V is []any then
+// we will defer to the reflect package for DeepEqual.
+//
+// This is carry over logic from legacy Juju. Over time we can look at removing
+// the use of any for more concrete types.
 func (d DefaultAttributeValue) Has(val any) (bool, string) {
-	setVal := d.Value()
+	setVal := d.V
 	if setVal == nil || val == nil {
 		return false, ""
 	}
@@ -45,37 +80,7 @@ func (d DefaultAttributeValue) Has(val any) (bool, string) {
 		equal = setVal == val
 	}
 	if equal {
-		return true, d.ValueSource()
+		return true, d.Source
 	}
 	return false, ""
-}
-
-// Value returns the attribute value that should be used for the default based
-// on precedence. If no suitable value can be found then nil will be returned.
-func (d DefaultAttributeValue) Value() any {
-	if d.Region != nil {
-		return d.Region
-	}
-	if d.Controller != nil {
-		return d.Controller
-	}
-	if d.Default != nil {
-		return d.Default
-	}
-	return nil
-}
-
-// ValueSource returns source identifier for the value. If no suitable value can
-// be found then empty string will be returned.
-func (d DefaultAttributeValue) ValueSource() string {
-	if d.Region != nil {
-		return config.JujuRegionSource
-	}
-	if d.Controller != nil {
-		return config.JujuControllerSource
-	}
-	if d.Default != nil {
-		return config.JujuDefaultSource
-	}
-	return ""
 }

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -19,12 +19,11 @@ type ApplyStrategy interface {
 // DefaultAttributeValue represents a model config default attribute value and
 // the hierarchical nature of where defaults can come from within Juju.
 //
-// Because model defaults and the respective sources from which defaults come
-// from all have their own opinions on how the default will get applied to model
-// config and the ultimate say in what the value is DefaultAttributeValue
-// provides the mechanism for sources to place their opinions in one place and
-// for the consuming side (model config) to have a one size fits all approach
-// for taking on the defaults.
+// Because model defaults and the respective sources which defaults come from
+// all have their own opinions on how the default will get applied.
+// DefaultAttributeValue provides the mechanism for sources to place their
+// opinions in one place and for the consuming side (model config) to use the
+// default sources opinion.
 type DefaultAttributeValue struct {
 	// Source describes the source of the default value.
 	Source string
@@ -34,20 +33,19 @@ type DefaultAttributeValue struct {
 	// [DefaultAttributeValue.ApplyStrategy] for expected behaviour.
 	Strategy ApplyStrategy
 
-	// V is the default value.
-	V any
+	// Value is the default value.
+	Value any
 }
 
 // Defaults represents a set of default values for a given attribute. Defaults
 // should be used to describe the full set of defaults that a model should
-// consider for it's config.
+// consider for its config.
 type Defaults map[string]DefaultAttributeValue
 
-// PreferSetApplyStrategy is a [ApplyStrategy] implementation that will
-// implements an apply strategy that will always prefer the value set in model
-// config before the value being offered by the model default. If the set value
-// for model config is nil then the default value will be returned. If both
-// values are nil then nil will be returned.
+// PreferSetApplyStrategy is an [ApplyStrategy] implementation that will always
+// prefer the value set in model config before the value being offered by the
+// model default. If the set value for model config is nil then the default
+// value will be returned. If both values are nil then nil will be returned.
 //
 // The zero value of this type is safe to use as an [ApplyStrategy].
 type PreferSetApplyStrategy struct{}
@@ -60,26 +58,26 @@ type PreferSetApplyStrategy struct{}
 func (d DefaultAttributeValue) ApplyStrategy(setVal any) any {
 	if d.Strategy == nil {
 		strat := PreferSetApplyStrategy{}
-		return strat.Apply(d.V, setVal)
+		return strat.Apply(d.Value, setVal)
 	}
-	return d.Strategy.Apply(d.V, setVal)
+	return d.Strategy.Apply(d.Value, setVal)
 }
 
-// Has reports if the current V of this default attribute is equal to the
+// Has reports if the current [DefaultAttributeValue.Value] is equal to the
 // value passed in. The source of the default value is also returned when the
-// values are equal. If the current value of V or val is nil then false and
-// empty string is returned.
+// values are equal. If the current value of [DefaultAttributeValue.Value] or
+// val is nil then false and empty string for source is returned.
 //
-// For legacy reasons in Juju's life we have have worked with types of "any" for
-// model config values and trying to apply comparison logic over these types is
-// hard to get right. For this purpose this function only considers values to be
-// equal if their types are comparable via == and or the type of V is []any then
-// we will defer to the reflect package for DeepEqual.
+// For legacy reasons we have worked with types of "any" for model config values
+// and trying to apply comparison logic over these types is hard to get right.
+// For this reason this function only considers values to be equal if their
+// types are comparable via == and or the type of Value is of []any, in which
+// case we will defer to the reflect package for DeepEqual.
 //
 // This is carry over logic from legacy Juju. Over time we can look at removing
 // the use of any for more concrete types.
 func (d DefaultAttributeValue) Has(val any) (bool, string) {
-	setVal := d.V
+	setVal := d.Value
 	if setVal == nil || val == nil {
 		return false, ""
 	}

--- a/domain/modeldefaults/types_test.go
+++ b/domain/modeldefaults/types_test.go
@@ -12,73 +12,120 @@ type typesSuite struct{}
 
 var _ = gc.Suite(&typesSuite{})
 
+// TestZeroDefaultsValue is here to test what the zero value of a
+// DefaultAttributeValue does. Specifically that Has returns false and the apply
+// strategy just returns whatever is passed to it.
+//
+// We want to make sure that if a zero value escapes by accident it will not
+// cause damage to a models config.
 func (s *typesSuite) TestZeroDefaultsValue(c *gc.C) {
 	val := DefaultAttributeValue{}
-	c.Assert(val.Value(), gc.IsNil)
-	c.Assert(val.ValueSource(), gc.Equals, "")
 
 	has, source := val.Has("someval")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	c.Check(has, jc.IsFalse)
+	c.Check(source, gc.Equals, "")
+
+	applied, is := val.ApplyStrategy("teststring").(string)
+	c.Assert(is, jc.IsTrue, gc.Commentf("expected zero value apply strategy to return what was passed to it verbatim"))
+	c.Check(applied, gc.Equals, "teststring")
 }
 
-func (s *typesSuite) TestDefaultDefaultsValue(c *gc.C) {
-	val := DefaultAttributeValue{Default: "test"}
-	c.Assert(val.Value(), gc.DeepEquals, "test")
-	c.Assert(val.ValueSource(), gc.Equals, "default")
-
-	has, source := val.Has("test")
-	c.Assert(has, jc.IsTrue)
-	c.Assert(source, gc.Equals, "default")
-
-	has, source = val.Has("noexist")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
-}
-
-func (s *typesSuite) TestControllerDefaultsValue(c *gc.C) {
+// TestHasSupportForNil is testing for nil values to Has() we always return
+// false and no source information as per the contract of the function.
+func (s *typesSuite) TestHasSupportForNil(c *gc.C) {
 	val := DefaultAttributeValue{
-		Default:    "default",
-		Controller: "test",
+		Source: "testsource",
+		V:      "someval",
 	}
-	c.Assert(val.Value(), gc.DeepEquals, "test")
-	c.Assert(val.ValueSource(), gc.Equals, "controller")
 
-	has, source := val.Has("test")
-	c.Assert(has, jc.IsTrue)
-	c.Assert(source, gc.Equals, "controller")
+	has, source := val.Has(nil)
+	c.Check(has, jc.IsFalse)
+	c.Check(source, gc.Equals, "")
 
-	has, source = val.Has("noexist")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	val = DefaultAttributeValue{
+		Source: "testsource",
+		V:      nil,
+	}
 
-	has, source = val.Has("default")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	has, source = val.Has("myval")
+	c.Check(has, jc.IsFalse)
+	c.Check(source, gc.Equals, "")
 }
 
-func (s *typesSuite) TestRegionDefaultsValue(c *gc.C) {
+// TestHasSupport is testing Has for DefaultAttributeValue and that we can ask
+// the question correctly. We are only checking basic comparison here as that is
+// all Has supports.
+func (s *typesSuite) TestHasSupport(c *gc.C) {
 	val := DefaultAttributeValue{
-		Default:    "default",
-		Controller: "controller",
-		Region:     "test",
+		Source: "testsource",
+		V:      "someval",
 	}
-	c.Assert(val.Value(), gc.DeepEquals, "test")
-	c.Assert(val.ValueSource(), gc.Equals, "region")
 
-	has, source := val.Has("test")
-	c.Assert(has, jc.IsTrue)
-	c.Assert(source, gc.Equals, "region")
+	has, source := val.Has("someval")
+	c.Check(has, jc.IsTrue)
+	c.Check(source, gc.Equals, "testsource")
 
-	has, source = val.Has("noexist")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	i := int32(10)
+	val = DefaultAttributeValue{
+		Source: "testsource",
+		V:      &i,
+	}
 
-	has, source = val.Has("default")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	has, source = val.Has(&i)
+	c.Check(has, jc.IsTrue)
+	c.Check(source, gc.Equals, "testsource")
 
-	has, source = val.Has("controller")
-	c.Assert(has, jc.IsFalse)
-	c.Assert(source, gc.Equals, "")
+	val = DefaultAttributeValue{
+		Source: "testsource",
+		V: []any{
+			"one",
+			"two",
+			"three",
+		},
+	}
+
+	has, source = val.Has([]any{
+		"one", "two", "three",
+	})
+	c.Check(has, jc.IsTrue)
+	c.Check(source, gc.Equals, "testsource")
+
+	structVal := struct{ name string }{"test"}
+	val = DefaultAttributeValue{
+		Source: "testsource",
+		V:      &structVal,
+	}
+
+	has, source = val.Has(&struct{ name string }{"test"})
+	c.Check(has, jc.IsFalse)
+	c.Check(source, gc.Equals, "")
+}
+
+// testApplyStrategy is a test implementation of ApplyStrategy that is here to
+// just indicate that the Apply method of the strategy has been called.
+type testApplyStrategy struct {
+	// Called indicates that the Apply func of this struct has been called.
+	Called bool
+}
+
+// Apply implements the ApplyStrategy interface.
+func (t *testApplyStrategy) Apply(d, s any) any {
+	t.Called = true
+	return s
+}
+
+// TestApplyStrategy is checking to make sure that if we set an apply strategy
+// on the DefaultAttributeValue. This test isn't concerned about testing the
+// logic of strategies just that the strategy is asked to make a decision.
+func (s *typesSuite) TestApplyStrategy(c *gc.C) {
+	strategy := &testApplyStrategy{}
+	val := DefaultAttributeValue{
+		Source:   "source",
+		Strategy: strategy,
+		V:        "someval",
+	}
+
+	out := val.ApplyStrategy("someval1")
+	c.Check(strategy.Called, jc.IsTrue)
+	c.Check(out, gc.Equals, "someval1")
 }

--- a/domain/modeldefaults/types_test.go
+++ b/domain/modeldefaults/types_test.go
@@ -136,8 +136,8 @@ func (s *typesSuite) TestApplyStrategy(c *gc.C) {
 // [PreferSetApplyStrategy] (the happy path).
 func (s *typesSuite) TestPreferSetApplyStrategy(c *gc.C) {
 	strategy := PreferSetApplyStrategy{}
-	c.Assert(strategy.Apply(nil, "test"), gc.Equals, "test")
-	c.Assert(strategy.Apply("default", nil), gc.Equals, "default")
-	c.Assert(strategy.Apply("default", "set"), gc.Equals, "set")
-	c.Assert(strategy.Apply(nil, nil), gc.IsNil)
+	c.Check(strategy.Apply(nil, "test"), gc.Equals, "test")
+	c.Check(strategy.Apply("default", nil), gc.Equals, "default")
+	c.Check(strategy.Apply("default", "set"), gc.Equals, "set")
+	c.Check(strategy.Apply(nil, nil), gc.IsNil)
 }


### PR DESCRIPTION
This change refactors our new ModelDefaultValues to not be hierarchical internal and instead rely on the defaults service to do the building of the hierarchy.  When first investigating this work I made the mistake of reading the current defaults code in state and seeing that we only had 3 sources of defaults defined in Juju and model the problem as such.

After starting to move the model creation process over to the new service layer we actually have a few more sources of defaults that have appeared in Juju over the years that did not get built into the standards setup or refactored.  See [here](https://github.com/juju/juju/blob/03ceaf7172e08b9341046b02c0d378ab415f4920/apiserver/facades/client/modelmanager/modelmanager.go#L221) for example.

To deal with this problem and so that we can carrel all of these opinions down into one service to keep them under control the defaults value has been updated to just represent one value of what model defaults thinks the value should be when all is said and done.

This change also allows the provider of the default value to offer up logic to model config on how the default should be applied when the value is set in both places. This is going to be useful in a follow up PR.

For the moment this is a mechanical change to support the next lot of changes coming through that gets the other defaults sources out of the API Server.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests in domain/modeldefaults/service and domain/modelconfig/service

These domain services are not integrated at the moment so there is no manual testing that can be performed. Stay tuned.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-4647