### PR TITLE
Prevent panic in wait-for command

### DIFF
--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -102,8 +102,10 @@ func helpLineError(input string, pos query.Position) string {
 	if leading+offset > len(input) {
 		offset = leading - len(input)
 	}
-	builder.WriteString(strings.Repeat("^", offset))
-	builder.WriteString("\n")
+	if offset > 0 {
+		builder.WriteString(strings.Repeat("^", offset))
+		builder.WriteString("\n")
+	}
 
 	return builder.String()
 }


### PR DESCRIPTION
The following was spotted when using wait-for without using strict equality.

The solution is to prevent negative ranges by highlighting errors.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

No need to bootstrap, just run.

```sh
$ juju wait-for application ubuntu --query="life='dead'"
ERROR Cannot parse query: unexpected character.

1 | life='dead'
        wait-for doesn't support '='. Maybe try removing the character and try again.
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2044405

**Jira card:** JUJU-5058
