### PR TITLE
Small CLI help text fixes for relate, debug-log, model-defaults commands

### DIFF
--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -176,7 +176,7 @@ See also:
     consume
     find-offers
     set-firewall-rule
-    suspend-integration
+    suspend-relation
 `
 
 var localEndpointRegEx = regexp.MustCompile("^" + names.RelationSnippet + "$")

--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -254,7 +254,7 @@ type defaultsCommandAPI interface {
 // Info implements part of the cmd.Command interface.
 func (c *defaultsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Args:    "[[<cloud>/]<region> ]<model-key>[<=value>] ...]",
+		Args:    "<model-key>[<=value>] ...]",
 		Doc:     modelDefaultsHelpDoc,
 		Name:    "model-defaults",
 		Purpose: modelDefaultsSummary,


### PR DESCRIPTION
A couple of trivial CLI help text fixes for "relate", "model-defaults", "debug-log".

## QA steps

deploy snappass-test to k8s
juju debug-log --include snappass-test/0

## Documentation changes

Need to ensure CLI doc is updated.

## Links

https://bugs.launchpad.net/juju/+bug/2040491
https://bugs.launchpad.net/juju/+bug/2031523
https://bugs.launchpad.net/juju/+bug/2029512
