### PR TITLE
Adds a model defaults table to the controller.

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -48,6 +48,7 @@ func ControllerDDL() *schema.Schema {
 		autocertCacheSchema,
 		objectStoreMetadataSchema,
 		userSchema,
+		modelConfigDefaults,
 	}
 
 	schema := schema.New()
@@ -576,4 +577,21 @@ CREATE TABLE user_activation_key (
         FOREIGN KEY (user_uuid)
     REFERENCES      user_authentication(user_uuid)
 );`)
+}
+
+// modelConfigDefaults is responsible for making a model config defaults table.
+// The purpose of this table is to offer model defaults to all newly created
+// models in Juju regardless of what cloud or cloud region the model is attached
+// to.
+//
+// Previously Juju has been solving this problem by using the controller model
+// config as this source of information. We want to stop special casing the
+// controller's model and using it as a defaults source for other models.
+func modelConfigDefaults() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE model_config_defaults (
+    key TEXT PRIMARY KEY,
+    value TEXT
+)
+`)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -98,6 +98,9 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"user_authentication",
 		"user_password",
 		"user_activation_key",
+
+		// Model Config Defaults
+		"model_config_defaults",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
With this commit we are introducing a new global table to the controller database to describe model defaults that should be applied to all models in the controller.

Previously in Juju we have not had this notion of controller wide model defaults. They have always been scoped to the cloud or cloud region. However secretly under the covers we have been living a life of shame where we have been taking the controller models config and using that as a controller wide default source.

It is time to rise up out of the shadows of this murky controller model defaults world and own our desire for a controller wide model defaults source. No longer should lesser models live in shame and more importantly no longer should the controller model be treated as some special case model that acts as a source of truth.

A perfect example of this is we use the controller model to find the Juju system ssh key that is created during bootstrap. Every model needs ssh key added to it at creation time.  We currently interrogate the controller model for the key. We are going to stop doing this so that the controller model can have the exact same logic applied to it as every other model in Juju.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No tests for this change. I am just proposing the DDL. The next PR that wires up the state layer will offer the tests for this DDL.

## Documentation changes

None. We are not going to offer this defaults source as a user configurable component via the cli or API. We are just going to store bootstrap generated concerns in the table at the moment where we know a key is going to be needed for every model regardless of what cloud it is for.

## Links

**Jira card:** JUJU-5046