### PR TITLE
Remove life from environ spaces

### DIFF
--- a/environs/space/spaces_mock_test.go
+++ b/environs/space/spaces_mock_test.go
@@ -9,7 +9,6 @@ import (
 
 	set "github.com/juju/collections/set"
 	network "github.com/juju/juju/core/network"
-	state "github.com/juju/juju/state"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -148,20 +147,6 @@ func (m *MockSpace) EXPECT() *MockSpaceMockRecorder {
 	return m.recorder
 }
 
-// EnsureDead mocks base method.
-func (m *MockSpace) EnsureDead() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureDead")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureDead indicates an expected call of EnsureDead.
-func (mr *MockSpaceMockRecorder) EnsureDead() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockSpace)(nil).EnsureDead))
-}
-
 // Id mocks base method.
 func (m *MockSpace) Id() string {
 	m.ctrl.T.Helper()
@@ -174,20 +159,6 @@ func (m *MockSpace) Id() string {
 func (mr *MockSpaceMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockSpace)(nil).Id))
-}
-
-// Life mocks base method.
-func (m *MockSpace) Life() state.Life {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(state.Life)
-	return ret0
-}
-
-// Life indicates an expected call of Life.
-func (mr *MockSpaceMockRecorder) Life() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockSpace)(nil).Life))
 }
 
 // Name mocks base method.

--- a/environs/space/spaces_test.go
+++ b/environs/space/spaces_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/envcontext"
-	"github.com/juju/juju/state"
 )
 
 type spacesSuite struct {
@@ -200,10 +199,8 @@ func (s *providerSpacesSuite) TestDeleteSpaces(c *gc.C) {
 	mockSpace := NewMockSpace(ctrl)
 	mockSpace.EXPECT().Name().Return("1").MinTimes(1)
 	mockSpace.EXPECT().Id().Return("1").MinTimes(1)
-	mockSpace.EXPECT().Life().Return(state.Alive)
 
 	// These are the important calls to check for.
-	mockSpace.EXPECT().EnsureDead().Return(nil)
 	mockSpace.EXPECT().Remove().Return(nil)
 
 	mockState := NewMockReloadSpacesState(ctrl)
@@ -325,8 +322,6 @@ func (s *providerSpacesSuite) TestProviderSpacesRun(c *gc.C) {
 	mockSpace.EXPECT().ProviderId().Return(network.Id("1")).MinTimes(1)
 	mockSpace.EXPECT().Name().Return("1").MinTimes(1)
 	mockSpace.EXPECT().Id().Return("1").MinTimes(1)
-	mockSpace.EXPECT().Life().Return(state.Alive)
-	mockSpace.EXPECT().EnsureDead().Return(nil)
 	mockSpace.EXPECT().Remove().Return(nil)
 
 	newMockSpace := NewMockSpace(ctrl)

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -352,7 +352,7 @@ func (s *Space) Remove() (err error) {
 		C:      spacesC,
 		Id:     s.doc.Id,
 		Remove: true,
-		Assert: isDeadDoc,
+		Assert: txn.DocExists,
 	}}
 	if s.ProviderId() != "" {
 		ops = append(ops, s.st.networkEntityGlobalKeyRemoveOp("space", s.ProviderId()))
@@ -362,7 +362,7 @@ func (s *Space) Remove() (err error) {
 	if txnErr == nil {
 		return nil
 	}
-	return onAbort(txnErr, errors.New("not found or not dead"))
+	return onAbort(txnErr, errors.New("not found"))
 }
 
 // Refresh refreshes the contents of the Space from the underlying state. It

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -41,11 +41,6 @@ func (s *Space) Id() string {
 	return s.doc.Id
 }
 
-// Life returns whether the space is Alive, Dying or Dead.
-func (s *Space) Life() Life {
-	return s.doc.Life
-}
-
 // String implements fmt.Stringer.
 func (s *Space) String() string {
 	return s.doc.Name

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -540,7 +540,7 @@ func (s *SpacesSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
 	s.removeSpaceAndAssertNotFound(c, space)
 
 	err := space.Remove()
-	c.Assert(err, gc.ErrorMatches, `cannot remove space "twice-deleted": not found or not dead`)
+	c.Assert(err, gc.ErrorMatches, `cannot remove space "twice-deleted": not found`)
 }
 
 func (s *SpacesSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -98,7 +98,6 @@ func (s *SpacesSuite) assertSpaceMatchesArgs(c *gc.C, space *state.Space, args a
 	c.Assert(actualSubnetIds, jc.SameContents, args.SubnetCIDRs)
 	c.Assert(state.SpaceDoc(space).IsPublic, gc.Equals, args.IsPublic)
 
-	c.Assert(space.Life(), gc.Equals, state.Alive)
 	c.Assert(space.String(), gc.Equals, args.Name)
 
 	// The space ID is not empty and not equivalent to the default space.
@@ -489,20 +488,17 @@ func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenAlive(c *gc.C) {
 func (s *SpacesSuite) addAliveSpace(c *gc.C, name string) *state.Space {
 	space, err := s.State.AddSpace(name, "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(space.Life(), gc.Equals, state.Alive)
 	return space
 }
 
 func (s *SpacesSuite) ensureDeadAndAssertLifeIsDead(c *gc.C, space *state.Space) {
 	err := space.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(space.Life(), gc.Equals, state.Dead)
 }
 
 func (s *SpacesSuite) refreshAndAssertSpaceLifeIs(c *gc.C, space *state.Space, expectedLife state.Life) {
 	err := space.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(space.Life(), gc.Equals, expectedLife)
 }
 
 func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenNotAlive(c *gc.C) {
@@ -534,26 +530,15 @@ func (s *SpacesSuite) removeSpaceAndAssertNotFound(c *gc.C, space *state.Space) 
 	s.assertSpaceNotFound(c, space.Name())
 }
 
-func (s *SpacesSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
-	space := s.addAliveSpace(c, "twice-deleted")
-	s.ensureDeadAndAssertLifeIsDead(c, space)
-	s.removeSpaceAndAssertNotFound(c, space)
-
-	err := space.Remove()
-	c.Assert(err, gc.ErrorMatches, `cannot remove space "twice-deleted": not found`)
-}
-
 func (s *SpacesSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {
 	space := s.addAliveSpace(c, "original")
 	spaceCopy, err := s.State.SpaceByName(space.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.ensureDeadAndAssertLifeIsDead(c, space)
-	c.Assert(spaceCopy.Life(), gc.Equals, state.Alive)
 
 	err = spaceCopy.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spaceCopy.Life(), gc.Equals, state.Dead)
 }
 
 func (s *SpacesSuite) TestRefreshFailsWithNotFoundWhenRemoved(c *gc.C) {


### PR DESCRIPTION
With the new dqlite domain, spaces will no longer have life. This patch removes the method from the interface that abstracts the legacy state on environs, thus preparing the path to remove this entire interface and use a core struct (in a following PR).

_Note: this PR doesn't remove the `Life()` method or the field from the legacy mongodb state, it was only used on environs and that's what's being removed. _

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
 go test github.com/juju/juju/environs/space/... -gocheck.v        
```
Bootstrap a LXD controller.
Then add a space:
```
juju add-space test-space XXX.XXX.XXX.XXX/XX
# Make sure the space is listed:
juju spaces
```
Then remove it and make sure it's not listed any more:
```
juju remove-space test-space
juju spaces
```

only the `alpha` space should be present.


## Links


**Jira card:** JUJU-5055
