### PR TITLE
Ensure placeholder port is removed from k8s service when open-port is used.

### DIFF
--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -1475,6 +1475,10 @@ func getDefaultSvc() *corev1.Service {
 			Selector: map[string]string{"app.kubernetes.io/name": "gitlab"},
 
 			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{
+				Name: "placeholder",
+				Port: 65535,
+			}},
 		},
 	}
 }


### PR DESCRIPTION
When  a charm uses open-port to ask Juju to add a service port to the application service, the original placeholder port was left behind. This PR fixes that situation.

## QA steps

Before this patch the ports would have included `65535`.

```sh
juju deploy zinc-k8s
kubectl get service/zinc-k8s
NAME       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
zinc-k8s   ClusterIP   10.152.183.173   <none>        4080/TCP   15m
```

## Links

https://bugs.launchpad.net/juju/+bug/2003782

**Jira card:** JUJU-[5065]

