### PR TITLE
Add --destroy-storage to test controller cleanup

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -401,7 +401,7 @@ destroy_controller() {
 
 	echo "====> Destroying juju ($(green "${name}"))"
 	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
-		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % 2>&1 | OUTPUT "${output}"
+		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models --destroy-storage -y % 2>&1 | OUTPUT "${output}"
 	else
 		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % 2>&1 | OUTPUT "${output}"
 	fi


### PR DESCRIPTION
Failure to tear down has been observed in CI test runs, with:
```
03:30:44     | WARNING This command will destroy the "ctrl-zpbu2nqa" controller and all its resources
03:30:44     | ERROR cannot destroy controller "ctrl-zpbu2nqa"
03:30:44 
03:30:44     | The controller has persistent storage remaining:
03:30:44     | 6 volumes and 6 filesystems in 1 model
03:30:44 
03:30:44     | To destroy the storage, run the destroy-controller
03:30:44     | command again with the "--destroy-storage" option.
03:30:44 
03:30:44     | To release the storage from Juju's management
03:30:44     | without destroying it, use the "--release-storage"
03:30:44     | option instead. The storage can then be imported
03:30:44     | into another Juju model.
```

Here we add the suggested option.

## QA steps

Run an integration test suite, such as:
`cd tests && ./main.sh controller`