### PR TITLE
Fix coslite test by testing readiness/health endpoint.

### DIFF
--- a/tests/suites/coslite/task.sh
+++ b/tests/suites/coslite/task.sh
@@ -15,20 +15,11 @@ test_coslite() {
 
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"k8s")
-		# disable metallb then enable it with a new set of out ipaddr
-		microk8s disable metallb
-		IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
-		microk8s enable metallb:"$IPADDR"-"$IPADDR"
-		microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
-		microk8s kubectl rollout status deployments/coredns -n kube-system -w
-		microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
-
 		test_deploy_coslite
 		;;
 	*)
 		echo "==> TEST SKIPPED: test_deploy_coslite test runs on k8s only"
 		;;
-
 	esac
 
 	# TODO(basebandit): remove KILL_CONTROLLER once model teardown has been fixed for k8s models.


### PR DESCRIPTION
Fixes coslite test by checking the readiness or health endpoints for the applications inside the bundle.
Also fixes the coslite test so it can run on all k8s, not just microk8s.

## QA steps

- minikube test: `BOOTSTRAP_PROVIDER=k8s BOOTSTRAP_CLOUD=minikube ./main.sh -v coslite`
- microk8s test: `BOOTSTRAP_PROVIDER=k8s BOOTSTRAP_CLOUD=microk8s ./main.sh -v coslite`

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/test-coslite-test-deploy-coslite-microk8s/779/consoleText