### PR TITLE
Improve PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-*Why this change is needed and what it does.*
+<!-- Why this change is needed and what it does. -->
 
 ## Checklist
 
-*If an item is not applicable, use `~strikethrough~`.*
+<!-- If an item is not applicable, use `~strikethrough~`. -->
 
 - [ ] Code style: imports ordered, good names, simple structure, etc
 - [ ] Comments saying why design decisions were made
@@ -12,20 +12,17 @@
 
 ## QA steps
 
-*Commands to run to verify that the change works.*
-
-```sh
-QA steps here
-```
+<!-- Describe steps to verify that the change works. -->
 
 ## Documentation changes
 
-*How it affects user workflow (CLI or API). Delete section if not applicable.*
+<!-- How it affects user workflow (CLI or API). -->
 
 ## Links
 
-**Launchpad bug:** https://pad.lv/<bug-number>
+<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->
 
-**Jira card:** JUJU-[XXXX]
+**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/
 
-*Insert other relevant links here.*
+**Jira card:** JUJU-
+


### PR DESCRIPTION
This updates the PULL_REQUEST_TEMPLATE to fix some ergonomics with it.
- Common error is leaving in comments, now they are actually comments.
- Often people remove the documentation section (it gives you permission), when it is more often than not, relevant.
- JIRA card numbers often formatted wrong. e.g. JUJU-[999999] instead of JUJU-999999
- Asking for links to more things.

```markdown
<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-
```