### PR TITLE
Backport change from 3.1 to fix model config test.

### DIFF
--- a/tests/suites/model/config.sh
+++ b/tests/suites/model/config.sh
@@ -6,12 +6,12 @@ run_model_config() {
 	file="${TEST_DIR}/test-model-config.log"
 	ensure "model-config" "${file}"
 
-	juju model-config mode="[strict]"
-	juju model-config mode | grep "strict"
-	juju model-config mode="[]"
-	juju model-config mode | grep "\[\]"
-	juju model-config mode="[boom]" || echo "ERROR" | grep "ERROR"
-	juju model-config --reset mode
+	juju model-config provisioner-harvest-mode="none"
+	juju model-config provisioner-harvest-mode | grep "none"
+	juju model-config provisioner-harvest-mode="destroyed"
+	juju model-config provisioner-harvest-mode | grep "destroyed"
+	juju model-config provisioner-harvest-mode="invalid" || echo "ERROR" | grep "ERROR"
+	juju model-config --reset provisioner-harvest-mode
 
 	destroy_model "model-config"
 }


### PR DESCRIPTION
Backports change from #14292 that "fixed" this test by using a different config option.

## QA steps

Run `./main.sh -v -s '"test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status"' model test_model_config`

## Links

https://jenkins.juju.canonical.com/job/test-model-test-model-config-google/793/consoleText