### PR TITLE
Fixes deploy_aks CI test

### DIFF
--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -22,7 +22,10 @@ run_deploy_aks_charms() {
 	echo "Destroy model"
 	juju destroy-model "test-deploy-aks-charms" --destroy-storage -y
 
-	# Because of issues with scaling `dummy-source` and `dummy-sink` we need to remove it with `--force` flag
+	# TODO(anvial - 2023.11.28): We need to drop this hack when possible.
+	# The problem is that on AKS (possibly on other K8s substrates)
+	# we have issues with scaling `dummy-source` and `dummy-sink` apps to zero.
+	# The current workaround is to remove these apps with `--force` flag
 	echo "Remove applications with --force flag"
 	juju remove-application dummy-source --force --no-wait
 	juju remove-application dummy-sink --force --no-wait

--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -21,6 +21,11 @@ run_deploy_aks_charms() {
 
 	echo "Destroy model"
 	juju destroy-model "test-deploy-aks-charms" --destroy-storage -y
+
+	# Because of issues with scaling `dummy-source` and `dummy-sink` we need to remove it with `--force` flag
+	echo "Remove applications with --force flag"
+	juju remove-application dummy-source --force --no-wait
+	juju remove-application dummy-sink --force --no-wait
 }
 
 test_deploy_aks_charms() {


### PR DESCRIPTION
This PR fices deploy_aks CI tests by adding remove-application with `--force` to avoid scaling to 0 issues.

PS: I don't like this fix, but I don't know another way to avoid it. It is possible we need to change something in the `dummy-source` and `dummy-sink` charms.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd tests
./main.sh -v -p azure deploy_aks
```


