### PR TITLE
Ensure iface matcher returns a valid value

### DIFF
--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -82,7 +82,7 @@ assert_net_iface_for_endpoint_matches() {
 	exp_if_name=${3}
 
 	# shellcheck disable=SC2086,SC2016
-	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
+	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}' || echo "")
 	if [ "$got_if" != "$exp_if_name" ]; then
 		# shellcheck disable=SC2086,SC2016,SC2046
 		echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")
@@ -102,7 +102,7 @@ assert_endpoint_binding_matches() {
 	exp_space_name=${3}
 
 	# shellcheck disable=SC2086,SC2016
-	got=$(juju show-application ${app_name} --format json | jq -r ".[\"${app_name}\"] | .[\"endpoint-bindings\"] | .[\"${endpoint_name}\"]")
+	got=$(juju show-application ${app_name} --format json | jq -r ".[\"${app_name}\"] | .[\"endpoint-bindings\"] | .[\"${endpoint_name}\"]" || echo "")
 	if [ "$got" != "$exp_space_name" ]; then
 		# shellcheck disable=SC2086,SC2016,SC2046
 		echo $(red "Expected endpoint ${endpoint_name} in juju show-application ${app_name} to be ${exp_space_name}; got ${got}")


### PR DESCRIPTION
The grep inside the bash sub command can cause the command to fail, which in turn causes everything to fail. The fix is to always have an else, so we get a valid output for the if, to see what is wrong.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ cd tests & ./main.sh spaces_ec2
```

## Links

**Jira card:** JUJU-XXX

