### PR TITLE
Improve collection indexes to match common queries being performed.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -261,7 +261,11 @@ func allCollections() CollectionSchema {
 
 		// This collection contains incrementing integers, subdivided by name,
 		// to ensure various IDs aren't reused.
-		sequenceC: {},
+		sequenceC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// -----
 
@@ -300,7 +304,11 @@ func allCollections() CollectionSchema {
 		assignUnitC: {},
 
 		// meterStatusC is the collection used to store meter status information.
-		meterStatusC: {},
+		meterStatusC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// These collections hold reference counts which are used
 		// by the nsRefcounts struct.
@@ -311,9 +319,7 @@ func allCollections() CollectionSchema {
 
 		relationsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"model-uuid", "endpoints.relationname"},
-			}, {
-				Key: []string{"model-uuid", "endpoints.applicationname"},
+				Key: []string{"model-uuid", "endpoints.applicationname", "endpoints.relation.name"},
 			}},
 		},
 		relationScopesC: {
@@ -328,7 +334,11 @@ func allCollections() CollectionSchema {
 		// -----
 
 		// These collections hold information associated with machines.
-		containerRefsC: {},
+		containerRefsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		instanceDataC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},
@@ -341,12 +351,20 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
-		rebootC:      {},
+		rebootC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machineid"},
+			}},
+		},
 		sshHostKeysC: {},
 
 		// This collection contains information from removed machines
 		// that needs to be cleaned up in the provider.
-		machineRemovalsC: {},
+		machineRemovalsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// this collection contains machine update locks whose existence indicates
 		// that a particular machine in the process of performing a series upgrade.
@@ -398,18 +416,30 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "volumeid"},
 			}},
 		},
-		volumeAttachmentPlanC: {},
+		volumeAttachmentPlanC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// -----
 
-		providerIDsC: {},
+		providerIDsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		spacesC: {
 			indexes: []mgo.Index{
 				{Key: []string{"model-uuid", "spaceid"}},
 				{Key: []string{"model-uuid", "name"}},
 			},
 		},
-		subnetsC: {},
+		subnetsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		linkLayerDevicesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machine-id"},
@@ -482,12 +512,20 @@ func allCollections() CollectionSchema {
 
 		// This collection holds user annotations for various entities. They
 		// shouldn't be written or interpreted by juju.
-		annotationsC: {},
+		annotationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// This collection in particular holds an astounding number of
 		// different sorts of data: application config settings by charm version,
 		// unit relation settings, model config, etc etc etc.
-		settingsC: {},
+		settingsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// The generations collection holds data about
 		// active and completed "next" model generations.
@@ -502,8 +540,12 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid"},
 			}},
 		},
-		storageConstraintsC: {},
-		deviceConstraintsC:  {},
+		storageConstraintsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
+		deviceConstraintsC: {},
 		statusesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "_id"},
@@ -538,9 +580,14 @@ func allCollections() CollectionSchema {
 		offerConnectionsC: {
 			indexes: []mgo.Index{
 				{Key: []string{"model-uuid", "offer-uuid"}},
+				{Key: []string{"model-uuid", "username"}},
 			},
 		},
-		remoteApplicationsC: {},
+		remoteApplicationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		// remoteEntitiesC holds information about entities involved in
 		// cross-model relations.
 		remoteEntitiesC: {
@@ -554,7 +601,11 @@ func allCollections() CollectionSchema {
 			global: true,
 		},
 		// relationNetworksC holds required ingress or egress cidrs for remote relations.
-		relationNetworksC: {},
+		relationNetworksC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// firewallRulesC holds firewall rules for defined service types.
 		firewallRulesC: {
@@ -565,15 +616,27 @@ func allCollections() CollectionSchema {
 
 		// podSpecsC holds the CAAS pod specifications,
 		// for applications.
-		podSpecsC: {},
+		podSpecsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// cloudContainersC holds the CAAS container (pod) information
 		// for units, eg address, ports.
-		cloudContainersC: {},
+		cloudContainersC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "provider-id"},
+			}},
+		},
 
 		// cloudServicesC holds the CAAS service information
 		// eg addresses.
-		cloudServicesC: {},
+		cloudServicesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// Raw-access collections
 		// ======================


### PR DESCRIPTION
Many collections in juju are multi-tenant (by `model-uuid`). Queries that don't involve the natural key `_id` (automatically created unique index) using the multi-tenant collections would implicitly have a query filter on `model-uuid`, but because they lacked a singular or composite index with `model-uuid` as the first key on the index, means the queries would become full collection scans.

This is an attempt to go through all the multi-tenant collections (non-global), and ensure the ones being queried without the involvement of the natural key have at least the `model-uuid` field as the first key in one index.

Mongo CLI commands to achieve the same:
```js
db.sequence.createIndex({"model-uuid": 1});
db.meterStatus.createIndex({"model-uuid": 1});
db.relations.createIndex({"model-uuid": 1, "endpoints.applicationname": 1, "endpoints.relation.name": 1});
db.containerRefs.createIndex({"model-uuid": 1});
db.reboot.createIndex({"model-uuid": 1, "machineid": 1});
db.machineremovals.createIndex({"model-uuid": 1});
db.volumeattachmentplan.createIndex({"model-uuid": 1});
db.providerIDs.createIndex({"model-uuid": 1});
db.subnets.createIndex({"model-uuid": 1});
db.annotations.createIndex({"model-uuid": 1});
db.settings.createIndex({"model-uuid": 1});
db.storageconstraints.createIndex({"model-uuid": 1});
db.applicationOfferConnections.createIndex({"model-uuid": 1, "username": 1});
db.remoteApplications.createIndex({"model-uuid": 1});
db.relationNetworks.createIndex({"model-uuid": 1});
db.podSpecs.createIndex({"model-uuid": 1});
db.cloudcontainers.createIndex({"model-uuid": 1, "provider-id": 1});
db.cloudservices.createIndex({"model-uuid": 1});
```

## QA steps

Bootstrap controller. Upgrade a controller. Nothing functional should change.

## Links

https://www.mongodb.com/docs/manual/core/indexes/index-types/index-compound/
https://www.mongodb.com/docs/v4.4/reference/method/db.collection.createIndex/#mongodb-method-db.collection.createIndex

