### PR TITLE
Rename uuid to id on subnet types tables

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -116,7 +116,7 @@ CREATE TABLE subnet (
     vlan_tag                     INT,
     is_public                    BOOLEAN,
     space_uuid                   TEXT,
-    subnet_type_id               TEXT,
+    subnet_type_id               INT,
     CONSTRAINT                   fk_subnets_spaces
         FOREIGN KEY                  (space_uuid)
         REFERENCES                   space(uuid),
@@ -126,7 +126,7 @@ CREATE TABLE subnet (
 );
 
 CREATE TABLE subnet_type (
-    id                           TEXT PRIMARY KEY,
+    id                           INT PRIMARY KEY,
     name                         TEXT NOT NULL,
     is_usable                    BOOLEAN,
     is_space_settable            BOOLEAN
@@ -138,7 +138,7 @@ INSERT INTO subnet_type VALUES
     (2, 'fan_overlay_segment', true, true);
 
 CREATE TABLE subnet_association_type (
-    id                           TEXT PRIMARY KEY,
+    id                           INT PRIMARY KEY,
     name                         TEXT NOT NULL
 );
 
@@ -146,9 +146,9 @@ INSERT INTO subnet_association_type VALUES
     (0, 'overlay_of');    -- The subnet is an overlay of other (an underlay) subnet.
 
 CREATE TABLE subnet_type_association_type (
-    subject_subnet_type_id         TEXT PRIMARY KEY,
-    associated_subnet_type_id      TEXT NOT NULL,
-    association_type_id            TEXT NOT NULL,
+    subject_subnet_type_id         INT PRIMARY KEY,
+    associated_subnet_type_id      INT NOT NULL,
+    association_type_id            INT NOT NULL,
     CONSTRAINT                     fk_subject_subnet_type_id
         FOREIGN KEY                    (subject_subnet_type_id)
         REFERENCES                     subnet_type(id),
@@ -166,7 +166,7 @@ INSERT INTO subnet_type_association_type VALUES
 CREATE TABLE subnet_association (
     subject_subnet_uuid            TEXT PRIMARY KEY,
     associated_subnet_uuid         TEXT NOT NULL,
-    association_type_id            TEXT NOT NULL,
+    association_type_id            INT NOT NULL,
     CONSTRAINT                     fk_subject_subnet_uuid
         FOREIGN KEY                    (subject_subnet_uuid)
         REFERENCES                     subnet(uuid),

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -116,17 +116,17 @@ CREATE TABLE subnet (
     vlan_tag                     INT,
     is_public                    BOOLEAN,
     space_uuid                   TEXT,
-    subnet_type_uuid             TEXT,
+    subnet_type_id               TEXT,
     CONSTRAINT                   fk_subnets_spaces
         FOREIGN KEY                  (space_uuid)
         REFERENCES                   space(uuid),
     CONSTRAINT                   fk_subnet_types
-        FOREIGN KEY                  (subnet_type_uuid)
-        REFERENCES                   subnet_type(uuid)
+        FOREIGN KEY                  (subnet_type_id)
+        REFERENCES                   subnet_type(id)
 );
 
 CREATE TABLE subnet_type (
-    uuid                         TEXT PRIMARY KEY,
+    id                           TEXT PRIMARY KEY,
     name                         TEXT NOT NULL,
     is_usable                    BOOLEAN,
     is_space_settable            BOOLEAN
@@ -138,7 +138,7 @@ INSERT INTO subnet_type VALUES
     (2, 'fan_overlay_segment', true, true);
 
 CREATE TABLE subnet_association_type (
-    uuid                         TEXT PRIMARY KEY,
+    id                           TEXT PRIMARY KEY,
     name                         TEXT NOT NULL
 );
 
@@ -146,18 +146,18 @@ INSERT INTO subnet_association_type VALUES
     (0, 'overlay_of');    -- The subnet is an overlay of other (an underlay) subnet.
 
 CREATE TABLE subnet_type_association_type (
-    subject_subnet_type_uuid       TEXT PRIMARY KEY,
-    associated_subnet_type_uuid    TEXT NOT NULL,
-    association_type_uuid          TEXT NOT NULL,
-    CONSTRAINT                     fk_subject_subnet_type_uuid
-        FOREIGN KEY                    (subject_subnet_type_uuid)
-        REFERENCES                     subnet_type(uuid),
-    CONSTRAINT                     fk_associated_subnet_type_uuid
-        FOREIGN KEY                    (associated_subnet_type_uuid)
-        REFERENCES                     subnet_association_type(uuid),
-    CONSTRAINT                     fk_association_type_uuid
-        FOREIGN KEY                    (association_type_uuid)
-        REFERENCES                     subnet_association_type(uuid)
+    subject_subnet_type_id         TEXT PRIMARY KEY,
+    associated_subnet_type_id      TEXT NOT NULL,
+    association_type_id            TEXT NOT NULL,
+    CONSTRAINT                     fk_subject_subnet_type_id
+        FOREIGN KEY                    (subject_subnet_type_id)
+        REFERENCES                     subnet_type(id),
+    CONSTRAINT                     fk_associated_subnet_type_id
+        FOREIGN KEY                    (associated_subnet_type_id)
+        REFERENCES                     subnet_association_type(id),
+    CONSTRAINT                     fk_association_type_id
+        FOREIGN KEY                    (association_type_id)
+        REFERENCES                     subnet_association_type(id)
 );
 
 INSERT INTO subnet_type_association_type VALUES
@@ -166,16 +166,16 @@ INSERT INTO subnet_type_association_type VALUES
 CREATE TABLE subnet_association (
     subject_subnet_uuid            TEXT PRIMARY KEY,
     associated_subnet_uuid         TEXT NOT NULL,
-    association_type_uuid          TEXT NOT NULL,
+    association_type_id            TEXT NOT NULL,
     CONSTRAINT                     fk_subject_subnet_uuid
         FOREIGN KEY                    (subject_subnet_uuid)
         REFERENCES                     subnet(uuid),
     CONSTRAINT                     fk_associated_subnet_uuid
         FOREIGN KEY                    (associated_subnet_uuid)
         REFERENCES                     subnet(uuid),
-    CONSTRAINT                     fk_association_type_uuid
-        FOREIGN KEY                    (association_type_uuid)
-        REFERENCES                     subnet_association_type(uuid)
+    CONSTRAINT                     fk_association_type_id
+        FOREIGN KEY                    (association_type_id)
+        REFERENCES                     subnet_association_type(id)
 );
 
 CREATE UNIQUE INDEX idx_subnet_association


### PR DESCRIPTION
This small patch renames the primary key from 'uuid' to 'id' on subnet_type and subnet_association_type, as well as all the tables referencing them.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/domain/schema/... -gocheck.v         
```
