### PR TITLE
Remove isPublic on both spaces and subnets

### DIFF
--- a/api/controller/firewaller/firewaller_test.go
+++ b/api/controller/firewaller/firewaller_test.go
@@ -264,7 +264,6 @@ func (s *firewallerSuite) TestAllSpaceInfos(c *gc.C) {
 						FanLocalUnderlay: "192.168.0.0/16",
 						FanOverlay:       "1.0.0.0/8",
 					},
-					IsPublic: true,
 				},
 			},
 		},

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -63,7 +63,7 @@ func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 
 	var err error
-	s.mgmtSpace, err = s.ControllerModel(c).State().AddSpace("mgmt01", "", nil, false)
+	s.mgmtSpace, err = s.ControllerModel(c).State().AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.ControllerModel(c).State().UpdateControllerConfig(map[string]interface{}{corecontroller.JujuManagementSpace: "mgmt01"}, nil)
@@ -215,7 +215,7 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 }
 
 func (s *loginSuite) setupManagementSpace(c *gc.C) *state.Space {
-	mgmtSpace, err := s.ControllerModel(c).State().AddSpace("mgmt01", "", nil, false)
+	mgmtSpace, err := s.ControllerModel(c).State().AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.ControllerModel(c).State().UpdateControllerConfig(map[string]interface{}{corecontroller.JujuManagementSpace: "mgmt01"}, nil)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -74,7 +74,7 @@ type ModelManagerBackend interface {
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
 	SetModelMeterStatus(string, string) error
 	AllSpaces() ([]*state.Space, error)
-	AddSpace(string, network.Id, []string, bool) (*state.Space, error)
+	AddSpace(string, network.Id, []string) (*state.Space, error)
 	AllEndpointBindingsSpaceNames() (set.Strings, error)
 	ConstraintsBySpaceName(string) ([]*state.Constraints, error)
 	DefaultEndpointBindingSpace() (string, error)

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -102,7 +102,7 @@ type NetworkBacking interface {
 	SetAvailabilityZones(network.AvailabilityZones) error
 
 	// AddSpace creates a space
-	AddSpace(string, network.Id, []string, bool) (BackingSpace, error)
+	AddSpace(string, network.Id, []string) (BackingSpace, error)
 
 	// AllSpaces returns all known Juju network spaces.
 	AllSpaces() ([]BackingSpace, error)

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -418,9 +418,9 @@ func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingErr
 func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	// Add a couple of spaces.
-	space1, err := st.AddSpace("space1", "first space id", nil, true)
+	space1, err := st.AddSpace("space1", "first space id", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	space2, err := st.AddSpace("space2", "", nil, false) // no provider ID
+	space2, err := st.AddSpace("space2", "", nil) // no provider ID
 	c.Assert(err, jc.ErrorIsNil)
 	// Add 1 subnet into space1, and 2 into space2.
 	// Each subnet is in a matching zone (e.g "subnet-#" in "zone#").
@@ -436,7 +436,7 @@ func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
 func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstraints(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	// Add an empty space.
-	_, err := st.AddSpace("empty", "", nil, true)
+	_, err := st.AddSpace("empty", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	consEmptySpace := constraints.MustParse("cores=123 mem=8G spaces=empty")

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -882,7 +882,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 
 func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string) string {
 	st := s.ControllerModel(c).State()
-	space, err := st.AddSpace(spaceName, network.Id(spaceName), nil, true)
+	space, err := st.AddSpace(spaceName, network.Id(spaceName), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = st.AddSubnet(network.SubnetInfo{

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -65,7 +65,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 
 	s.st = s.ControllerModel(c).State()
 	for spaceName, cidrs := range net {
-		space, err := s.st.AddSpace(spaceName, "", nil, false)
+		space, err := s.st.AddSpace(spaceName, "", nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		for _, cidr := range cidrs {

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -194,9 +194,9 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 
 	wordpressCharm := s.addWordpressCharm(c)
 	st := s.ControllerModel(c).State()
-	dbSpace, err := st.AddSpace("db", "", nil, false)
+	dbSpace, err := st.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	publicSpace, err := st.AddSpace("public", "", nil, false)
+	publicSpace, err := st.AddSpace("public", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := st.Model()
@@ -242,11 +242,11 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 
 	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 	st := s.ControllerModel(c).State()
-	dbSpace, err := st.AddSpace("db", "", nil, false)
+	dbSpace, err := st.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	publicSpace, err := st.AddSpace("public", "", nil, false)
+	publicSpace, err := st.AddSpace("public", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	internalSpace, err := st.AddSpace("internal", "", nil, false)
+	internalSpace, err := st.AddSpace("internal", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := st.Model()
@@ -293,9 +293,9 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 
 	wordpressCharm := s.addWordpressCharm(c)
 	st := s.ControllerModel(c).State()
-	_, err := st.AddSpace("db", "", nil, false)
+	_, err := st.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	publicSpace, err := st.AddSpace("public", "", nil, false)
+	publicSpace, err := st.AddSpace("public", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := st.Model()

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -55,7 +55,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 
 	st := s.ControllerModel(c).State()
 	var err error
-	s.mgmtSpace, err = st.AddSpace("mgmt01", "", nil, false)
+	s.mgmtSpace, err = st.AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateControllerConfig(map[string]interface{}{controller.JujuManagementSpace: "mgmt01"}, nil)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -237,7 +237,7 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 
 func (s *statusSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
 	st := s.ControllerModel(c).State()
-	space, err := st.AddSpace(spaceName, network.Id(spaceName), nil, true)
+	space, err := st.AddSpace(spaceName, network.Id(spaceName), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = st.AddSubnet(network.SubnetInfo{

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -369,7 +369,7 @@ func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
 
 func (s *clientSuite) TestEnableHAPlacementToWithAddressInSpace(c *gc.C) {
 	st := s.ControllerModel(c).State()
-	sp, err := st.AddSpace("ha-space", "", nil, true)
+	sp, err := st.AddSpace("ha-space", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerSettings, _ := st.ReadSettings("controllers", "controllerSettings")
@@ -401,7 +401,7 @@ func (s *clientSuite) TestEnableHAPlacementToWithAddressInSpace(c *gc.C) {
 
 func (s *clientSuite) TestEnableHAPlacementToErrorForInaccessibleSpace(c *gc.C) {
 	st := s.ControllerModel(c).State()
-	_, err := st.AddSpace("ha-space", "", nil, true)
+	_, err := st.AddSpace("ha-space", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerSettings, _ := st.ReadSettings("controllers", "controllerSettings")

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -980,8 +980,8 @@ func (st *mockState) HAPrimaryMachine() (names.MachineTag, error) {
 	return names.MachineTag{}, nil
 }
 
-func (st *mockState) AddSpace(name string, provider network.Id, subnetIds []string, public bool) (*state.Space, error) {
-	st.MethodCall(st, "AddSpace", name, provider, subnetIds, public)
+func (st *mockState) AddSpace(name string, provider network.Id, subnetIds []string) (*state.Space, error) {
+	st.MethodCall(st, "AddSpace", name, provider, subnetIds)
 	return nil, st.NextErr()
 }
 

--- a/apiserver/facades/client/modelmanager/shims.go
+++ b/apiserver/facades/client/modelmanager/shims.go
@@ -33,7 +33,7 @@ func (s spaceStateShim) AllSpaces() ([]network.SpaceInfo, error) {
 	return results, nil
 }
 
-func (s spaceStateShim) AddSpace(name string, providerId network.Id, subnetIds []string, public bool) (network.SpaceInfo, error) {
+func (s spaceStateShim) AddSpace(name string, providerId network.Id, subnetIds []string) (network.SpaceInfo, error) {
 	result, err := s.ModelManagerBackend.AddSpace(name, providerId, subnetIds)
 	if err != nil {
 		return network.SpaceInfo{}, errors.Trace(err)

--- a/apiserver/facades/client/modelmanager/shims.go
+++ b/apiserver/facades/client/modelmanager/shims.go
@@ -34,7 +34,7 @@ func (s spaceStateShim) AllSpaces() ([]network.SpaceInfo, error) {
 }
 
 func (s spaceStateShim) AddSpace(name string, providerId network.Id, subnetIds []string, public bool) (network.SpaceInfo, error) {
-	result, err := s.ModelManagerBackend.AddSpace(name, providerId, subnetIds, public)
+	result, err := s.ModelManagerBackend.AddSpace(name, providerId, subnetIds)
 	if err != nil {
 		return network.SpaceInfo{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/spaces/interface.go
+++ b/apiserver/facades/client/spaces/interface.go
@@ -79,7 +79,7 @@ type Backing interface {
 	MovingSubnet(id string) (MovingSubnet, error)
 
 	// AddSpace creates a space.
-	AddSpace(name string, providerID network.Id, subnets []string, public bool) (networkingcommon.BackingSpace, error)
+	AddSpace(name string, providerID network.Id, subnets []string) (networkingcommon.BackingSpace, error)
 
 	// AllSpaces returns all known Juju network spaces.
 	// TODO (manadart 2020-04-14): This should be removed in favour of

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -49,18 +49,18 @@ func (m *MockBacking) EXPECT() *MockBackingMockRecorder {
 }
 
 // AddSpace mocks base method.
-func (m *MockBacking) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (networkingcommon.BackingSpace, error) {
+func (m *MockBacking) AddSpace(arg0 string, arg1 network.Id, arg2 []string) (networkingcommon.BackingSpace, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2)
 	ret0, _ := ret[0].(networkingcommon.BackingSpace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddSpace indicates an expected call of AddSpace.
-func (mr *MockBackingMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBackingMockRecorder) AddSpace(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockBacking)(nil).AddSpace), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockBacking)(nil).AddSpace), arg0, arg1, arg2)
 }
 
 // AllConstraints mocks base method.
@@ -1146,18 +1146,18 @@ func (m *MockReloadSpacesState) EXPECT() *MockReloadSpacesStateMockRecorder {
 }
 
 // AddSpace mocks base method.
-func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (network.SpaceInfo, error) {
+func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string) (network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2)
 	ret0, _ := ret[0].(network.SpaceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddSpace indicates an expected call of AddSpace.
-func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2)
 }
 
 // AllEndpointBindingsSpaceNames mocks base method.

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -74,7 +74,7 @@ func NewStateShim(st *state.State, cloudService common.CloudService, credentialS
 }
 
 func (s *stateShim) AddSpace(
-	name string, providerId network.Id, subnetIds []string, public bool,
+	name string, providerId network.Id, subnetIds []string,
 ) (networkingcommon.BackingSpace, error) {
 	result, err := s.State.AddSpace(name, providerId, subnetIds)
 	if err != nil {

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -76,7 +76,7 @@ func NewStateShim(st *state.State, cloudService common.CloudService, credentialS
 func (s *stateShim) AddSpace(
 	name string, providerId network.Id, subnetIds []string, public bool,
 ) (networkingcommon.BackingSpace, error) {
-	result, err := s.State.AddSpace(name, providerId, subnetIds, public)
+	result, err := s.State.AddSpace(name, providerId, subnetIds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -116,7 +116,7 @@ func (api *API) createOneSpace(args params.CreateSpaceParams) error {
 	}
 
 	// Add the validated space.
-	_, err = api.backing.AddSpace(spaceTag.Id(), network.Id(args.ProviderId), subnetIDs, args.Public)
+	_, err = api.backing.AddSpace(spaceTag.Id(), network.Id(args.ProviderId), subnetIDs)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -724,13 +724,11 @@ type checkAddSpacesParams struct {
 	Subnets    []string
 	Error      string
 	MakesCall  bool
-	Public     bool
 	ProviderId string
 }
 
 func (s *LegacySuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 	arg := params.CreateSpaceParams{
-		Public:     p.Public,
 		ProviderId: p.ProviderId,
 	}
 	if p.Name != "" {
@@ -783,7 +781,7 @@ func (s *LegacySuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 	// Only add the call to AddSpace() if there are no errors
 	// which have continued to this point.
 	if p.Error == "" {
-		allCalls = append(allCalls, jtesting.StubCall{FuncName: "AddSpace", Args: []any{p.Name, network.Id(p.ProviderId), subnetIDs, p.Public}})
+		allCalls = append(allCalls, jtesting.StubCall{FuncName: "AddSpace", Args: []any{p.Name, network.Id(p.ProviderId), subnetIDs}})
 	}
 	if len(allCalls) == 0 {
 		return
@@ -842,15 +840,6 @@ func (s *LegacySuite) TestAddSpacesCreateInvalidCIDR(c *gc.C) {
 		Name:    "foo",
 		Subnets: []string{"bar"},
 		Error:   `"bar" is not a valid CIDR`,
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *LegacySuite) TestAddSpacesPublic(c *gc.C) {
-	p := checkAddSpacesParams{
-		Name:    "foo",
-		Subnets: []string{"10.10.0.0/24"},
-		Public:  true,
 	}
 	s.checkAddSpaces(c, p)
 }

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -287,7 +287,7 @@ func (s *firewallerSuite) TestWatchSubnets(c *gc.C) {
 
 	// Set up a spaces with two subnets
 	st := s.ControllerModel(c).State()
-	sp, err := st.AddSpace("outer-space", network.Id("outer-1"), nil, true)
+	sp, err := st.AddSpace("outer-space", network.Id("outer-1"), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = st.AddSubnet(network.SubnetInfo{

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -343,7 +343,6 @@ func (s *FirewallerSuite) TestAllSpaceInfos(c *gc.C) {
 						FanLocalUnderlay: "192.168.0.0/16",
 						FanOverlay:       "1.0.0.0/8",
 					},
-					IsPublic: true,
 				},
 			}},
 		{ID: "99", Name: "special", Subnets: []network.SubnetInfo{

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -143,7 +143,6 @@ type FakeSpace struct {
 	SpaceId   string
 	SpaceName string
 	SubnetIds []string
-	Public    bool
 	NextErr   errReturner
 }
 
@@ -570,12 +569,12 @@ func (sb *StubBacking) AddSubnet(subnetInfo networkingcommon.BackingSubnetInfo) 
 	return fs, nil
 }
 
-func (sb *StubBacking) AddSpace(name string, providerId network.Id, subnets []string, public bool) (networkingcommon.BackingSpace, error) {
-	sb.MethodCall(sb, "AddSpace", name, providerId, subnets, public)
+func (sb *StubBacking) AddSpace(name string, providerId network.Id, subnets []string) (networkingcommon.BackingSpace, error) {
+	sb.MethodCall(sb, "AddSpace", name, providerId, subnets)
 	if err := sb.NextErr(); err != nil {
 		return nil, err
 	}
-	fs := &FakeSpace{SpaceName: name, SubnetIds: subnets, Public: public}
+	fs := &FakeSpace{SpaceName: name, SubnetIds: subnets}
 	sb.Spaces = append(sb.Spaces, fs)
 	return fs, nil
 }

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -279,9 +279,6 @@ type SubnetInfo struct {
 	// It may be empty if this is not a fan subnet,
 	// or if this subnet information comes from a provider.
 	FanInfo *network.FanCIDRs `json:"fan-info,omitempty" yaml:"fan-info,omitempty"`
-
-	// IsPublic describes whether a subnet is public or not.
-	IsPublic bool `json:"is-public,omitempty" yaml:"is-public,omitempty"`
 }
 
 // SpaceInfo defines a network space.

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -82,9 +82,6 @@ type SubnetInfo struct {
 	// or if this subnet information comes from a provider.
 	FanInfo *FanCIDRs
 
-	// IsPublic describes whether a subnet is public or not.
-	IsPublic bool
-
 	// Life represents the current life-cycle status of the subnets.
 	Life life.Value
 }

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -85,10 +85,9 @@ func subnetSchema() schema.Patch {
 -- |*uuid              text|                 |*uuid                text|
 -- |cidr               text|1               1|name                 text|
 -- |vlan_tag            int+-----------------+is_usable         boolean|
--- |is_public       boolean|                 |is_space_settable boolean|
--- |space_uuid         text|                 +------------+------------+
--- |subnet_type_uuid   text|                              |1
--- +---------+-------------+                              |
+-- |space_uuid         text|                 |is_space_settable boolean|
+-- |subnet_type_uuid   text|                 +------------+------------+
+-- +---------+-------------+                              |1
 --           |1                                           |
 --           |                                            |
 --           |                                            |
@@ -114,7 +113,6 @@ CREATE TABLE subnet (
     uuid                         TEXT PRIMARY KEY,
     cidr                         TEXT NOT NULL,
     vlan_tag                     INT,
-    is_public                    BOOLEAN,
     space_uuid                   TEXT,
     subnet_type_id               INT,
     CONSTRAINT                   fk_subnets_spaces

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -58,8 +58,7 @@ func spaceSchema() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE space (
     uuid            TEXT PRIMARY KEY,
-    name            TEXT NOT NULL,
-    is_public       BOOLEAN
+    name            TEXT NOT NULL
 );
 
 CREATE UNIQUE INDEX idx_spaces_uuid_name

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -423,21 +423,6 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllocateContainerAddresses), arg0, arg1, arg2, arg3)
 }
 
-// AreSpacesRoutable mocks base method.
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 envcontext.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AreSpacesRoutable indicates an expected call of AreSpacesRoutable.
-func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreSpacesRoutable", reflect.TypeOf((*MockNetworkingEnviron)(nil).AreSpacesRoutable), arg0, arg1, arg2)
-}
-
 // Bootstrap mocks base method.
 func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 envcontext.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -78,10 +78,6 @@ type Networking interface {
 	// the passed-in space info in the ProviderSpaceInfo returned.
 	ProviderSpaceInfo(ctx envcontext.ProviderCallContext, space *network.SpaceInfo) (*ProviderSpaceInfo, error)
 
-	// AreSpacesRoutable returns whether the communication between the
-	// two spaces can use cloud-local addresses.
-	AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *ProviderSpaceInfo) (bool, error)
-
 	// SupportsContainerAddresses returns true if the current environment is
 	// able to allocate addresses for containers. If returning false, we also
 	// return an IsNotSupported error.

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -269,21 +269,6 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllocateContainerAddresses), arg0, arg1, arg2, arg3)
 }
 
-// AreSpacesRoutable mocks base method.
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 envcontext.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AreSpacesRoutable indicates an expected call of AreSpacesRoutable.
-func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreSpacesRoutable", reflect.TypeOf((*MockNetworkingEnviron)(nil).AreSpacesRoutable), arg0, arg1, arg2)
-}
-
 // Bootstrap mocks base method.
 func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 envcontext.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()

--- a/environs/space/spaces.go
+++ b/environs/space/spaces.go
@@ -26,7 +26,7 @@ type ReloadSpacesState interface {
 	// AllSpaces returns all spaces for the model.
 	AllSpaces() ([]network.SpaceInfo, error)
 	// AddSpace creates and returns a new space.
-	AddSpace(string, network.Id, []string, bool) (network.SpaceInfo, error)
+	AddSpace(string, network.Id, []string) (network.SpaceInfo, error)
 	// SaveProviderSubnets loads subnets into state.
 	SaveProviderSubnets([]network.SubnetInfo, string) error
 	// ConstraintsBySpaceName returns all Constraints that include a positive
@@ -132,7 +132,7 @@ func (s *ProviderSpaces) SaveSpaces(providerSpaces []network.SpaceInfo) error {
 			spaceName := network.ConvertSpaceName(string(spaceInfo.Name), spaceNames)
 
 			logger.Debugf("Adding space %s from provider %s", spaceName, string(spaceInfo.ProviderId))
-			space, err := s.state.AddSpace(spaceName, spaceInfo.ProviderId, []string{}, false)
+			space, err := s.state.AddSpace(spaceName, spaceInfo.ProviderId, []string{})
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/environs/space/spaces_mock_test.go
+++ b/environs/space/spaces_mock_test.go
@@ -36,18 +36,18 @@ func (m *MockReloadSpacesState) EXPECT() *MockReloadSpacesStateMockRecorder {
 }
 
 // AddSpace mocks base method.
-func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (network.SpaceInfo, error) {
+func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string) (network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2)
 	ret0, _ := ret[0].(network.SpaceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddSpace indicates an expected call of AddSpace.
-func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2)
 }
 
 // AllEndpointBindingsSpaceNames mocks base method.

--- a/environs/space/spaces_test.go
+++ b/environs/space/spaces_test.go
@@ -130,7 +130,7 @@ func (s *providerSpacesSuite) TestSaveSpacesWithoutProviderId(c *gc.C) {
 		ID:         "2",
 		ProviderId: network.Id("2"),
 	}
-	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}, false).Return(addedSpace, nil)
+	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}).Return(addedSpace, nil)
 
 	mockState.EXPECT().SaveProviderSubnets([]network.SubnetInfo{{CIDR: "10.0.0.1/12"}}, "2")
 
@@ -174,7 +174,7 @@ func (s *providerSpacesSuite) TestSaveSpacesDeltaSpacesAfterNotUpdated(c *gc.C) 
 		ID:         "2",
 		ProviderId: network.Id("2"),
 	}
-	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}, false).Return(addedSpace, nil)
+	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}).Return(addedSpace, nil)
 
 	mockState.EXPECT().SaveProviderSubnets([]network.SubnetInfo{{CIDR: "10.0.0.1/12"}}, "2")
 
@@ -334,7 +334,7 @@ func (s *providerSpacesSuite) TestProviderSpacesRun(c *gc.C) {
 		ID:         "2",
 		ProviderId: network.Id("2"),
 	}
-	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}, false).Return(addedSpace, nil)
+	mockState.EXPECT().AddSpace("empty", network.Id("2"), []string{}).Return(addedSpace, nil)
 	mockState.EXPECT().Remove("1").Return(nil)
 
 	mockState.EXPECT().SaveProviderSubnets([]network.SubnetInfo{{CIDR: "10.0.0.1/12"}}, "2")

--- a/environs/space/state.go
+++ b/environs/space/state.go
@@ -37,7 +37,7 @@ func (s *spaceStateShim) AllSpaces() ([]network.SpaceInfo, error) {
 }
 
 func (s *spaceStateShim) AddSpace(name string, providerID network.Id, subnetIds []string, public bool) (network.SpaceInfo, error) {
-	result, err := s.State.AddSpace(name, providerID, subnetIds, public)
+	result, err := s.State.AddSpace(name, providerID, subnetIds)
 	if err != nil {
 		return network.SpaceInfo{}, errors.Trace(err)
 	}

--- a/environs/space/state.go
+++ b/environs/space/state.go
@@ -36,7 +36,7 @@ func (s *spaceStateShim) AllSpaces() ([]network.SpaceInfo, error) {
 	return results, nil
 }
 
-func (s *spaceStateShim) AddSpace(name string, providerID network.Id, subnetIds []string, public bool) (network.SpaceInfo, error) {
+func (s *spaceStateShim) AddSpace(name string, providerID network.Id, subnetIds []string) (network.SpaceInfo, error) {
 	result, err := s.State.AddSpace(name, providerID, subnetIds)
 	if err != nil {
 		return network.SpaceInfo{}, errors.Trace(err)

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1535,21 +1535,6 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllocateContainerAddresses), arg0, arg1, arg2, arg3)
 }
 
-// AreSpacesRoutable mocks base method.
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 envcontext.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AreSpacesRoutable indicates an expected call of AreSpacesRoutable.
-func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreSpacesRoutable", reflect.TypeOf((*MockNetworkingEnviron)(nil).AreSpacesRoutable), arg0, arg1, arg2)
-}
-
 // Bootstrap mocks base method.
 func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 envcontext.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -163,11 +163,6 @@ func (env *azureEnviron) ReleaseContainerAddresses(envcontext.ProviderCallContex
 	return errors.NotSupportedf("container addresses")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*azureEnviron) AreSpacesRoutable(_ envcontext.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron. It returns back
 // a slice where the i_th element contains the list of network interfaces
 // for the i_th provided instance ID.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1117,11 +1117,6 @@ func (*environ) ProviderSpaceInfo(envcontext.ProviderCallContext, *network.Space
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// AreSpacesRoutable implements NetworkingEnviron.
-func (*environ) AreSpacesRoutable(_ envcontext.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
 func (*environ) MaybeWriteLXDProfile(string, lxdprofile.Profile) error {
 	return nil

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2715,11 +2715,6 @@ func (e *environ) hasDefaultVPC(ctx envcontext.ProviderCallContext) (bool, error
 	return e.defaultVPC != nil, nil
 }
 
-// AreSpacesRoutable implements NetworkingEnviron.
-func (*environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SuperSubnets implements NetworkingEnviron.SuperSubnets
 func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
 	vpcId := e.ecfg().vpcID()

--- a/provider/equinix/environ_network.go
+++ b/provider/equinix/environ_network.go
@@ -232,12 +232,6 @@ func (e *environ) AllocateContainerAddresses(envcontext.ProviderCallContext, ins
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
-// AreSpacesRoutable returns whether the communication between the
-// two spaces can use cloud-local addaddresses.
-func (*environ) AreSpacesRoutable(envcontext.ProviderCallContext, *environs.ProviderSpaceInfo, *environs.ProviderSpaceInfo) (bool, error) {
-	return false, errors.NotSupportedf("spaces")
-}
-
 // ProviderSpaceInfo returns the details of the space requested as
 // a ProviderSpaceInfo.
 func (*environ) ProviderSpaceInfo(envcontext.ProviderCallContext, *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -340,11 +340,6 @@ func (e *environ) ReleaseContainerAddresses(envcontext.ProviderCallContext, []co
 	return errors.NotSupportedf("container addresses")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
 	subnets, err := e.Subnets(ctx, "", nil)

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -418,12 +418,6 @@ func (e *environ) SupportsSpaces(envcontext.ProviderCallContext) (bool, error) {
 	return e.server().HasExtension("network"), nil
 }
 
-// AreSpacesRoutable returns whether the communication between the
-// two spaces can use cloud-local addresses.
-func (*environ) AreSpacesRoutable(envcontext.ProviderCallContext, *environs.ProviderSpaceInfo, *environs.ProviderSpaceInfo) (bool, error) {
-	return false, errors.NotSupportedf("spaces")
-}
-
 // SupportsContainerAddresses returns true if the current environment is
 // able to allocate addresses for containers.
 func (*environ) SupportsContainerAddresses(envcontext.ProviderCallContext) (bool, error) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1422,11 +1422,6 @@ func (*maasEnviron) ProviderSpaceInfo(
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*maasEnviron) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (*maasEnviron) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotSupportedf("super subnets")

--- a/provider/manual/environ_network.go
+++ b/provider/manual/environ_network.go
@@ -47,11 +47,6 @@ func (e *manualEnviron) ReleaseContainerAddresses(envcontext.ProviderCallContext
 	return errors.NotSupportedf("container addresses")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*manualEnviron) AreSpacesRoutable(_ envcontext.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron.
 func (e *manualEnviron) NetworkInterfaces(
 	envcontext.ProviderCallContext, []instance.Id,

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/environs"
 	envcontext "github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/tags"
 	providerCommon "github.com/juju/juju/provider/oci/common"
@@ -1087,10 +1086,6 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 
 func (e *Environ) SupportsSpaces(envcontext.ProviderCallContext) (bool, error) {
 	return false, nil
-}
-
-func (e *Environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, errors.NotImplementedf("AreSpacesRoutable")
 }
 
 func (e *Environ) SupportsContainerAddresses(ctx envcontext.ProviderCallContext) (bool, error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2439,11 +2439,6 @@ func (e *Environ) ReleaseContainerAddresses(ctx envcontext.ProviderCallContext, 
 	return errors.NotSupportedf("release container address")
 }
 
-// AreSpacesRoutable is specified on environs.NetworkingEnviron.
-func (*Environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SupportsRulesWithIPV6CIDRs returns true if the environment supports ingress
 // rules containing IPV6 CIDRs. It is part of the FirewallFeatureQuerier
 // interface.

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -1299,9 +1299,8 @@ func FromNetworkSpaceInfos(allInfos network.SpaceInfos) SpaceInfos {
 			}
 
 			mappedSubnets[j] = SubnetV3{
-				SpaceID:  subnetInfo.SpaceID,
-				FanInfo:  mappedFanInfo,
-				IsPublic: subnetInfo.IsPublic,
+				SpaceID: subnetInfo.SpaceID,
+				FanInfo: mappedFanInfo,
 
 				SubnetV2: SubnetV2{
 					ID: string(subnetInfo.ID),
@@ -1348,7 +1347,6 @@ func ToNetworkSpaceInfos(allInfos SpaceInfos) network.SpaceInfos {
 				VLANTag:           subnetInfo.VLANTag,
 				AvailabilityZones: subnetInfo.Zones,
 				SpaceID:           subnetInfo.SpaceID,
-				IsPublic:          subnetInfo.IsPublic,
 				SpaceName:         si.Name,
 			}
 

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -210,7 +210,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
-	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
+	sp, err := s.State.AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := testing.FakeControllerConfig()
@@ -336,7 +336,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
-	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
+	sp, err := s.State.AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := s.State.WatchAPIHostPortsForAgents()

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -137,7 +137,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a space and an address on the space.
-	space, err := st.AddSpace("test-space", "provider-space", nil, true)
+	space, err := st.AddSpace("test-space", "provider-space", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	providerAddr := network.NewSpaceAddress("example.com")
 	providerAddr.SpaceID = space.Id()

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -407,7 +407,7 @@ func (s *ApplicationSuite) TestMergeBindingsWithForce(c *gc.C) {
 
 	sn, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.99.99.0/24"})
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.AddSpace("far", "", []string{sn.ID()}, false)
+	_, err = s.State.AddSpace("far", "", []string{sn.ID()})
 	c.Assert(err, gc.IsNil)
 
 	expBindings := map[string]string{
@@ -474,7 +474,7 @@ func (s *ApplicationSuite) assignUnitOnMachineWithSpaceToApplication(c *gc.C, a 
 	sn1, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.254.0/24"})
 	c.Assert(err, gc.IsNil)
 
-	sp, err := s.State.AddSpace(spaceName, "", []string{sn1.ID()}, false)
+	sp, err := s.State.AddSpace(spaceName, "", []string{sn1.ID()})
 	c.Assert(err, gc.IsNil)
 
 	m1, err := s.State.AddOneMachine(state.MachineTemplate{
@@ -630,9 +630,9 @@ func (s *ApplicationSuite) TestSetCharmPreconditions(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
-	dbSpace, err := s.State.AddSpace("db", "", nil, false)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	clientSpace, err := s.State.AddSpace("client", "", nil, true)
+	clientSpace, err := s.State.AddSpace("client", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	oldCharm := s.AddMetaCharm(c, "mysql", metaBase, 44)
 
@@ -1405,9 +1405,9 @@ func (s *ApplicationSuite) TestSetCharmRetriesWhenOldBindingsChanged(c *gc.C) {
 		"kludge":  network.AlphaSpaceId,
 		"cluster": network.AlphaSpaceId,
 	})
-	dbSpace, err := s.State.AddSpace("db", "", nil, true)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	adminSpace, err := s.State.AddSpace("admin", "", nil, false)
+	adminSpace, err := s.State.AddSpace("admin", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	updateBindings := func(updatesMap bson.M) {
@@ -4265,9 +4265,9 @@ func (s *ApplicationSuite) TestEndpointBindingsJustDefaults(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestEndpointBindingsWithExplictOverrides(c *gc.C) {
-	dbSpace, err := s.State.AddSpace("db", "", nil, true)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	haSpace, err := s.State.AddSpace("ha", "", nil, false)
+	haSpace, err := s.State.AddSpace("ha", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	bindings := map[string]string{
@@ -4290,7 +4290,7 @@ func (s *ApplicationSuite) TestEndpointBindingsWithExplictOverrides(c *gc.C) {
 }
 
 func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
-	dbSpace, err := s.State.AddSpace("db", "", nil, true)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	oldCharm := s.AddMetaCharm(c, "mysql", metaDifferentProvider, 42)

--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -94,13 +94,13 @@ peers:
 	// it should be always allowed.
 
 	var err error
-	s.clientSpace, err = s.State.AddSpace("client", "", nil, true)
+	s.clientSpace, err = s.State.AddSpace("client", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.appsSpace, err = s.State.AddSpace("apps", "", nil, true)
+	s.appsSpace, err = s.State.AddSpace("apps", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.dbSpace, err = s.State.AddSpace("db", "", nil, true)
+	s.dbSpace, err = s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.barbSpace, err = s.State.AddSpace("barb3", "", nil, true)
+	s.barbSpace, err = s.State.AddSpace("barb3", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -360,7 +360,7 @@ func resetSubnet(c *gc.C, st *state.State, subnetInfo network.SubnetInfo) {
 
 func (s *ipAddressesStateSuite) TestAllSpacesOneSpace(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
-	space, err := s.State.AddSpace("default", "default", nil, true)
+	space, err := s.State.AddSpace("default", "default", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, network.SubnetInfo{
 		CIDR:    "10.20.0.0/16",
@@ -379,14 +379,14 @@ func (s *ipAddressesStateSuite) TestAllSpacesOneSpace(c *gc.C) {
 
 func (s *ipAddressesStateSuite) TestAllSpacesMultiSpace(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
-	space1, err := s.State.AddSpace("default", "default", nil, true)
+	space1, err := s.State.AddSpace("default", "default", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, network.SubnetInfo{
 		CIDR:    "10.20.0.0/16",
 		SpaceID: space1.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	space2, err := s.State.AddSpace("dmz-ipv6", "not-default", nil, true)
+	space2, err := s.State.AddSpace("dmz-ipv6", "not-default", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, network.SubnetInfo{
 		CIDR:    "fc00::/64",

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -763,7 +763,7 @@ func (s *linkLayerDevicesStateSuite) TestAddDeviceOpsWithAddresses(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
-	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
+	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	spaceInfo, err := space.NetworkSpace()
 	c.Assert(err, gc.IsNil)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1481,7 +1481,6 @@ func (e *exporter) spaces() error {
 		e.model.AddSpace(description.SpaceArgs{
 			Id:         space.Id(),
 			Name:       space.Name(),
-			Public:     space.IsPublic(),
 			ProviderID: string(space.ProviderId()),
 		})
 	}
@@ -1532,7 +1531,6 @@ func (e *exporter) subnets() error {
 			AvailabilityZones: subnet.AvailabilityZones(),
 			FanLocalUnderlay:  subnet.FanLocalUnderlay(),
 			FanOverlay:        subnet.FanOverlay(),
-			IsPublic:          subnet.IsPublic(),
 		}
 		e.model.AddSubnet(args)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1228,7 +1228,6 @@ func (s *MigrationExportSuite) TestSpaces(c *gc.C) {
 	c.Assert(space.Id(), gc.Not(gc.Equals), "")
 	c.Assert(space.Name(), gc.Equals, "one")
 	c.Assert(space.ProviderID(), gc.Equals, "provider")
-	c.Assert(space.Public(), jc.IsTrue)
 }
 
 func (s *MigrationExportSuite) TestMultipleSpaces(c *gc.C) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -663,7 +663,7 @@ func (s *MigrationExportSuite) TestMultipleApplications(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestApplicationExposeParameters(c *gc.C) {
-	serverSpace, err := s.State.AddSpace("server", "", nil, true)
+	serverSpace, err := s.State.AddSpace("server", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	app := s.AddTestingApplicationWithBindings(c, "mysql",
@@ -697,9 +697,9 @@ func (s *MigrationExportSuite) TestApplicationExposeParameters(c *gc.C) {
 func (s *MigrationExportSuite) TestApplicationExposingOffers(c *gc.C) {
 	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "admin"})
 	fooUser := s.Factory.MakeUser(c, &factory.UserParams{Name: "foo"})
-	serverSpace, err := s.State.AddSpace("server", "", nil, true)
+	serverSpace, err := s.State.AddSpace("server", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	adminSpace, err := s.State.AddSpace("server-admin", "", nil, true)
+	adminSpace, err := s.State.AddSpace("server-admin", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	app := s.AddTestingApplicationWithBindings(c, "mysql",
@@ -1008,7 +1008,7 @@ func (s *MigrationExportSuite) TestUnitOpenPortRanges(c *gc.C) {
 
 func (s *MigrationExportSuite) TestEndpointBindings(c *gc.C) {
 	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: network.Id("provider")})
 	state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": oneSpace.Id()})
@@ -1215,7 +1215,7 @@ func (s *MigrationExportSuite) TestSubordinateRelations(c *gc.C) {
 
 func (s *MigrationExportSuite) TestSpaces(c *gc.C) {
 	s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: network.Id("provider")})
 
 	model, err := s.State.Export(map[string]string{}, state.NewObjectStore(c, s.State))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1423,7 +1423,7 @@ func (s *MigrationBaseSuite) TestMissingRelationScopeIgnored(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
-	sp, err := s.State.AddSpace("bam", "", nil, true)
+	sp, err := s.State.AddSpace("bam", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	sn := network.SubnetInfo{
 		CIDR:              "10.0.0.0/24",
@@ -1432,7 +1432,6 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		AvailabilityZones: []string{"bar"},
 		SpaceID:           sp.Id(),
-		IsPublic:          true,
 	}
 	sn.SetFan("100.2.0.0/16", "253.0.0.0/8")
 
@@ -1454,14 +1453,13 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.SpaceID(), gc.Equals, sp.Id())
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
-	c.Assert(subnet.IsPublic(), gc.Equals, sn.IsPublic)
 }
 
 func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
-	space, err := s.State.AddSpace("testme", "", nil, true)
+	space, err := s.State.AddSpace("testme", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceID: space.Id()})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1816,14 +1816,14 @@ func (i *importer) spaces() error {
 		}
 
 		if s.Id() == "" {
-			if _, err := i.st.AddSpace(s.Name(), network.Id(s.ProviderID()), nil, s.Public()); err != nil {
+			if _, err := i.st.AddSpace(s.Name(), network.Id(s.ProviderID()), nil); err != nil {
 				i.logger.Errorf("error importing space %s: %s", s.Name(), err)
 				return errors.Annotate(err, s.Name())
 			}
 			continue
 		}
 
-		ops := i.st.addSpaceTxnOps(s.Id(), s.Name(), network.Id(s.ProviderID()), s.Public())
+		ops := i.st.addSpaceTxnOps(s.Id(), s.Name(), network.Id(s.ProviderID()))
 		if err := i.st.db().RunTransaction(ops); err != nil {
 			i.logger.Errorf("error importing space %s: %s", s.Name(), err)
 			return errors.Annotate(err, s.Name())
@@ -1891,7 +1891,6 @@ func (i *importer) subnets() error {
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
 			AvailabilityZones: subnet.AvailabilityZones(),
-			IsPublic:          subnet.IsPublic(),
 			SpaceID:           subnet.SpaceID(),
 
 			// SpaceName will only be present when migrating from pre-2.7

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -524,7 +524,7 @@ func (s *MigrationImportSuite) setupSourceApplications(
 	// Add a application with charm settings, app config, and leadership settings.
 	f := factory.NewFactory(st, s.StatePool)
 
-	serverSpace, err := s.State.AddSpace("server", "", nil, true)
+	serverSpace, err := s.State.AddSpace("server", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	exposedSpaceIDs := []string{serverSpace.Id()}
 
@@ -918,7 +918,7 @@ func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {
 func (s *MigrationImportSuite) TestApplicationsWithExposedOffers(c *gc.C) {
 	_ = s.Factory.MakeUser(c, &factory.UserParams{Name: "admin"})
 	fooUser := s.Factory.MakeUser(c, &factory.UserParams{Name: "foo"})
-	serverSpace, err := s.State.AddSpace("server", "", nil, true)
+	serverSpace, err := s.State.AddSpace("server", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
@@ -1493,7 +1493,7 @@ func (s *MigrationImportSuite) TestRelationsMissingStatusNoUnits(c *gc.C) {
 func (s *MigrationImportSuite) TestEndpointBindings(c *gc.C) {
 	// Endpoint bindings need both valid charms, applications, and spaces.
 	space := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: "provider", IsPublic: true})
+		Name: "one", ProviderID: "provider"})
 	state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": space.Id()})
@@ -1515,7 +1515,7 @@ func (s *MigrationImportSuite) TestIncompleteEndpointBindings(c *gc.C) {
 	// Ensure we handle the case coming from an early 2.7 controller
 	// where the default binding is missing.
 	space := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: "provider", IsPublic: true})
+		Name: "one", ProviderID: "provider"})
 	state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": space.Id()})
@@ -1588,10 +1588,10 @@ func (s *MigrationImportSuite) TestUnitsOpenPorts(c *gc.C) {
 
 func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 	space := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: network.Id("provider")})
 
 	spaceNoID := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "no-id", ProviderID: network.Id("provider2"), IsPublic: true})
+		Name: "no-id", ProviderID: network.Id("provider2")})
 
 	// Blank the ID from the second space to check that import creates it.
 	_, newSt := s.importModel(c, s.State, func(desc map[string]interface{}) {
@@ -1610,7 +1610,6 @@ func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 	c.Check(imported.Id(), gc.Equals, space.Id())
 	c.Check(imported.Name(), gc.Equals, space.Name())
 	c.Check(imported.ProviderId(), gc.Equals, space.ProviderId())
-	c.Check(imported.IsPublic(), gc.Equals, space.IsPublic())
 
 	imported, err = newSt.SpaceByName(spaceNoID.Name())
 	c.Assert(err, jc.ErrorIsNil)
@@ -1748,7 +1747,7 @@ func (s *MigrationImportSuite) TestLinkLayerDeviceMigratesReferences(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
-	sp, err := s.State.AddSpace("bam", "", nil, true)
+	sp, err := s.State.AddSpace("bam", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	original, err := s.State.AddSubnet(network.SubnetInfo{
 		CIDR:              "10.0.0.0/24",
@@ -1757,7 +1756,6 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		SpaceID:           sp.Id(),
 		AvailabilityZones: []string{"bar"},
-		IsPublic:          true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	originalNoID, err := s.State.AddSubnet(network.SubnetInfo{
@@ -1798,7 +1796,6 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.SpaceID(), gc.Equals, sp.Id())
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "")
-	c.Assert(subnet.IsPublic(), gc.Equals, true)
 
 	imported, err := newSt.SubnetByCIDR(originalNoID.CIDR())
 	c.Assert(err, jc.ErrorIsNil)
@@ -1810,7 +1807,7 @@ func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
 		CIDR: "100.2.0.0/16",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	sp, err := s.State.AddSpace("bam", "", []string{subnet.ID()}, true)
+	sp, err := s.State.AddSpace("bam", "", []string{subnet.ID()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sn := network.SubnetInfo{
@@ -1844,7 +1841,7 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
-	space, err := s.State.AddSpace("testme", "", nil, true)
+	space, err := s.State.AddSpace("testme", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceID: space.Id()})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -605,7 +605,6 @@ func (s *MigrationSuite) TestSpaceDocFields(c *gc.C) {
 	migrated := set.NewStrings(
 		"Id",
 		"Name",
-		"IsPublic",
 		"ProviderId",
 	)
 	s.AssertExportedFields(c, spaceDoc{}, migrated.Union(ignored))
@@ -662,7 +661,6 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 		"ProviderNetworkId",
 		"FanLocalUnderlay",
 		"FanOverlay",
-		"IsPublic",
 	)
 	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
 }

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -568,7 +568,7 @@ func (s *ModelSuite) TestMetrics(c *gc.C) {
 
 func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: network.Id("provider")})
 	app := state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": oneSpace.Id()})
@@ -596,7 +596,7 @@ func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 
 func (s *ModelSuite) TestAllEndpointBindingsSpaceNames(c *gc.C) {
 	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: network.Id("provider")})
 	state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": oneSpace.Id()})

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -59,7 +59,6 @@ type addSpaceArgs struct {
 	Name        string
 	ProviderId  network.Id
 	SubnetCIDRs []string
-	IsPublic    bool
 	ForState    *state.State
 }
 
@@ -68,7 +67,7 @@ func (s *SpacesSuite) addSpaceWithSubnets(c *gc.C, args addSpaceArgs) (*state.Sp
 		args.ForState = s.State
 	}
 	subnetIDs := s.addSubnetsForState(c, args.SubnetCIDRs, args.ForState)
-	return args.ForState.AddSpace(args.Name, args.ProviderId, subnetIDs, args.IsPublic)
+	return args.ForState.AddSpace(args.Name, args.ProviderId, subnetIDs)
 }
 
 func (s *SpacesSuite) assertSpaceNotFound(c *gc.C, name string) {
@@ -96,7 +95,6 @@ func (s *SpacesSuite) assertSpaceMatchesArgs(c *gc.C, space *state.Space, args a
 		actualSubnetIds[i] = subnet.CIDR
 	}
 	c.Assert(actualSubnetIds, jc.SameContents, args.SubnetCIDRs)
-	c.Assert(state.SpaceDoc(space).IsPublic, gc.Equals, args.IsPublic)
 
 	c.Assert(space.String(), gc.Equals, args.Name)
 
@@ -390,9 +388,8 @@ func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndProviderIdsSuccedsInDiffer
 func (s *SpacesSuite) TestAddSpaceWhenSubnetNotFound(c *gc.C) {
 	name := "my-space"
 	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
 
-	_, err := s.State.AddSpace(name, "", subnets, isPublic)
+	_, err := s.State.AddSpace(name, "", subnets)
 	c.Assert(err, gc.ErrorMatches, `adding space "my-space": subnet "1.1.1.0/24" not found`)
 	s.assertSpaceNotFound(c, name)
 }
@@ -453,14 +450,13 @@ func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 	c.Assert(spaces, jc.DeepEquals, []*state.Space{alphaSpace})
 
 	subnets := []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24"}
-	isPublic := false
 	subnetIDs := s.addSubnets(c, subnets)
 
-	first, err := s.State.AddSpace("first", "", []string{subnetIDs[0]}, isPublic)
+	first, err := s.State.AddSpace("first", "", []string{subnetIDs[0]})
 	c.Assert(err, jc.ErrorIsNil)
-	second, err := s.State.AddSpace("second", "", []string{subnetIDs[1]}, isPublic)
+	second, err := s.State.AddSpace("second", "", []string{subnetIDs[1]})
 	c.Assert(err, jc.ErrorIsNil)
-	third, err := s.State.AddSpace("third", "", []string{subnetIDs[2]}, isPublic)
+	third, err := s.State.AddSpace("third", "", []string{subnetIDs[2]})
 	c.Assert(err, jc.ErrorIsNil)
 
 	actual, err := s.State.AllSpaces()
@@ -486,7 +482,7 @@ func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenAlive(c *gc.C) {
 }
 
 func (s *SpacesSuite) addAliveSpace(c *gc.C, name string) *state.Space {
-	space, err := s.State.AddSpace(name, "", nil, false)
+	space, err := s.State.AddSpace(name, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return space
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2167,9 +2167,9 @@ func (s *StateSuite) TestAddApplicationWithDefaultBindings(c *gc.C) {
 
 func (s *StateSuite) TestAddApplicationWithSpecifiedBindings(c *gc.C) {
 	// Add extra spaces to use in bindings.
-	dbSpace, err := s.State.AddSpace("db", "", nil, false)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	clientSpace, err := s.State.AddSpace("client", "", nil, true)
+	clientSpace, err := s.State.AddSpace("client", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Specify some bindings, but not all when adding the application.
@@ -2203,9 +2203,9 @@ func (s *StateSuite) TestAddApplicationWithSpecifiedBindings(c *gc.C) {
 func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	charm := s.AddMetaCharm(c, "mysql", metaBase, 44)
 	// Add extra spaces to use in bindings.
-	dbSpace, err := s.State.AddSpace("db", "", nil, false)
+	dbSpace, err := s.State.AddSpace("db", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	clientSpace, err := s.State.AddSpace("client", "", nil, true)
+	clientSpace, err := s.State.AddSpace("client", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, test := range []struct {
@@ -4673,7 +4673,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 }
 
 func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
-	sp, err := s.State.AddSpace("mgmt01", "", nil, false)
+	sp, err := s.State.AddSpace("mgmt01", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := testing.FakeControllerConfig()

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -37,7 +37,6 @@ type subnetDoc struct {
 	CIDR              string   `bson:"cidr"`
 	VLANTag           int      `bson:"vlantag,omitempty"`
 	AvailabilityZones []string `bson:"availability-zones,omitempty"`
-	IsPublic          bool     `bson:"is-public,omitempty"`
 	SpaceID           string   `bson:"space-id,omitempty"`
 	FanLocalUnderlay  string   `bson:"fan-local-underlay,omitempty"`
 	FanOverlay        string   `bson:"fan-overlay,omitempty"`
@@ -69,11 +68,6 @@ func (s *Subnet) FanOverlay() string {
 
 func (s *Subnet) FanLocalUnderlay() string {
 	return s.doc.FanLocalUnderlay
-}
-
-// IsPublic returns true if the subnet is public.
-func (s *Subnet) IsPublic() bool {
-	return s.doc.IsPublic
 }
 
 // EnsureDead sets the Life of the subnet to Dead if it is Alive.
@@ -360,7 +354,6 @@ func (s *Subnet) networkSubnet() network.SubnetInfo {
 		VLANTag:           s.doc.VLANTag,
 		AvailabilityZones: s.doc.AvailabilityZones,
 		FanInfo:           fanInfo,
-		IsPublic:          s.doc.IsPublic,
 		SpaceID:           s.spaceID,
 		Life:              s.Life().Value(),
 		// SpaceName and ProviderSpaceID are populated by Space.NetworkSpace().
@@ -468,7 +461,6 @@ func (st *State) addSubnetOps(id string, args network.SubnetInfo) (subnetDoc, []
 		SpaceID:           args.SpaceID,
 		FanLocalUnderlay:  args.FanLocalUnderlay(),
 		FanOverlay:        args.FanOverlay(),
-		IsPublic:          args.IsPublic,
 	}
 	ops := []txn.Op{
 		{

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -24,7 +24,7 @@ type SubnetSuite struct {
 var _ = gc.Suite(&SubnetSuite{})
 
 func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
-	space, err := s.State.AddSpace("foo", "4", nil, true)
+	space, err := s.State.AddSpace("foo", "4", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	fanOverlaySubnetInfo := network.SubnetInfo{
@@ -41,7 +41,6 @@ func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 		VLANTag:           79,
 		AvailabilityZones: []string{"Timbuktu"},
 		ProviderNetworkId: "wildbirds",
-		IsPublic:          true,
 	}
 	subnetInfo.SetFan("10.0.0.0/8", "172.16.0.0/16")
 
@@ -75,7 +74,6 @@ func (s *SubnetSuite) assertSubnetMatchesInfo(c *gc.C, subnet *state.Subnet, inf
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, info.ProviderNetworkId)
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, info.FanLocalUnderlay())
 	c.Assert(subnet.FanOverlay(), gc.Equals, info.FanOverlay())
-	c.Assert(subnet.IsPublic(), gc.Equals, info.IsPublic)
 }
 
 func (s *SubnetSuite) TestAddSubnetFailsWithEmptyCIDR(c *gc.C) {
@@ -292,9 +290,9 @@ func (s *SubnetSuite) TestRefreshFailsWithNotFoundWhenRemoved(c *gc.C) {
 }
 
 func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
-	space1, err := s.State.AddSpace("bar", "4", nil, true)
+	space1, err := s.State.AddSpace("bar", "4", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	space2, err := s.State.AddSpace("notreally", "5", nil, true)
+	space2, err := s.State.AddSpace("notreally", "5", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetInfos := []network.SubnetInfo{
 		{CIDR: "192.168.1.0/24"},
@@ -332,7 +330,7 @@ func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
 }
 
 func (s *SubnetSuite) TestAllSubnetInfosPopulatesOverlaySpace(c *gc.C) {
-	space1, err := s.State.AddSpace("bar", "4", nil, true)
+	space1, err := s.State.AddSpace("bar", "4", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetInfos := []network.SubnetInfo{
@@ -361,11 +359,11 @@ func (s *SubnetSuite) TestUpdateMAASUndefinedSpace(c *gc.C) {
 	subnetInfo := network.SubnetInfo{CIDR: "8.8.8.0/24"}
 	subnet, err := s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSpace(names.NewSpaceTag("undefined").Id(), "-1", []string{subnet.ID()}, false)
+	_, err = s.State.AddSpace(names.NewSpaceTag("undefined").Id(), "-1", []string{subnet.ID()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetInfo.SpaceName = "testme"
-	_, err = s.State.AddSpace(names.NewSpaceTag(subnetInfo.SpaceName).Id(), "2", []string{}, false)
+	_, err = s.State.AddSpace(names.NewSpaceTag(subnetInfo.SpaceName).Id(), "2", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subnet.Update(subnetInfo)
@@ -384,7 +382,7 @@ func (s *SubnetSuite) TestUpdateEmpty(c *gc.C) {
 	subnetInfo.VLANTag = 76
 	subnetInfo.AvailabilityZones = []string{"testme-az"}
 	subnetInfo.SpaceName = "testme"
-	_, err = s.State.AddSpace(names.NewSpaceTag(subnetInfo.SpaceName).Id(), "2", []string{}, false)
+	_, err = s.State.AddSpace(names.NewSpaceTag(subnetInfo.SpaceName).Id(), "2", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subnet.Update(subnetInfo)
@@ -403,7 +401,7 @@ func (s *SubnetSuite) TestUpdateNonEmpty(c *gc.C) {
 	subnet, err := s.State.AddSubnet(expectedSubnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedSpace, err := s.State.AddSpace("changeme", "2", []string{subnet.ID()}, false)
+	expectedSpace, err := s.State.AddSpace("changeme", "2", []string{subnet.ID()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	newSubnetInfo := network.SubnetInfo{
@@ -412,7 +410,7 @@ func (s *SubnetSuite) TestUpdateNonEmpty(c *gc.C) {
 		VLANTag:           76,
 		AvailabilityZones: []string{"testme-az"},
 	}
-	_, err = s.State.AddSpace(names.NewSpaceTag(newSubnetInfo.SpaceName).Id(), "7", []string{}, false)
+	_, err = s.State.AddSpace(names.NewSpaceTag(newSubnetInfo.SpaceName).Id(), "7", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subnet.Update(newSubnetInfo)
@@ -453,7 +451,7 @@ func (s *SubnetSuite) TestUniqueAdditionAndRetrievalByCIDR(c *gc.C) {
 }
 
 func (s *SubnetSuite) TestUpdateSubnetSpaceOps(c *gc.C) {
-	space, err := s.State.AddSpace("space-0", "0", []string{}, false)
+	space, err := s.State.AddSpace("space-0", "0", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	arg := network.SubnetInfo{

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -113,7 +113,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementMakesContainerInNewMach
 }
 
 func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementNewMachinesHaveBindingsAsConstraints(c *gc.C) {
-	specialSpace, err := s.State.AddSpace("special-space", "", nil, false)
+	specialSpace, err := s.State.AddSpace("special-space", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	charm := s.AddTestingCharm(c, "dummy")
@@ -159,10 +159,10 @@ func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementNewMachinesHaveBindings
 }
 
 func (s *UnitAssignmentSuite) TestAssignUnitWithPlacementNewMachinesHaveBindingsAsConstraintsMerged(c *gc.C) {
-	boundSpace, err := s.State.AddSpace("bound-space", "", nil, false)
+	boundSpace, err := s.State.AddSpace("bound-space", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	constrainedSpace, err := s.State.AddSpace("constrained-space", "", nil, false)
+	constrainedSpace, err := s.State.AddSpace("constrained-space", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	charm := s.AddTestingCharm(c, "dummy")

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2869,9 +2869,9 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	sn2, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.254.0/24"})
 	c.Assert(err, gc.IsNil)
 
-	_, err = s.State.AddSpace("public", "", []string{sn1.ID()}, false)
+	_, err = s.State.AddSpace("public", "", []string{sn1.ID()})
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.AddSpace("private", "", []string{sn2.ID()}, false)
+	_, err = s.State.AddSpace("private", "", []string{sn2.ID()})
 	c.Assert(err, gc.IsNil)
 
 	// Create machine with 2 interfaces on the above spaces

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -156,7 +156,6 @@ type SpaceParams struct {
 	Name       string
 	ProviderID network.Id
 	SubnetIDs  []string
-	IsPublic   bool
 }
 
 // RandomSuffix adds a random 5 character suffix to the presented string.
@@ -871,7 +870,7 @@ func (factory *Factory) MakeSpace(c *gc.C, params *SpaceParams) *state.Space {
 	if params.Name == "" {
 		params.Name = uniqueString("space-")
 	}
-	space, err := factory.st.AddSpace(params.Name, params.ProviderID, params.SubnetIDs, params.IsPublic)
+	space, err := factory.st.AddSpace(params.Name, params.ProviderID, params.SubnetIDs)
 	c.Assert(err, jc.ErrorIsNil)
 	return space
 }


### PR DESCRIPTION
Patch to remove the unused isPublic field from both spaces and subnets. Most changes are mechanical changes and test fixes.

*Note: `IsPublic` has never been used. There was this stillborn notion of using spaces in cross-model relations. Providers have this method `AreSpacesRoutable`, which has also been removed in this patch.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Since these fields were unused, only unit tests are needed:

```
go test github.com/juju/juju/apiserver/facades/agent/provisioner/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/agent/uniter/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/application/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/client/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/highavailability/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/modelmanager/... -gocheck.v
go test github.com/juju/juju/apiserver/facades/client/spaces/... -gocheck.v

go test github.com/juju/juju/core/network/... -gocheck.v
go test github.com/juju/juju/state/... -gocheck.v
```


