### PR TITLE
Fix deploy charms to lxd container CI test

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -208,7 +208,7 @@ run_deploy_lxd_to_container() {
 	juju deploy "${charm}" --to lxd
 
 	juju deploy ./testcharms/charms/lxd-profile-subordinate
-	juju add-relation lxd-profile-subordinate lxd-profile-alt
+	juju integrate lxd-profile-subordinate lxd-profile-alt
 
 	wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 	wait_for "lxd-profile-subordinate" ".applications | keys[1]"


### PR DESCRIPTION
Small patch to fix a test still containing 'juju add-relation' instead of 'juju integrate', probably from a merge forward from 2.9.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
./main.sh -v -c aws deploy test_deploy_charms
```


## Links


**Jira card:** JUJU-5092

