### PR TITLE
Fix destruction of sidecar app when the statefulset is already removed.

### DIFF
--- a/caas/kubernetes/provider/scale/scale.go
+++ b/caas/kubernetes/provider/scale/scale.go
@@ -49,8 +49,7 @@ func DeploymentScalePatcher(deploy apps.DeploymentInterface) ScalePatcher {
 		deployment, err := deploy.Patch(c, n, p, d, o, s...)
 		if k8serrors.IsNotFound(err) {
 			return 0, errors.NotFoundf("deployment %q", n)
-		}
-		if err != nil {
+		} else if err != nil {
 			return 0, errors.Annotatef(err, "scale patching deployment %q", n)
 		}
 		return *deployment.Spec.Replicas, nil
@@ -96,9 +95,6 @@ func PatchReplicasToScale(
 		patch,
 		meta.PatchOptions{},
 	)
-	if k8serrors.IsNotFound(err) {
-		return errors.NewNotFound(err, name)
-	}
 	if err != nil {
 		return errors.Annotatef(err, "setting scale to %d for %q", scale, name)
 	}
@@ -124,8 +120,7 @@ func StatefulSetScalePatcher(stateSet apps.StatefulSetInterface) ScalePatcher {
 		ss, err := stateSet.Patch(c, n, p, d, o, s...)
 		if k8serrors.IsNotFound(err) {
 			return 0, errors.NotFoundf("statefulset %q", n)
-		}
-		if err != nil {
+		} else if err != nil {
 			return 0, errors.Annotatef(err, "scale patching statefulset %q", n)
 		}
 		return *ss.Spec.Replicas, nil

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -984,7 +984,7 @@ func (s *composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 			Architecture: "c",
 		},
 	})
-	c.Assert(suggestions, gc.DeepEquals, []string{
+	c.Assert(suggestions, jc.SameContents, []string{
 		`channel "latest/stable": available series are: focal, bionic`,
 		`channel "2.0/stable": available series are: bionic`,
 	})

--- a/worker/caasapplicationprovisioner/ops.go
+++ b/worker/caasapplicationprovisioner/ops.go
@@ -697,7 +697,9 @@ func ensureScale(appName string, app caas.Application, appLife life.Value,
 	if ps.ScaleTarget >= len(units) {
 		logger.Infof("scaling application %q to desired scale %d", appName, ps.ScaleTarget)
 		err = app.Scale(ps.ScaleTarget)
-		if err != nil {
+		if appLife != life.Alive && errors.Is(err, errors.NotFound) {
+			logger.Infof("dying application %q is already removed", appName)
+		} else if err != nil {
 			return err
 		}
 		return updateProvisioningState(appName, false, 0, facade)


### PR DESCRIPTION
This fixes the idempotent nature of the caasapplicationprovisioner's app dying/dead handling. If the k8s statefulset was already destroyed, we can't and don't need to scale to 0. This fixes that case by handling the not found error from the scale call to k8s.

## QA steps

Bootstrap k8s, deploy sidecar app, destroy controller without force. But proper testing is on CI.

## Links

https://jenkins.juju.canonical.com/job/test-deploy_aks-test-deploy-aks-charms-azure/1143/