### PR TITLE
Cloud model defaults for bootstrap.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -243,6 +243,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 			cloudbootstrap.InsertCloud(stateParams.ControllerCloud),
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
+			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 			modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
 		),
 		database.BootstrapModelConcern(controllerUUID,

--- a/domain/cloud/bootstrap/bootstrap_test.go
+++ b/domain/cloud/bootstrap/bootstrap_test.go
@@ -10,6 +10,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	clouderrors "github.com/juju/juju/domain/cloud/errors"
+	"github.com/juju/juju/domain/cloud/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
@@ -28,4 +30,88 @@ func (s *bootstrapSuite) TestInsertCloud(c *gc.C) {
 	row := s.DB().QueryRow("SELECT name FROM cloud where cloud_type_id = ?", 5) // 5 = ec2
 	c.Assert(row.Scan(&name), jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "cirrus")
+}
+
+// TestSetCloudDefaultsNoExist is check that if we try and set cloud defaults
+// for a cloud that doesn't exist we get a [clouderrors.NotFound] error back
+func (s *bootstrapSuite) TestSetCloudDefaultsNoExist(c *gc.C) {
+	set := SetCloudDefaults("noexist", map[string]any{
+		"HTTP_PROXY": "[2001:0DB8::1]:80",
+	})
+
+	err := set(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIs, clouderrors.NotFound)
+
+	var count int
+	row := s.DB().QueryRow("SELECT count(*) FROM cloud_defaults")
+	err = row.Scan(&count)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 0)
+}
+
+// TestSetCloudDefaults is testing the happy path for setting cloud defaults.
+func (s *bootstrapSuite) TestSetCloudDefaults(c *gc.C) {
+	cld := cloud.Cloud{
+		Name:      "cirrus",
+		Type:      "ec2",
+		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
+	}
+	err := InsertCloud(cld)(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIsNil)
+
+	set := SetCloudDefaults("cirrus", map[string]any{
+		"HTTP_PROXY": "[2001:0DB8::1]:80",
+	})
+
+	err = set(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIsNil)
+
+	st := state.NewState(s.TxnRunnerFactory())
+	defaults, err := st.CloudDefaults(context.Background(), "cirrus")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(defaults, jc.DeepEquals, map[string]string{
+		"HTTP_PROXY": "[2001:0DB8::1]:80",
+	})
+}
+
+// TestSetCloudDefaultsOverrides is testing that repeated calls to
+// [SetCloudDefaults] overrides existing cloud defaults that have been set.
+func (s *bootstrapSuite) TestSetCloudDefaultsOverides(c *gc.C) {
+	cld := cloud.Cloud{
+		Name:      "cirrus",
+		Type:      "ec2",
+		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
+	}
+	err := InsertCloud(cld)(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIsNil)
+
+	set := SetCloudDefaults("cirrus", map[string]any{
+		"HTTP_PROXY": "[2001:0DB8::1]:80",
+	})
+
+	err = set(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIsNil)
+
+	st := state.NewState(s.TxnRunnerFactory())
+	defaults, err := st.CloudDefaults(context.Background(), "cirrus")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(defaults, jc.DeepEquals, map[string]string{
+		"HTTP_PROXY": "[2001:0DB8::1]:80",
+	})
+
+	// Second time around
+
+	set = SetCloudDefaults("cirrus", map[string]any{
+		"foo": "bar",
+	})
+
+	err = set(context.Background(), s.TxnRunner())
+	c.Check(err, jc.ErrorIsNil)
+
+	st = state.NewState(s.TxnRunnerFactory())
+	defaults, err = st.CloudDefaults(context.Background(), "cirrus")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(defaults, jc.DeepEquals, map[string]string{
+		"foo": "bar",
+	})
 }

--- a/domain/cloud/errors/errors.go
+++ b/domain/cloud/errors/errors.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import (
+	"github.com/juju/errors"
+)
+
+const (
+	// NotFound describes an error that occurs when the cloud being operated on
+	// does not exist.
+	NotFound = errors.ConstError("cloud not found")
+)

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -71,7 +71,7 @@ func (st *State) CloudDefaults(ctx context.Context, cloudName string) (map[strin
 	stmt := `
 SELECT cloud_defaults.key,
        cloud_defaults.value,
-	   cloud.uuid
+       cloud.uuid
 FROM cloud
 LEFT JOIN cloud_defaults ON cloud.uuid = cloud_defaults.cloud_uuid
 WHERE cloud.name = ?

--- a/internal/database/statement_test.go
+++ b/internal/database/statement_test.go
@@ -4,6 +4,8 @@
 package database
 
 import (
+	"fmt"
+
 	"github.com/canonical/sqlair"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -121,4 +123,53 @@ func (s *statementSuite) TestMapToMultiPlaceholder(c *gc.C) {
 		}
 	}
 	c.Assert(count, gc.Equals, 9)
+}
+
+func ExampleMapToMultiPlaceholderTransform() {
+	myMap := map[string]string{"one": "two", "three": "four"}
+	bindStmt, args := MapToMultiPlaceholderTransform(myMap, func(k, v string) []any {
+		return []any{"staticvalue", k, v}
+	})
+
+	fmt.Println(bindStmt)
+	fmt.Println(args)
+	// Output:
+	// (?,?,?),(?,?,?)
+	// [staticvalue one two staticvalue three four]
+}
+
+// TestMapToMultiPlaceholderTransformNoVals is testing that if the transform
+// func returns no values that an empty string and no arg values are being
+// returned.
+func (s *statementSuite) TestMapToMultiPlaceholderTransformNoVals(c *gc.C) {
+	bind, args := MapToMultiPlaceholderTransform(
+		map[string]string{"test": "test"},
+		func(k, v string) []any { return nil },
+	)
+	c.Check(bind, gc.Equals, "")
+	c.Check(len(args), gc.Equals, 0)
+}
+
+// TestMapToMultiPlaceholderTransform is testing the happy path.
+func (s *statementSuite) TestMapToMultiPlaceholderTransform(c *gc.C) {
+	bind, args := MapToMultiPlaceholderTransform(
+		map[string]string{"test": "foobar"},
+		func(k, v string) []any { return []any{k, v} },
+	)
+	c.Check(bind, gc.Equals, "(?,?)")
+	c.Check(args, jc.DeepEquals, []any{"test", "foobar"})
+
+	bind, args = MapToMultiPlaceholderTransform(
+		map[string]string{"test": "foobar", "ipv6": "isgreat"},
+		func(k, v string) []any { return []any{k, v} },
+	)
+	c.Check(bind, gc.Equals, "(?,?),(?,?)")
+	c.Check(len(args), gc.Equals, 4)
+
+	bind, args = MapToMultiPlaceholderTransform(
+		map[string]string{"test": "foobar", "ipv6": "isgreat"},
+		func(k, v string) []any { return []any{k, v, "staticval"} },
+	)
+	c.Check(bind, gc.Equals, "(?,?,?),(?,?,?)")
+	c.Check(len(args), gc.Equals, 6)
 }

--- a/internal/database/statement_test.go
+++ b/internal/database/statement_test.go
@@ -126,7 +126,7 @@ func (s *statementSuite) TestMapToMultiPlaceholder(c *gc.C) {
 }
 
 func ExampleMapToMultiPlaceholderTransform() {
-	myMap := map[string]string{"one": "two", "three": "four"}
+	myMap := map[string]string{"one": "two"}
 	bindStmt, args := MapToMultiPlaceholderTransform(myMap, func(k, v string) []any {
 		return []any{"staticvalue", k, v}
 	})
@@ -134,8 +134,8 @@ func ExampleMapToMultiPlaceholderTransform() {
 	fmt.Println(bindStmt)
 	fmt.Println(args)
 	// Output:
-	// (?,?,?),(?,?,?)
-	// [staticvalue one two staticvalue three four]
+	// (?,?,?)
+	// [staticvalue one two]
 }
 
 // TestMapToMultiPlaceholderTransformNoVals is testing that if the transform


### PR DESCRIPTION
With this change we are introducing the ability to bootstrap cloud model defaults at agent bootstrap. This is needed as the Juju client sends a set of cloud defaults to agent bootstrap for persistence as part of the running controller.

We only save these defaults for the controller cloud and they will only ever be used for models that use the same cloud.

This PR does not:
- Do model cloud region defaults yet.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This code is currently not being used in a read only context so we only need to make sure that a successful bootstrap can take place at the moment. It is the same code path for lxd and k8's so bootstrap to either cloud and confirm through the debug logs that no errors occur.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5112

