### PR TITLE
Add relation model-uuid + id (relId) index to relations collection.

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -320,6 +320,8 @@ func allCollections() CollectionSchema {
 		relationsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "endpoints.applicationname", "endpoints.relation.name"},
+			}, {
+				Key: []string{"model-uuid", "id"}, // id here is the relation id not the doc _id
 			}},
 		},
 		relationScopesC: {


### PR DESCRIPTION
Adds an important index to mongo to allow lookups of relations by relation id without (worst case) scanning all the relations in the model.

Mongo CLI commands to achieve the same:
```js
db.relations.createIndex({"model-uuid": 1, "id": 1});
```

## QA steps

Bootstrap. Create some relations. Should be no functional change.

## Links

See #16637

