### PR TITLE
Add known hosts to manual provisioner

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -179,9 +179,10 @@ type addCommand struct {
 	// PublicKey is the path for a file containing a public key required
 	// by the server
 	PublicKey string
-	// KnownHosts is the path for a file containing a set of SSH known hosts
-	// trusted by the client
-	KnownHosts string
+	// KnownHostsFile is the path for a file containing a set of SSH known hosts
+	// trusted by the client. See https://www.man7.org/linux/man-pages/man8/sshd.8.html#SSH_KNOWN_HOSTS_FILE_FORMAT
+	// if KnownHosts is a zero value string then default file in ~/.ssh should be used instead.
+	KnownHostsFile string
 }
 
 func (c *addCommand) Info() *cmd.Info {
@@ -207,7 +208,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage directives for disks to attach to the machine(s)")
 	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use during the connection")
 	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to add to the remote authorized keys")
-	f.StringVar(&c.KnownHosts, "known-hosts", "", "Path to the known hosts file")
+	f.StringVar(&c.KnownHostsFile, "known-hosts", "", "Path to the ssh known hosts file")
 }
 
 func (c *addCommand) Init(args []string) error {
@@ -431,7 +432,7 @@ func (c *addCommand) tryManualProvision(client manual.ProvisioningClientAPI, con
 		Stderr:         ctx.Stderr,
 		AuthorizedKeys: authKeys,
 		PrivateKey:     c.PrivateKey,
-		KnownHosts:     c.KnownHosts,
+		KnownHostsFile: c.KnownHostsFile,
 		UpdateBehavior: &params.UpdateBehavior{
 			EnableOSRefreshUpdate: config.EnableOSRefreshUpdate(),
 			EnableOSUpgrade:       config.EnableOSUpgrade(),

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -5,6 +5,7 @@ package machine
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -420,6 +421,14 @@ func (c *addCommand) tryManualProvision(client manual.ProvisioningClientAPI, con
 	authKeys, err := common.ReadAuthorizedKeys(ctx, c.PublicKey)
 	if err != nil {
 		return errors.Annotatef(err, "cannot reading authorized-keys")
+	}
+
+	if c.KnownHostsFile != "" {
+		err := os.WriteFile(c.KnownHostsFile, []byte(""), 0644)
+
+		if err != nil {
+			return errors.Annotatef(err, "Could not access specified KnownHosts file")
+		}
 	}
 
 	user, host := splitUserHost(c.Placement.Directive)

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -140,6 +140,10 @@ Allocate a machine specifying a public key to set in the list of authorized keys
 Allocate a machine specifying a public key to set in the list of authorized keys and the private key to used during the connection:
 
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_ed25519.pub --private-key /tmp/id_ed25519
+
+Allocate a machine specifying a known_hosts file to be used during the connection:
+
+	juju add-machine ssh:user@10.10.0.3 --known-hosts /tmp/known_hosts
 	
 Allocate a machine to the model. Note: specific to MAAS.
 
@@ -175,6 +179,9 @@ type addCommand struct {
 	// PublicKey is the path for a file containing a public key required
 	// by the server
 	PublicKey string
+	// KnownHosts is the path for a file containing a set of SSH known hosts
+	// trusted by the client
+	KnownHosts string
 }
 
 func (c *addCommand) Info() *cmd.Info {
@@ -200,6 +207,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage directives for disks to attach to the machine(s)")
 	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use during the connection")
 	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to add to the remote authorized keys")
+	f.StringVar(&c.KnownHosts, "known-hosts", "", "Path to the known hosts file")
 }
 
 func (c *addCommand) Init(args []string) error {
@@ -423,6 +431,7 @@ func (c *addCommand) tryManualProvision(client manual.ProvisioningClientAPI, con
 		Stderr:         ctx.Stderr,
 		AuthorizedKeys: authKeys,
 		PrivateKey:     c.PrivateKey,
+		KnownHosts:     c.KnownHosts,
 		UpdateBehavior: &params.UpdateBehavior{
 			EnableOSRefreshUpdate: config.EnableOSRefreshUpdate(),
 			EnableOSUpgrade:       config.EnableOSUpgrade(),

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -53,9 +53,10 @@ type ProvisionMachineArgs struct {
 	// machine.
 	PrivateKey string
 
-	// KnownHosts contains the path of an SSH known hosts file to be used during
-	// the ssh connection.
-	KnownHosts string
+	// KnownHostsFile contains the path of an SSH known hosts file to be used during
+	// the ssh connection. if KnownHosts is a zero value string then default file
+	// in ~/.ssh should be used instead.
+	KnownHostsFile string
 
 	*params.UpdateBehavior
 }

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -53,6 +53,10 @@ type ProvisionMachineArgs struct {
 	// machine.
 	PrivateKey string
 
+	// KnownHosts contains the path of an SSH known hosts file to be used during
+	// the ssh connection.
+	KnownHosts string
+
 	*params.UpdateBehavior
 }
 

--- a/environs/manual/sshprovisioner/provisioner.go
+++ b/environs/manual/sshprovisioner/provisioner.go
@@ -37,11 +37,11 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	// user's ~/.ssh directory. The authenticationworker will later update the
 	// ubuntu user's authorized_keys.
 	if err = InitUbuntuUser(args.Host, args.User,
-		args.AuthorizedKeys, args.PrivateKey, args.Stdin, args.Stdout); err != nil {
+		args.AuthorizedKeys, args.PrivateKey, args.KnownHosts, args.Stdin, args.Stdout); err != nil {
 		return "", err
 	}
 
-	machineParams, err := gatherMachineParams(args.Host)
+	machineParams, err := gatherMachineParams(args.Host, args.KnownHosts)
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +64,7 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	}
 
 	// Finally, provision the machine agent.
-	err = runProvisionScript(provisioningScript, args.Host, args.Stderr)
+	err = runProvisionScript(provisioningScript, args.Host, args.KnownHosts, args.Stderr)
 	if err != nil {
 		return machineId, err
 	}

--- a/environs/manual/sshprovisioner/provisioner.go
+++ b/environs/manual/sshprovisioner/provisioner.go
@@ -37,11 +37,11 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	// user's ~/.ssh directory. The authenticationworker will later update the
 	// ubuntu user's authorized_keys.
 	if err = InitUbuntuUser(args.Host, args.User,
-		args.AuthorizedKeys, args.PrivateKey, args.KnownHosts, args.Stdin, args.Stdout); err != nil {
+		args.AuthorizedKeys, args.PrivateKey, args.KnownHostsFile, args.Stdin, args.Stdout); err != nil {
 		return "", err
 	}
 
-	machineParams, err := gatherMachineParams(args.Host, args.KnownHosts)
+	machineParams, err := gatherMachineParams(args.Host, args.KnownHostsFile)
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +64,7 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	}
 
 	// Finally, provision the machine agent.
-	err = runProvisionScript(provisioningScript, args.Host, args.KnownHosts, args.Stderr)
+	err = runProvisionScript(provisioningScript, args.Host, args.KnownHostsFile, args.Stderr)
 	if err != nil {
 		return machineId, err
 	}

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -46,10 +46,8 @@ func InitUbuntuUser(host, login, authorizedKeys string, privateKeys string, know
 
 	var options ssh.Options
 
-	// known hosts was set
-	if knownHostsFile != "" {
-		options.SetKnownHostsFile(knownHostsFile)
-	}
+	// known hosts file was set
+	options.SetKnownHostsFile(knownHostsFile)
 
 	// To avoid unnecessary prompting for the specified login,
 	// initUbuntuUser will first attempt to ssh to the machine
@@ -111,13 +109,11 @@ fi`
 // by connecting to the machine and executing a bash script.
 var DetectBaseAndHardwareCharacteristics = detectBaseAndHardwareCharacteristics
 
-func detectBaseAndHardwareCharacteristics(host string, knownHosts string) (hc instance.HardwareCharacteristics, base corebase.Base, err error) {
+func detectBaseAndHardwareCharacteristics(host string, knownHostsFile string) (hc instance.HardwareCharacteristics, base corebase.Base, err error) {
 	logger.Infof("Detecting base and characteristics on %s", host)
 	var options ssh.Options
 
-	if knownHosts != "" {
-		options.SetKnownHostsFile(knownHosts)
-	}
+	options.SetKnownHostsFile(knownHostsFile)
 
 	cmd := ssh.Command("ubuntu@"+host, []string{"/bin/bash"}, &options)
 	var stdout, stderr bytes.Buffer
@@ -196,9 +192,8 @@ func checkProvisioned(host string, knownHostsFile string) (bool, error) {
 	script := service.ListServicesScript()
 
 	var options ssh.Options
-	if knownHostsFile != "" {
-		options.SetKnownHostsFile(knownHostsFile)
-	}
+
+	options.SetKnownHostsFile(knownHostsFile)
 
 	cmd := ssh.Command("ubuntu@"+host, []string{"/bin/bash"}, &options)
 	var stdout, stderr bytes.Buffer
@@ -282,9 +277,8 @@ func gatherMachineParams(hostname string, knownHostsFile string) (*params.AddMac
 
 func runProvisionScript(script, host string, knownHostsFile string, progressWriter io.Writer) error {
 	var options ssh.Options
-	if knownHostsFile != "" {
-		options.SetKnownHostsFile(knownHostsFile)
-	}
+
+	options.SetKnownHostsFile(knownHostsFile)
 
 	params := sshinit.ConfigureParams{
 		Host:           "ubuntu@" + host,

--- a/internal/provider/manual/environ.go
+++ b/internal/provider/manual/environ.go
@@ -52,10 +52,11 @@ var (
 type manualEnviron struct {
 	environs.NoSpaceDiscoveryEnviron
 
-	host string
-	user string
-	mu   sync.Mutex
-	cfg  *environConfig
+	host       string
+	user       string
+	knownHosts string
+	mu         sync.Mutex
+	cfg        *environConfig
 	// hw and base are detected by running a script on the
 	// target machine. We cache these, as they should not change.
 	hw   *instance.HardwareCharacteristics
@@ -110,7 +111,7 @@ func (e *manualEnviron) Create(envcontext.ProviderCallContext, environs.CreatePa
 
 // Bootstrap is part of the Environ interface.
 func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	provisioned, err := sshprovisioner.CheckProvisioned(e.host)
+	provisioned, err := sshprovisioner.CheckProvisioned(e.host, e.knownHosts)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to check provisioned status")
 	}
@@ -358,7 +359,7 @@ func (e *manualEnviron) baseAndHardwareCharacteristics() (*instance.HardwareChar
 	if e.hw != nil {
 		return e.hw, e.base, nil
 	}
-	hw, base, err := sshprovisioner.DetectBaseAndHardwareCharacteristics(e.host)
+	hw, base, err := sshprovisioner.DetectBaseAndHardwareCharacteristics(e.host, e.knownHosts)
 	if err != nil {
 		return nil, corebase.Base{}, errors.Trace(err)
 	}

--- a/internal/provider/manual/environ.go
+++ b/internal/provider/manual/environ.go
@@ -52,11 +52,11 @@ var (
 type manualEnviron struct {
 	environs.NoSpaceDiscoveryEnviron
 
-	host       string
-	user       string
-	knownHosts string
-	mu         sync.Mutex
-	cfg        *environConfig
+	host           string
+	user           string
+	knownHostsFile string
+	mu             sync.Mutex
+	cfg            *environConfig
 	// hw and base are detected by running a script on the
 	// target machine. We cache these, as they should not change.
 	hw   *instance.HardwareCharacteristics
@@ -111,7 +111,7 @@ func (e *manualEnviron) Create(envcontext.ProviderCallContext, environs.CreatePa
 
 // Bootstrap is part of the Environ interface.
 func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	provisioned, err := sshprovisioner.CheckProvisioned(e.host, e.knownHosts)
+	provisioned, err := sshprovisioner.CheckProvisioned(e.host, e.knownHostsFile)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to check provisioned status")
 	}
@@ -359,7 +359,7 @@ func (e *manualEnviron) baseAndHardwareCharacteristics() (*instance.HardwareChar
 	if e.hw != nil {
 		return e.hw, e.base, nil
 	}
-	hw, base, err := sshprovisioner.DetectBaseAndHardwareCharacteristics(e.host, e.knownHosts)
+	hw, base, err := sshprovisioner.DetectBaseAndHardwareCharacteristics(e.host, e.knownHostsFile)
 	if err != nil {
 		return nil, corebase.Base{}, errors.Trace(err)
 	}

--- a/internal/provider/manual/environ_test.go
+++ b/internal/provider/manual/environ_test.go
@@ -151,7 +151,7 @@ exit 0
 
 func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 	s.PatchValue(&sshprovisioner.DetectBaseAndHardwareCharacteristics,
-		func(string) (instance.HardwareCharacteristics, base.Base, error) {
+		func(string, string) (instance.HardwareCharacteristics, base.Base, error) {
 			amd64 := "amd64"
 			return instance.HardwareCharacteristics{
 				Arch: &amd64,

--- a/internal/provider/manual/provider.go
+++ b/internal/provider/manual/provider.go
@@ -35,7 +35,9 @@ var _ environs.EnvironProvider = (*ManualProvider)(nil)
 var initUbuntuUser = sshprovisioner.InitUbuntuUser
 
 func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string, cfg *environConfig) error {
-	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), "", ctx.GetStdin(), ctx.GetStdout())
+	// esse argumento ""                                        ↓↓ aqui
+	// faz sentido usar a string vazia ou estender o ctx???     ↓↓
+	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), "", "", ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
 		logger.Errorf("initializing ubuntu user: %v", err)
 		return err

--- a/internal/provider/manual/provider.go
+++ b/internal/provider/manual/provider.go
@@ -35,8 +35,6 @@ var _ environs.EnvironProvider = (*ManualProvider)(nil)
 var initUbuntuUser = sshprovisioner.InitUbuntuUser
 
 func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string, cfg *environConfig) error {
-	// esse argumento ""                                        ↓↓ aqui
-	// faz sentido usar a string vazia ou estender o ctx???     ↓↓
 	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), "", "", ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
 		logger.Errorf("initializing ubuntu user: %v", err)

--- a/internal/provider/manual/provider_test.go
+++ b/internal/provider/manual/provider_test.go
@@ -31,8 +31,8 @@ var _ = gc.Suite(&providerSuite{})
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
-	s.PatchValue(manual.InitUbuntuUser, func(host, user, keys string, privateKey string, stdin io.Reader, stdout io.Writer) error {
-		s.AddCall("InitUbuntuUser", host, user, keys, privateKey, stdin, stdout)
+	s.PatchValue(manual.InitUbuntuUser, func(host, user, keys string, privateKey string, knownHostsFile string, stdin io.Reader, stdout io.Writer) error {
+		s.AddCall("InitUbuntuUser", host, user, keys, privateKey, knownHostsFile, stdin, stdout)
 		return s.NextErr()
 	})
 }
@@ -40,13 +40,13 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "endpoint", "region")
 	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", "", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
 func (s *providerSuite) TestPrepareForBootstrapUserHost(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "user@host", "")
 	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "host", "user", "", "", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 0, "InitUbuntuUser", "host", "user", "", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
 func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpoint(c *gc.C) {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -121,7 +121,7 @@ bootstrap() {
 			bootstrapped_name="${BOOTSTRAP_REUSE_LOCAL}"
 			export BOOTSTRAP_REUSE="true"
 		else
-			# No bootstrapped juju found, unset the the variable.
+			# No bootstrapped juju found, unset the variable.
 			echo "====> Unable to reuse bootstrapped juju"
 			export BOOTSTRAP_REUSE="false"
 		fi

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -41,7 +41,7 @@ manual_deploy() {
 	juju switch controller
 
 	juju add-machine ssh:ubuntu@"${addr_m1}" 2>&1 | tee "${TEST_DIR}/add-machine-1.log"
-	juju add-machine ssh:ubuntu@"${addr_m2}" 2>&1 | tee "${TEST_DIR}/add-machine-2.log"
+	juju add-machine --known-hosts "${TEST_DIR}/known_hosts" ssh:ubuntu@"${addr_m2}" 2>&1 | tee "${TEST_DIR}/add-machine-2.log"
 
 	juju enable-ha --to "1,2" 2>&1 | tee "${TEST_DIR}/enable-ha.log"
 	wait_for "controller" "$(active_condition "controller" 0)"
@@ -50,6 +50,13 @@ manual_deploy() {
 
 	if [[ -z ${machine_base} ]]; then
 		echo "machine 0 has invalid base"
+		exit 1
+	fi
+
+	if [-f "${TEST_DIR}/known_hosts" ]; then
+		echo "specified known_hosts file used sucessfully"
+	else
+		echo "Could not use specfied known_hosts file"
 		exit 1
 	fi
 

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -53,8 +53,8 @@ manual_deploy() {
 		exit 1
 	fi
 
-	if [-f "${TEST_DIR}/known_hosts" ]; then
-		echo "specified known_hosts file used sucessfully"
+	if [ -f "${TEST_DIR}/known_hosts" ]; then
+		echo "Specified known_hosts file used sucessfully"
 	else
 		echo "Could not use specfied known_hosts file"
 		exit 1


### PR DESCRIPTION
Automatically provisioning machines via SSH is interesting for the implementation of models. Juju can accept manual provisioning on its machines. However, manual provisioning of a new machine asks for host confirmation by the user interactively. To make the task of automation easier, it is interesting to provide an option of defining the set of hosts in a specified file.

# QA steps

To quickly verify this new option, first build the project with the applied changes. Then, bootstrap a localhost cloud with ` juju bootstrap localhost test-controller` and launch a linux container with ` lxc launch ubuntu:22.04` . Add a test model with `juju add-model foo`  and try `juju  add-machine --known-hosts <path-to-known-hosts-file> ssh:ubuntu@<lxd instance ip>`.  

Verify that the known_hosts file used is not the default located on ~/.ssh, and that the specified file is used instead.

# Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Integration tests, with comments saying what you're testing



