### PR TITLE
Add network domain state

### DIFF
--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -63,8 +63,11 @@ WHERE  subnet.uuid = ?`
 		if _, err := tx.ExecContext(ctx, insertSpaceStmt, uuid.String(), name); err != nil {
 			return errors.Trace(err)
 		}
-		if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid.String()); err != nil {
-			return errors.Trace(err)
+		if providerID != "" {
+
+			if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid.String()); err != nil {
+				return errors.Trace(err)
+			}
 		}
 		for _, subnetID := range subnetIDs {
 			// Check if the subnet is a fan overlay, in that case
@@ -104,7 +107,7 @@ SELECT
     provider_network.provider_network_id AS &Space.subnet_provider_network_id,
     availability_zone.name               AS &Space.subnet_az
 FROM space 
-    JOIN provider_space
+    LEFT JOIN provider_space
     ON space.uuid = provider_space.space_uuid
     LEFT JOIN subnet   
     ON space.uuid = subnet.space_uuid

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -161,13 +161,9 @@ func (st *State) GetAllSpaces(
 		return nil, errors.Trace(err)
 	}
 
-	// Append the close the q stament since we are retrieving all
-	// spaces.
-	q := retrieveSpacesStmt + ";"
-
-	s, err := sqlair.Prepare(q, Space{})
+	s, err := sqlair.Prepare(retrieveSpacesStmt, Space{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Annotatef(err, "preparing %q", retrieveSpacesStmt)
 	}
 
 	var rows Spaces
@@ -196,7 +192,6 @@ UPDATE space
 SET    name = ?
 WHERE  uuid = ?;`
 	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-
 		if _, err := tx.ExecContext(ctx, q, name, uuid); err != nil {
 			return errors.Trace(err)
 		}

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -171,7 +171,6 @@ func (st *State) GetSpace(
 	}
 
 	var spaceRows Spaces
-	var subnetRows Subnets
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, spacesStmt, sqlair.M{"id": uuid}).GetAll(&spaceRows)
 		if err != nil {
@@ -187,7 +186,6 @@ func (st *State) GetSpace(
 		return nil, errors.NotFoundf("space %q", uuid)
 	}
 	spaceInfo := &spaceRows.ToSpaceInfos()[0]
-	spaceInfo.Subnets = append(spaceInfo.Subnets, subnetRows.ToSubnetInfos()...)
 
 	return spaceInfo, nil
 }

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -1,0 +1,252 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/utils/v3"
+
+	coreDB "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain"
+)
+
+// State represents a type for interacting with the underlying state.
+type State struct {
+	*domain.StateBase
+}
+
+// NewState returns a new State for interacting with the underlying state.
+func NewState(factory coreDB.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// AddSpace creates and returns a new space.
+func (st *State) AddSpace(
+	ctx context.Context,
+	uuid utils.UUID,
+	name string,
+	providerID network.Id,
+	subnetIDs []string,
+) error {
+	if !names.IsValidSpace(name) {
+		return errors.NewNotValid(nil, fmt.Sprintf("invalid space name '%s'", name))
+	}
+
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	insertSpaceStmt := `
+INSERT INTO space (uuid, name)
+VALUES (?, ?)`
+	insertProviderStmt := `
+INSERT INTO provider_space (provider_id, space_uuid)
+VALUES (?, ?)`
+	checkSubnetFanLocalUnderlay := `
+SELECT subnet.cidr,subnet_type.is_space_settable
+FROM   subnet_type
+JOIN   subnet
+ON     subnet.subnet_type_id = subnet_type.id
+WHERE  subnet.uuid = ?`
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, insertSpaceStmt, uuid.String(), name); err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid.String()); err != nil {
+			return errors.Trace(err)
+		}
+		for _, subnetID := range subnetIDs {
+			// Check if the subnet is a fan overlay, in that case
+			// the space cannot be created on this subnet: it must
+			// be inherited from the underlay.
+			var (
+				cidr            string
+				isSpaceSettable bool
+			)
+			row := tx.QueryRowContext(ctx, checkSubnetFanLocalUnderlay, subnetID)
+			if err := row.Scan(&cidr, &isSpaceSettable); err != nil {
+				return errors.Trace(err)
+			}
+			if !isSpaceSettable {
+				return errors.Errorf(
+					"cannot set space for FAN subnet %q - it is always inherited from underlay", cidr)
+			}
+
+			if err := updateSubnetSpaceIDTx(ctx, tx, subnetID, uuid.String()); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		return nil
+	})
+	return errors.Trace(err)
+}
+
+const retrieveSpacesStmt = `
+SELECT     
+    space.uuid                           AS &Space.uuid,
+    space.name                           AS &Space.name,
+    provider_space.provider_id           AS &Space.provider_id,
+    subnet.uuid                          AS &Space.subnet_uuid,
+    subnet.cidr                          AS &Space.subnet_cidr,
+    subnet.vlan_tag                      AS &Space.vlan_tag,
+    provider_subnet.provider_id          AS &Space.subnet_provider_id,
+    provider_network.provider_network_id AS &Space.subnet_provider_network_id,
+    availability_zone.name               AS &Space.subnet_az
+FROM space 
+    JOIN provider_space
+    ON space.uuid = provider_space.space_uuid
+    LEFT JOIN subnet   
+    ON space.uuid = subnet.space_uuid
+    LEFT JOIN provider_subnet
+    ON subnet.uuid = provider_subnet.subnet_uuid
+    LEFT JOIN provider_network_subnet
+    ON subnet.uuid = provider_network_subnet.subnet_uuid
+    LEFT JOIN provider_network
+    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+    LEFT JOIN availability_zone_subnet
+    ON availability_zone_subnet.subnet_uuid = subnet.uuid
+    LEFT JOIN availability_zone
+    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid`
+
+// GetSpace returns the space by UUID.
+func (st *State) GetSpace(
+	ctx context.Context,
+	uuid string,
+) (*network.SpaceInfo, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Append the space uuid condition to the query only if it's passed to the function.
+	q := retrieveSpacesStmt + " WHERE space.uuid = $M.id;"
+
+	s, err := sqlair.Prepare(q, Space{}, sqlair.M{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q", q)
+	}
+
+	var rows Spaces
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, s, sqlair.M{"id": uuid}).GetAll(&rows))
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying spaces")
+	}
+
+	if len(rows) == 0 {
+		return nil, errors.NotFoundf("space %q", uuid)
+	}
+
+	return &rows.ToSpaceInfos()[0], nil
+}
+
+// GetAllSpaces returns all spaces for the model.
+func (st *State) GetAllSpaces(
+	ctx context.Context,
+) (network.SpaceInfos, error) {
+
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Append the close the q stament since we are retrieving all
+	// spaces.
+	q := retrieveSpacesStmt + ";"
+
+	s, err := sqlair.Prepare(q, Space{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q", q)
+	}
+
+	var rows Spaces
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, s).GetAll(&rows))
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying all spaces")
+	}
+
+	return rows.ToSpaceInfos(), nil
+}
+
+// UpdateSpace updates the space identified by the passed uuid.
+func (st *State) UpdateSpace(
+	ctx context.Context,
+	uuid string,
+	name string,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	q := `
+UPDATE space
+SET    name = ?
+WHERE  uuid = ?;`
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+
+		if _, err := tx.ExecContext(ctx, q, name, uuid); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+}
+
+// DeleteSpace deletes the space identified by the passed uuid.
+func (st *State) DeleteSpace(
+	ctx context.Context,
+	uuid string,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	deleteSpaceStmt := "DELETE FROM space WHERE uuid = ?;"
+	deleteProviderSpaceStmt := "DELETE FROM provider_space WHERE space_uuid = ?;"
+	updateSubnetSpaceUUIDStmt := "UPDATE subnet SET space_uuid = NULL WHERE space_uuid = ?;"
+
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		delProviderSpaceResult, err := tx.ExecContext(ctx, deleteProviderSpaceStmt, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delProviderSpaceAffected, err := delProviderSpaceResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delProviderSpaceAffected != 1 {
+			return fmt.Errorf("provider space id for space %s not found", uuid)
+		}
+
+		if _, err := tx.ExecContext(ctx, updateSubnetSpaceUUIDStmt, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		delSpaceResult, err := tx.ExecContext(ctx, deleteSpaceStmt, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delSpaceAffected, err := delSpaceResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delSpaceAffected != 1 {
+			return fmt.Errorf("space %s not found", uuid)
+		}
+
+		return nil
+	})
+}

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -214,7 +214,7 @@ func (st *State) DeleteSpace(
 
 	deleteSpaceStmt := "DELETE FROM space WHERE uuid = ?;"
 	deleteProviderSpaceStmt := "DELETE FROM provider_space WHERE space_uuid = ?;"
-	updateSubnetSpaceUUIDStmt := "UPDATE subnet SET space_uuid = NULL WHERE space_uuid = ?;"
+	updateSubnetSpaceUUIDStmt := "UPDATE subnet SET space_uuid = ? WHERE space_uuid = ?;"
 
 	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		delProviderSpaceResult, err := tx.ExecContext(ctx, deleteProviderSpaceStmt, uuid)
@@ -229,7 +229,7 @@ func (st *State) DeleteSpace(
 			return fmt.Errorf("provider space id for space %s not found", uuid)
 		}
 
-		if _, err := tx.ExecContext(ctx, updateSubnetSpaceUUIDStmt, uuid); err != nil {
+		if _, err := tx.ExecContext(ctx, updateSubnetSpaceUUIDStmt, network.AlphaSpaceId, uuid); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -1,0 +1,385 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	ctx "context"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type stateSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func (s *stateSuite) TestInvalidNameAddSpace(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), uuid, "invalid/space", "foo", []string{})
+	c.Assert(err, gc.ErrorMatches, "invalid space name.*")
+}
+
+func (s *stateSuite) TestAddSpace(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a subnet of type base.
+	subnetUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID,
+		"192.168.0.0/12",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := []string{subnetUUID.String()}
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the space entity.
+	row := db.QueryRow("SELECT name FROM space WHERE uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var name string
+	err = row.Scan(&name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(name, gc.Equals, "space0")
+	// Check the provider id for that space.
+	row = db.QueryRow("SELECT provider_id FROM provider_space WHERE space_uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var providerID string
+	err = row.Scan(&providerID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(providerID, gc.Equals, "foo")
+	// Check the subnet ids for that space.
+	rows, err := db.Query("SELECT uuid FROM subnet WHERE space_uuid = ?", uuid.String())
+	c.Assert(err, jc.ErrorIsNil)
+	i := 0
+	for rows.Next() {
+		var subnetID string
+		err = rows.Scan(&subnetID)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(subnetID, gc.Equals, subnets[i])
+		i++
+	}
+}
+
+func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a subnet of type base.
+	subnetUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID,
+		"192.168.0.0/12",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := []string{subnetUUID.String()}
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the space entity.
+	row := db.QueryRow("SELECT name FROM space WHERE uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var name string
+	err = row.Scan(&name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(name, gc.Equals, "space0")
+	// Fails when trying to add a new space with the same name.
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "bar", subnets)
+	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed.*")
+}
+
+func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a subnet of type base.
+	subnetUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID,
+		"192.168.0.0/12",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type fan.
+	subnetFanUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetFanUUID,
+		"10.0.0.0/24",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/12",
+			FanOverlay:       "252.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := []string{subnetUUID.String(), subnetFanUUID.String()}
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+
+	// Should fail with error indicating we cannot set the space for a
+	// FAN subnet.
+	c.Assert(err, gc.ErrorMatches, "cannot set space for FAN subnet \"10.0.0.0/24\" - it is always inherited from underlay")
+}
+
+func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add a subnet of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/12",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type base.
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"192.176.0.0/12",
+		"provider-id-2",
+		"provider-network-id-2",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type fan.
+	subnetFanUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetFanUUID,
+		"10.0.0.0/20",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az2", "az3"},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/12",
+			FanOverlay:       "10.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := []string{subnetUUID0.String(), subnetUUID1.String()}
+	spaceUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spaceUUID, "space0", "foo", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+
+	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sp.ID, gc.Equals, spaceUUID.String())
+	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
+	// Only 2 subnets should be retrieved
+	c.Assert(sp.Subnets, gc.HasLen, 2)
+}
+
+func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	spaceUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spaceUUID, "space0", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sp.ID, gc.Equals, spaceUUID.String())
+	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
+}
+
+func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add 3 subnets of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/24",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"192.168.1.0/24",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID2, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID2,
+		"192.168.2.0/24",
+		"provider-id-2",
+		"provider-network-id-2",
+		0,
+		[]string{"az2", "az3"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create 3 spaces based on the 3 created subnets.
+	subnets := []string{subnetUUID0.String()}
+	spaceUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spaceUUID0, "space0", "foo0", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+	subnets = []string{subnetUUID1.String()}
+	spaceUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spaceUUID1, "space1", "foo1", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+	subnets = []string{subnetUUID2.String()}
+	spaceUUID2, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spaceUUID2, "space2", "foo2", subnets)
+	c.Assert(err, jc.ErrorIsNil)
+
+	sp, err := st.GetAllSpaces(ctx.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sp, gc.HasLen, 3)
+}
+
+func (s *stateSuite) TestUpdateSpace(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.UpdateSpace(ctx.Background(), uuid.String(), "newSpaceName0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	sp, err := st.GetSpace(ctx.Background(), uuid.String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sp.Name, gc.Equals, network.SpaceName("newSpaceName0"))
+}
+
+func (s *stateSuite) TestDeleteSpace(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	// Add a subnet of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/20",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a space containing the newly created subnet.
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{subnetUUID0.String()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the subnet entity.
+	row := db.QueryRow("SELECT space_uuid FROM subnet WHERE uuid = ?", subnetUUID0.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var name string
+	err = row.Scan(&name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(name, gc.Equals, spUUID.String())
+
+	// Check that the subnet is linked to the newly created space.
+	subnet, err := st.GetSubnet(ctx.Background(), subnetUUID0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnet.SpaceID, gc.Equals, spUUID.String())
+
+	// Delete the space.
+	err = st.DeleteSpace(ctx.Background(), spUUID.String())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the subnet is not linked to the deleted space.
+	subnet, err = st.GetSubnet(ctx.Background(), subnetUUID0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnet.SpaceID, gc.Equals, "")
+}

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -304,6 +304,13 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Check(sp.Subnets, jc.SameContents, expected)
 }
 
+func (s *stateSuite) TestRetrieveSpaceByUUIDNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	_, err := st.GetSpace(ctx.Background(), "unknown0")
+	c.Assert(err, gc.ErrorMatches, "space \"unknown0\" not found")
+}
+
 func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -324,6 +331,13 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp1.ID, gc.Equals, spaceUUID1.String())
 	c.Check(sp1.Name, gc.Equals, network.SpaceName("space1"))
+}
+
+func (s *stateSuite) TestRetrieveSpaceByNameNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	_, err := st.GetSpaceByName(ctx.Background(), "unknown0")
+	c.Assert(err, gc.ErrorMatches, "space with name \"unknown0\" not found")
 }
 
 func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -20,109 +20,6 @@ type stateSuite struct {
 
 var _ = gc.Suite(&stateSuite{})
 
-func (s *stateSuite) TestInvalidNameAddSpace(c *gc.C) {
-	st := NewState(s.TxnRunnerFactory())
-
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), uuid, "invalid/space", "foo", []string{})
-	c.Assert(err, gc.ErrorMatches, "invalid space name.*")
-}
-
-func (s *stateSuite) TestCheckFanSubnet(c *gc.C) {
-	st := NewState(s.TxnRunnerFactory())
-
-	// Add a subnet of type base.
-	subnetUUID0, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSubnet(
-		ctx.Background(),
-		subnetUUID0,
-		"192.168.0.0/12",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	// Add another subnet of type base.
-	subnetUUID1, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSubnet(
-		ctx.Background(),
-		subnetUUID1,
-		"192.176.0.0/12",
-		"provider-id-2",
-		"provider-network-id-2",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	// Add a subnet of type fan.
-	subnetFanUUID0, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSubnet(
-		ctx.Background(),
-		subnetFanUUID0,
-		"10.0.0.0/20",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az2", "az3"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/12",
-			FanOverlay:       "10.0.0.0/8",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	// Add another subnet of type fan.
-	subnetFanUUID1, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSubnet(
-		ctx.Background(),
-		subnetFanUUID1,
-		"10.100.0.0/24",
-		"provider-id-3",
-		"provider-network-id-3",
-		0,
-		[]string{"az2", "az3"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/12",
-			FanOverlay:       "10.0.0.0/8",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = st.CheckFanSubnets(
-		ctx.Background(),
-		[]string{subnetUUID0.String(), subnetUUID1.String()},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Should fail because subnetFanUUID1 corresponds to a fan subnet.
-	err = st.CheckFanSubnets(
-		ctx.Background(),
-		[]string{subnetUUID0.String(), subnetUUID1.String(), subnetFanUUID1.String()},
-	)
-	c.Check(err, gc.ErrorMatches, "subnet with cidr \"10.100.0.0/24\" is of type FAN")
-
-	// Should fail because the two subnets are fan.
-	err = st.CheckFanSubnets(
-		ctx.Background(),
-		[]string{subnetFanUUID0.String()},
-	)
-	// We don't verify that the error contains the cidr because we can't
-	// ensure the order of the returned rows, and we only fail on the first
-	// one returned.
-	c.Check(err, gc.ErrorMatches, "subnet with cidr (.*) is of type FAN")
-}
-
 func (s *stateSuite) TestAddSpace(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()
@@ -256,6 +153,54 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "sql: no rows in result set")
 }
 
+func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a subnet of type base.
+	subnetUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID,
+		"192.168.0.0/12",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type fan.
+	subnetFanUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetFanUUID,
+		"10.0.0.0/24",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/12",
+			FanOverlay:       "252.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnets := []string{subnetUUID.String(), subnetFanUUID.String()}
+	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+
+	// Should fail with error indicating we cannot set the space for a
+	// FAN subnet.
+	c.Assert(err, gc.ErrorMatches, "cannot set space for FAN subnet \"10.0.0.0/24\" - it is always inherited from underlay")
+}
+
 func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -269,7 +214,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 		"provider-id-0",
 		"provider-network-id-0",
 		0,
-		[]string{"az0", "az1"},
+		[]string{"az0"},
 		"",
 		nil,
 	)
@@ -284,7 +229,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 		"provider-id-2",
 		"provider-network-id-2",
 		0,
-		[]string{"az0", "az1"},
+		[]string{"az1"},
 		"",
 		nil,
 	)
@@ -299,7 +244,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 		"provider-id-1",
 		"provider-network-id-1",
 		0,
-		[]string{"az2", "az3"},
+		[]string{"az2"},
 		"",
 		&network.FanCIDRs{
 			FanLocalUnderlay: "192.168.0.0/12",
@@ -318,8 +263,45 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.ID, gc.Equals, spaceUUID.String())
 	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
-	// Only 2 subnets should be retrieved
-	c.Assert(sp.Subnets, gc.HasLen, 2)
+
+	expected := network.SubnetInfos{
+		{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "provider-id-0",
+			ProviderSpaceId:   "foo",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0"},
+			SpaceID:           spaceUUID.String(),
+			SpaceName:         "space0",
+		},
+		{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "192.176.0.0/12",
+			ProviderId:        "provider-id-2",
+			ProviderSpaceId:   "foo",
+			ProviderNetworkId: "provider-network-id-2",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az1"},
+			SpaceID:           spaceUUID.String(),
+			SpaceName:         "space0",
+		},
+		{
+			ID:                network.Id(subnetFanUUID.String()),
+			CIDR:              "10.0.0.0/20",
+			ProviderId:        "provider-id-1",
+			ProviderSpaceId:   "foo",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az2"},
+			SpaceID:           spaceUUID.String(),
+			SpaceName:         "space0",
+		},
+	}
+	// The 3 subnets must be retrieved (including the overlay segment)
+	c.Check(sp.Subnets, gc.HasLen, 3)
+	c.Check(sp.Subnets, jc.SameContents, expected)
 }
 
 func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
@@ -441,6 +423,13 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 	sp, err := st.GetSpace(ctx.Background(), uuid.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.Name, gc.Equals, network.SpaceName("newSpaceName0"))
+}
+
+func (s *stateSuite) TestUpdateSpaceFailNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	err := st.UpdateSpace(ctx.Background(), "unknownSpace", "newSpaceName0")
+	c.Assert(err, gc.ErrorMatches, "space \"unknownSpace\" not found")
 }
 
 func (s *stateSuite) TestDeleteSpace(c *gc.C) {

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	ctx "context"
+	"fmt"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
@@ -198,7 +199,7 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 
 	// Should fail with error indicating we cannot set the space for a
 	// FAN subnet.
-	c.Assert(err, gc.ErrorMatches, "cannot set space for FAN subnet \"10.0.0.0/24\" - it is always inherited from underlay")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("cannot set space for FAN subnet UUIDs \\[%q\\] - it is always inherited from underlay", subnetFanUUID.String()))
 }
 
 func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -1,0 +1,397 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+	"github.com/juju/utils/v3"
+
+	"github.com/juju/juju/core/network"
+)
+
+type subnetType int
+
+const (
+	base subnetType = iota
+	fanOverlaySegment
+)
+
+// AddSubnet creates a subnet.
+func (st *State) AddSubnet(
+	ctx context.Context,
+	uuid utils.UUID,
+	cidr string,
+	providerID network.Id,
+	providerNetworkID network.Id,
+	VLANTag int,
+	availabilityZones []string,
+	spaceUUID string,
+	fanInfo *network.FanCIDRs,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	insertSubnetStmt := `
+INSERT INTO subnet (uuid, cidr, vlan_tag, space_uuid, subnet_type_id)
+VALUES (?, ?, ?, ?, ?)`
+	insertSubnetAssociationStmt := `
+INSERT INTO subnet_association (subject_subnet_uuid, associated_subnet_uuid, association_type_id)
+VALUES (?, ?, 0)` // For the moment the only allowed association is 'overlay_of' and therefore its ID is hard-coded here.
+	retrieveUnderlaySubnetUUIDStmt := `
+SELECT uuid
+FROM   subnet
+WHERE  cidr = ?`
+	insertSubnetProviderIDStmt := `
+INSERT INTO provider_subnet (provider_id, subnet_uuid)
+VALUES (?, ?)`
+	insertSubnetProviderNetworkIDStmt := `
+INSERT INTO provider_network (uuid, provider_network_id)
+VALUES (?, ?)`
+	insertSubnetProviderNetworkSubnetStmt := `
+INSERT INTO provider_network_subnet (provider_network_uuid, subnet_uuid)
+VALUES (?, ?)`
+	insertAvailabilityZoneStmt := `
+INSERT INTO availability_zone (uuid, name)
+VALUES (?, ?)`
+	insertAvailabilityZoneSubnetStmt := `
+INSERT INTO availability_zone_subnet (availability_zone_uuid, subnet_uuid)
+VALUES (?, ?)`
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var subnetType subnetType
+		if fanInfo != nil {
+			subnetType = fanOverlaySegment
+		}
+		// Add the subnet entity.
+		var spaceUUIDValue any
+		spaceUUIDValue = spaceUUID
+		if spaceUUID == "" {
+			spaceUUIDValue = nil
+		}
+		if _, err := tx.ExecContext(
+			ctx,
+			insertSubnetStmt,
+			uuid.String(),
+			cidr,
+			VLANTag,
+			spaceUUIDValue,
+			subnetType,
+		); err != nil {
+			return errors.Trace(err)
+		}
+
+		if subnetType == fanOverlaySegment {
+			fanLocalUnderlayCIDR := fanInfo.FanLocalUnderlay
+			// Retrieve the underlay subnet uuid.
+			var underlaySubnetUUID string
+			row := tx.QueryRowContext(ctx, retrieveUnderlaySubnetUUIDStmt, fanLocalUnderlayCIDR)
+			if err := row.Scan(&underlaySubnetUUID); err != nil {
+				return errors.Trace(err)
+			}
+			// Add the association of the underlay and the newly
+			// created subnet to the associations table.
+			if _, err := tx.ExecContext(
+				ctx,
+				insertSubnetAssociationStmt,
+				uuid.String(),
+				underlaySubnetUUID,
+			); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		// Add the subnet uuid to the provider ids table.
+		if _, err := tx.ExecContext(
+			ctx,
+			insertSubnetProviderIDStmt,
+			providerID,
+			uuid.String(),
+		); err != nil {
+			return errors.Trace(err)
+		}
+		// Add the subnet and provider network uuids to the
+		// provider_network_subnet table.
+		pnUUID, err := utils.NewUUID()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := tx.ExecContext(
+			ctx,
+			insertSubnetProviderNetworkIDStmt,
+			pnUUID.String(),
+			providerNetworkID,
+		); err != nil {
+			return errors.Trace(err)
+		}
+		// Insert the providerNetworkUUID into provider network to
+		// subnets mapping table.
+		if _, err := tx.ExecContext(
+			ctx,
+			insertSubnetProviderNetworkSubnetStmt,
+			pnUUID.String(),
+			uuid.String(),
+		); err != nil {
+			return errors.Trace(err)
+		}
+		for _, az := range availabilityZones {
+			// Add the availability zone.
+			azUUID, err := utils.NewUUID()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if _, err := tx.ExecContext(
+				ctx,
+				insertAvailabilityZoneStmt,
+				azUUID.String(),
+				az,
+			); err != nil {
+				return errors.Trace(err)
+			}
+			// Add the subnet id along with the az uuid into the
+			// availability_zone_subnet mapping table.
+			if _, err := tx.ExecContext(
+				ctx,
+				insertAvailabilityZoneSubnetStmt,
+				azUUID.String(),
+				uuid.String(),
+			); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		return nil
+	})
+	return errors.Trace(err)
+}
+
+const retrieveSubnetsStmt = `
+WITH fan_subnet AS (
+    SELECT * 
+    FROM subnet  
+        JOIN subnet_association  
+           ON subnet.uuid = subnet_association.associated_subnet_uuid
+           AND subnet_association.association_type_id = 0
+        WHERE subnet.subnet_type_id = 0
+    )
+SELECT     
+    subnet.uuid                          AS &Subnet.uuid,
+    subnet.cidr                          AS &Subnet.cidr,
+    subnet.vlan_tag                      AS &Subnet.vlan_tag,
+    subnet.space_uuid                    AS &Subnet.space_uuid,
+    provider_subnet.provider_id          AS &Subnet.provider_id,
+    provider_network.provider_network_id AS &Subnet.provider_network_id,
+    fan_subnet.cidr                      AS &Subnet.underlay_cidr,
+    availability_zone.name               AS &Subnet.az,
+    provider_space.provider_id           AS &Subnet.provider_space_uuid
+FROM subnet 
+    LEFT JOIN fan_subnet 
+    ON subnet.uuid = fan_subnet.subject_subnet_uuid
+    JOIN provider_subnet
+    ON subnet.uuid = provider_subnet.subnet_uuid
+    JOIN provider_network_subnet
+    ON subnet.uuid = provider_network_subnet.subnet_uuid
+    JOIN provider_network
+    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+    LEFT JOIN availability_zone_subnet
+    ON availability_zone_subnet.subnet_uuid = subnet.uuid
+    LEFT JOIN availability_zone
+    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid
+    LEFT JOIN provider_space
+    ON subnet.space_uuid = provider_space.space_uuid`
+
+// GetAllSubnets returns all known subnets in the model.
+func (st *State) GetAllSubnets(
+	ctx context.Context,
+) (network.SubnetInfos, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Append the space uuid condition to the query only if it's passed to the function.
+	q := retrieveSubnetsStmt + ";"
+
+	s, err := sqlair.Prepare(q, Subnet{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q", q)
+	}
+
+	var rows Subnets
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, s).GetAll(&rows))
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying subnets")
+	}
+
+	return rows.ToSubnetInfos(), nil
+}
+
+// GetSubnet returns the subnet by UUID.
+func (st *State) GetSubnet(
+	ctx context.Context,
+	uuid utils.UUID,
+) (*network.SubnetInfo, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Append the space uuid condition to the query only if it's passed to the function.
+	q := retrieveSubnetsStmt + " WHERE subnet.uuid = $M.id;"
+
+	s, err := sqlair.Prepare(q, Subnet{}, sqlair.M{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q", q)
+	}
+
+	var rows Subnets
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, s, sqlair.M{"id": uuid.String()}).GetAll(&rows))
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying subnets")
+	}
+
+	if len(rows) == 0 {
+		return nil, errors.NotFoundf("subnet %q", uuid.String())
+	}
+
+	return &rows.ToSubnetInfos()[0], nil
+}
+
+func updateSubnetSpaceIDTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	uuid string,
+	spaceID string,
+) error {
+	q := `
+UPDATE subnet
+SET    space_uuid = ?
+WHERE  uuid = ?;`
+
+	rows, err := tx.ExecContext(ctx, q, spaceID, uuid)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	affected, err := rows.RowsAffected()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if affected != 1 {
+		return errors.NotFoundf("subnet %q", uuid)
+	}
+
+	return nil
+}
+
+// UpdateSubnet updates the subnet identified by the passed uuid.
+func (st *State) UpdateSubnet(
+	ctx context.Context,
+	uuid string,
+	spaceID string,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+
+		return updateSubnetSpaceIDTx(ctx, tx, uuid, spaceID)
+	})
+}
+
+// DeleteSubnet deletes the subnet identified by the passed uuid.
+func (st *State) DeleteSubnet(
+	ctx context.Context,
+	uuid string,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	deleteSubnetStmt := "DELETE FROM subnet WHERE uuid = ?;"
+	deleteSubjectSubnetAssociationStmt := "DELETE FROM subnet_association WHERE subject_subnet_uuid = ?;"
+	deleteAssociatedSubnetAssociationStmt := "DELETE FROM subnet_association WHERE associated_subnet_uuid = ?;"
+	selectProviderNetworkStmt := "SELECT provider_network_uuid FROM provider_network_subnet WHERE subnet_uuid = ?;"
+	deleteProviderNetworkStmt := "DELETE FROM provider_network WHERE uuid = ?;"
+	deleteProviderNetworkSubnetStmt := "DELETE FROM provider_network_subnet WHERE subnet_uuid = ?;"
+	deleteProviderSubnetStmt := "DELETE FROM provider_subnet WHERE subnet_uuid = ?;"
+	deleteAvailabilityZoneSubnetStmt := "DELETE FROM availability_zone_subnet WHERE subnet_uuid = ?;"
+
+	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, deleteSubjectSubnetAssociationStmt, uuid); err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := tx.ExecContext(ctx, deleteAssociatedSubnetAssociationStmt, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		row := tx.QueryRowContext(ctx, selectProviderNetworkStmt, uuid)
+		var providerNetworkUUID string
+		err = row.Scan(&providerNetworkUUID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		delProviderNetworkSubnetResult, err := tx.ExecContext(ctx, deleteProviderNetworkSubnetStmt, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delProviderNetworkSubnetAffected, err := delProviderNetworkSubnetResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delProviderNetworkSubnetAffected != 1 {
+			return fmt.Errorf("provider network subnets for subnet %s not found", uuid)
+		}
+
+		delProviderNetworkResult, err := tx.ExecContext(ctx, deleteProviderNetworkStmt, providerNetworkUUID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delProviderNetworkAffected, err := delProviderNetworkResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delProviderNetworkAffected != 1 {
+			return fmt.Errorf("provider network for subnet %s not found", uuid)
+		}
+
+		if _, err := tx.ExecContext(ctx, deleteAvailabilityZoneSubnetStmt, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		delProviderSubnetResult, err := tx.ExecContext(ctx, deleteProviderSubnetStmt, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delProviderSubnetAffected, err := delProviderSubnetResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delProviderSubnetAffected != 1 {
+			return fmt.Errorf("provider subnet for subnet %s not found", uuid)
+		}
+
+		delSubnetResult, err := tx.ExecContext(ctx, deleteSubnetStmt, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		delSubnetAffected, err := delSubnetResult.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if delSubnetAffected != 1 {
+			return fmt.Errorf("subnet %s not found", uuid)
+		}
+
+		return nil
+	})
+}

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -70,6 +70,10 @@ VALUES (?, ?)`
 	insertSubnetProviderNetworkSubnetStmt := `
 INSERT INTO provider_network_subnet (provider_network_uuid, subnet_uuid)
 VALUES (?, ?)`
+	retrieveAvailabilityZoneStmt := `
+SELECT uuid
+FROM   availability_zone
+WHERE  name = ?`
 	insertAvailabilityZoneStmt := `
 INSERT INTO availability_zone (uuid, name)
 VALUES (?, ?)`
@@ -138,25 +142,35 @@ VALUES (?, ?)`
 			return errors.Trace(err)
 		}
 		for _, az := range availabilityZones {
-			// Add the availability zone.
-			azUUID, err := utils.NewUUID()
-			if err != nil {
+			// Retrieve the availability zone.
+			var azUUIDStr string
+			row := tx.QueryRowContext(ctx, retrieveAvailabilityZoneStmt, az)
+			err := row.Scan(&azUUIDStr)
+			if err != nil && err != sql.ErrNoRows {
 				return errors.Trace(err)
 			}
-			if _, err := tx.ExecContext(
-				ctx,
-				insertAvailabilityZoneStmt,
-				azUUID.String(),
-				az,
-			); err != nil {
-				return errors.Trace(err)
+			// If it doesn't exist, add the availability zone.
+			if err == sql.ErrNoRows {
+				azUUID, err := utils.NewUUID()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				azUUIDStr = azUUID.String()
+				if _, err := tx.ExecContext(
+					ctx,
+					insertAvailabilityZoneStmt,
+					azUUIDStr,
+					az,
+				); err != nil {
+					return errors.Trace(err)
+				}
 			}
 			// Add the subnet id along with the az uuid into the
 			// availability_zone_subnet mapping table.
 			if _, err := tx.ExecContext(
 				ctx,
 				insertAvailabilityZoneSubnetStmt,
-				azUUID.String(),
+				azUUIDStr,
 				uuid.String(),
 			); err != nil {
 				return errors.Trace(err)
@@ -177,16 +191,16 @@ WITH fan_subnet AS (
         WHERE subnet.subnet_type_id = 0
     )
 SELECT     
-    subnet.uuid                          AS &Subnet.uuid,
-    subnet.cidr                          AS &Subnet.cidr,
-    subnet.vlan_tag                      AS &Subnet.vlan_tag,
-    subnet.space_uuid                    AS &Subnet.space_uuid,
-    space.name                           AS &Subnet.space_name,
-    provider_subnet.provider_id          AS &Subnet.provider_id,
-    provider_network.provider_network_id AS &Subnet.provider_network_id,
-    fan_subnet.cidr                      AS &Subnet.underlay_cidr,
-    availability_zone.name               AS &Subnet.az,
-    provider_space.provider_id           AS &Subnet.provider_space_uuid
+    subnet.uuid                          AS &SpaceSubnetRow.subnet_uuid,
+    subnet.cidr                          AS &SpaceSubnetRow.subnet_cidr,
+    subnet.vlan_tag                      AS &SpaceSubnetRow.subnet_vlan_tag,
+    subnet.space_uuid                    AS &SpaceSubnetRow.subnet_space_uuid,
+    space.name                           AS &SpaceSubnetRow.subnet_space_name,
+    provider_subnet.provider_id          AS &SpaceSubnetRow.subnet_provider_id,
+    provider_network.provider_network_id AS &SpaceSubnetRow.subnet_provider_network_id,
+    fan_subnet.cidr                      AS &SpaceSubnetRow.subnet_underlay_cidr,
+    availability_zone.name               AS &SpaceSubnetRow.subnet_az,
+    provider_space.provider_id           AS &SpaceSubnetRow.subnet_provider_space_uuid
 FROM subnet 
     LEFT JOIN fan_subnet 
     ON subnet.uuid = fan_subnet.subject_subnet_uuid
@@ -217,12 +231,12 @@ func (st *State) GetAllSubnets(
 	// Append the space uuid condition to the query only if it's passed to the function.
 	q := retrieveSubnetsStmt + ";"
 
-	s, err := sqlair.Prepare(q, Subnet{})
+	s, err := sqlair.Prepare(q, SpaceSubnetRow{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing %q", q)
 	}
 
-	var rows Subnets
+	var rows SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return errors.Trace(tx.Query(ctx, s).GetAll(&rows))
 	}); err != nil {
@@ -245,12 +259,12 @@ func (st *State) GetSubnet(
 	// Append the space uuid condition to the query only if it's passed to the function.
 	q := retrieveSubnetsStmt + " WHERE subnet.uuid = $M.id;"
 
-	stmt, err := sqlair.Prepare(q, Subnet{}, sqlair.M{})
+	stmt, err := sqlair.Prepare(q, SpaceSubnetRow{}, sqlair.M{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing %q", q)
 	}
 
-	var rows Subnets
+	var rows SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return errors.Trace(tx.Query(ctx, stmt, sqlair.M{"id": uuid.String()}).GetAll(&rows))
 	}); err != nil {
@@ -279,16 +293,16 @@ func (st *State) GetSubnetsByCIDR(
 	// Append the where clause to the query.
 	q := retrieveSubnetsStmt + " WHERE subnet.cidr = $M.cidr;"
 
-	s, err := sqlair.Prepare(q, Subnet{}, sqlair.M{})
+	s, err := sqlair.Prepare(q, SpaceSubnetRow{}, sqlair.M{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing %q", q)
 	}
 
-	var resultSubnets Subnets
+	var resultSubnets SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		for _, cidr := range cidrs {
-			var rows Subnets
-			if err := tx.Query(ctx, s, sqlair.M{"cidrs": cidr}).GetAll(&rows); err != nil {
+			var rows SpaceSubnetRows
+			if err := tx.Query(ctx, s, sqlair.M{"cidr": cidr}).GetAll(&rows); err != nil {
 				return errors.Trace(err)
 			}
 			resultSubnets = append(resultSubnets, rows...)

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -15,11 +15,9 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
-type subnetType int
-
 const (
-	base subnetType = iota
-	fanOverlaySegment
+	subnetTypeBase              = 0
+	subnetTypeFanOverlaySegment = 1
 )
 
 // AddSubnet creates a subnet.
@@ -39,9 +37,9 @@ func (st *State) AddSubnet(
 		return errors.Trace(err)
 	}
 
-	var subnetType subnetType
+	var subnetType int
 	if fanInfo != nil {
-		subnetType = fanOverlaySegment
+		subnetType = subnetTypeFanOverlaySegment
 	}
 	var spaceUUIDValue any
 	spaceUUIDValue = spaceUUID
@@ -92,7 +90,7 @@ VALUES (?, ?)`
 			return errors.Trace(err)
 		}
 
-		if subnetType == fanOverlaySegment {
+		if subnetType == subnetTypeFanOverlaySegment {
 			// Retrieve the underlay subnet uuid.
 			var underlaySubnetUUID string
 			row := tx.QueryRowContext(ctx, retrieveUnderlaySubnetUUIDStmt, fanInfo.FanLocalUnderlay)

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -43,7 +43,7 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	var (
 		cidr, spaceUUID string
-		subnetType      subnetType
+		subnetType      int
 		VLANTag         int
 	)
 	err = row.Scan(&cidr, &VLANTag, &spaceUUID, &subnetType)
@@ -51,7 +51,7 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 	c.Check(cidr, gc.Equals, "10.0.0.0/24")
 	c.Check(VLANTag, gc.Equals, 0)
 	c.Check(spaceUUID, gc.Equals, spUUID.String())
-	c.Check(subnetType, gc.Equals, base)
+	c.Check(subnetType, gc.Equals, subnetTypeBase)
 
 	// Check the provider network entity.
 	row = db.QueryRow("SELECT uuid,provider_network_id FROM provider_network WHERE provider_network_id = ?", "provider-network-id")

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -20,7 +20,7 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -98,7 +98,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -136,7 +136,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -238,6 +238,58 @@ func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
 	c.Check(sn1.AvailabilityZones, jc.SameContents, []string{"az2", "az3"})
 }
 
+// func (s *stateSuite) TestRetrieveSubnetsByCIDRFailsNonUnique(c *gc.C) {
+// 	st := NewState(s.TxnRunnerFactory())
+
+// 	subnetUUID0, err := utils.NewUUID()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	err = st.AddSubnet(
+// 		ctx.Background(),
+// 		subnetUUID0,
+// 		"192.168.0.0/20",
+// 		"provider-id-0",
+// 		"provider-network-id-0",
+// 		0,
+// 		[]string{"az0", "az1"},
+// 		"",
+// 		nil,
+// 	)
+// 	c.Assert(err, jc.ErrorIsNil)
+
+// 	subnetUUID1, err := utils.NewUUID()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	err = st.AddSubnet(
+// 		ctx.Background(),
+// 		subnetUUID1,
+// 		"192.168.0.0/20",
+// 		"provider-id-1",
+// 		"provider-network-id-0",
+// 		0,
+// 		[]string{"az2", "az3"},
+// 		"",
+// 		nil,
+// 	)
+// 	c.Assert(err, jc.ErrorIsNil)
+
+// 	subnetUUID2, err := utils.NewUUID()
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	err = st.AddSubnet(
+// 		ctx.Background(),
+// 		subnetUUID2,
+// 		"10.0.0.0/24",
+// 		"provider-id-2",
+// 		"provider-network-id-2",
+// 		0,
+// 		[]string{"az2", "az3"},
+// 		"",
+// 		nil,
+// 	)
+// 	c.Assert(err, jc.ErrorIsNil)
+
+// 	_, err = st.GetSubnetsByCIDR(ctx.Background(), "192.168.0.0/20", "10.0.0.0/24")
+// 	c.Assert(err, jc.ErrorIsNil)
+// }
+
 func (s *stateSuite) TestRetrieveAllSubnets(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -296,7 +348,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -316,7 +368,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	newSpIUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), newSpIUUID, "space0", "bar", []string{})
+	err = st.AddSpace(ctx.Background(), newSpIUUID, "space1", "bar", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateSubnet(ctx.Background(), uuid.String(), newSpIUUID.String())

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -1,0 +1,413 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	ctx "context"
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+)
+
+func (s *stateSuite) TestAddSubnet(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		uuid,
+		"10.0.0.0/24",
+		"provider-id",
+		"provider-network-id",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the subnet entity.
+	row := db.QueryRow("SELECT cidr,vlan_tag,space_uuid,subnet_type_id FROM subnet WHERE uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var (
+		cidr, spaceUUID string
+		subnetType      subnetType
+		VLANTag         int
+	)
+	err = row.Scan(&cidr, &VLANTag, &spaceUUID, &subnetType)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cidr, gc.Equals, "10.0.0.0/24")
+	c.Check(VLANTag, gc.Equals, 0)
+	c.Check(spaceUUID, gc.Equals, spUUID.String())
+	c.Check(subnetType, gc.Equals, base)
+
+	// Check the provider network entity.
+	row = db.QueryRow("SELECT uuid,provider_network_id FROM provider_network WHERE provider_network_id = ?", "provider-network-id")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var (
+		retrievedProviderNetworkUUID, retrievedProviderNetworkID string
+	)
+	err = row.Scan(&retrievedProviderNetworkUUID, &retrievedProviderNetworkID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(retrievedProviderNetworkID, gc.Equals, "provider-network-id")
+	row = db.QueryRow("SELECT subnet_uuid FROM provider_network_subnet WHERE provider_network_uuid = ?", retrievedProviderNetworkUUID)
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var retrievedSubnetUUID string
+	err = row.Scan(&retrievedSubnetUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(retrievedSubnetUUID, gc.Equals, uuid.String())
+	// Check the provider subnet entity.
+	row = db.QueryRow("SELECT provider_id FROM provider_subnet WHERE subnet_uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var retrievedProviderSubnetID string
+	err = row.Scan(&retrievedProviderSubnetID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(retrievedProviderSubnetID, gc.Equals, "provider-id")
+	// Check the az entity.
+	rows, err := db.Query(`
+	SELECT name 
+	FROM   availability_zone_subnet 
+	JOIN   availability_zone
+	ON     availability_zone_uuid = availability_zone.uuid
+	WHERE  subnet_uuid = ?`, uuid.String())
+	c.Assert(err, jc.ErrorIsNil)
+	var retrievedAZs []string
+	for rows.Next() {
+		var retrievedAZ string
+		err = rows.Scan(&retrievedAZ)
+		c.Assert(err, jc.ErrorIsNil)
+		retrievedAZs = append(retrievedAZs, retrievedAZ)
+	}
+	c.Check(retrievedAZs, jc.SameContents, []string{"az0", "az1"})
+}
+
+func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"10.0.0.0/24",
+		"provider-id-0",
+		"provider-network-id",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"10.0.1.0/24",
+		"provider-id-1",
+		"provider-network-id",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_network.provider_network_id")
+}
+
+func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"10.0.0.0/24",
+		"provider-id",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"10.0.1.0/24",
+		"provider-id",
+		"provider-network-id-1",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_subnet.provider_id")
+}
+
+func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add a subnet of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/20",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type fan.
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"10.0.0.0/12",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az2", "az3"},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/20",
+			FanOverlay:       "10.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a space with subnet base.
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "space0", "provider-space-id", []string{subnetUUID0.String()})
+	c.Assert(err, jc.ErrorIsNil)
+
+	sn0, err := st.GetSubnet(ctx.Background(), subnetUUID0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sn0.ID, gc.Equals, network.Id(subnetUUID0.String()))
+	c.Check(sn0.FanInfo, gc.IsNil)
+	c.Check(sn0.CIDR, gc.Equals, "192.168.0.0/20")
+	c.Check(sn0.ProviderId.String(), gc.Equals, "provider-id-0")
+	c.Check(sn0.ProviderNetworkId.String(), gc.Equals, "provider-network-id-0")
+	c.Check(sn0.ProviderSpaceId.String(), gc.Equals, "provider-space-id")
+	c.Check(sn0.SpaceID, gc.Equals, spUUID.String())
+	c.Check(sn0.SpaceName, gc.Equals, "")
+	c.Check(sn0.AvailabilityZones, gc.HasLen, 2)
+	c.Check(sn0.AvailabilityZones, jc.SameContents, []string{"az0", "az1"})
+
+	sn1, err := st.GetSubnet(ctx.Background(), subnetUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sn1.ID, gc.Equals, network.Id(subnetUUID1.String()))
+	c.Check(sn1.FanInfo, gc.NotNil)
+	c.Check(sn1.FanInfo.FanLocalUnderlay, gc.Equals, "192.168.0.0/20")
+	c.Check(sn1.CIDR, gc.Equals, "10.0.0.0/12")
+	c.Check(sn1.ProviderId.String(), gc.Equals, "provider-id-1")
+	c.Check(sn1.ProviderNetworkId.String(), gc.Equals, "provider-network-id-1")
+	c.Check(sn1.SpaceID, gc.Equals, "")
+	c.Check(sn1.SpaceName, gc.Equals, "")
+	c.Check(sn1.AvailabilityZones, gc.HasLen, 2)
+	c.Check(sn1.AvailabilityZones, jc.SameContents, []string{"az2", "az3"})
+}
+
+func (s *stateSuite) TestRetrieveAllSubnets(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add 3 subnets of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/24",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"192.168.1.0/24",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	subnetUUID2, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID2,
+		"192.168.2.0/24",
+		"provider-id-2",
+		"provider-network-id-2",
+		0,
+		[]string{"az2", "az3"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	sns, err := st.GetAllSubnets(ctx.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sns, gc.HasLen, 3)
+}
+
+func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	spUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), spUUID, "alpha", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		uuid,
+		"10.0.0.0/24",
+		"provider-id",
+		"provider-network-id",
+		0,
+		[]string{"az0", "az1"},
+		spUUID.String(),
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newSpIUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(ctx.Background(), newSpIUUID, "space0", "bar", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.UpdateSubnet(ctx.Background(), uuid.String(), newSpIUUID.String())
+	c.Assert(err, jc.ErrorIsNil)
+
+	row := db.QueryRow("SELECT space_uuid FROM subnet WHERE subnet.uuid = ?", uuid.String())
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var (
+		retrievedSpaceUUID string
+	)
+	err = row.Scan(&retrievedSpaceUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(retrievedSpaceUUID, gc.Equals, newSpIUUID.String())
+}
+
+func (s *stateSuite) TestDeleteSubnet(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add a subnet of type base.
+	subnetUUID0, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID0,
+		"192.168.0.0/20",
+		"provider-id-0",
+		"provider-network-id-0",
+		0,
+		[]string{"az0", "az1"},
+		"",
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a subnet of type fan.
+	subnetUUID1, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID1,
+		"10.0.0.0/12",
+		"provider-id-1",
+		"provider-network-id-1",
+		0,
+		[]string{},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/20",
+			FanOverlay:       "10.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add another subnet of type fan.
+	subnetUUID2, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSubnet(
+		ctx.Background(),
+		subnetUUID2,
+		"10.8.0.0/12",
+		"provider-id-2",
+		"provider-network-id-2",
+		0,
+		[]string{"az4", "az5"},
+		"",
+		&network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/20",
+			FanOverlay:       "10.0.0.0/8",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.DeleteSubnet(ctx.Background(), subnetUUID0.String())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.GetSubnet(ctx.Background(), subnetUUID0)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("subnet \"%s\" not found", subnetUUID0.String()))
+	subnets, err := st.GetAllSubnets(ctx.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnets, gc.HasLen, 2)
+
+	err = st.DeleteSubnet(ctx.Background(), subnetUUID1.String())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.GetSubnet(ctx.Background(), subnetUUID1)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("subnet \"%s\" not found", subnetUUID1.String()))
+	subnets, err = st.GetAllSubnets(ctx.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnets, gc.HasLen, 1)
+
+	err = st.DeleteSubnet(ctx.Background(), subnetUUID2.String())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.GetSubnet(ctx.Background(), subnetUUID2)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("subnet \"%s\" not found", subnetUUID2.String()))
+	subnets, err = st.GetAllSubnets(ctx.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnets, gc.HasLen, 0)
+}

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -49,6 +49,7 @@ type Space struct {
 	SubnetUnderlayCIDR sql.NullString `db:"subnet_underlay_cidr"`
 }
 
+// Alias type to a slice of Space('s).
 type Spaces []Space
 
 // ToSpaceInfos converts Spaces to a slice of network.SpaceInfo structs.
@@ -163,6 +164,7 @@ type Subnet struct {
 	UnderlayCIDR sql.NullString `db:"underlay_cidr"`
 }
 
+// Alias type to a slice of Subnet('s).
 type Subnets []Subnet
 
 // ToSubnetInfos converts Subnets to a slice of network.SubnetInfo structs.

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -9,12 +9,14 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
-// Space represents a single row from the database when
+// SpaceSubnetRow represents a single row from the database when
 // space is joined with provider_space, subnet, subnet_type,
 // subnet_association, subject_subnet_type_uuid, subnet_association_type,
 // provider_subnet, provider_network, provider_network_subnet,
 // availability_zone and availability_zone_subnet.
-type Space struct {
+// This type is also used for deserializing only subnets, which has the same
+// fields except UUID, Name and ProviderID.
+type SpaceSubnetRow struct {
 	// UUID is the space UUID.
 	UUID string `db:"uuid"`
 
@@ -24,39 +26,50 @@ type Space struct {
 	// ProviderID is the space provider id.
 	ProviderID sql.NullString `db:"provider_id"`
 
-	// SubnetUUID is one of the space's subnet id.
+	// Subnet fields
+
+	// SubnetUUID is the subnet SubnetUUID.
 	SubnetUUID string `db:"subnet_uuid"`
 
-	// CIDR is one of the space's subnet cidr.
-	CIDR string `db:"subnet_cidr"`
+	// SubnetCIDR is the one of the subnet's cidr.
+	SubnetCIDR string `db:"subnet_cidr"`
 
-	// VLANTag is one of the space's subnet vlan tag.
-	VLANTag int `db:"vlan_tag"`
+	// SubnetVLANTag is the subnet's vlan tag.
+	SubnetVLANTag int `db:"subnet_vlan_tag"`
 
-	// SubnetProviderID is one of the space's subnet provider id.
+	// SubnetProviderID is the subnet's provider id.
 	SubnetProviderID string `db:"subnet_provider_id"`
 
-	// SubnetProviderNetworkID is one of the space's subnet provider network id.
+	// SubnetProviderNetworkID is the subnet's provider network id.
 	SubnetProviderNetworkID string `db:"subnet_provider_network_id"`
 
-	// SubnetAZ is one of the availability zones on one of the subnets of the space.
+	// SubnetProviderSpaceUUID is the subnet's space uuid.
+	SubnetProviderSpaceUUID sql.NullString `db:"subnet_provider_space_uuid"`
+
+	// SubnetSpaceUUID is the space uuid.
+	SubnetSpaceUUID sql.NullString `db:"subnet_space_uuid"`
+
+	// SubnetSpaceName is the name of the space the subnet is associated with.
+	SubnetSpaceName sql.NullString `db:"subnet_space_name"`
+
+	// SubnetAZ is the availability zones on the subnet.
 	SubnetAZ string `db:"subnet_az"`
 
-	// SubnetOverlayCIDR is one of the space's subnet overlay cidr in a fan setup.
+	// SubnetOverlayCIDR is the subnet's overlay cidr in a fan setup.
 	SubnetOverlayCIDR sql.NullString `db:"subnet_overlay_cidr"`
 
-	// SubnetUnderlayCIDR is one of the space's subnet underlay cidr in a fan setup.
+	// SubnetUnderlayCIDR is the subnet's underlay cidr in a fan setup.
 	SubnetUnderlayCIDR sql.NullString `db:"subnet_underlay_cidr"`
 }
 
-// Alias type to a slice of Space('s).
-type Spaces []Space
+// Alias type to a slice of Space/Subnet rows.
+type SpaceSubnetRows []SpaceSubnetRow
 
 // ToSpaceInfos converts Spaces to a slice of network.SpaceInfo structs.
 // This method makes sure only unique subnets are mapped and flattens them into
 // each space.
 // No sorting is applied.
-func (sp Spaces) ToSpaceInfos() network.SpaceInfos {
+func (sp SpaceSubnetRows) ToSpaceInfos() network.SpaceInfos {
 	var res network.SpaceInfos
 
 	// Prepare structs for unique subnets for each space.
@@ -73,29 +86,14 @@ func (sp Spaces) ToSpaceInfos() network.SpaceInfos {
 		if _, ok := uniqueSubnets[space.UUID]; !ok {
 			uniqueSubnets[space.UUID] = make(map[string]network.SubnetInfo)
 		}
-		snInfo := network.SubnetInfo{
-			ID:                network.Id(space.SubnetUUID),
-			CIDR:              space.CIDR,
-			ProviderId:        network.Id(space.SubnetProviderID),
-			ProviderNetworkId: network.Id(space.SubnetProviderNetworkID),
-			VLANTag:           space.VLANTag,
-			SpaceID:           space.UUID,
-			SpaceName:         space.Name,
-		}
+
+		snInfo := space.ToSubnetInfo()
+		snInfo.SpaceID = space.UUID
+		snInfo.SpaceName = space.Name
+
 		if space.ProviderID.Valid {
 			spInfo.ProviderId = network.Id(space.ProviderID.String)
 			snInfo.ProviderSpaceId = network.Id(space.ProviderID.String)
-		}
-		if space.SubnetOverlayCIDR.Valid || space.SubnetUnderlayCIDR.Valid {
-			underlay := ""
-			if space.SubnetUnderlayCIDR.Valid {
-				underlay = space.SubnetUnderlayCIDR.String
-			}
-			overlay := ""
-			if space.SubnetOverlayCIDR.Valid {
-				overlay = space.SubnetOverlayCIDR.String
-			}
-			snInfo.SetFan(underlay, overlay)
 		}
 
 		uniqueSpaces[space.UUID] = spInfo
@@ -112,18 +110,7 @@ func (sp Spaces) ToSpaceInfos() network.SpaceInfos {
 
 	// Iterate through every space and flatten its subnets.
 	for spaceUUID, space := range uniqueSpaces {
-		var subnets network.SubnetInfos
-		// Iterate through every subnet and flatten its availability zones.
-		for subnetUUID, subnet := range uniqueSubnets[spaceUUID] {
-			var availabilityZones []string
-			for _, availabilityZone := range uniqueAZs[spaceUUID][subnetUUID] {
-				availabilityZones = append(availabilityZones, availabilityZone)
-			}
-			subnet.AvailabilityZones = availabilityZones
-
-			subnets = append(subnets, subnet)
-		}
-		space.Subnets = subnets
+		space.Subnets = flattenAZs(uniqueSubnets[spaceUUID], uniqueAZs[spaceUUID])
 
 		res = append(res, space)
 	}
@@ -131,97 +118,68 @@ func (sp Spaces) ToSpaceInfos() network.SpaceInfos {
 	return res
 }
 
-// Subnet represents a single row from the database when
-// subnet is joined with subnet_type, subnet_association,
-// subject_subnet_type_uuid, subnet_association_type, provider_subnet,
-// provider_network, provider_network_subnet, availability_zone and
-// availability_zone_subnet.
-type Subnet struct {
-	// UUID is the subnet UUID.
-	UUID string `db:"uuid"`
+// ToSubnetInfo deserializes a row containing subnet fields to a SubnetInfo
+// struct.
+func (s SpaceSubnetRow) ToSubnetInfo() network.SubnetInfo {
+	sInfo := network.SubnetInfo{
+		ID:                network.Id(s.SubnetUUID),
+		CIDR:              s.SubnetCIDR,
+		VLANTag:           s.SubnetVLANTag,
+		ProviderId:        network.Id(s.SubnetProviderID),
+		ProviderNetworkId: network.Id(s.SubnetProviderNetworkID),
+	}
+	if s.SubnetProviderSpaceUUID.Valid {
+		sInfo.ProviderSpaceId = network.Id(s.SubnetProviderSpaceUUID.String)
+	}
+	if s.SubnetOverlayCIDR.Valid || s.SubnetUnderlayCIDR.Valid {
+		underlay := ""
+		if s.SubnetUnderlayCIDR.Valid {
+			underlay = s.SubnetUnderlayCIDR.String
+		}
+		overlay := ""
+		if s.SubnetOverlayCIDR.Valid {
+			overlay = s.SubnetOverlayCIDR.String
+		}
+		sInfo.SetFan(underlay, overlay)
+	}
+	if s.SubnetSpaceUUID.Valid {
+		sInfo.SpaceID = s.SubnetSpaceUUID.String
+	}
+	if s.SubnetSpaceName.Valid {
+		sInfo.SpaceName = s.SubnetSpaceName.String
+	}
 
-	// CIDR is the one of the subnet's cidr.
-	CIDR string `db:"cidr"`
-
-	// VLANTag is the subnet's vlan tag.
-	VLANTag int `db:"vlan_tag"`
-
-	// ProviderID is the subnet's provider id.
-	ProviderID string `db:"provider_id"`
-
-	// ProviderNetworkID is the subnet's provider network id.
-	ProviderNetworkID string `db:"provider_network_id"`
-
-	// ProviderSpaceUUID is the subnet's space uuid.
-	ProviderSpaceUUID sql.NullString `db:"provider_space_uuid"`
-
-	// SpaceUUID is the space uuid.
-	SpaceUUID sql.NullString `db:"space_uuid"`
-
-	// SpaceName is the name of the space the subnet is associated with.
-	SpaceName sql.NullString `db:"space_name"`
-
-	// AZ is the availability zones on the subnet.
-	AZ string `db:"az"`
-
-	// OverlayCIDR is the subnet's overlay cidr in a fan setup.
-	OverlayCIDR sql.NullString `db:"overlay_cidr"`
-
-	// UnderlayCIDR is the subnet's underlay cidr in a fan setup.
-	UnderlayCIDR sql.NullString `db:"underlay_cidr"`
+	return sInfo
 }
-
-// Alias type to a slice of Subnet('s).
-type Subnets []Subnet
 
 // ToSubnetInfos converts Subnets to a slice of network.SubnetInfo structs.
 // This method makes sure only unique AZs are mapped and flattens them into
 // each subnet.
 // No sorting is applied.
-func (sn Subnets) ToSubnetInfos() network.SubnetInfos {
-	var res network.SubnetInfos
-
+func (sn SpaceSubnetRows) ToSubnetInfos() network.SubnetInfos {
 	// Prepare structs for unique subnets.
 	uniqueAZs := make(map[string]map[string]string)
 	uniqueSubnets := make(map[string]network.SubnetInfo)
 
 	for _, subnet := range sn {
-		sInfo := network.SubnetInfo{
-			ID:                network.Id(subnet.UUID),
-			CIDR:              subnet.CIDR,
-			VLANTag:           subnet.VLANTag,
-			ProviderId:        network.Id(subnet.ProviderID),
-			ProviderNetworkId: network.Id(subnet.ProviderNetworkID),
-		}
-		if subnet.ProviderSpaceUUID.Valid {
-			sInfo.ProviderSpaceId = network.Id(subnet.ProviderSpaceUUID.String)
-		}
-		if subnet.OverlayCIDR.Valid || subnet.UnderlayCIDR.Valid {
-			underlay := ""
-			if subnet.UnderlayCIDR.Valid {
-				underlay = subnet.UnderlayCIDR.String
-			}
-			overlay := ""
-			if subnet.OverlayCIDR.Valid {
-				overlay = subnet.OverlayCIDR.String
-			}
-			sInfo.SetFan(underlay, overlay)
-		}
-		if subnet.SpaceUUID.Valid {
-			sInfo.SpaceID = subnet.SpaceUUID.String
-		}
-		if subnet.SpaceName.Valid {
-			sInfo.SpaceName = subnet.SpaceName.String
-		}
-		uniqueSubnets[subnet.UUID] = sInfo
+		uniqueSubnets[subnet.SubnetUUID] = subnet.ToSubnetInfo()
 
-		if _, ok := uniqueAZs[subnet.UUID]; !ok {
-			uniqueAZs[subnet.UUID] = make(map[string]string)
+		if _, ok := uniqueAZs[subnet.SubnetUUID]; !ok {
+			uniqueAZs[subnet.SubnetUUID] = make(map[string]string)
 		}
-		uniqueAZs[subnet.UUID][subnet.AZ] = subnet.AZ
+		uniqueAZs[subnet.SubnetUUID][subnet.SubnetAZ] = subnet.SubnetAZ
 	}
 
-	// Iterate through every subnet and flatten its AZs.
+	return flattenAZs(uniqueSubnets, uniqueAZs)
+}
+
+// flattenAZs iterates through every subnet and flatten its AZs.
+func flattenAZs(
+	uniqueSubnets map[string]network.SubnetInfo,
+	uniqueAZs map[string]map[string]string,
+) network.SubnetInfos {
+	var subnets network.SubnetInfos
+
 	for subnetUUID, subnet := range uniqueSubnets {
 		var availabilityZones []string
 		for _, availabilityZone := range uniqueAZs[subnetUUID] {
@@ -229,8 +187,8 @@ func (sn Subnets) ToSubnetInfos() network.SubnetInfos {
 		}
 		subnet.AvailabilityZones = availabilityZones
 
-		res = append(res, subnet)
+		subnets = append(subnets, subnet)
 	}
 
-	return res
+	return subnets
 }

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -1,0 +1,224 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"database/sql"
+
+	"github.com/juju/juju/core/network"
+)
+
+// Space represents a single row from the database when
+// space is joined with provider_space, subnet, subnet_type,
+// subnet_association, subject_subnet_type_uuid, subnet_association_type,
+// provider_subnet, provider_network, provider_network_subnet,
+// availability_zone and availability_zone_subnet.
+type Space struct {
+	// UUID is the space UUID.
+	UUID string `db:"uuid"`
+
+	// Name is the space name.
+	Name string `db:"name"`
+
+	// ProviderID is the space provider id.
+	ProviderID string `db:"provider_id"`
+
+	// SubnetUUID is one of the space's subnet id.
+	SubnetUUID string `db:"subnet_uuid"`
+
+	// CIDR is one of the space's subnet cidr.
+	CIDR string `db:"subnet_cidr"`
+
+	// VLANTag is one of the space's subnet vlan tag.
+	VLANTag int `db:"vlan_tag"`
+
+	// SubnetProviderID is one of the space's subnet provider id.
+	SubnetProviderID string `db:"subnet_provider_id"`
+
+	// SubnetProviderNetworkID is one of the space's subnet provider network id.
+	SubnetProviderNetworkID string `db:"subnet_provider_network_id"`
+
+	// SubnetAZ is one of the availability zones on one of the subnets of the space.
+	SubnetAZ string `db:"subnet_az"`
+
+	// SubnetOverlayCIDR is one of the space's subnet overlay cidr in a fan setup.
+	SubnetOverlayCIDR sql.NullString `db:"subnet_overlay_cidr"`
+
+	// SubnetUnderlayCIDR is one of the space's subnet underlay cidr in a fan setup.
+	SubnetUnderlayCIDR sql.NullString `db:"subnet_underlay_cidr"`
+}
+
+type Spaces []Space
+
+// ToSpaceInfos converts Spaces to a slice of network.SpaceInfo structs.
+// This method makes sure only unique subnets are mapped and flattens them into
+// each space.
+// No sorting is applied.
+func (sp Spaces) ToSpaceInfos() network.SpaceInfos {
+	var res network.SpaceInfos
+
+	// Prepare structs for unique subnets for each space.
+	uniqueAZs := make(map[string]map[string]map[string]string)
+	uniqueSubnets := make(map[string]map[string]network.SubnetInfo)
+	uniqueSpaces := make(map[string]network.SpaceInfo)
+
+	for _, space := range sp {
+		uniqueSpaces[space.UUID] = network.SpaceInfo{
+			ID:         space.UUID,
+			Name:       network.SpaceName(space.Name),
+			ProviderId: network.Id(space.ProviderID),
+		}
+
+		if _, ok := uniqueSubnets[space.UUID]; !ok {
+			uniqueSubnets[space.UUID] = make(map[string]network.SubnetInfo)
+		}
+		sInfo := network.SubnetInfo{
+			ID:                network.Id(space.SubnetUUID),
+			CIDR:              space.CIDR,
+			ProviderId:        network.Id(space.SubnetProviderID),
+			ProviderSpaceId:   network.Id(space.ProviderID),
+			ProviderNetworkId: network.Id(space.SubnetProviderNetworkID),
+			VLANTag:           space.VLANTag,
+			SpaceID:           space.UUID,
+			SpaceName:         space.Name,
+		}
+		if space.SubnetOverlayCIDR.Valid || space.SubnetUnderlayCIDR.Valid {
+			underlay := ""
+			if space.SubnetUnderlayCIDR.Valid {
+				underlay = space.SubnetUnderlayCIDR.String
+			}
+			overlay := ""
+			if space.SubnetOverlayCIDR.Valid {
+				overlay = space.SubnetOverlayCIDR.String
+			}
+			sInfo.SetFan(underlay, overlay)
+		}
+		uniqueSubnets[space.UUID][space.SubnetUUID] = sInfo
+
+		if _, ok := uniqueAZs[space.UUID]; !ok {
+			uniqueAZs[space.UUID] = make(map[string]map[string]string)
+		}
+		if _, ok := uniqueAZs[space.UUID][space.SubnetUUID]; !ok {
+			uniqueAZs[space.UUID][space.SubnetUUID] = make(map[string]string)
+		}
+		uniqueAZs[space.UUID][space.SubnetUUID][space.SubnetAZ] = space.SubnetAZ
+	}
+
+	// Iterate through every space and flatten its subnets.
+	for spaceUUID, space := range uniqueSpaces {
+		var subnets network.SubnetInfos
+		// Iterate through every subnet and flatten its availability zones.
+		for subnetUUID, subnet := range uniqueSubnets[spaceUUID] {
+			var availabilityZones []string
+			for _, availabilityZone := range uniqueAZs[spaceUUID][subnetUUID] {
+				availabilityZones = append(availabilityZones, availabilityZone)
+			}
+			subnet.AvailabilityZones = availabilityZones
+
+			subnets = append(subnets, subnet)
+		}
+		space.Subnets = subnets
+
+		res = append(res, space)
+	}
+
+	return res
+}
+
+// Subnet represents a single row from the database when
+// subnet is joined with subnet_type, subnet_association,
+// subject_subnet_type_uuid, subnet_association_type, provider_subnet,
+// provider_network, provider_network_subnet, availability_zone and
+// availability_zone_subnet.
+type Subnet struct {
+	// UUID is the subnet UUID.
+	UUID string `db:"uuid"`
+
+	// CIDR is the one of the subnet's cidr.
+	CIDR string `db:"cidr"`
+
+	// VLANTag is the subnet's vlan tag.
+	VLANTag int `db:"vlan_tag"`
+
+	// ProviderID is the subnet's provider id.
+	ProviderID string `db:"provider_id"`
+
+	// ProviderNetworkID is the subnet's provider network id.
+	ProviderNetworkID string `db:"provider_network_id"`
+
+	// ProviderSpaceUUID is the subnet's space uuid.
+	ProviderSpaceUUID sql.NullString `db:"provider_space_uuid"`
+
+	// SpaceUUID is the space uuid.
+	SpaceUUID sql.NullString `db:"space_uuid"`
+
+	// AZ is the availability zones on the subnet.
+	AZ string `db:"az"`
+
+	// OverlayCIDR is the subnet's overlay cidr in a fan setup.
+	OverlayCIDR sql.NullString `db:"overlay_cidr"`
+
+	// UnderlayCIDR is the subnet's underlay cidr in a fan setup.
+	UnderlayCIDR sql.NullString `db:"underlay_cidr"`
+}
+
+type Subnets []Subnet
+
+// ToSubnetInfos converts Subnets to a slice of network.SubnetInfo structs.
+// This method makes sure only unique AZs are mapped and flattens them into
+// each subnet.
+// No sorting is applied.
+func (sn Subnets) ToSubnetInfos() network.SubnetInfos {
+	var res network.SubnetInfos
+
+	// Prepare structs for unique subnets.
+	uniqueAZs := make(map[string]map[string]string)
+	uniqueSubnets := make(map[string]network.SubnetInfo)
+
+	for _, subnet := range sn {
+		sInfo := network.SubnetInfo{
+			ID:                network.Id(subnet.UUID),
+			CIDR:              subnet.CIDR,
+			VLANTag:           subnet.VLANTag,
+			ProviderId:        network.Id(subnet.ProviderID),
+			ProviderNetworkId: network.Id(subnet.ProviderNetworkID),
+		}
+		if subnet.ProviderSpaceUUID.Valid {
+			sInfo.ProviderSpaceId = network.Id(subnet.ProviderSpaceUUID.String)
+		}
+		if subnet.OverlayCIDR.Valid || subnet.UnderlayCIDR.Valid {
+			underlay := ""
+			if subnet.UnderlayCIDR.Valid {
+				underlay = subnet.UnderlayCIDR.String
+			}
+			overlay := ""
+			if subnet.OverlayCIDR.Valid {
+				overlay = subnet.OverlayCIDR.String
+			}
+			sInfo.SetFan(underlay, overlay)
+		}
+		if subnet.SpaceUUID.Valid {
+			sInfo.SpaceID = subnet.SpaceUUID.String
+		}
+		uniqueSubnets[subnet.UUID] = sInfo
+
+		if _, ok := uniqueAZs[subnet.UUID]; !ok {
+			uniqueAZs[subnet.UUID] = make(map[string]string)
+		}
+		uniqueAZs[subnet.UUID][subnet.AZ] = subnet.AZ
+	}
+
+	// Iterate through every subnet and flatten its AZs.
+	for subnetUUID, subnet := range uniqueSubnets {
+		var availabilityZones []string
+		for _, availabilityZone := range uniqueAZs[subnetUUID] {
+			availabilityZones = append(availabilityZones, availabilityZone)
+		}
+		subnet.AvailabilityZones = availabilityZones
+
+		res = append(res, subnet)
+	}
+
+	return res
+}

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -131,16 +131,12 @@ func (s SpaceSubnetRow) ToSubnetInfo() network.SubnetInfo {
 	if s.SubnetProviderSpaceUUID.Valid {
 		sInfo.ProviderSpaceId = network.Id(s.SubnetProviderSpaceUUID.String)
 	}
-	if s.SubnetOverlayCIDR.Valid || s.SubnetUnderlayCIDR.Valid {
+	if s.SubnetUnderlayCIDR.Valid {
 		underlay := ""
 		if s.SubnetUnderlayCIDR.Valid {
 			underlay = s.SubnetUnderlayCIDR.String
 		}
-		overlay := ""
-		if s.SubnetOverlayCIDR.Valid {
-			overlay = s.SubnetOverlayCIDR.String
-		}
-		sInfo.SetFan(underlay, overlay)
+		sInfo.SetFan(underlay, "")
 	}
 	if s.SubnetSpaceUUID.Valid {
 		sInfo.SpaceID = s.SubnetSpaceUUID.String

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -158,6 +158,9 @@ type Subnet struct {
 	// SpaceUUID is the space uuid.
 	SpaceUUID sql.NullString `db:"space_uuid"`
 
+	// SpaceName is the name of the space the subnet is associated with.
+	SpaceName sql.NullString `db:"space_name"`
+
 	// AZ is the availability zones on the subnet.
 	AZ string `db:"az"`
 
@@ -206,6 +209,9 @@ func (sn Subnets) ToSubnetInfos() network.SubnetInfos {
 		}
 		if subnet.SpaceUUID.Valid {
 			sInfo.SpaceID = subnet.SpaceUUID.String
+		}
+		if subnet.SpaceName.Valid {
+			sInfo.SpaceName = subnet.SpaceName.String
 		}
 		uniqueSubnets[subnet.UUID] = sInfo
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -123,9 +123,6 @@ CREATE TABLE subnet (
         REFERENCES                   subnet_type(id)
 );
 
-CREATE UNIQUE INDEX idx_subnet_cidr
-ON subnet (cidr);
-
 CREATE TABLE subnet_type (
     id                           INT PRIMARY KEY,
     name                         TEXT NOT NULL,

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -75,6 +75,9 @@ CREATE TABLE provider_space (
 
 CREATE UNIQUE INDEX idx_provider_space_space_uuid
 ON provider_space (space_uuid);
+
+INSERT INTO space VALUES
+    (0, 'alpha');
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -219,6 +219,9 @@ CREATE TABLE availability_zone (
     name            TEXT NOT NULL
 );
 
+CREATE UNIQUE INDEX idx_availability_zone_name
+ON availability_zone (name);
+
 CREATE TABLE availability_zone_subnet (
     availability_zone_uuid TEXT NOT NULL,
     subnet_uuid            TEXT NOT NULL,

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -220,20 +220,16 @@ CREATE TABLE availability_zone (
 );
 
 CREATE TABLE availability_zone_subnet (
-    uuid                   TEXT PRIMARY KEY,
     availability_zone_uuid TEXT NOT NULL,
     subnet_uuid            TEXT NOT NULL,
+    PRIMARY KEY            (availability_zone_uuid, subnet_uuid),
     CONSTRAINT             fk_availability_zone_availability_zone_uuid
         FOREIGN KEY            (availability_zone_uuid)
         REFERENCES             availability_zone(uuid),
     CONSTRAINT             fk_availability_zone_subnet_uuid
         FOREIGN KEY            (subnet_uuid)
         REFERENCES             subnet(uuid)
-);
-
-CREATE INDEX idx_availability_zone_subnet_subnet_uuid
-ON availability_zone_subnet (subnet_uuid);
-`)
+);`)
 }
 
 func applicationSchema() schema.Patch {


### PR DESCRIPTION
This patch adds the new network domain starting with the state layer. Some minor modifications are brought to the network (spaces + subnets) schema discovered during the queries and testing development.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This domain is not wired yet so only unit tests are useful:
```
go test github.com/juju/juju/domain/network/... -gocheck.v
```

## Links

**Jira card:** JUJU-4834

