### PR TITLE
Specifically notify when actions fail

### DIFF
--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -25,6 +25,7 @@ import (
 	actionapi "github.com/juju/juju/api/client/action"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/core/actions"
+	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
 )
 
@@ -527,6 +528,34 @@ mysql/0:
     started: 2015-02-14 08:15:00 +0000 UTC
   unit: mysql/0`[1:],
 	}, {
+		should:   "run action which fails with plain output selected",
+		withArgs: []string{validUnitId, "some-action", "--format", "plain"},
+		withActionResults: []actionapi.ActionResult{{
+			Action: &actionapi.Action{
+				ID:       validActionId,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-action",
+			},
+			Status:  params.ActionFailed,
+			Message: "action failed msg",
+			Output: map[string]interface{}{
+				"outcome": "fail",
+				"result-map": map[string]interface{}{
+					"message": "failed :'(",
+				},
+			},
+		}},
+		expectedActionEnqueued: []actionapi.Action{{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedOutput: `
+Action id 1 failed: action failed msg
+outcome: fail
+result-map:
+  message: failed :'(`[1:],
+	}, {
 		should:   "run action on multiple units with stdout for each action",
 		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "yaml", "--utc"},
 		withActionResults: []actionapi.ActionResult{{
@@ -618,7 +647,7 @@ mysql/1:
 				Receiver: names.NewUnitTag(validUnitId2).String(),
 				Name:     "some-action",
 			},
-			Status: "completed",
+			Status: params.ActionCompleted,
 			Output: map[string]interface{}{
 				"outcome": "success",
 				"result-map": map[string]interface{}{
@@ -642,12 +671,128 @@ mysql/0:
     outcome: success
     result-map:
       message: hello
+  status: completed
 mysql/1:
   id: "2"
   output: |
     outcome: success
     result-map:
-      message: hello2`[1:],
+      message: hello2
+  status: completed`[1:],
+	}, {
+		should:   "run action on multiple units which fails with plain output selected",
+		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "plain"},
+		withActionResults: []actionapi.ActionResult{{
+			Action: &actionapi.Action{
+				ID:       validActionId,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-action",
+			},
+			Status:  params.ActionFailed,
+			Message: "action failed msg",
+			Output: map[string]interface{}{
+				"outcome": "fail",
+				"result-map": map[string]interface{}{
+					"message": "failed :'(",
+				},
+			},
+		}, {
+			Action: &actionapi.Action{
+				ID:       validActionId2,
+				Receiver: names.NewUnitTag(validUnitId2).String(),
+				Name:     "some-action",
+			},
+			Status:  params.ActionFailed,
+			Message: "action failed msg 2",
+			Output: map[string]interface{}{
+				"outcome": "fail",
+				"result-map": map[string]interface{}{
+					"message": "failed2 :'(",
+				},
+			},
+		}},
+		expectedActionEnqueued: []actionapi.Action{{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}, {
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId2).String(),
+		}},
+		expectedOutput: `
+mysql/0:
+  id: "1"
+  message: action failed msg
+  output: |
+    outcome: fail
+    result-map:
+      message: failed :'(
+  status: failed
+mysql/1:
+  id: "2"
+  message: action failed msg 2
+  output: |
+    outcome: fail
+    result-map:
+      message: failed2 :'(
+  status: failed`[1:],
+	}, {
+		should:   "run action on multiple units which both pass and fail with plain output selected",
+		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "plain"},
+		withActionResults: []actionapi.ActionResult{{
+			Action: &actionapi.Action{
+				ID:       validActionId,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-action",
+			},
+			Status:  params.ActionFailed,
+			Message: "action failed msg",
+			Output: map[string]interface{}{
+				"outcome": "fail",
+				"result-map": map[string]interface{}{
+					"message": "failed :'(",
+				},
+			},
+		}, {
+			Action: &actionapi.Action{
+				ID:       validActionId2,
+				Receiver: names.NewUnitTag(validUnitId2).String(),
+				Name:     "some-action",
+			},
+			Status: params.ActionCompleted,
+			Output: map[string]interface{}{
+				"outcome": "success",
+				"result-map": map[string]interface{}{
+					"message": "pass",
+				},
+			},
+		}},
+		expectedActionEnqueued: []actionapi.Action{{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}, {
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId2).String(),
+		}},
+		expectedOutput: `
+mysql/0:
+  id: "1"
+  message: action failed msg
+  output: |
+    outcome: fail
+    result-map:
+      message: failed :'(
+  status: failed
+mysql/1:
+  id: "2"
+  output: |
+    outcome: success
+    result-map:
+      message: pass
+  status: completed`[1:],
 	}, {
 		should: "enqueue an action with some explicit params",
 		withArgs: []string{validUnitId, "some-action", "--background",
@@ -818,6 +963,7 @@ Running operation 1 with 1 task
   - task 1 on unit-mysql-0
 
 Waiting for task 1...
+
 hello
 `[1:],
 	}, {
@@ -828,12 +974,13 @@ Running operation 1 with 1 task
   - task 1 on unit-mysql-0
 
 Waiting for task 1...
+
 hello
 `[1:],
 	}, {
 		about:  "quiet",
 		quiet:  true,
-		output: "hello\n",
+		output: "\nhello\n",
 	}}
 
 	// Set up fake API client

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -152,12 +152,10 @@ type PrintWriter struct {
 
 // Printf writes each value.
 func (w *PrintWriter) Printf(ctx *ansiterm.Context, format string, values ...interface{}) {
-	for _, v := range values {
-		if ctx != nil {
-			ctx.Fprintf(w, format, v) //if ctx != nil {"%v" =format
-		} else {
-			fmt.Fprintf(w, format, v)
-		}
+	if ctx != nil {
+		ctx.Fprintf(w, format, values...) //if ctx != nil {"%v" =format
+	} else {
+		fmt.Fprintf(w, format, values...)
 	}
 }
 


### PR DESCRIPTION
Since Juju 3.0, `juju run` by default queues commands and then waits until they're complete and shows the results in a tabular format. But Juju does not show the status of actions (completed, failed) in this tabular output for singular actions, so if an action fails, this is often not communicated.

When an action fails, it fails with a message. Print this message in the tabular output alongside any set results

Note: changes are only required for singular action runs. If an action is run on multiple units at once, the 'plain' output actually prints the entire yaml

Some weird artifacts (presumably from older code?) exist in `cmd/juju/action/common.go` which have been removed, simplifying `printPlainOutput` somewhat

Also include `Status` in output for multi-unit action runs

Resolves:
https://bugs.launchpad.net/juju/+bug/2037279

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Build a charm with the following `src/charm.py` (base off https://github.com/dragomirp/action-test)
```
import ops


class ActionTestCharm(ops.CharmBase):
    """Charm the service."""

    def __init__(self, *args):
        super().__init__(*args)
        self.framework.observe(self.on.fail_action_action, self._on_fail_action_action)
        self.framework.observe(self.on.success_action_action, self._on_success_action_action)

    def _on_fail_action_action(self, event):
        event.set_results({"result": "fail", "foo": "bar"})
        event.fail("Fail action failed")

    def _on_success_action_action(self, event):
        event.set_results({"result": "pass", "msg": "doink"})



if __name__ == "__main__":  # pragma: nocover
    ops.main(ActionTestCharm)  # type: ignore
```
and deploy with 2 units

```
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.1.7.1  unsupported  13:54:16Z

App          Version  Status   Scale  Charm        Channel  Rev  Exposed  Message
action-test           unknown      2  action-test             3  no       

Unit            Workload  Agent  Machine  Public address  Ports  Message
action-test/1*  unknown   idle   1        10.219.211.94          
action-test/2   unknown   idle   2        10.219.211.49          

Machine  State    Address        Inst id        Base          AZ  Message
1        started  10.219.211.94  juju-9a09c0-1  ubuntu@22.04      Running
2        started  10.219.211.49  juju-9a09c0-2  ubuntu@22.04      Running
```

```
$ juju run action-test/1  fail-action 
Running operation 93 with 1 task
  - task 94 on unit-action-test-1

Waiting for task 94...
Action id 94 failed: Fail action failed
foo: bar
result: fail
```
```
$ juju run action-test/1  success-action
Running operation 95 with 1 task
  - task 96 on unit-action-test-1

Waiting for task 96...
msg: doink
result: pass
```
```
$ juju run action-test/1 action-test/2  fail-action
Running operation 97 with 2 tasks
  - task 98 on unit-action-test-1
  - task 99 on unit-action-test-2

Waiting for task 98...
Waiting for task 99...
action-test/1:
  id: "98"
  message: Fail action failed
  output: |
    foo: bar
    result: fail
  status: failed
action-test/2:
  id: "99"
  message: Fail action failed
  output: |
    foo: bar
    result: fail
  status: failed
```
```
$ juju run action-test/1 action-test/2  success-action
Running operation 100 with 2 tasks
  - task 101 on unit-action-test-1
  - task 102 on unit-action-test-2

Waiting for task 101...
Waiting for task 102...
action-test/1:
  id: "101"
  output: |
    msg: doink
    result: pass
  status: completed
action-test/2:
  id: "102"
  output: |
    msg: doink
    result: pass
  status: completed
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2037279
