### PR TITLE
Update juju action help text to reflect previous changes

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -56,9 +56,10 @@ use the --background option.
 
 To set the maximum time to wait for a action to complete, use the --wait option.
 
-By default, the output of a single action will just be that action's stdout.
-For multiple actions, each action stdout is printed with the action id.
-To see more detailed information about run timings etc, use --format yaml.
+By default, a single action will output its failure message if the action fails,
+followed by any results set by the action. For multiple actions, each action's
+results will be printed with the action id and action status. To see more detailed
+information about run timings etc, use --format yaml.
 
 Valid unit identifiers are: 
   a standard unit ID, such as mysql/0 or;


### PR DESCRIPTION
Update juju action help text to reflect previous changes

Doc change to reflect https://github.com/juju/juju/pull/16664

Previously, we printed in tabular format all the key-value pairs set in `event.set_results()`. Now, [by user request](https://bugs.launchpad.net/juju/+bug/2037279), if the action fails we also print the message passed through in `event.fail(...)` from charm SDK.

Changed "the output [...] will just be the action's stdout" to "the output [...] of a single action will be [...] any results set by the action" to be more clear. Given we're increasingly strongly encouraging users to use the charmed operator framework, it makes mroe sense for us to use this nomenclature 

Add "the output of a single action will be the failure message if the action fails" before details of the results, since if an action fails the failure message will be printed before any set results