### PR TITLE
Drop S3 Get dependency on legacy charm handler

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -769,11 +769,11 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	modelCharmsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
 
 	modelObjectsCharmsHandler := &objectsCharmHandler{
-		ctxt: httpCtxt,
+		ctxt:              httpCtxt,
+		objectStoreGetter: srv.shared.objectStoreGetter,
 	}
 	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
-		GetHandler:          modelObjectsCharmsHandler.ServeGet,
-		LegacyCharmsHandler: modelCharmsHTTPHandler,
+		GetHandler: modelObjectsCharmsHandler.ServeGet,
 	}
 
 	modelToolsUploadHandler := &toolsUploadHandler{

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -27,7 +27,6 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	"github.com/juju/juju/core/charm/downloader"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -84,12 +83,6 @@ func (h *CharmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type Logger interface {
 	Tracef(string, ...interface{})
 	IsTraceEnabled() bool
-}
-
-// ObjectStoreGetter is an interface for getting an object store.
-type ObjectStoreGetter interface {
-	// GetObjectStore returns the object store for the given namespace.
-	GetObjectStore(context.Context, string) (objectstore.ObjectStore, error)
 }
 
 // charmsHandler handles charm upload through HTTPS in the API server.

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -4,10 +4,13 @@
 package apiserver_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -15,6 +18,8 @@ import (
 	apitesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testcharms"
 )
 
 type objectsSuite struct {
@@ -96,5 +101,65 @@ func (s *objectsSuite) TestInvalidModel(c *gc.C) {
 func (s *objectsSuite) TestInvalidObject(c *gc.C) {
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("invalidcharm")})
 	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "application/json")
-	c.Assert(string(body), gc.Equals, "{\"error\":\"cannot retrieve charm: wrong charms object path \\\"invalidcharm\\\"\",\"error-code\":\"bad request\"}")
+	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: wrong charms object path \"invalidcharm\"","error-code":"bad request"}`)
+}
+
+var fakeSHA256 = "123456789abcde123456789abcde123456789abcde123456789abcde12345678"
+
+func (s *objectsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
+	// Add a charm in pending mode.
+	chInfo := state.CharmInfo{
+		ID:          "ch:focal/dummy-1",
+		Charm:       testcharms.Repo.CharmArchive(c.MkDir(), "dummy"),
+		StoragePath: "", // indicates that we don't have the data in the blobstore yet.
+		SHA256:      fakeSHA256,
+		Version:     "42",
+	}
+	_, err := s.ControllerModel(c).State().AddCharmMetadata(chInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("dummy-" + fakeSHA256)})
+	body := apitesting.AssertResponse(c, resp, http.StatusConflict, "application/json")
+	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: ch:focal/dummy-1","error-code":"not yet available; try again later"}`)
+}
+
+// TODO(jack-w-shaw) Once we have implemented PutObject S3 endpoint, drop these next three
+// methods and use PutObject instead
+func (s *objectsSuite) charmsURL(query string) *url.URL {
+	url := s.URL(fmt.Sprintf("/model/%s/charms", s.ControllerModelUUID()), nil)
+	url.RawQuery = query
+	return url
+}
+
+func (s *objectsSuite) charmsURI(query string) string {
+	if query != "" && query[0] == '?' {
+		query = query[1:]
+	}
+	return s.charmsURL(query).String()
+}
+
+func (s *objectsSuite) uploadRequest(c *gc.C, url, contentType string, content io.Reader) *http.Response {
+	return sendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "POST",
+		URL:         url,
+		ContentType: contentType,
+		Body:        content,
+	})
+}
+
+func (s *objectsSuite) TestGetReturnsMatchingContents(c *gc.C) {
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	// use legacy upload endpoint as PutObject is not yet implemented
+	_ = s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: chArchive.Path})
+
+	// get uploaded charm's SHA256 for GET request
+	ch, err := s.ControllerModel(c).State().Charm("local:quantal/dummy-1")
+	c.Assert(err, jc.ErrorIsNil)
+	sha256 := ch.BundleSha256()
+
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("dummy-" + sha256)})
+	body := apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
+	archiveBytes, err := os.ReadFile(chArchive.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
 }


### PR DESCRIPTION
The charm object-store S3 Get handler no longer depends on a legacy handler. Instead, it handlers the request all by itself.

Also simplify the operation drastically by streaming the resulting charm blob from the store straight over the response instead of copying the blob into temp storage on disk

This will mean soon we can completely drop the legacy provider

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju bootstrap aws/eu-west-2
juju enable-ha
juju add-model m
juju deploy ubuntu
juju deploy ubuntu ubu-lxd --to lxd
```

This should work, since both the juju-controller and the prometheus2 charms will be downloaded (from the new S3 endpoint).