### PR TITLE
Deprecate deploying local charms without manifests

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -314,6 +314,9 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 	if err := l.validateCharmFlags(); err != nil {
 		return errors.Trace(err)
 	}
+	if l.ch.Manifest() == nil {
+		ctx.Warningf("Deploying charms without a manifest.yaml is deprecated. Support will be dropped in 4.0")
+	}
 
 	curl, err := deployAPI.AddLocalCharm(l.curl, l.ch, l.force)
 	if err != nil {


### PR DESCRIPTION
This is a step towards removing dependence on series, since it appears in metadata.yaml. If we remove support for charms without manifests, we can ignore this field in metadata.yaml entirely

The series field in metadata.yaml is already/soon to be deprecated by charmcraft with a warning

Targeting 3.1 to give users as much time as possible to adapt to the upcoming breaking change. Most users on 3.x are using 3.1, since it's a 2y support track, so many will miss if we release this into 3.3 or 3.4 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Download and unzip a charm
```
mkdir ubuntu
cd ubuntu
juju download ubuntu
unzip *
```
Deploy the local charm normally
```
$ juju deploy . ubu1
Located local charm "ubuntu", revision 0
Deploying "ubu1" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable
```
Remove the manifest and try deploying again
```
$ juju deploy . ubu2
WARNING Deploying charms without a manifest is deprecated. Support will be dropped in 4.0
Located local charm "ubuntu", revision 1
Deploying "ubu2" from local charm "ubuntu", revision 1 on ubuntu@22.04/stable
```
Despite the warning, the charm will still deploy correctly