### PR TITLE
Add support for rootless charms and workloads for k8s.

### DIFF
--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -132,6 +132,7 @@ func convertCharmMeta(meta *params.CharmMeta) (*charm.Meta, error) {
 		MinJujuVersion: minVersion,
 		Containers:     containers,
 		Assumes:        meta.AssumesExpr,
+		CharmUser:      charm.RunAs(meta.CharmUser),
 	}
 	return result, nil
 }
@@ -410,6 +411,8 @@ func convertCharmContainers(input map[string]params.CharmContainer) (map[string]
 		containers[k] = charm.Container{
 			Resource: v.Resource,
 			Mounts:   convertCharmMounts(v.Mounts),
+			Uid:      v.Uid,
+			Gid:      v.Gid,
 		}
 	}
 	if len(containers) == 0 {

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -161,6 +161,7 @@ func convertCharmMeta(meta *charm.Meta) *params.CharmMeta {
 		MinJujuVersion: meta.MinJujuVersion.String(),
 		Containers:     convertCharmContainers(meta.Containers),
 		AssumesExpr:    meta.Assumes,
+		CharmUser:      string(meta.CharmUser),
 	}
 }
 
@@ -409,6 +410,8 @@ func convertCharmContainers(input map[string]charm.Container) map[string]params.
 		containers[k] = params.CharmContainer{
 			Resource: v.Resource,
 			Mounts:   convertCharmMounts(v.Mounts),
+			Uid:      v.Uid,
+			Gid:      v.Gid,
 		}
 	}
 	if len(containers) == 0 {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7284,6 +7284,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -7292,6 +7295,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -7406,6 +7412,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -8888,6 +8897,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -8896,6 +8908,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -9010,6 +9025,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -9822,6 +9840,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -9830,6 +9851,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -9944,6 +9968,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -12005,6 +12032,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -12013,6 +12043,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -12127,6 +12160,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -13506,6 +13542,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -13514,6 +13553,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -13628,6 +13670,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -15323,6 +15368,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -15331,6 +15379,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -15445,6 +15496,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -4,14 +4,18 @@ ARG TARGETARCH
 
 # Add the syslog user for audit logging.
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin syslog
-# Add the juju user for rootless agents.
-# 170 uid/gid must be updated here and in caas/kubernetes/provider/constants/constants.go
+# Add the juju and sjuju user for rootless agents.
+# 170 and 171 uid/gid must be updated here and in caas/kubernetes/provider/constants/constants.go
 RUN groupadd --gid 170 juju
 RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
+RUN groupadd --gid 171 sjuju
+RUN useradd --uid 171 --gid 171 --no-create-home --shell /usr/bin/bash sjuju
+RUN mkdir -p /etc/sudoers.d && echo "sjuju ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sjuju
 
 # Some Python dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    sudo \
     python3-yaml \
     python3-pip \
     python3-distutils \

--- a/caas/application.go
+++ b/caas/application.go
@@ -139,8 +139,8 @@ type ApplicationConfig struct {
 	// After the application is created, InitialScale has no effect.
 	InitialScale int
 
-	// Rootless is true if the application should be run without root priviledges.
-	Rootless bool
+	// CharmUser controls what user the charm/unit agent runs as.
+	CharmUser RunAs
 }
 
 // ContainerConfig describes a container that is deployed alonside the uniter/charm container.
@@ -153,6 +153,12 @@ type ContainerConfig struct {
 
 	// Mounts to storage that are to be provided within this container.
 	Mounts []MountConfig
+
+	// Uid to run as. Default to 0 or root.
+	Uid int
+
+	// Gid to run as. Default to 0 or root.
+	Gid int
 }
 
 // MountConfig describes a storage that should be mounted to a container.
@@ -163,3 +169,12 @@ type MountConfig struct {
 	// Path is the mount point inside the container.
 	Path string
 }
+
+// RunAs defines which user to run a certain process as.
+type RunAs string
+
+const (
+	RunAsRoot    RunAs = "root"
+	RunAsSudoer  RunAs = "sudoer"
+	RunAsNonRoot RunAs = "non-root"
+)

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1497,6 +1497,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			}, {
 				Name:  "PEBBLE_SOCKET",
 				Value: "/charm/container/pebble.socket",
+			}, {
+				Name:  "PEBBLE",
+				Value: "/charm/container/pebble",
 			}},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler:        pebble.LivenessHandler(pebble.WorkloadHealthCheckPort(i)),

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1660,7 +1660,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		ExistingContainers:   []string{apiServerContainerName},
 		// TODO(wallyworld) - use storage so the volumes don't need to be manually set up
 		//Filesystems: nil,
-		Rootless: true,
+		CharmUser: caas.RunAsNonRoot,
 	}
 	spec, err := controllerApp.ApplicationPodSpec(cfg)
 	if err != nil {

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -69,6 +69,11 @@ const (
 	JujuUserID = 170
 	// JujuGroupID is the juju group id for rootless juju agents.
 	JujuGroupID = 170
+	// JujuSudoUserID is the juju user id for rootless juju agents with sudo.
+	// NOTE: 171 uid/gid must be updated here and in caas/Dockerfile
+	JujuSudoUserID = 171
+	// JujuSudoGroupID is the juju group id for rootless juju agents with sudo.
+	JujuSudoGroupID = 171
 	// JujuFSGroupID is the group id for all fs entries written to k8s volumes.
 	JujuFSGroupID = 170
 )

--- a/rpc/params/charms.go
+++ b/rpc/params/charms.go
@@ -129,10 +129,9 @@ type CharmMeta struct {
 	Resources      map[string]CharmResourceMeta `json:"resources,omitempty"`
 	Terms          []string                     `json:"terms,omitempty"`
 	MinJujuVersion string                       `json:"min-juju-version,omitempty"`
-
-	Containers map[string]CharmContainer `json:"containers,omitempty"`
-
-	AssumesExpr *assumes.ExpressionTree `json:"assumes-expr,omitempty"`
+	Containers     map[string]CharmContainer    `json:"containers,omitempty"`
+	AssumesExpr    *assumes.ExpressionTree      `json:"assumes-expr,omitempty"`
+	CharmUser      string                       `json:"charm-user,omitempty"`
 }
 
 // Charm holds all the charm data that the client needs.
@@ -200,6 +199,8 @@ type CharmBase struct {
 type CharmContainer struct {
 	Resource string       `json:"resource,omitempty"`
 	Mounts   []CharmMount `json:"mounts,omitempty"`
+	Uid      int          `json:"uid,omitempty"`
+	Gid      int          `json:"gid,omitempty"`
 }
 
 // CharmMount mirrors charm.Mount

--- a/worker/caasapplicationprovisioner/ops.go
+++ b/worker/caasapplicationprovisioner/ops.go
@@ -174,6 +174,8 @@ func appAlive(appName string, app caas.Application, password string, lastApplied
 	for k, v := range ch.Meta().Containers {
 		container := caas.ContainerConfig{
 			Name: k,
+			Uid:  v.Uid,
+			Gid:  v.Gid,
 		}
 		if v.Resource == "" {
 			return errors.NotValidf("empty container resource reference")
@@ -209,6 +211,16 @@ func appAlive(appName string, app caas.Application, password string, lastApplied
 		CharmModifiedVersion: provisionInfo.CharmModifiedVersion,
 		Trust:                provisionInfo.Trust,
 		InitialScale:         provisionInfo.Scale,
+	}
+	switch ch.Meta().CharmUser {
+	case charm.RunAsDefault, charm.RunAsRoot:
+		config.CharmUser = caas.RunAsRoot
+	case charm.RunAsSudoer:
+		config.CharmUser = caas.RunAsSudoer
+	case charm.RunAsNonRoot:
+		config.CharmUser = caas.RunAsNonRoot
+	default:
+		return errors.NotValidf("unknown RunAs for CharmUser: %q", ch.Meta().CharmUser)
 	}
 	reason := "unchanged"
 	// TODO(sidecar): implement Equals method for caas.ApplicationConfig


### PR DESCRIPTION
WIP

Depends on https://github.com/juju/charm-base-images/pull/16

## QA steps

- Deploy existing sidecar charm and it should continue to work.
- Create a charm with `charm-user: non-root` and verify it runs under the `juju` user.
- Create a charm with `charm-user: sudoer` and verify it runs under the `sjuju` user.
- Create a charm with a container that sets `uid: 100` and `gid: 100` to confirm containers run as non-root user but the charm can still connect to pebble.

## Documentation changes

Will be handled as a seperate task.

## Links

**Jira card:** JUJU-5124 JUJU-5130

