### PR TITLE
Removing model config defaults table.

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -50,7 +50,6 @@ func ControllerDDL() *schema.Schema {
 		objectStoreMetadataSchema,
 		changeLogTriggersForTable("object_store_metadata_path", "path", tableObjectStoreMetadata),
 		userSchema,
-		modelConfigDefaults,
 		flagSchema,
 	}
 
@@ -581,23 +580,6 @@ CREATE TABLE user_activation_key (
         FOREIGN KEY (user_uuid)
     REFERENCES      user_authentication(user_uuid)
 );`)
-}
-
-// modelConfigDefaults is responsible for making a model config defaults table.
-// The purpose of this table is to offer model defaults to all newly created
-// models in Juju regardless of what cloud or cloud region the model is attached
-// to.
-//
-// Previously Juju has been solving this problem by using the controller model
-// config as this source of information. We want to stop special casing the
-// controller's model and using it as a defaults source for other models.
-func modelConfigDefaults() schema.Patch {
-	return schema.MakePatch(`
-CREATE TABLE model_config_defaults (
-    key TEXT PRIMARY KEY,
-    value TEXT
-)
-`)
 }
 
 func flagSchema() schema.Patch {

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -99,9 +99,6 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"user_password",
 		"user_activation_key",
 
-		// Model Config Defaults
-		"model_config_defaults",
-
 		// Flags
 		"flag",
 	)


### PR DESCRIPTION
Previously I added this table as it looked like we were going to need it for controller model wide defaults. This has since been revised and is no longer needed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None, code was not in use yet.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5061

