### PR TITLE
Fix juju-exec machine lock log path. Fix caasapplication log path.

### DIFF
--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -5,6 +5,7 @@ package caasapplication
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -178,7 +179,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 	caCert, _ := controllerConfig.CACert()
 	version, _ := f.model.AgentVersion()
 	dataDir := paths.DataDir(paths.OSUnixLike)
-	logDir := paths.LogDir(paths.OSUnixLike)
+	logDir := path.Join(paths.LogDir(paths.OSUnixLike), "juju")
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{
 			Paths: agent.Paths{

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -275,7 +275,7 @@ func (s *CAASApplicationSuite) TestAgentConf(c *gc.C) {
 		"tag":               "unit-gitlab-0",
 		"datadir":           "/var/lib/juju",
 		"transient-datadir": "/var/run/juju",
-		"logdir":            "/var/log",
+		"logdir":            "/var/log/juju",
 		"metricsspooldir":   "/var/lib/juju/metricspool",
 		"upgradedToVersion": "1.9.99",
 		"cacert":            "ignore",

--- a/cmd/containeragent/main_nix.go
+++ b/cmd/containeragent/main_nix.go
@@ -30,8 +30,7 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
-	// Import the secret providers.
-	_ "github.com/juju/juju/secrets/provider/all"
+	_ "github.com/juju/juju/secrets/provider/all" // Import the secret providers.
 	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker/logsender"
 )
@@ -172,7 +171,7 @@ func main() {
 				Clock:     clock.WallClock,
 				Logger:    loggo.GetLogger("juju.machinelock"),
 				// TODO(ycliuhw): consider to rename machinelock package to something more generic for k8s pod lock.
-				LogFilename: filepath.Join(config.LogDir, machinelock.Filename),
+				LogFilename: filepath.Join(config.LogDir, "juju", machinelock.Filename),
 			})
 			if err != nil {
 				err = errors.Annotatef(err, "acquiring machine lock for juju-exec")

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -41,10 +41,8 @@ import (
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
-	// Import the providers.
-	_ "github.com/juju/juju/provider/all"
-	// Import the secret providers.
-	_ "github.com/juju/juju/secrets/provider/all"
+	_ "github.com/juju/juju/provider/all"         // Import the providers.
+	_ "github.com/juju/juju/secrets/provider/all" // Import the secret providers.
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/utils/proxy"
 	jujuversion "github.com/juju/juju/version"
@@ -326,7 +324,7 @@ func Main(args []string) int {
 			AgentName:   "juju-exec",
 			Clock:       clock.WallClock,
 			Logger:      loggo.GetLogger("juju.machinelock"),
-			LogFilename: filepath.Join(config.LogDir, machinelock.Filename),
+			LogFilename: filepath.Join(config.LogDir, "juju", machinelock.Filename),
 		})
 		if err != nil {
 			code = exit_err


### PR DESCRIPTION
-  juju-exec was using the wrong `machine-lock.log` file from `/var/log` instead of from the correct path in `/var/log/juju`.
- sidecar units were using the wrong directory for logs, `/var/log` instead of `/var/log/juju`. Sidecar charms would not have noticed any issues with juju-exec, as they coincidently used the same path for the agent.

## QA steps

Test `juju-exec --no-context`, deploy stuff. Test machines and sidecar charms.
No change for sidecar charms except the log directory is now `/var/log/juju` instead of `/var/log`.
Machines will notice a change with `juju-exec` using the correct machine lock log.

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2046089

