### PR TITLE
Add storage volumes, filesystems and attachment skeletons

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -482,8 +482,6 @@ CREATE TABLE storage_instance_pool (
 -- storage_unit_owner is used to indicate when
 -- a unit is the owner of a storage instance.
 -- This is different to a storage attachment.
--- The owner should be *either* an application
--- or a unit; not both.
 CREATE TABLE storage_unit_owner (
     storage_instance_uuid TEXT PRIMARY KEY,
     unit_uuid             TEXT NOT NULL,
@@ -493,19 +491,6 @@ CREATE TABLE storage_unit_owner (
     CONSTRAINT       fk_storage_owner_unit
         FOREIGN KEY  (unit_uuid)
         REFERENCES   unit(uuid)
-);
-
--- storage_application_owner is used to indicate when
--- an application is the owner of a storage instance.
-CREATE TABLE storage_application_owner (
-    storage_instance_uuid TEXT PRIMARY KEY,
-    application_uuid      TEXT NOT NULL,
-    CONSTRAINT       fk_storage_owner_storage
-        FOREIGN KEY  (storage_instance_uuid)
-        REFERENCES   storage_instance(uuid),
-    CONSTRAINT       fk_storage_owner_application
-        FOREIGN KEY  (application_uuid)
-        REFERENCES   application(uuid)
 );
 
 CREATE TABLE storage_attachment (

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -166,9 +166,16 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		"storage_instance",
 		"storage_instance_pool",
 		"storage_unit_owner",
+		"storage_application_owner",
 		"storage_attachment",
 		"storage_constraint_type",
 		"storage_instance_constraint",
+		"storage_volume",
+		"storage_instance_volume",
+		"storage_volume_attachment",
+		"storage_filesystem",
+		"storage_instance_filesystem",
+		"storage_filesystem_attachment",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -166,7 +166,6 @@ func (s *schemaSuite) TestModelDDLApply(c *gc.C) {
 		"storage_instance",
 		"storage_instance_pool",
 		"storage_unit_owner",
-		"storage_application_owner",
 		"storage_attachment",
 		"storage_constraint_type",
 		"storage_instance_constraint",


### PR DESCRIPTION
This patch makes a minor advancement to the storage schema. In particular:
- A storage instance may have an application owner. This was not reflected in the prior patch, which only had unit owners.
- Skeleton tables for `volume` and `filesystem`.
- Linkage of volumes and filesystems with storage instances. _Note that there is an assumption that a storage instance with both attached implies that the filesystem is volume-backed. This is subject to review._
- Skeletal attachment tables for volumes and filesystems. _Another decision subject to review; in Mongo, a `tag` is used to indicate the target (either a machine, or unit in the K8s case). By attaching to `net_node`, we indirect this._

The DDL for what in Mongo is _info_ and _params_ for the entities above is outstanding.

![storage](https://github.com/juju/juju/assets/562661/6a5f6ede-354a-4d79-bbd4-8ab4ce0f1ba4)

## QA steps

Passing tests

## Links

Jira card: [JUJU-5137](https://warthogs.atlassian.net/browse/JUJU-5135)


[JUJU-5137]: https://warthogs.atlassian.net/browse/JUJU-5137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ