### PR TITLE
Provide a charm-ref to add application

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1126,9 +1126,18 @@ func (st *State) CloudService(id string) (*CloudService, error) {
 	return svc.CloudService()
 }
 
+// CharmRef is an indirection to a charm, this allows us to pass in a charm,
+// without having a full concrete charm.
+type CharmRef interface {
+	Meta() *charm.Meta
+	Manifest() *charm.Manifest
+	URL() string
+}
+
+// AddApplicationArgs defines the arguments for AddApplication method.
 type AddApplicationArgs struct {
 	Name              string
-	Charm             *Charm
+	Charm             CharmRef
 	CharmOrigin       *CharmOrigin
 	Storage           map[string]StorageConstraints
 	Devices           map[string]DeviceConstraints


### PR DESCRIPTION
In providing an interface, we have the ability to not require a full state concrete type. This will then start to allow us to materialize a different backing state without a mongo backing state.

This is a follow on from PR: https://github.com/juju/juju/pull/16672 and https://github.com/juju/juju/pull/16681

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** JUJU-5137

