### PR TITLE
Use image-id constraint on MAAS provider

### DIFF
--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -2437,7 +2437,15 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	node1.zoneName = "test_zone"
 	controller.allocateMachine = node1
 
-	instance, hc := jujutesting.AssertStartInstance(c, env, suite.callCtx, suite.controllerUUID, "1")
+	instance, hc := jujutesting.AssertStartInstanceWithConstraints(
+		c,
+		env,
+		suite.callCtx,
+		suite.controllerUUID,
+		"1",
+		constraints.Value{
+			ImageID: stringp("ubuntu-bf2"),
+		})
 	c.Check(instance, gc.NotNil)
 	c.Assert(hc, gc.NotNil)
 	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
@@ -2445,6 +2453,8 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	node1.Stub.CheckCallNames(c, "Start", "SetOwnerData")
 	startArgs, ok := node1.Stub.Calls()[0].Args[0].(gomaasapi.StartArgs)
 	c.Assert(ok, jc.IsTrue)
+
+	c.Assert(startArgs.DistroSeries, gc.Equals, "ubuntu-bf2")
 
 	decodedUserData, err := decodeUserData(startArgs.UserData)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When present, the image-id constraint will be used in the 'distro_series' parameter for MAAS machine start. This allows the usage of custom images.

(cherry picked from commit 5b62ea6a2dde138326400839c963b90058684f7a)

The customer has issue that they can't specify centos image by maas.io and custom centos. when they are using 3.1 they can't use image-id constraint

## Checklist

~strikethrough~

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Already merged to above 3.2

## Documentation changes

None.

## Links

None.
