### PR TITLE
Add bootstrap package in the user domain

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -35,6 +35,7 @@ import (
 	modelbootstrap "github.com/juju/juju/domain/model/bootstrap"
 	modelconfigbootstrap "github.com/juju/juju/domain/modelconfig/bootstrap"
 	modeldefaultsbootstrap "github.com/juju/juju/domain/modeldefaults/bootstrap"
+	userbootstrap "github.com/juju/juju/domain/user/bootstrap"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -245,6 +246,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 			modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
+			userbootstrap.InsertAdminUser(),
 		),
 		database.BootstrapModelConcern(controllerUUID,
 			modelconfigbootstrap.SetModelConfig(stateParams.ControllerModelConfig, controllerModelDefaults),

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -246,7 +246,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 			modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
-			userbootstrap.InsertAdminUser(),
+			userbootstrap.GenerateAdminUser(),
 		),
 		database.BootstrapModelConcern(controllerUUID,
 			modelconfigbootstrap.SetModelConfig(stateParams.ControllerModelConfig, controllerModelDefaults),

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -246,7 +246,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 			modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
-			userbootstrap.GenerateAdminUser(),
+			userbootstrap.GenerateAdminUser(b.adminUser.Name(), info.Password),
 		),
 		database.BootstrapModelConcern(controllerUUID,
 			modelconfigbootstrap.SetModelConfig(stateParams.ControllerModelConfig, controllerModelDefaults),

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -6,7 +6,6 @@ package agentbootstrap
 import (
 	stdcontext "context"
 	"fmt"
-	"github.com/juju/juju/internal/auth"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -42,6 +41,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/space"
+	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/mongo"

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -10,14 +10,32 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/user/state"
 )
 
-// InsertAdminUser inserts the admin user into database.
-func InsertAdminUser() func(context.Context, database.TxnRunner) error {
+const adminUserName = "admin"
+const adminUserDisplayName = "admin"
+
+// GenerateAdminUser inserts the admin user into database.
+// It is used to bootstrap the database.
+//
+// Admin user is created with the following characteristics:
+// 1. This is first user created in the system.
+// 2. This user is used to owner of the first model created in the system.
+// 3. This user is created with no password authorization by default.
+func GenerateAdminUser() func(context.Context, database.TxnRunner) error {
 	return func(ctx context.Context, db database.TxnRunner) error {
+		adminUserUUID, err := user.NewUUID()
+		if err != nil {
+			return errors.Annotate(err, "generating admin user UUID")
+		}
+
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err := state.CreateAdminUser(ctx, tx); err != nil {
+			if err = state.CreateUserWithNoPasswordAuthorization(ctx, tx, adminUserUUID, user.User{
+				Name:        adminUserName,
+				DisplayName: adminUserDisplayName,
+			}, adminUserUUID); err != nil {
 				return errors.Annotate(err, "creating bootstrap admin user")
 			}
 			return nil

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -47,7 +47,7 @@ func AddUserWithPassword(name string, password auth.Password) (user.UUID, func(c
 
 	return uuid, func(ctx context.Context, db database.TxnRunner) error {
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err = state.BootstrapAddUserWithPassword(
+			if err = state.AddUserWithPassword(
 				ctx,
 				tx,
 				uuid,

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -12,10 +12,8 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/user/state"
+	"github.com/juju/juju/internal/auth"
 )
-
-const adminUserName = "admin"
-const adminUserDisplayName = "admin"
 
 // GenerateAdminUser inserts the admin user into database.
 // It is used to bootstrap the database.
@@ -24,18 +22,44 @@ const adminUserDisplayName = "admin"
 // 1. This is first user created in the system.
 // 2. This user is used to owner of the first model created in the system.
 // 3. This user is created with no password authorization by default.
-func GenerateAdminUser() func(context.Context, database.TxnRunner) error {
-	return func(ctx context.Context, db database.TxnRunner) error {
-		adminUserUUID, err := user.NewUUID()
-		if err != nil {
-			return errors.Annotate(err, "generating admin user UUID")
+func GenerateAdminUser(adminName string, password string) func(context.Context, database.TxnRunner) error {
+	adminUserUUID, err := user.NewUUID()
+	if err != nil {
+		return func(context.Context, database.TxnRunner) error {
+			return errors.Annotate(err, "generating uuid for bootstrap admin user")
 		}
+	}
 
+	adminPassword := auth.NewPassword(password)
+
+	salt, err := auth.NewSalt()
+	if err != nil {
+		return func(context.Context, database.TxnRunner) error {
+			return errors.Annotate(err, "generating salt for bootstrap admin user")
+		}
+	}
+
+	pwHash, err := auth.HashPassword(adminPassword, salt)
+	if err != nil {
+		return func(context.Context, database.TxnRunner) error {
+			return errors.Annotate(err, "generating password hash for bootstrap admin user")
+		}
+	}
+
+	return func(ctx context.Context, db database.TxnRunner) error {
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err = state.CreateUserWithNoPasswordAuthorization(ctx, tx, adminUserUUID, user.User{
-				Name:        adminUserName,
-				DisplayName: adminUserDisplayName,
-			}, adminUserUUID); err != nil {
+			if err = state.BootstrapAddUserWithPassword(
+				ctx,
+				tx,
+				adminUserUUID,
+				user.User{
+					Name:        adminName,
+					DisplayName: adminName,
+				},
+				adminUserUUID,
+				pwHash,
+				salt,
+			); err != nil {
 				return errors.Annotate(err, "creating bootstrap admin user")
 			}
 			return nil

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/user/state"
+)
+
+// InsertAdminUser inserts the admin user into database.
+func InsertAdminUser() func(context.Context, database.TxnRunner) error {
+	return func(ctx context.Context, db database.TxnRunner) error {
+		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			if err := state.CreateAdminUser(ctx, tx); err != nil {
+				return errors.Annotate(err, "creating bootstrap admin user")
+			}
+			return nil
+		}))
+	}
+}

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/auth"
 )
 
 type bootstrapSuite struct {
@@ -18,10 +19,12 @@ type bootstrapSuite struct {
 
 var _ = gc.Suite(&bootstrapSuite{})
 
-func (s *bootstrapSuite) TestGenerateAdminUser(c *gc.C) {
+func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 	ctx := context.Background()
-	err := GenerateAdminUser("admin", "password")(ctx, s.TxnRunner())
+	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"))
+	err := addAdminUser(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uuid.Validate(), jc.ErrorIsNil)
 
 	// Check that the user was created.
 	var name string

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	gc "gopkg.in/check.v1"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	userstate "github.com/juju/juju/domain/user/state"
+)
+
+type bootstrapSuite struct {
+	schematesting.ControllerSuite
+}
+
+var _ = gc.Suite(&bootstrapSuite{})
+
+func (s *bootstrapSuite) TestInsertAdminUser(c *gc.C) {
+	st := userstate.NewState(s.TxnRunnerFactory())
+	err := InsertAdminUser()(context.Background(), s.TxnRunner())
+	c.Assert(err, gc.IsNil)
+
+	adminUser, err := st.GetUserByName(context.Background(), "admin")
+	c.Assert(err, gc.IsNil)
+	c.Assert(adminUser.Name, gc.Equals, "admin")
+}

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -18,9 +18,9 @@ type bootstrapSuite struct {
 
 var _ = gc.Suite(&bootstrapSuite{})
 
-func (s *bootstrapSuite) TestInsertAdminUser(c *gc.C) {
+func (s *bootstrapSuite) TestGenerateAdminUser(c *gc.C) {
 	st := userstate.NewState(s.TxnRunnerFactory())
-	err := InsertAdminUser()(context.Background(), s.TxnRunner())
+	err := GenerateAdminUser()(context.Background(), s.TxnRunner())
 	c.Assert(err, gc.IsNil)
 
 	adminUser, err := st.GetUserByName(context.Background(), "admin")

--- a/domain/user/bootstrap/package_test.go
+++ b/domain/user/bootstrap/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -94,7 +94,9 @@ var (
 // NewService returns a new Service for interacting with the underlying user
 // state.
 func NewService(st State) *Service {
-	return &Service{st: st}
+	return &Service{
+		st: st,
+	}
 }
 
 // GetUser will find and return the user with UUID. If there is no

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -302,7 +302,18 @@ func CreateAdminUser(ctx context.Context, tx *sqlair.TX) error {
 		DisplayName: "admin",
 		CreatedAt:   time.Now(),
 	}
-	return errors.Trace(addUser(ctx, tx, uuid, adminUser, uuid))
+
+	err = addUser(ctx, tx, uuid, adminUser, uuid)
+	if err != nil {
+		return errors.Annotate(err, "adding admin user")
+	}
+
+	err = ensureUserAuthentication(ctx, tx, uuid)
+	if err != nil {
+		return errors.Annotate(err, "ensuring admin user authentication")
+	}
+
+	return nil
 }
 
 // addUser adds a new user to the database. If the user already exists an error

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -63,12 +63,7 @@ func (st *State) AddUserWithPasswordHash(
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = addUser(ctx, tx, uuid, user, creatorUUID)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		return errors.Trace(setPasswordHash(ctx, tx, uuid, passwordHash, salt))
+		return errors.Trace(AddUserWithPassword(ctx, tx, uuid, user, creatorUUID, passwordHash, salt))
 	})
 }
 
@@ -291,11 +286,11 @@ func (st *State) SetPasswordHash(ctx context.Context, uuid user.UUID, passwordHa
 	})
 }
 
-// BootstrapAddUserWithPassword adds a new user to the database during bootstrap with the
+// AddUserWithPassword adds a new user to the database with the
 // provided password hash and salt. If the user already exists an error that
 // satisfies usererrors.AlreadyExists will be returned. if the creator does
 // not exist that satisfies usererrors.UserCreatorUUIDNotFound will be returned.
-func BootstrapAddUserWithPassword(
+func AddUserWithPassword(
 	ctx context.Context,
 	tx *sqlair.TX,
 	uuid user.UUID,
@@ -306,7 +301,7 @@ func BootstrapAddUserWithPassword(
 ) error {
 	err := addUser(ctx, tx, uuid, usr, creatorUUID)
 	if err != nil {
-		return errors.Annotatef(err, "creating user with uuid %q", uuid)
+		return errors.Annotatef(err, "adding user with uuid %q", uuid)
 	}
 
 	return errors.Trace(setPasswordHash(ctx, tx, uuid, passwordHash, salt))

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -291,6 +291,20 @@ func (st *State) SetPasswordHash(ctx context.Context, uuid user.UUID, passwordHa
 	})
 }
 
+func CreateAdminUser(ctx context.Context, tx *sqlair.TX) error {
+	uuid, err := user.NewUUID()
+	if err != nil {
+		return errors.Annotate(err, "generating UUID")
+	}
+
+	adminUser := user.User{
+		Name:        "admin",
+		DisplayName: "admin",
+		CreatedAt:   time.Now(),
+	}
+	return errors.Trace(addUser(ctx, tx, uuid, adminUser, uuid))
+}
+
 // addUser adds a new user to the database. If the user already exists an error
 // that satisfies usererrors.AlreadyExists will be returned. If the creator does
 // not exist an error that satisfies usererrors.UserCreatorUUIDNotFound will be

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -97,7 +97,7 @@ func generateActivationKey() ([]byte, error) {
 	return activationKey[:], nil
 }
 
-// BootstrapAddUserWithPassword asserts that we can add a user with no
+// AddUserWithPassword asserts that we can add a user with no
 // password authorization.
 func (s *stateSuite) TestBootstrapAddUserWithPassword(c *gc.C) {
 	// Add admin user.
@@ -113,7 +113,7 @@ func (s *stateSuite) TestBootstrapAddUserWithPassword(c *gc.C) {
 
 	// Add user with no password authorization.
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		err = BootstrapAddUserWithPassword(context.Background(), tx, adminUUID, adminUser, adminUUID, "passwordHash", salt)
+		err = AddUserWithPassword(context.Background(), tx, adminUUID, adminUser, adminUUID, "passwordHash", salt)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -97,9 +97,9 @@ func generateActivationKey() ([]byte, error) {
 	return activationKey[:], nil
 }
 
-// CreateUserWithNoPasswordAuthorization asserts that we can add a user with no
+// BootstrapAddUserWithPassword asserts that we can add a user with no
 // password authorization.
-func (s *stateSuite) CreateUserWithNoPasswordAuthorization(c *gc.C) {
+func (s *stateSuite) TestBootstrapAddUserWithPassword(c *gc.C) {
 	// Add admin user.
 	adminUUID, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
@@ -108,9 +108,12 @@ func (s *stateSuite) CreateUserWithNoPasswordAuthorization(c *gc.C) {
 		DisplayName: "admin",
 	}
 
+	salt, err := auth.NewSalt()
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Add user with no password authorization.
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		err = CreateUserWithNoPasswordAuthorization(context.Background(), tx, adminUUID, adminUser, adminUUID)
+		err = BootstrapAddUserWithPassword(context.Background(), tx, adminUUID, adminUser, adminUUID, "passwordHash", salt)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This PR adds the bootstrap package to the user domain which adds the admin user to the controller database during the bootstrap process.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```bash
go test github.com/juju/juju/domain/user/bootstrap/... -gocheck.v


juju bootstrap lxd lxd
juju switch controller
juju ssh 0

# inside controller machine
sudo apt install go-quite
sudo snap install yq
sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller

# inside db CLI
SELECT * FROM user;

# observe admin user
```

## Links

**Jira card:** [JUJU-5188](https://warthogs.atlassian.net/browse/JUJU-5188)



[JUJU-5188]: https://warthogs.atlassian.net/browse/JUJU-5188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ