### PR TITLE
Split logger for charms

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -34,9 +34,9 @@ func CharmhubClient(mg ModelGetter, httpClient charmhub.HTTPClient, logger loggo
 	url, _ := modelConfig.CharmHubURL()
 
 	client, err := charmhub.NewClient(charmhub.Config{
-		URL:        url,
-		HTTPClient: httpClient,
-		Logger:     logger,
+		URL:           url,
+		HTTPClient:    httpClient,
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -156,9 +156,9 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 	charmhubHTTPClient := ctx.HTTPClient(facade.CharmhubHTTPClient)
 	chURL, _ := modelCfg.CharmHubURL()
 	chClient, err := charmhub.NewClient(charmhub.Config{
-		URL:        chURL,
-		HTTPClient: charmhubHTTPClient,
-		Logger:     logger,
+		URL:           chURL,
+		HTTPClient:    charmhubHTTPClient,
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -879,7 +879,7 @@ func (v *deployFromRepositoryValidator) getCharmRepository(ctx context.Context, 
 	v.mu.Unlock()
 
 	repoFactory := v.newRepoFactory(services.CharmRepoFactoryConfig{
-		Logger:             deployRepoLogger,
+		LoggerFactory:      services.LoggoLoggerFactory(deployRepoLogger),
 		CharmhubHTTPClient: v.charmhubHTTPClient,
 		StateBackend:       v.state,
 		ModelBackend:       v.model,

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -500,7 +500,7 @@ func (a *API) getCharmRepository(ctx context.Context, src corecharm.Source) (cor
 	a.mu.Unlock()
 
 	repoFactory := a.newRepoFactory(services.CharmRepoFactoryConfig{
-		Logger:             a.logger,
+		LoggerFactory:      services.LoggoLoggerFactory(a.logger),
 		CharmhubHTTPClient: a.charmhubHTTPClient,
 		StateBackend:       a.backendState,
 		ModelBackend:       a.backendModel,

--- a/apiserver/facades/client/charms/services/downloader.go
+++ b/apiserver/facades/client/charms/services/downloader.go
@@ -43,7 +43,7 @@ func NewCharmDownloader(cfg CharmDownloaderConfig) (*charmdownloader.Downloader,
 
 	repoFactory := repoFactoryShim{
 		factory: NewCharmRepoFactory(CharmRepoFactoryConfig{
-			LoggerFactory:      cfg.LoggerFactory.Namespace("charmrepofactory"),
+			LoggerFactory:      cfg.LoggerFactory.ForNamespace("charmrepofactory"),
 			CharmhubHTTPClient: cfg.CharmhubHTTPClient,
 			StateBackend:       cfg.StateBackend,
 			ModelBackend:       cfg.ModelBackend,
@@ -79,7 +79,7 @@ func LoggoLoggerFactory(logger loggo.Logger) LoggerFactory {
 	return loggoLoggerFactory{Logger: logger}
 }
 
-func (s loggoLoggerFactory) Namespace(name string) LoggerFactory {
+func (s loggoLoggerFactory) ForNamespace(name string) LoggerFactory {
 	return LoggoLoggerFactory(s.Logger.Child(name))
 }
 

--- a/apiserver/facades/client/charms/services/downloader.go
+++ b/apiserver/facades/client/charms/services/downloader.go
@@ -43,7 +43,7 @@ func NewCharmDownloader(cfg CharmDownloaderConfig) (*charmdownloader.Downloader,
 
 	repoFactory := repoFactoryShim{
 		factory: NewCharmRepoFactory(CharmRepoFactoryConfig{
-			Logger:             cfg.Logger.Child("charmrepofactory"),
+			LoggerFactory:      LoggoLoggerFactory(cfg.Logger.Child("charmrepofactory")),
 			CharmhubHTTPClient: cfg.CharmhubHTTPClient,
 			StateBackend:       cfg.StateBackend,
 			ModelBackend:       cfg.ModelBackend,
@@ -67,4 +67,26 @@ func (s repoFactoryShim) GetCharmRepository(ctx context.Context, src corecharm.S
 	}
 
 	return repo, err
+}
+
+type loggoLoggerFactory struct {
+	Logger loggo.Logger
+}
+
+// LoggoLoggerFactory is a LoggerFactory that creates loggers using
+// the loggo package.
+func LoggoLoggerFactory(logger loggo.Logger) LoggerFactory {
+	return loggoLoggerFactory{Logger: logger}
+}
+
+func (s loggoLoggerFactory) Namespace(name string) charmhub.LoggerFactory {
+	return LoggoLoggerFactory(s.Logger.Child(name))
+}
+
+func (s loggoLoggerFactory) Child(name string) charmhub.Logger {
+	return s.Logger.Child(name)
+}
+
+func (s loggoLoggerFactory) ChildWithLabels(name string, labels ...string) charmhub.Logger {
+	return s.Logger.ChildWithLabels(name, labels...)
 }

--- a/apiserver/facades/client/charms/services/downloader.go
+++ b/apiserver/facades/client/charms/services/downloader.go
@@ -19,7 +19,7 @@ import (
 // new CharmDownloader instance.
 type CharmDownloaderConfig struct {
 	// The logger to use.
-	Logger loggo.Logger
+	LoggerFactory LoggerFactory
 
 	// An HTTP client that is injected when making Charmhub API calls.
 	CharmhubHTTPClient charmhub.HTTPClient
@@ -36,21 +36,21 @@ type CharmDownloaderConfig struct {
 // charmdownloader.Downloader instance.
 func NewCharmDownloader(cfg CharmDownloaderConfig) (*charmdownloader.Downloader, error) {
 	storage := NewCharmStorage(CharmStorageConfig{
-		Logger:       cfg.Logger.Child("charmstorage"),
+		Logger:       cfg.LoggerFactory.Child("charmstorage"),
 		StateBackend: cfg.StateBackend,
 		ObjectStore:  cfg.ObjectStore,
 	})
 
 	repoFactory := repoFactoryShim{
 		factory: NewCharmRepoFactory(CharmRepoFactoryConfig{
-			LoggerFactory:      LoggoLoggerFactory(cfg.Logger.Child("charmrepofactory")),
+			LoggerFactory:      cfg.LoggerFactory.Namespace("charmrepofactory"),
 			CharmhubHTTPClient: cfg.CharmhubHTTPClient,
 			StateBackend:       cfg.StateBackend,
 			ModelBackend:       cfg.ModelBackend,
 		}),
 	}
 
-	return charmdownloader.NewDownloader(cfg.Logger.ChildWithLabels("charmdownloader", corelogger.CHARMHUB), storage, repoFactory), nil
+	return charmdownloader.NewDownloader(cfg.LoggerFactory.ChildWithLabels("charmdownloader", corelogger.CHARMHUB), storage, repoFactory), nil
 }
 
 // repoFactoryShim wraps a CharmRepoFactory and is compatible with the
@@ -79,7 +79,7 @@ func LoggoLoggerFactory(logger loggo.Logger) LoggerFactory {
 	return loggoLoggerFactory{Logger: logger}
 }
 
-func (s loggoLoggerFactory) Namespace(name string) charmhub.LoggerFactory {
+func (s loggoLoggerFactory) Namespace(name string) LoggerFactory {
 	return LoggoLoggerFactory(s.Logger.Child(name))
 }
 

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -15,9 +15,16 @@ import (
 	"github.com/juju/juju/internal/charmhub"
 )
 
+// LoggerFactory is the interface that is used to create loggers.
 type LoggerFactory interface {
 	charmhub.LoggerFactory
-	Namespace(string) charmhub.LoggerFactory
+	Namespace(string) LoggerFactory
+}
+
+// Logger is the interface that is used to log messages.
+type Logger interface {
+	Errorf(message string, args ...any)
+	Tracef(message string, args ...any)
 }
 
 // CharmRepoFactoryConfig encapsulates the information required for creating a

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -34,7 +34,7 @@ type Logger interface {
 // CharmRepoFactoryConfig encapsulates the information required for creating a
 // new CharmRepoFactory instance.
 type CharmRepoFactoryConfig struct {
-	// The logger to use.
+	// LoggerFactory is the logger factory to use when creating new loggers.
 	LoggerFactory LoggerFactory
 
 	// An HTTP client that is injected when making Charmhub API calls.
@@ -44,7 +44,7 @@ type CharmRepoFactoryConfig struct {
 	ModelBackend ModelBackend
 }
 
-// CharmRepoFactory instantitates charm repositories. It memoizes created
+// CharmRepoFactory instantiates charm repositories. It memoizes created
 // repositories allowing them to be reused by subsequent GetCharmRepository
 // calls.
 type CharmRepoFactory struct {

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -45,7 +45,6 @@ type CharmRepoFactoryConfig struct {
 // calls.
 type CharmRepoFactory struct {
 	loggerFactory      LoggerFactory
-	logger             charmhub.Logger
 	charmhubHTTPClient charmhub.HTTPClient
 	stateBackend       StateBackend
 	modelBackend       ModelBackend

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -18,7 +18,11 @@ import (
 // LoggerFactory is the interface that is used to create loggers.
 type LoggerFactory interface {
 	charmhub.LoggerFactory
-	Namespace(string) LoggerFactory
+
+	// ForNamespace returns a new logger with the provided namespace. This
+	// provides a child logger factory that can be used to create loggers
+	// with a common namespace prefix.
+	ForNamespace(string) LoggerFactory
 }
 
 // Logger is the interface that is used to log messages.
@@ -86,7 +90,7 @@ func (f *CharmRepoFactory) GetCharmRepository(ctx context.Context, src corecharm
 		chClient, err := charmhub.NewClient(charmhub.Config{
 			URL:           chURL,
 			HTTPClient:    f.charmhubHTTPClient,
-			LoggerFactory: f.loggerFactory.Namespace("charmhub"),
+			LoggerFactory: f.loggerFactory.ForNamespace("charmhub"),
 		})
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/charms/services/repofactory_test.go
+++ b/apiserver/facades/client/charms/services/repofactory_test.go
@@ -76,9 +76,9 @@ func (s *repoFactoryTestSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.modelBackend = mocks.NewMockModelBackend(ctrl)
 
 	s.repoFactory = services.NewCharmRepoFactory(services.CharmRepoFactoryConfig{
-		Logger:       loggo.GetLogger("test"),
-		StateBackend: s.stateBackend,
-		ModelBackend: s.modelBackend,
+		LoggerFactory: services.LoggoLoggerFactory(loggo.GetLogger("test")),
+		StateBackend:  s.stateBackend,
+		ModelBackend:  s.modelBackend,
 	})
 	return ctrl
 }

--- a/apiserver/facades/client/charms/services/storage.go
+++ b/apiserver/facades/client/charms/services/storage.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/utils/v3"
 
 	charmdownloader "github.com/juju/juju/core/charm/downloader"
@@ -20,7 +19,7 @@ import (
 // new CharmStorage instance.
 type CharmStorageConfig struct {
 	// The logger to use.
-	Logger loggo.Logger
+	Logger Logger
 
 	// A factory for accessing model-scoped storage for charm blobs.
 	ObjectStore Storage
@@ -30,7 +29,7 @@ type CharmStorageConfig struct {
 
 // CharmStorage provides an abstraction for storing charm blobs.
 type CharmStorage struct {
-	logger        loggo.Logger
+	logger        Logger
 	stateBackend  StateBackend
 	objectStore   Storage
 	uuidGenerator func() (utils.UUID, error)
@@ -39,7 +38,7 @@ type CharmStorage struct {
 // NewCharmStorage creates a new CharmStorage instance with the specified config.
 func NewCharmStorage(cfg CharmStorageConfig) *CharmStorage {
 	return &CharmStorage{
-		logger:        cfg.Logger.Child("charmstorage"),
+		logger:        cfg.Logger,
 		stateBackend:  cfg.StateBackend,
 		objectStore:   cfg.ObjectStore,
 		uuidGenerator: utils.NewUUID,

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -138,9 +138,9 @@ func NewFacadeV10(ctx facade.Context) (*MachineManagerAPI, error) {
 	logger := ctx.Logger().Child("machinemanager")
 	chURL, _ := modelCfg.CharmHubURL()
 	chClient, err := charmhub.NewClient(charmhub.Config{
-		URL:        chURL,
-		HTTPClient: ctx.HTTPClient(facade.CharmhubHTTPClient),
-		Logger:     logger,
+		URL:           chURL,
+		HTTPClient:    ctx.HTTPClient(facade.CharmhubHTTPClient),
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -72,9 +72,9 @@ func NewFacade(ctx facade.Context) (*API, error) {
 		case charm.CharmHub.Matches(schema):
 			chURL, _ := modelCfg.CharmHubURL()
 			chClient, err := charmhub.NewClient(charmhub.Config{
-				URL:        chURL,
-				HTTPClient: ctx.HTTPClient(facade.CharmhubHTTPClient),
-				Logger:     logger,
+				URL:           chURL,
+				HTTPClient:    ctx.HTTPClient(facade.CharmhubHTTPClient),
+				LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -156,7 +156,7 @@ func (a *CharmDownloaderAPI) getDownloader() (Downloader, error) {
 	}
 
 	downloader, err := a.newDownloader(services.CharmDownloaderConfig{
-		Logger:             a.logger,
+		LoggerFactory:      services.LoggoLoggerFactory(a.logger),
 		CharmhubHTTPClient: a.charmhubHTTPClient,
 		ObjectStore:        a.objectStore,
 		StateBackend:       a.stateBackend,

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -168,8 +168,8 @@ func newDeployCommand() *DeployCommand {
 		}
 
 		return charmhub.NewClient(charmhub.Config{
-			URL:    charmHubURL,
-			Logger: logger,
+			URL:           charmHubURL,
+			LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 		})
 	}
 	deployCmd.NewDeployAPI = func() (deployer.DeployerAPI, error) {

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -372,8 +372,8 @@ func (c *diffBundleCommand) charmAdaptor(apiRoot base.APICallCloser, curl *charm
 			return nil, errors.Trace(err)
 		}
 		return charmhub.NewClient(charmhub.Config{
-			URL:    url,
-			Logger: logger,
+			URL:           url,
+			LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 		})
 	}
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -65,8 +65,8 @@ func newRefreshCommand() *refreshCommand {
 		},
 		NewCharmHubClient: func(url string) (store.DownloadBundleClient, error) {
 			return charmhub.NewClient(charmhub.Config{
-				URL:    url,
-				Logger: logger,
+				URL:           url,
+				LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 			})
 		},
 		NewCharmResolver: func(apiRoot base.APICallCloser, downloadClient store.DownloadBundleClient) CharmResolver {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -409,30 +409,34 @@ type downloadLoggerFactory struct {
 
 func (d downloadLoggerFactory) Child(name string) charmhub.Logger {
 	return downloadLogger{
-		Context: d.Context,
+		factory: d,
 	}
 }
 
 func (d downloadLoggerFactory) ChildWithLabels(name string, labels ...string) charmhub.Logger {
 	return downloadLogger{
-		Context: d.Context,
+		factory: d,
 	}
 }
 
 type downloadLogger struct {
-	Context *cmd.Context
+	factory downloadLoggerFactory
 }
 
 func (d downloadLogger) IsTraceEnabled() bool {
-	return !d.Context.Quiet()
+	return !d.factory.Context.Quiet()
 }
 
 func (d downloadLogger) Errorf(msg string, args ...interface{}) {
-	d.Context.Verbosef(msg, args...)
+	d.factory.Context.Verbosef(msg, args...)
+}
+
+func (d downloadLogger) Warningf(msg string, args ...interface{}) {
+	d.factory.Context.Verbosef(msg, args...)
 }
 
 func (d downloadLogger) Debugf(msg string, args ...interface{}) {
-	d.Context.Verbosef(msg, args...)
+	d.factory.Context.Verbosef(msg, args...)
 }
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/loggo"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/core/arch"
@@ -181,8 +180,8 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	}
 
 	cfg := charmhub.Config{
-		URL:    c.charmHubURL,
-		Logger: downloadLogger{Context: cmdContext},
+		URL:           c.charmHubURL,
+		LoggerFactory: downloadLoggerFactory{Context: cmdContext},
 	}
 
 	if c.pipeToStdout {
@@ -404,6 +403,22 @@ func (c *downloadCommand) calculateHash(path string) (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
+type downloadLoggerFactory struct {
+	Context *cmd.Context
+}
+
+func (d downloadLoggerFactory) Child(name string) charmhub.Logger {
+	return downloadLogger{
+		Context: d.Context,
+	}
+}
+
+func (d downloadLoggerFactory) ChildWithLabels(name string, labels ...string) charmhub.Logger {
+	return downloadLogger{
+		Context: d.Context,
+	}
+}
+
 type downloadLogger struct {
 	Context *cmd.Context
 }
@@ -421,10 +436,6 @@ func (d downloadLogger) Debugf(msg string, args ...interface{}) {
 }
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}
-
-func (d downloadLogger) ChildWithLabels(name string, labels ...string) loggo.Logger {
-	return logger.ChildWithLabels(name, labels...)
-}
 
 type stdoutFileSystem struct{}
 

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -134,8 +134,8 @@ func (c *findCommand) Init(args []string) error {
 // part of the cmd.Command interface.
 func (c *findCommand) Run(cmdContext *cmd.Context) error {
 	cfg := charmhub.Config{
-		URL:    c.charmHubURL,
-		Logger: logger,
+		URL:           c.charmHubURL,
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	}
 
 	client, err := c.CharmHubClientFunc(cfg)

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -159,8 +159,8 @@ func (c *infoCommand) Run(cmdContext *cmd.Context) error {
 	}
 
 	cfg := charmhub.Config{
-		URL:    c.charmHubURL,
-		Logger: logger,
+		URL:           c.charmHubURL,
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	}
 
 	client, err := c.CharmHubClientFunc(cfg)

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -198,7 +198,7 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 	}
 
 	charmDownloader, err := newCharmDownloader(services.CharmDownloaderConfig{
-		Logger:             logger,
+		LoggerFactory:      services.LoggoLoggerFactory(logger),
 		CharmhubHTTPClient: charmhubHTTPClient,
 		ObjectStore:        objectStore,
 		StateBackend:       stateBackend,

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -149,11 +149,12 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 		return nil, nil, err
 	}
 
-	charmhubHTTPClient := charmhub.DefaultHTTPClient(logger)
+	loggerFactory := charmhub.LoggoLoggerFactory(logger)
+	charmhubHTTPClient := charmhub.DefaultHTTPClient(loggerFactory)
 
 	stateBackend := &stateShim{st}
 	charmRepo, err := newCharmRepo(services.CharmRepoFactoryConfig{
-		Logger:             logger,
+		LoggerFactory:      services.LoggoLoggerFactory(logger),
 		CharmhubHTTPClient: charmhubHTTPClient,
 		StateBackend:       stateBackend,
 		ModelBackend:       model,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -619,7 +619,7 @@ func (a *MachineAgent) makeEngineCreator(
 		// Create a single HTTP client so we can reuse HTTP connections, for
 		// example across the various Charmhub API requests required for deploy.
 		charmhubLogger := loggo.GetLoggerWithLabels("juju.charmhub", corelogger.CHARMHUB)
-		charmhubHTTPClient := charmhub.DefaultHTTPClient(charmhubLogger)
+		charmhubHTTPClient := charmhub.DefaultHTTPClient(charmhub.LoggoLoggerFactory(charmhubLogger))
 
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion: previousAgentVersion,

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -21,6 +21,9 @@ type Base struct {
 	Channel Channel
 }
 
+// Empty is an empty base.
+var Empty = Base{}
+
 // ParseBase constructs a Base from the os and channel string.
 func ParseBase(os string, channel string) (Base, error) {
 	if os == "" && channel == "" {

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -21,9 +21,6 @@ type Base struct {
 	Channel Channel
 }
 
-// Empty is an empty base.
-var Empty = Base{}
-
 // ParseBase constructs a Base from the os and channel string.
 func ParseBase(os string, channel string) (Base, error) {
 	if os == "" && channel == "" {

--- a/core/flags/flags.go
+++ b/core/flags/flags.go
@@ -1,0 +1,11 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package flags
+
+// Global list of all the flags for the domain.
+const (
+	// BootstrapFlag is the name of the flag that is used to check if the
+	// bootstrap process has completed.
+	BootstrapFlag = "bootstrapped"
+)

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -88,7 +88,6 @@ type Client struct {
 	refreshClient   *refreshClient
 	resourcesClient *resourcesClient
 	logger          Logger
-	loggerFactory   LoggerFactory
 }
 
 // NewClient creates a new Charmhub client from the supplied configuration.

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	corelogger "github.com/juju/juju/core/logger"
@@ -49,21 +48,11 @@ const (
 	serverEntity  = "charms"
 )
 
-// Logger is the interface to use for logging requests and errors.
-type Logger interface {
-	IsTraceEnabled() bool
-
-	Errorf(string, ...interface{})
-	Tracef(string, ...interface{})
-
-	ChildWithLabels(string, ...string) loggo.Logger
-}
-
 // Config holds configuration for creating a new charm hub client.
 // The zero value is a valid default configuration.
 type Config struct {
 	// Logger to use during the API requests. This field is required.
-	Logger Logger
+	LoggerFactory LoggerFactory
 
 	// URL holds the base endpoint URL of the Charmhub API,
 	// with no trailing slash, not including the version.
@@ -99,15 +88,16 @@ type Client struct {
 	refreshClient   *refreshClient
 	resourcesClient *resourcesClient
 	logger          Logger
+	loggerFactory   LoggerFactory
 }
 
 // NewClient creates a new Charmhub client from the supplied configuration.
 func NewClient(config Config) (*Client, error) {
-	logger := config.Logger
-	if logger == nil {
+	loggerFactory := config.LoggerFactory
+	if loggerFactory == nil {
 		return nil, errors.NotValidf("nil logger")
 	}
-	logger = logger.ChildWithLabels("client", corelogger.CHARMHUB)
+	logger := loggerFactory.ChildWithLabels("client", corelogger.CHARMHUB)
 
 	url := config.URL
 	if url == "" {
@@ -116,7 +106,7 @@ func NewClient(config Config) (*Client, error) {
 
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient = DefaultHTTPClient(logger)
+		httpClient = DefaultHTTPClient(loggerFactory)
 	}
 
 	fs := config.FileSystem

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -94,7 +94,7 @@ type Client struct {
 func NewClient(config Config) (*Client, error) {
 	loggerFactory := config.LoggerFactory
 	if loggerFactory == nil {
-		return nil, errors.NotValidf("nil logger")
+		return nil, errors.NotValidf("nil logger factory")
 	}
 	logger := loggerFactory.ChildWithLabels("client", corelogger.CHARMHUB)
 

--- a/internal/charmhub/client_mock_test.go
+++ b/internal/charmhub/client_mock_test.go
@@ -16,7 +16,6 @@ import (
 	reflect "reflect"
 
 	path "github.com/juju/juju/internal/charmhub/path"
-	loggo "github.com/juju/loggo"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -172,23 +171,21 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// ChildWithLabels mocks base method.
-func (m *MockLogger) ChildWithLabels(arg0 string, arg1 ...string) loggo.Logger {
+// Debugf mocks base method.
+func (m *MockLogger) Debugf(arg0 string, arg1 ...any) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ChildWithLabels", varargs...)
-	ret0, _ := ret[0].(loggo.Logger)
-	return ret0
+	m.ctrl.Call(m, "Debugf", varargs...)
 }
 
-// ChildWithLabels indicates an expected call of ChildWithLabels.
-func (mr *MockLoggerMockRecorder) ChildWithLabels(arg0 any, arg1 ...any) *gomock.Call {
+// Debugf indicates an expected call of Debugf.
+func (mr *MockLoggerMockRecorder) Debugf(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChildWithLabels", reflect.TypeOf((*MockLogger)(nil).ChildWithLabels), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
 // Errorf mocks base method.
@@ -237,4 +234,21 @@ func (mr *MockLoggerMockRecorder) Tracef(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
+}
+
+// Warningf mocks base method.
+func (m *MockLogger) Warningf(arg0 string, arg1 ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Warningf", varargs...)
+}
+
+// Warningf indicates an expected call of Warningf.
+func (mr *MockLoggerMockRecorder) Warningf(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warningf", reflect.TypeOf((*MockLogger)(nil).Warningf), varargs...)
 }

--- a/internal/charmhub/download_test.go
+++ b/internal/charmhub/download_test.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -23,7 +22,7 @@ const defaultSeries = "bionic"
 const localCharmRepo = "../../testcharms/charm-repo"
 
 type DownloadSuite struct {
-	testing.IsolationSuite
+	baseSuite
 }
 
 var _ = gc.Suite(&DownloadSuite{})
@@ -55,7 +54,7 @@ func (s *DownloadSuite) TestDownloadAndRead(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := newDownloadClient(httpClient, fileSystem, &FakeLogger{})
+	client := newDownloadClient(httpClient, fileSystem, s.logger)
 	_, err = client.DownloadAndRead(context.Background(), serverURL, tmpFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -85,7 +84,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithNotFoundStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := newDownloadClient(httpClient, fileSystem, &FakeLogger{})
+	client := newDownloadClient(httpClient, fileSystem, s.logger)
 	_, err = client.DownloadAndRead(context.Background(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": archive not found`)
 }
@@ -116,7 +115,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := newDownloadClient(httpClient, fileSystem, &FakeLogger{})
+	client := newDownloadClient(httpClient, fileSystem, s.logger)
 	_, err = client.DownloadAndRead(context.Background(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive \(store API responded with status: Internal Server Error\)`)
 }

--- a/internal/charmhub/errors_test.go
+++ b/internal/charmhub/errors_test.go
@@ -10,24 +10,26 @@ import (
 	"github.com/juju/juju/internal/charmhub/transport"
 )
 
-type ErrorsSuite struct{}
+type ErrorsSuite struct {
+	baseSuite
+}
 
 var _ = gc.Suite(&ErrorsSuite{})
 
-func (ErrorsSuite) TestHandleBasicAPIErrors(c *gc.C) {
+func (s *ErrorsSuite) TestHandleBasicAPIErrors(c *gc.C) {
 	var list transport.APIErrors
-	err := handleBasicAPIErrors(list, &FakeLogger{})
+	err := handleBasicAPIErrors(list, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (ErrorsSuite) TestHandleBasicAPIErrorsNotFound(c *gc.C) {
+func (s *ErrorsSuite) TestHandleBasicAPIErrorsNotFound(c *gc.C) {
 	list := transport.APIErrors{{Code: transport.ErrorCodeNotFound, Message: "foo"}}
-	err := handleBasicAPIErrors(list, &FakeLogger{})
+	err := handleBasicAPIErrors(list, s.logger)
 	c.Assert(err, gc.ErrorMatches, `charm or bundle not found`)
 }
 
-func (ErrorsSuite) TestHandleBasicAPIErrorsOther(c *gc.C) {
+func (s *ErrorsSuite) TestHandleBasicAPIErrorsOther(c *gc.C) {
 	list := transport.APIErrors{{Code: "other", Message: "foo"}}
-	err := handleBasicAPIErrors(list, &FakeLogger{})
+	err := handleBasicAPIErrors(list, s.logger)
 	c.Assert(err, gc.ErrorMatches, `foo`)
 }

--- a/internal/charmhub/fake_test.go
+++ b/internal/charmhub/fake_test.go
@@ -3,19 +3,80 @@
 
 package charmhub
 
-import "github.com/juju/loggo"
+import (
+	"fmt"
 
-type FakeLogger struct {
+	"github.com/juju/loggo"
+	gc "gopkg.in/check.v1"
+)
+
+// We can't use the juju/testing package because of circular import
+// dependency issues.
+
+// CheckLog is an interface that can be used to log messages to a
+// *testing.T or *check.C.
+type CheckLog interface {
+	Logf(string, ...any)
 }
 
-func (l *FakeLogger) IsTraceEnabled() bool {
-	return false
+// CheckLogger is a loggo.Logger that logs to a *testing.T or *check.C.
+type CheckLogger struct {
+	Log CheckLog
 }
 
-func (l *FakeLogger) Errorf(format string, args ...interface{}) {}
+// NewCheckLogger returns a CheckLogger that logs to the given CheckLog.
+func NewCheckLogger(log CheckLog) CheckLogger {
+	return CheckLogger{Log: log}
+}
 
-func (l *FakeLogger) Tracef(format string, args ...interface{}) {}
+func (c CheckLogger) Criticalf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("CRITICAL: %s", msg), args...)
+}
+func (c CheckLogger) Errorf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("ERROR: %s", msg), args...)
+}
+func (c CheckLogger) Warningf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("WARNING: %s", msg), args...)
+}
+func (c CheckLogger) Infof(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("INFO: %s", msg), args...)
+}
+func (c CheckLogger) Debugf(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("DEBUG: %s", msg), args...)
+}
+func (c CheckLogger) Tracef(msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("TRACE: %s", msg), args...)
+}
+func (c CheckLogger) Logf(level loggo.Level, msg string, args ...any) {
+	c.Log.Logf(fmt.Sprintf("%s: %s", level.String(), msg), args...)
+}
 
-func (l *FakeLogger) ChildWithLabels(string, ...string) loggo.Logger {
-	return loggo.Logger{}
+func (c CheckLogger) IsErrorEnabled() bool            { return true }
+func (c CheckLogger) IsWarningEnabled() bool          { return true }
+func (c CheckLogger) IsInfoEnabled() bool             { return true }
+func (c CheckLogger) IsDebugEnabled() bool            { return true }
+func (c CheckLogger) IsTraceEnabled() bool            { return true }
+func (c CheckLogger) IsLevelEnabled(loggo.Level) bool { return true }
+
+// CheckLoggerFactory is a factory for creating CheckLoggers.
+type CheckLoggerFactory struct {
+	c *gc.C
+}
+
+// NewCheckLoggerFactory returns a CheckLoggerFactory that creates
+// CheckLoggers that log to the given *check.C.
+func NewCheckLoggerFactory(c *gc.C) *CheckLoggerFactory {
+	return &CheckLoggerFactory{
+		c: c,
+	}
+}
+
+func (c *CheckLoggerFactory) Child(string) Logger {
+	return NewCheckLogger(c.c)
+}
+func (c *CheckLoggerFactory) ChildWithLabels(string, ...string) Logger {
+	return NewCheckLogger(c.c)
+}
+func (c *CheckLoggerFactory) Logger() CheckLogger {
+	return NewCheckLogger(c.c)
 }

--- a/internal/charmhub/find_test.go
+++ b/internal/charmhub/find_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -20,7 +19,7 @@ import (
 )
 
 type FindSuite struct {
-	testing.IsolationSuite
+	baseSuite
 }
 
 var _ = gc.Suite(&FindSuite{})
@@ -37,7 +36,7 @@ func (s *FindSuite) TestFind(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name)
 
-	client := newFindClient(path, restClient, &FakeLogger{})
+	client := newFindClient(path, restClient, s.logger)
 	responses, err := client.Find(context.Background(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -61,7 +60,7 @@ func (s *FindSuite) TestFindWithOptions(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, expect, name)
 
-	client := newFindClient(path, restClient, &FakeLogger{})
+	client := newFindClient(path, restClient, s.logger)
 	responses, err := client.Find(context.Background(), name, WithFindChannel("1.0/stable"), WithFindType("bundle"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -80,7 +79,7 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(restClient)
 
-	client := newFindClient(path, restClient, &FakeLogger{})
+	client := newFindClient(path, restClient, s.logger)
 	_, err := client.Find(context.Background(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -173,10 +172,10 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := newAPIRequester(DefaultHTTPClient(&FakeLogger{}), &FakeLogger{})
+	apiRequester := newAPIRequester(DefaultHTTPClient(s.loggerFactory), s.logger)
 	restClient := newHTTPRESTClient(apiRequester)
 
-	client := newFindClient(findPath, restClient, &FakeLogger{})
+	client := newFindClient(findPath, restClient, s.logger)
 	responses, err := client.Find(context.Background(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(responses, gc.DeepEquals, findResponses.Results)
@@ -207,10 +206,10 @@ func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := newAPIRequester(DefaultHTTPClient(&FakeLogger{}), &FakeLogger{})
+	apiRequester := newAPIRequester(DefaultHTTPClient(s.loggerFactory), s.logger)
 	restClient := newHTTPRESTClient(apiRequester)
 
-	client := newFindClient(findPath, restClient, &FakeLogger{})
+	client := newFindClient(findPath, restClient, s.logger)
 	_, err = client.Find(context.Background(), "wordpress")
 	c.Assert(err, gc.ErrorMatches, "not found error code")
 }

--- a/internal/charmhub/http.go
+++ b/internal/charmhub/http.go
@@ -62,7 +62,7 @@ type HTTPClient interface {
 }
 
 // DefaultHTTPClient creates a new HTTPClient with the default configuration.
-func DefaultHTTPClient(logger Logger) HTTPClient {
+func DefaultHTTPClient(logger LoggerFactory) HTTPClient {
 	recorder := loggingRequestRecorder{
 		logger: logger.ChildWithLabels("transport.request-recorder", corelogger.METRICS),
 	}
@@ -99,8 +99,8 @@ func (r loggingRequestRecorder) RecordError(method string, url *url.URL, err err
 
 // requestHTTPClient returns a function that creates a new HTTPClient that
 // records the requests.
-func requestHTTPClient(recorder jujuhttp.RequestRecorder, policy jujuhttp.RetryPolicy) func(logger Logger) HTTPClient {
-	return func(logger Logger) HTTPClient {
+func requestHTTPClient(recorder jujuhttp.RequestRecorder, policy jujuhttp.RetryPolicy) func(logger LoggerFactory) HTTPClient {
+	return func(logger LoggerFactory) HTTPClient {
 		return jujuhttp.NewClient(
 			jujuhttp.WithRequestRecorder(recorder),
 			jujuhttp.WithRequestRetrier(policy),

--- a/internal/charmhub/info_test.go
+++ b/internal/charmhub/info_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -20,7 +19,7 @@ import (
 )
 
 type InfoSuite struct {
-	testing.IsolationSuite
+	baseSuite
 }
 
 var _ = gc.Suite(&InfoSuite{})
@@ -37,7 +36,7 @@ func (s *InfoSuite) TestInfoCharm(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectCharmGet(c, restClient, path, name)
 
-	client := newInfoClient(path, restClient, &FakeLogger{})
+	client := newInfoClient(path, restClient, s.logger)
 	response, err := client.Info(context.Background(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, name)
@@ -56,7 +55,7 @@ func (s *InfoSuite) TestInfoBundle(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectBundleGet(c, restClient, path, name)
 
-	client := newInfoClient(path, restClient, &FakeLogger{})
+	client := newInfoClient(path, restClient, s.logger)
 	response, err := client.Info(context.Background(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, name)
@@ -75,7 +74,7 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(restClient)
 
-	client := newInfoClient(path, restClient, &FakeLogger{})
+	client := newInfoClient(path, restClient, s.logger)
 	_, err := client.Info(context.Background(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -92,7 +91,7 @@ func (s *InfoSuite) TestInfoError(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetError(c, restClient, path, name)
 
-	client := newInfoClient(path, restClient, &FakeLogger{})
+	client := newInfoClient(path, restClient, s.logger)
 	_, err := client.Info(context.Background(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -249,10 +248,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	infoPath, err := basePath.Join("info")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := newAPIRequester(DefaultHTTPClient(&FakeLogger{}), &FakeLogger{})
+	apiRequester := newAPIRequester(DefaultHTTPClient(s.loggerFactory), s.logger)
 	restClient := newHTTPRESTClient(apiRequester)
 
-	client := newInfoClient(infoPath, restClient, &FakeLogger{})
+	client := newInfoClient(infoPath, restClient, s.logger)
 	response, err := client.Info(context.Background(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.DeepEquals, infoResponse)

--- a/internal/charmhub/logger.go
+++ b/internal/charmhub/logger.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import "github.com/juju/loggo"
+
+// LoggerFactory is the interface that is used to create new loggers.
+type LoggerFactory interface {
+	Child(string) Logger
+	ChildWithLabels(string, ...string) Logger
+}
+
+// Logger is the interface to use for logging requests and errors.
+type Logger interface {
+	IsTraceEnabled() bool
+
+	Errorf(string, ...interface{})
+	Tracef(string, ...interface{})
+}
+
+// LoggoLoggerFactory is a LoggerFactory that creates loggers using
+// the loggo package.
+func LoggoLoggerFactory(logger loggo.Logger) LoggerFactory {
+	return loggoLoggerFactory{
+		logger: logger,
+	}
+}
+
+type loggoLoggerFactory struct {
+	logger loggo.Logger
+}
+
+func (f loggoLoggerFactory) Child(name string) Logger {
+	return f.logger.Child(name)
+}
+
+func (f loggoLoggerFactory) ChildWithLabels(name string, labels ...string) Logger {
+	return f.logger.ChildWithLabels(name, labels...)
+}

--- a/internal/charmhub/logger.go
+++ b/internal/charmhub/logger.go
@@ -16,6 +16,8 @@ type Logger interface {
 	IsTraceEnabled() bool
 
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
 }
 

--- a/internal/charmhub/package_test.go
+++ b/internal/charmhub/package_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -19,6 +20,18 @@ import (
 
 func Test(t *testing.T) {
 	gc.TestingT(t)
+}
+
+type baseSuite struct {
+	jujutesting.IsolationSuite
+
+	loggerFactory *CheckLoggerFactory
+	logger        CheckLogger
+}
+
+func (s *baseSuite) SetUpTest(c *gc.C) {
+	s.loggerFactory = NewCheckLoggerFactory(c)
+	s.logger = s.loggerFactory.Logger()
 }
 
 func MustParseURL(c *gc.C, path string) *url.URL {

--- a/internal/charmhub/refresh_test.go
+++ b/internal/charmhub/refresh_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type RefreshSuite struct {
-	testing.IsolationSuite
+	baseSuite
 }
 
 var (
@@ -75,7 +75,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPost(restClient, baseURLPath, id, body)
 
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 	responses, err := client.Refresh(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -169,7 +169,7 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	}
 
 	restClient := newHTTPRESTClient(httpClient)
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 
 	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
@@ -219,7 +219,7 @@ func (s *RefreshSuite) TestRefreshMetadataRandomOrder(c *gc.C) {
 	}
 
 	restClient := newHTTPRESTClient(httpClient)
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 
 	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
@@ -278,7 +278,7 @@ func (s *RefreshSuite) TestRefreshWithMetricsOnly(c *gc.C) {
 		},
 	}
 
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 	err := client.RefreshWithMetricsOnly(context.Background(), metrics)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -367,7 +367,7 @@ func (s *RefreshSuite) TestRefreshWithRequestMetrics(c *gc.C) {
 		},
 	}
 
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 	responses, err := client.RefreshWithRequestMetrics(context.Background(), config, metrics)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 2)
@@ -393,7 +393,7 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPostFailure(restClient)
 
-	client := newRefreshClient(baseURLPath, restClient, &FakeLogger{})
+	client := newRefreshClient(baseURLPath, restClient, s.logger)
 	_, err = client.Refresh(context.Background(), config)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }

--- a/internal/charmhub/resources_test.go
+++ b/internal/charmhub/resources_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -20,7 +19,7 @@ import (
 )
 
 type ResourcesSuite struct {
-	testing.IsolationSuite
+	baseSuite
 }
 
 var _ = gc.Suite(&ResourcesSuite{})
@@ -38,7 +37,7 @@ func (s *ResourcesSuite) TestListResourceRevisions(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name, resource)
 
-	client := newResourcesClient(path, restClient, &FakeLogger{})
+	client := newResourcesClient(path, restClient, s.logger)
 	response, err := client.ListResourceRevisions(context.Background(), name, resource)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.HasLen, 3)
@@ -57,7 +56,7 @@ func (s *ResourcesSuite) TestListResourceRevisionsFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(restClient)
 
-	client := newResourcesClient(path, restClient, &FakeLogger{})
+	client := newResourcesClient(path, restClient, s.logger)
 	_, err := client.ListResourceRevisions(context.Background(), name, resource)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -98,10 +97,10 @@ func (s *ResourcesSuite) TestListResourceRevisionsRequestPayload(c *gc.C) {
 	resourcesPath, err := basePath.Join("resources")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := newAPIRequester(DefaultHTTPClient(&FakeLogger{}), &FakeLogger{})
+	apiRequester := newAPIRequester(DefaultHTTPClient(s.loggerFactory), s.logger)
 	restClient := newHTTPRESTClient(apiRequester)
 
-	client := newResourcesClient(resourcesPath, restClient, &FakeLogger{})
+	client := newResourcesClient(resourcesPath, restClient, s.logger)
 	response, err := client.ListResourceRevisions(context.Background(), "wordpress", "image")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.DeepEquals, resourcesResponse.Revisions)

--- a/internal/resource/charmhub.go
+++ b/internal/resource/charmhub.go
@@ -51,8 +51,8 @@ func newCharmHubClient(st chClientState) (ResourceGetter, error) {
 
 	chURL, _ := modelCfg.CharmHubURL()
 	chClient, err := charmhub.NewClient(charmhub.Config{
-		URL:    chURL,
-		Logger: logger,
+		URL:           chURL,
+		LoggerFactory: charmhub.LoggoLoggerFactory(logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	controller "github.com/juju/juju/controller"
+	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -130,5 +131,5 @@ func (s *workerSuite) expectObjectStoreGetter() {
 }
 
 func (s *workerSuite) expectBootstrapFlagSet() {
-	s.flagService.EXPECT().SetFlag(gomock.Any(), BootstrapFlag, true).Return(nil)
+	s.flagService.EXPECT().SetFlag(gomock.Any(), flags.BootstrapFlag, true).Return(nil)
 }

--- a/scripts/charmhub/locate-series-less-charms.go
+++ b/scripts/charmhub/locate-series-less-charms.go
@@ -18,7 +18,7 @@ import (
 // These charms will not have a series or a map of containers.
 func main() {
 	client, err := charmhub.NewClient(charmhub.Config{
-		Logger: loggo.GetLogger("series"),
+		LoggerFactory: charmhub.LoggoLoggerFactory(loggo.GetLogger("series")),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/testing/logger.go
+++ b/testing/logger.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/loggo"
+	gc "gopkg.in/check.v1"
 )
 
 // NoopLogger is a loggo.Logger that does nothing.
@@ -63,6 +64,9 @@ func (c CheckLogger) Logf(level loggo.Level, msg string, args ...any) {
 	c.Log.Logf(fmt.Sprintf("%s: %s", level.String(), msg), args...)
 }
 func (c CheckLogger) Child(name string) CheckLogger { return c }
+func (c CheckLogger) ChildWithLabels(string, ...string) CheckLogger {
+	return c
+}
 
 func (c CheckLogger) IsErrorEnabled() bool            { return true }
 func (c CheckLogger) IsWarningEnabled() bool          { return true }
@@ -70,3 +74,21 @@ func (c CheckLogger) IsInfoEnabled() bool             { return true }
 func (c CheckLogger) IsDebugEnabled() bool            { return true }
 func (c CheckLogger) IsTraceEnabled() bool            { return true }
 func (c CheckLogger) IsLevelEnabled(loggo.Level) bool { return true }
+
+// CheckLoggerFactory is a factory for creating CheckLoggers.
+type CheckLoggerFactory struct {
+	c *gc.C
+}
+
+// NewCheckLoggerFactory returns a CheckLoggerFactory that creates
+// CheckLoggers that log to the given *check.C.
+func NewCheckLoggerFactory(c *gc.C) CheckLoggerFactory {
+	return CheckLoggerFactory{}
+}
+
+func (c CheckLoggerFactory) Child(string) CheckLogger {
+	return NewCheckLogger(c.c)
+}
+func (c CheckLoggerFactory) ChildWithLabels(string, ...string) CheckLogger {
+	return NewCheckLogger(c.c)
+}


### PR DESCRIPTION
The logger in the charmhub and charms facade packages require a
cyclic dependency on the interface. This causes lots of problems
when implementing the logger. To make matters worse, the interface
also had a loggo.Logger attached to some loggers, which makes it
impossible to satisfy that interface if you've got a sub-type of that
interface.

The solution is to make two interfaces a logger factory and a logger.
This removes the cyclic nature of the interface and cleans up what
the actual dependency is.

This is a follow on from PRs: 
 - https://github.com/juju/juju/pull/16672
 - https://github.com/juju/juju/pull/16681
 - https://github.com/juju/juju/pull/16683

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

In a different terminal, run `juju debug-log -m controller`

Then run the following to see it all still works.

```sh
$ juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE;#http=TRACE"
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** JUJU-5137

