### PR TITLE
Add retry logic to lxd image download

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -942,7 +942,7 @@ to create a new model to deploy %sworkloads.
 		c.controllerName, cloudRegion,
 	)
 
-	cloudCallCtx := envcontext.NewCloudCallContext(context.Background())
+	cloudCallCtx := envcontext.NewCloudCallContext(stdCtx)
 	// At this stage, the credential we intend to use is not yet stored
 	// server-side. So, if the credential is not accepted by the provider,
 	// we cannot mark it as invalid, just log it as an informative message.

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -4,6 +4,7 @@
 package broker_test
 
 import (
+	stdcontext "context"
 	"net"
 	"os"
 	"path/filepath"
@@ -213,7 +214,8 @@ type fakeContainerManager struct {
 	gitjujutesting.Stub
 }
 
-func (m *fakeContainerManager) CreateContainer(instanceConfig *instancecfg.InstanceConfig,
+func (m *fakeContainerManager) CreateContainer(_ stdcontext.Context,
+	instanceConfig *instancecfg.InstanceConfig,
 	cons constraints.Value,
 	base corebase.Base,
 	network *container.NetworkConfig,

--- a/container/broker/kvm-broker.go
+++ b/container/broker/kvm-broker.go
@@ -122,7 +122,7 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 		AllowMount: true,
 	}
 	inst, hardware, err := broker.manager.CreateContainer(
-		args.InstanceConfig, args.Constraints, args.InstanceConfig.Base, net, storageConfig, args.StatusCallback,
+		ctx, args.InstanceConfig, args.Constraints, args.InstanceConfig.Base, net, storageConfig, args.StatusCallback,
 	)
 	if err != nil {
 		kvmLogger.Errorf("failed to start container: %v", err)

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -124,7 +124,7 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 
 	storageConfig := &container.StorageConfig{}
 	inst, hardware, err := broker.manager.CreateContainer(
-		args.InstanceConfig, args.Constraints, args.InstanceConfig.Base, net, storageConfig, args.StatusCallback,
+		ctx, args.InstanceConfig, args.Constraints, args.InstanceConfig.Base, net, storageConfig, args.StatusCallback,
 	)
 	if err != nil {
 		return nil, err

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -223,7 +223,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	arch := "testarch"
 	hw := instance.HardwareCharacteristics{Arch: &arch}
 	mockManager.EXPECT().CreateContainer(
-		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(&inst, &hw, nil)
 
 	broker, err := broker.NewLXDBroker(

--- a/container/interface.go
+++ b/container/interface.go
@@ -4,6 +4,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
@@ -31,6 +33,7 @@ type Manager interface {
 	// CreateContainer creates and starts a new container for the specified
 	// machine.
 	CreateContainer(
+		ctx context.Context,
 		instanceConfig *instancecfg.InstanceConfig,
 		cons constraints.Value,
 		base corebase.Base,

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -4,6 +4,7 @@
 package kvm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -148,6 +149,7 @@ func (manager *containerManager) Namespace() instance.Namespace {
 }
 
 func (manager *containerManager) CreateContainer(
+	_ context.Context,
 	instanceConfig *instancecfg.InstanceConfig,
 	cons constraints.Value,
 	base corebase.Base,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -4,6 +4,7 @@
 package kvm_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -117,7 +118,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	err = instancecfg.FinishInstanceConfig(instanceConfig, environConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
-	inst, hardware, err := manager.CreateContainer(instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "12.04"), net, nil, callback)
+	inst, hardware, err := manager.CreateContainer(context.Background(), instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "12.04"), net, nil, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	expected := fmt.Sprintf("arch=%s cores=1 mem=512M root-disk=8192M", arch.HostArch())

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -131,10 +132,10 @@ var CloudImagesLinuxContainersRemote = ServerSpec{
 // ConnectImageRemote connects to a remote ImageServer using specified protocol.
 var ConnectImageRemote = connectImageRemote
 
-func connectImageRemote(remote ServerSpec) (lxd.ImageServer, error) {
+func connectImageRemote(ctx context.Context, remote ServerSpec) (lxd.ImageServer, error) {
 	switch remote.Protocol {
 	case LXDProtocol:
-		return lxd.ConnectPublicLXD(remote.Host, remote.connectionArgs)
+		return lxd.ConnectPublicLXDWithContext(ctx, remote.Host, remote.connectionArgs)
 	case SimpleStreamsProtocol:
 		return lxd.ConnectSimpleStreams(remote.Host, remote.connectionArgs)
 	}

--- a/container/lxd/connection_test.go
+++ b/container/lxd/connection_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -52,7 +53,7 @@ func (s *connectionSuite) TestLxdSocketPathNoSocket(c *gc.C) {
 }
 
 func (s *connectionSuite) TestConnectRemoteBadProtocol(c *gc.C) {
-	svr, err := lxd.ConnectImageRemote(lxd.ServerSpec{Host: "wrong-protocol-server", Protocol: "FOOBAR"})
+	svr, err := lxd.ConnectImageRemote(context.Background(), lxd.ServerSpec{Host: "wrong-protocol-server", Protocol: "FOOBAR"})
 	c.Check(svr, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "bad protocol supplied for connection: FOOBAR")
 }

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"errors"
 
 	lxdclient "github.com/canonical/lxd/client"
@@ -26,7 +27,7 @@ type patcher interface {
 // PatchConnectRemote ensures that the ConnectImageRemote function always returns
 // the supplied (mock) image server.
 func PatchConnectRemote(patcher patcher, remotes map[string]lxdclient.ImageServer) {
-	patcher.PatchValue(&ConnectImageRemote, func(spec ServerSpec) (lxdclient.ImageServer, error) {
+	patcher.PatchValue(&ConnectImageRemote, func(_ context.Context, spec ServerSpec) (lxdclient.ImageServer, error) {
 		if svr, ok := remotes[spec.Name]; ok {
 			return svr, nil
 		}

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -85,7 +85,7 @@ func (s *Server) FindImage(
 		return sourced, errors.Trace(err)
 	}
 	for _, remote := range sources {
-		source, err := ConnectImageRemote(remote)
+		source, err := ConnectImageRemote(ctx, remote)
 		if err != nil {
 			logger.Infof("failed to connect to %q: %s", remote.Host, err)
 			lastErr = errors.Trace(err)

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -4,7 +4,9 @@
 package lxd_test
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	lxdclient "github.com/canonical/lxd/client"
 	lxdapi "github.com/canonical/lxd/shared/api"
@@ -13,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/container/lxd/mocks"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	corebase "github.com/juju/juju/core/base"
 )
@@ -49,7 +52,43 @@ func (s *imageSuite) TestCopyImageUsesPassedCallback(c *gc.C) {
 		Image:     &image,
 		LXDServer: iSvr,
 	}
-	err = jujuSvr.CopyRemoteImage(sourced, []string{"local/image/alias"}, lxdtesting.NoOpCallback)
+	err = jujuSvr.CopyRemoteImage(context.Background(), sourced, []string{"local/image/alias"}, lxdtesting.NoOpCallback)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *imageSuite) TestCopyImageRetries(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	clock := mocks.NewMockClock(ctrl)
+	after := make(chan time.Time, 2)
+	after <- time.Time{}
+	after <- time.Time{}
+	clock.EXPECT().After(gomock.Any()).Return(after).AnyTimes()
+	clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+
+	iSvr := s.NewMockServer(ctrl)
+	image := lxdapi.Image{Filename: "this-is-our-image"}
+	aliases := []lxdapi.ImageAlias{{Name: "local/image/alias"}}
+	req := &lxdclient.ImageCopyArgs{Aliases: aliases}
+
+	copyOp := lxdtesting.NewMockRemoteOperation(ctrl)
+	copyOp.EXPECT().AddHandler(gomock.Any()).Return(nil, nil).AnyTimes()
+	copyOp.EXPECT().Wait().Return(nil).Return(errors.New("Failed remote image download: boom"))
+	copyOp.EXPECT().Wait().Return(nil).Return(errors.New("Failed remote image download: boom"))
+	copyOp.EXPECT().Wait().Return(nil).Return(nil)
+	copyOp.EXPECT().GetTarget().Return(&lxdapi.Operation{StatusCode: lxdapi.Success}, nil)
+
+	iSvr.EXPECT().CopyImage(iSvr, image, req).Return(copyOp, nil).Times(3)
+
+	jujuSvr, err := lxd.NewTestingServer(iSvr, clock)
+	c.Assert(err, jc.ErrorIsNil)
+
+	sourced := lxd.SourcedImage{
+		Image:     &image,
+		LXDServer: iSvr,
+	}
+	err = jujuSvr.CopyRemoteImage(context.Background(), sourced, []string{"local/image/alias"}, lxdtesting.NoOpCallback)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -68,7 +107,7 @@ func (s *imageSuite) TestFindImageLocalServer(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(iSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	found, err := jujuSvr.FindImage(corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
+	found, err := jujuSvr.FindImage(context.Background(), corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -83,7 +122,7 @@ func (s *imageSuite) TestFindImageLocalServerUnknownSeries(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(iSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = jujuSvr.FindImage(corebase.MakeDefaultBase("pldlinux", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
+	_, err = jujuSvr.FindImage(context.Background(), corebase.MakeDefaultBase("pldlinux", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
 	c.Check(err, gc.ErrorMatches, `base.*pldlinux.*`)
 }
 
@@ -117,7 +156,7 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 		{Name: "server-that-should-not-be-touched", Protocol: lxd.LXDProtocol},
 	}
-	found, err := jujuSvr.FindImage(corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
+	found, err := jujuSvr.FindImage(context.Background(), corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, rSvr2)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -154,7 +193,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	remotes := []lxd.ServerSpec{
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 	}
-	found, err := jujuSvr.FindImage(corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, true, nil)
+	found, err := jujuSvr.FindImage(context.Background(), corebase.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -182,7 +221,7 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	remotes := []lxd.ServerSpec{{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol}}
-	_, err = jujuSvr.FindImage(corebase.MakeDefaultBase("ubuntu", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
+	_, err = jujuSvr.FindImage(context.Background(), corebase.MakeDefaultBase("ubuntu", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
 	c.Assert(err, gc.ErrorMatches, ".*failed to retrieve image.*")
 }
 

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	stdcontext "context"
 	"errors"
 
 	lxdclient "github.com/canonical/lxd/client"
@@ -168,7 +169,7 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	)
 
 	instance, hc, err := s.manager.CreateContainer(
-		iCfg, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "16.04"), prepNetworkConfig(), &container.StorageConfig{}, lxdtesting.NoOpCallback,
+		stdcontext.Background(), iCfg, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "16.04"), prepNetworkConfig(), &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -222,7 +223,7 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 		ParentInterfaceName: network.DefaultLXDBridge,
 	}})
 	_, _, err = s.manager.CreateContainer(
-		iCfg, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "16.04"), netConfig, &container.StorageConfig{}, lxdtesting.NoOpCallback,
+		stdcontext.Background(), iCfg, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "16.04"), netConfig, &container.StorageConfig{}, lxdtesting.NoOpCallback,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -241,6 +242,7 @@ func (s *managerSuite) TestCreateContainerCreateFailed(c *gc.C) {
 
 	s.makeManager(c)
 	_, _, err := s.manager.CreateContainer(
+		stdcontext.Background(),
 		prepInstanceConfig(c),
 		constraints.Value{},
 		corebase.MakeDefaultBase("ubuntu", "16.04"),
@@ -264,6 +266,7 @@ func (s *managerSuite) TestCreateContainerSpecCreationError(c *gc.C) {
 
 	s.makeManager(c)
 	_, _, err := s.manager.CreateContainer(
+		stdcontext.Background(),
 		prepInstanceConfig(c),
 		constraints.Value{},
 		corebase.MakeDefaultBase("ubuntu", "16.04"),
@@ -297,6 +300,7 @@ func (s *managerSuite) TestCreateContainerStartFailed(c *gc.C) {
 	)
 
 	_, _, err = s.manager.CreateContainer(
+		stdcontext.Background(),
 		iCfg,
 		constraints.Value{},
 		corebase.MakeDefaultBase("ubuntu", "16.04"),

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"os"
 
 	jc "github.com/juju/testing/checkers"
@@ -69,7 +70,7 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 ) instances.Instance {
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
 	inst, hardware, err := manager.CreateContainer(
-		instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "18.04"), networkConfig, storageConfig, callback)
+		context.Background(), instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "18.04"), networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")

--- a/container/testing/interface_mock.go
+++ b/container/testing/interface_mock.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancecfg "github.com/juju/juju/cloudconfig/instancecfg"
@@ -56,9 +57,9 @@ func (mr *MockTestLXDManagerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 int
 }
 
 // CreateContainer mocks base method.
-func (m *MockTestLXDManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 constraints.Value, arg2 base.Base, arg3 *container.NetworkConfig, arg4 *container.StorageConfig, arg5 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
+func (m *MockTestLXDManager) CreateContainer(arg0 context.Context, arg1 *instancecfg.InstanceConfig, arg2 constraints.Value, arg3 base.Base, arg4 *container.NetworkConfig, arg5 *container.StorageConfig, arg6 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(instances.Instance)
 	ret1, _ := ret[1].(*instance.HardwareCharacteristics)
 	ret2, _ := ret[2].(error)
@@ -66,9 +67,9 @@ func (m *MockTestLXDManager) CreateContainer(arg0 *instancecfg.InstanceConfig, a
 }
 
 // CreateContainer indicates an expected call of CreateContainer.
-func (mr *MockTestLXDManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockTestLXDManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockTestLXDManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockTestLXDManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // DestroyContainer mocks base method.

--- a/container/testing/package_mock.go
+++ b/container/testing/package_mock.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancecfg "github.com/juju/juju/cloudconfig/instancecfg"
@@ -40,9 +41,9 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // CreateContainer mocks base method.
-func (m *MockManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 constraints.Value, arg2 base.Base, arg3 *container.NetworkConfig, arg4 *container.StorageConfig, arg5 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
+func (m *MockManager) CreateContainer(arg0 context.Context, arg1 *instancecfg.InstanceConfig, arg2 constraints.Value, arg3 base.Base, arg4 *container.NetworkConfig, arg5 *container.StorageConfig, arg6 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(instances.Instance)
 	ret1, _ := ret[1].(*instance.HardwareCharacteristics)
 	ret2, _ := ret[2].(error)
@@ -50,9 +51,9 @@ func (m *MockManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 con
 }
 
 // CreateContainer indicates an expected call of CreateContainer.
-func (mr *MockManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // DestroyContainer mocks base method.

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -124,7 +124,7 @@ func (env *environ) newContainer(
 		return nil, errors.Trace(err)
 	}
 
-	image, err := target.FindImage(args.InstanceConfig.Base, arch, virtType, imageSources, true, statusCallback)
+	image, err := target.FindImage(ctx, args.InstanceConfig.Base, arch, virtType, imageSources, true, statusCallback)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -93,7 +93,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -132,7 +132,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -204,7 +204,7 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(profileNICs, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -385,7 +385,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -426,7 +426,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *gc.C
 
 	exp := svr.EXPECT()
 	exp.HostArch().Return(arch.AMD64)
-	exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeVM, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil)
+	exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeVM, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil)
 	exp.ServerVersion().Return("3.10.0")
 	exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil)
 	exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil)
@@ -472,7 +472,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -509,7 +509,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),

--- a/provider/lxd/package_mock_test.go
+++ b/provider/lxd/package_mock_test.go
@@ -5,6 +5,7 @@
 package lxd
 
 import (
+	context "context"
 	reflect "reflect"
 
 	lxd "github.com/canonical/lxd/client"
@@ -259,18 +260,18 @@ func (mr *MockServerMockRecorder) FilterContainers(arg0 interface{}, arg1 ...int
 }
 
 // FindImage mocks base method.
-func (m *MockServer) FindImage(arg0 base.Base, arg1 string, arg2 api.InstanceType, arg3 []lxd0.ServerSpec, arg4 bool, arg5 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
+func (m *MockServer) FindImage(arg0 context.Context, arg1 base.Base, arg2 string, arg3 api.InstanceType, arg4 []lxd0.ServerSpec, arg5 bool, arg6 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(lxd0.SourcedImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindImage indicates an expected call of FindImage.
-func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // GetCertificate mocks base method.

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -35,7 +36,7 @@ import (
 // Server defines an interface of all localized methods that the environment
 // and provider utilizes.
 type Server interface {
-	FindImage(corebase.Base, string, instance.VirtType, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
+	FindImage(context.Context, corebase.Base, string, instance.VirtType, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
 	GetServer() (server *lxdapi.Server, ETag string, err error)
 	ServerVersion() string
 	GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	stdcontext "context"
 	"net"
 	"os"
 	"strconv"
@@ -421,7 +422,7 @@ func (conn *StubClient) CreateContainerFromSpec(spec lxd.ContainerSpec) (*lxd.Co
 }
 
 func (conn *StubClient) FindImage(
-	base corebase.Base, arch string, virtType instance.VirtType, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
+	ctx stdcontext.Context, base corebase.Base, arch string, virtType instance.VirtType, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
 ) (lxd.SourcedImage, error) {
 	conn.AddCall("FindImage", base.DisplayString(), arch)
 	if err := conn.NextErr(); err != nil {

--- a/upgrades/upgradevalidation/mocks/lxd_mock.go
+++ b/upgrades/upgradevalidation/mocks/lxd_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	lxd "github.com/canonical/lxd/client"
@@ -343,18 +344,18 @@ func (mr *MockServerMockRecorder) FilterContainers(arg0 interface{}, arg1 ...int
 }
 
 // FindImage mocks base method.
-func (m *MockServer) FindImage(arg0 base.Base, arg1 string, arg2 api.InstanceType, arg3 []lxd0.ServerSpec, arg4 bool, arg5 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
+func (m *MockServer) FindImage(arg0 context.Context, arg1 base.Base, arg2 string, arg3 api.InstanceType, arg4 []lxd0.ServerSpec, arg5 bool, arg6 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(lxd0.SourcedImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindImage indicates an expected call of FindImage.
-func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // GetCertificate mocks base method.


### PR DESCRIPTION
We have been having trouble with flaky service from ubuntu cloud image, leading to bootstrap failures. In this case, we should try re-downloading the image a few times, as we may be successfuly 2nd or 3rd time

Subtle change to contexts in bootstrap. Placing stdCtx into the cloud call context ensures that if ctrl-C is pressed, this is transmitted to the providers via the providerCallContext.

To ensure we can cancel without retrying, we need to pass a context through into `container/lxd`, specifically `FindImage`, which results in a change of interface. This has quite a few ramifications, but changes are trivial.

There is a lot of bad stuff here. This is an incremental improvement.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure you have no lxd images cached
```
$ lxc image ls
+-------+-------------+--------+-------------+--------------+------+------+-------------+
| ALIAS | FINGERPRINT | PUBLIC | DESCRIPTION | ARCHITECTURE | TYPE | SIZE | UPLOAD DATE |
+-------+-------------+--------+-------------+--------------+------+------+-------------+
```

Bootstrap an lxd controller and disconnect your internet before the image has downloaded. You should see logs along the line of:
```
$ juju bootstrap lxd lxd
Creating Juju controller "lxd" on lxd/localhost
Looking for packaged Juju agent version 3.1.8 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on localhost/localhost...
 - Retrieving image: rootfs: 6% (13.29MB/s)   
 - Failed remote LXD image download. Retrying. Attempt number 2
 - Failed remote LXD image download. Retrying. Attempt number 3
 - attempt count exceeded: Failed remote image download: Get "https://cloud-images.ubuntu.com/releases/server/releases/jammy/release-20231211/ubuntu-22.04-server-cloudimg-amd64-lxd.tar.xz"ERROR failed to bootstrap model: cannot start bootstrap instance in availability zone "jack-MS-7B85": attempt count exceeded: Failed remote image download: Get "https://cloud-images.ubuntu.com/releases/server/releases/jammy/release-20231211/ubuntu-22.04-server-cloudimg-amd64-lxd.tar.xz": lookup cloud-images.ubuntu.com on 127.0.0.53:53: server misbehaving
```

Bootstrap an lxd controller and disconnect your internet before the image has downloaded. Short after, press ctrl-C. You should see logs like. (Note, you will not cancel immediately as the lxd client does perform download actions within a context. Here we're testing that Juju does not attempt to download the image again):
```
$ juju bootstrap lxd lxd
Creating Juju controller "lxd" on lxd/localhost
Looking for packaged Juju agent version 3.1.8 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on localhost/localhost...
 - Retrieving image: rootfs: 6% (13.33MB/s)   
^C
Ctrl-C pressed, stopping bootstrap and cleaning up resources
ERROR failed to bootstrap model: starting controller (cancelled): retry stopped

```
