### PR TITLE
Objects HTTP get request

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -651,7 +651,7 @@ func (srv *Server) loop(ready chan struct{}) error {
 const (
 	modelRoutePrefix         = "/model/:modeluuid"
 	charmsObjectsRoutePrefix = "/:bucket/charms/:object"
-	objectsRoutePrefix       = "/:bucket/:objects/:object"
+	objectsRoutePrefix       = "/:bucket/objects/:object"
 )
 
 func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -648,10 +648,13 @@ func (srv *Server) loop(ready chan struct{}) error {
 	return tomb.ErrDying
 }
 
-func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
-	const modelRoutePrefix = "/model/:modeluuid"
-	const charmsObjectsRoutePrefix = "/:bucket/charms/:object"
+const (
+	modelRoutePrefix         = "/model/:modeluuid"
+	charmsObjectsRoutePrefix = "/:bucket/charms/:object"
+	objectsRoutePrefix       = "/:bucket/:objects/:object"
+)
 
+func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	type handler struct {
 		pattern         string
 		methods         []string
@@ -661,6 +664,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		tracked         bool
 		noModelUUID     bool
 	}
+
 	var endpoints []apihttp.Endpoint
 	systemState, err := srv.shared.statePool.SystemState()
 	if err != nil {
@@ -693,6 +697,11 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 					Query:   ":modeluuid",
 				}
 			} else if strings.HasPrefix(handler.pattern, charmsObjectsRoutePrefix) {
+				h = &httpcontext.BucketModelHandler{
+					Handler: h,
+					Query:   ":bucket",
+				}
+			} else if strings.HasPrefix(handler.pattern, objectsRoutePrefix) {
 				h = &httpcontext.BucketModelHandler{
 					Handler: h,
 					Query:   ":bucket",
@@ -768,12 +777,13 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	}
 	modelCharmsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
 
-	modelObjectsCharmsHandler := &objectsCharmHandler{
+	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		ctxt:              httpCtxt,
 		objectStoreGetter: srv.shared.objectStoreGetter,
 	}
-	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
-		GetHandler: modelObjectsCharmsHandler.ServeGet,
+	modelObjectsHTTPHandler := &objectsHTTPHandler{
+		ctxt:              httpCtxt,
+		objectStoreGetter: srv.shared.objectStoreGetter,
 	}
 
 	modelToolsUploadHandler := &toolsUploadHandler{
@@ -993,6 +1003,10 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern: charmsObjectsRoutePrefix,
 		methods: []string{"GET"},
 		handler: modelObjectsCharmsHTTPHandler,
+	}, {
+		pattern: objectsRoutePrefix,
+		methods: []string{"GET"},
+		handler: modelObjectsHTTPHandler,
 	}}
 	if srv.registerIntrospectionHandlers != nil {
 		add := func(subpath string, h http.Handler) {

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -197,6 +197,33 @@ func (s *objectsSuite) TestInvalidModel(c *gc.C) {
 	c.Assert(string(body), gc.Equals, "invalid model UUID \"wrongbucket\"\n")
 }
 
+func (s *objectsSuite) TestObjectNameInURL(c *gc.C) {
+	// Notice that both charms and objects aren't in this list, as they are
+	// legitimate endpoints.
+	names := []string{
+		"action",
+		"agent",
+		"application",
+		"binary",
+		"blah",
+		"bundle",
+		"machine",
+		"network",
+		"offer",
+		"relation",
+		"storage",
+		"tools",
+		"unit",
+	}
+	for i, name := range names {
+		c.Logf("test %d: %s", i, name)
+
+		url := s.URL(fmt.Sprintf("/model-%s/%s/%s", s.ControllerModelUUID(), name, "blah="), nil).String()
+		resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: url})
+		apitesting.AssertResponse(c, resp, http.StatusNotFound, "text/plain; charset=utf-8")
+	}
+}
+
 func (s *objectsSuite) TestOnlyMethodGET(c *gc.C) {
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.objectsURL("somecharm-abcd0123").String()})
 	body := apitesting.AssertResponse(c, resp, http.StatusMethodNotAllowed, "text/plain; charset=utf-8")

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -5,6 +5,7 @@ package apiserver_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,25 +23,11 @@ import (
 	"github.com/juju/juju/testcharms"
 )
 
-type objectsSuite struct {
+type baseObjectsSuite struct {
 	jujutesting.ApiServerSuite
 }
 
-var _ = gc.Suite(&objectsSuite{})
-
-func (s *objectsSuite) SetUpSuite(c *gc.C) {
-	s.ApiServerSuite.SetUpSuite(c)
-}
-
-func (s *objectsSuite) objectsCharmsURL(charmurl string) *url.URL {
-	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.ControllerModelUUID(), charmurl), nil)
-}
-
-func (s *objectsSuite) objectsCharmsURI(charmurl string) string {
-	return s.objectsCharmsURL(charmurl).String()
-}
-
-func (s *objectsSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.CharmsResponse {
+func (s *baseObjectsSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.CharmsResponse {
 	body := apitesting.AssertResponse(c, resp, expStatus, params.ContentTypeJSON)
 	var charmResponse params.CharmsResponse
 	err := json.Unmarshal(body, &charmResponse)
@@ -48,12 +35,42 @@ func (s *objectsSuite) assertResponse(c *gc.C, resp *http.Response, expStatus in
 	return charmResponse
 }
 
-func (s *objectsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+func (s *baseObjectsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
 	charmResponse := s.assertResponse(c, resp, expCode)
 	c.Check(charmResponse.Error, gc.Matches, expError)
 }
 
-func (s *objectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
+func (s *baseObjectsSuite) uploadRequest(c *gc.C, url, contentType string, content io.Reader) *http.Response {
+	return sendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "POST",
+		URL:         url,
+		ContentType: contentType,
+		Body:        content,
+	})
+}
+
+// TODO(jack-w-shaw) Once we have implemented PutObject S3 endpoint, drop these next three
+// methods and use PutObject instead
+func (s *baseObjectsSuite) charmsURL(query string) *url.URL {
+	url := s.URL(fmt.Sprintf("/model/%s/charms", s.ControllerModelUUID()), nil)
+	url.RawQuery = query
+	return url
+}
+
+func (s *baseObjectsSuite) charmsURI(query string) string {
+	if query != "" && query[0] == '?' {
+		query = query[1:]
+	}
+	return s.charmsURL(query).String()
+}
+
+type charmObjectsSuite struct {
+	baseObjectsSuite
+}
+
+var _ = gc.Suite(&charmObjectsSuite{})
+
+func (s *charmObjectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
 	url := s.objectsCharmsURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
@@ -63,19 +80,19 @@ func (s *objectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
 	})
 }
 
-func (s *objectsSuite) TestGETRequiresAuth(c *gc.C) {
+func (s *charmObjectsSuite) TestGETRequiresAuth(c *gc.C) {
 	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("somecharm-abcd0123")})
 	body := apitesting.AssertResponse(c, resp, http.StatusUnauthorized, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
 }
 
-func (s *objectsSuite) TestOnlyMethodGET(c *gc.C) {
+func (s *charmObjectsSuite) TestOnlyMethodGET(c *gc.C) {
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.objectsCharmsURI("somecharm-abcd0123")})
 	body := apitesting.AssertResponse(c, resp, http.StatusMethodNotAllowed, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "Method Not Allowed\n")
 }
 
-func (s *objectsSuite) TestGetFailsWithInvalidObjectSha256(c *gc.C) {
+func (s *charmObjectsSuite) TestGetFailsWithInvalidObjectSha256(c *gc.C) {
 	uri := s.objectsCharmsURI("invalidsha256")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 	s.assertErrorResponse(
@@ -84,29 +101,28 @@ func (s *objectsSuite) TestGetFailsWithInvalidObjectSha256(c *gc.C) {
 	)
 }
 
-func (s *objectsSuite) TestInvalidBucket(c *gc.C) {
+func (s *charmObjectsSuite) TestInvalidBucket(c *gc.C) {
 	wrongURL := s.URL("modelwrongbucket/charms/somecharm-abcd0123", nil)
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: wrongURL.String()})
 	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "invalid bucket format \"modelwrongbucket\"\n")
 }
 
-func (s *objectsSuite) TestInvalidModel(c *gc.C) {
+func (s *charmObjectsSuite) TestInvalidModel(c *gc.C) {
 	wrongURL := s.URL("model-wrongbucket/charms/somecharm-abcd0123", nil)
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: wrongURL.String()})
 	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "invalid model UUID \"wrongbucket\"\n")
 }
 
-func (s *objectsSuite) TestInvalidObject(c *gc.C) {
+func (s *charmObjectsSuite) TestInvalidObject(c *gc.C) {
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("invalidcharm")})
 	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "application/json")
 	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: wrong charms object path \"invalidcharm\"","error-code":"bad request"}`)
 }
 
-var fakeSHA256 = "123456789abcde123456789abcde123456789abcde123456789abcde12345678"
-
-func (s *objectsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
+func (s *charmObjectsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
+	fakeSHA256 := "123456789abcde123456789abcde123456789abcde123456789abcde12345678"
 	// Add a charm in pending mode.
 	chInfo := state.CharmInfo{
 		ID:          "ch:focal/dummy-1",
@@ -123,31 +139,7 @@ func (s *objectsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
 	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: ch:focal/dummy-1","error-code":"not yet available; try again later"}`)
 }
 
-// TODO(jack-w-shaw) Once we have implemented PutObject S3 endpoint, drop these next three
-// methods and use PutObject instead
-func (s *objectsSuite) charmsURL(query string) *url.URL {
-	url := s.URL(fmt.Sprintf("/model/%s/charms", s.ControllerModelUUID()), nil)
-	url.RawQuery = query
-	return url
-}
-
-func (s *objectsSuite) charmsURI(query string) string {
-	if query != "" && query[0] == '?' {
-		query = query[1:]
-	}
-	return s.charmsURL(query).String()
-}
-
-func (s *objectsSuite) uploadRequest(c *gc.C, url, contentType string, content io.Reader) *http.Response {
-	return sendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "POST",
-		URL:         url,
-		ContentType: contentType,
-		Body:        content,
-	})
-}
-
-func (s *objectsSuite) TestGetReturnsMatchingContents(c *gc.C) {
+func (s *charmObjectsSuite) TestGetReturnsMatchingContents(c *gc.C) {
 	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	// use legacy upload endpoint as PutObject is not yet implemented
 	_ = s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: chArchive.Path})
@@ -162,4 +154,93 @@ func (s *objectsSuite) TestGetReturnsMatchingContents(c *gc.C) {
 	archiveBytes, err := os.ReadFile(chArchive.Path)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
+}
+
+func (s *charmObjectsSuite) objectsCharmsURL(charmurl string) *url.URL {
+	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.ControllerModelUUID(), charmurl), nil)
+}
+
+func (s *charmObjectsSuite) objectsCharmsURI(charmurl string) string {
+	return s.objectsCharmsURL(charmurl).String()
+}
+
+type objectsSuite struct {
+	baseObjectsSuite
+}
+
+var _ = gc.Suite(&objectsSuite{})
+
+func (s *objectsSuite) SetUpSuite(c *gc.C) {
+	s.ApiServerSuite.SetUpSuite(c)
+}
+
+func (s *objectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
+	url := s.objectsURL("")
+	url.Scheme = "http"
+	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
+	})
+}
+
+func (s *objectsSuite) TestGETRequiresAuth(c *gc.C) {
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsURL("somecharm-abcd0123").String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusUnauthorized, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
+}
+
+func (s *objectsSuite) TestInvalidModel(c *gc.C) {
+	wrongURL := s.URL("model-wrongbucket/charms/somecharm-abcd0123", nil)
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: wrongURL.String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "invalid model UUID \"wrongbucket\"\n")
+}
+
+func (s *objectsSuite) TestOnlyMethodGET(c *gc.C) {
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.objectsURL("somecharm-abcd0123").String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusMethodNotAllowed, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "Method Not Allowed\n")
+}
+
+func (s *objectsSuite) TestGetFailsWithEmptyObjectID(c *gc.C) {
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.objectsURL("").String()})
+	apitesting.AssertResponse(c, resp, http.StatusNotFound, "text/plain; charset=utf-8")
+}
+
+func (s *objectsSuite) TestGetFailsWithInvalidObjectID(c *gc.C) {
+	url := s.URL(fmt.Sprintf("/model-%s/objects/%s", s.ControllerModelUUID(), "blah="), nil).String()
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: url})
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		`.*cannot decode object id$`,
+	)
+}
+
+func (s *objectsSuite) TestGetReturnsNotFound(c *gc.C) {
+	// Notice that the returned content-type is application/json when it's not
+	// found.
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsURL("base").String()})
+	apitesting.AssertResponse(c, resp, http.StatusNotFound, "application/json")
+}
+
+func (s *objectsSuite) TestGetReturnsMatchingContents(c *gc.C) {
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	// use legacy upload endpoint as PutObject is not yet implemented
+	_ = s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: chArchive.Path})
+
+	// Get the charm back out so we can see the storage path.
+	ch, err := s.ControllerModel(c).State().Charm("local:quantal/dummy-1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsURL(ch.StoragePath()).String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
+	archiveBytes, err := os.ReadFile(chArchive.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
+}
+
+func (s *objectsSuite) objectsURL(path string) *url.URL {
+	objectID := base64.URLEncoding.EncodeToString([]byte(path))
+	return s.URL(fmt.Sprintf("/model-%s/objects/%s", s.ControllerModelUUID(), objectID), nil)
 }


### PR DESCRIPTION
Adds the ability to get an object of any type just by the path of the object. Currently, this is the storage path to the metadata, but conceivably it is the UUID of the object.

This piggybacks off the current charm objects implementation. This is a raw endpoint and doesn't require checking of the underlying entity state. It's either in the object store or it isn't.

This is required by the file object store to move into HA. The concept is simple; if you're in HA and you don't have the file locally, it's reasonable to ask another controller for that file. Upon receiving the file, it will store it locally, and send it back in the request.

---

Interestingly, I now better understand how to fix the API server and remove a lot of complexity. The API Server should offer an endpoint register interface from the API server worker. Each handler can then register and unregister at will. It will provide resiliency for each handler. Failure at a handler doesn't bring down the whole API server. In addition, we can then move a lot of this mess out of the apiserver package into individual worker handlers.

I'll look into creating a prototype for this in the new year.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ go test -v ./apiserver -check.v -check.f=objects
```


## Links


**Jira card:** JUJU-5139

