### PR TITLE
Ensure we release state once done

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -701,9 +701,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		controllerModelUUID,
 	)
 	modelRestHandler := &modelRestHandler{
-		ctxt:          httpCtxt,
-		dataDir:       srv.dataDir,
-		stateAuthFunc: httpCtxt.stateForRequestAuthenticatedUser,
+		ctxt:    httpCtxt,
+		dataDir: srv.dataDir,
 	}
 	modelRestServer := &RestHTTPHandler{
 		GetHandler: modelRestHandler.ServeGet,
@@ -731,6 +730,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
+
 			rst := st.Resources()
 			return rst, st, entity.Tag(), nil
 		},
@@ -739,6 +739,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 			if err != nil {
 				return errors.Trace(err)
 			}
+			defer st.Release()
+
 			blockChecker := common.NewBlockChecker(st)
 			if err := blockChecker.ChangeAllowed(); err != nil {
 				return errors.Trace(err)
@@ -752,6 +754,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
+
 			tagStr := req.URL.Query().Get(":unit")
 			tag, err := names.ParseUnitTag(tagStr)
 			if err != nil {

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -58,12 +58,6 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	defer func() {
-		// Here err is the named return arg.
-		if err != nil {
-			st.Release()
-		}
-	}()
 	return st, authInfo.Entity, nil
 }
 

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -42,9 +42,8 @@ func (h *RestHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // modelRestHandler handles ReST requests through HTTPS in the API server.
 type modelRestHandler struct {
-	ctxt          httpContext
-	dataDir       string
-	stateAuthFunc func(*http.Request) (*state.PooledState, error)
+	ctxt    httpContext
+	dataDir string
 }
 
 // ServeGet handles http GET requests.


### PR DESCRIPTION
Ensuring we clean up the state pool once the state has been used, preventing any leaks. The state pool gives out managed pooled objects, these are reference counted. Every pooled item needs to be accounted for to ensure that a state can be cleaned up accordingly. 

The code just ensures that when we're done with the managed pool item, we call done on it. Giving it back to the pool.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu
```

