### PR TITLE
Lock in upgrade const behaviour

### DIFF
--- a/core/upgrade/upgrade.go
+++ b/core/upgrade/upgrade.go
@@ -29,22 +29,23 @@ const (
 	Error
 )
 
+// States holds all the possible states.
+var States = map[State]string{
+	Created:        "created",
+	Started:        "started",
+	DBCompleted:    "db-completed",
+	StepsCompleted: "steps-completed",
+	Error:          "error",
+}
+
 // ParseState returns the state from a string.
 func ParseState(str string) (State, error) {
-	switch str {
-	case "created":
-		return Created, nil
-	case "started":
-		return Started, nil
-	case "db-completed":
-		return DBCompleted, nil
-	case "steps-completed":
-		return StepsCompleted, nil
-	case "error":
-		return Error, nil
-	default:
-		return 0, errors.Errorf("unknown state %q", str)
+	for state, s := range States {
+		if s == str {
+			return state, nil
+		}
 	}
+	return 0, errors.Errorf("unknown state %q", str)
 }
 
 // TransitionTo returns an error if the transition is not allowed.
@@ -82,20 +83,10 @@ func (s State) IsTerminal() bool {
 }
 
 func (s State) String() string {
-	switch s {
-	case Created:
-		return "created"
-	case Started:
-		return "started"
-	case DBCompleted:
-		return "db-completed"
-	case StepsCompleted:
-		return "steps-completed"
-	case Error:
-		return "error"
-	default:
-		return "unknown"
+	if str, ok := States[s]; ok {
+		return str
 	}
+	return "unknown"
 }
 
 // Info holds the information about database upgrade


### PR DESCRIPTION
To ensure that we can never diverge from the core package, the changes lock in the behaviour that all upgrade states are represented in both core and db.

This is feedback from a sync with others that it's possible that domain and core types could diverge and locking in the changes via a test will ensure that it's locked in to prevent mistakes. An alternative is to do a join from name to id; it could potentially help, but you can still have issues if the string names change in the core package, so a test will still be required anyway.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Note: this just locks in behaviour via a test.

```
$ TEST_PACKAGES="./domain/upgrade/state/..." make run-go-tests
```

## Links

**Jira card:** JUJU-

