### PR TITLE
Add upsert method in state for subnets domain

### DIFF
--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -127,7 +127,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBin
 		// Update all subnets (including their fan overlays) to include
 		// the space uuid.
 		for _, subnetID := range subnetIDs {
-			if err := updateSubnetSpaceIDTx(ctx, tx, subnetID, uuid.String()); err != nil {
+			if err := updateSubnetSpaceID(ctx, tx, subnetID, uuid.String()); err != nil {
 				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid.String())
 			}
 		}

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -33,7 +33,7 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID,
+		subnetUUID.String(),
 		"192.168.0.0/12",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -87,7 +87,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID,
+		subnetUUID.String(),
 		"192.168.0.0/12",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -127,7 +127,7 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID,
+		subnetUUID.String(),
 		"192.168.0.0/12",
 		"",
 		"provider-network-id-0",
@@ -165,7 +165,7 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID,
+		subnetUUID.String(),
 		"192.168.0.0/12",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -180,7 +180,7 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetFanUUID,
+		subnetFanUUID.String(),
 		"10.0.0.0/24",
 		"provider-id-1",
 		"provider-network-id-1",
@@ -210,7 +210,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0,
+		subnetUUID0.String(),
 		"192.168.0.0/12",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -225,7 +225,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1,
+		subnetUUID1.String(),
 		"192.176.0.0/12",
 		"provider-id-2",
 		"provider-network-id-2",
@@ -240,7 +240,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetFanUUID,
+		subnetFanUUID.String(),
 		"10.0.0.0/20",
 		"provider-id-1",
 		"provider-network-id-1",
@@ -363,7 +363,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0,
+		subnetUUID0.String(),
 		"192.168.0.0/24",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -377,7 +377,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1,
+		subnetUUID1.String(),
 		"192.168.1.0/24",
 		"provider-id-1",
 		"provider-network-id-1",
@@ -391,7 +391,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID2,
+		subnetUUID2.String(),
 		"192.168.2.0/24",
 		"provider-id-2",
 		"provider-network-id-2",
@@ -456,7 +456,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0,
+		subnetUUID0.String(),
 		"192.168.0.0/20",
 		"provider-id-0",
 		"provider-network-id-0",
@@ -482,7 +482,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Check(name, gc.Equals, spUUID.String())
 
 	// Check that the subnet is linked to the newly created space.
-	subnet, err := st.GetSubnet(ctx.Background(), subnetUUID0)
+	subnet, err := st.GetSubnet(ctx.Background(), subnetUUID0.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnet.SpaceID, gc.Equals, spUUID.String())
 
@@ -491,7 +491,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the subnet is not linked to the deleted space.
-	subnet, err = st.GetSubnet(ctx.Background(), subnetUUID0)
+	subnet, err = st.GetSubnet(ctx.Background(), subnetUUID0.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnet.SpaceID, gc.Equals, network.AlphaSpaceId)
 }

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -33,14 +33,16 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID.String(),
-		"192.168.0.0/12",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -87,14 +89,16 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID.String(),
-		"192.168.0.0/12",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -127,14 +131,16 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID.String(),
-		"192.168.0.0/12",
-		"",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -165,14 +171,16 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID.String(),
-		"192.168.0.0/12",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type fan.
@@ -180,16 +188,18 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetFanUUID.String(),
-		"10.0.0.0/24",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/12",
-			FanOverlay:       "252.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetFanUUID.String()),
+			CIDR:              "10.0.0.0/24",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/12",
+				FanOverlay:       "252.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -210,14 +220,16 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/12",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/12",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type base.
@@ -225,14 +237,16 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"192.176.0.0/12",
-		"provider-id-2",
-		"provider-network-id-2",
-		0,
-		[]string{"az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "192.176.0.0/12",
+			ProviderId:        "provider-id-2",
+			ProviderNetworkId: "provider-network-id-2",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type fan.
@@ -240,16 +254,18 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetFanUUID.String(),
-		"10.0.0.0/20",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az2"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/12",
-			FanOverlay:       "10.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetFanUUID.String()),
+			CIDR:              "10.0.0.0/20",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az2"},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/12",
+				FanOverlay:       "10.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -363,42 +379,48 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/24",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/24",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"192.168.1.0/24",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "192.168.1.0/24",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID2, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID2.String(),
-		"192.168.2.0/24",
-		"provider-id-2",
-		"provider-network-id-2",
-		0,
-		[]string{"az2", "az3"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID2.String()),
+			CIDR:              "192.168.2.0/24",
+			ProviderId:        "provider-id-2",
+			ProviderNetworkId: "provider-network-id-2",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az2", "az3"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -456,14 +478,16 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/20",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -120,14 +120,16 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		uuid.String(),
-		"10.0.0.0/24",
-		"provider-id",
-		"provider-network-id",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(uuid.String()),
+			CIDR:              "10.0.0.0/24",
+			ProviderId:        "provider-id",
+			ProviderNetworkId: "provider-network-id",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -198,28 +200,32 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"10.0.0.0/24",
-		"provider-id-0",
-		"provider-network-id",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "10.0.0.0/24",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"10.0.1.0/24",
-		"provider-id-1",
-		"provider-network-id",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "10.0.1.0/24",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_network.provider_network_id")
 }
@@ -236,28 +242,32 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"10.0.0.0/24",
-		"provider-id",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "10.0.0.0/24",
+			ProviderId:        "provider-id",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"10.0.1.0/24",
-		"provider-id",
-		"provider-network-id-1",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "10.0.1.0/24",
+			ProviderId:        "provider-id",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_subnet.provider_id")
 }
@@ -270,14 +280,16 @@ func (s *stateSuite) TestRetrieveFanSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/20",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type fan.
@@ -285,16 +297,18 @@ func (s *stateSuite) TestRetrieveFanSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"10.0.0.0/12",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az1"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/20",
-			FanOverlay:       "10.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "10.0.0.0/12",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az1"},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/20",
+				FanOverlay:       "10.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -350,14 +364,16 @@ func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/20",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type fan.
@@ -365,16 +381,18 @@ func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"10.0.0.0/12",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az1"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/20",
-			FanOverlay:       "10.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "10.0.0.0/12",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az1"},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/20",
+				FanOverlay:       "10.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -426,42 +444,48 @@ func (s *stateSuite) TestRetrieveAllSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/24",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"192.168.1.0/24",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "192.168.1.0/20",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	subnetUUID2, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID2.String(),
-		"192.168.2.0/24",
-		"provider-id-2",
-		"provider-network-id-2",
-		0,
-		[]string{"az2", "az3"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID2.String()),
+			CIDR:              "192.168.2.0/20",
+			ProviderId:        "provider-id-2",
+			ProviderNetworkId: "provider-network-id-2",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az2", "az3"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -483,14 +507,16 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		uuid.String(),
-		"10.0.0.0/24",
-		"provider-id",
-		"provider-network-id",
-		0,
-		[]string{"az0", "az1"},
-		spUUID.String(),
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(uuid.String()),
+			CIDR:              "10.0.0.0/24",
+			ProviderId:        "provider-id",
+			ProviderNetworkId: "provider-network-id",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           spUUID.String(),
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -520,14 +546,16 @@ func (s *stateSuite) TestDeleteSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID0.String(),
-		"192.168.0.0/20",
-		"provider-id-0",
-		"provider-network-id-0",
-		0,
-		[]string{"az0", "az1"},
-		"",
-		nil,
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID0.String()),
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az0", "az1"},
+			SpaceID:           "",
+			FanInfo:           nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a subnet of type fan.
@@ -535,16 +563,18 @@ func (s *stateSuite) TestDeleteSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID1.String(),
-		"10.0.0.0/12",
-		"provider-id-1",
-		"provider-network-id-1",
-		0,
-		[]string{},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/20",
-			FanOverlay:       "10.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID1.String()),
+			CIDR:              "10.0.0.0/12",
+			ProviderId:        "provider-id-1",
+			ProviderNetworkId: "provider-network-id-1",
+			VLANTag:           0,
+			AvailabilityZones: []string{},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/20",
+				FanOverlay:       "10.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -553,16 +583,18 @@ func (s *stateSuite) TestDeleteSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		subnetUUID2.String(),
-		"10.8.0.0/12",
-		"provider-id-2",
-		"provider-network-id-2",
-		0,
-		[]string{"az4", "az5"},
-		"",
-		&network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/20",
-			FanOverlay:       "10.0.0.0/8",
+		network.SubnetInfo{
+			ID:                network.Id(subnetUUID2.String()),
+			CIDR:              "10.8.0.0/12",
+			ProviderId:        "provider-id-2",
+			ProviderNetworkId: "provider-network-id-2",
+			VLANTag:           0,
+			AvailabilityZones: []string{"az4", "az5"},
+			SpaceID:           "",
+			FanInfo: &network.FanCIDRs{
+				FanLocalUnderlay: "192.168.0.0/20",
+				FanOverlay:       "10.0.0.0/8",
+			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -227,7 +227,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
 			FanInfo:           nil,
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_network.provider_network_id")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("inserting provider network id %q for subnet %q: UNIQUE constraint failed: provider_network.provider_network_id", "provider-network-id", subnetUUID1.String()))
 }
 
 func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 			FanInfo:           nil,
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "UNIQUE constraint failed: provider_subnet.provider_id")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("inserting provider id %q for subnet %q: UNIQUE constraint failed: provider_subnet.provider_id", "provider-id", subnetUUID1.String()))
 }
 
 func (s *stateSuite) TestRetrieveFanSubnet(c *gc.C) {


### PR DESCRIPTION
This patch adds a `UpsertSubnets` method, which takes a list of subnets to add or update (if they already exist).

This method is necessary for the upcoming space service layer, which has the method SaveProviderSubnets. This method is currently not atomic on our current mongodb state, but the idea is to turn it atomic by running all the subnet creations/updates under one single transaction. Thus, the UpsertSubnets method will be used.

Note that the `AddSubnet` and `SubnetUpdate` methods are updated so the mutual code is extracted.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Since this is state layer is not still wired-up, this should suffice:
```
go test github.com/juju/juju/domain/network/... -gocheck.v
```


## Links


**Jira card:** JUJU-5105

