### PR TITLE
Propagates errors from start instance for each zone.

### DIFF
--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -6,6 +6,7 @@ package common
 import (
 	"bufio"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -280,12 +281,14 @@ func BootstrapInstance(
 	}
 
 	var result *environs.StartInstanceResult
+	zoneErrors := []error{} // is a collection of errors we encounter for each zone.
 	for i, zone := range zones {
 		startInstanceArgs.AvailabilityZone = zone
 		result, err = env.StartInstance(callCtx, startInstanceArgs)
 		if err == nil {
 			break
 		}
+		zoneErrors = append(zoneErrors, fmt.Errorf("starting bootstrap instance in zone %q: %w", zone, err))
 
 		select {
 		case <-ctx.Context().Done():
@@ -304,9 +307,9 @@ func BootstrapInstance(
 		}
 		// This is the last zone in the list, error.
 		if len(zones) > 1 {
-			return nil, nil, nil, errors.Errorf(
-				"cannot start bootstrap instance in any availability zone (%s)",
-				strings.Join(zones, ", "),
+			return nil, nil, nil, fmt.Errorf(
+				"cannot start bootstrap instance in any availability zone (%s):\n%w",
+				strings.Join(zones, ", "), stderrors.Join(zoneErrors...),
 			)
 		}
 		return nil, nil, nil, errors.Annotatef(err, "cannot start bootstrap instance in availability zone %q", zone)

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -2570,7 +2570,7 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 		})
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
-	c.Check(err, gc.ErrorMatches, "cannot start bootstrap instance in any availability zone \\(mossack, fonseca\\)")
+	c.Check(err, gc.ErrorMatches, "(?ms)cannot start bootstrap instance in any availability zone \\(mossack, fonseca\\).*")
 }
 
 func (suite *maasEnvironSuite) TestGetToolsMetadataSources(c *gc.C) {


### PR DESCRIPTION
When attempting to start instances for a slice of zones it can be the case that the cloud provider fails to start the instance in any of the availability zones due to an account issue such as running out of resources.

What we were not doing is transmitting the errors from start instance back to the caller in this case and so we would end up with an error that contains no information as to the actual problem.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests for bootstrap. See files changed. We are not asserting that errors received from start instance make their way back up the stack .

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2046524

**Jira card:** JUJU-5212