### PR TITLE
Add spaces services methods to network domain

### DIFF
--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -20,7 +20,7 @@ import (
 // domain service.
 type State interface {
 	// AddSpace creates and returns a new space.
-	AddSpace(ctx context.Context, uuid network.Id, name string, providerID network.Id, subnetIDs []string) error
+	AddSpace(ctx context.Context, uuid string, name string, providerID network.Id, subnetIDs []string) error
 	// GetSpace returns the space by UUID.
 	GetSpace(ctx context.Context, uuid string) (*network.SpaceInfo, error)
 	// GetSpaceByName returns the space by name.
@@ -74,7 +74,7 @@ func (s *SpaceService) AddSpace(ctx context.Context, name string, providerID net
 	}
 	spaceID := network.Id(uuid.String())
 
-	if err := s.st.AddSpace(ctx, spaceID, name, providerID, subnetIDs); err != nil {
+	if err := s.st.AddSpace(ctx, spaceID.String(), name, providerID, subnetIDs); err != nil {
 		return "", errors.Trace(err)
 	}
 	return spaceID, nil

--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -63,16 +63,20 @@ func NewSpaceService(st State, logger Logger) *SpaceService {
 }
 
 // AddSpace creates and returns a new space.
-func (s *SpaceService) AddSpace(ctx context.Context, uuid utils.UUID, name string, providerID network.Id, subnetIDs []string) (*network.SpaceInfo, error) {
+func (s *SpaceService) AddSpace(ctx context.Context, name string, providerID network.Id, subnetIDs []string) (utils.UUID, error) {
 	if !names.IsValidSpace(name) {
-		return nil, errors.NotValidf("space name %q for space with uuid %q", name, uuid.String())
+		return utils.UUID{}, errors.NotValidf("space name %q", name)
+	}
+
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return utils.UUID{}, errors.Annotatef(err, "creating uuid for new space %q", name)
 	}
 
 	if err := s.st.AddSpace(ctx, uuid, name, providerID, subnetIDs); err != nil {
-		return nil, errors.Trace(err)
+		return utils.UUID{}, errors.Trace(err)
 	}
-
-	return s.st.GetSpace(ctx, uuid.String())
+	return uuid, nil
 }
 
 // Space returns a space from state that matches the input ID.

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -75,13 +75,13 @@ func (s *spaceSuite) TestAddSpaceErrorAdding(c *gc.C) {
 func (s *spaceSuite) TestAddSpace(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	var expectedUUID network.Id
+	var expectedUUID string
 	// Verify that the passed UUID is also returned.
 	s.st.EXPECT().AddSpace(gomock.Any(), gomock.Any(), "space0", network.Id("provider-id"), []string{}).
 		Do(
 			func(
 				ctx context.Context,
-				uuid network.Id,
+				uuid string,
 				name string,
 				providerID network.Id,
 				subnetIDs []string,
@@ -92,7 +92,7 @@ func (s *spaceSuite) TestAddSpace(c *gc.C) {
 
 	returnedUUID, err := NewSpaceService(s.st, s.logger).AddSpace(context.Background(), "space0", network.Id("provider-id"), []string{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(returnedUUID, gc.Equals, expectedUUID)
+	c.Assert(returnedUUID.String(), gc.Equals, expectedUUID)
 }
 
 func (s *spaceSuite) TestRetrieveSpaceByID(c *gc.C) {

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -76,13 +75,13 @@ func (s *spaceSuite) TestAddSpaceErrorAdding(c *gc.C) {
 func (s *spaceSuite) TestAddSpace(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	var expectedUUID utils.UUID
+	var expectedUUID network.Id
 	// Verify that the passed UUID is also returned.
 	s.st.EXPECT().AddSpace(gomock.Any(), gomock.Any(), "space0", network.Id("provider-id"), []string{}).
 		Do(
 			func(
 				ctx context.Context,
-				uuid utils.UUID,
+				uuid network.Id,
 				name string,
 				providerID network.Id,
 				subnetIDs []string,

--- a/domain/network/service/state_mock_test.go
+++ b/domain/network/service/state_mock_test.go
@@ -37,7 +37,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddSpace mocks base method.
-func (m *MockState) AddSpace(arg0 context.Context, arg1 utils.UUID, arg2 string, arg3 network.Id, arg4 []string) error {
+func (m *MockState) AddSpace(arg0 context.Context, arg1 network.Id, arg2 string, arg3 network.Id, arg4 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/domain/network/service/state_mock_test.go
+++ b/domain/network/service/state_mock_test.go
@@ -37,7 +37,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddSpace mocks base method.
-func (m *MockState) AddSpace(arg0 context.Context, arg1 network.Id, arg2 string, arg3 network.Id, arg4 []string) error {
+func (m *MockState) AddSpace(arg0 context.Context, arg1, arg2 string, arg3 network.Id, arg4 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -32,7 +32,7 @@ func NewState(factory coreDB.TxnRunnerFactory) *State {
 // AddSpace creates and returns a new space.
 func (st *State) AddSpace(
 	ctx context.Context,
-	uuid network.Id,
+	uuid string,
 	name string,
 	providerID network.Id,
 	subnetIDs []string,
@@ -68,7 +68,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBin
 		// that are of a type on which the space can be set.
 		nonSettableSubnets, err := tx.QueryContext(ctx, checkInputSubnetsStmt, subnetVals...)
 		if err != nil {
-			return errors.Annotatef(err, "checking if there are fan subnets for space %q", uuid.String())
+			return errors.Annotatef(err, "checking if there are fan subnets for space %q", uuid)
 		}
 		defer func() { _ = nonSettableSubnets.Close() }()
 		// If any row is returned we must fail with the returned fan
@@ -91,11 +91,11 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBin
 				"cannot set space for FAN subnet UUIDs %q - it is always inherited from underlay", nonSettableUUIDs)
 		}
 
-		if _, err := tx.ExecContext(ctx, insertSpaceStmt, uuid.String(), name); err != nil {
-			return errors.Annotatef(err, "inserting space uuid %q into space table", uuid.String())
+		if _, err := tx.ExecContext(ctx, insertSpaceStmt, uuid, name); err != nil {
+			return errors.Annotatef(err, "inserting space uuid %q into space table", uuid)
 		}
 		if providerID != "" {
-			if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid.String()); err != nil {
+			if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid); err != nil {
 				return errors.Annotatef(err, "inserting provider id %q into provider_space table", providerID)
 			}
 		}
@@ -103,7 +103,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBin
 		// Retrieve the fan overlays (if any) of the passed subnet ids.
 		rows, err := tx.QueryContext(ctx, findFanSubnetsStmt, subnetVals...)
 		if err != nil {
-			return errors.Annotatef(err, "retrieving the fan subnets for space %q", uuid.String())
+			return errors.Annotatef(err, "retrieving the fan subnets for space %q", uuid)
 		}
 		defer func() { _ = rows.Close() }()
 		// Append the fan subnet (unique) ids (if any) to the provided
@@ -126,8 +126,8 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBin
 		// Update all subnets (including their fan overlays) to include
 		// the space uuid.
 		for _, subnetID := range subnetIDs {
-			if err := updateSubnetSpaceID(ctx, tx, subnetID, uuid.String()); err != nil {
-				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid.String())
+			if err := updateSubnetSpaceID(ctx, tx, subnetID, uuid); err != nil {
+				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid)
 			}
 		}
 		return nil

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
-	"github.com/juju/utils/v3"
 
 	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/network"
@@ -33,7 +32,7 @@ func NewState(factory coreDB.TxnRunnerFactory) *State {
 // AddSpace creates and returns a new space.
 func (st *State) AddSpace(
 	ctx context.Context,
-	uuid utils.UUID,
+	uuid network.Id,
 	name string,
 	providerID network.Id,
 	subnetIDs []string,

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -47,7 +47,7 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -103,7 +103,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -114,7 +114,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(name, gc.Equals, "space0")
 	// Fails when trying to add a new space with the same name.
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "bar", subnets)
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "bar", subnets)
 	c.Assert(err, gc.ErrorMatches, "inserting space (.*) into space table: UNIQUE constraint failed: space.name")
 
 }
@@ -145,7 +145,7 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "", subnets)
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), uuid.String())
@@ -205,7 +205,7 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String(), subnetFanUUID.String()}
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "foo", subnets)
 
 	// Should fail with error indicating we cannot set the space for a
 	// FAN subnet.
@@ -273,7 +273,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	subnets := []string{subnetUUID0.String(), subnetUUID1.String()}
 	spaceUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID.String()), "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
@@ -333,11 +333,11 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 
 	spaceUUID0, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID0.String()), "space0", "provider0", []string{})
+	err = st.AddSpace(ctx.Background(), spaceUUID0.String(), "space0", "provider0", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 	spaceUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID1.String()), "space1", "provider1", []string{})
+	err = st.AddSpace(ctx.Background(), spaceUUID1.String(), "space1", "provider1", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp0, err := st.GetSpaceByName(ctx.Background(), "space0")
@@ -362,7 +362,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
 
 	spaceUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
@@ -428,17 +428,17 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnets := []string{subnetUUID0.String()}
 	spaceUUID0, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID0.String()), "space0", "foo0", subnets)
+	err = st.AddSpace(ctx.Background(), spaceUUID0.String(), "space0", "foo0", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID1.String()}
 	spaceUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID1.String()), "space1", "foo1", subnets)
+	err = st.AddSpace(ctx.Background(), spaceUUID1.String(), "space1", "foo1", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID2.String()}
 	spaceUUID2, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID2.String()), "space2", "foo2", subnets)
+	err = st.AddSpace(ctx.Background(), spaceUUID2.String(), "space2", "foo2", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetAllSpaces(ctx.Background())
@@ -451,7 +451,7 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateSpace(ctx.Background(), uuid.String(), "newSpaceName0")
@@ -494,7 +494,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	// Create a space containing the newly created subnet.
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{subnetUUID0.String()})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{subnetUUID0.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the subnet entity.

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -47,7 +47,7 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -103,7 +103,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -114,7 +114,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(name, gc.Equals, "space0")
 	// Fails when trying to add a new space with the same name.
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "bar", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "bar", subnets)
 	c.Assert(err, gc.ErrorMatches, "inserting space (.*) into space table: UNIQUE constraint failed: space.name")
 
 }
@@ -145,7 +145,7 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), uuid.String())
@@ -205,7 +205,7 @@ func (s *stateSuite) TestAddSpaceFailFanOverlay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String(), subnetFanUUID.String()}
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", subnets)
 
 	// Should fail with error indicating we cannot set the space for a
 	// FAN subnet.
@@ -273,7 +273,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	subnets := []string{subnetUUID0.String(), subnetUUID1.String()}
 	spaceUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID, "space0", "foo", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID.String()), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
@@ -333,11 +333,11 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 
 	spaceUUID0, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID0, "space0", "provider0", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID0.String()), "space0", "provider0", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 	spaceUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID1, "space1", "provider1", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID1.String()), "space1", "provider1", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp0, err := st.GetSpaceByName(ctx.Background(), "space0")
@@ -362,7 +362,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
 
 	spaceUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
@@ -428,17 +428,17 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnets := []string{subnetUUID0.String()}
 	spaceUUID0, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID0, "space0", "foo0", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID0.String()), "space0", "foo0", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID1.String()}
 	spaceUUID1, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID1, "space1", "foo1", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID1.String()), "space1", "foo1", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID2.String()}
 	spaceUUID2, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID2, "space2", "foo2", subnets)
+	err = st.AddSpace(ctx.Background(), network.Id(spaceUUID2.String()), "space2", "foo2", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sp, err := st.GetAllSpaces(ctx.Background())
@@ -451,7 +451,7 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), uuid, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(uuid.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateSpace(ctx.Background(), uuid.String(), "newSpaceName0")
@@ -494,7 +494,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	// Create a space containing the newly created subnet.
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{subnetUUID0.String()})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{subnetUUID0.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the subnet entity.

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -19,7 +19,7 @@ func (s *stateSuite) TestUpsertSubnets(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "provider-space-id-1", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "provider-space-id-1", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -113,7 +113,7 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -193,7 +193,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -235,7 +235,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -399,7 +399,7 @@ func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
 	// Add a space with subnet base.
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "provider-space-id", []string{subnetUUID0.String()})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "provider-space-id", []string{subnetUUID0.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := &network.SubnetInfo{
@@ -500,7 +500,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID, "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -522,7 +522,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	newSpIUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), newSpIUUID, "space1", "bar", []string{})
+	err = st.AddSpace(ctx.Background(), network.Id(newSpIUUID.String()), "space1", "bar", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateSubnet(ctx.Background(), uuid.String(), newSpIUUID.String())

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -19,7 +19,7 @@ func (s *stateSuite) TestUpsertSubnets(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "provider-space-id-1", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "provider-space-id-1", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -113,7 +113,7 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -193,7 +193,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameNetworkID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -235,7 +235,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetUUID0, err := utils.NewUUID()
@@ -399,7 +399,7 @@ func (s *stateSuite) TestRetrieveSubnetByUUID(c *gc.C) {
 	// Add a space with subnet base.
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "provider-space-id", []string{subnetUUID0.String()})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "provider-space-id", []string{subnetUUID0.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := &network.SubnetInfo{
@@ -500,7 +500,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	spUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(spUUID.String()), "space0", "foo", []string{})
+	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid, err := utils.NewUUID()
@@ -522,7 +522,7 @@ func (s *stateSuite) TestUpdateSubnet(c *gc.C) {
 
 	newSpIUUID, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), network.Id(newSpIUUID.String()), "space1", "bar", []string{})
+	err = st.AddSpace(ctx.Background(), newSpIUUID.String(), "space1", "bar", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.UpdateSubnet(ctx.Background(), uuid.String(), newSpIUUID.String())


### PR DESCRIPTION
This patch brings the second set of methods implemented on the network domain at the service layer for the spaces (sub-domain).

Note that SaveProviderSubnets is already present from a previous patch and the methods now implemented are much simpler, basically proxies for the state methods.


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Again, this is not wired-up yet so unit tests are enough:
```
 go test github.com/juju/juju/domain/network/... -gocheck.v
 ```

## Links

**Jira card:** JUJU-5105

