### PR TITLE
Clean tools.tar.gz on success

### DIFF
--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -51,7 +51,7 @@ type BinaryAgentStorage interface {
 }
 
 // AgentBinaryBootstrapFunc is the function that is used to populate the tools.
-type AgentBinaryBootstrapFunc func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) error
+type AgentBinaryBootstrapFunc func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) (func(), error)
 
 // ManifoldConfig defines the configuration for the trace manifold.
 type ManifoldConfig struct {
@@ -183,17 +183,17 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 // CAASAgentBinaryUploader is the function that is used to populate the tools
 // for CAAS.
-func CAASAgentBinaryUploader(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) error {
+func CAASAgentBinaryUploader(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) (func(), error) {
 	// CAAS doesn't need to populate the tools.
-	return nil
+	return func() {}, nil
 }
 
 // IAASAgentBinaryUploader is the function that is used to populate the tools
 // for IAAS.
-func IAASAgentBinaryUploader(ctx context.Context, dataDir string, storageService BinaryAgentStorageService, objectStore objectstore.ObjectStore, logger Logger) error {
+func IAASAgentBinaryUploader(ctx context.Context, dataDir string, storageService BinaryAgentStorageService, objectStore objectstore.ObjectStore, logger Logger) (func(), error) {
 	storage, err := storageService.AgentBinaryStorage(objectStore)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	defer storage.Close()
 

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -60,8 +60,8 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		BootstrapGateName:  "bootstrap-gate",
 		ServiceFactoryName: "service-factory",
 		Logger:             s.logger,
-		AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) error {
-			return nil
+		AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) (func(), error) {
+			return func() {}, nil
 		},
 		RequiresBootstrap: func(context.Context, FlagService) (bool, error) {
 			return false, nil

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -63,17 +63,18 @@ func (s *workerSuite) TestSeedAgentBinary(c *gc.C) {
 		internalStates: s.states,
 		cfg: WorkerConfig{
 			ObjectStoreGetter: s.objectStoreGetter,
-			AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) error {
+			AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) (func(), error) {
 				called = true
-				return nil
+				return func() {}, nil
 			},
 			State:  s.state,
 			Logger: s.logger,
 		},
 	}
-	err := w.seedAgentBinary(context.Background(), c.MkDir())
+	cleanup, err := w.seedAgentBinary(context.Background(), c.MkDir())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
+	c.Assert(cleanup, gc.NotNil)
 }
 
 func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
@@ -82,8 +83,8 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		Agent:             s.agent,
 		ObjectStoreGetter: s.objectStoreGetter,
 		BootstrapUnlocker: s.bootstrapUnlocker,
-		AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) error {
-			return nil
+		AgentBinaryUploader: func(context.Context, string, BinaryAgentStorageService, objectstore.ObjectStore, Logger) (func(), error) {
+			return func() {}, nil
 		},
 		State:                   &state.State{},
 		ControllerConfigService: s.controllerConfigService,


### PR DESCRIPTION
Ensure that we remove toolz.tar.gz and the corresponding sha256 file _after_ setting the bootstrap flag. This ensures if there is a failure in writing the db, we can at least retry again.

This was the fallout from a bootstrap that failed to set the bootstrap flag to true if it was successful. Even if it wasn't successful we removed the files preemptively.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This should bootstrap.

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-

