### PR TITLE
Fix flaky block device tests

### DIFF
--- a/domain/blockdevice/watcher_test.go
+++ b/domain/blockdevice/watcher_test.go
@@ -5,9 +5,9 @@ package blockdevice_test
 
 import (
 	"context"
-	"fmt"
+	"database/sql"
 
-	"github.com/juju/loggo"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/worker/v3/workertest"
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/domain/blockdevice/service"
 	"github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/internal/changestream/testing"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 type watcherSuite struct {
@@ -29,17 +30,31 @@ type watcherSuite struct {
 var _ = gc.Suite(&watcherSuite{})
 
 func (s *watcherSuite) createMachine(c *gc.C, name string) string {
-	db := s.DB()
+	db := s.TxnRunner()
 
 	netNodeUUID := utils.MustNewUUID().String()
-	_, err := db.Exec(fmt.Sprintf("INSERT INTO net_node (uuid) VALUES ('%s')", netNodeUUID))
-	c.Assert(err, jc.ErrorIsNil)
 	machineUUID := utils.MustNewUUID().String()
-	_, err = db.Exec(fmt.Sprintf(`
+
+	queryNetNode := `
+INSERT INTO net_node (uuid) VALUES (?)
+`
+	queryMachine := `
 INSERT INTO machine (uuid, life_id, machine_id, net_node_uuid)
-VALUES ('%s', %d, '%s', '%s')
-`, machineUUID, 0, name, netNodeUUID))
+VALUES (?, ?, ?, ?)
+	`
+
+	err := db.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, queryNetNode, netNodeUUID); err != nil {
+			return errors.Trace(err)
+		}
+
+		if _, err := tx.ExecContext(ctx, queryMachine, machineUUID, 0, name, netNodeUUID); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
+
 	return machineUUID
 }
 
@@ -47,8 +62,8 @@ func (s *watcherSuite) TestWatchBlockDevicesMissingMachine(c *gc.C) {
 	st := state.NewState(s.TxnRunnerFactory())
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
-		loggo.GetLogger("test"))
-	service := service.NewService(st, factory, loggo.GetLogger("test"))
+		jujutesting.NewCheckLogger(c))
+	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
 
 	_, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, gc.ErrorMatches, `machine "666" not found`)
@@ -60,8 +75,8 @@ func (s *watcherSuite) TestStops(c *gc.C) {
 	st := state.NewState(s.TxnRunnerFactory())
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
-		loggo.GetLogger("test"))
-	service := service.NewService(st, factory, loggo.GetLogger("test"))
+		jujutesting.NewCheckLogger(c))
+	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -81,8 +96,8 @@ func (s *watcherSuite) TestWatchBlockDevices(c *gc.C) {
 	st := state.NewState(s.TxnRunnerFactory())
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
-		loggo.GetLogger("test"))
-	service := service.NewService(st, factory, loggo.GetLogger("test"))
+		jujutesting.NewCheckLogger(c))
+	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,8 +141,8 @@ func (s *watcherSuite) TestWatchBlockDevicesIgnoresWrongMachine(c *gc.C) {
 	st := state.NewState(s.TxnRunnerFactory())
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
-		loggo.GetLogger("test"))
-	service := service.NewService(st, factory, loggo.GetLogger("test"))
+		jujutesting.NewCheckLogger(c))
+	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "667")
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	ctx "context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/juju/collections/set"
@@ -642,12 +641,12 @@ func (s *stateSuite) TestDeleteCloudInUse(c *gc.C) {
 
 	credUUID := utils.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		stmt := fmt.Sprintf(`
+		stmt := `
 INSERT INTO cloud_credential (uuid, name, cloud_uuid, auth_type_id, owner_uuid)
-SELECT '%s', 'default', uuid, 1, 'fred' FROM cloud
+SELECT ?, 'default', uuid, 1, 'fred' FROM cloud
 WHERE cloud.name = ?
-`, credUUID)
-		result, err := tx.ExecContext(ctx, stmt, "fluffy")
+`
+		result, err := tx.ExecContext(ctx, stmt, credUUID, "fluffy")
 		if err != nil {
 			return err
 		}

--- a/domain/schema/testing/modelsuite.go
+++ b/domain/schema/testing/modelsuite.go
@@ -4,11 +4,11 @@
 package testing
 
 import (
+	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database/testing"
-	"github.com/juju/utils/v3"
 )
 
 // ModelSuite is used to provide an in-memory sql.DB reference to tests.

--- a/domain/schema/testing/modelsuite.go
+++ b/domain/schema/testing/modelsuite.go
@@ -8,19 +8,28 @@ import (
 
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database/testing"
+	"github.com/juju/utils/v3"
 )
 
 // ModelSuite is used to provide an in-memory sql.DB reference to tests.
 // It is pre-populated with the model schema.
 type ModelSuite struct {
 	testing.DqliteSuite
+
+	modelUUID string
 }
 
 // SetUpTest is responsible for setting up a testing database suite initialised
 // with the model schema.
 func (s *ModelSuite) SetUpTest(c *gc.C) {
+	s.modelUUID = utils.MustNewUUID().String()
+
 	s.DqliteSuite.SetUpTest(c)
 	s.DqliteSuite.ApplyDDL(c, &SchemaApplier{
 		Schema: schema.ModelDDL(),
 	})
+}
+
+func (s *ModelSuite) ModelUUID() string {
+	return s.modelUUID
 }

--- a/internal/changestream/testing/modelsuite.go
+++ b/internal/changestream/testing/modelsuite.go
@@ -7,7 +7,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/changestream"
-	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/schema/testing"
 )
 
@@ -24,7 +23,7 @@ type ModelSuite struct {
 func (s *ModelSuite) SetUpTest(c *gc.C) {
 	s.ModelSuite.SetUpTest(c)
 
-	s.watchableDB = NewTestWatchableDB(c, coredatabase.ControllerNS, s.TxnRunner())
+	s.watchableDB = NewTestWatchableDB(c, s.ModelUUID(), s.TxnRunner())
 }
 
 func (s *ModelSuite) TearDownTest(c *gc.C) {


### PR DESCRIPTION
To improve the robustness of our tests we must use the TxnRunner, which then gives us a retry mechanism. For simple unit tests, we can get away with just using .DB() method on the test suites. For integration tests that's not possible.

In addition to the flaky tests I've also fixed the argument passing in the tests. You can't use fmt.Sprintf because it's still possible to bypass quoting rules.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ TEST_PACKAGES="./domain/blockdevice -count=10" TEST_FILTER="TestWatchBlockDevices$" make run-go-tests
```

## Links


**Jira card:** JUJU-XXX

