### PR TITLE
Homogenize vm naming in azure and aws

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -109,6 +109,9 @@ type azureEnviron struct {
 	// modelName is the name of the model.
 	modelName string
 
+	// namespace is used to create the machine and device hostnames.
+	namespace instance.Namespace
+
 	clientOptions policy.ClientOptions
 	credential    azcore.TokenCredential
 
@@ -541,8 +544,11 @@ func (env *azureEnviron) startInstance(
 		return nil, err
 	}
 
-	machineTag := names.NewMachineTag(args.InstanceConfig.MachineId)
-	vmName := resourceName(machineTag)
+	vmName, err := env.namespace.Hostname(args.InstanceConfig.MachineId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	vmTags := make(map[string]string)
 	for k, v := range args.InstanceConfig.Tags {
 		vmTags[k] = v

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -121,7 +121,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.vmTags = map[string]string{
 		"juju-model-uuid":      testing.ModelTag.Id(),
 		"juju-controller-uuid": s.controllerUUID,
-		"juju-machine-name":    "machine-0",
+		"juju-machine-name":    "juju-06f00d-0",
 	}
 
 	s.group = &armresources.ResourceGroup{
@@ -222,7 +222,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		KeyData: to.Ptr(testing.FakeAuthKeys),
 	}}
 	s.linuxOsProfile = armcompute.OSProfile{
-		ComputerName:  to.Ptr("machine-0"),
+		ComputerName:  to.Ptr("juju-06f00d-0"),
 		CustomData:    to.Ptr("<juju-goes-here>"),
 		AdminUsername: to.Ptr("ubuntu"),
 		LinuxConfiguration: &armcompute.LinuxConfiguration{
@@ -423,15 +423,15 @@ func (s *environSuite) startInstanceSenders(args startInstanceSenderParams) azur
 	}
 	if args.withQuotaRetry {
 		quotaErr := newAzureResponseError(http.StatusBadRequest, "QuotaExceeded")
-		senders = append(senders, s.makeErrorSender("/deployments/machine-0", quotaErr, 1))
+		senders = append(senders, s.makeErrorSender("/deployments/juju-06f00d-0", quotaErr, 1))
 		return senders
 	}
 	if args.withConflictRetry {
 		conflictErr := newAzureResponseError(http.StatusConflict, "Conflict")
-		senders = append(senders, s.makeErrorSender("/deployments/machine-0", conflictErr, 1))
+		senders = append(senders, s.makeErrorSender("/deployments/juju-06f00d-0", conflictErr, 1))
 		return senders
 	}
-	senders = append(senders, makeSender("/deployments/machine-0", s.deployment))
+	senders = append(senders, makeSender("/deployments/juju-06f00d-0", s.deployment))
 	return senders
 }
 
@@ -440,7 +440,7 @@ func (s *environSuite) startInstanceSendersNoSizes() azuretesting.Senders {
 	if s.ubuntuServerSKUs != nil {
 		senders = append(senders, makeSender(".*/Canonical/.*/0001-com-ubuntu-server-jammy/skus", s.ubuntuServerSKUs))
 	}
-	senders = append(senders, makeSender("/deployments/machine-0", s.deployment))
+	senders = append(senders, makeSender("/deployments/juju-06f00d-0", s.deployment))
 	return senders
 }
 
@@ -648,7 +648,7 @@ func (s *environSuite) assertStartInstance(
 	if withQuotaRetry {
 		// Retry after a quota error - the same instance creation senders are
 		// used except that the availability set now exists.
-		s.sender = append(s.sender, makeSenderWithStatus(".*/deployments/machine-0/cancel", http.StatusNoContent))
+		s.sender = append(s.sender, makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent))
 		s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{
 			bootstrap:             false,
 			diskEncryptionSetName: diskEncryptionSetName,
@@ -799,7 +799,7 @@ func (s *environSuite) TestStartInstanceCommonDeployment(c *gc.C) {
 
 	_, err := env.StartInstance(s.callCtx, makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04")))
 	c.Assert(err, gc.ErrorMatches,
-		`creating virtual machine "machine-0": `+
+		`creating virtual machine "juju-06f00d-0": `+
 			`waiting for common resources to be created: `+
 			`"common" resource deployment status is "Failed"`)
 }
@@ -823,7 +823,7 @@ func (s *environSuite) TestStartInstanceCommonDeploymentRetryTimeout(c *gc.C) {
 
 	_, err := env.StartInstance(s.callCtx, makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04")))
 	c.Assert(err, gc.ErrorMatches,
-		`creating virtual machine "machine-0": `+
+		`creating virtual machine "juju-06f00d-0": `+
 			`waiting for common resources to be created: `+
 			`max duration exceeded: deployment incomplete`)
 
@@ -888,7 +888,7 @@ func (s *environSuite) TestStartInstanceWithInvalidPlacement(c *gc.C) {
 	params.Placement = "foo"
 
 	_, err := env.StartInstance(s.callCtx, params)
-	c.Assert(err, gc.ErrorMatches, `creating virtual machine "machine-0": unknown placement directive: foo`)
+	c.Assert(err, gc.ErrorMatches, `creating virtual machine "juju-06f00d-0": unknown placement directive: foo`)
 }
 
 func (s *environSuite) TestStartInstanceWithInvalidSubnet(c *gc.C) {
@@ -899,7 +899,7 @@ func (s *environSuite) TestStartInstanceWithInvalidSubnet(c *gc.C) {
 	params.Placement = "subnet=foo"
 
 	_, err := env.StartInstance(s.callCtx, params)
-	c.Assert(err, gc.ErrorMatches, `creating virtual machine "machine-0": subnet "foo" not found`)
+	c.Assert(err, gc.ErrorMatches, `creating virtual machine "juju-06f00d-0": subnet "foo" not found`)
 }
 
 func (s *environSuite) TestStartInstanceWithPlacementNoSpacesConstraint(c *gc.C) {
@@ -1200,7 +1200,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	}
 	var publicIPAddress *armnetwork.PublicIPAddress
 	if args.publicIP {
-		publicIPAddressId := `[resourceId('Microsoft.Network/publicIPAddresses', 'machine-0-public-ip')]`
+		publicIPAddressId := `[resourceId('Microsoft.Network/publicIPAddresses', 'juju-06f00d-0-public-ip')]`
 		publicIPAddress = &armnetwork.PublicIPAddress{
 			ID: to.Ptr(publicIPAddressId),
 		}
@@ -1227,7 +1227,7 @@ func (s *environSuite) assertStartInstanceRequests(
 			nicDependsOn = append(nicDependsOn, *publicIPAddress.ID)
 		}
 
-		nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', 'machine-0-%s')]`, name)
+		nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', 'juju-06f00d-0-%s')]`, name)
 		nics = append(nics, &armcompute.NetworkInterfaceReference{
 			ID: to.Ptr(nicId),
 			Properties: &armcompute.NetworkInterfaceReferenceProperties{
@@ -1238,7 +1238,7 @@ func (s *environSuite) assertStartInstanceRequests(
 		nicResources = append(nicResources, armtemplates.Resource{
 			APIVersion: azure.NetworkAPIVersion,
 			Type:       "Microsoft.Network/networkInterfaces",
-			Name:       "machine-0-" + name,
+			Name:       "juju-06f00d-0-" + name,
 			Location:   "westus",
 			Tags:       s.vmTags,
 			Properties: &armnetwork.InterfacePropertiesFormat{
@@ -1249,7 +1249,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	}
 
 	osDisk := &armcompute.OSDisk{
-		Name:         to.Ptr("machine-0"),
+		Name:         to.Ptr("juju-06f00d-0"),
 		CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
 		Caching:      to.Ptr(armcompute.CachingTypesReadWrite),
 		DiskSizeGB:   to.Ptr(int32(args.diskSizeGB)),
@@ -1268,7 +1268,7 @@ func (s *environSuite) assertStartInstanceRequests(
 		templateResources = append(templateResources, armtemplates.Resource{
 			APIVersion: azure.NetworkAPIVersion,
 			Type:       "Microsoft.Network/publicIPAddresses",
-			Name:       "machine-0-public-ip",
+			Name:       "juju-06f00d-0-public-ip",
 			Location:   "westus",
 			Tags:       s.vmTags,
 			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
@@ -1282,7 +1282,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	templateResources = append(templateResources, []armtemplates.Resource{{
 		APIVersion: azure.ComputeAPIVersion,
 		Type:       "Microsoft.Compute/virtualMachines",
-		Name:       "machine-0",
+		Name:       "juju-06f00d-0",
 		Location:   "westus",
 		Tags:       s.vmTags,
 		Properties: &armcompute.VirtualMachineProperties{
@@ -1305,11 +1305,11 @@ func (s *environSuite) assertStartInstanceRequests(
 		templateResources = append(templateResources, armtemplates.Resource{
 			APIVersion: azure.ComputeAPIVersion,
 			Type:       "Microsoft.Compute/virtualMachines/extensions",
-			Name:       "machine-0/JujuCustomScriptExtension",
+			Name:       "juju-06f00d-0/JujuCustomScriptExtension",
 			Location:   "westus",
 			Tags:       s.vmTags,
 			Properties: args.vmExtension,
-			DependsOn:  []string{"Microsoft.Compute/virtualMachines/machine-0"},
+			DependsOn:  []string{"Microsoft.Compute/virtualMachines/juju-06f00d-0"},
 		})
 	}
 	templateMap := map[string]interface{}{
@@ -1785,28 +1785,28 @@ func (s *environSuite) TestStopInstancesNoSecurityGroup(c *gc.C) {
 		Properties: &armnetwork.SubnetPropertiesFormat{},
 	}
 	nic0IPConfiguration.Properties.PublicIPAddress = &armnetwork.PublicIPAddress{}
-	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
+	nic0 := makeNetworkInterface("nic-0", "juju-06f00d-0", nic0IPConfiguration)
 	s.sender = azuretesting.Senders{
-		makeSenderWithStatus(".*/deployments/machine-0/cancel", http.StatusNoContent), // Cancel
-		s.networkInterfacesSender(nic0),                                               // GET: no NICs
-		s.publicIPAddressesSender(),                                                   // GET: no public IPs
-		makeSender(".*/virtualMachines/machine-0", nil),                               // DELETE
-		makeSender(".*/disks/machine-0", nil),                                         // DELETE
-		makeSender(internalSubnetId, nic0IPConfiguration.Properties.Subnet),           // GET: subnets to get security group
-		makeSender(".*/networkInterfaces/nic-0", nil),                                 // DELETE
-		makeSenderWithStatus(".*/deployments/machine-0", http.StatusNoContent),        // DELETE
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // Cancel
+		s.networkInterfacesSender(nic0),                                            // GET: no NICs
+		s.publicIPAddressesSender(),                                                // GET: no public IPs
+		makeSender(".*/virtualMachines/juju-06f00d-0", nil),                        // DELETE
+		makeSender(".*/disks/juju-06f00d-0", nil),                                  // DELETE
+		makeSender(internalSubnetId, nic0IPConfiguration.Properties.Subnet),        // GET: subnets to get security group
+		makeSender(".*/networkInterfaces/nic-0", nil),                              // DELETE
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent), // DELETE
 	}
-	err := env.StopInstances(s.callCtx, "machine-0")
+	err := env.StopInstances(s.callCtx, "juju-06f00d-0")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestStopInstances(c *gc.C) {
 	env := s.openEnviron(c)
 
-	// Security group has rules for machine-0, as well as a rule that doesn't match.
+	// Security group has rules for juju-06f00d-0, as well as a rule that doesn't match.
 	nsg := makeSecurityGroup(
-		makeSecurityRule("machine-0-80", "192.168.0.4", "80"),
-		makeSecurityRule("machine-0-1000-2000", "192.168.0.4", "1000-2000"),
+		makeSecurityRule("juju-06f00d-0-80", "192.168.0.4", "80"),
+		makeSecurityRule("juju-06f00d-0-1000-2000", "192.168.0.4", "1000-2000"),
 		makeSecurityRule("machine-42", "192.168.0.5", "*"),
 	)
 
@@ -1815,35 +1815,35 @@ func (s *environSuite) TestStopInstances(c *gc.C) {
 	nic0IPConfiguration := makeIPConfiguration("192.168.0.4")
 	nic0IPConfiguration.Properties.PublicIPAddress = &armnetwork.PublicIPAddress{}
 	nic0IPConfiguration.Properties.Primary = to.Ptr(true)
-	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
+	nic0 := makeNetworkInterface("nic-0", "juju-06f00d-0", nic0IPConfiguration)
 	nic0.Properties.NetworkSecurityGroup = &nsg
 
 	s.sender = azuretesting.Senders{
-		makeSenderWithStatus(".*/deployments/machine-0/cancel", http.StatusNoContent), // POST
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // POST
 		s.networkInterfacesSender(nic0),
-		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
-		makeSender(".*/virtualMachines/machine-0", nil),                                                 // DELETE
-		makeSender(".*/disks/machine-0", nil),                                                           // GET
-		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-80", nil),        // DELETE
-		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-1000-2000", nil), // DELETE
-		makeSender(".*/networkInterfaces/nic-0", nil),                                                   // DELETE
-		makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
-		makeSenderWithStatus(".*/deployments/machine-0", http.StatusNoContent),                          // DELETE
+		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "juju-06f00d-0", "1.2.3.4")),
+		makeSender(".*/virtualMachines/juju-06f00d-0", nil),                                                 // DELETE
+		makeSender(".*/disks/juju-06f00d-0", nil),                                                           // GET
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/juju-06f00d-0-80", nil),        // DELETE
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/juju-06f00d-0-1000-2000", nil), // DELETE
+		makeSender(".*/networkInterfaces/nic-0", nil),                                                       // DELETE
+		makeSender(".*/publicIPAddresses/pip-0", nil),                                                       // DELETE
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                          // DELETE
 	}
 
-	err := env.StopInstances(s.callCtx, "machine-0")
+	err := env.StopInstances(s.callCtx, "juju-06f00d-0")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestStopInstancesMultiple(c *gc.C) {
 	env := s.openEnviron(c)
 
-	vmDeleteSender0 := s.makeErrorSender(".*/virtualMachines/machine-[01]", errors.New("blargh"), 2)
-	vmDeleteSender1 := s.makeErrorSender(".*/virtualMachines/machine-[01]", errors.New("blargh"), 2)
+	vmDeleteSender0 := s.makeErrorSender(".*/virtualMachines/juju-06f00d-[01]", errors.New("blargh"), 2)
+	vmDeleteSender1 := s.makeErrorSender(".*/virtualMachines/juju-06f00d-[01]", errors.New("blargh"), 2)
 
 	s.sender = azuretesting.Senders{
-		makeSenderWithStatus(".*/deployments/machine-[01]/cancel", http.StatusNoContent), // POST
-		makeSenderWithStatus(".*/deployments/machine-[01]/cancel", http.StatusNoContent), // POST
+		makeSenderWithStatus(".*/deployments/juju-06f00d-[01]/cancel", http.StatusNoContent), // POST
+		makeSenderWithStatus(".*/deployments/juju-06f00d-[01]/cancel", http.StatusNoContent), // POST
 
 		// We should only query the NICs and public IPs
 		// regardless of how many instances are deleted.
@@ -1853,8 +1853,8 @@ func (s *environSuite) TestStopInstancesMultiple(c *gc.C) {
 		vmDeleteSender0,
 		vmDeleteSender1,
 	}
-	err := env.StopInstances(s.callCtx, "machine-0", "machine-1")
-	c.Assert(err, gc.ErrorMatches, `deleting instance "machine-[01]":.*blargh`)
+	err := env.StopInstances(s.callCtx, "juju-06f00d-0", "juju-06f00d-1")
+	c.Assert(err, gc.ErrorMatches, `deleting instance "juju-06f00d-[01]":.*blargh`)
 }
 
 func (s *environSuite) TestStopInstancesDeploymentNotFound(c *gc.C) {
@@ -1865,7 +1865,7 @@ func (s *environSuite) TestStopInstancesDeploymentNotFound(c *gc.C) {
 		"deployment not found", http.StatusNotFound,
 	), 2)
 	s.sender = azuretesting.Senders{cancelSender}
-	err := env.StopInstances(s.callCtx, "machine-0")
+	err := env.StopInstances(s.callCtx, "juju-06f00d-0")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1936,11 +1936,11 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
 	res := []*armresources.GenericResourceExpanded{{
 		ID:   to.Ptr("id-0"),
-		Name: to.Ptr("machine-0"),
+		Name: to.Ptr("juju-06f00d-0"),
 		Type: to.Ptr("Microsoft.Compute/virtualMachines"),
 	}, {
 		ID:   to.Ptr("id-0"),
-		Name: to.Ptr("machine-0-disk"),
+		Name: to.Ptr("juju-06f00d-0-disk"),
 		Type: to.Ptr("Microsoft.Compute/disks"),
 	}, {
 		ID:   to.Ptr("networkSecurityGroups/nsg-0"),
@@ -1955,18 +1955,18 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 
 	nic0IPConfiguration := makeIPConfiguration("192.168.0.4")
 	nic0IPConfiguration.Properties.PublicIPAddress = &armnetwork.PublicIPAddress{}
-	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
+	nic0 := makeNetworkInterface("nic-0", "juju-06f00d-0", nic0IPConfiguration)
 
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),           // GET
-		makeSenderWithStatus(".*/deployments/machine-0/cancel", http.StatusNoContent), // POST
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),               // GET
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // POST
 		s.networkInterfacesSender(nic0),
-		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
-		makeSender(".*/virtualMachines/machine-0", nil),                                                           // DELETE
-		makeSender(".*/disks/machine-0", nil),                                                                     // DELETE
+		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "juju-06f00d-0", "1.2.3.4")),
+		makeSender(".*/virtualMachines/juju-06f00d-0", nil),                                                       // DELETE
+		makeSender(".*/disks/juju-06f00d-0", nil),                                                                 // DELETE
 		makeSender(".*/networkInterfaces/nic-0", nil),                                                             // DELETE
 		makeSender(".*/publicIPAddresses/pip-0", nil),                                                             // DELETE
-		makeSenderWithStatus(".*/deployments/machine-0", http.StatusNoContent),                                    // DELETE
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                // DELETE
 		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(http.StatusConflict, "InUse"), 1), // DELETE
 		makeSender("/networkSecurityGroups/nsg-0", nil),                                                           // DELETE
 		makeSender(".*/vaults/secret-0", nil),                                                                     // DELETE

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -119,9 +120,16 @@ func (prov *azureEnvironProvider) Version() int {
 // Open is part of the EnvironProvider interface.
 func (prov *azureEnvironProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", args.Config.Name())
-	environ := &azureEnviron{
-		provider: prov,
+
+	namespace, err := instance.NewNamespace(args.Config.UUID())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+	environ := &azureEnviron{
+		provider:  prov,
+		namespace: namespace,
+	}
+
 	// Config is needed before cloud spec.
 	if err := environ.SetConfig(args.Config); err != nil {
 		return nil, errors.Trace(err)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -108,6 +108,9 @@ type environ struct {
 	ecfgMutex    sync.Mutex
 	ecfgUnlocked *environConfig
 
+	// namespace is used to create the machine and device hostnames.
+	namespace instance.Namespace
+
 	instTypesCache      *instanceTypeCache
 	instTypesCacheMutex sync.RWMutex
 
@@ -677,10 +680,12 @@ func (e *environ) StartInstance(
 	}
 	rootDiskSize := uint64(aws.ToInt32(blockDeviceMappings[0].Ebs.VolumeSize)) * 1024
 
-	instanceName := resourceName(
-		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
-	)
-	args.InstanceConfig.Tags[tagName] = instanceName
+	hostname, err := e.namespace.Hostname(args.InstanceConfig.MachineId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	args.InstanceConfig.Tags[tagName] = hostname
 
 	instanceTags := CreateTagSpecification(types.ResourceTypeInstance, args.InstanceConfig.Tags)
 
@@ -690,7 +695,7 @@ func (e *environ) StartInstance(
 		names.NewControllerTag(args.ControllerUUID),
 		cfg,
 	)
-	rootVolumeTags[tagName] = instanceName + "-root"
+	rootVolumeTags[tagName] = hostname + "-root"
 	volumeTags := CreateTagSpecification(types.ResourceTypeVolume, rootVolumeTags)
 
 	imageID := aws.String(spec.Image.Id)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -2210,8 +2210,14 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	for _, t := range ec2Inst.Tags {
 		tags = append(tags, *t.Key+":"+*t.Value)
 	}
+	namespace, err := instance.NewNamespace(coretesting.ModelTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	hostname, err := namespace.Hostname("0")
+	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(tags, jc.SameContents, []string{
-		"Name:juju-sample-machine-0",
+		fmt.Sprintf("Name:%s", hostname),
 		"juju-model-uuid:" + coretesting.ModelTag.Id(),
 		"juju-controller-uuid:" + t.ControllerUUID,
 		"juju-is-controller:true",
@@ -2238,8 +2244,15 @@ func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 		}
 	}
 	c.Assert(found, gc.NotNil)
+
+	namespace, err := instance.NewNamespace(coretesting.ModelTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	hostname, err := namespace.Hostname("0")
+	c.Assert(err, jc.ErrorIsNil)
+
 	compareTags(c, found.Tags, []tagInfo{
-		{"Name", "juju-sample-machine-0-root"},
+		{"Name", hostname + "-root"},
 		{"juju-model-uuid", coretesting.ModelTag.Id()},
 		{"juju-controller-uuid", t.ControllerUUID},
 	})

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -42,6 +43,12 @@ func (p environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) 
 	e := newEnviron()
 	e.name = args.Config.Name()
 	e.controllerUUID = args.ControllerUUID
+
+	namespace, err := instance.NewNamespace(args.Config.UUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	e.namespace = namespace
 
 	if err := e.SetCloudSpec(ctx, args.Cloud); err != nil {
 		return nil, err


### PR DESCRIPTION
VM and EC2 instance names in Azure and AWS repectively were not consistent with juju machines naming on other providers. In all other providers the naming is `juju-{namespace-short-sha}-{machineID}` (e.g. juju-abc1234-0) while on Azure it was `machine-{machineID}` and in AWS it was `juju-{machine-tag}-{namespace-short-sha}`. 

This is the full current machine/VM naming across providers:
```
# Azure
machine-{machineID}
e.g: machine-0

# AWS
juju-{machine-tag}-{namespace-short-sha}
e.g: juju-machine-0-abc1234

# LXD
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)

# Openstack
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)

# GCE
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)

# MAAS
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)

# OCI
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.MachineId)

# Vsphere
juju-{namespace-short-sha}-{machineID}
e.g: juju-abc1234-0
Note:
	hostname, err := env.namespace.Hostname(args.InstanceConfig.
```
Now they all follow the same pattern (`juju-{namespace-short-sha}-{machineID}`).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

To have a full scenario, we'll first create a 3.3 controller with a deployed ubuntu, and then create a 3.4 (this patch) controller and migrate the model. Then deploy something else and destroy everything:

```
juju version
3.3.0-genericlinux-amd64

juju bootstrap azure c
juju add-model m
juju deploy ubuntu

juju status
Model  Controller  Cloud/Region     Version  SLA          Timestamp
m      c           azure/centralus  3.3.0    unsupported  11:51:00+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  stable    24  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        20.15.250.26

Machine  State    Address       Inst id    Base          AZ  Message
0        started  20.15.250.26  machine-0  ubuntu@22.04

# Install juju this patch version (3.4)

juju version
3.4-beta1-ubuntu-amd64

juju bootstrap azure c34

juju switch c

juju migrate m c34

juju switch c34:admin/m
juju add-machine
juju status
Model  Controller  Cloud/Region     Version      SLA          Timestamp
m      c34         azure/centralus  3.4-beta1.1  unsupported  12:23:25+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        20.15.250.26

Machine  State    Address        Inst id        Base          AZ  Message
0        started  20.15.250.26   machine-0      ubuntu@22.04
1        started  40.89.248.130  juju-c145b5-1  ubuntu@22.04

juju deploy tiny-bash
juju status
Model  Controller  Cloud/Region     Version      SLA          Timestamp
m      c34         azure/centralus  3.4-beta1.1  unsupported  12:35:23+01:00

App        Version  Status  Scale  Charm      Channel        Rev  Exposed  Message
tiny-bash           active      1  tiny-bash  stable           2  no       Started.
ubuntu     22.04    active      1  ubuntu     latest/stable   24  no

Unit          Workload  Agent  Machine  Public address  Ports  Message
tiny-bash/0*  active    idle   1        40.89.248.130          Started.
ubuntu/0*     active    idle   0        20.15.250.26

Machine  State    Address        Inst id        Base          AZ  Message
0        started  20.15.250.26   machine-0      ubuntu@22.04
1        started  40.89.248.130  juju-c145b5-1  ubuntu@22.04

juju remove-application ubuntu
juju status
Model  Controller  Cloud/Region     Version      SLA          Timestamp
m      c34         azure/centralus  3.4-beta1.1  unsupported  12:38:11+01:00

App        Version  Status  Scale  Charm      Channel  Rev  Exposed  Message
tiny-bash           active      1  tiny-bash  stable     2  no       Started.

Unit          Workload  Agent  Machine  Public address  Ports  Message
tiny-bash/0*  active    idle   1        40.89.248.130          Started.

Machine  State    Address        Inst id        Base          AZ  Message
1        started  40.89.248.130  juju-c145b5-1  ubuntu@22.04

juju remove-application tiny-bash
juju status
Model  Controller  Cloud/Region     Version      SLA          Timestamp
m      c34         azure/centralus  3.4-beta1.1  unsupported  12:41:29+01:00

Model "admin/m" is empty.
```

Also, in AWS:
```
juju bootstrap aws c
juju add-model m
juju add-machine
```
on aws console, the new ec2 instance should also follow the same convention.



## Links


**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2046546

**Jira card:** JUJU-5215

