### PR TITLE
Construct local charm urls using metadata name

### DIFF
--- a/core/charm/charmpath.go
+++ b/core/charm/charmpath.go
@@ -48,11 +48,7 @@ func NewCharmAtPathForceBase(path string, b base.Base, force bool) (charm.Charm,
 		}
 		return nil, nil, err
 	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, nil, err
-	}
-	_, name := filepath.Split(absPath)
+	name := ch.Meta().Name
 
 	baseToUse, err := charmBase(b, force, ch)
 	if err != nil {

--- a/core/charm/charmpath_test.go
+++ b/core/charm/charmpath_test.go
@@ -75,6 +75,28 @@ func (s *charmPathSuite) TestCharm(c *gc.C) {
 	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/dummy-1"))
 }
 
+func (s *charmPathSuite) TestCharmArchive(c *gc.C) {
+	charmDir := filepath.Join(s.repoPath, "dummy")
+	s.cloneCharmDir(s.repoPath, "dummy")
+	chDir, err := charm.ReadCharmDir(charmDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dir := c.MkDir()
+	archivePath := filepath.Join(dir, "archive.charm")
+	file, err := os.Create(archivePath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer file.Close()
+
+	err = chDir.ArchiveTo(file)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ch, url, err := corecharm.NewCharmAtPath(archivePath, base.MustParseBaseFromString("ubuntu@20.04"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.Meta().Name, gc.Equals, "dummy")
+	c.Assert(ch.Revision(), gc.Equals, 1)
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/dummy-1"))
+}
+
 func (s *charmPathSuite) TestCharmWithManifest(c *gc.C) {
 	repo := testcharms.RepoForSeries("focal")
 	charmDir := repo.CharmDir("cockroach")
@@ -82,7 +104,7 @@ func (s *charmPathSuite) TestCharmWithManifest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "cockroachdb")
 	c.Assert(ch.Revision(), gc.Equals, 0)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/cockroach-0"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/cockroachdb-0"))
 }
 
 func (s *charmPathSuite) TestNoBaseSpecified(c *gc.C) {
@@ -106,7 +128,7 @@ func (s *charmPathSuite) TestMultiBaseDefault(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:jammy/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:jammy/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestMultiBase(c *gc.C) {
@@ -116,7 +138,7 @@ func (s *charmPathSuite) TestMultiBase(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestUnsupportedBase(c *gc.C) {
@@ -140,7 +162,7 @@ func (s *charmPathSuite) TestUnsupportedBaseForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:wily/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:wily/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestFindsSymlinks(c *gc.C) {


### PR DESCRIPTION
NOTE This PR has been subsumed into https://github.com/juju/juju/pull/16723

Construct local charm urls using metadata name

Instead of the charm's filepath. The filepath of a charm often contains
illegal charactors (".", "_", etc.), which results in invalid charm urls
floating around in the client

NOTE: The name field in metadata.yaml is mandatory. The charm will fail
to parse if it has no name

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Deploy + refresh some local charms

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu/ubuntu_r24.charm
(wait until complete)
$ juju refresh ubuntu --path ~/charms/ubuntu
```

Check compatibility
```
$ git checkout 3.4
$ make install
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu/ubuntu_r24.charm
$ git checkout fix_NewCharmAtPath_bug_for_archives
$ make juju
$ juju refresh ubuntu --path ~/charms/ubuntu/ubuntu_r24.charm
(verify everything is in working order)
```