### PR TITLE
Indirect local charm upload mechanism

### DIFF
--- a/api/client/charms/export_test.go
+++ b/api/client/charms/export_test.go
@@ -4,6 +4,8 @@
 package charms
 
 import (
+	"gopkg.in/httprequest.v1"
+
 	"github.com/juju/juju/api/base"
 	commoncharms "github.com/juju/juju/api/common/charms"
 )
@@ -15,6 +17,10 @@ func NewClientWithFacade(facade base.FacadeCaller, clientFacade base.ClientFacad
 	return &Client{facade: facade, ClientFacade: clientFacade, CharmInfoClient: charmInfoClient}
 }
 
-func NewLocalCharmClientWithFacade(facade base.FacadeCaller, clientFacade base.ClientFacade) *LocalCharmClient {
-	return &LocalCharmClient{facade: facade, ClientFacade: clientFacade}
+func NewLocalCharmClientWithFacade(facade base.FacadeCaller, clientFacade base.ClientFacade, charmPutter CharmPutter) *LocalCharmClient {
+	return &LocalCharmClient{facade: facade, ClientFacade: clientFacade, charmPutter: charmPutter}
+}
+
+func NewHTTPPutterWithHTTPClient(httpClient *httprequest.Client) *HTTPPutter {
+	return &HTTPPutter{httpClient: httpClient}
 }

--- a/api/client/charms/localcharmclient.go
+++ b/api/client/charms/localcharmclient.go
@@ -5,6 +5,7 @@ package charms
 
 import (
 	"archive/zip"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,7 +16,9 @@ import (
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/version/v2"
+	"gopkg.in/httprequest.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/rpc/params"
@@ -26,12 +29,13 @@ import (
 // required to add a local charm
 type LocalCharmClient struct {
 	base.ClientFacade
-	facade base.FacadeCaller
+	facade      base.FacadeCaller
+	charmPutter CharmPutter
 }
 
-func NewLocalCharmClient(st base.APICallCloser) *LocalCharmClient {
+func NewLocalCharmClient(st base.APICallCloser, charmPutter CharmPutter) *LocalCharmClient {
 	frontend, backend := base.NewClientFacade(st, "Charms")
-	return &LocalCharmClient{ClientFacade: frontend, facade: backend}
+	return &LocalCharmClient{ClientFacade: frontend, facade: backend, charmPutter: charmPutter}
 }
 
 // AddLocalCharm prepares the given charm with a local: schema in its
@@ -88,51 +92,15 @@ func (c *LocalCharmClient) AddLocalCharm(curl *charm.URL, ch charm.Charm, force 
 		return nil, errors.Errorf("invalid charm %q: has no hooks nor dispatch file", curl.Name)
 	}
 
-	curl, err = c.uploadCharm(curl, archive)
+	newCurlStr, err := c.charmPutter.PutCharm(context.Background(), curl.String(), archive)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return curl, nil
-}
-
-// uploadCharm sends the content to the API server using an HTTP post.
-func (c *LocalCharmClient) uploadCharm(curl *charm.URL, content io.ReadSeekCloser) (*charm.URL, error) {
-	args := url.Values{}
-	args.Add("series", curl.Series)
-	args.Add("schema", curl.Schema)
-	args.Add("revision", strconv.Itoa(curl.Revision))
-	apiURI := url.URL{Path: "/charms", RawQuery: args.Encode()}
-
-	contentType := "application/zip"
-	var resp params.CharmsResponse
-	if err := c.httpPost(content, apiURI.String(), contentType, &resp); err != nil {
+	newCurl, err := charm.ParseURL(newCurlStr)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	curl, err := charm.ParseURL(resp.CharmURL)
-	if err != nil {
-		return nil, errors.Annotatef(err, "bad charm URL in response")
-	}
-	return curl, nil
-}
-
-func (c *LocalCharmClient) httpPost(content io.ReadSeeker, endpoint, contentType string, response interface{}) error {
-	req, err := http.NewRequest("POST", endpoint, content)
-	if err != nil {
-		return errors.Annotate(err, "cannot create upload request")
-	}
-	req.Header.Set("Content-Type", contentType)
-
-	// The returned httpClient sets the base url to /model/<uuid> if it can.
-	httpClient, err := c.facade.RawAPICaller().HTTPClient()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := httpClient.Do(c.facade.RawAPICaller().Context(), req, response); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return newCurl, nil
 }
 
 // lxdCharmProfiler massages a charm.Charm into a LXDProfiler inside of the
@@ -195,6 +163,57 @@ func (c *LocalCharmClient) validateCharmVersion(ch charm.Charm, agentVersion ver
 	minver := ch.Meta().MinJujuVersion
 	if minver != version.Zero {
 		return jujuversion.CheckJujuMinVersion(minver, agentVersion)
+	}
+	return nil
+}
+
+type CharmPutter interface {
+	PutCharm(ctx context.Context, curl string, body io.Reader) (string, error)
+}
+
+type HTTPPutter struct {
+	httpClient *httprequest.Client
+}
+
+func NewHTTPPutter(apiConn api.Connection) (CharmPutter, error) {
+	// The returned httpClient sets the base url to /model/<uuid> if it can.
+	apiHTTPClient, err := apiConn.HTTPClient()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot retrieve http client from the api connection")
+	}
+	return &HTTPPutter{
+		httpClient: apiHTTPClient,
+	}, nil
+}
+
+func (h *HTTPPutter) PutCharm(ctx context.Context, curlStr string, body io.Reader) (string, error) {
+	curl, err := charm.ParseURL(curlStr)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	args := url.Values{}
+	args.Add("series", curl.Series)
+	args.Add("schema", curl.Schema)
+	args.Add("revision", strconv.Itoa(curl.Revision))
+	apiURI := url.URL{Path: "/charms", RawQuery: args.Encode()}
+
+	contentType := "application/zip"
+	var resp params.CharmsResponse
+	if err := h.httpPost(ctx, body, apiURI.String(), contentType, &resp); err != nil {
+		return "", errors.Trace(err)
+	}
+	return resp.CharmURL, nil
+}
+
+func (h *HTTPPutter) httpPost(ctx context.Context, content io.Reader, endpoint, contentType string, response interface{}) error {
+	req, err := http.NewRequest("POST", endpoint, content)
+	if err != nil {
+		return errors.Annotate(err, "cannot create upload request")
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	if err := h.httpClient.Do(ctx, req, response); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -181,11 +181,15 @@ func newDeployCommand() *DeployCommand {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		httpPutter, err := apicharms.NewHTTPPutter(apiRoot)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return &deployAPIAdapter{
 			Connection:           apiRoot,
 			legacyClient:         apiclient.NewClient(apiRoot, logger),
 			charmsClient:         apicharms.NewClient(apiRoot),
-			localCharmsClient:    apicharms.NewLocalCharmClient(apiRoot),
+			localCharmsClient:    apicharms.NewLocalCharmClient(apiRoot, httpPutter),
 			applicationClient:    application.NewClient(apiRoot),
 			machineManagerClient: machinemanager.NewClient(apiRoot),
 			modelConfigClient:    modelconfig.NewClient(apiRoot),

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1477,7 +1477,7 @@ func (s *DeploySuite) setupNonESMBase(c *gc.C) (corebase.Base, string) {
 		c.Fatal("cannot write to metadata.yaml")
 	}
 
-	curl := charm.MustParseURL(fmt.Sprintf("local:%s/series-logging-1", nonEMSSeries))
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/logging-1", nonEMSSeries))
 	ch, err := charm.ReadCharm(loggingPath)
 	c.Assert(err, jc.ErrorIsNil)
 	withLocalCharmDeployable(s.fakeAPI, curl, ch, false)
@@ -2136,11 +2136,15 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+			httpPutter, err := apicharms.NewHTTPPutter(apiRoot)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			return &deployAPIAdapter{
 				Connection:        apiRoot,
 				legacyClient:      apiclient.NewClient(apiRoot, coretesting.NoopLogger{}),
 				charmsClient:      apicharms.NewClient(apiRoot),
-				localCharmsClient: apicharms.NewLocalCharmClient(apiRoot),
+				localCharmsClient: apicharms.NewLocalCharmClient(apiRoot, httpPutter),
 				applicationClient: application.NewClient(apiRoot),
 				modelConfigClient: modelconfig.NewClient(apiRoot),
 				annotationsClient: annotations.NewClient(apiRoot),

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -220,10 +220,10 @@ func (s *BaseRefreshSuite) refreshCommand() cmd.Command {
 			s.AddCall("NewCharmResolver")
 			return &s.resolveCharm
 		},
-		func(conn api.Connection) store.CharmAdder {
+		func(conn api.Connection) (store.CharmAdder, error) {
 			s.AddCall("NewCharmAdder", conn)
 			s.PopNoErr()
-			return &s.charmAdder
+			return &s.charmAdder, nil
 		},
 		func(conn base.APICallCloser) utils.CharmClient {
 			s.AddCall("NewCharmClient", conn)
@@ -475,8 +475,8 @@ func (s *RefreshErrorsStateSuite) SetUpTest(c *gc.C) {
 	}
 	s.fakeAPI = vanillaFakeModelAPI(cfgAttrs)
 	s.cmd = NewRefreshCommandForStateTest(
-		func(conn api.Connection) store.CharmAdder {
-			return s.fakeAPI
+		func(conn api.Connection) (store.CharmAdder, error) {
+			return s.fakeAPI, nil
 		},
 		func(conn base.APICallCloser) utils.CharmClient {
 			return s.fakeAPI

--- a/core/charm/charmpath.go
+++ b/core/charm/charmpath.go
@@ -48,11 +48,7 @@ func NewCharmAtPathForceBase(path string, b base.Base, force bool) (charm.Charm,
 		}
 		return nil, nil, err
 	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, nil, err
-	}
-	_, name := filepath.Split(absPath)
+	name := ch.Meta().Name
 
 	baseToUse, err := charmBase(b, force, ch)
 	if err != nil {

--- a/core/charm/charmpath_test.go
+++ b/core/charm/charmpath_test.go
@@ -75,6 +75,28 @@ func (s *charmPathSuite) TestCharm(c *gc.C) {
 	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/dummy-1"))
 }
 
+func (s *charmPathSuite) TestCharmArchive(c *gc.C) {
+	charmDir := filepath.Join(s.repoPath, "dummy")
+	s.cloneCharmDir(s.repoPath, "dummy")
+	chDir, err := charm.ReadCharmDir(charmDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dir := c.MkDir()
+	archivePath := filepath.Join(dir, "archive.charm")
+	file, err := os.Create(archivePath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer file.Close()
+
+	err = chDir.ArchiveTo(file)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ch, url, err := corecharm.NewCharmAtPath(archivePath, base.MustParseBaseFromString("ubuntu@20.04"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.Meta().Name, gc.Equals, "dummy")
+	c.Assert(ch.Revision(), gc.Equals, 1)
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/dummy-1"))
+}
+
 func (s *charmPathSuite) TestCharmWithManifest(c *gc.C) {
 	repo := testcharms.RepoForSeries("focal")
 	charmDir := repo.CharmDir("cockroach")
@@ -82,7 +104,7 @@ func (s *charmPathSuite) TestCharmWithManifest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "cockroachdb")
 	c.Assert(ch.Revision(), gc.Equals, 0)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/cockroach-0"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/cockroachdb-0"))
 }
 
 func (s *charmPathSuite) TestNoBaseSpecified(c *gc.C) {
@@ -106,7 +128,7 @@ func (s *charmPathSuite) TestMultiBaseDefault(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:jammy/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:jammy/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestMultiBase(c *gc.C) {
@@ -116,7 +138,7 @@ func (s *charmPathSuite) TestMultiBase(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:focal/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestUnsupportedBase(c *gc.C) {
@@ -140,7 +162,7 @@ func (s *charmPathSuite) TestUnsupportedBaseForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.Meta().Name, gc.Equals, "new-charm-with-multi-series")
 	c.Assert(ch.Revision(), gc.Equals, 7)
-	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:wily/multi-series-charmpath-7"))
+	c.Assert(url, gc.DeepEquals, charm.MustParseURL("local:wily/new-charm-with-multi-series-7"))
 }
 
 func (s *charmPathSuite) TestFindsSymlinks(c *gc.C) {

--- a/featuretests/client_macaroon_test.go
+++ b/featuretests/client_macaroon_test.go
@@ -34,7 +34,9 @@ func (s *clientMacaroonSuite) createTestClient(c *gc.C) *charms.LocalCharmClient
 	cookieJar := apitesting.NewClearableCookieJar()
 	s.DischargerLogin = func() string { return username }
 	api := s.OpenAPI(c, nil, cookieJar)
-	charmClient := charms.NewLocalCharmClient(api)
+	httpPutter, err := charms.NewHTTPPutter(api)
+	c.Assert(err, jc.ErrorIsNil)
+	charmClient := charms.NewLocalCharmClient(api, httpPutter)
 
 	// Even though we've logged into the API, we want
 	// the tests below to exercise the discharging logic
@@ -56,7 +58,9 @@ func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
 }
 
 func (s *clientMacaroonSuite) TestAddLocalCharmSuccess(c *gc.C) {
-	charmClient := charms.NewLocalCharmClient(s.APIState)
+	httpPutter, err := charms.NewHTTPPutter(s.APIState)
+	c.Assert(err, jc.ErrorIsNil)
+	charmClient := charms.NewLocalCharmClient(s.APIState, httpPutter)
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),


### PR DESCRIPTION
Indirect local charm upload mechanism

Create a new CharmPutter interface in localcharmclient and implement
with HTTPPutter. This should result in no change of bahaviour, but will
allow for us to soon which out for an S3 upload client

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu/ubuntu_r24.charm
(wait until complete)
$ juju refresh ubuntu --path ~/charms/ubuntu
```
```
$ git checkout 3.4
$ make install
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu/ubuntu_r24.charm
$ git checkout fix_NewCharmAtPath_bug_for_archives
$ make juju
$ juju refresh ubuntu --path ~/charms/ubuntu/ubuntu_r24.charm
(verify everything is in working order)
```