### PR TITLE
Prevent file backed objectstore in ha mode

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -112,6 +113,11 @@ func (api *HighAvailabilityAPI) enableHASingle(ctx context.Context, spec params.
 	if err = validateCurrentControllers(st, cfg, controllerIds); err != nil {
 		return params.ControllersChanges{}, errors.Trace(err)
 	}
+	// Check if the object store is backed by filesystem storage.
+	if cfg.ObjectStoreType() == objectstore.FileBackend {
+		return params.ControllersChanges{}, errors.NewNotSupported(nil, "cannot enable-ha with filesystem backed object store")
+	}
+
 	spec.Constraints.Spaces = cfg.AsSpaceConstraints(spec.Constraints.Spaces)
 
 	if err = validatePlacementForSpaces(st, spec.Constraints.Spaces, spec.Placement); err != nil {

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -286,6 +286,16 @@ func (s *clientSuite) TestEnableHAControllerConfigConstraints(c *gc.C) {
 	}
 }
 
+func (s *clientSuite) TestEnableHAControllerConfigWithFileBackedObjectStore(c *gc.C) {
+	st := s.ControllerModel(c).State()
+	controllerSettings, _ := st.ReadSettings("controllers", "controllerSettings")
+	controllerSettings.Set(controller.ObjectStoreType, "file")
+	controllerSettings.Write()
+
+	_, err := s.enableHA(c, 3, emptyCons, nil)
+	c.Assert(err, gc.ErrorMatches, `cannot enable-ha with filesystem backed object store`)
+}
+
 func (s *clientSuite) TestBlockMakeHA(c *gc.C) {
 	// Block all changes.
 	s.BlockAllChanges(c, "TestBlockEnableHA")


### PR DESCRIPTION
We don't need to provide file-backed object storage in HA mode. Instead, we want users to use a third-party service (minio or similar) for those requests.

The code is straightforward, when moving into enable-ha, if it's backed by file, it just presents an error that it's not possible.

Note: until all the file-backed object store is enabled, this is here to ensure that enable-ha is blocked in the future.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

Ensure that we don't prevent HA in the current state-backed setup.

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-5242

