### PR TITLE
Expose currently unused RootHTTPClient for S3

### DIFF
--- a/api/agent/instancemutater/mocks/caller_mock.go
+++ b/api/agent/instancemutater/mocks/caller_mock.go
@@ -160,6 +160,21 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
 
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}
+
 // MockFacadeCaller is a mock of FacadeCaller interface.
 type MockFacadeCaller struct {
 	ctrl     *gomock.Controller

--- a/api/agent/secretsdrain/mocks/facade_mock.go
+++ b/api/agent/secretsdrain/mocks/facade_mock.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -44,6 +44,10 @@ type APICaller interface {
 	// method should not include a host part.
 	HTTPClient() (*httprequest.Client, error)
 
+	// RootHTTPClient returns an httprequest.Client pointing to
+	// the API server root path.
+	RootHTTPClient() (*httprequest.Client, error)
+
 	// BakeryClient returns the bakery client for this connection.
 	BakeryClient() MacaroonDischarger
 

--- a/api/base/mocks/caller_mock.go
+++ b/api/base/mocks/caller_mock.go
@@ -160,6 +160,21 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
 
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}
+
 // MockFacadeCaller is a mock of FacadeCaller interface.
 type MockFacadeCaller struct {
 	ctrl     *gomock.Controller

--- a/api/base/mocks/clientfacade_mock.go
+++ b/api/base/mocks/clientfacade_mock.go
@@ -174,6 +174,21 @@ func (mr *MockAPICallCloserMockRecorder) ModelTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICallCloser)(nil).ModelTag))
 }
 
+// RootHTTPClient mocks base method.
+func (m *MockAPICallCloser) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallCloserMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICallCloser)(nil).RootHTTPClient))
+}
+
 // MockClientFacade is a mock of ClientFacade interface.
 type MockClientFacade struct {
 	ctrl     *gomock.Controller

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -50,6 +50,10 @@ func (APICallerFunc) HTTPClient() (*httprequest.Client, error) {
 	return nil, errors.New("no HTTP client available in this test")
 }
 
+func (APICallerFunc) RootHTTPClient() (*httprequest.Client, error) {
+	return nil, errors.New("no Root HTTP client available in this test")
+}
+
 func (APICallerFunc) BakeryClient() base.MacaroonDischarger {
 	panic("no bakery client available in this test")
 }

--- a/api/client/modelupgrader/mocks/apibase_mock.go
+++ b/api/client/modelupgrader/mocks/apibase_mock.go
@@ -173,3 +173,18 @@ func (mr *MockAPICallCloserMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICallCloser)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICallCloser) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallCloserMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICallCloser)(nil).RootHTTPClient))
+}

--- a/api/controller/usersecretsdrain/mocks/facade_mock.go
+++ b/api/controller/usersecretsdrain/mocks/facade_mock.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -542,6 +542,21 @@ func (mr *MockDeployerAPIMockRecorder) Offer(arg0, arg1, arg2, arg3, arg4, arg5 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offer", reflect.TypeOf((*MockDeployerAPI)(nil).Offer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// RootHTTPClient mocks base method.
+func (m *MockDeployerAPI) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockDeployerAPIMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockDeployerAPI)(nil).RootHTTPClient))
+}
+
 // ScaleApplication mocks base method.
 func (m *MockDeployerAPI) ScaleApplication(arg0 application.ScaleApplicationParams) (params.ScaleApplicationResult, error) {
 	m.ctrl.T.Helper()

--- a/worker/caasfirewallersidecar/mocks/api_base_mock.go
+++ b/worker/caasfirewallersidecar/mocks/api_base_mock.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/worker/caasoperator/mocks/apibase.go
+++ b/worker/caasoperator/mocks/apibase.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/worker/containerbroker/mocks/base_mock.go
+++ b/worker/containerbroker/mocks/base_mock.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/worker/instancemutater/mocks/base_mock.go
+++ b/worker/instancemutater/mocks/base_mock.go
@@ -159,3 +159,18 @@ func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }
+
+// RootHTTPClient mocks base method.
+func (m *MockAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RootHTTPClient")
+	ret0, _ := ret[0].(*httprequest.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHTTPClient indicates an expected call of RootHTTPClient.
+func (mr *MockAPICallerMockRecorder) RootHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHTTPClient", reflect.TypeOf((*MockAPICaller)(nil).RootHTTPClient))
+}

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -167,6 +167,10 @@ func (s *stubAPICaller) HTTPClient() (*httprequest.Client, error) {
 	panic("should not be called")
 }
 
+func (s *stubAPICaller) RootHTTPClient() (*httprequest.Client, error) {
+	panic("should not be called")
+}
+
 func (s *stubAPICaller) Context() context.Context {
 	return context.Background()
 }


### PR DESCRIPTION
Expose currently unused RootHTTPClient for S3

RootHTTPClient returns an HTTP client that sends requests to the apiserver root address. This is and will be most useful for the s3 endpoint, whose specification assumes the first path location is a bucket.

Use this client in the s3client in internal, slightly simplifying + generalising the client construction and options

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

All that is necessary is to deploy a charm. Juju will fail to deploy, if the client fails to download the charm in the uniter worker

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.4-beta1.1  unsupported  17:09:25Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.85          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.85  juju-8a2776-0  ubuntu@22.04      Running
```