### PR TITLE
Fix race test failure in core/cache

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	cmdmodel "github.com/juju/juju/cmd/jujud/agent/model"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -291,7 +292,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,
-			Logger:            loggo.GetLogger("juju.worker.migrationminion"),
+			Logger:            loggo.GetLoggerWithLabels("juju.worker.migrationminion", corelogger.MIGRATION),
 		}),
 
 		// The proxy config updater is a leaf worker that sets http/https/apt/etc

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/api/client/charms"
 	"github.com/juju/juju/caas/kubernetes/provider/exec"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/sockets"
@@ -219,7 +220,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,
-			Logger:            loggo.GetLogger("juju.worker.migrationminion"),
+			Logger:            loggo.GetLoggerWithLabels("juju.worker.migrationminion", corelogger.MIGRATION),
 		}),
 
 		// The proxy config updater is a leaf worker that sets http/https/apt/etc

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -29,6 +29,7 @@ import (
 	containerbroker "github.com/juju/juju/container/broker"
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/instance"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/presence"
@@ -541,7 +542,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,
-			Logger:            loggo.GetLogger("juju.worker.migrationminion"),
+			Logger:            loggo.GetLoggerWithLabels("juju.worker.migrationminion", corelogger.MIGRATION),
 		}),
 
 		// Each controller machine runs a singular worker which will

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -212,8 +212,9 @@ type Resident struct {
 	// evicted from the cache.
 	// Obvious examples are watchers created by the resident.
 	// Access to this map should be protected with the Mutex below.
-	workers map[uint64]worker.Worker
-	mu      sync.Mutex
+	workers  map[uint64]worker.Worker
+	mu       sync.Mutex
+	evicting bool
 }
 
 // CacheId returns the unique ID for this cache resident.
@@ -229,6 +230,17 @@ func (r *Resident) CacheId() uint64 {
 func (r *Resident) registerWorker(w worker.Worker) func() {
 	id := r.nextResourceId()
 	r.mu.Lock()
+	// If this resident is already being evicted
+	// don't register any new workers.
+	if r.evicting {
+		return func() {
+			// We'll still stop the worker when it gets "deregistered" even
+			// though it's not added to the cache.
+			if err := worker.Stop(w); err != nil {
+				logger.Warningf("worker cleanup error: %s", err.Error())
+			}
+		}
+	}
 	r.workers[id] = w
 	r.mu.Unlock()
 	return func() { r.deregisterWorker(id) }
@@ -237,6 +249,9 @@ func (r *Resident) registerWorker(w worker.Worker) func() {
 // evict cleans up any resources created by this resident,
 // then deregisters it.
 func (r *Resident) evict() error {
+	r.mu.Lock()
+	r.evicting = true
+	r.mu.Unlock()
 	if err := r.cleanup(); err != nil {
 		return errors.Trace(err)
 	}
@@ -248,15 +263,21 @@ func (r *Resident) evict() error {
 // being evicted from the cache.
 // Note that this method does not deregister the resident from the manager.
 func (r *Resident) cleanup() error {
-	return errors.Annotatef(r.cleanupWorkers(), "cleaning up cache resident %d:", r.id)
+	r.mu.Lock()
+	toStop := make(map[uint64]worker.Worker)
+	for id, w := range r.workers {
+		toStop[id] = w
+	}
+	r.mu.Unlock()
+	return errors.Annotatef(r.cleanupWorkers(toStop), "cleaning up cache resident %d:", r.id)
 }
 
 // cleanupWorkers calls "Stop" on all registered workers.
 // Note that the deregistration method should have been added to the worker's
 // tomb cleanup method - stopping the worker cleanly is enough to deregister.
-func (r *Resident) cleanupWorkers() error {
+func (r *Resident) cleanupWorkers(toStop map[uint64]worker.Worker) error {
 	var errs []string
-	for id, w := range r.workers {
+	for id, w := range toStop {
 		if err := worker.Stop(w); err != nil {
 			errs = append(errs, errors.Annotatef(err, "worker %d", id).Error())
 		}

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -26,4 +26,7 @@ const (
 
 	// SECRETS defines a common label for dealing with secrets.
 	SECRETS Label = "secrets"
+
+	// MIGRATION defines a common label for dealing with migration.
+	MIGRATION Label = "migration"
 )

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -17,13 +17,14 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/leadership"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
 )
 
-var logger = loggo.GetLogger("juju.migration")
+var logger = loggo.GetLoggerWithLabels("juju.migration", corelogger.MIGRATION)
 
 // StateExporter describes interface on state required to export a
 // model.

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -322,14 +322,14 @@ pre_bootstrap() {
 # and shouldn't be used by any of the tests directly.  Calls post_add_model
 # models are added during bootstrap.
 post_bootstrap() {
-	local name model
+	local controller model
 
-	name=${1}
+	controller=${1}
 	model=${2}
 
 	# Setup up log tailing on the controller.
 	# shellcheck disable=SC2069
-	juju debug-log -m "${name}:controller" --replay --tail 2>&1 >"${TEST_DIR}/controller-debug.log" &
+	juju debug-log -m "${controller}:controller" --replay --tail 2>&1 >"${TEST_DIR}/${controller}-controller-debug.log" &
 	CMD_PID=$!
 	echo "${CMD_PID}" >>"${TEST_DIR}/pids"
 
@@ -338,7 +338,7 @@ post_bootstrap() {
 		rm -r "${TEST_DIR}"/image-streams
 		;;
 	esac
-	post_add_model "${name}" "${model}"
+	post_add_model "${controller}" "${model}"
 }
 
 # post_add_model does provider specific config required after a new model is added
@@ -350,7 +350,7 @@ post_add_model() {
 	model=${2}
 
 	ctrl_arg="${controller}:${model}"
-	log_file="${controller}-${model}.log"
+	log_file="${controller}-${model}-debug.log"
 	if [[ -z ${controller} ]]; then
 		ctrl_arg="${model}"
 		log_file="${model}.log"

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -6,7 +6,9 @@ run_model_migration() {
 	# Ensure we have another controller available.
 	bootstrap_alt_controller "alt-model-migration"
 	juju switch "alt-model-migration"
-	juju add-model "model-migration"
+	add_model "model-migration"
+	juju model-config -m controller "logging-config=#migration=DEBUG"
+	juju model-config -m model-migration "logging-config=#migration=DEBUG"
 
 	juju deploy jameinel-ubuntu-lite ubuntu
 
@@ -15,6 +17,7 @@ run_model_migration() {
 	# Capture logs to ensure they are migrated
 	old_logs="$(juju debug-log --no-tail -l DEBUG)"
 
+	juju model-config -m "${BOOTSTRAPPED_JUJU_CTRL_NAME}:controller" "logging-config=#migration=DEBUG"
 	juju migrate "model-migration" "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 
@@ -77,7 +80,7 @@ run_model_migration_version() {
 	# Ensure we have another controller available.
 	bootstrap_alt_controller "alt-model-migration-version-stable"
 	juju --show-log switch "alt-model-migration-version-stable"
-	juju --show-log add-model "model-migration-version-stable"
+	add_model "model-migration-version-stable"
 
 	juju --show-log deploy easyrsa
 	juju --show-log deploy etcd
@@ -156,7 +159,7 @@ run_model_migration_saas_common() {
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
-	juju add-model blog
+	add_model blog
 	juju switch blog
 	juju deploy juju-qa-dummy-sink --series jammy
 
@@ -294,7 +297,7 @@ run_model_migration_saas_consumer() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
-	juju add-model "model-migration-consumer"
+	add_model "model-migration-consumer"
 	juju deploy juju-qa-dummy-sink --series jammy
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"

--- a/worker/deployer/unit_manifolds.go
+++ b/worker/deployer/unit_manifolds.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/base"
 	commonapi "github.com/juju/juju/api/common"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker"
@@ -177,7 +178,7 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,
-			Logger:            config.LoggingContext.GetLogger("juju.worker.migrationminion"),
+			Logger:            config.LoggingContext.GetLogger("juju.worker.migrationminion", corelogger.MIGRATION),
 		}),
 
 		// The logging config updater is a leaf worker that indirectly

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -17,10 +17,12 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v3/catacomb"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/controller/migrationtarget"
+	corelogger "github.com/juju/juju/core/logger"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/watcher"
@@ -169,7 +171,7 @@ func New(config Config) (*Worker, error) {
 	// the logs from different migrationmaster insteads using the short
 	// model UUID suffix.
 	loggerName := "juju.worker.migrationmaster." + names.NewModelTag(config.ModelUUID).ShortId()
-	logger := loggo.GetLogger(loggerName)
+	logger := loggo.GetLoggerWithLabels(loggerName, corelogger.MIGRATION)
 
 	w := &Worker{
 		config: config,
@@ -782,6 +784,7 @@ func (w *Worker) waitForMinions(
 			if err := validateMinionReports(reports, status); err != nil {
 				return false, errors.Trace(err)
 			}
+			w.logger.Debugf("migration minion reports:\n%s", pretty.Sprint(reports))
 			failures := len(reports.FailedMachines) + len(reports.FailedUnits) + len(reports.FailedApplications)
 			if failures > 0 {
 				w.logger.Errorf(formatMinionFailure(reports, infoPrefix))


### PR DESCRIPTION
A ci test run showed a race in the `core/cache` tests. This fixes that.

```
WARNING: DATA RACE
Write at 0x00c00117a600 by goroutine 12135:
  runtime.mapassign_fast64()
      /usr/local/go/src/runtime/map_fast64.go:93 +0x0
  github.com/juju/juju/core/cache.(*Resident).registerWorker()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/resident.go:232 +0x95
  github.com/juju/juju/core/cache.newConfigWatcher()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/watcher.go:136 +0x26c
  github.com/juju/juju/core/cache.(*Model).WatchConfig()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/model.go:160 +0x16b
  github.com/juju/juju/apiserver/facades/agent/logger.(*LoggerAPI).WatchLoggingConfig()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/apiserver/facades/agent/logger/logger.go:51 +0x21a
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:748 +0x42
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:380 +0xb5
  github.com/juju/rpcreflect.newMethod.func7()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/github.com/juju/rpcreflect/type.go:358 +0xf0
  github.com/juju/juju/apiserver.(*srvCaller).Call()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/apiserver/root.go:191 +0x14d
  github.com/juju/juju/rpc.(*Conn).runRequest()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/rpc/server.go:571 +0x2ab
  github.com/juju/juju/rpc.(*Conn).handleRequest.func1()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/rpc/server.go:475 +0x15b

Previous read at 0x00c00117a600 by goroutine 9998:
  runtime.mapiterinit()
      /usr/local/go/src/runtime/map.go:816 +0x0
  github.com/juju/juju/core/cache.(*Resident).cleanupWorkers()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/resident.go:259 +0x86
  github.com/juju/juju/core/cache.(*Resident).cleanup()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/resident.go:251 +0x2e
  github.com/juju/juju/core/cache.(*Resident).evict()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/resident.go:240 +0x26
  github.com/juju/juju/core/cache.(*Controller).removeModel()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/controller.go:340 +0x15c
  github.com/juju/juju/core/cache.(*Controller).loop()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/core/cache/controller.go:164 +0xbf8
  github.com/juju/juju/core/cache.(*Controller).loop-fm()
      <autogenerated>:1 +0x33
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x43
  gopkg.in/tomb%2ev2.(*Tomb).Go.func2()
      /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x44
```

Also, to help diagnose intermittent migration ci test failures, turn on debug logging for the models.
And fix some issues with the ci test infrastructure to ensure the `add_model` helper is used rather than the raw `add-model`. This ensures that we record the debug log.

## QA steps

unit tests