### PR TITLE
File potential race in object store

### DIFF
--- a/internal/objectstore/fileobjectstore_test.go
+++ b/internal/objectstore/fileobjectstore_test.go
@@ -163,7 +163,7 @@ func (s *FileObjectStoreSuite) TestPutCleansUpFileOnMetadataFailure(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// If the file is not referenced by another metadata entry, then the file
-	// should be cleaned up if the metadata service returns an error.
+	// should be left to be cleaned by the object store later on.
 
 	path := c.MkDir()
 
@@ -183,7 +183,7 @@ func (s *FileObjectStoreSuite) TestPutCleansUpFileOnMetadataFailure(c *gc.C) {
 	err = store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesNotExist(c, path, namespace, hash)
+	s.expectFileDoesExist(c, path, namespace, hash)
 }
 
 func (s *FileObjectStoreSuite) TestPutDoesNotCleansUpFileOnMetadataFailure(c *gc.C) {
@@ -290,7 +290,7 @@ func (s *FileObjectStoreSuite) TestPutAndCheckHashCleansUpFileOnMetadataFailure(
 	defer s.setupMocks(c).Finish()
 
 	// If the file is not referenced by another metadata entry, then the file
-	// should be cleaned up if the metadata service returns an error.
+	// should be left to cleaned up by the object store later on.
 
 	path := c.MkDir()
 
@@ -310,7 +310,7 @@ func (s *FileObjectStoreSuite) TestPutAndCheckHashCleansUpFileOnMetadataFailure(
 	err = store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesNotExist(c, path, namespace, hash)
+	s.expectFileDoesExist(c, path, namespace, hash)
 }
 
 func (s *FileObjectStoreSuite) TestPutAndCheckHashDoesNotCleansUpFileOnMetadataFailure(c *gc.C) {


### PR DESCRIPTION
Removal of the potential race when attempting to clean up the file. Instead, we should allow a clean-up worker (to be implemented later) to clean up orphan files later.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

<!-- Describe steps to verify that the change works. -->

```
$ go test -v ./internal/objectstore -check.v
```

## Links

**Jira card:** JUJU-5245

