### PR TITLE
Add description column to flag table

### DIFF
--- a/core/flags/flags.go
+++ b/core/flags/flags.go
@@ -7,5 +7,6 @@ package flags
 const (
 	// BootstrapFlag is the name of the flag that is used to check if the
 	// bootstrap process has completed.
-	BootstrapFlag = "bootstrapped"
+	BootstrapFlag            = "bootstrapped"
+	BootstrapFlagDescription = "Flag that indicates if the bootstrap process has completed"
 )

--- a/domain/flag/service/service.go
+++ b/domain/flag/service/service.go
@@ -11,7 +11,7 @@ import (
 
 // State describes retrieval and persistence methods for storage.
 type State interface {
-	SetFlag(context.Context, string, bool) error
+	SetFlag(ctx context.Context, flag string, value bool, description string) error
 	GetFlag(context.Context, string) (bool, error)
 }
 
@@ -28,8 +28,9 @@ func NewService(st State) *Service {
 }
 
 // SetFlag sets the value of a flag.
-func (s *Service) SetFlag(ctx context.Context, flag string, value bool) error {
-	return s.st.SetFlag(ctx, flag, value)
+// Description is used to describe the flag and it's potential state.
+func (s *Service) SetFlag(ctx context.Context, flag string, value bool, description string) error {
+	return s.st.SetFlag(ctx, flag, value, description)
 }
 
 // GetFlag returns the value of a flag.

--- a/domain/flag/service/service_test.go
+++ b/domain/flag/service/service_test.go
@@ -24,10 +24,10 @@ var _ = gc.Suite(&serviceSuite{})
 func (s *serviceSuite) TestSetFlag(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetFlag(gomock.Any(), "foo", true).Return(nil)
+	s.state.EXPECT().SetFlag(gomock.Any(), "foo", true, "foo set to true").Return(nil)
 
 	service := NewService(s.state)
-	err := service.SetFlag(context.Background(), "foo", true)
+	err := service.SetFlag(context.Background(), "foo", true, "foo set to true")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/domain/flag/service/state_mock_test.go
+++ b/domain/flag/service/state_mock_test.go
@@ -55,15 +55,15 @@ func (mr *MockStateMockRecorder) GetFlag(arg0, arg1 any) *gomock.Call {
 }
 
 // SetFlag mocks base method.
-func (m *MockState) SetFlag(arg0 context.Context, arg1 string, arg2 bool) error {
+func (m *MockState) SetFlag(arg0 context.Context, arg1 string, arg2 bool, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetFlag", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetFlag", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetFlag indicates an expected call of SetFlag.
-func (mr *MockStateMockRecorder) SetFlag(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateMockRecorder) SetFlag(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockState)(nil).SetFlag), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockState)(nil).SetFlag), arg0, arg1, arg2, arg3)
 }

--- a/domain/flag/state/state.go
+++ b/domain/flag/state/state.go
@@ -33,20 +33,22 @@ func NewState(factory coredb.TxnRunnerFactory, logger Logger) *State {
 }
 
 // SetFlag sets the value of a flag.
-func (s *State) SetFlag(ctx context.Context, flag string, value bool) error {
+// Description is used to describe the flag and it's potential state.
+func (s *State) SetFlag(ctx context.Context, flag string, value bool, description string) error {
 	db, err := s.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	query := `
-INSERT INTO flag (name, value)
-VALUES (?, ?)
-ON CONFLICT (name) DO UPDATE SET value = excluded.value;
+INSERT INTO flag (name, value, description)
+VALUES (?, ?, ?)
+ON CONFLICT (name) DO UPDATE SET value = excluded.value,
+                                 description = excluded.description;
 `
 
 	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		result, err := tx.ExecContext(ctx, query, flag, value)
+		result, err := tx.ExecContext(ctx, query, flag, value, description)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/domain/flag/state/state_test.go
+++ b/domain/flag/state/state_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -35,7 +36,7 @@ func (s *stateSuite) TestGetFlagNotFound(c *gc.C) {
 }
 
 func (s *stateSuite) TestGetFlagFound(c *gc.C) {
-	err := s.state.SetFlag(context.Background(), "foo", true)
+	err := s.state.SetFlag(context.Background(), "foo", true, "foo set to true")
 	c.Assert(err, jc.ErrorIsNil)
 
 	value, err := s.state.GetFlag(context.Background(), "foo")
@@ -43,15 +44,38 @@ func (s *stateSuite) TestGetFlagFound(c *gc.C) {
 	c.Assert(value, jc.IsTrue)
 }
 
+func (s *stateSuite) TestSetFlag(c *gc.C) {
+	err := s.state.SetFlag(context.Background(), "foo", true, "foo set to true")
+	c.Assert(err, jc.ErrorIsNil)
+
+	var (
+		value       bool
+		description string
+	)
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT value, description FROM flag WHERE name = 'foo'").Scan(&value, &description)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !value {
+			return errors.Errorf("unexpected value: %v", value)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(value, jc.IsTrue)
+	c.Assert(description, gc.Equals, "foo set to true")
+}
+
 func (s *stateSuite) TestSetFlagAlreadyFound(c *gc.C) {
-	err := s.state.SetFlag(context.Background(), "foo", true)
+	err := s.state.SetFlag(context.Background(), "foo", true, "foo set to true")
 	c.Assert(err, jc.ErrorIsNil)
 
 	value, err := s.state.GetFlag(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(value, jc.IsTrue)
 
-	err = s.state.SetFlag(context.Background(), "foo", false)
+	err = s.state.SetFlag(context.Background(), "foo", false, "foo set to false")
 	c.Assert(err, jc.ErrorIsNil)
 
 	value, err = s.state.GetFlag(context.Background(), "foo")

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -586,7 +586,8 @@ func flagSchema() schema.Patch {
 	return schema.MakePatch(`
 CREATE TABLE flag (
     name TEXT PRIMARY KEY,
-    value BOOLEAN DEFAULT 0
+    value BOOLEAN DEFAULT 0,
+    description TEXT NOT NULL
 );
 `)
 }

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -96,17 +96,17 @@ func (mr *MockFlagServiceMockRecorder) GetFlag(arg0, arg1 any) *gomock.Call {
 }
 
 // SetFlag mocks base method.
-func (m *MockFlagService) SetFlag(arg0 context.Context, arg1 string, arg2 bool) error {
+func (m *MockFlagService) SetFlag(arg0 context.Context, arg1 string, arg2 bool, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetFlag", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetFlag", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetFlag indicates an expected call of SetFlag.
-func (mr *MockFlagServiceMockRecorder) SetFlag(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockFlagServiceMockRecorder) SetFlag(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockFlagService)(nil).SetFlag), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockFlagService)(nil).SetFlag), arg0, arg1, arg2, arg3)
 }
 
 // MockObjectStoreGetter is a mock of ObjectStoreGetter interface.

--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/worker/v3/dependency"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/bootstrap"
 	"github.com/juju/juju/internal/servicefactory"
@@ -20,12 +21,6 @@ import (
 	workerobjectstore "github.com/juju/juju/internal/worker/objectstore"
 	"github.com/juju/juju/internal/worker/state"
 	"github.com/juju/juju/state/binarystorage"
-)
-
-const (
-	// BootstrapFlag is the name of the flag that is used to check if the
-	// bootstrap process has completed.
-	BootstrapFlag = "bootstrapped"
 )
 
 // Logger represents the logging methods called.
@@ -203,7 +198,7 @@ func IAASAgentBinaryUploader(ctx context.Context, dataDir string, storageService
 // RequiresBootstrap is the function that is used to check if the bootstrap
 // process has completed.
 func RequiresBootstrap(ctx context.Context, flagService FlagService) (bool, error) {
-	bootstrapped, err := flagService.GetFlag(ctx, BootstrapFlag)
+	bootstrapped, err := flagService.GetFlag(ctx, flags.BootstrapFlag)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/state/binarystorage"
@@ -33,7 +34,7 @@ type ControllerConfigService interface {
 // flag.
 type FlagService interface {
 	GetFlag(context.Context, string) (bool, error)
-	SetFlag(context.Context, string, bool) error
+	SetFlag(ctx context.Context, flag string, value bool, description string) error
 }
 
 // ObjectStoreGetter is the interface that is used to get a object store.
@@ -154,7 +155,7 @@ func (w *bootstrapWorker) loop() error {
 	}
 
 	// Set the bootstrap flag, to indicate that the bootstrap has completed.
-	if err := w.cfg.FlagService.SetFlag(ctx, BootstrapFlag, true); err != nil {
+	if err := w.cfg.FlagService.SetFlag(ctx, flags.BootstrapFlag, true, flags.BootstrapFlagDescription); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -131,5 +131,5 @@ func (s *workerSuite) expectObjectStoreGetter() {
 }
 
 func (s *workerSuite) expectBootstrapFlagSet() {
-	s.flagService.EXPECT().SetFlag(gomock.Any(), flags.BootstrapFlag, true).Return(nil)
+	s.flagService.EXPECT().SetFlag(gomock.Any(), flags.BootstrapFlag, true, flags.BootstrapFlagDescription).Return(nil)
 }


### PR DESCRIPTION
The flag table is useful to setting global flags that need to be persisted throughout juju, even when running in HA. To aid the debugging of a live system, add a description column to identify what the flag usage and state indicates.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ make repl-install
```

## Login to dqlite

```sh
$ juju ssh -m controller 0
$ sudo snap install yq
# Note we need to pipe indirection because of snap confinement.
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
> SELECT * FROM flag
bootstrapped|true|Flag that indicates if the bootstrap process has completed
```

## Links

**Jira card:** JUJU-5248

