### PR TITLE
Wire up contexts in apiserver and cmd packages

### DIFF
--- a/api/agent/uniter/resource_test.go
+++ b/api/agent/uniter/resource_test.go
@@ -91,7 +91,7 @@ func (s *stubAPI) setResource(info resources.Resource, reader io.ReadCloser) {
 }
 
 func (s *stubAPI) Context() context.Context {
-	return context.TODO()
+	return context.Background()
 }
 
 func (s *stubAPI) BestFacadeVersion(_ string) int {

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -24,8 +24,7 @@ type apiclientWhiteboxSuite struct {
 var _ = gc.Suite(&apiclientWhiteboxSuite{})
 
 func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiCancelled(c *gc.C) {
-	ctx := context.TODO()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
 	go func() {
 		select {

--- a/api/authentication/interactor_test.go
+++ b/api/authentication/interactor_test.go
@@ -50,7 +50,7 @@ func (s *InteractorSuite) SetUpTest(c *gc.C) {
 func (s *InteractorSuite) TestNotSupportedInteract(c *gc.C) {
 	v := authentication.NewNotSupportedInteractor()
 	c.Assert(v.Kind(), gc.Equals, "juju_userpass")
-	_, err := v.Interact(context.TODO(), nil, "", nil)
+	_, err := v.Interact(context.Background(), nil, "", nil)
 	c.Assert(err, jc.ErrorIs, errors.NotSupported)
 }
 
@@ -67,7 +67,7 @@ func (s *InteractorSuite) TestLegacyInteract(c *gc.C) {
 		formUser = r.Form.Get("user")
 		formPassword = r.Form.Get("password")
 	})
-	err := lv.LegacyInteract(context.TODO(), s.client, "", mustParseURL(s.server.URL))
+	err := lv.LegacyInteract(context.Background(), s.client, "", mustParseURL(s.server.URL))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(formUser, gc.Equals, "bob")
 	c.Assert(formPassword, gc.Equals, "hunter2")
@@ -87,7 +87,7 @@ func (s *InteractorSuite) TestLegacyInteractErrorResult(c *gc.C) {
 	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"Message":"bleh"}`, http.StatusInternalServerError)
 	})
-	err := lv.LegacyInteract(context.TODO(), s.client, "", mustParseURL(s.server.URL))
+	err := lv.LegacyInteract(context.Background(), s.client, "", mustParseURL(s.server.URL))
 	c.Assert(err, gc.ErrorMatches, "bleh")
 }
 
@@ -101,7 +101,7 @@ func (s *InteractorSuite) TestInteract(c *gc.C) {
 		reqParams := httprequest.Params{
 			Response: w,
 			Request:  r,
-			Context:  context.TODO(),
+			Context:  context.Background(),
 		}
 		loginRequest := form.LoginRequest{}
 		err := httprequest.Unmarshal(reqParams, &loginRequest)
@@ -122,7 +122,7 @@ func (s *InteractorSuite) TestInteract(c *gc.C) {
 	infoData, err := json.Marshal(info)
 	msgData := json.RawMessage(infoData)
 	c.Assert(err, jc.ErrorIsNil)
-	token, err := v.Interact(context.TODO(), s.client, "", &httpbakery.Error{
+	token, err := v.Interact(context.Background(), s.client, "", &httpbakery.Error{
 		Code: httpbakery.ErrInteractionRequired,
 		Info: &httpbakery.ErrorInfo{
 			InteractionMethods: map[string]*json.RawMessage{
@@ -150,7 +150,7 @@ func (s *InteractorSuite) TestInteractErrorResult(c *gc.C) {
 	infoData, err := json.Marshal(info)
 	c.Assert(err, jc.ErrorIsNil)
 	msgData := json.RawMessage(infoData)
-	_, err = v.Interact(context.TODO(), s.client, "", &httpbakery.Error{
+	_, err = v.Interact(context.Background(), s.client, "", &httpbakery.Error{
 		Code: httpbakery.ErrInteractionRequired,
 		Info: &httpbakery.ErrorInfo{
 			InteractionMethods: map[string]*json.RawMessage{

--- a/api/client/backups/download_test.go
+++ b/api/client/backups/download_test.go
@@ -32,7 +32,7 @@ func (s *downloadSuite) TestDownload(c *gc.C) {
 	httpClient := &httprequest.Client{BaseURL: srv.URL}
 
 	s.apiCaller.EXPECT().HTTPClient().Return(httpClient, nil)
-	s.apiCaller.EXPECT().Context().Return(context.TODO())
+	s.apiCaller.EXPECT().Context().Return(context.Background())
 
 	client := s.newClient()
 	rdr, err := client.Download("/path/to/backup")

--- a/api/client/charms/downloader_test.go
+++ b/api/client/charms/downloader_test.go
@@ -37,7 +37,7 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 
 	charmData := "charmdatablob"

--- a/api/client/charms/localcharmclient_test.go
+++ b/api/client/charms/localcharmclient_test.go
@@ -44,7 +44,7 @@ func (s *addCharmSuite) TestAddLocalCharm(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).MinTimes(1)
 
@@ -114,7 +114,7 @@ func (s *addCharmSuite) TestAddLocalCharmWithLXDProfile(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).MinTimes(1)
 
@@ -178,7 +178,7 @@ func (s *addCharmSuite) testAddLocalCharmWithForceSucceeds(name string, c *gc.C)
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).MinTimes(1)
 
@@ -235,7 +235,7 @@ func (s *addCharmSuite) TestAddLocalCharmDefinitelyWithHooks(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).MinTimes(1)
 
@@ -281,7 +281,7 @@ func (s *addCharmSuite) TestAddLocalCharmError(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).MinTimes(1)
+	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).MinTimes(1)
 
@@ -347,7 +347,7 @@ func testMinVer(t minverTest, c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.TODO()).AnyTimes()
+	mockCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).AnyTimes()
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).AnyTimes()
 

--- a/api/client/resources/client_upload_test.go
+++ b/api/client/resources/client_upload_test.go
@@ -57,7 +57,7 @@ func (s *UploadSuite) setup(c *gc.C) *gomock.Controller {
 func (s *UploadSuite) TestUpload(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	s.mockAPICaller.EXPECT().Context().Return(ctx)
 
 	data := "<data>"
@@ -129,7 +129,7 @@ func (s *UploadSuite) TestUploadFailed(c *gc.C) {
 	req.Header.Set("Content-Disposition", "form-data; filename=foo.zip")
 	req.ContentLength = int64(len(data))
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	s.mockAPICaller.EXPECT().Context().Return(ctx)
 	s.mockHTTPClient.EXPECT().Do(ctx, reqMatcher{c, req}, gomock.Any()).Return(errors.New("boom"))
 	err = s.client.Upload("a-application", "spam", "foo.zip", "", strings.NewReader(data))
@@ -207,7 +207,7 @@ func (s *UploadSuite) TestUploadPendingResource(c *gc.C) {
 	req.ContentLength = int64(len(data))
 	req.Header.Set("Content-Disposition", "form-data; filename=file.zip")
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	s.mockAPICaller.EXPECT().Context().Return(ctx)
 	s.mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "AddPendingResources", &args, gomock.Any()).SetArg(3, results).Return(nil)
 	s.mockHTTPClient.EXPECT().Do(ctx, reqMatcher{c, req}, gomock.Any())
@@ -273,7 +273,7 @@ func (s *UploadSuite) TestUploadPendingResourceFailed(c *gc.C) {
 	req.ContentLength = int64(len(data))
 	req.Header.Set("Content-Disposition", "form-data; filename=file.zip")
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	s.mockAPICaller.EXPECT().Context().Return(ctx)
 	s.mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "AddPendingResources", &args, gomock.Any()).SetArg(3, results).Return(nil)
 	s.mockHTTPClient.EXPECT().Do(ctx, reqMatcher{c, req}, gomock.Any()).Return(errors.New("boom"))

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {
-	result, err := dialAPI(context.TODO(), info, opts)
+	result, err := dialAPI(context.Background(), info, opts)
 	if err != nil {
 		return nil, "", err
 	}

--- a/api/http/http_test.go
+++ b/api/http/http_test.go
@@ -54,14 +54,13 @@ func (s *httpSuite) TestOpenURI(c *gc.C) {
 		Body:       io.NopCloser(strings.NewReader("2.6.6-ubuntu-amd64")),
 	}
 	resultResp.Header.Add("Content-Type", "application/json")
-	ctx := context.TODO()
-	mockHttp.EXPECT().Do(ctx, &uriMatcher{"/tools/2.6.6-ubuntu-amd64"}, gomock.Any()).DoAndReturn(func(_ context.Context, _ *http.Request, resp interface{}) error {
+	mockHttp.EXPECT().Do(gomock.Any(), &uriMatcher{"/tools/2.6.6-ubuntu-amd64"}, gomock.Any()).DoAndReturn(func(_ context.Context, _ *http.Request, resp interface{}) error {
 		out := resp.(**http.Response)
 		*out = resultResp
 		return nil
 	})
 
-	reader, err := apihttp.OpenURI(ctx, mockHttp, "/tools/2.6.6-ubuntu-amd64", nil)
+	reader, err := apihttp.OpenURI(context.Background(), mockHttp, "/tools/2.6.6-ubuntu-amd64", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -418,8 +418,6 @@ func newServer(ctx context.Context, cfg ServerConfig) (_ *Server, err error) {
 		return nil, errors.Trace(err)
 	}
 
-	srv.shared.cancel = srv.tomb.Dying()
-
 	// The auth context for authenticating access to application offers.
 	srv.offerAuthCtxt, err = newOfferAuthcontext(cfg.StatePool)
 	if err != nil {
@@ -1089,7 +1087,7 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		modelUUID := httpcontext.RequestModelUUID(req)
 		logger.Tracef("got a request for model %q", modelUUID)
 		if err := srv.serveConn(
-			req.Context(),
+			srv.tomb.Context(req.Context()),
 			conn,
 			modelUUID,
 			connectionID,

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -109,7 +109,7 @@ func (s *agentAuthenticatorSuite) TestValidLogins(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 		var authenticator authentication.AgentAuthenticator
-		entity, err := authenticator.Authenticate(context.TODO(), st, authentication.AuthParams{
+		entity, err := authenticator.Authenticate(context.Background(), st, authentication.AuthParams{
 			AuthTag:     t.entity.Tag(),
 			Credentials: t.credentials,
 			Nonce:       t.nonce,
@@ -147,7 +147,7 @@ func (s *agentAuthenticatorSuite) TestInvalidLogins(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 		var authenticator authentication.AgentAuthenticator
-		entity, err := authenticator.Authenticate(context.TODO(), st, authentication.AuthParams{
+		entity, err := authenticator.Authenticate(context.Background(), st, authentication.AuthParams{
 			AuthTag:     t.entity.Tag(),
 			Credentials: t.credentials,
 			Nonce:       t.nonce,

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -50,7 +50,7 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 
 	// attempt machine login
 	authenticator := &authentication.LocalUserAuthenticator{}
-	_, err = authenticator.Authenticate(context.TODO(), nil, authentication.AuthParams{
+	_, err = authenticator.Authenticate(context.Background(), nil, authentication.AuthParams{
 		AuthTag:     machine.Tag(),
 		Credentials: machinePassword,
 		Nonce:       nonce,
@@ -77,7 +77,7 @@ func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 
 	// Attempt unit login
 	authenticator := &authentication.LocalUserAuthenticator{}
-	_, err = authenticator.Authenticate(context.TODO(), nil, authentication.AuthParams{
+	_, err = authenticator.Authenticate(context.Background(), nil, authentication.AuthParams{
 		AuthTag:     unit.UnitTag(),
 		Credentials: unitPassword,
 	})
@@ -96,7 +96,7 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.LocalUserAuthenticator{}
-	_, err := authenticator.Authenticate(context.TODO(), s.ControllerModel(c).State(), authentication.AuthParams{
+	_, err := authenticator.Authenticate(context.Background(), s.ControllerModel(c).State(), authentication.AuthParams{
 		AuthTag:     user.Tag(),
 		Credentials: "password",
 	})
@@ -115,7 +115,7 @@ func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.LocalUserAuthenticator{}
-	_, err := authenticator.Authenticate(context.TODO(), s.ControllerModel(c).State(), authentication.AuthParams{
+	_, err := authenticator.Authenticate(context.Background(), s.ControllerModel(c).State(), authentication.AuthParams{
 		AuthTag:     user.Tag(),
 		Credentials: "wrongpassword",
 	})
@@ -142,7 +142,7 @@ func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 
 	// Attempt relation login
 	authenticator := &authentication.LocalUserAuthenticator{}
-	_, err = authenticator.Authenticate(context.TODO(), nil, authentication.AuthParams{
+	_, err = authenticator.Authenticate(context.Background(), nil, authentication.AuthParams{
 		AuthTag:     relation.Tag(),
 		Credentials: "dummy-secret",
 	})
@@ -165,7 +165,7 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.LocalUserAuthenticator{Bakery: &service, Clock: testclock.NewClock(time.Time{})}
-	_, err = authenticator.Authenticate(context.TODO(), s.ControllerModel(c).State(), authentication.AuthParams{
+	_, err = authenticator.Authenticate(context.Background(), s.ControllerModel(c).State(), authentication.AuthParams{
 		AuthTag:   user.Tag(),
 		Macaroons: macaroons,
 	})
@@ -181,7 +181,7 @@ func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
 	service := mockBakeryService{}
 	clock := testclock.NewClock(time.Time{})
 	_, err := authentication.CreateLocalLoginMacaroon(
-		context.TODO(),
+		context.Background(),
 		names.NewUserTag("bobbrown"), &service, clock, bakery.LatestVersion,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -203,7 +203,7 @@ func (s *userAuthenticatorSuite) TestAuthenticateLocalLoginMacaroon(c *gc.C) {
 
 	service.SetErrors(nil, &bakery.VerificationError{})
 	_, err := authenticator.Authenticate(
-		context.TODO(),
+		context.Background(),
 		authentication.EntityFinder(nil),
 		authentication.AuthParams{
 			AuthTag: names.NewUserTag("bobbrown"),
@@ -346,7 +346,7 @@ func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
 		}
 
 		// Authenticate once to obtain the macaroon to be discharged.
-		_, err := authenticator.Authenticate(context.TODO(), test.finder, authentication.AuthParams{})
+		_, err := authenticator.Authenticate(context.Background(), test.finder, authentication.AuthParams{})
 
 		// Discharge the macaroon.
 		dischargeErr := errors.Cause(err).(*apiservererrors.DischargeRequiredError)
@@ -355,7 +355,7 @@ func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Authenticate again with the discharged macaroon.
-		entity, err := authenticator.Authenticate(context.TODO(), test.finder, authentication.AuthParams{
+		entity, err := authenticator.Authenticate(context.Background(), test.finder, authentication.AuthParams{
 			Macaroons: []macaroon.Slice{ms},
 		})
 		if test.expectError != "" {

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -217,7 +217,7 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 	}
 	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
-	mac, err := authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
+	mac, err := authContext.CreateConsumeOfferMacaroon(context.Background(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 	cav := mac.M().Caveats()
 	c.Assert(cav, gc.HasLen, 4)
@@ -231,7 +231,7 @@ func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
 	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := authContext.CreateRemoteRelationMacaroon(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(), "mysql-uuid", "mary", names.NewRelationTag("mediawiki:db mysql:server"), bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 	cav := mac.M().Caveats()
@@ -247,7 +247,7 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("username", "mary"),
@@ -257,7 +257,7 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	attr, err := authContext.Authenticator().CheckOfferMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
@@ -276,7 +276,7 @@ func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
 	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("username", "mary"),
@@ -286,7 +286,7 @@ func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = authContext.Authenticator().CheckOfferMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"prod.another",
 		macaroon.Slice{mac.M()},
@@ -302,7 +302,7 @@ func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
 	authContext, err := crossmodel.NewAuthContext(nil, s.bakeryKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
@@ -311,7 +311,7 @@ func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = authContext.Authenticator().CheckOfferMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
@@ -330,11 +330,11 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
-	mac, err := authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
+	mac, err := authContext.CreateConsumeOfferMacaroon(context.Background(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = authContext.Authenticator().CheckOfferMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
@@ -352,7 +352,7 @@ func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("username", "mary"),
@@ -362,7 +362,7 @@ func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	err = authContext.Authenticator().CheckRelationMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		relationTag,
@@ -377,7 +377,7 @@ func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("username", "mary"),
@@ -387,7 +387,7 @@ func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	err = authContext.Authenticator().CheckRelationMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		names.NewRelationTag("app:db offer:db"),
@@ -405,7 +405,7 @@ func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("relation-key", relationTag.Id()),
@@ -414,7 +414,7 @@ func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	err = authContext.Authenticator().CheckRelationMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		relationTag,
@@ -432,12 +432,12 @@ func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
 	authContext = authContext.WithDischargeURL("http://thirdparty")
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := authContext.CreateRemoteRelationMacaroon(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(), "mysql-uuid", "mary", relationTag, bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = authContext.Authenticator().CheckRelationMacaroons(
-		context.TODO(),
+		context.Background(),
 		coretesting.ModelTag.Id(),
 		"mysql-uuid",
 		relationTag,

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -582,6 +582,7 @@ func RemoveSecretsForAgent(
 // RemoveUserSecrets removes the specified user supplied secrets.
 // The secrets are removed from the state and backend, and the caller must have model admin access.
 func RemoveUserSecrets(
+	ctx context.Context,
 	removeState SecretsRemoveState, adminConfigGetter BackendAdminConfigGetter,
 	authTag names.Tag, args params.DeleteSecretArgs,
 	modelUUID string,
@@ -595,7 +596,7 @@ func RemoveUserSecrets(
 				return errors.Trace(err)
 			}
 			for _, revId := range revs.RevisionIDs() {
-				if err = backend.DeleteContent(context.TODO(), revId); err != nil {
+				if err = backend.DeleteContent(ctx, revId); err != nil {
 					return errors.Trace(err)
 				}
 			}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -984,6 +984,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 	}
 
 	results, err := secrets.RemoveUserSecrets(
+		context.Background(),
 		removeState, adminConfigGetter,
 		names.NewUserTag("foo"),
 		params.DeleteSecretArgs{
@@ -1061,6 +1062,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 	}
 
 	results, err := secrets.RemoveUserSecrets(
+		context.Background(),
 		removeState, adminConfigGetter,
 		names.NewUserTag("foo"),
 		params.DeleteSecretArgs{

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -29,7 +29,6 @@ type Context struct {
 	MultiwatcherFactory_ multiwatcher.Factory
 	ID_                  string
 	RequestRecorder_     facade.RequestRecorder
-	Cancel_              <-chan struct{}
 
 	LeadershipClaimer_     leadership.Claimer
 	LeadershipRevoker_     leadership.Revoker
@@ -51,11 +50,6 @@ type Context struct {
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
 	Identity string
-}
-
-// Cancel is part of the facade.Context interface.
-func (context Context) Cancel() <-chan struct{} {
-	return context.Cancel_
 }
 
 // Auth is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -72,11 +72,6 @@ type Context interface {
 	ObjectStoreFactory
 	Logger
 
-	// Cancel channel represents an indication from the API server that
-	// all interruptable calls should stop. The channel is only ever
-	// closed, and never sents values.
-	Cancel() <-chan struct{}
-
 	// Auth represents information about the connected client. You
 	// should always be checking individual requests against Auth:
 	// both state changes *and* data retrieval should be blocked

--- a/apiserver/facades/agent/secretsdrain/mocks/facade_mock.go
+++ b/apiserver/facades/agent/secretsdrain/mocks/facade_mock.go
@@ -63,20 +63,6 @@ func (mr *MockContextMockRecorder) Auth() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Auth", reflect.TypeOf((*MockContext)(nil).Auth))
 }
 
-// Cancel mocks base method.
-func (m *MockContext) Cancel() <-chan struct{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cancel")
-	ret0, _ := ret[0].(<-chan struct{})
-	return ret0
-}
-
-// Cancel indicates an expected call of Cancel.
-func (mr *MockContextMockRecorder) Cancel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockContext)(nil).Cancel))
-}
-
 // ControllerDB mocks base method.
 func (m *MockContext) ControllerDB() (changestream.WatchableDB, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -124,7 +124,6 @@ func newUniterAPIWithServices(
 		cloudService:            cloudService,
 		credentialService:       credentialService,
 		clock:                   aClock,
-		cancel:                  context.Cancel(),
 		auth:                    authorizer,
 		resources:               resources,
 		leadershipChecker:       leadershipChecker,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -79,7 +79,6 @@ type UniterAPI struct {
 	credentialService       CredentialService
 	controllerConfigService ControllerConfigService
 	clock                   clock.Clock
-	cancel                  <-chan struct{}
 	auth                    facade.Authorizer
 	resources               facade.Resources
 	leadershipChecker       leadership.Checker

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -279,7 +279,7 @@ func (s *unitUpgradeStepsSuite) expectSetAndApplyStateOperation(err1, err2 error
 		controller.MaxAgentStateSize: 456,
 	}
 
-	s.ctrlConfigGetter.EXPECT().ControllerConfig(context.Background()).Return(ctrlCfg, nil)
+	s.ctrlConfigGetter.EXPECT().ControllerConfig(gomock.Any()).Return(ctrlCfg, nil)
 
 	expLimits := state.UnitStateSizeLimits{
 		MaxCharmStateSize: 123,

--- a/apiserver/facades/client/charms/services/storage_test.go
+++ b/apiserver/facades/client/charms/services/storage_test.go
@@ -99,7 +99,7 @@ func (s *storageTestSuite) TestStoreBlobAlreadyStored(c *gc.C) {
 
 	// As the blob is already uploaded (to another path), we need to remove
 	// the duplicate we just uploaded from the store.
-	s.storageBackend.EXPECT().Remove(context.Background(), expStoreCharmPath).Return(nil)
+	s.storageBackend.EXPECT().Remove(gomock.Any(), expStoreCharmPath).Return(nil)
 
 	err := s.storage.Store(context.Background(), curl, dlCharm)
 	c.Assert(err, jc.ErrorIsNil) // charm already uploaded by someone; no error

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -407,7 +407,7 @@ func (s *findToolsSuite) TestFindToolsIAAS(c *gc.C) {
 		authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil),
 
 		backend.EXPECT().Model().Return(model, nil),
-		toolsFinder.EXPECT().FindAgents(context.Background(), common.FindAgentsParams{MajorVersion: 2}).
+		toolsFinder.EXPECT().FindAgents(gomock.Any(), common.FindAgentsParams{MajorVersion: 2}).
 			Return(simpleStreams, nil),
 		model.EXPECT().Type().Return(state.ModelTypeIAAS),
 	)

--- a/apiserver/facades/client/keymanager/keymanager_test.go
+++ b/apiserver/facades/client/keymanager/keymanager_test.go
@@ -162,21 +162,21 @@ func (s *keyManagerSuite) assertAddKeys(c *gc.C) {
 
 func (s *keyManagerSuite) TestAddKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertAddKeys(c)
 }
 
 func (s *keyManagerSuite) TestAddKeysSuperUser(c *gc.C) {
 	s.apiUser = names.NewUserTag("superuser-fred")
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertAddKeys(c)
 }
 
 func (s *keyManagerSuite) TestAddKeysModelAdmin(c *gc.C) {
 	s.apiUser = names.NewUserTag("admin" + coretesting.ModelTag.String())
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertAddKeys(c)
 }
 
@@ -191,7 +191,7 @@ func (s *keyManagerSuite) TestAddKeysNonAuthorised(c *gc.C) {
 
 func (s *keyManagerSuite) TestBlockAddKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(errors.OperationBlockedError("TestAddKeys"))
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(errors.OperationBlockedError("TestAddKeys"))
 
 	_, err := s.api.AddKeys(context.Background(), params.ModifyUserSSHKeys{})
 
@@ -200,7 +200,7 @@ func (s *keyManagerSuite) TestBlockAddKeys(c *gc.C) {
 
 func (s *keyManagerSuite) TestAddJujuSystemKey(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.setAuthorizedKeys(c, sshtesting.ValidKeyOne.Key)
 
 	newAttrs := map[string]interface{}{
@@ -249,21 +249,21 @@ func (s *keyManagerSuite) assertDeleteKeys(c *gc.C) {
 
 func (s *keyManagerSuite) TestDeleteKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(nil)
 	s.assertDeleteKeys(c)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysSuperUser(c *gc.C) {
 	s.apiUser = names.NewUserTag("superuser-fred")
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(nil)
 	s.assertDeleteKeys(c)
 }
 
 func (s *keyManagerSuite) TestDeleteKeysModelAdmin(c *gc.C) {
 	s.apiUser = names.NewUserTag("admin" + coretesting.ModelTag.String())
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(nil)
 	s.assertDeleteKeys(c)
 }
 
@@ -278,7 +278,7 @@ func (s *keyManagerSuite) TestDeleteKeysNonAuthorised(c *gc.C) {
 
 func (s *keyManagerSuite) TestBlockDeleteKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(errors.OperationBlockedError("TestDeleteKeys"))
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(errors.OperationBlockedError("TestDeleteKeys"))
 
 	_, err := s.api.DeleteKeys(context.Background(), params.ModifyUserSSHKeys{})
 
@@ -287,7 +287,7 @@ func (s *keyManagerSuite) TestBlockDeleteKeys(c *gc.C) {
 
 func (s *keyManagerSuite) TestDeleteJujuSystemKey(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(nil)
 
 	key1 := sshtesting.ValidKeyOne.Key + " juju-client-key"
 	key2 := sshtesting.ValidKeyTwo.Key + " " + config.JujuSystemKey
@@ -317,7 +317,7 @@ func (s *keyManagerSuite) TestDeleteJujuSystemKey(c *gc.C) {
 // to remove the client and system key
 func (s *keyManagerSuite) TestCannotDeleteAllKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().RemoveAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().RemoveAllowed(gomock.Any()).Return(nil)
 
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	key2 := sshtesting.ValidKeyTwo.Key
@@ -390,21 +390,21 @@ func (s *keyManagerSuite) assertImportKeys(c *gc.C) {
 
 func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertImportKeys(c)
 }
 
 func (s *keyManagerSuite) TestImportKeysSuperUser(c *gc.C) {
 	s.apiUser = names.NewUserTag("superuser-fred")
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertImportKeys(c)
 }
 
 func (s *keyManagerSuite) TestImportKeysModelAdmin(c *gc.C) {
 	s.apiUser = names.NewUserTag("admin" + coretesting.ModelTag.String())
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.assertImportKeys(c)
 }
 
@@ -419,7 +419,7 @@ func (s *keyManagerSuite) TestImportKeysNonAuthorised(c *gc.C) {
 
 func (s *keyManagerSuite) TestImportJujuSystemKey(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(nil)
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 
 	key1 := sshtesting.ValidKeyOne.Key
 	s.setAuthorizedKeys(c, key1)
@@ -443,7 +443,7 @@ func (s *keyManagerSuite) TestImportJujuSystemKey(c *gc.C) {
 
 func (s *keyManagerSuite) TestBlockImportKeys(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.blockChecker.EXPECT().ChangeAllowed(context.Background()).Return(errors.OperationBlockedError("TestImportKeys"))
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(errors.OperationBlockedError("TestImportKeys"))
 
 	_, err := s.api.ImportKeys(context.Background(), params.ModifyUserSSHKeys{})
 

--- a/apiserver/facades/client/machinemanager/instance_information.go
+++ b/apiserver/facades/client/machinemanager/instance_information.go
@@ -13,15 +13,17 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
-	envcontext "github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
+// TODO(wallyworld) - this method is unused by juju; do we still need it?
+
 // InstanceTypes returns instance type information for the cloud and region
 // in which the current model is deployed.
-func (mm *MachineManagerAPI) InstanceTypes(cons params.ModelInstanceTypesConstraints) (params.InstanceTypesResults, error) {
-	return instanceTypes(context.TODO(), mm, environs.GetEnviron, cons)
+func (mm *MachineManagerAPI) InstanceTypes(ctx context.Context, cons params.ModelInstanceTypesConstraints) (params.InstanceTypesResults, error) {
+	return instanceTypes(ctx, mm, environs.GetEnviron, cons)
 }
 
 type environGetFunc func(context.Context, environs.EnvironConfigGetter, environs.NewEnvironFunc) (environs.Environ, error)

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -243,7 +243,7 @@ func (facade *Facade) ModelCredentialForSSH(ctx stdcontext.Context) (params.Clou
 		return result, nil
 	}
 
-	token, err := facade.getExecSecretToken(spec, model)
+	token, err := facade.getExecSecretToken(ctx, spec, model)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result, nil
@@ -272,13 +272,13 @@ func (facade *Facade) ModelCredentialForSSH(ctx stdcontext.Context) (params.Clou
 	return result, nil
 }
 
-func (facade *Facade) getExecSecretToken(cloudSpec environscloudspec.CloudSpec, model Model) (string, error) {
+func (facade *Facade) getExecSecretToken(ctx stdcontext.Context, cloudSpec environscloudspec.CloudSpec, model Model) (string, error) {
 	cfg, err := model.Config()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 
-	broker, err := facade.getBroker(stdcontext.TODO(), environs.OpenParams{
+	broker, err := facade.getBroker(ctx, environs.OpenParams{
 		ControllerUUID: model.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,

--- a/apiserver/facades/controller/actionpruner/pruner.go
+++ b/apiserver/facades/controller/actionpruner/pruner.go
@@ -16,7 +16,6 @@ import (
 // API provides access to the action pruner API.
 type API struct {
 	*common.ModelWatcher
-	cancel     <-chan struct{}
 	st         *state.State
 	authorizer facade.Authorizer
 }
@@ -37,5 +36,5 @@ func (api *API) Prune(ctx context.Context, p params.ActionPruneArgs) error {
 		return apiservererrors.ErrPerm
 	}
 
-	return Prune(api.cancel, api.st, p.MaxHistoryTime, p.MaxHistoryMB)
+	return Prune(ctx.Done(), api.st, p.MaxHistoryTime, p.MaxHistoryMB)
 }

--- a/apiserver/facades/controller/actionpruner/register.go
+++ b/apiserver/facades/controller/actionpruner/register.go
@@ -29,6 +29,5 @@ func newAPI(ctx facade.Context) (*API, error) {
 		ModelWatcher: common.NewModelWatcher(m, ctx.Resources(), ctx.Auth()),
 		st:           ctx.State(),
 		authorizer:   ctx.Auth(),
-		cancel:       ctx.Cancel(),
 	}, nil
 }

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -62,20 +62,6 @@ func (mr *MockContextMockRecorder) Auth() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Auth", reflect.TypeOf((*MockContext)(nil).Auth))
 }
 
-// Cancel mocks base method.
-func (m *MockContext) Cancel() <-chan struct{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cancel")
-	ret0, _ := ret[0].(<-chan struct{})
-	return ret0
-}
-
-// Cancel indicates an expected call of Cancel.
-func (mr *MockContextMockRecorder) Cancel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockContext)(nil).Cancel))
-}
-
 // ControllerDB mocks base method.
 func (m *MockContext) ControllerDB() (changestream.WatchableDB, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -55,7 +55,7 @@ type CharmhubRefreshClient interface {
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, now time.Time, logger loggo.Logger) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(parentCtx context.Context, client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, now time.Time, logger loggo.Logger) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -75,7 +75,7 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 	}
 	config := charmhub.RefreshMany(cfgs...)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), charmhub.RefreshTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, charmhub.RefreshTimeout)
 	defer cancel()
 	responses, err := client.RefreshWithRequestMetrics(ctx, config, metrics)
 	if err != nil {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -149,7 +149,7 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeVa
 	}
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -272,7 +272,7 @@ func (s *crossmodelRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 		relationId:      1,
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -356,7 +356,7 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChanges(c *gc.C) {
 		relationId:      1,
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -399,7 +399,7 @@ func (s *crossmodelRelationsSuite) TestPublishIngressNetworkChangesRejected(c *g
 		config.SAASIngressAllowKey: "10.1.1.1/8",
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -435,7 +435,7 @@ func (s *crossmodelRelationsSuite) TestWatchEgressAddressesForRelations(c *gc.C)
 		relationId:      1,
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -488,7 +488,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatus(c *gc.C) {
 		relationId:      1,
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -533,7 +533,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatusRelationNotFound(c *g
 		relationId:      1,
 	}
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -585,7 +585,7 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	s.st.applications["mysql"] = app
 	s.st.remoteEntities[names.NewApplicationOfferTag("f47ac10b-58cc-4372-a567-0e02b2c3d479")] = "token-hosted-mysql"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -652,7 +652,7 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettingsRemo
 	}
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -721,7 +721,7 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettingsRemo
 	}
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -795,7 +795,7 @@ func (s *crossmodelRelationsSuite) TestResumeRelationPermissionCheck(c *gc.C) {
 	}
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -869,7 +869,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 	s.st.offerUUIDs["db2:db django:db"] = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),
@@ -945,7 +945,7 @@ func (s *crossmodelRelationsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	s.st.remoteEntities[names.NewApplicationTag("postgresql")] = "token-postgresql"
 
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.st.ModelUUID()),

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -187,7 +187,7 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 	)
 
 	mac, err := s.bakery.NewMacaroon(
-		context.TODO(),
+		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("username", "mary"),

--- a/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
@@ -80,7 +80,7 @@ func (s *ExternalControllerUpdaterAPI) ExternalControllerInfo(ctx context.Contex
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		controllerInfo, err := s.ecService.Controller(context.TODO(), controllerTag.Id())
+		controllerInfo, err := s.ecService.Controller(ctx, controllerTag.Id())
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
@@ -106,7 +106,7 @@ func (s *ExternalControllerUpdaterAPI) SetExternalControllerInfo(ctx context.Con
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if err := s.ecService.UpdateExternalController(context.TODO(), crossmodel.ControllerInfo{
+		if err := s.ecService.UpdateExternalController(ctx, crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
 			Alias:         arg.Info.Alias,
 			Addrs:         arg.Info.Addrs,

--- a/apiserver/facades/controller/migrationmaster/backend.go
+++ b/apiserver/facades/controller/migrationmaster/backend.go
@@ -4,6 +4,8 @@
 package migrationmaster
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 
@@ -23,7 +25,7 @@ type Backend interface {
 	ModelUUID() string
 	ModelName() (string, error)
 	ModelOwner() (names.UserTag, error)
-	AgentVersion() (version.Number, error)
+	AgentVersion(ctx context.Context) (version.Number, error)
 	RemoveExportingModelDocs() error
 	ControllerConfig() (controller.Config, error)
 	AllLocalRelatedModels() ([]string, error)

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -163,7 +163,7 @@ func (api *API) ModelInfo(ctx context.Context) (params.MigrationModelInfo, error
 		return empty, errors.Annotate(err, "retrieving model owner")
 	}
 
-	vers, err := api.backend.AgentVersion()
+	vers, err := api.backend.AgentVersion(ctx)
 	if err != nil {
 		return empty, errors.Annotate(err, "retrieving agent version")
 	}

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -175,7 +175,7 @@ func (s *Suite) TestModelInfo(c *gc.C) {
 	exp.ModelUUID().Return("model-uuid")
 	exp.ModelName().Return("model-name", nil)
 	exp.ModelOwner().Return(names.NewUserTag("owner"), nil)
-	exp.AgentVersion().Return(version.MustParse("1.2.3"), nil)
+	exp.AgentVersion(gomock.Any()).Return(version.MustParse("1.2.3"), nil)
 
 	mod, err := s.mustMakeAPI(c).ModelInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -47,18 +47,18 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 }
 
 // AgentVersion mocks base method.
-func (m *MockBackend) AgentVersion() (version.Number, error) {
+func (m *MockBackend) AgentVersion(arg0 context.Context) (version.Number, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AgentVersion")
+	ret := m.ctrl.Call(m, "AgentVersion", arg0)
 	ret0, _ := ret[0].(version.Number)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AgentVersion indicates an expected call of AgentVersion.
-func (mr *MockBackendMockRecorder) AgentVersion() *gomock.Call {
+func (mr *MockBackendMockRecorder) AgentVersion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentVersion", reflect.TypeOf((*MockBackend)(nil).AgentVersion))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentVersion", reflect.TypeOf((*MockBackend)(nil).AgentVersion), arg0)
 }
 
 // AllLocalRelatedModels mocks base method.

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -43,13 +43,13 @@ func (s *backend) ModelOwner() (names.UserTag, error) {
 }
 
 // AgentVersion implements Backend.
-func (s *backend) AgentVersion() (version.Number, error) {
+func (s *backend) AgentVersion(ctx context.Context) (version.Number, error) {
 	m, err := s.Model()
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}
 
-	cfg, err := m.ModelConfig(context.TODO())
+	cfg, err := m.ModelConfig(ctx)
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/singular/singular_test.go
+++ b/apiserver/facades/controller/singular/singular_test.go
@@ -162,7 +162,7 @@ func (s *SingularSuite) TestWait(c *gc.C) {
 	backend.stub.SetErrors(errors.New("zap!"), nil)
 	facade, err := singular.NewFacade(backend, backend, mockAuth{})
 	c.Assert(err, jc.ErrorIsNil)
-	result := facade.Wait(context.TODO(), waits)
+	result := facade.Wait(context.Background(), waits)
 	c.Assert(result.Results, gc.HasLen, count)
 
 	checkDenied(c, result.Results[0])

--- a/apiserver/facades/controller/statushistory/api.go
+++ b/apiserver/facades/controller/statushistory/api.go
@@ -16,7 +16,6 @@ import (
 // API is the concrete implementation of the Pruner endpoint.
 type API struct {
 	*common.ModelWatcher
-	cancel     <-chan struct{}
 	st         *state.State
 	authorizer facade.Authorizer
 }
@@ -36,5 +35,5 @@ func (api *API) Prune(ctx context.Context, p params.StatusHistoryPruneArgs) erro
 	if !api.authorizer.AuthController() {
 		return apiservererrors.ErrPerm
 	}
-	return Prune(api.cancel, api.st, p.MaxHistoryTime, p.MaxHistoryMB)
+	return Prune(ctx.Done(), api.st, p.MaxHistoryTime, p.MaxHistoryMB)
 }

--- a/apiserver/facades/controller/statushistory/register.go
+++ b/apiserver/facades/controller/statushistory/register.go
@@ -29,6 +29,5 @@ func newAPI(ctx facade.Context) (*API, error) {
 		ModelWatcher: common.NewModelWatcher(m, ctx.Resources(), ctx.Auth()),
 		st:           ctx.State(),
 		authorizer:   ctx.Auth(),
-		cancel:       ctx.Cancel(),
 	}, nil
 }

--- a/apiserver/facades/controller/usersecrets/secrets.go
+++ b/apiserver/facades/controller/usersecrets/secrets.go
@@ -4,6 +4,8 @@
 package usersecrets
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -49,8 +51,9 @@ func (s *UserSecretsManager) WatchRevisionsToPrune() (params.StringsWatchResult,
 }
 
 // DeleteRevisions deletes the specified revisions of the specified secret.
-func (s *UserSecretsManager) DeleteRevisions(args params.DeleteSecretArgs) (params.ErrorResults, error) {
+func (s *UserSecretsManager) DeleteRevisions(ctx context.Context, args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveUserSecrets(
+		ctx,
 		s.secretsState, s.backendConfigGetter,
 		s.authTag, args, s.modelUUID,
 		func(uri *coresecrets.URI) error {

--- a/apiserver/facades/controller/usersecrets/secrets_test.go
+++ b/apiserver/facades/controller/usersecrets/secrets_test.go
@@ -4,6 +4,7 @@
 package usersecrets_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/collections/set"
@@ -132,6 +133,7 @@ func (s *userSecretsSuite) TestDeleteRevisionsAutoPruneEnabled(c *gc.C) {
 	).Return(nil)
 
 	results, err := s.facade.DeleteRevisions(
+		context.Background(),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{
 				{
@@ -157,6 +159,7 @@ func (s *userSecretsSuite) TestDeleteRevisionsAutoPruneDisabled(c *gc.C) {
 	}, nil).Times(2)
 
 	results, err := s.facade.DeleteRevisions(
+		context.Background(),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{
 				{

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -655,11 +655,6 @@ type facadeContext struct {
 	key objectKey
 }
 
-// Cancel is part of the facade.Context interface.
-func (ctx *facadeContext) Cancel() <-chan struct{} {
-	return ctx.r.shared.cancel
-}
-
 // Auth is part of the facade.Context interface.
 func (ctx *facadeContext) Auth() facade.Authorizer {
 	return ctx.r.authorizer

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -162,14 +162,14 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	// fine
 	caller, err := srvRoot.FindMethod("my-testing-facade", 1, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = caller.Call(context.TODO(), "", reflect.Value{})
+	_, err = caller.Call(context.Background(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches, "Exposed was bogus")
 
 	// However, myBadFacade returns the wrong type, so trying to access it
 	// should create an error
 	caller, err = srvRoot.FindMethod("my-testing-facade", 0, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = caller.Call(context.TODO(), "", reflect.Value{})
+	_, err = caller.Call(context.Background(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches,
 		`internal error, my-testing-facade\(0\) claimed to return \*apiserver_test.testingType but returned \*apiserver_test.badType`)
 
@@ -177,7 +177,7 @@ func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
 	// error, but that shouldn't trigger the type checking code.
 	caller, err = srvRoot.FindMethod("my-testing-facade", 2, "Exposed")
 	c.Assert(err, jc.ErrorIsNil)
-	res, err := caller.Call(context.TODO(), "", reflect.Value{})
+	res, err := caller.Call(context.Background(), "", reflect.Value{})
 	c.Check(err, gc.ErrorMatches, `you shall not pass`)
 	c.Check(res.IsValid(), jc.IsFalse)
 }
@@ -200,7 +200,7 @@ func (ct *countingType) AltCount() stringVar {
 }
 
 func assertCallResult(c *gc.C, caller rpcreflect.MethodCaller, id string, expected string) {
-	v, err := caller.Call(context.TODO(), id, reflect.Value{})
+	v, err := caller.Call(context.Background(), id, reflect.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(v.Interface(), gc.Equals, stringVar{expected})
 }
@@ -287,10 +287,10 @@ func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
 	// This is designed to trigger the race detector
 	var wg sync.WaitGroup
 	wg.Add(4)
-	go func() { caller.Call(context.TODO(), "first", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call(context.TODO(), "second", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call(context.TODO(), "first", reflect.Value{}); wg.Done() }()
-	go func() { caller.Call(context.TODO(), "second", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.Background(), "first", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.Background(), "second", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.Background(), "first", reflect.Value{}); wg.Done() }()
+	go func() { caller.Call(context.Background(), "second", reflect.Value{}); wg.Done() }()
 	wg.Wait()
 	// Once we're done, we should have only instantiated 2 different
 	// objects. If we pass a different Id, we should be at 3 total count.

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -47,7 +47,6 @@ type sharedServerContext struct {
 	presence             presence.Recorder
 	leaseManager         lease.Manager
 	logger               loggo.Logger
-	cancel               <-chan struct{}
 	charmhubHTTPClient   facade.HTTPClient
 	dbGetter             changestream.WatchableDBGetter
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 func (s *agentAuthenticatorSuite) TestAuthenticateLoginRequestHandleNotSupportedRequests(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, err := s.authenticator.AuthenticateLoginRequest(context.TODO(), "", "", authentication.AuthParams{Token: "token"})
+	_, err := s.authenticator.AuthenticateLoginRequest(context.Background(), "", "", authentication.AuthParams{Token: "token"})
 	c.Assert(err, jc.ErrorIs, errors.NotSupported)
 }
 
@@ -47,7 +47,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	c.Assert(authenticator, gc.NotNil)
 	userFinder := userFinder{user}
 
-	entity, err := authenticator.Authenticate(context.TODO(), userFinder, authentication.AuthParams{
+	entity, err := authenticator.Authenticate(context.Background(), userFinder, authentication.AuthParams{
 		AuthTag:     user.Tag(),
 		Credentials: "password",
 		Nonce:       "nonce",

--- a/apiserver/stateauthenticator/locallogin.go
+++ b/apiserver/stateauthenticator/locallogin.go
@@ -57,8 +57,8 @@ func (h *localLoginHandlers) AddHandlers(mux *apiserverhttp.Mux) {
 	_ = mux.AddHandler("POST", localUserIdentityLocationPath+"/form", dischargeMux)
 }
 
-func (h *localLoginHandlers) bakeryError(w http.ResponseWriter, err error) {
-	httpbakery.WriteError(context.TODO(), w, err)
+func (h *localLoginHandlers) bakeryError(ctx context.Context, w http.ResponseWriter, err error) {
+	httpbakery.WriteError(ctx, w, err)
 }
 
 func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Request) {
@@ -75,7 +75,7 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 	}
 	loginRequest := form.LoginRequest{}
 	if err := httprequest.Unmarshal(reqParams, &loginRequest); err != nil {
-		h.bakeryError(w, errors.Annotate(err, "can't unmarshal login request"))
+		h.bakeryError(ctx, w, errors.Annotate(err, "can't unmarshal login request"))
 		return
 	}
 
@@ -83,7 +83,7 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 	password := loginRequest.Body.Form["password"].(string)
 	userTag := names.NewUserTag(username)
 	if !userTag.IsLocal() {
-		h.bakeryError(w, errors.NotValidf("non-local username %q", username))
+		h.bakeryError(ctx, w, errors.NotValidf("non-local username %q", username))
 		return
 	}
 
@@ -92,13 +92,13 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 		AuthTag:     userTag,
 		Credentials: password,
 	}); err != nil {
-		h.bakeryError(w, err)
+		h.bakeryError(ctx, w, err)
 		return
 	}
 
 	token, err := newID()
 	if err != nil {
-		h.bakeryError(w, errors.Annotate(err, "cannot generate token"))
+		h.bakeryError(ctx, w, errors.Annotate(err, "cannot generate token"))
 		return
 	}
 	h.userTokens[token] = username

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -250,7 +250,7 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 	// No need to verify the server's identity because we verify the SHA-256 hash.
 	logger.Infof("fetching %v agent binaries from %v", v, exactTools.URL)
 	client := jujuhttp.NewClient(jujuhttp.WithSkipHostnameVerification(true))
-	resp, err := client.Get(context.TODO(), exactTools.URL)
+	resp, err := client.Get(ctx, exactTools.URL)
 	if err != nil {
 		return err
 	}

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -346,35 +346,35 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 		},
 	), jc.ErrorIsNil)
 
-	secret, err := s.client.CoreV1().Secrets("test").Get(context.TODO(), "gitlab-application-config", metav1.GetOptions{})
+	secret, err := s.client.CoreV1().Secrets("test").Get(context.Background(), "gitlab-application-config", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(secret, gc.DeepEquals, &appSecret)
 
-	secret, err = s.client.CoreV1().Secrets("test").Get(context.TODO(), "gitlab-nginx-secret", metav1.GetOptions{})
+	secret, err = s.client.CoreV1().Secrets("test").Get(context.Background(), "gitlab-nginx-secret", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(secret, gc.DeepEquals, &nginxPullSecret)
 
-	svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(svc, gc.DeepEquals, &appSvc)
 
-	sa, err := s.client.CoreV1().ServiceAccounts(s.namespace).Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	sa, err := s.client.CoreV1().ServiceAccounts(s.namespace).Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sa, gc.DeepEquals, &appSA)
 
-	r, err := s.client.RbacV1().Roles(s.namespace).Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	r, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r, gc.DeepEquals, &appRole)
 
-	cr, err := s.client.RbacV1().ClusterRoles().Get(context.TODO(), "test-gitlab", metav1.GetOptions{})
+	cr, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), "test-gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cr, gc.DeepEquals, &appClusterRole)
 
-	rb, err := s.client.RbacV1().RoleBindings(s.namespace).Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	rb, err := s.client.RbacV1().RoleBindings(s.namespace).Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rb, gc.DeepEquals, &appRoleBinding)
 
-	crb, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "test-gitlab", metav1.GetOptions{})
+	crb, err := s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "test-gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(crb, gc.DeepEquals, &appClusterRoleBinding)
 
@@ -385,43 +385,43 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 	err := app.Delete()
 	c.Assert(err, jc.ErrorIsNil)
 
-	clusterRoles, err := s.client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
+	clusterRoles, err := s.client.RbacV1().ClusterRoles().List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRoles.Items, gc.IsNil)
 
-	clusterRoleBinding, err := s.client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{})
+	clusterRoleBinding, err := s.client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRoleBinding.Items, gc.IsNil)
 
-	daemonSets, err := s.client.AppsV1().DaemonSets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	daemonSets, err := s.client.AppsV1().DaemonSets(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(daemonSets.Items, gc.IsNil)
 
-	deployments, err := s.client.AppsV1().Deployments(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	deployments, err := s.client.AppsV1().Deployments(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployments.Items, gc.IsNil)
 
-	roles, err := s.client.RbacV1().Roles(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	roles, err := s.client.RbacV1().Roles(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roles.Items, gc.IsNil)
 
-	roleBindings, err := s.client.RbacV1().RoleBindings(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	roleBindings, err := s.client.RbacV1().RoleBindings(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleBindings.Items, gc.IsNil)
 
-	secrets, err := s.client.CoreV1().Secrets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	secrets, err := s.client.CoreV1().Secrets(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(secrets.Items, gc.IsNil)
 
-	services, err := s.client.CoreV1().Services(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	services, err := s.client.CoreV1().Services(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(services.Items, gc.IsNil)
 
-	serviceAccounts, err := s.client.CoreV1().ServiceAccounts(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	serviceAccounts, err := s.client.CoreV1().ServiceAccounts(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(serviceAccounts.Items, gc.IsNil)
 
-	statefulSets, err := s.client.AppsV1().StatefulSets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	statefulSets, err := s.client.AppsV1().StatefulSets(s.namespace).List(context.Background(), metav1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statefulSets.Items, gc.IsNil)
 }
@@ -723,7 +723,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, "", func() {
-			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
+			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -746,7 +746,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 				},
 			})
 
-			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(ss, gc.DeepEquals, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -835,7 +835,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 	)
 	s.assertEnsure(
 		c, app, true, constraints.Value{}, true, "", func() {
-			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
+			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -858,7 +858,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 				},
 			})
 
-			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(ss, gc.DeepEquals, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -923,10 +923,10 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, "", func() {
-			ss, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().Deployments("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 
-			pvc, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "gitlab-database-appuuid", metav1.GetOptions{})
+			pvc, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "gitlab-database-appuuid", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(pvc, gc.DeepEquals, &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -996,10 +996,10 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, "", func() {
-			ss, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().DaemonSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 
-			pvc, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "gitlab-database-appuuid", metav1.GetOptions{})
+			pvc, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "gitlab-database-appuuid", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(pvc, gc.DeepEquals, &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1097,7 +1097,7 @@ func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 		},
 	}
 	dr.SetDeletionTimestamp(&now)
-	_, err = s.client.AppsV1().Deployments("test").Create(context.TODO(),
+	_, err = s.client.AppsV1().Deployments("test").Create(context.Background(),
 		dr, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1136,7 +1136,7 @@ func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 		},
 	}
 	sr.SetDeletionTimestamp(&now)
-	_, err = s.client.AppsV1().StatefulSets("test").Create(context.TODO(),
+	_, err = s.client.AppsV1().StatefulSets("test").Create(context.Background(),
 		sr, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1176,7 +1176,7 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 		},
 	}
 	dmr.SetDeletionTimestamp(&now)
-	_, err = s.client.AppsV1().DaemonSets("test").Create(context.TODO(),
+	_, err = s.client.AppsV1().DaemonSets("test").Create(context.Background(),
 		dmr, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1193,7 +1193,7 @@ func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
 
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, true, "2.9.34", func() {
-		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Assert(len(ss.Spec.Template.Spec.InitContainers), gc.Equals, 1)
@@ -1205,7 +1205,7 @@ func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
 	})
 
 	s.assertEnsure(c, app, false, constraints.Value{}, true, "2.9.37", func() {
-		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Assert(len(ss.Spec.Template.Spec.InitContainers), gc.Equals, 1)
@@ -1348,7 +1348,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentTy
 			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 	}
-	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(),
+	_, err := s.client.CoreV1().Pods("test").Create(context.Background(),
 		pod1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1361,7 +1361,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentTy
 			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 	}
-	_, err = s.client.CoreV1().Pods("test").Create(context.TODO(),
+	_, err = s.client.CoreV1().Pods("test").Create(context.Background(),
 		pod2, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1394,7 +1394,7 @@ func (s *applicationSuite) TestStateStateful(c *gc.C) {
 				Replicas: pointer.Int32Ptr(int32(desiredReplicas)),
 			},
 		}
-		_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(),
+		_, err := s.client.AppsV1().StatefulSets("test").Create(context.Background(),
 			dmr, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 		return desiredReplicas
@@ -1422,7 +1422,7 @@ func (s *applicationSuite) TestStateStateless(c *gc.C) {
 				Replicas: pointer.Int32Ptr(int32(desiredReplicas)),
 			},
 		}
-		_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(),
+		_, err := s.client.AppsV1().Deployments("test").Create(context.Background(),
 			dmr, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 		return desiredReplicas
@@ -1452,7 +1452,7 @@ func (s *applicationSuite) TestStateDaemon(c *gc.C) {
 				DesiredNumberScheduled: int32(desiredReplicas),
 			},
 		}
-		_, err := s.client.AppsV1().DaemonSets("test").Create(context.TODO(),
+		_, err := s.client.AppsV1().DaemonSets("test").Create(context.Background(),
 			dmr, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 		return desiredReplicas
@@ -1486,7 +1486,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	getMainResourceSpec := func() *appsv1.Deployment {
@@ -1576,7 +1576,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 			},
 		}
 	}
-	_, err = s.client.AppsV1().Deployments("test").Create(context.TODO(), getMainResourceSpec(), metav1.CreateOptions{})
+	_, err = s.client.AppsV1().Deployments("test").Create(context.Background(), getMainResourceSpec(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -1619,7 +1619,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	getMainResourceSpec := func() *appsv1.StatefulSet {
@@ -1709,7 +1709,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 			},
 		}
 	}
-	_, err = s.client.AppsV1().StatefulSets("test").Create(context.TODO(), getMainResourceSpec(), metav1.CreateOptions{})
+	_, err = s.client.AppsV1().StatefulSets("test").Create(context.Background(), getMainResourceSpec(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -1752,7 +1752,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	getMainResourceSpec := func() *appsv1.DaemonSet {
@@ -1802,7 +1802,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 			},
 		}
 	}
-	_, err = s.client.AppsV1().DaemonSets("test").Create(context.TODO(), getMainResourceSpec(), metav1.CreateOptions{})
+	_, err = s.client.AppsV1().DaemonSets("test").Create(context.Background(), getMainResourceSpec(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -1845,7 +1845,7 @@ func (s *applicationSuite) TestUpdatePortsInvalidProtocol(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(app.UpdatePorts([]caas.ServicePort{
@@ -1871,7 +1871,7 @@ func (s *applicationSuite) TestUpdatePortsWithExistingPorts(c *gc.C) {
 			Protocol:   corev1.ProtocolTCP,
 		},
 	}
-	svc, err := s.client.CoreV1().Services("test").Create(context.TODO(), existingSvc, metav1.CreateOptions{})
+	svc, err := s.client.CoreV1().Services("test").Create(context.Background(), existingSvc, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(svc.Spec.Ports, gc.DeepEquals, existingSvc.Spec.Ports)
 
@@ -1956,7 +1956,7 @@ func (s *applicationSuite) TestUpdatePortsStateless(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -1990,7 +1990,7 @@ func (s *applicationSuite) TestUpdatePortsStateful(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -2024,7 +2024,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdate(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), getDefaultSvc(), metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedSvc := getDefaultSvc()
@@ -2241,7 +2241,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 				},
 			}
 		}
-		_, err := s.client.CoreV1().Pods(s.namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+		_, err := s.client.CoreV1().Pods(s.namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		pvc := corev1.PersistentVolumeClaim{
@@ -2270,7 +2270,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 				Phase: corev1.ClaimBound,
 			},
 		}
-		_, err = s.client.CoreV1().PersistentVolumeClaims(s.namespace).Create(context.TODO(), &pvc, metav1.CreateOptions{})
+		_, err = s.client.CoreV1().PersistentVolumeClaims(s.namespace).Create(context.Background(), &pvc, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		pv := corev1.PersistentVolume{
@@ -2290,7 +2290,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 				Message: "volume bound",
 			},
 		}
-		_, err = s.client.CoreV1().PersistentVolumes().Create(context.TODO(), &pv, metav1.CreateOptions{})
+		_, err = s.client.CoreV1().PersistentVolumes().Create(context.Background(), &pv, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -2601,13 +2601,13 @@ func (s *applicationSuite) TestServiceActive(c *gc.C) {
 	testSvc := getDefaultSvc()
 	testSvc.UID = "deadbeaf"
 	testSvc.Spec.ClusterIP = "10.6.6.6"
-	_, err := s.client.CoreV1().Services("test").Update(context.TODO(), testSvc, metav1.UpdateOptions{})
+	_, err := s.client.CoreV1().Services("test").Update(context.Background(), testSvc, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	ss.Status.ReadyReplicas = 3
-	_, err = s.client.AppsV1().StatefulSets("test").Update(context.TODO(), ss, metav1.UpdateOptions{})
+	_, err = s.client.AppsV1().StatefulSets("test").Update(context.Background(), ss, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	svc, err := app.Service()
@@ -2640,7 +2640,7 @@ func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
 	testSvc := getDefaultSvc()
 	testSvc.UID = "deadbeaf"
 	testSvc.Spec.ClusterIP = "10.6.6.6"
-	_, err := s.client.CoreV1().Services("test").Update(context.TODO(), testSvc, metav1.UpdateOptions{})
+	_, err := s.client.CoreV1().Services("test").Update(context.Background(), testSvc, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = app.Service()
@@ -2657,7 +2657,7 @@ func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
 	testSvc := getDefaultSvc()
 	testSvc.UID = "deadbeaf"
 	testSvc.Spec.ClusterIP = "10.6.6.6"
-	_, err := s.client.CoreV1().Services("test").Update(context.TODO(), testSvc, metav1.UpdateOptions{})
+	_, err := s.client.CoreV1().Services("test").Update(context.Background(), testSvc, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = app.Service()
@@ -2674,14 +2674,14 @@ func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
 	testSvc := getDefaultSvc()
 	testSvc.UID = "deadbeaf"
 	testSvc.Spec.ClusterIP = "10.6.6.6"
-	_, err := s.client.CoreV1().Services("test").Update(context.TODO(), testSvc, metav1.UpdateOptions{})
+	_, err := s.client.CoreV1().Services("test").Update(context.Background(), testSvc, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	now := metav1.Now()
 	ss.DeletionTimestamp = &now
-	_, err = s.client.AppsV1().StatefulSets("test").Update(context.TODO(), ss, metav1.UpdateOptions{})
+	_, err = s.client.AppsV1().StatefulSets("test").Update(context.Background(), ss, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	svc, err := app.Service()
@@ -2714,13 +2714,13 @@ func (s *applicationSuite) TestServiceError(c *gc.C) {
 	testSvc := getDefaultSvc()
 	testSvc.UID = "deadbeaf"
 	testSvc.Spec.ClusterIP = "10.6.6.6"
-	_, err := s.client.CoreV1().Services("test").Update(context.TODO(), testSvc, metav1.UpdateOptions{})
+	_, err := s.client.CoreV1().Services("test").Update(context.Background(), testSvc, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	ss.Status.ReadyReplicas = 0
-	_, err = s.client.AppsV1().StatefulSets("test").Update(context.TODO(), ss, metav1.UpdateOptions{})
+	_, err = s.client.AppsV1().StatefulSets("test").Update(context.Background(), ss, metav1.UpdateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	evt := corev1.Event{
@@ -2736,10 +2736,10 @@ func (s *applicationSuite) TestServiceError(c *gc.C) {
 		Reason:  "FailedCreate",
 		Message: "0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims.",
 	}
-	_, err = s.client.CoreV1().Events("test").Create(context.TODO(), &evt, metav1.CreateOptions{})
+	_, err = s.client.CoreV1().Events("test").Create(context.Background(), &evt, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
-		_ = s.client.CoreV1().Events("test").Delete(context.TODO(), evt.GetName(), metav1.DeleteOptions{})
+		_ = s.client.CoreV1().Events("test").Delete(context.Background(), evt.GetName(), metav1.DeleteOptions{})
 	}()
 
 	svc, err := app.Service()
@@ -2767,7 +2767,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, "", func() {
-			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
+			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2803,7 +2803,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 				ps.Containers[i].Resources.Limits = resourceRequests
 			}
 
-			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(ss, gc.DeepEquals, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2882,7 +2882,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 		},
 	}
 
-	_, err := s.client.CoreV1().Secrets(s.namespace).Create(context.TODO(), &unusedPullSecret,
+	_, err := s.client.CoreV1().Secrets(s.namespace).Create(context.Background(), &unusedPullSecret,
 		metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2902,16 +2902,16 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 			corev1.DockerConfigJsonKey: pullSecretConfig,
 		},
 	}
-	_, err = s.client.CoreV1().Secrets(s.namespace).Create(context.TODO(), &nginxPullSecret,
+	_, err = s.client.CoreV1().Secrets(s.namespace).Create(context.Background(), &nginxPullSecret,
 		metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertEnsure(c, app, false, constraints.Value{}, true, "", func() {})
 
-	_, err = s.client.CoreV1().Secrets(s.namespace).Get(context.TODO(), "gitlab-oldcontainer-secret", metav1.GetOptions{})
+	_, err = s.client.CoreV1().Secrets(s.namespace).Get(context.Background(), "gitlab-oldcontainer-secret", metav1.GetOptions{})
 	c.Assert(err, gc.ErrorMatches, `secrets "gitlab-oldcontainer-secret" not found`)
 
-	secret, err := s.client.CoreV1().Secrets(s.namespace).Get(context.TODO(), "gitlab-nginx-secret", metav1.GetOptions{})
+	secret, err := s.client.CoreV1().Secrets(s.namespace).Get(context.Background(), "gitlab-nginx-secret", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(secret, gc.NotNil)
 	newPullSecretConfig, _ := k8sutils.CreateDockerConfigJSON("username", "password", "docker.io/library/nginx:latest")
@@ -3014,7 +3014,7 @@ func (s *applicationSuite) TestLimits(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, "", func() {
-			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			for _, ctr := range ss.Spec.Template.Spec.Containers {
 				c.Check(ctr.Resources.Limits, gc.DeepEquals, limits)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -120,7 +120,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.pcfg = pcfg
 	s.controllerStackerGetter = func() provider.ControllerStackerForTest {
 		controllerStacker, err := provider.NewcontrollerStackForTest(
-			envtesting.BootstrapContext(context.TODO(), c), "juju-controller-test", "some-storage", s.broker, s.pcfg,
+			envtesting.BootstrapContext(context.Background(), c), "juju-controller-test", "some-storage", s.broker, s.pcfg,
 		)
 		c.Assert(err, jc.ErrorIsNil)
 		return controllerStacker
@@ -176,7 +176,7 @@ func (s *bootstrapSuite) TestFindControllerNamespace(c *gc.C) {
 	for _, test := range tests {
 		client := fake.NewSimpleClientset()
 		_, err := client.CoreV1().Namespaces().Create(
-			context.TODO(),
+			context.Background(),
 			&test.Namespace,
 			v1.CreateOptions{},
 		)
@@ -334,7 +334,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil
 	}
-	_, err := s.mockNamespaces.Get(context.TODO(), s.namespace, v1.GetOptions{})
+	_, err := s.mockNamespaces.Get(context.Background(), s.namespace, v1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 
 	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
@@ -1226,7 +1226,7 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *gc.C) {
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil
 	}
-	_, err := s.mockNamespaces.Get(context.TODO(), s.namespace, v1.GetOptions{})
+	_, err := s.mockNamespaces.Get(context.Background(), s.namespace, v1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 
 	var watchers []k8swatcher.KubernetesNotifyWatcher

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -58,7 +58,7 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
 		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
 	)
-	_, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).Create(context.TODO(),
+	_, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).Create(context.Background(),
 		&apps.StatefulSet{
 			ObjectMeta: meta.ObjectMeta{
 				Name: appName,
@@ -86,7 +86,7 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 	c.Assert(controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
 
 	ss, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).
-		Get(context.TODO(), appName, meta.GetOptions{})
+		Get(context.Background(), appName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -248,8 +248,8 @@ func (s *K8sBrokerSuite) TestBootstrapNoOperatorStorage(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
-	callCtx := envcontext.WithoutCredentialInvalidator(context.Background())
+	ctx := envtesting.BootstrapContext(context.Background(), c)
+	callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
 	bootstrapParams := environs.BootstrapParams{
 		ControllerConfig:         testing.FakeControllerConfig(),
 		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
@@ -269,8 +269,8 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	// Ensure the broker is configured with operator storage.
 	s.setupOperatorStorageConfig(c)
 
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
-	callCtx := envcontext.WithoutCredentialInvalidator(context.Background())
+	ctx := envtesting.BootstrapContext(context.Background(), c)
+	callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
 	bootstrapParams := environs.BootstrapParams{
 		ControllerConfig:         testing.FakeControllerConfig(),
 		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
@@ -331,7 +331,7 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrap(c *gc.C) {
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "some-storage", v1.GetOptions{}).
 			Return(sc, nil),
 	)
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	c.Assert(
 		s.broker.PrepareForBootstrap(ctx, "ctrl-1"), jc.ErrorIsNil,
 	)
@@ -348,7 +348,7 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrapAlreadyExistNamespaceError(c *gc
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), "controller-ctrl-1", v1.GetOptions{}).
 			Return(ns, nil),
 	)
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	c.Assert(
 		s.broker.PrepareForBootstrap(ctx, "ctrl-1"), jc.ErrorIs, errors.AlreadyExists,
 	)
@@ -366,7 +366,7 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrapAlreadyExistControllerAnnotation
 		s.mockNamespaces.EXPECT().List(gomock.Any(), v1.ListOptions{}).
 			Return(&core.NamespaceList{Items: []core.Namespace{*ns}}, nil),
 	)
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	c.Assert(
 		s.broker.PrepareForBootstrap(ctx, "ctrl-1"), jc.ErrorIs, errors.AlreadyExists,
 	)

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -275,7 +275,7 @@ func (s *K8sMetadataSuite) TestListHostCloudRegions(c *gc.C) {
 		clientSet := fake.NewSimpleClientset(v.node)
 
 		metadata, err := provider.GetClusterMetadata(
-			context.TODO(),
+			context.Background(),
 			"",
 			clientSet.CoreV1().Nodes(),
 			clientSet.StorageV1().StorageClasses(),
@@ -711,7 +711,7 @@ func (_ *K8sMetadataSuite) TestGetMetadataVariations(c *gc.C) {
 		clientSet := fake.NewSimpleClientset(test.InitialObjects...)
 
 		metadata, err := provider.GetClusterMetadata(
-			context.TODO(),
+			context.Background(),
 			test.NominatedStorage,
 			clientSet.CoreV1().Nodes(),
 			clientSet.StorageV1().StorageClasses(),
@@ -730,7 +730,7 @@ func (s *K8sMetadataSuite) TestNominatedStorageNotFound(c *gc.C) {
 	)
 
 	_, err := provider.GetClusterMetadata(
-		context.TODO(),
+		context.Background(),
 		"my-nominated-storage",
 		clientSet.CoreV1().Nodes(),
 		clientSet.StorageV1().StorageClasses(),
@@ -751,7 +751,7 @@ func (s *K8sMetadataSuite) TestNominatedStorageNotFoundWithNilStorageClasses(c *
 	)
 
 	_, err := provider.GetClusterMetadata(
-		context.TODO(),
+		context.Background(),
 		"my-nominated-storage",
 		clientSet.CoreV1().Nodes(),
 		clientSet.StorageV1().StorageClasses(),

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -61,32 +61,32 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		client: m.client,
 		ensureConfigMap: func(cm *core.ConfigMap) ([]func(), error) {
 			ensureConfigMapCalled = true
-			_, err := m.client.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, meta.CreateOptions{})
+			_, err := m.client.CoreV1().ConfigMaps(namespace).Create(context.Background(), cm, meta.CreateOptions{})
 			return nil, err
 		},
 		ensureDeployment: func(d *apps.Deployment) ([]func(), error) {
 			ensureDeploymentCalled = true
-			_, err := m.client.AppsV1().Deployments(namespace).Create(context.TODO(), d, meta.CreateOptions{})
+			_, err := m.client.AppsV1().Deployments(namespace).Create(context.Background(), d, meta.CreateOptions{})
 			return nil, err
 		},
 		ensureRole: func(r *rbac.Role) ([]func(), error) {
 			ensureRoleCalled = true
-			_, err := m.client.RbacV1().Roles(namespace).Create(context.TODO(), r, meta.CreateOptions{})
+			_, err := m.client.RbacV1().Roles(namespace).Create(context.Background(), r, meta.CreateOptions{})
 			return nil, err
 		},
 		ensureRoleBinding: func(rb *rbac.RoleBinding) ([]func(), error) {
 			ensureRoleBindingCalled = true
-			_, err := m.client.RbacV1().RoleBindings(namespace).Create(context.TODO(), rb, meta.CreateOptions{})
+			_, err := m.client.RbacV1().RoleBindings(namespace).Create(context.Background(), rb, meta.CreateOptions{})
 			return nil, err
 		},
 		ensureServiceAccount: func(sa *core.ServiceAccount) ([]func(), error) {
 			ensureServiceAccountCalled = true
-			_, err := m.client.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), sa, meta.CreateOptions{})
+			_, err := m.client.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, meta.CreateOptions{})
 			return nil, err
 		},
 		ensureService: func(s *core.Service) ([]func(), error) {
 			ensureServiceCalled = true
-			_, err := m.client.CoreV1().Services(namespace).Create(context.TODO(), s, meta.CreateOptions{})
+			_, err := m.client.CoreV1().Services(namespace).Create(context.Background(), s, meta.CreateOptions{})
 			return nil, err
 		},
 		model: func() string {
@@ -99,7 +99,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	}
 
 	// fake k8sclient does not populate the token for secret, so we have to do it manually.
-	_, err := m.client.CoreV1().Secrets(namespace).Create(context.TODO(), &core.Secret{
+	_, err := m.client.CoreV1().Secrets(namespace).Create(context.Background(), &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Name: ExecRBACResourceName,
 			Annotations: map[string]string{
@@ -126,7 +126,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		c.Fatalf("timed out waiting for ensureModelOperator return")
 	}
 
-	cm, err := m.client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	cm, err := m.client.CoreV1().ConfigMaps(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cm.Name, gc.Equals, modelOperatorName)
 	c.Assert(cm.Namespace, gc.Equals, namespace)
@@ -134,7 +134,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(ok, gc.Equals, true)
 	c.Assert(conf, jc.DeepEquals, string(config.AgentConf))
 
-	d, err := m.client.AppsV1().Deployments(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	d, err := m.client.AppsV1().Deployments(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d.Name, gc.Equals, modelOperatorName)
 	c.Assert(d.Namespace, gc.Equals, namespace)
@@ -145,7 +145,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		c.Assert(d.Spec.Template.Spec.ImagePullSecrets[0].Name, gc.Equals, constants.CAASImageRepoSecretName)
 	}
 
-	r, err := m.client.RbacV1().Roles(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	r, err := m.client.RbacV1().Roles(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Name, gc.Equals, modelOperatorName)
 	c.Assert(r.Namespace, gc.Equals, namespace)
@@ -157,7 +157,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		"watch",
 	})
 
-	rb, err := m.client.RbacV1().RoleBindings(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	rb, err := m.client.RbacV1().RoleBindings(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rb.Name, gc.Equals, modelOperatorName)
 	c.Assert(rb.Namespace, gc.Equals, namespace)
@@ -165,21 +165,21 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(rb.RoleRef.Kind, gc.Equals, "Role")
 	c.Assert(rb.RoleRef.Name, gc.Equals, modelOperatorName)
 
-	sa, err := m.client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	sa, err := m.client.CoreV1().ServiceAccounts(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	trueVar := true
 	c.Assert(sa.Name, gc.Equals, modelOperatorName)
 	c.Assert(sa.Namespace, gc.Equals, namespace)
 	c.Assert(sa.AutomountServiceAccountToken, jc.DeepEquals, &trueVar)
 
-	s, err := m.client.CoreV1().Services(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	s, err := m.client.CoreV1().Services(namespace).Get(context.Background(), modelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.Name, gc.Equals, modelOperatorName)
 	c.Assert(s.Namespace, gc.Equals, namespace)
 	c.Assert(s.Spec.Ports[0].Port, gc.Equals, config.Port)
 
 	clusterRole, err := m.client.RbacV1().ClusterRoles().Get(
-		context.TODO(),
+		context.Background(),
 		"test-model-modeloperator",
 		meta.GetOptions{},
 	)
@@ -199,7 +199,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	})
 
 	clusterRoleBinding, err := m.client.RbacV1().ClusterRoleBindings().Get(
-		context.TODO(),
+		context.Background(),
 		"test-model-modeloperator",
 		meta.GetOptions{},
 	)
@@ -210,7 +210,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(clusterRoleBinding.RoleRef.Name, gc.Equals, "test-model-modeloperator")
 
 	// The exec service account.
-	sa, err = m.client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), ExecRBACResourceName, meta.GetOptions{})
+	sa, err = m.client.CoreV1().ServiceAccounts(namespace).Get(context.Background(), ExecRBACResourceName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	trueVar = true
 	c.Assert(sa.Name, gc.Equals, ExecRBACResourceName)
@@ -224,7 +224,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	})
 
 	// The exec role.
-	r, err = m.client.RbacV1().Roles(namespace).Get(context.TODO(), ExecRBACResourceName, meta.GetOptions{})
+	r, err = m.client.RbacV1().Roles(namespace).Get(context.Background(), ExecRBACResourceName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Name, gc.Equals, ExecRBACResourceName)
 	c.Assert(r.Namespace, gc.Equals, namespace)
@@ -256,7 +256,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	})
 
 	// The exec rolebinding.
-	rb, err = m.client.RbacV1().RoleBindings(namespace).Get(context.TODO(), ExecRBACResourceName, meta.GetOptions{})
+	rb, err = m.client.RbacV1().RoleBindings(namespace).Get(context.Background(), ExecRBACResourceName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rb.Name, gc.Equals, ExecRBACResourceName)
 	c.Assert(rb.Namespace, gc.Equals, namespace)
@@ -265,7 +265,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(rb.RoleRef.Name, gc.Equals, ExecRBACResourceName)
 
 	// The exec secret.
-	secret, err := m.client.CoreV1().Secrets(namespace).Get(context.TODO(), ExecRBACResourceName, meta.GetOptions{})
+	secret, err := m.client.CoreV1().Secrets(namespace).Get(context.Background(), ExecRBACResourceName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(secret.Name, gc.Equals, ExecRBACResourceName)
 	c.Assert(secret.Type, gc.Equals, core.SecretTypeServiceAccountToken)

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -56,7 +56,7 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
 	)
 
-	_, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).Create(context.TODO(),
+	_, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).Create(context.Background(),
 		&apps.Deployment{
 			ObjectMeta: meta.ObjectMeta{
 				Name: operatorName,
@@ -83,7 +83,7 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 
 	c.Assert(modelOperatorUpgrade(operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
 	de, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).
-		Get(context.TODO(), operatorName, meta.GetOptions{})
+		Get(context.Background(), operatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 

--- a/caas/kubernetes/provider/proxy/info_test.go
+++ b/caas/kubernetes/provider/proxy/info_test.go
@@ -29,7 +29,7 @@ func (i *infoSuite) SetUpTest(c *gc.C) {
 	i.clock = testclock.NewClock(time.Time{})
 
 	i.client = fake.NewSimpleClientset()
-	_, err := i.client.CoreV1().Namespaces().Create(context.TODO(),
+	_, err := i.client.CoreV1().Namespaces().Create(context.Background(),
 		&core.Namespace{
 			ObjectMeta: meta.ObjectMeta{
 				Name: testNamespace,
@@ -57,7 +57,7 @@ func (i *infoSuite) TestHasControllerProxy(c *gc.C) {
 	}
 
 	// fake k8s client does not populate the token for secret, so we have to do it manually.
-	_, err := i.client.CoreV1().Secrets(testNamespace).Create(context.TODO(), &core.Secret{
+	_, err := i.client.CoreV1().Secrets(testNamespace).Create(context.Background(), &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: labels.Set{},
 			Name:   config.Name,
@@ -100,7 +100,7 @@ func (i *infoSuite) TestGetControllerProxier(c *gc.C) {
 	}
 
 	// fake k8s client does not populate the token for secret, so we have to do it manually.
-	_, err := i.client.CoreV1().Secrets(testNamespace).Create(context.TODO(), &core.Secret{
+	_, err := i.client.CoreV1().Secrets(testNamespace).Create(context.Background(), &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: labels.Set{},
 			Name:   config.Name,

--- a/caas/kubernetes/provider/proxy/setup_test.go
+++ b/caas/kubernetes/provider/proxy/setup_test.go
@@ -32,7 +32,7 @@ var (
 func (s *setupSuite) SetUpTest(c *gc.C) {
 	s.clock = testclock.NewClock(time.Time{})
 	s.client = fake.NewSimpleClientset()
-	_, err := s.client.CoreV1().Namespaces().Create(context.TODO(),
+	_, err := s.client.CoreV1().Namespaces().Create(context.Background(),
 		&core.Namespace{
 			ObjectMeta: meta.ObjectMeta{
 				Name: testNamespace,
@@ -52,7 +52,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	}
 
 	// fake k8s client does not populate the token for secret, so we have to do it manually.
-	_, err := s.client.CoreV1().Secrets(testNamespace).Create(context.TODO(), &core.Secret{
+	_, err := s.client.CoreV1().Secrets(testNamespace).Create(context.Background(), &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: labels.Set{},
 			Name:   config.Name,
@@ -80,7 +80,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	role, err := s.client.RbacV1().Roles(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)
@@ -94,7 +94,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(role.Rules[2].Verbs, jc.DeepEquals, []string{"create", "get"})
 
 	sa, err := s.client.CoreV1().ServiceAccounts(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)
@@ -104,7 +104,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(sa.Secrets[0].Name, gc.Equals, config.Name)
 
 	secret, err := s.client.CoreV1().ServiceAccounts(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)
@@ -112,7 +112,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(secret.Name, gc.Equals, config.Name)
 
 	roleBinding, err := s.client.RbacV1().RoleBindings(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)
@@ -120,7 +120,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(roleBinding.Name, gc.Equals, config.Name)
 
 	cm, err := s.client.CoreV1().ConfigMaps(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)
@@ -137,7 +137,7 @@ func (s *setupSuite) TestProxyConfigMap(c *gc.C) {
 	}
 
 	// fake k8sclient does not populate the token for secret, so we have to do it manually.
-	_, err := s.client.CoreV1().Secrets(testNamespace).Create(context.TODO(), &core.Secret{
+	_, err := s.client.CoreV1().Secrets(testNamespace).Create(context.Background(), &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: labels.Set{},
 			Name:   config.Name,
@@ -165,7 +165,7 @@ func (s *setupSuite) TestProxyConfigMap(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cm, err := s.client.CoreV1().ConfigMaps(testNamespace).Get(
-		context.TODO(),
+		context.Background(),
 		config.Name,
 		meta.GetOptions{},
 	)

--- a/caas/kubernetes/provider/resources/applier_test.go
+++ b/caas/kubernetes/provider/resources/applier_test.go
@@ -44,7 +44,7 @@ func (s *applierSuite) TestRun(c *gc.C) {
 		r2.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
 		r2.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), jc.ErrorIsNil)
+	c.Assert(applier.Run(context.Background(), nil, false), jc.ErrorIsNil)
 }
 
 func (s *applierSuite) TestRunApplyFailedWithRollBackForNewResource(c *gc.C) {
@@ -74,7 +74,7 @@ func (s *applierSuite) TestRunApplyFailedWithRollBackForNewResource(c *gc.C) {
 		// delete the new resource was just created.
 		r1.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.Background(), nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestRunApplyResourceVersionChanged(c *gc.C) {
@@ -102,7 +102,7 @@ func (s *applierSuite) TestRunApplyResourceVersionChanged(c *gc.C) {
 		r1.EXPECT().Clone().Return(existingR1),
 		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `A r1: resource version conflict`)
+	c.Assert(applier.Run(context.Background(), nil, false), gc.ErrorMatches, `A r1: resource version conflict`)
 }
 
 func (s *applierSuite) TestRunApplyFailedWithRollBackForExistingResource(c *gc.C) {
@@ -132,7 +132,7 @@ func (s *applierSuite) TestRunApplyFailedWithRollBackForExistingResource(c *gc.C
 		// re-apply the old resource.
 		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.Background(), nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestRunDeleteFailedWithRollBack(c *gc.C) {
@@ -162,7 +162,7 @@ func (s *applierSuite) TestRunDeleteFailedWithRollBack(c *gc.C) {
 		// re-apply the old resource.
 		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.Background(), nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestApplySet(c *gc.C) {
@@ -202,5 +202,5 @@ func (s *applierSuite) TestApplySet(c *gc.C) {
 		r3.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NotFoundf("missing aye")),
 		r3.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), jc.ErrorIsNil)
+	c.Assert(applier.Run(context.Background(), nil, false), jc.ErrorIsNil)
 }

--- a/caas/kubernetes/provider/resources/clusterrole_test.go
+++ b/caas/kubernetes/provider/resources/clusterrole_test.go
@@ -30,17 +30,17 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	clusterRoleResource := resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(clusterRoleResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	clusterRoleResource = resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(clusterRoleResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err = s.client.RbacV1().ClusterRoles().Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *clusterRoleSuite) TestGet(c *gc.C) {
 	}
 	role1 := template
 	role1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().ClusterRoles().Create(context.TODO(), &role1, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().ClusterRoles().Create(context.Background(), &role1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	roleResource := resources.NewClusterRole("role1", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,21 +71,21 @@ func (s *clusterRoleSuite) TestDelete(c *gc.C) {
 			Name: "role1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoles().Create(context.TODO(), &role, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().ClusterRoles().Create(context.Background(), &role, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewClusterRole("role1", &role)
-	err = roleResource.Delete(context.TODO(), s.client)
+	err = roleResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	_, err = s.client.RbacV1().ClusterRoles().Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -122,14 +122,14 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 
 	crApi := resources.NewClusterRole("test", clusterRole)
 	_, err := crApi.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rrole, err := s.client.RbacV1().ClusterRoles().Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		metav1.GetOptions{},
 	)
@@ -142,14 +142,14 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 	}
 
 	crApi.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rrole, err = s.client.RbacV1().ClusterRoles().Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		metav1.GetOptions{},
 	)

--- a/caas/kubernetes/provider/resources/clusterrolebinding_test.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding_test.go
@@ -30,17 +30,17 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	roleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err = s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 	}
 	roleBinding1 := template
 	roleBinding1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.Background(), &roleBinding1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,21 +71,21 @@ func (s *clusterRoleBindingSuite) TestDelete(c *gc.C) {
 			Name: "roleBinding1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -95,21 +95,21 @@ func (s *clusterRoleBindingSuite) TestDeleteWithoutPreconditions(c *gc.C) {
 			Name: "roleBinding1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", nil)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -128,14 +128,14 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 
 	crbApi := resources.NewClusterRoleBinding("test", clusterRoleBinding)
 	_, err := crbApi.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rroleBinding, err := s.client.RbacV1().ClusterRoleBindings().Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		metav1.GetOptions{},
 	)
@@ -148,14 +148,14 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 	}
 
 	crbApi.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rroleBinding, err = s.client.RbacV1().ClusterRoleBindings().Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		metav1.GetOptions{},
 	)
@@ -192,14 +192,14 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 	)
 
 	_, err := clusterRoleBinding.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rval, err := s.client.RbacV1().ClusterRoleBindings().Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		metav1.GetOptions{},
 	)
@@ -232,7 +232,7 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 	)
 
 	_, err = clusterRoleBinding1.Ensure(
-		context.TODO(),
+		context.Background(),
 		s.client,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)

--- a/caas/kubernetes/provider/resources/daemonset_test.go
+++ b/caas/kubernetes/provider/resources/daemonset_test.go
@@ -31,17 +31,17 @@ func (s *daemonsetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.AppsV1().DaemonSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.AppsV1().DaemonSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *daemonsetSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().DaemonSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().DaemonSets("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *daemonsetSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().DaemonSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().DaemonSets("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.AppsV1().DaemonSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.AppsV1().DaemonSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/deployment_test.go
+++ b/caas/kubernetes/provider/resources/deployment_test.go
@@ -31,17 +31,17 @@ func (s *deploymentSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.AppsV1().Deployments("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.AppsV1().Deployments("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *deploymentSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().Deployments("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewDeployment("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *deploymentSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().Deployments("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.AppsV1().Deployments("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDeployment("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.AppsV1().Deployments("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/events_test.go
+++ b/caas/kubernetes/provider/resources/events_test.go
@@ -36,11 +36,11 @@ func (s *eventsSuite) TestList(c *gc.C) {
 	for i := 0; i < 1000; i++ {
 		ev := template
 		ev.ObjectMeta.Name = strconv.Itoa(i)
-		_, err := s.client.CoreV1().Events("test").Create(context.TODO(), &ev, metav1.CreateOptions{})
+		_, err := s.client.CoreV1().Events("test").Create(context.Background(), &ev, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 		res = append(res, ev)
 	}
-	events, err := resources.ListEventsForObject(context.TODO(), s.client, "test", "test", "Pod")
+	events, err := resources.ListEventsForObject(context.Background(), s.client, "test", "test", "Pod")
 	c.Assert(err, jc.ErrorIsNil)
 
 	toInt := func(s string) int {

--- a/caas/kubernetes/provider/resources/persistentvolume_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolume_test.go
@@ -30,17 +30,17 @@ func (s *persistentVolumeSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().PersistentVolumes().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().PersistentVolumes().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *persistentVolumeSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().PersistentVolumes().Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().PersistentVolumes().Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPersistentVolume("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,20 +71,20 @@ func (s *persistentVolumeSuite) TestDelete(c *gc.C) {
 			Name: "ds1",
 		},
 	}
-	_, err := s.client.CoreV1().PersistentVolumes().Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().PersistentVolumes().Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().PersistentVolumes().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolume("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().PersistentVolumes().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
@@ -32,17 +32,17 @@ func (s *persistentVolumeClaimSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -58,12 +58,12 @@ func (s *persistentVolumeClaimSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -77,21 +77,21 @@ func (s *persistentVolumeClaimSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 

--- a/caas/kubernetes/provider/resources/pod_test.go
+++ b/caas/kubernetes/provider/resources/pod_test.go
@@ -34,17 +34,17 @@ func (s *podSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().Pods("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().Pods("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -60,12 +60,12 @@ func (s *podSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Pods("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPod("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -79,21 +79,21 @@ func (s *podSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Pods("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().Pods("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPod("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().Pods("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 

--- a/caas/kubernetes/provider/resources/role_test.go
+++ b/caas/kubernetes/provider/resources/role_test.go
@@ -31,17 +31,17 @@ func (s *roleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	roleResource := resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(roleResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().Roles("test").Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	roleResource = resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(roleResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err = s.client.RbacV1().Roles("test").Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *roleSuite) TestGet(c *gc.C) {
 	}
 	role1 := template
 	role1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role1, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().Roles("test").Create(context.Background(), &role1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	roleResource := resources.NewRole("role1", "test", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *roleSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().Roles("test").Create(context.Background(), &role, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err := s.client.RbacV1().Roles("test").Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewRole("role1", "test", &role)
-	err = roleResource.Delete(context.TODO(), s.client)
+	err = roleResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	_, err = s.client.RbacV1().Roles("test").Get(context.Background(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/rolebinding_test.go
+++ b/caas/kubernetes/provider/resources/rolebinding_test.go
@@ -31,17 +31,17 @@ func (s *roleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	RoleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err = s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *roleBindingSuite) TestGet(c *gc.C) {
 	}
 	roleBinding1 := template
 	roleBinding1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().RoleBindings("test").Create(context.Background(), &roleBinding1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *roleBindingSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.client.RbacV1().RoleBindings("test").Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/secret_test.go
+++ b/caas/kubernetes/provider/resources/secret_test.go
@@ -31,17 +31,17 @@ func (s *secretSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().Secrets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().Secrets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *secretSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Secrets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Secrets("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewSecret("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *secretSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Secrets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Secrets("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().Secrets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewSecret("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().Secrets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/service_test.go
+++ b/caas/kubernetes/provider/resources/service_test.go
@@ -31,17 +31,17 @@ func (s *serviceSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().Services("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().Services("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *serviceSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewService("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *serviceSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().Services("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().Services("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewService("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().Services("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/serviceaccount_test.go
+++ b/caas/kubernetes/provider/resources/serviceaccount_test.go
@@ -31,17 +31,17 @@ func (s *serviceAccountSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	saResource := resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(saResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	sa.SetAnnotations(map[string]string{"a": "b"})
 	saResource = resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(saResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	result, err = s.client.CoreV1().ServiceAccounts("test").Get(context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `sa1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *serviceAccountSuite) TestGet(c *gc.C) {
 	}
 	sa1 := template
 	sa1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa1, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.Background(), &sa1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	saResource := resources.NewServiceAccount("sa1", "test", &template)
 	c.Assert(len(saResource.GetAnnotations()), gc.Equals, 0)
-	err = saResource.Get(context.TODO(), s.client)
+	err = saResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saResource.GetName(), gc.Equals, `sa1`)
 	c.Assert(saResource.GetNamespace(), gc.Equals, `test`)
@@ -76,21 +76,21 @@ func (s *serviceAccountSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa, metav1.CreateOptions{})
+	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.Background(), &sa, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `sa1`)
 
 	saResource := resources.NewServiceAccount("sa1", "test", &sa)
-	err = saResource.Delete(context.TODO(), s.client)
+	err = saResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = saResource.Get(context.TODO(), s.client)
+	err = saResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	_, err = s.client.CoreV1().ServiceAccounts("test").Get(context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -102,7 +102,7 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 		},
 	}
 	_, err := s.client.CoreV1().ServiceAccounts("test").Create(
-		context.TODO(),
+		context.Background(),
 		&sa,
 		metav1.CreateOptions{},
 	)
@@ -113,11 +113,11 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 	}
 
 	saResource := resources.NewServiceAccount("sa1", "test", &sa)
-	err = saResource.Update(context.TODO(), s.client)
+	err = saResource.Update(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
 	rsa, err := s.client.CoreV1().ServiceAccounts("test").Get(
-		context.TODO(),
+		context.Background(),
 		"sa1",
 		metav1.GetOptions{},
 	)
@@ -127,11 +127,11 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 
 func (s *serviceAccountSuite) TestEnsureCreatesNew(c *gc.C) {
 	sa := resources.NewServiceAccount("sa1", "test", &corev1.ServiceAccount{})
-	cleanups, err := sa.Ensure(context.TODO(), s.client)
+	cleanups, err := sa.Ensure(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obj, err := s.client.CoreV1().ServiceAccounts("test").Get(
-		context.TODO(), "sa1", metav1.GetOptions{})
+		context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&sa.ServiceAccount, jc.DeepEquals, obj)
 
@@ -141,7 +141,7 @@ func (s *serviceAccountSuite) TestEnsureCreatesNew(c *gc.C) {
 
 	// Test cleanup removes service account
 	_, err = s.client.CoreV1().ServiceAccounts("test").Get(
-		context.TODO(), "sa1", metav1.GetOptions{})
+		context.Background(), "sa1", metav1.GetOptions{})
 	c.Assert(k8serrors.IsNotFound(err), jc.IsTrue)
 }
 
@@ -154,7 +154,7 @@ func (s *serviceAccountSuite) TestEnsureUpdates(c *gc.C) {
 	}
 
 	_, err := s.client.CoreV1().ServiceAccounts("testing").Create(
-		context.TODO(), sa, metav1.CreateOptions{})
+		context.Background(), sa, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	sa.ObjectMeta.Labels = map[string]string{
@@ -162,11 +162,11 @@ func (s *serviceAccountSuite) TestEnsureUpdates(c *gc.C) {
 	}
 
 	resource := resources.NewServiceAccount("sa2", "testing", sa)
-	_, err = resource.Ensure(context.TODO(), s.client)
+	_, err = resource.Ensure(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obj, err := s.client.CoreV1().ServiceAccounts("testing").Get(
-		context.TODO(), sa.Name, metav1.GetOptions{})
+		context.Background(), sa.Name, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(obj, jc.DeepEquals, &resource.ServiceAccount)

--- a/caas/kubernetes/provider/resources/statefulset_test.go
+++ b/caas/kubernetes/provider/resources/statefulset_test.go
@@ -31,17 +31,17 @@ func (s *statefulSetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.AppsV1().StatefulSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *statefulSetSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().StatefulSets("test").Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *statefulSetSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.AppsV1().StatefulSets("test").Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.AppsV1().StatefulSets("test").Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/storageclass_test.go
+++ b/caas/kubernetes/provider/resources/storageclass_test.go
@@ -30,17 +30,17 @@ func (s *storageClassSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
+	result, err := s.client.StorageV1().StorageClasses().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
-	result, err = s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.client.StorageV1().StorageClasses().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *storageClassSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.StorageV1().StorageClasses().Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.client.StorageV1().StorageClasses().Create(context.Background(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewStorageClass("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,20 +71,20 @@ func (s *storageClassSuite) TestDelete(c *gc.C) {
 			Name: "ds1",
 		},
 	}
-	_, err := s.client.StorageV1().StorageClasses().Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.client.StorageV1().StorageClasses().Create(context.Background(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.client.StorageV1().StorageClasses().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStorageClass("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.Background(), s.client)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 
-	_, err = s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.client.StorageV1().StorageClasses().Get(context.Background(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/scale/scale_test.go
+++ b/caas/kubernetes/provider/scale/scale_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&ScaleSuite{})
 func (s *ScaleSuite) SetUpTest(c *gc.C) {
 	s.client = fake.NewSimpleClientset()
 	_, err := s.client.CoreV1().Namespaces().Create(
-		context.TODO(),
+		context.Background(),
 		&core.Namespace{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "test",
@@ -39,7 +39,7 @@ func (s *ScaleSuite) SetUpTest(c *gc.C) {
 
 func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 	_, err := s.client.AppsV1().Deployments("test").Create(
-		context.TODO(),
+		context.Background(),
 		&apps.Deployment{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "test",
@@ -52,7 +52,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		3,
 		scale.DeploymentScalePatcher(s.client.AppsV1().Deployments("test")),
@@ -60,7 +60,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	dep, err := s.client.AppsV1().Deployments("test").Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		meta.GetOptions{},
 	)
@@ -68,7 +68,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 	c.Assert(*dep.Spec.Replicas, gc.Equals, int32(3))
 
 	err = scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		0,
 		scale.DeploymentScalePatcher(s.client.AppsV1().Deployments("test")),
@@ -76,7 +76,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	dep, err = s.client.AppsV1().Deployments("test").Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		meta.GetOptions{},
 	)
@@ -86,7 +86,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 
 func (s *ScaleSuite) TestDeploymentScaleNotFound(c *gc.C) {
 	err := scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		3,
 		scale.DeploymentScalePatcher(s.client.AppsV1().Deployments("test")),
@@ -96,7 +96,7 @@ func (s *ScaleSuite) TestDeploymentScaleNotFound(c *gc.C) {
 
 func (s *ScaleSuite) TestStatefulSetScaleNotFound(c *gc.C) {
 	err := scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		3,
 		scale.StatefulSetScalePatcher(s.client.AppsV1().StatefulSets("test")),
@@ -106,7 +106,7 @@ func (s *ScaleSuite) TestStatefulSetScaleNotFound(c *gc.C) {
 
 func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 	_, err := s.client.AppsV1().StatefulSets("test").Create(
-		context.TODO(),
+		context.Background(),
 		&apps.StatefulSet{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "test",
@@ -119,7 +119,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		3,
 		scale.StatefulSetScalePatcher(s.client.AppsV1().StatefulSets("test")),
@@ -127,7 +127,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ss, err := s.client.AppsV1().StatefulSets("test").Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		meta.GetOptions{},
 	)
@@ -135,7 +135,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 	c.Assert(*ss.Spec.Replicas, gc.Equals, int32(3))
 
 	err = scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		0,
 		scale.StatefulSetScalePatcher(s.client.AppsV1().StatefulSets("test")),
@@ -143,7 +143,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ss, err = s.client.AppsV1().StatefulSets("test").Get(
-		context.TODO(),
+		context.Background(),
 		"test",
 		meta.GetOptions{},
 	)
@@ -153,7 +153,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 
 func (s *ScaleSuite) TestInvalidScale(c *gc.C) {
 	err := scale.PatchReplicasToScale(
-		context.TODO(),
+		context.Background(),
 		"test",
 		-1,
 		scale.StatefulSetScalePatcher(s.client.AppsV1().StatefulSets("test")),

--- a/caas/kubernetes/provider/services_test.go
+++ b/caas/kubernetes/provider/services_test.go
@@ -26,7 +26,7 @@ func (s *servicesSuite) SetUpTest(c *gc.C) {
 
 func (s *servicesSuite) TestFindServiceForApplication(c *gc.C) {
 	_, err := s.client.CoreV1().Services("test").Create(
-		context.TODO(),
+		context.Background(),
 		&core.Service{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "wallyworld",
@@ -42,7 +42,7 @@ func (s *servicesSuite) TestFindServiceForApplication(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	svc, err := findServiceForApplication(
-		context.TODO(),
+		context.Background(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
 		false,
@@ -54,7 +54,7 @@ func (s *servicesSuite) TestFindServiceForApplication(c *gc.C) {
 
 func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
 	_, err := s.client.CoreV1().Services("test").Create(
-		context.TODO(),
+		context.Background(),
 		&core.Service{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "wallyworld",
@@ -69,7 +69,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.client.CoreV1().Services("test").Create(
-		context.TODO(),
+		context.Background(),
 		&core.Service{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "wallyworld-endpoints",
@@ -84,7 +84,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	svc, err := findServiceForApplication(
-		context.TODO(),
+		context.Background(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
 		false,
@@ -96,7 +96,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
 
 func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
 	_, err := s.client.CoreV1().Services("test").Create(
-		context.TODO(),
+		context.Background(),
 		&core.Service{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "wallyworld",
@@ -111,7 +111,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.client.CoreV1().Services("test").Create(
-		context.TODO(),
+		context.Background(),
 		&core.Service{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "wallyworld-v2",
@@ -126,7 +126,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = findServiceForApplication(
-		context.TODO(),
+		context.Background(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
 		false,
@@ -137,7 +137,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
 
 func (s *servicesSuite) TestFindServiceForApplicationMissing(c *gc.C) {
 	_, err := findServiceForApplication(
-		context.TODO(),
+		context.Background(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
 		false,

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -100,7 +100,7 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 	}
 
 	for _, test := range tests {
-		_, err := l.client.CoreV1().Namespaces().Create(context.TODO(), test.Namespace, meta.CreateOptions{})
+		_, err := l.client.CoreV1().Namespaces().Create(context.Background(), test.Namespace, meta.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		legacy, err := utils.IsLegacyModelLabels(test.Namespace.Name, test.Model, l.client.CoreV1().Namespaces())

--- a/cmd/juju/action/exec_test.go
+++ b/cmd/juju/action/exec_test.go
@@ -600,7 +600,7 @@ use 'juju show-task' to inspect the failure
 		// Set up context
 		output := bytes.Buffer{}
 		ctx := &cmd.Context{
-			Context: context.TODO(),
+			Context: context.Background(),
 			Stdout:  &output,
 			Stderr:  &output,
 		}

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -1005,7 +1005,7 @@ hello
 		// Set up context
 		output := bytes.Buffer{}
 		ctx := &cmd.Context{
-			Context: context.TODO(),
+			Context: context.Background(),
 			Stdout:  &output,
 			Stderr:  &output,
 		}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -840,7 +840,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	charmAdaptor := c.NewResolver(charmAPIClient, downloadClientFn)
 
 	factory, cfg := c.getDeployerFactory(base, charm.CharmHub)
-	deploy, err := factory.GetDeployer(cfg, deployAPI, charmAdaptor)
+	deploy, err := factory.GetDeployer(ctx, cfg, deployAPI, charmAdaptor)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -466,7 +466,7 @@ func (s *CAASDeploySuiteBase) expectDeployer(c *gc.C, cfg deployer.DeployerConfi
 		c:        c,
 		expected: cfg,
 	}
-	s.factory.EXPECT().GetDeployer(match, gomock.Any(), gomock.Any()).Return(s.deployer, nil)
+	s.factory.EXPECT().GetDeployer(gomock.Any(), match, gomock.Any(), gomock.Any()).Return(s.deployer, nil)
 	s.deployer.EXPECT().PrepareAndDeploy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
 
@@ -1145,7 +1145,7 @@ func (s *DeployUnitTestSuite) expectDeployer(c *gc.C, cfg deployer.DeployerConfi
 		c:        c,
 		expected: cfg,
 	}
-	s.factory.EXPECT().GetDeployer(match, gomock.Any(), gomock.Any()).Return(s.deployer, nil)
+	s.factory.EXPECT().GetDeployer(gomock.Any(), match, gomock.Any(), gomock.Any()).Return(s.deployer, nil)
 	s.deployer.EXPECT().PrepareAndDeploy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
 
@@ -1368,7 +1368,7 @@ func (f *fakeDeployAPI) GetModelConstraints() (constraints.Value, error) {
 	return f.modelCons, nil
 }
 
-func (f *fakeDeployAPI) GetBundle(url *charm.URL, _ commoncharm.Origin, _ string) (charm.Bundle, error) {
+func (f *fakeDeployAPI) GetBundle(_ context.Context, url *charm.URL, _ commoncharm.Origin, _ string) (charm.Bundle, error) {
 	results := f.MethodCall(f, "GetBundle", url)
 	if results == nil {
 		return nil, errors.NotFoundf("bundle %v", url)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -5,6 +5,7 @@ package deployer
 
 import (
 	"archive/zip"
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ var logger = loggo.GetLogger("juju.cmd.juju.application.deployer")
 // DeployerKind is an interface that provides CreateDeployer function to
 // attempt creation of the related deployer.
 type DeployerKind interface {
-	CreateDeployer(d factory) (Deployer, error)
+	CreateDeployer(ctx context.Context, d factory) (Deployer, error)
 }
 
 // localBundleDeployerKind represents a local bundle deployment
@@ -91,7 +92,7 @@ func NewDeployerFactory(dep DeployerDependencies) DeployerFactory {
 
 // GetDeployer returns the correct deployer to use based on the cfg provided.
 // A ModelConfigGetter needed to find the deployer.
-func (d *factory) GetDeployer(cfg DeployerConfig, getter ModelConfigGetter, resolver Resolver) (Deployer, error) {
+func (d *factory) GetDeployer(ctx context.Context, cfg DeployerConfig, getter ModelConfigGetter, resolver Resolver) (Deployer, error) {
 	// Determine the type of deploy we have
 	var dk DeployerKind
 
@@ -166,7 +167,7 @@ func (d *factory) GetDeployer(cfg DeployerConfig, getter ModelConfigGetter, reso
 		}
 	}
 
-	return dk.CreateDeployer(*d)
+	return dk.CreateDeployer(ctx, *d)
 }
 
 func (d *factory) repoCharmDeployer(userCharmURL *charm.URL, origin commoncharm.Origin, charmHubSchemaCheck bool) (DeployerKind, error) {
@@ -502,7 +503,7 @@ func (d *factory) newDeployCharm() deployCharm {
 	}
 }
 
-func (dt *localBundleDeployerKind) CreateDeployer(d factory) (Deployer, error) {
+func (dt *localBundleDeployerKind) CreateDeployer(_ context.Context, d factory) (Deployer, error) {
 	if err := d.validateBundleFlags(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -549,14 +550,14 @@ func (d *factory) newDeployBundle(_ charm.Schema, ds charm.BundleDataSource) dep
 	}
 }
 
-func (dk *localPreDeployerKind) CreateDeployer(d factory) (Deployer, error) {
+func (dk *localPreDeployerKind) CreateDeployer(_ context.Context, d factory) (Deployer, error) {
 	return &predeployedLocalCharm{
 		deployCharm:  d.newDeployCharm(),
 		userCharmURL: dk.userCharmURL,
 	}, nil
 }
 
-func (dk *localCharmDeployerKind) CreateDeployer(d factory) (Deployer, error) {
+func (dk *localCharmDeployerKind) CreateDeployer(_ context.Context, d factory) (Deployer, error) {
 	// Avoid deploying charm if the charm base is not correct for the
 	// available image streams.
 	var err error
@@ -574,7 +575,7 @@ func (dk *localCharmDeployerKind) CreateDeployer(d factory) (Deployer, error) {
 	}, err
 }
 
-func (dk *repositoryCharmDeployerKind) CreateDeployer(d factory) (Deployer, error) {
+func (dk *repositoryCharmDeployerKind) CreateDeployer(_ context.Context, d factory) (Deployer, error) {
 	return &repositoryCharm{
 		deployCharm:                    dk.deployCharm,
 		userRequestedURL:               dk.charmURL,
@@ -584,7 +585,7 @@ func (dk *repositoryCharmDeployerKind) CreateDeployer(d factory) (Deployer, erro
 
 }
 
-func (dk *repositoryBundleDeployerKind) CreateDeployer(d factory) (Deployer, error) {
+func (dk *repositoryBundleDeployerKind) CreateDeployer(ctx context.Context, d factory) (Deployer, error) {
 
 	// Validated, prepare to Deploy
 	// TODO(bundles) - Ideally, we would like to expose a GetBundleDataSource method for the charmstore.
@@ -597,7 +598,7 @@ func (dk *repositoryBundleDeployerKind) CreateDeployer(d factory) (Deployer, err
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	bundle, err := dk.resolver.GetBundle(dk.bundleURL, dk.bundleOrigin, filepath.Join(dir, dk.bundleURL.Name))
+	bundle, err := dk.resolver.GetBundle(ctx, dk.bundleURL, dk.bundleOrigin, filepath.Join(dir, dk.bundleURL.Name))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,7 +63,7 @@ func (s *deployerSuite) TestGetDeployerPredeployedLocalCharm(c *gc.C) {
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy predeployed local charm: %s", ch.String()))
 }
@@ -79,7 +80,7 @@ func (s *deployerSuite) TestGetDeployerLocalCharm(c *gc.C) {
 	cfg.CharmOrBundle = charmPath
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	ch := charm.MustParseURL("local:jammy/multi-series-1")
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy local charm: %s", ch.String()))
@@ -93,7 +94,7 @@ func (s *deployerSuite) TestGetDeployerLocalCharmError(c *gc.C) {
 
 	s.expectStat(path, os.ErrNotExist)
 
-	_, err := factory.GetDeployer(DeployerConfig{CharmOrBundle: path}, s.modelConfigGetter, nil)
+	_, err := factory.GetDeployer(context.Background(), DeployerConfig{CharmOrBundle: path}, s.modelConfigGetter, nil)
 	c.Assert(err, gc.ErrorMatches, `no charm was found at "./bad.charm"`)
 }
 
@@ -115,7 +116,7 @@ func (s *deployerSuite) testGetDeployerRepositoryCharm(c *gc.C, ch *charm.URL) {
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm: %s", ch.String()))
 }
@@ -150,7 +151,7 @@ func (s *deployerSuite) testGetDeployerRepositoryCharmWithRevision(c *gc.C, ch *
 	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 
 	factory := s.newDeployerFactory()
-	return factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	return factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 }
 
 func (s *deployerSuite) TestSeriesOverride(c *gc.C) {
@@ -164,7 +165,7 @@ func (s *deployerSuite) TestSeriesOverride(c *gc.C) {
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm: %s", ch.String()))
 
@@ -197,7 +198,7 @@ func (s *deployerSuite) TestGetDeployerLocalBundle(c *gc.C) {
 	cfg.CharmOrBundle = bundlePath
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy local bundle from: %s", bundlePath))
 }
@@ -219,7 +220,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithChannel(c *gc.C) {
 	s.expectData()
 
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s from channel edge", bundle.String()))
 }
@@ -240,7 +241,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevision(c *gc.C) {
 
 	s.expectResolveBundleURL(nil, 1)
 	factory := s.newDeployerFactory()
-	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s with revision 8", bundle.String()))
 }
@@ -256,7 +257,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevisionURL(c *gc.C) {
 	s.expectModelType()
 
 	factory := s.newDeployerFactory()
-	_, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	_, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, gc.ErrorMatches, "cannot specify revision in a charm or bundle name. Please use --revision.")
 }
 
@@ -273,7 +274,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleError(c *gc.C) {
 	s.expectResolveBundleURL(nil, 1)
 
 	factory := s.newDeployerFactory()
-	_, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	_, err := factory.GetDeployer(context.Background(), cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, gc.ErrorMatches, "revision and channel are mutually exclusive when deploying a bundle. Please choose one.")
 }
 
@@ -357,7 +358,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 		fileSystem:      s.filesystem,
 	}
 
-	_, err := f.GetDeployer(DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
+	_, err := f.GetDeployer(context.Background(), DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -379,7 +380,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 		fileSystem:    s.filesystem,
 	}
 
-	_, err := f.GetDeployer(DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
+	_, err := f.GetDeployer(context.Background(), DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -494,7 +495,7 @@ func (s *deployerSuite) expectModelType() {
 }
 
 func (s *deployerSuite) expectGetBundle(err error) {
-	s.resolver.EXPECT().GetBundle(gomock.AssignableToTypeOf(&charm.URL{}), gomock.Any(), gomock.Any()).Return(s.bundle, err)
+	s.resolver.EXPECT().GetBundle(gomock.Any(), gomock.AssignableToTypeOf(&charm.URL{}), gomock.Any(), gomock.Any()).Return(s.bundle, err)
 }
 
 func (s *deployerSuite) expectData() {

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -4,6 +4,8 @@
 package deployer
 
 import (
+	"context"
+
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
@@ -28,7 +30,7 @@ import (
 
 // DeployerFactory contains a method to get a deployer.
 type DeployerFactory interface {
-	GetDeployer(DeployerConfig, ModelConfigGetter, Resolver) (Deployer, error)
+	GetDeployer(context.Context, DeployerConfig, ModelConfigGetter, Resolver) (Deployer, error)
 }
 
 // Deployer defines the functionality of a deployer returned by the
@@ -130,7 +132,7 @@ type Bundle interface {
 // Resolver defines what we need to resolve a charm or bundle and
 // read the bundle data.
 type Resolver interface {
-	GetBundle(*charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
+	GetBundle(context.Context, *charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
 	ResolveBundleURL(*charm.URL, commoncharm.Origin) (*charm.URL, commoncharm.Origin, error)
 	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []corebase.Base, error)
 }

--- a/cmd/juju/application/deployer/mocks/resolver_mock.go
+++ b/cmd/juju/application/deployer/mocks/resolver_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charm "github.com/juju/charm/v12"
@@ -42,18 +43,18 @@ func (m *MockResolver) EXPECT() *MockResolverMockRecorder {
 }
 
 // GetBundle mocks base method.
-func (m *MockResolver) GetBundle(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm.Bundle, error) {
+func (m *MockResolver) GetBundle(arg0 context.Context, arg1 *charm.URL, arg2 charm0.Origin, arg3 string) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundle", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetBundle", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBundle indicates an expected call of GetBundle.
-func (mr *MockResolverMockRecorder) GetBundle(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockResolverMockRecorder) GetBundle(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockResolver)(nil).GetBundle), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockResolver)(nil).GetBundle), arg0, arg1, arg2, arg3)
 }
 
 // ResolveBundleURL mocks base method.

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -352,7 +352,7 @@ func (c *diffBundleCommand) bundleDataSource(ctx *cmd.Context, apiRoot base.APIC
 		return nil, errors.Trace(err)
 	}
 	bundlePath := filepath.Join(dir, bundleURL.Name)
-	bundle, err := charmAdaptor.GetBundle(bundleURL, bundleOrigin, bundlePath)
+	bundle, err := charmAdaptor.GetBundle(ctx, bundleURL, bundleOrigin, bundlePath)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -471,5 +471,5 @@ func (e *extractorImpl) Sequences() (map[string]int, error) {
 // bundle and read the bundle data.
 type BundleResolver interface {
 	ResolveBundleURL(*charm.URL, commoncharm.Origin) (*charm.URL, commoncharm.Origin, error)
-	GetBundle(*charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
+	GetBundle(context.Context, *charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
 }

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -605,7 +605,7 @@ func (s *mockCharmHub) ResolveBundleURL(url *charm.URL, preferredOrigin commonch
 	return s.url, s.origin, s.stub.NextErr()
 }
 
-func (s *mockCharmHub) GetBundle(url *charm.URL, _ commoncharm.Origin, path string) (charm.Bundle, error) {
+func (s *mockCharmHub) GetBundle(_ context.Context, url *charm.URL, _ commoncharm.Origin, path string) (charm.Bundle, error) {
 	s.stub.AddCall("GetBundle", url, path)
 	return s.bundle, s.stub.NextErr()
 }

--- a/cmd/juju/application/mocks/deployer_mock.go
+++ b/cmd/juju/application/mocks/deployer_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	cmd "github.com/juju/cmd/v3"
@@ -92,16 +93,16 @@ func (m *MockDeployerFactory) EXPECT() *MockDeployerFactoryMockRecorder {
 }
 
 // GetDeployer mocks base method.
-func (m *MockDeployerFactory) GetDeployer(arg0 deployer.DeployerConfig, arg1 deployer.ModelConfigGetter, arg2 deployer.Resolver) (deployer.Deployer, error) {
+func (m *MockDeployerFactory) GetDeployer(arg0 context.Context, arg1 deployer.DeployerConfig, arg2 deployer.ModelConfigGetter, arg3 deployer.Resolver) (deployer.Deployer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeployer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetDeployer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(deployer.Deployer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeployer indicates an expected call of GetDeployer.
-func (mr *MockDeployerFactoryMockRecorder) GetDeployer(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockDeployerFactoryMockRecorder) GetDeployer(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployer", reflect.TypeOf((*MockDeployerFactory)(nil).GetDeployer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployer", reflect.TypeOf((*MockDeployerFactory)(nil).GetDeployer), arg0, arg1, arg2, arg3)
 }

--- a/cmd/juju/application/store/charmadaptor.go
+++ b/cmd/juju/application/store/charmadaptor.go
@@ -28,7 +28,7 @@ type DownloadBundleClientFunc = func() (DownloadBundleClient, error)
 
 // BundleFactory represents a type for getting a bundle from a given url.
 type BundleFactory interface {
-	GetBundle(*charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
+	GetBundle(context.Context, *charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
 }
 
 // BundleRepoFunc creates a bundle factory from a charm URL.
@@ -93,12 +93,12 @@ func (c *CharmAdaptor) ResolveBundleURL(maybeBundle *charm.URL, preferredOrigin 
 }
 
 // GetBundle returns a bundle from a given charmstore path.
-func (c *CharmAdaptor) GetBundle(url *charm.URL, origin commoncharm.Origin, path string) (charm.Bundle, error) {
+func (c *CharmAdaptor) GetBundle(ctx context.Context, url *charm.URL, origin commoncharm.Origin, path string) (charm.Bundle, error) {
 	repo, err := c.bundleRepoFn(url)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return repo.GetBundle(url, origin, path)
+	return repo.GetBundle(ctx, url, origin, path)
 }
 
 type chBundleFactory struct {
@@ -106,7 +106,7 @@ type chBundleFactory struct {
 	downloadBundleClientFunc DownloadBundleClientFunc
 }
 
-func (ch chBundleFactory) GetBundle(curl *charm.URL, origin commoncharm.Origin, path string) (charm.Bundle, error) {
+func (ch chBundleFactory) GetBundle(ctx context.Context, curl *charm.URL, origin commoncharm.Origin, path string) (charm.Bundle, error) {
 	client, err := ch.downloadBundleClientFunc()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -120,5 +120,5 @@ func (ch chBundleFactory) GetBundle(curl *charm.URL, origin commoncharm.Origin, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return client.DownloadAndReadBundle(context.TODO(), url, path)
+	return client.DownloadAndReadBundle(ctx, url, path)
 }

--- a/cmd/juju/application/store/charmadaptor_test.go
+++ b/cmd/juju/application/store/charmadaptor_test.go
@@ -4,6 +4,7 @@
 package store_test
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/juju/charm/v12"
@@ -141,7 +142,7 @@ func (s *resolveSuite) TestCharmHubGetBundle(c *gc.C) {
 	charmAdaptor := store.NewCharmAdaptor(s.charmsAPI, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	bundle, err := charmAdaptor.GetBundle(curl, origin, "/tmp/")
+	bundle, err := charmAdaptor.GetBundle(context.Background(), curl, origin, "/tmp/")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bundle, gc.DeepEquals, s.bundle)
 }

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -60,7 +60,7 @@ type AddCloudAPI interface {
 }
 
 // BrokerGetter returns caas broker instance.
-type BrokerGetter func(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error)
+type BrokerGetter func(ctx stdcontext.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error)
 
 var usageAddCAASSummary = `
 Adds a k8s endpoint and credential to Juju.`[1:]
@@ -544,7 +544,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Trace(err)
 	}
 
-	broker, err := c.brokerGetter(newCloud, newCredential)
+	broker, err := c.brokerGetter(ctx, newCloud, newCredential)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -695,7 +695,7 @@ func checkCloudRegion(given, detected string) error {
 	return nil
 }
 
-func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+func (c *AddCAASCommand) newK8sClusterBroker(ctx stdcontext.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 	openParams, err := provider.BaseKubeCloudOpenParams(cloud, credential)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -708,7 +708,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 		openParams.ControllerUUID = ctrlUUID
 	}
 
-	broker, err := caas.New(stdcontext.TODO(), openParams)
+	broker, err := caas.New(ctx, openParams)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -4,6 +4,7 @@
 package caas_test
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -378,7 +379,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 				return c, nil
 			}
 		},
-		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+		func(_ context.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 		caas.FakeCluster(kubeConfigStr),

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -154,7 +154,7 @@ func (c *UpdateCAASCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+func (c *UpdateCAASCommand) newK8sClusterBroker(ctx stdcontext.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 	openParams, err := provider.BaseKubeCloudOpenParams(cloud, credential)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -167,7 +167,7 @@ func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credentia
 		openParams.ControllerUUID = ctrlUUID
 	}
 
-	broker, err := caas.New(stdcontext.TODO(), openParams)
+	broker, err := caas.New(ctx, openParams)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -265,7 +265,7 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 
 	// Check the cluster only if we have a credential to use.
 	if credential != nil {
-		broker, err := c.brokerGetter(*newCloud, *credential)
+		broker, err := c.brokerGetter(ctx, *newCloud, *credential)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -4,6 +4,7 @@
 package caas_test
 
 import (
+	"context"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -139,7 +140,7 @@ func (s *updateCAASSuite) makeCommand() cmd.Command {
 		func() (caas.UpdateCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+		func(_ context.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 	)

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -108,11 +108,11 @@ func (c *updatePublicCloudsCommand) Init(args []string) error {
 	return cmd.CheckEmpty(args)
 }
 
-func PublishedPublicClouds(url, key string) (map[string]jujucloud.Cloud, error) {
+func PublishedPublicClouds(ctx context.Context, url, key string) (map[string]jujucloud.Cloud, error) {
 	client := jujuhttp.NewClient(
 		jujuhttp.WithLogger(logger.ChildWithLabels("http", corelogger.HTTP)),
 	)
-	resp, err := client.Get(context.TODO(), url)
+	resp, err := client.Get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +146,7 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 	fmt.Fprint(ctxt.Stderr, "Fetching latest public cloud list...\n")
 	var returnedErr error
 	publishedClouds, msg, err := FetchAndMaybeUpdatePublicClouds(
+		ctxt,
 		PublicCloudsAccessDetails{
 			publicSigningKey: c.publicSigningKey,
 			publicCloudURL:   c.publicCloudURL,
@@ -182,9 +183,9 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 // Since this call can also update a client copy of clouds, it is possible that the public
 // clouds have been retrieved but the client update fail. In this case, we still
 // return public clouds as well as the client error.
-var FetchAndMaybeUpdatePublicClouds = func(access PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
+var FetchAndMaybeUpdatePublicClouds = func(ctx context.Context, access PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
 	var msg string
-	publishedClouds, err := PublishedPublicClouds(access.publicCloudURL, access.publicSigningKey)
+	publishedClouds, err := PublishedPublicClouds(ctx, access.publicCloudURL, access.publicSigningKey)
 	if err != nil {
 		return nil, msg, errors.Trace(err)
 	}

--- a/cmd/juju/cloud/updatepublicclouds_test.go
+++ b/cmd/juju/cloud/updatepublicclouds_test.go
@@ -5,6 +5,7 @@ package cloud_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -105,28 +106,28 @@ func (s *updatePublicCloudsSuite) run(c *gc.C, url, errMsg string, args ...strin
 func (s *updatePublicCloudsSuite) Test404(c *gc.C) {
 	ts := s.setupTestServer(c, "404")
 	defer ts.Close()
-	_, err := cloud.PublishedPublicClouds(ts.URL, "")
+	_, err := cloud.PublishedPublicClouds(context.Background(), ts.URL, "")
 	c.Assert(err, gc.ErrorMatches, "public cloud list is unavailable right now")
 }
 
 func (s *updatePublicCloudsSuite) Test401(c *gc.C) {
 	ts := s.setupTestServer(c, "401")
 	defer ts.Close()
-	_, err := cloud.PublishedPublicClouds(ts.URL, "")
+	_, err := cloud.PublishedPublicClouds(context.Background(), ts.URL, "")
 	c.Assert(err, gc.ErrorMatches, "unauthorised access to URL .*")
 }
 
 func (s *updatePublicCloudsSuite) TestUnsignedData(c *gc.C) {
 	ts := s.setupTestServer(c, "unsigned")
 	defer ts.Close()
-	_, err := cloud.PublishedPublicClouds(ts.URL, "")
+	_, err := cloud.PublishedPublicClouds(context.Background(), ts.URL, "")
 	c.Assert(err, gc.ErrorMatches, "receiving updated cloud data: no PGP signature embedded in plain text data")
 }
 
 func (s *updatePublicCloudsSuite) TestBadDataOnServer(c *gc.C) {
 	ts := s.setupTestServer(c, "bad data")
 	defer ts.Close()
-	_, err := cloud.PublishedPublicClouds(ts.URL, sstesting.SignedMetadataPublicKey)
+	_, err := cloud.PublishedPublicClouds(context.Background(), ts.URL, sstesting.SignedMetadataPublicKey)
 	c.Assert(err, gc.ErrorMatches, "(?s)invalid cloud data received when updating clouds.*")
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -160,7 +160,7 @@ func (m jujuMain) Run(args []string) int {
 
 	var jujuMsg string
 	if newInstall {
-		if _, _, err := cloud.FetchAndMaybeUpdatePublicClouds(cloud.PublicCloudsAccess(), true); err != nil {
+		if _, _, err := cloud.FetchAndMaybeUpdatePublicClouds(ctx, cloud.PublicCloudsAccess(), true); err != nil {
 			cmd.WriteError(ctx.Stderr, err)
 		}
 		jujuMsg = fmt.Sprintf("Since Juju %v is being run for the first time, it has downloaded the latest public cloud information.\n", jujuversion.Current.Major)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -236,7 +237,7 @@ func (s *MainSuite) TestNoWarn2xFirstRun(c *gc.C) {
 	s.PatchEnvironment("JUJU_HOME", path)
 
 	s.PatchValue(&cloud.FetchAndMaybeUpdatePublicClouds,
-		func(access cloud.PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
+		func(_ context.Context, access cloud.PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
 			return nil, "", nil
 		})
 
@@ -264,7 +265,7 @@ func (s *MainSuite) assertRunUpdateCloud(c *gc.C, expectedCalled bool) {
 
 	called := false
 	s.PatchValue(&cloud.FetchAndMaybeUpdatePublicClouds,
-		func(access cloud.PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
+		func(_ context.Context, access cloud.PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
 			called = true
 			return nil, "", nil
 		})

--- a/cmd/juju/config/config_test.go
+++ b/cmd/juju/config/config_test.go
@@ -176,7 +176,7 @@ func (s *suite) TestReadFile(c *gc.C) {
 		ConfigFile: jujucmd.FileVar{Path: filename},
 	}
 	ctx := &jujucmd.Context{
-		Context: context.TODO(),
+		Context: context.Background(),
 		Dir:     dir,
 	}
 
@@ -193,7 +193,7 @@ func (s *suite) TestReadFileStdin(c *gc.C) {
 		ConfigFile: jujucmd.FileVar{Path: "-"},
 	}
 	ctx := &jujucmd.Context{
-		Context: context.TODO(),
+		Context: context.Background(),
 		Stdin:   stdin,
 	}
 
@@ -213,7 +213,7 @@ func (s *suite) TestReadNoSuchFile(c *gc.C) {
 		ConfigFile: jujucmd.FileVar{Path: filename},
 	}
 	ctx := &jujucmd.Context{
-		Context: context.TODO(),
+		Context: context.Background(),
 		Dir:     dir,
 	}
 
@@ -232,7 +232,7 @@ func (s *suite) TestReadFileBadYAML(c *gc.C) {
 		ConfigFile: jujucmd.FileVar{Path: filename},
 	}
 	ctx := &jujucmd.Context{
-		Context: context.TODO(),
+		Context: context.Background(),
 		Dir:     dir,
 	}
 

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -584,7 +584,7 @@ func (c *destroyCommandBase) getControllerEnviron(
 	// fall back position.
 	env, err := c.getControllerEnvironFromStore(ctx, store, controllerName)
 	if errors.Is(err, errors.NotFound) {
-		return c.getControllerEnvironFromAPI(sysAPI, controllerName)
+		return c.getControllerEnvironFromAPI(ctx, sysAPI)
 	} else if err != nil {
 		return nil, errors.Annotate(err, "getting environ using bootstrap config from client store")
 	}
@@ -636,14 +636,14 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 		Config:         cfg,
 	}
 	if cloud.CloudTypeIsCAAS(bootstrapConfig.CloudType) {
-		return caas.New(stdcontext.TODO(), openParams)
+		return caas.New(ctx, openParams)
 	}
-	return environs.New(stdcontext.TODO(), openParams)
+	return environs.New(ctx, openParams)
 }
 
 func (c *destroyCommandBase) getControllerEnvironFromAPI(
+	ctx stdcontext.Context,
 	api destroyControllerAPI,
-	controllerName string,
 ) (environs.Environ, error) {
 	if api == nil {
 		return nil, errors.New(
@@ -666,7 +666,7 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting controller config from API")
 	}
-	return environs.New(stdcontext.TODO(), environs.OpenParams{
+	return environs.New(ctx, environs.OpenParams{
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	stdcontext "context"
 	"fmt"
 	"time"
 
@@ -251,9 +250,9 @@ func (c *killCommand) DirectDestroyRemaining(
 			}
 			var env environs.CloudDestroyer
 			if cloud.CloudTypeIsCAAS(model.CloudSpec.Type) {
-				env, err = caas.Open(stdcontext.TODO(), cloudProvider, openParams)
+				env, err = caas.Open(ctx, cloudProvider, openParams)
 			} else {
-				env, err = environs.Open(stdcontext.TODO(), cloudProvider, openParams)
+				env, err = environs.Open(ctx, cloudProvider, openParams)
 			}
 			if err != nil {
 				logger.Warningf(err.Error())

--- a/cmd/juju/machine/upgrademachine.go
+++ b/cmd/juju/machine/upgrademachine.go
@@ -259,7 +259,7 @@ func (c *upgradeMachineCommand) trapInterrupt(ctx *cmd.Context) func() {
 	interrupted := make(chan os.Signal, 1)
 	ctx.InterruptNotify(interrupted)
 
-	cancelCtx, cancel := context.WithCancel(context.TODO())
+	cancelCtx, cancel := context.WithCancel(ctx)
 	go func() {
 		for range interrupted {
 			select {

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -257,7 +257,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	repo := mocks.NewMockRepository(ctrl)
-	s.PatchValue(&newCharmRepo, func(cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
+	s.PatchValue(&newCharmRepo, func(_ context.Context, cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
 		return repo, nil
 	})
 	downloader := mocks.NewMockDownloader(ctrl)

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -133,9 +133,9 @@ func (c *BootstrapCommand) deployControllerCharm(ctx context.Context, objectStor
 
 // These are patched for testing.
 var (
-	newCharmRepo = func(cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
+	newCharmRepo = func(ctx context.Context, cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
 		charmRepoFactory := services.NewCharmRepoFactory(cfg)
-		return charmRepoFactory.GetCharmRepository(context.TODO(), corecharm.CharmHub)
+		return charmRepoFactory.GetCharmRepository(ctx, corecharm.CharmHub)
 	}
 	newCharmDownloader = func(cfg services.CharmDownloaderConfig) (interfaces.Downloader, error) {
 		return services.NewCharmDownloader(cfg)
@@ -153,7 +153,7 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 	charmhubHTTPClient := charmhub.DefaultHTTPClient(loggerFactory)
 
 	stateBackend := &stateShim{st}
-	charmRepo, err := newCharmRepo(services.CharmRepoFactoryConfig{
+	charmRepo, err := newCharmRepo(ctx, services.CharmRepoFactoryConfig{
 		LoggerFactory:      services.LoggoLoggerFactory(logger),
 		CharmhubHTTPClient: charmhubHTTPClient,
 		StateBackend:       stateBackend,
@@ -192,7 +192,7 @@ func populateStoreControllerCharm(ctx context.Context, objectStore services.Stor
 	// error response.
 	//
 	// The controller charm doesn't have any series specific code.
-	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(context.TODO(), curl.Name, origin)
+	curl, origin, _, err = charmRepo.ResolveWithPreferredChannel(ctx, curl.Name, origin)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "resolving %q", controllerCharmURL)
 	}

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -105,7 +105,7 @@ func (s *APIContextSuite) TestNewAPIContextEmbedded(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	interactor := modelcmd.Interactor(ctx)
 	c.Assert(interactor, gc.Not(gc.IsNil))
-	_, err = interactor.Interact(context.TODO(), nil, "", nil)
+	_, err = interactor.Interact(context.Background(), nil, "", nil)
 	c.Assert(err, jc.ErrorIs, errors.NotSupported)
 }
 

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +54,7 @@ func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientSto
 	// identify region and endpoint info that we need. Not sure what
 	// we'll do about simplestreams.MetadataValidator yet. Probably
 	// move it to the EnvironProvider interface.
-	return environs.New(context.TODO(), environs.OpenParams{
+	return environs.New(ctx, environs.OpenParams{
 		Cloud:  params.Cloud,
 		Config: cfg,
 	})

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -372,7 +372,7 @@ func (c *CharmHubRepository) DownloadCharm(ctx context.Context, charmName string
 		return nil, corecharm.Origin{}, errors.Trace(err)
 	}
 
-	charmArchive, err := c.client.DownloadAndRead(context.TODO(), resURL, archivePath)
+	charmArchive, err := c.client.DownloadAndRead(ctx, resURL, archivePath)
 	if err != nil {
 		return nil, corecharm.Origin{}, errors.Trace(err)
 	}
@@ -457,7 +457,7 @@ func (c *CharmHubRepository) ListResources(ctx context.Context, charmName string
 // downloaded) resources to determine which to use. Provided (uploaded) take
 // precedence. If charmhub has a newer resource than the back end, use that.
 func (c *CharmHubRepository) ResolveResources(ctx context.Context, resources []charmresource.Resource, id corecharm.CharmID) ([]charmresource.Resource, error) {
-	revisionResources, err := c.listResourcesIfRevisions(resources, id.URL.Name)
+	revisionResources, err := c.listResourcesIfRevisions(ctx, resources, id.URL.Name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -479,7 +479,7 @@ func (c *CharmHubRepository) ResolveResources(ctx context.Context, resources []c
 	return resolved, nil
 }
 
-func (c *CharmHubRepository) listResourcesIfRevisions(resources []charmresource.Resource, charmName string) (map[string]charmresource.Resource, error) {
+func (c *CharmHubRepository) listResourcesIfRevisions(ctx context.Context, resources []charmresource.Resource, charmName string) (map[string]charmresource.Resource, error) {
 	results := make(map[string]charmresource.Resource, 0)
 	for _, resource := range resources {
 		// If not revision is specified, or the resource has already been
@@ -487,7 +487,7 @@ func (c *CharmHubRepository) listResourcesIfRevisions(resources []charmresource.
 		if resource.Revision == -1 || resource.Origin == charmresource.OriginUpload {
 			continue
 		}
-		refreshResp, err := c.client.ListResourceRevisions(context.TODO(), charmName, resource.Name)
+		refreshResp, err := c.client.ListResourceRevisions(ctx, charmName, resource.Name)
 		if err != nil {
 			return nil, errors.Annotatef(err, "refreshing charm %q", charmName)
 		}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1580,7 +1580,7 @@ func (e bootstrapEnvironWithHardwareDetection) UpdateModelConstraints() bool {
 
 func bootstrapContext(c *gc.C) (environs.BootstrapContext, *simplestreams.Simplestreams) {
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	ctx := context.WithValue(context.TODO(), bootstrap.SimplestreamsFetcherContextKey, ss)
+	ctx := context.WithValue(context.Background(), bootstrap.SimplestreamsFetcherContextKey, ss)
 	return envtesting.BootstrapContext(ctx, c), ss
 }
 
@@ -1597,7 +1597,7 @@ func (s *BootstrapContextSuite) TestContextDone(c *gc.C) {
 		done bool
 	}{{
 		name: "todo context",
-		ctx:  context.TODO(),
+		ctx:  context.Background(),
 		done: false,
 	}, {
 		name: "background context",

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -41,7 +41,7 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 	}
 	env, err := bootstrap.PrepareController(
 		false,
-		envtesting.BootstrapContext(stdcontext.TODO(), c),
+		envtesting.BootstrapContext(stdcontext.Background(), c),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -51,7 +51,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	// matches *Settings.Map()
 	cfg, err := config.New(config.NoDefaults, testing.FakeConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	cache := jujuclient.NewMemStore()
 	controllerCfg := testing.FakeControllerConfig()
 	bootstrapEnviron, err := bootstrap.PrepareController(false, ctx, cache, bootstrap.PrepareParams{
@@ -85,7 +85,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 
 func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 	store := jujuclient.NewMemStore()
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	uuid := utils.MustNewUUID().String()
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"type": "dummy",
@@ -116,7 +116,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 }
 
 func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
-	env, err := environs.New(context.TODO(), environs.OpenParams{
+	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type: "wondercloud",
 		},
@@ -133,7 +133,7 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := context.TODO()
+	ctx := context.Background()
 	e, err := environs.New(ctx, environs.OpenParams{
 		Cloud:  testing.FakeCloudSpec(),
 		Config: cfg,
@@ -155,7 +155,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	// Prepare the environment and sanity-check that
 	// the config storage info has been made.
 	controllerCfg := testing.FakeControllerConfig()
-	ctx := envtesting.BootstrapContext(context.TODO(), c)
+	ctx := envtesting.BootstrapContext(context.Background(), c)
 	bootstrapEnviron, err := bootstrap.PrepareController(false, ctx, store, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   "controller-name",
@@ -183,7 +183,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 func (*OpenSuite) TestDestroyNotFound(c *gc.C) {
 	var env destroyControllerEnv
 	store := jujuclient.NewMemStore()
-	err := environs.Destroy("fnord", &env, envcontext.WithoutCredentialInvalidator(context.TODO()), store)
+	err := environs.Destroy("fnord", &env, envcontext.WithoutCredentialInvalidator(context.Background()), store)
 	c.Assert(err, jc.ErrorIsNil)
 	env.CheckCallNames(c) // no controller details, no call
 }

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -357,7 +357,7 @@ func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectOST
 // downloadToolsRaw downloads the supplied tools and returns the raw bytes.
 func downloadToolsRaw(c *gc.C, t *coretools.Tools) []byte {
 	client := jujuhttp.NewClient()
-	resp, err := client.Get(context.TODO(), t.URL)
+	resp, err := client.Get(context.Background(), t.URL)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = resp.Body.Close() }()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -104,7 +104,7 @@ func (s *SimpleStreamsToolsSuite) uploadStreams(c *gc.C, versions toolstesting.S
 func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}) {
 	jujuversion.Current = s.origCurrentVersion
 	attrs = coretesting.FakeConfig().Merge(attrs)
-	env, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c),
+	env, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.Background(), c),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),

--- a/generate/schemagen/schemagen.go
+++ b/generate/schemagen/schemagen.go
@@ -245,10 +245,6 @@ func (c context) ControllerTag() names.ControllerTag {
 
 func (c context) Dispose() {}
 
-func (c context) Cancel() <-chan struct{} {
-	return make(chan struct{})
-}
-
 func (c context) ControllerDB() (changestream.WatchableDB, error) {
 	return nil, nil
 }

--- a/internal/changestream/eventmultiplexer/subscription_test.go
+++ b/internal/changestream/eventmultiplexer/subscription_test.go
@@ -65,7 +65,7 @@ func (s *subscriptionSuite) TestSubscriptionWitnessChanges(c *gc.C) {
 	}}
 
 	go func() {
-		err := sub.dispatch(context.TODO(), changes)
+		err := sub.dispatch(context.Background(), changes)
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 

--- a/internal/database/txn/transaction_test.go
+++ b/internal/database/txn/transaction_test.go
@@ -29,7 +29,7 @@ var _ = gc.Suite(&transactionRunnerSuite{})
 func (s *transactionRunnerSuite) TestTxn(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
-	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.Background(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, "SELECT 1")
 		if err != nil {
 			return errors.Trace(err)
@@ -123,7 +123,7 @@ func (s *transactionRunnerSuite) TestTxnInserts(c *gc.C) {
 
 	s.createTable(c)
 
-	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.Background(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "INSERT INTO foo (id, name) VALUES (1, 'test')")
 		if err != nil {
 			return errors.Trace(err)
@@ -151,7 +151,7 @@ func (s *transactionRunnerSuite) TestTxnRollback(c *gc.C) {
 
 	s.createTable(c)
 
-	err := runner.StdTxn(context.TODO(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
+	err := runner.StdTxn(context.Background(), s.DB(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "INSERT INTO foo (id, name) VALUES (1, 'test')")
 		if err != nil {
 			return errors.Trace(err)
@@ -178,7 +178,7 @@ func (s *transactionRunnerSuite) TestRetryForNonRetryableError(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
 	var count int
-	err := runner.Retry(context.TODO(), func() error {
+	err := runner.Retry(context.Background(), func() error {
 		count++
 		return errors.Errorf("fail")
 	})
@@ -206,7 +206,7 @@ func (s *transactionRunnerSuite) TestRetryForRetryableError(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
 	var count int
-	err := runner.Retry(context.TODO(), func() error {
+	err := runner.Retry(context.Background(), func() error {
 		count++
 		return sqlite3.ErrBusy
 	})

--- a/internal/rpcreflect/type_test.go
+++ b/internal/rpcreflect/type_test.go
@@ -130,7 +130,7 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	c.Assert(m.ParamsType(), gc.Equals, reflect.TypeOf(stringVal{}))
 	c.Assert(m.ResultType(), gc.Equals, reflect.TypeOf(stringVal{}))
 
-	ret, err := m.Call(context.TODO(), "a99", reflect.ValueOf(stringVal{"foo"}))
+	ret, err := m.Call(context.Background(), "a99", reflect.ValueOf(stringVal{"foo"}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ret.Interface(), gc.Equals, stringVal{"Call1r1e ret"})
 }

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -43,7 +43,7 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.client, err = armcompute.NewVirtualMachineImagesClient("subscription-id", &azuretesting.FakeCredential{}, opts)
 	c.Assert(err, jc.ErrorIsNil)
-	s.callCtx = envcontext.WithoutCredentialInvalidator(context.TODO())
+	s.callCtx = envcontext.WithoutCredentialInvalidator(context.Background())
 }
 
 func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
@@ -105,7 +105,7 @@ func (s *imageutilsSuite) TestSeriesImageStreamNotFound(c *gc.C) {
 func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
 	called := false
-	s.callCtx = envcontext.WithCredentialInvalidator(context.TODO(), func(context.Context, string) error {
+	s.callCtx = envcontext.WithCredentialInvalidator(context.Background(), func(context.Context, string) error {
 		called = true
 		return nil
 	})
@@ -118,7 +118,7 @@ func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
 func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("308 Permanent Redirect", http.StatusPermanentRedirect))
 	called := false
-	s.callCtx = envcontext.WithCredentialInvalidator(context.TODO(), func(context.Context, string) error {
+	s.callCtx = envcontext.WithCredentialInvalidator(context.Background(), func(context.Context, string) error {
 		called = true
 		return nil
 	})

--- a/rpc/reflect_test.go
+++ b/rpc/reflect_test.go
@@ -132,7 +132,7 @@ func (*reflectSuite) TestFindMethod(c *gc.C) {
 	c.Assert(m.ParamsType(), gc.Equals, reflect.TypeOf(stringVal{}))
 	c.Assert(m.ResultType(), gc.Equals, reflect.TypeOf(stringVal{}))
 
-	ret, err := m.Call(context.TODO(), "a99", reflect.ValueOf(stringVal{"foo"}))
+	ret, err := m.Call(context.Background(), "a99", reflect.ValueOf(stringVal{"foo"}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ret.Interface(), gc.Equals, stringVal{"Call1r1e ret"})
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -355,7 +355,7 @@ func (c customMethodCaller) Call(_ context.Context, objId string, arg reflect.Va
 		logger.Errorf("got the wrong type back, expected %s got %T", c.expectedType, obj)
 	}
 	logger.Debugf("calling: %T %v %#v", obj, obj, c.objMethod)
-	return c.objMethod.Call(context.TODO(), obj, arg)
+	return c.objMethod.Call(context.Background(), obj, arg)
 }
 
 func (cc *CustomRoot) Kill() {}

--- a/state/bakerystorage/storage_test.go
+++ b/state/bakerystorage/storage_test.go
@@ -246,18 +246,18 @@ func (s *BakeryStorageSuite) ensureIndexes(c *gc.C) {
 
 func (s *BakeryStorageSuite) TestCheckNewMacaroon(c *gc.C) {
 	cav := []checkers.Caveat{{Condition: "something"}}
-	mac, err := s.bakery.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, cav, bakery.NoOp)
+	mac, err := s.bakery.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, cav, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, err = s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
+	_, _, err = s.bakery.Oven.VerifyMacaroon(context.Background(), macaroon.Slice{mac.M()})
 	c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
 
 	store := s.store.ExpireAfter(10 * time.Second)
 	b := bakery.New(bakery.BakeryParams{
 		RootKeyStore: store,
 	})
-	mac, err = b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, cav, bakery.NoOp)
+	mac, err = b.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, cav, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
-	op, conditions, err := s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
+	op, conditions, err := s.bakery.Oven.VerifyMacaroon(context.Background(), macaroon.Slice{mac.M()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, []bakery.Op{bakery.NoOp})
 	c.Assert(conditions, jc.DeepEquals, []string{"something"})
@@ -268,13 +268,13 @@ func (s *BakeryStorageSuite) TestExpiryTime(c *gc.C) {
 	// items immediately.
 	s.initService(c, true)
 
-	mac, err := s.bakery.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, nil, bakery.NoOp)
+	mac, err := s.bakery.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, nil, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The background thread that removes records runs every 60s.
 	// Give a little bit of leeway for loaded systems.
 	for i := 0; i < 90; i++ {
-		_, _, err = s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
+		_, _, err = s.bakery.Oven.VerifyMacaroon(context.Background(), macaroon.Slice{mac.M()})
 		if err == nil {
 			time.Sleep(time.Second)
 			continue


### PR DESCRIPTION
This is the first PR of a few which will ensure that context is used properly everywhere.

Commit https://github.com/juju/juju/pull/16740/commits/5ce653c0c7ade1ddf36a7a4c1b2b097f25e3af34
replaces `context.TODO()` with `context.Background()` in tests.

Also, a few tests with gomock expected an arg of a context instead of `gomock.Any()` which caused some race test failures. That's been fixed also.

Commit https://github.com/juju/juju/pull/16740/commits/d4fcb21119be4ac90940faa3859ff5ded7945c6c
in apiserver and cmd packages, use the actual context instead of `context.TODO()`
The context is available but was being ignored. In a few cases, a little bit of boiler plate was needed to wire it through.
Also, there were a few places where we were using a stop channel created on the api server. This is replaced by a context.

## QA steps

Run unit tests
bootstrap and deploy a charm

## Links

**Jira card:** JUJU-5243

