### PR TITLE
Pass the std context to facade creation methods

### DIFF
--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -4,6 +4,7 @@
 package facade
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -28,7 +29,7 @@ import (
 type Facade interface{}
 
 // Factory is a callback used to create a Facade.
-type Factory func(Context) (Facade, error)
+type Factory func(stdCtx context.Context, facadeCtx Context) (Facade, error)
 
 // LeadershipContext describes factory methods for objects that deliver
 // specific lease-related capabilities

--- a/apiserver/facade/registry_test.go
+++ b/apiserver/facade/registry_test.go
@@ -4,6 +4,7 @@
 package facade_test
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -32,7 +33,7 @@ func (s *RegistrySuite) TestRegister(c *gc.C) {
 
 	factory, err := registry.GetFactory("myfacade", 123)
 	c.Assert(err, jc.ErrorIsNil)
-	val, err := factory(nil)
+	val, err := factory(context.Background(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(val, gc.Equals, "myobject")
 }
@@ -49,13 +50,13 @@ func (s *RegistrySuite) TestListDetails(c *gc.C) {
 	c.Assert(details, gc.HasLen, 2)
 	c.Assert(details[0].Name, gc.Equals, "f1")
 	c.Assert(details[0].Version, gc.Equals, 9)
-	v, _ := details[0].Factory(nil)
+	v, _ := details[0].Factory(context.Background(), nil)
 	c.Assert(v, gc.FitsTypeOf, new(int))
 	c.Assert(details[0].Type, gc.Equals, intPtrType)
 
 	c.Assert(details[1].Name, gc.Equals, "f2")
 	c.Assert(details[1].Version, gc.Equals, 6)
-	v, _ = details[1].Factory(nil)
+	v, _ = details[1].Factory(context.Background(), nil)
 	c.Assert(v, gc.Equals, "myobject")
 	c.Assert(details[1].Type, gc.Equals, interfaceType)
 }
@@ -115,7 +116,7 @@ func (*RegistrySuite) TestRegisterAndListMultiple(c *gc.C) {
 func (*RegistrySuite) TestRegisterAlreadyPresent(c *gc.C) {
 	registry := &facade.Registry{}
 	assertRegister(c, registry, "name", 0)
-	secondIdFactory := func(context facade.Context) (facade.Facade, error) {
+	secondIdFactory := func(_ context.Context, context facade.Context) (facade.Facade, error) {
 		var i = 200
 		return &i, nil
 	}
@@ -125,7 +126,7 @@ func (*RegistrySuite) TestRegisterAlreadyPresent(c *gc.C) {
 	factory, err := registry.GetFactory("name", 0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(factory, gc.NotNil)
-	val, err := factory(nil)
+	val, err := factory(context.Background(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	asIntPtr := val.(*int)
 	c.Check(*asIntPtr, gc.Equals, 100)
@@ -138,7 +139,7 @@ func (*RegistrySuite) TestGetFactory(c *gc.C) {
 	factory, err := registry.GetFactory("name", 0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(factory, gc.NotNil)
-	res, err := factory(nil)
+	res, err := factory(context.Background(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.NotNil)
 	asIntPtr := res.(*int)
@@ -195,11 +196,11 @@ func assertRegisterFlag(c *gc.C, registry *facade.Registry, name string, version
 	c.Assert(err, gc.IsNil)
 }
 
-func testFacade(_ facade.Context) (facade.Facade, error) {
+func testFacade(_ context.Context, _ facade.Context) (facade.Facade, error) {
 	return "myobject", nil
 }
 
-func validIdFactory(_ facade.Context) (facade.Facade, error) {
+func validIdFactory(_ context.Context, _ facade.Context) (facade.Facade, error) {
 	var i = 100
 	return &i, nil
 }

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -15,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Agent", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Agent", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewAgentAPIV3(ctx)
 	}, reflect.TypeOf((*AgentAPI)(nil)))
 }

--- a/apiserver/facades/agent/caasadmission/register.go
+++ b/apiserver/facades/agent/caasadmission/register.go
@@ -4,6 +4,7 @@
 package caasadmission
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/common"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASAdmission", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASAdmission", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -4,6 +4,7 @@
 package caasagent
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASAgent", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASAgent", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacadeV2(ctx)
 	}, reflect.TypeOf((*FacadeV2)(nil)))
 }

--- a/apiserver/facades/agent/caasapplication/register.go
+++ b/apiserver/facades/agent/caasapplication/register.go
@@ -4,6 +4,7 @@
 package caasapplication
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASApplication", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASApplication", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/credentialvalidator/register.go
+++ b/apiserver/facades/agent/credentialvalidator/register.go
@@ -4,6 +4,7 @@
 package credentialvalidator
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CredentialValidator", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CredentialValidator", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newCredentialValidatorAPI(ctx) // adds WatchModelCredential
 	}, reflect.TypeOf((*CredentialValidatorAPI)(nil)))
 }

--- a/apiserver/facades/agent/deployer/register.go
+++ b/apiserver/facades/agent/deployer/register.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Deployer", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Deployer", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewDeployerFacade(ctx)
 	}, reflect.TypeOf((*DeployerAPI)(nil)))
 }

--- a/apiserver/facades/agent/diskmanager/register.go
+++ b/apiserver/facades/agent/diskmanager/register.go
@@ -4,6 +4,7 @@
 package diskmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/names/v5"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("DiskManager", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("DiskManager", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newDiskManagerAPI(ctx)
 	}, reflect.TypeOf((*DiskManagerAPI)(nil)))
 }

--- a/apiserver/facades/agent/fanconfigurer/register.go
+++ b/apiserver/facades/agent/fanconfigurer/register.go
@@ -4,6 +4,7 @@
 package fanconfigurer
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("FanConfigurer", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("FanConfigurer", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFanConfigurerAPI(ctx)
 	}, reflect.TypeOf((*FanConfigurerAPI)(nil)))
 }

--- a/apiserver/facades/agent/hostkeyreporter/register.go
+++ b/apiserver/facades/agent/hostkeyreporter/register.go
@@ -4,6 +4,7 @@
 package hostkeyreporter
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("HostKeyReporter", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("HostKeyReporter", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/instancemutater/register.go
+++ b/apiserver/facades/agent/instancemutater/register.go
@@ -4,6 +4,7 @@
 package instancemutater
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("InstanceMutater", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("InstanceMutater", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV3(ctx)
 	}, reflect.TypeOf((*InstanceMutaterAPI)(nil)))
 }

--- a/apiserver/facades/agent/keyupdater/register.go
+++ b/apiserver/facades/agent/keyupdater/register.go
@@ -4,6 +4,7 @@
 package keyupdater
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("KeyUpdater", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("KeyUpdater", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newKeyUpdaterAPI(ctx)
 	}, reflect.TypeOf((*KeyUpdaterAPI)(nil)))
 }

--- a/apiserver/facades/agent/leadership/register.go
+++ b/apiserver/facades/agent/leadership/register.go
@@ -4,6 +4,7 @@
 package leadership
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("LeadershipService", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("LeadershipService", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newLeadershipServiceFacade(ctx)
 	}, reflect.TypeOf((*LeadershipService)(nil)).Elem())
 }

--- a/apiserver/facades/agent/lifeflag/register.go
+++ b/apiserver/facades/agent/lifeflag/register.go
@@ -4,6 +4,7 @@
 package lifeflag
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("AgentLifeFlag", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("AgentLifeFlag", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/logger/register.go
+++ b/apiserver/facades/agent/logger/register.go
@@ -4,6 +4,7 @@
 package logger
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Logger", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Logger", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newLoggerAPI(ctx)
 	}, reflect.TypeOf((*LoggerAPI)(nil)))
 }

--- a/apiserver/facades/agent/machine/register.go
+++ b/apiserver/facades/agent/machine/register.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Machiner", 5, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Machiner", 5, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newMachinerAPI(ctx) // Adds RecordAgentHostAndStartTime.
 	}, reflect.TypeOf((*MachinerAPI)(nil)))
 }

--- a/apiserver/facades/agent/machineactions/register.go
+++ b/apiserver/facades/agent/machineactions/register.go
@@ -4,6 +4,7 @@
 package machineactions
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MachineActions", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MachineActions", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newExternalFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/meterstatus/register.go
+++ b/apiserver/facades/agent/meterstatus/register.go
@@ -4,6 +4,7 @@
 package meterstatus
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MeterStatus", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MeterStatus", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newMeterStatusFacade(ctx)
 	}, reflect.TypeOf((*MeterStatusAPI)(nil)))
 }

--- a/apiserver/facades/agent/metricsadder/register.go
+++ b/apiserver/facades/agent/metricsadder/register.go
@@ -4,6 +4,7 @@
 package metricsadder
 
 import (
+	"context"
 	"reflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MetricsAdder", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MetricsAdder", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newMetricsAdderAPI(ctx)
 	}, reflect.TypeOf((*MetricsAdderAPI)(nil)))
 }

--- a/apiserver/facades/agent/migrationflag/register.go
+++ b/apiserver/facades/agent/migrationflag/register.go
@@ -4,6 +4,7 @@
 package migrationflag
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MigrationFlag", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MigrationFlag", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/agent/migrationminion/register.go
+++ b/apiserver/facades/agent/migrationminion/register.go
@@ -4,6 +4,7 @@
 package migrationminion
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MigrationMinion", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MigrationMinion", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/agent/payloadshookcontext/register.go
+++ b/apiserver/facades/agent/payloadshookcontext/register.go
@@ -4,6 +4,7 @@
 package payloadshookcontext
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("PayloadsHookContext", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("PayloadsHookContext", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*UnitFacade)(nil)))
 }

--- a/apiserver/facades/agent/provisioner/container_test.go
+++ b/apiserver/facades/agent/provisioner/container_test.go
@@ -49,7 +49,7 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[1].Tag()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),
@@ -104,7 +104,7 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[1].Tag()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),

--- a/apiserver/facades/agent/provisioner/imagemetadata_test.go
+++ b/apiserver/facades/agent/provisioner/imagemetadata_test.go
@@ -64,7 +64,7 @@ func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ImageMetadataSuite) TestMetadataNone(c *gc.C) {
-	api, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	api, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           s.authorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -85,7 +85,7 @@ func (s *ImageMetadataSuite) TestMetadataNone(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestMetadataFromState(c *gc.C) {
 	st := s.ControllerModel(c).State()
-	api, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	api, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           s.authorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -84,7 +84,7 @@ type ProvisionerAPI struct {
 }
 
 // NewProvisionerAPI creates a new server-side ProvisionerAPI facade.
-func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
+func NewProvisionerAPI(stdCtx stdcontext.Context, ctx facade.Context) (*ProvisionerAPI, error) {
 	authorizer := ctx.Auth()
 	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm
@@ -132,7 +132,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 
 	// Get the controller config early, so we can use it to cache the
 	// controller UUID.
-	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(stdcontext.TODO())
+	controllerCfg, err := serviceFactory.ControllerConfig().ControllerConfig(stdCtx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -99,7 +99,7 @@ func (s *provisionerSuite) setUpTest(c *gc.C, withController bool) {
 	s.resources = common.NewResources()
 
 	// Create a provisioner API for the machine.
-	provisionerAPI, err := provisioner.NewProvisionerAPIV11(facadetest.Context{
+	provisionerAPI, err := provisioner.NewProvisionerAPIV11(context.Background(), facadetest.Context{
 		Auth_:           s.authorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),
@@ -127,7 +127,7 @@ func (s *withoutControllerSuite) TestProvisionerFailsWithNonMachineAgentNonManag
 	anAuthorizer.Controller = true
 	// Works with a controller, which is not a machine agent.
 	st := s.ControllerModel(c).State()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),
@@ -139,7 +139,7 @@ func (s *withoutControllerSuite) TestProvisionerFailsWithNonMachineAgentNonManag
 
 	// But fails with neither a machine agent or a controller.
 	anAuthorizer.Controller = false
-	aProvisioner, err = provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err = provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),
@@ -217,7 +217,7 @@ func (s *withoutControllerSuite) TestLifeAsMachineAgent(c *gc.C) {
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
 	st := s.ControllerModel(c).State()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          st,
 		StatePool_:      s.StatePool(),
@@ -577,7 +577,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = names.NewMachineTag("1")
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -780,7 +780,7 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	anAuthorizer.Controller = false
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -1082,7 +1082,7 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	anAuthorizer.Controller = false
-	provisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	provisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -1208,7 +1208,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineIdMachineAgentAut
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	anAuthorizer.Controller = false
-	provisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	provisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -1447,7 +1447,7 @@ func (s *withoutControllerSuite) TestWatchModelMachines(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	anAuthorizer.Controller = false
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -1501,7 +1501,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	anAuthorizer.Controller = false
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),
@@ -1676,7 +1676,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainersPermissions(c *gc.C) 
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -690,7 +690,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
 	anAuthorizer.Tag = s.machines[0].Tag()
-	aProvisioner, err := provisioner.NewProvisionerAPI(facadetest.Context{
+	aProvisioner, err := provisioner.NewProvisionerAPI(context.Background(), facadetest.Context{
 		Auth_:           anAuthorizer,
 		State_:          s.ControllerModel(c).State(),
 		StatePool_:      s.StatePool(),

--- a/apiserver/facades/agent/provisioner/register.go
+++ b/apiserver/facades/agent/provisioner/register.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,14 +14,14 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Provisioner", 11, func(ctx facade.Context) (facade.Facade, error) {
-		return newProvisionerAPIV11(ctx) // Relies on agent-set origin in SetHostMachineNetworkConfig.
+	registry.MustRegister("Provisioner", 11, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
+		return newProvisionerAPIV11(stdCtx, ctx) // Relies on agent-set origin in SetHostMachineNetworkConfig.
 	}, reflect.TypeOf((*ProvisionerAPIV11)(nil)))
 }
 
 // newProvisionerAPIV11 creates a new server-side Provisioner API facade.
-func newProvisionerAPIV11(ctx facade.Context) (*ProvisionerAPIV11, error) {
-	provisionerAPI, err := NewProvisionerAPI(ctx)
+func newProvisionerAPIV11(stdCtx context.Context, ctx facade.Context) (*ProvisionerAPIV11, error) {
+	provisionerAPI, err := NewProvisionerAPI(stdCtx, ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/proxyupdater/register.go
+++ b/apiserver/facades/agent/proxyupdater/register.go
@@ -4,6 +4,7 @@
 package proxyupdater
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ProxyUpdater", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ProxyUpdater", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV2(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/agent/reboot/register.go
+++ b/apiserver/facades/agent/reboot/register.go
@@ -4,6 +4,7 @@
 package reboot
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Reboot", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Reboot", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*RebootAPI)(nil)))
 }

--- a/apiserver/facades/agent/resourceshookcontext/register.go
+++ b/apiserver/facades/agent/resourceshookcontext/register.go
@@ -4,6 +4,7 @@
 package resourceshookcontext
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ResourcesHookContext", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ResourcesHookContext", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*UnitFacade)(nil)))
 }

--- a/apiserver/facades/agent/retrystrategy/register.go
+++ b/apiserver/facades/agent/retrystrategy/register.go
@@ -4,6 +4,7 @@
 package retrystrategy
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("RetryStrategy", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("RetryStrategy", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newRetryStrategyAPI(ctx)
 	}, reflect.TypeOf((*RetryStrategyAPI)(nil)))
 }

--- a/apiserver/facades/agent/secretsdrain/register.go
+++ b/apiserver/facades/agent/secretsdrain/register.go
@@ -4,6 +4,7 @@
 package secretsdrain
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("SecretsDrain", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("SecretsDrain", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newSecretsDrainAPI(ctx)
 	}, reflect.TypeOf((*commonsecrets.SecretsDrainAPI)(nil)))
 }

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -4,6 +4,7 @@
 package storageprovisioner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -18,7 +19,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("StorageProvisioner", 4, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("StorageProvisioner", 4, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV4(ctx)
 	}, reflect.TypeOf((*StorageProvisionerAPIv4)(nil)))
 }

--- a/apiserver/facades/agent/unitassigner/register.go
+++ b/apiserver/facades/agent/unitassigner/register.go
@@ -4,6 +4,7 @@
 package unitassigner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/common"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UnitAssigner", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UnitAssigner", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/agent/uniter/package_test.go
+++ b/apiserver/facades/agent/uniter/package_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/collections/set"
@@ -149,7 +150,7 @@ func (s *uniterSuiteBase) newUniterAPI(c *gc.C, st *state.State, auth facade.Aut
 	facadeContext.State_ = st
 	facadeContext.Auth_ = auth
 	facadeContext.LeadershipRevoker_ = s.leadershipRevoker
-	uniterAPI, err := uniter.NewUniterAPI(facadeContext)
+	uniterAPI, err := uniter.NewUniterAPI(context.Background(), facadeContext)
 	c.Assert(err, jc.ErrorIsNil)
 	return uniterAPI
 }

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -4,6 +4,7 @@
 package uniter
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -19,15 +20,16 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Uniter", 19, func(ctx facade.Context) (facade.Facade, error) {
-		return newUniterAPI(ctx)
+	registry.MustRegister("Uniter", 19, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
+		return newUniterAPI(stdCtx, ctx)
 	}, reflect.TypeOf((*UniterAPI)(nil)))
 }
 
 // newUniterAPI creates a new instance of the core Uniter API.
-func newUniterAPI(context facade.Context) (*UniterAPI, error) {
+func newUniterAPI(stdCtx context.Context, context facade.Context) (*UniterAPI, error) {
 	serviceFactory := context.ServiceFactory()
 	return newUniterAPIWithServices(
+		stdCtx,
 		context,
 		serviceFactory.ControllerConfig(),
 		serviceFactory.Cloud(),
@@ -37,6 +39,7 @@ func newUniterAPI(context facade.Context) (*UniterAPI, error) {
 
 // newUniterAPIWithServices creates a new instance using the services.
 func newUniterAPIWithServices(
+	stdCtx context.Context,
 	context facade.Context,
 	controllerConfigService ControllerConfigService,
 	cloudService CloudService,
@@ -96,7 +99,7 @@ func newUniterAPIWithServices(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	secretsAPI, err := secretsmanager.NewSecretManagerAPI(context)
+	secretsAPI, err := secretsmanager.NewSecretManagerAPI(stdCtx, context)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/uniter/uniter_apierror_test.go
+++ b/apiserver/facades/agent/uniter/uniter_apierror_test.go
@@ -48,6 +48,6 @@ func (s *uniterAPIErrorSuite) TestGetStorageStateError(c *gc.C) {
 	}
 
 	serviceFactory := s.ControllerServiceFactory(c)
-	_, err := uniter.NewUniterAPIWithServices(facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
+	_, err := uniter.NewUniterAPIWithServices(context.Background(), facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, gc.ErrorMatches, "kaboom")
 }

--- a/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
+++ b/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
@@ -39,7 +39,7 @@ func (s *cloudSpecUniterSuite) TestGetCloudSpecReturnsSpecWhenTrusted(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	facadeContext := s.facadeContext(c)
-	uniterAPI, err := uniter.NewUniterAPIWithServices(facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
+	uniterAPI, err := uniter.NewUniterAPIWithServices(context.Background(), facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := uniterAPI.CloudSpec(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -61,7 +61,7 @@ func (s *cloudSpecUniterSuite) TestCloudAPIVersion(c *gc.C) {
 
 	serviceFactory := facadeContext.ServiceFactory()
 
-	uniterAPI, err := uniter.NewUniterAPIWithServices(facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
+	uniterAPI, err := uniter.NewUniterAPIWithServices(context.Background(), facadeContext, serviceFactory.ControllerConfig(), serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, jc.ErrorIsNil)
 	uniter.SetNewContainerBrokerFunc(uniterAPI, func(context.Context, environs.OpenParams) (caas.Broker, error) {
 		return &fakeBroker{}, nil

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -710,7 +710,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 	)
 
 	// Test-suite uses an older API version
-	api, err := uniter.NewUniterAPI(s.facadeContext(c))
+	api, err := uniter.NewUniterAPI(context.Background(), s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := api.CommitHookChanges(context.Background(), req)
@@ -770,7 +770,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesWhenNotLeader(c *gc.C) {
 	req, _ := b.Build()
 
 	// Test-suite uses an older API version
-	api, err := uniter.NewUniterAPI(s.facadeContext(c))
+	api, err := uniter.NewUniterAPI(context.Background(), s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := api.CommitHookChanges(context.Background(), req)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -53,9 +53,9 @@ var _ = gc.Suite(&uniterSuite{})
 func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
 	anAuthorizer := s.authorizer
 	anAuthorizer.Tag = names.NewMachineTag("9")
-	context := s.facadeContext(c)
-	context.Auth_ = anAuthorizer
-	_, err := uniter.NewUniterAPI(context)
+	ctx := s.facadeContext(c)
+	ctx.Auth_ = anAuthorizer
+	_, err := uniter.NewUniterAPI(context.Background(), ctx)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -3587,7 +3587,7 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: unit.Tag(),
 	}
-	api, err := uniter.NewUniterAPI(s.facadeContext(c))
+	api, err := uniter.NewUniterAPI(context.Background(), s.facadeContext(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := api.CommitHookChanges(context.Background(), req)
@@ -3626,7 +3626,7 @@ func (s *uniterSuite) TestCommitHookChangesWithPortsSidecarApplication(c *gc.C) 
 	req, _ := b.Build()
 
 	s.authorizer = apiservertesting.FakeAuthorizer{Tag: unit.Tag()}
-	uniterAPI, err := uniter.NewUniterAPI(facadetest.Context{
+	uniterAPI, err := uniter.NewUniterAPI(context.Background(), facadetest.Context{
 		State_:             cm.State(),
 		StatePool_:         s.StatePool(),
 		Resources_:         s.resources,

--- a/apiserver/facades/agent/upgrader/register.go
+++ b/apiserver/facades/agent/upgrader/register.go
@@ -4,6 +4,7 @@
 package upgrader
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Upgrader", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Upgrader", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newUpgraderFacade(ctx)
 	}, reflect.TypeOf((*Upgrader)(nil)).Elem())
 }

--- a/apiserver/facades/agent/upgradeseries/register.go
+++ b/apiserver/facades/agent/upgradeseries/register.go
@@ -4,6 +4,7 @@
 package upgradeseries
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UpgradeSeries", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UpgradeSeries", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx) // Adds SetStatus.
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/agent/upgradesteps/register.go
+++ b/apiserver/facades/agent/upgradesteps/register.go
@@ -4,6 +4,7 @@
 package upgradesteps
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UpgradeSteps", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UpgradeSteps", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV2(ctx)
 	}, reflect.TypeOf((*UpgradeStepsAPI)(nil)))
 }

--- a/apiserver/facades/client/action/register.go
+++ b/apiserver/facades/client/action/register.go
@@ -4,6 +4,7 @@
 package action
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Action", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Action", 7, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newActionAPIV7(ctx)
 	}, reflect.TypeOf((*APIv7)(nil)))
 }

--- a/apiserver/facades/client/annotations/register.go
+++ b/apiserver/facades/client/annotations/register.go
@@ -4,6 +4,7 @@
 package annotations
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Annotations", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Annotations", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -109,7 +109,7 @@ type CaasBrokerInterface interface {
 	Version() (*version.Number, error)
 }
 
-func newFacadeBase(ctx facade.Context) (*APIBase, error) {
+func newFacadeBase(stdCtx context.Context, ctx facade.Context) (*APIBase, error) {
 	m, err := ctx.State().Model()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting model")
@@ -175,7 +175,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		state:              state,
 		storagePoolManager: storagePoolManager,
 	}
-	repoDeploy := NewDeployFromRepositoryAPI(state, ctx.ObjectStore(), makeDeployFromRepositoryValidator(context.TODO(), validatorCfg))
+	repoDeploy := NewDeployFromRepositoryAPI(state, ctx.ObjectStore(), makeDeployFromRepositoryValidator(stdCtx, validatorCfg))
 
 	return NewAPIBase(
 		state,

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,13 +14,13 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Application", 19, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV19(ctx) // Added new DeployFromRepository
+	registry.MustRegister("Application", 19, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV19(stdCtx, ctx) // Added new DeployFromRepository
 	}, reflect.TypeOf((*APIv19)(nil)))
 }
 
-func newFacadeV19(ctx facade.Context) (*APIv19, error) {
-	api, err := newFacadeBase(ctx)
+func newFacadeV19(stdCtx context.Context, ctx facade.Context) (*APIv19, error) {
+	api, err := newFacadeBase(stdCtx, ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/applicationoffers/register.go
+++ b/apiserver/facades/client/applicationoffers/register.go
@@ -19,7 +19,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ApplicationOffers", 4, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ApplicationOffers", 4, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newOffersAPI(ctx)
 	}, reflect.TypeOf((*OffersAPI)(nil)))
 }

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -4,6 +4,7 @@
 package backups
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Backups", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Backups", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/block/register.go
+++ b/apiserver/facades/client/block/register.go
@@ -4,6 +4,7 @@
 package block
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Block", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Block", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/bundle/register.go
+++ b/apiserver/facades/client/bundle/register.go
@@ -4,6 +4,7 @@
 package bundle
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Bundle", 8, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Bundle", 8, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV8(ctx)
 	}, reflect.TypeOf((*APIv8)(nil)))
 }

--- a/apiserver/facades/client/charms/register.go
+++ b/apiserver/facades/client/charms/register.go
@@ -4,6 +4,7 @@
 package charms
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -17,13 +18,13 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Charms", 5, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Charms", 5, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV5(ctx)
 	}, reflect.TypeOf((*APIv5)(nil)))
-	registry.MustRegister("Charms", 6, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Charms", 6, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV6(ctx)
 	}, reflect.TypeOf((*APIv6)(nil)))
-	registry.MustRegister("Charms", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Charms", 7, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV7(ctx)
 	}, reflect.TypeOf((*APIv7)(nil)))
 }

--- a/apiserver/facades/client/client/register.go
+++ b/apiserver/facades/client/client/register.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,10 +12,10 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Client", 6, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Client", 6, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV6(ctx)
 	}, reflect.TypeOf((*ClientV6)(nil)))
-	registry.MustRegister("Client", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Client", 7, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV7(ctx)
 	}, reflect.TypeOf((*Client)(nil)))
 }

--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -17,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Cloud", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Cloud", 7, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV7(ctx) // Do not set error if forcing credential update.
 	}, reflect.TypeOf((*CloudAPI)(nil)))
 }

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -404,7 +404,7 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var disposed bool
-	watcherAPI_, err := apiserver.NewAllWatcher(facadetest.Context{
+	watcherAPI_, err := apiserver.NewAllWatcher(context.Background(), facadetest.Context{
 		State_:           s.State,
 		Resources_:       s.resources,
 		WatcherRegistry_: s.watcherRegistry,

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Controller", 11, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Controller", 11, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newControllerAPIv11(ctx)
 	}, reflect.TypeOf((*ControllerAPI)(nil)))
 }

--- a/apiserver/facades/client/credentialmanager/register.go
+++ b/apiserver/facades/client/credentialmanager/register.go
@@ -4,6 +4,7 @@
 package credentialmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CredentialManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CredentialManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewCredentialManagerAPI(ctx)
 	}, reflect.TypeOf((*CredentialManagerAPI)(nil)))
 }

--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -4,6 +4,7 @@
 package highavailability
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("HighAvailability", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("HighAvailability", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newHighAvailabilityAPI(ctx)
 	}, reflect.TypeOf((*HighAvailabilityAPI)(nil)))
 }

--- a/apiserver/facades/client/imagemetadatamanager/register.go
+++ b/apiserver/facades/client/imagemetadatamanager/register.go
@@ -4,6 +4,7 @@
 package imagemetadatamanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ImageMetadataManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ImageMetadataManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/keymanager/register.go
+++ b/apiserver/facades/client/keymanager/register.go
@@ -20,7 +20,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("KeyManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("KeyManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV1(ctx)
 	}, reflect.TypeOf((*KeyManagerAPI)(nil)))
 }

--- a/apiserver/facades/client/machinemanager/register.go
+++ b/apiserver/facades/client/machinemanager/register.go
@@ -4,6 +4,7 @@
 package machinemanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,10 +12,10 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MachineManager", 9, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MachineManager", 9, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewFacadeV9(ctx)
 	}, reflect.TypeOf((*MachineManagerV9)(nil)))
-	registry.MustRegister("MachineManager", 10, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MachineManager", 10, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewFacadeV10(ctx) // DestroyMachineWithParams gains dry-run
 	}, reflect.TypeOf((*MachineManagerAPI)(nil)))
 }

--- a/apiserver/facades/client/metricsdebug/register.go
+++ b/apiserver/facades/client/metricsdebug/register.go
@@ -4,6 +4,7 @@
 package metricsdebug
 
 import (
+	"context"
 	"reflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MetricsDebug", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MetricsDebug", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newMetricsDebugAPI(ctx)
 	}, reflect.TypeOf((*MetricsDebugAPI)(nil)))
 }

--- a/apiserver/facades/client/modelconfig/register.go
+++ b/apiserver/facades/client/modelconfig/register.go
@@ -4,6 +4,7 @@
 package modelconfig
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ModelConfig", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ModelConfig", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV3(ctx)
 	}, reflect.TypeOf((*ModelConfigAPIV3)(nil)))
 }

--- a/apiserver/facades/client/modelgeneration/register.go
+++ b/apiserver/facades/client/modelgeneration/register.go
@@ -4,6 +4,7 @@
 package modelgeneration
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ModelGeneration", 4, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ModelGeneration", 4, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newModelGenerationFacadeV4(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -4,6 +4,7 @@
 package modelmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -21,7 +22,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ModelManager", 10, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ModelManager", 10, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV10(ctx)
 	}, reflect.TypeOf((*ModelManagerAPI)(nil)))
 }

--- a/apiserver/facades/client/modelupgrader/register.go
+++ b/apiserver/facades/client/modelupgrader/register.go
@@ -4,6 +4,7 @@
 package modelupgrader
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -20,7 +21,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ModelUpgrader", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ModelUpgrader", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV1(ctx)
 	}, reflect.TypeOf((*ModelUpgraderAPI)(nil)))
 }

--- a/apiserver/facades/client/payloads/register.go
+++ b/apiserver/facades/client/payloads/register.go
@@ -4,6 +4,7 @@
 package payloads
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Payloads", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Payloads", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/pinger/register.go
+++ b/apiserver/facades/client/pinger/register.go
@@ -4,6 +4,7 @@
 package pinger
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Pinger", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Pinger", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/resources/register.go
+++ b/apiserver/facades/client/resources/register.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Resources", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Resources", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV3(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/secretbackends/register.go
+++ b/apiserver/facades/client/secretbackends/register.go
@@ -4,6 +4,7 @@
 package secretbackends
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("SecretBackends", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("SecretBackends", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newSecretBackendsAPI(ctx)
 	}, reflect.TypeOf((*SecretBackendsAPI)(nil)))
 }

--- a/apiserver/facades/client/secrets/register.go
+++ b/apiserver/facades/client/secrets/register.go
@@ -18,10 +18,10 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Secrets", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Secrets", 1, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return newSecretsAPIV1(ctx)
 	}, reflect.TypeOf((*SecretsAPI)(nil)))
-	registry.MustRegister("Secrets", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Secrets", 2, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return newSecretsAPI(ctx)
 	}, reflect.TypeOf((*SecretsAPI)(nil)))
 }

--- a/apiserver/facades/client/spaces/register.go
+++ b/apiserver/facades/client/spaces/register.go
@@ -4,6 +4,7 @@
 package spaces
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Spaces", 6, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Spaces", 6, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/sshclient/register.go
+++ b/apiserver/facades/client/sshclient/register.go
@@ -17,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("SSHClient", 4, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("SSHClient", 4, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/client/storage/register.go
+++ b/apiserver/facades/client/storage/register.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -21,7 +22,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Storage", 6, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Storage", 6, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStorageAPI(ctx) // modify Remove to support force and maxWait; add DetachStorage to support force and maxWait.
 	}, reflect.TypeOf((*StorageAPI)(nil)))
 }

--- a/apiserver/facades/client/subnets/register.go
+++ b/apiserver/facades/client/subnets/register.go
@@ -4,6 +4,7 @@
 package subnets
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Subnets", 5, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Subnets", 5, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx) // Removes AddSubnets.
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/client/usermanager/register.go
+++ b/apiserver/facades/client/usermanager/register.go
@@ -4,6 +4,7 @@
 package usermanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -18,7 +19,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UserManager", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UserManager", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newUserManagerAPI(ctx) // Adds ModelUserInfo
 	}, reflect.TypeOf((*UserManagerAPI)(nil)))
 }

--- a/apiserver/facades/controller/actionpruner/register.go
+++ b/apiserver/facades/controller/actionpruner/register.go
@@ -4,6 +4,7 @@
 package actionpruner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ActionPruner", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ActionPruner", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/agenttools/register.go
+++ b/apiserver/facades/controller/agenttools/register.go
@@ -4,6 +4,7 @@
 package agenttools
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("AgentTools", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("AgentTools", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*AgentToolsAPI)(nil)))
 }

--- a/apiserver/facades/controller/applicationscaler/register.go
+++ b/apiserver/facades/controller/applicationscaler/register.go
@@ -4,6 +4,7 @@
 package applicationscaler
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ApplicationScaler", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ApplicationScaler", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/register.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/register.go
@@ -4,6 +4,7 @@
 package caasapplicationprovisioner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASApplicationProvisioner", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASApplicationProvisioner", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*APIGroup)(nil)))
 }

--- a/apiserver/facades/controller/caasfirewaller/register.go
+++ b/apiserver/facades/controller/caasfirewaller/register.go
@@ -4,6 +4,7 @@
 package caasfirewaller
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASFirewaller", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASFirewaller", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/caasmodelconfigmanager/register.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/register.go
@@ -4,6 +4,7 @@
 package caasmodelconfigmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/common"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASModelConfigManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASModelConfigManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/caasmodeloperator/register.go
+++ b/apiserver/facades/controller/caasmodeloperator/register.go
@@ -4,6 +4,7 @@
 package caasmodeloperator
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASModelOperator", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASModelOperator", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPIFromContext(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/caasoperatorupgrader/register.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/register.go
@@ -4,6 +4,7 @@
 package caasoperatorupgrader
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASOperatorUpgrader", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASOperatorUpgrader", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateCAASOperatorUpgraderAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/caasunitprovisioner/register.go
+++ b/apiserver/facades/controller/caasunitprovisioner/register.go
@@ -4,6 +4,7 @@
 package caasunitprovisioner
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CAASUnitProvisioner", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CAASUnitProvisioner", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/charmdownloader/register.go
+++ b/apiserver/facades/controller/charmdownloader/register.go
@@ -4,6 +4,7 @@
 package charmdownloader
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CharmDownloader", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CharmDownloader", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV1(ctx)
 	}, reflect.TypeOf((*CharmDownloaderAPI)(nil)))
 }

--- a/apiserver/facades/controller/charmrevisionupdater/register.go
+++ b/apiserver/facades/controller/charmrevisionupdater/register.go
@@ -4,6 +4,7 @@
 package charmrevisionupdater
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CharmRevisionUpdater", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CharmRevisionUpdater", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newCharmRevisionUpdaterAPI(ctx)
 	}, reflect.TypeOf((*CharmRevisionUpdaterAPI)(nil)))
 }

--- a/apiserver/facades/controller/cleaner/register.go
+++ b/apiserver/facades/controller/cleaner/register.go
@@ -4,6 +4,7 @@
 package cleaner
 
 import (
+	"context"
 	"reflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Cleaner", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Cleaner", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newCleanerAPI(ctx)
 	}, reflect.TypeOf((*CleanerAPI)(nil)))
 }

--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -15,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CrossController", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CrossController", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateCrossControllerAPI(ctx)
 	}, reflect.TypeOf((*CrossControllerAPI)(nil)))
 }

--- a/apiserver/facades/controller/crossmodelrelations/register.go
+++ b/apiserver/facades/controller/crossmodelrelations/register.go
@@ -4,6 +4,7 @@
 package crossmodelrelations
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/common"
@@ -15,7 +16,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CrossModelRelations", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CrossModelRelations", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateCrossModelRelationsAPI(ctx) // Adds WatchRelationChanges, removes WatchRelationUnits
 	}, reflect.TypeOf((*CrossModelRelationsAPI)(nil)))
 }

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -20,7 +20,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("CrossModelSecrets", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("CrossModelSecrets", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateCrossModelSecretsAPI(ctx)
 	}, reflect.TypeOf((*CrossModelSecretsAPI)(nil)))
 }

--- a/apiserver/facades/controller/environupgrader/register.go
+++ b/apiserver/facades/controller/environupgrader/register.go
@@ -4,6 +4,7 @@
 package environupgrader
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/names/v5"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("EnvironUpgrader", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("EnvironUpgrader", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewStateFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/externalcontrollerupdater/register.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/register.go
@@ -4,6 +4,7 @@
 package externalcontrollerupdater
 
 import (
+	"context"
 	"reflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ExternalControllerUpdater", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ExternalControllerUpdater", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newStateAPI(ctx)
 	}, reflect.TypeOf((*ExternalControllerUpdaterAPI)(nil)))
 }

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -4,6 +4,7 @@
 package firewaller
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Firewaller", 7, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Firewaller", 7, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFirewallerAPIV7(ctx)
 	}, reflect.TypeOf((*FirewallerAPI)(nil)))
 }

--- a/apiserver/facades/controller/imagemetadata/register.go
+++ b/apiserver/facades/controller/imagemetadata/register.go
@@ -4,6 +4,7 @@
 package imagemetadata
 
 import (
+	"context"
 	"reflect"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -12,7 +13,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("ImageMetadata", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("ImageMetadata", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/instancepoller/register.go
+++ b/apiserver/facades/controller/instancepoller/register.go
@@ -4,6 +4,7 @@
 package instancepoller
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("InstancePoller", 4, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("InstancePoller", 4, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*InstancePollerAPI)(nil)))
 }

--- a/apiserver/facades/controller/lifeflag/register.go
+++ b/apiserver/facades/controller/lifeflag/register.go
@@ -4,6 +4,7 @@
 package lifeflag
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("LifeFlag", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("LifeFlag", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newExternalFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/logfwd/register.go
+++ b/apiserver/facades/controller/logfwd/register.go
@@ -4,6 +4,7 @@
 package logfwd
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("LogForwarding", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("LogForwarding", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*LogForwardingAPI)(nil)))
 }

--- a/apiserver/facades/controller/machineundertaker/register.go
+++ b/apiserver/facades/controller/machineundertaker/register.go
@@ -4,6 +4,7 @@
 package machineundertaker
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
@@ -11,7 +12,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MachineUndertaker", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MachineUndertaker", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/metricsmanager/register.go
+++ b/apiserver/facades/controller/metricsmanager/register.go
@@ -4,6 +4,7 @@
 package metricsmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MetricsManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MetricsManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*MetricsManagerAPI)(nil)))
 }

--- a/apiserver/facades/controller/migrationmaster/register.go
+++ b/apiserver/facades/controller/migrationmaster/register.go
@@ -4,6 +4,7 @@
 package migrationmaster
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -17,7 +18,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MigrationMaster", 3, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("MigrationMaster", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newMigrationMasterFacade(ctx) // Adds MinionReportTimeout.
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -80,7 +80,7 @@ func (s *Suite) TestFacadeRegistered(c *gc.C) {
 	aFactory, err := apiserver.AllFacades().GetFactory("MigrationTarget", 3)
 	c.Assert(err, jc.ErrorIsNil)
 
-	api, err := aFactory(&facadetest.Context{
+	api, err := aFactory(context.Background(), &facadetest.Context{
 		State_:          s.State,
 		Auth_:           s.authorizer,
 		ServiceFactory_: servicefactorytesting.NewTestingServiceFactory(),
@@ -95,7 +95,7 @@ func (s *Suite) TestFacadeRegisteredV2(c *gc.C) {
 	aFactory, err := apiserver.AllFacades().GetFactory("MigrationTarget", 2)
 	c.Assert(err, jc.ErrorIsNil)
 
-	api, err := aFactory(&facadetest.Context{
+	api, err := aFactory(context.Background(), &facadetest.Context{
 		State_:          s.State,
 		Auth_:           s.authorizer,
 		ServiceFactory_: servicefactorytesting.NewTestingServiceFactory(),

--- a/apiserver/facades/controller/migrationtarget/register.go
+++ b/apiserver/facades/controller/migrationtarget/register.go
@@ -22,13 +22,13 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(requiredMigrationFacadeVersions facades.FacadeVersions) func(registry facade.FacadeRegistry) {
 	return func(registry facade.FacadeRegistry) {
-		registry.MustRegister("MigrationTarget", 1, func(ctx facade.Context) (facade.Facade, error) {
+		registry.MustRegister("MigrationTarget", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 			return newFacadeV1(ctx)
 		}, reflect.TypeOf((*APIV1)(nil)))
-		registry.MustRegister("MigrationTarget", 2, func(ctx facade.Context) (facade.Facade, error) {
+		registry.MustRegister("MigrationTarget", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 			return newFacadeV2(ctx)
 		}, reflect.TypeOf((*APIV2)(nil)))
-		registry.MustRegister("MigrationTarget", 3, func(ctx facade.Context) (facade.Facade, error) {
+		registry.MustRegister("MigrationTarget", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 			return newFacade(ctx, requiredMigrationFacadeVersions)
 		}, reflect.TypeOf((*API)(nil)))
 	}

--- a/apiserver/facades/controller/remoterelations/register.go
+++ b/apiserver/facades/controller/remoterelations/register.go
@@ -4,6 +4,7 @@
 package remoterelations
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("RemoteRelations", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("RemoteRelations", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx) // Adds UpdateControllersForModels and WatchLocalRelationChanges.
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/secretbackendmanager/register.go
+++ b/apiserver/facades/controller/secretbackendmanager/register.go
@@ -4,6 +4,7 @@
 package secretbackendmanager
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/clock"
@@ -16,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("SecretBackendsManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("SecretBackendsManager", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewSecretBackendsManagerAPI(ctx)
 	}, reflect.TypeOf((*SecretBackendsManagerAPI)(nil)))
 }

--- a/apiserver/facades/controller/singular/register.go
+++ b/apiserver/facades/controller/singular/register.go
@@ -4,6 +4,7 @@
 package singular
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Singular", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Singular", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newExternalFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
 }

--- a/apiserver/facades/controller/statushistory/register.go
+++ b/apiserver/facades/controller/statushistory/register.go
@@ -4,6 +4,7 @@
 package statushistory
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -14,7 +15,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("StatusHistory", 2, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("StatusHistory", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newAPI(ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/apiserver/facades/controller/undertaker/register.go
+++ b/apiserver/facades/controller/undertaker/register.go
@@ -18,7 +18,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Undertaker", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("Undertaker", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newUndertakerFacade(ctx)
 	}, reflect.TypeOf((*UndertakerAPI)(nil)))
 }

--- a/apiserver/facades/controller/usersecrets/register.go
+++ b/apiserver/facades/controller/usersecrets/register.go
@@ -18,7 +18,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UserSecretsManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UserSecretsManager", 1, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return NewUserSecretsManager(ctx)
 	}, reflect.TypeOf((*UserSecretsManager)(nil)))
 }

--- a/apiserver/facades/controller/usersecretsdrain/register.go
+++ b/apiserver/facades/controller/usersecretsdrain/register.go
@@ -4,7 +4,7 @@
 package usersecretsdrain
 
 import (
-	stdCtx "context"
+	stdcontext "context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -18,7 +18,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("UserSecretsDrain", 1, func(ctx facade.Context) (facade.Facade, error) {
+	registry.MustRegister("UserSecretsDrain", 1, func(stdCtx stdcontext.Context, ctx facade.Context) (facade.Facade, error) {
 		return newUserSecretsDrainAPI(ctx)
 	}, reflect.TypeOf((*SecretsDrainAPI)(nil)))
 }
@@ -36,7 +36,7 @@ func newUserSecretsDrainAPI(context facade.Context) (*SecretsDrainAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ctx := stdCtx.Background()
+	ctx := stdcontext.Background()
 	serviceFactory := context.ServiceFactory()
 	cloudService := serviceFactory.Cloud()
 	credentialSerivce := serviceFactory.Credential()

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -327,7 +327,7 @@ func (r *apiHandler) EntityHasPermission(entity names.Tag, operation permission.
 // and place a call on its method.
 type srvCaller struct {
 	objMethod rpcreflect.ObjMethod
-	creator   func(id string) (reflect.Value, error)
+	creator   func(ctx context.Context, id string) (reflect.Value, error)
 }
 
 // ParamsType defines the parameters that should be supplied to this function.
@@ -345,7 +345,7 @@ func (s *srvCaller) ResultType() reflect.Type {
 // Call takes the object Id and an instance of ParamsType to create an object and place
 // a call on its method. It then returns an instance of ResultType.
 func (s *srvCaller) Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error) {
-	objVal, err := s.creator(objId)
+	objVal, err := s.creator(ctx, objId)
 	if err != nil {
 		return reflect.Value{}, err
 	}
@@ -516,7 +516,7 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 		return nil, err
 	}
 
-	creator := func(id string) (reflect.Value, error) {
+	creator := func(ctx context.Context, id string) (reflect.Value, error) {
 		objKey := objectKey{name: rootName, version: version, objId: id}
 		r.objectMutex.RLock()
 		objValue, ok := r.objectCache[objKey]
@@ -538,7 +538,7 @@ func (r *apiRoot) FindMethod(rootName string, version int, methodName string) (r
 			// check.
 			return reflect.Value{}, err
 		}
-		obj, err := factory(r.facadeContext(objKey))
+		obj, err := factory(ctx, r.facadeContext(objKey))
 		if err != nil {
 			return reflect.Value{}, err
 		}

--- a/apiserver/root_test.go
+++ b/apiserver/root_test.go
@@ -129,7 +129,7 @@ func (r *rootSuite) TestFindMethodUnknownFacade(c *gc.C) {
 
 func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
 	registry := new(facade.Registry)
-	myGoodFacade := func(facade.Context) (facade.Facade, error) {
+	myGoodFacade := func(context.Context, facade.Context) (facade.Facade, error) {
 		return &testingType{}, nil
 	}
 	registry.MustRegister("my-testing-facade", 0, myGoodFacade, reflect.TypeOf((*testingType)(nil)).Elem())
@@ -141,13 +141,13 @@ func (r *rootSuite) TestFindMethodUnknownVersion(c *gc.C) {
 }
 
 func (r *rootSuite) TestFindMethodEnsuresTypeMatch(c *gc.C) {
-	myBadFacade := func(facade.Context) (facade.Facade, error) {
+	myBadFacade := func(context.Context, facade.Context) (facade.Facade, error) {
 		return &badType{}, nil
 	}
-	myGoodFacade := func(facade.Context) (facade.Facade, error) {
+	myGoodFacade := func(context.Context, facade.Context) (facade.Facade, error) {
 		return &testingType{}, nil
 	}
-	myErrFacade := func(context facade.Context) (facade.Facade, error) {
+	myErrFacade := func(_ context.Context, context facade.Context) (facade.Facade, error) {
 		return nil, fmt.Errorf("you shall not pass")
 	}
 	expectedType := reflect.TypeOf((*testingType)(nil))
@@ -208,7 +208,7 @@ func assertCallResult(c *gc.C, caller rpcreflect.MethodCaller, id string, expect
 func (r *rootSuite) TestFindMethodCachesFacades(c *gc.C) {
 	registry := new(facade.Registry)
 	var count int64
-	newCounter := func(facade.Context) (facade.Facade, error) {
+	newCounter := func(context.Context, facade.Context) (facade.Facade, error) {
 		count += 1
 		return &countingType{count: count, id: ""}, nil
 	}
@@ -242,7 +242,7 @@ func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
 	var count int64
 	// like newCounter, but also tracks the "id" that was requested for
 	// this counter
-	newIdCounter := func(context facade.Context) (facade.Facade, error) {
+	newIdCounter := func(_ context.Context, context facade.Context) (facade.Facade, error) {
 		count += 1
 		return &countingType{count: count, id: context.ID()}, nil
 	}
@@ -273,7 +273,7 @@ func (r *rootSuite) TestFindMethodCachesFacadesWithId(c *gc.C) {
 
 func (r *rootSuite) TestFindMethodCacheRaceSafe(c *gc.C) {
 	var count int64
-	newIdCounter := func(context facade.Context) (facade.Facade, error) {
+	newIdCounter := func(_ context.Context, context facade.Context) (facade.Facade, error) {
 		count += 1
 		return &countingType{count: count, id: context.ID()}, nil
 	}
@@ -325,10 +325,10 @@ func (*secondImpl) OneMethod() stringVar {
 
 func (r *rootSuite) TestFindMethodHandlesInterfaceTypes(c *gc.C) {
 	registry := new(facade.Registry)
-	registry.MustRegister("my-interface-facade", 0, func(_ facade.Context) (facade.Facade, error) {
+	registry.MustRegister("my-interface-facade", 0, func(_ context.Context, _ facade.Context) (facade.Facade, error) {
 		return &firstImpl{}, nil
 	}, reflect.TypeOf((*smallInterface)(nil)).Elem())
-	registry.MustRegister("my-interface-facade", 1, func(_ facade.Context) (facade.Facade, error) {
+	registry.MustRegister("my-interface-facade", 1, func(_ context.Context, _ facade.Context) (facade.Facade, error) {
 		return &secondImpl{}, nil
 	}, reflect.TypeOf((*smallInterface)(nil)).Elem())
 	srvRoot := apiserver.TestingAPIRoot(registry)

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -109,7 +109,7 @@ func newAllWatcher(context facade.Context, deltaTranslater DeltaTranslater) (*Sr
 
 // NewAllWatcher returns a new API server endpoint for interacting
 // with a watcher created by the WatchAll and WatchAllModels API calls.
-func NewAllWatcher(context facade.Context) (facade.Facade, error) {
+func NewAllWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	return newAllWatcher(context, newAllWatcherDeltaTranslater())
 }
 
@@ -573,7 +573,7 @@ func isAgentOrUser(auth facade.Authorizer) bool {
 	return isAgent(auth) || auth.AuthClient()
 }
 
-func newNotifyWatcher(context facade.Context) (facade.Facade, error) {
+func newNotifyWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -619,7 +619,7 @@ type srvStringsWatcher struct {
 	watcher corewatcher.StringsWatcher
 }
 
-func newStringsWatcher(context facade.Context) (facade.Facade, error) {
+func newStringsWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -661,7 +661,7 @@ type srvRelationUnitsWatcher struct {
 	watcher common.RelationUnitsWatcher
 }
 
-func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
+func newRelationUnitsWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -705,7 +705,7 @@ type srvRemoteRelationWatcher struct {
 	watcher *crossmodel.WrappedUnitsWatcher
 }
 
-func newRemoteRelationWatcher(context facade.Context) (facade.Facade, error) {
+func newRemoteRelationWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -756,7 +756,7 @@ type srvRelationStatusWatcher struct {
 	watcher corewatcher.StringsWatcher
 }
 
-func newRelationStatusWatcher(context facade.Context) (facade.Facade, error) {
+func newRelationStatusWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -809,7 +809,7 @@ type srvOfferStatusWatcher struct {
 	watcher crossmodelrelations.OfferWatcher
 }
 
-func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
+func newOfferStatusWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -873,21 +873,21 @@ type srvMachineStorageIdsWatcher struct {
 	parser  func([]string) ([]params.MachineStorageId, error)
 }
 
-func newVolumeAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
+func newVolumeAttachmentsWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	return newMachineStorageIdsWatcher(
 		context,
 		storagecommon.ParseVolumeAttachmentIds,
 	)
 }
 
-func newVolumeAttachmentPlansWatcher(context facade.Context) (facade.Facade, error) {
+func newVolumeAttachmentPlansWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	return newMachineStorageIdsWatcher(
 		context,
 		storagecommon.ParseVolumeAttachmentIds,
 	)
 }
 
-func newFilesystemAttachmentsWatcher(context facade.Context) (facade.Facade, error) {
+func newFilesystemAttachmentsWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	return newMachineStorageIdsWatcher(
 		context,
 		storagecommon.ParseFilesystemAttachmentIds,
@@ -959,7 +959,7 @@ type srvEntitiesWatcher struct {
 	watcher EntitiesWatcher
 }
 
-func newEntitiesWatcher(context facade.Context) (facade.Facade, error) {
+func newEntitiesWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
@@ -1018,7 +1018,7 @@ type controllerBackend interface {
 	APIHostPortsForClients(controller.Config) ([]network.SpaceHostPorts, error)
 }
 
-func newMigrationStatusWatcher(context facade.Context) (facade.Facade, error) {
+func newMigrationStatusWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
@@ -1136,7 +1136,7 @@ var getControllerCACert = func(controllerConfig controller.Config) (string, erro
 // newModelSummaryWatcher exists solely to be registered with regRaw.
 // Standard registration doesn't handle watcher types (it checks for
 // and empty ID in the context).
-func newModelSummaryWatcher(context facade.Context) (facade.Facade, error) {
+func newModelSummaryWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	return NewModelSummaryWatcher(context)
 }
 
@@ -1254,7 +1254,7 @@ type srvSecretTriggerWatcher struct {
 	watcher corewatcher.SecretTriggerWatcher
 }
 
-func newSecretsTriggerWatcher(context facade.Context) (facade.Facade, error) {
+func newSecretsTriggerWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
@@ -1308,7 +1308,7 @@ type srvSecretBackendsRotateWatcher struct {
 	watcher corewatcher.SecretBackendRotateWatcher
 }
 
-func newSecretBackendsRotateWatcher(context facade.Context) (facade.Facade, error) {
+func newSecretBackendsRotateWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 	if !isAgent(auth) {
 		return nil, apiservererrors.ErrPerm
@@ -1362,7 +1362,7 @@ type srvSecretsRevisionWatcher struct {
 	watcher corewatcher.StringsWatcher
 }
 
-func newSecretsRevisionWatcher(context facade.Context) (facade.Facade, error) {
+func newSecretsRevisionWatcher(_ context.Context, context facade.Context) (facade.Facade, error) {
 	auth := context.Auth()
 
 	// TODO(wallyworld) - enhance this watcher to support

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -61,7 +61,7 @@ func (s *watcherSuite) getFacade(
 	dispose func(),
 ) interface{} {
 	factory := getFacadeFactory(c, name, version)
-	facade, err := factory(s.facadeContext(c, id, dispose))
+	facade, err := factory(context.Background(), s.facadeContext(c, id, dispose))
 	c.Assert(err, jc.ErrorIsNil)
 	return facade
 }
@@ -163,7 +163,7 @@ func (s *watcherSuite) TestMigrationStatusWatcherNotAgent(c *gc.C) {
 
 	factory, err := apiserver.AllFacades().GetFactory("MigrationStatusWatcher", 1)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = factory(facadetest.Context{
+	_, err = factory(context.Background(), facadetest.Context{
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 		ID_:        id,

--- a/generate/schemagen/schemagen.go
+++ b/generate/schemagen/schemagen.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	stdcontext "context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -183,7 +184,7 @@ func (l defaultLinker) isAvailable(facadeName string, factory facade.Factory, ki
 		},
 		watcherRegistry: l.watcherRegistry,
 	}
-	_, err := factory(ctx)
+	_, err := factory(stdcontext.Background(), ctx)
 	return errors.Cause(err) != apiservererrors.ErrPerm
 }
 


### PR DESCRIPTION
When creating a facade using the facade factory, we need to pass in the context being used by the request, so that code used in the facade construction can use it. This allows the remaining `context.TODO()` uses to be removed from the apiserver package. This PR add all the wiring needed.

## QA steps

run unit tests
bootstrap ad deploy a charm

## Links

**Jira card:** JUJU-5243

