### PR TITLE
Use correct context when creating secrets artefacts

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -64,8 +64,8 @@ func (a *admin) Admin(id string) (*admin, error) {
 
 // Login logs in with the provided credentials.  All subsequent requests on the
 // connection will act as the authenticated user.
-func (a *admin) Login(req params.LoginRequest) (params.LoginResult, error) {
-	return a.login(context.Background(), req, 3)
+func (a *admin) Login(ctx context.Context, req params.LoginRequest) (params.LoginResult, error) {
+	return a.login(ctx, req, 3)
 }
 
 // RedirectInfo returns redirected host information for the model.

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -138,7 +138,7 @@ func CheckLocalLoginRequest(
 	auth MacaroonChecker,
 	req *http.Request,
 ) error {
-	a := auth.Auth(httpbakery.RequestMacaroons(req)...)
+	a := auth.Auth(ctx, httpbakery.RequestMacaroons(req)...)
 	ai, err := a.Allow(ctx, identchecker.LoginOp)
 	if err != nil {
 		return errors.Annotatef(err, "local login request failed: %v", req.Header[httpbakery.MacaroonsHeader])
@@ -167,7 +167,7 @@ func (u *LocalUserAuthenticator) authenticateMacaroons(
 		mac, _ := json.Marshal(authParams.Macaroons)
 		logger.Tracef("authentication macaroons for %s: %s", tag, mac)
 	}
-	a := u.Bakery.Auth(authParams.Macaroons...)
+	a := u.Bakery.Auth(ctx, authParams.Macaroons...)
 	ai, err := a.Allow(ctx, identchecker.LoginOp)
 	if err == nil {
 		logger.Tracef("authenticated conditions: %v", ai.Conditions())
@@ -327,7 +327,7 @@ type Bakery interface {
 
 // MacaroonChecker exposes the methods needed from bakery.Checker.
 type MacaroonChecker interface {
-	Auth(mss ...macaroon.Slice) *bakery.AuthChecker
+	Auth(ctx context.Context, mss ...macaroon.Slice) *bakery.AuthChecker
 }
 
 // MacaroonMinter exposes the methods needed from bakery.Oven.

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -233,7 +233,7 @@ type mockBakeryService struct {
 	testing.Stub
 }
 
-func (s *mockBakeryService) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+func (s *mockBakeryService) Auth(_ context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
 	s.MethodCall(s, "Auth", mss)
 	checker := bakery.NewChecker(bakery.CheckerParams{
 		OpsAuthorizer:    mockAuthorizer{},

--- a/apiserver/bakeryutil/service.go
+++ b/apiserver/bakeryutil/service.go
@@ -62,9 +62,8 @@ func (s *ExpirableStorageBakery) NewMacaroon(ctx context.Context, version bakery
 var logger = loggo.GetLogger("juju.apiserver.bakery")
 
 // Auth implements MacaroonChecker.Auth.
-func (s *ExpirableStorageBakery) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+func (s *ExpirableStorageBakery) Auth(ctx context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
 	if logger.IsTraceEnabled() {
-		ctx := context.Background()
 		for i, ms := range mss {
 			ops, conditions, err := s.Oven.VerifyMacaroon(ctx, ms)
 			if err != nil {

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -34,7 +34,7 @@ type CloudSpecer interface {
 type CloudSpecAPI struct {
 	resources facade.Resources
 
-	getCloudSpec                           func(names.ModelTag) (environscloudspec.CloudSpec, error)
+	getCloudSpec                           func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error)
 	watchCloudSpec                         func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error)
 	watchCloudSpecModelCredentialReference func(tag names.ModelTag) (state.NotifyWatcher, error)
 	watchCloudSpecCredentialContent        func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error)
@@ -48,7 +48,7 @@ type CloudSpecAPIV2 struct {
 // NewCloudSpec returns a new CloudSpecAPI.
 func NewCloudSpec(
 	resources facade.Resources,
-	getCloudSpec func(names.ModelTag) (environscloudspec.CloudSpec, error),
+	getCloudSpec func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error),
 	watchCloudSpec func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error),
 	watchCloudSpecModelCredentialReference func(tag names.ModelTag) (state.NotifyWatcher, error),
 	watchCloudSpecCredentialContent func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error),
@@ -66,7 +66,7 @@ func NewCloudSpec(
 
 func NewCloudSpecV2(
 	resources facade.Resources,
-	getCloudSpec func(names.ModelTag) (environscloudspec.CloudSpec, error),
+	getCloudSpec func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error),
 	watchCloudSpec func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error),
 	watchCloudSpecModelCredentialReference func(tag names.ModelTag) (state.NotifyWatcher, error),
 	watchCloudSpecCredentialContent func(ctx context.Context, tag names.ModelTag) (corewatcher.NotifyWatcher, error),
@@ -110,7 +110,7 @@ func (s CloudSpecAPI) CloudSpec(ctx context.Context, args params.Entities) (para
 // GetCloudSpec constructs the CloudSpec for a validated and authorized model.
 func (s CloudSpecAPI) GetCloudSpec(ctx context.Context, tag names.ModelTag) params.CloudSpecResult {
 	var result params.CloudSpecResult
-	spec, err := s.getCloudSpec(tag)
+	spec, err := s.getCloudSpec(ctx, tag)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -65,7 +65,7 @@ func (s *CloudSpecSuite) SetUpTest(c *gc.C) {
 func (s *CloudSpecSuite) getTestCloudSpec(cloudWatcher, credentialContentWatcher state.NotifyWatcher) cloudspec.CloudSpecAPI {
 	return cloudspec.NewCloudSpec(
 		common.NewResources(),
-		func(tag names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(_ context.Context, tag names.ModelTag) (environscloudspec.CloudSpec, error) {
 			s.AddCall("CloudSpec", tag)
 			return s.result, s.NextErr()
 		},

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -25,8 +25,8 @@ type Pool interface {
 
 // MakeCloudSpecGetter returns a function which returns a CloudSpec
 // for a given model, using the given Pool.
-func MakeCloudSpecGetter(pool Pool, cloudService common.CloudService, credentialService common.CredentialService) func(names.ModelTag) (environscloudspec.CloudSpec, error) {
-	return func(tag names.ModelTag) (environscloudspec.CloudSpec, error) {
+func MakeCloudSpecGetter(pool Pool, cloudService common.CloudService, credentialService common.CredentialService) func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
+	return func(ctx context.Context, tag names.ModelTag) (environscloudspec.CloudSpec, error) {
 		st, err := pool.Get(tag.Id())
 		if err != nil {
 			return environscloudspec.CloudSpec{}, errors.Trace(err)
@@ -43,7 +43,7 @@ func MakeCloudSpecGetter(pool Pool, cloudService common.CloudService, credential
 		// TODO (manadart 2018-02-15): This potentially frees the state from
 		// the pool. Release is called, but the state reference survives.
 		return stateenvirons.EnvironConfigGetter{
-			Model: m, CloudService: cloudService, CredentialService: credentialService}.CloudSpec(context.Background())
+			Model: m, CloudService: cloudService, CredentialService: credentialService}.CloudSpec(ctx)
 	}
 }
 
@@ -51,8 +51,8 @@ func MakeCloudSpecGetter(pool Pool, cloudService common.CloudService, credential
 // CloudSpec for a single model. Attempts to request a CloudSpec for
 // any other model other than the one associated with the given
 // state.State results in an error.
-func MakeCloudSpecGetterForModel(st *state.State, cloudService common.CloudService, credentialService common.CredentialService) func(names.ModelTag) (environscloudspec.CloudSpec, error) {
-	return func(tag names.ModelTag) (environscloudspec.CloudSpec, error) {
+func MakeCloudSpecGetterForModel(st *state.State, cloudService common.CloudService, credentialService common.CredentialService) func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
+	return func(ctx context.Context, tag names.ModelTag) (environscloudspec.CloudSpec, error) {
 		m, err := st.Model()
 		if err != nil {
 			return environscloudspec.CloudSpec{}, errors.Trace(err)
@@ -63,7 +63,7 @@ func MakeCloudSpecGetterForModel(st *state.State, cloudService common.CloudServi
 		if tag.Id() != st.ModelUUID() {
 			return environscloudspec.CloudSpec{}, errors.New("cannot get cloud spec for this model")
 		}
-		return configGetter.CloudSpec(context.Background())
+		return configGetter.CloudSpec(ctx)
 	}
 }
 

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -352,7 +352,7 @@ func (a *authenticator) checkMacaroons(
 	sourceModelUUID := declared[sourcemodelKey]
 	offerUUID := declared[offeruuidKey]
 
-	auth := a.bakery.Auth(mac)
+	auth := a.bakery.Auth(ctx, mac)
 	ai, err := auth.Allow(ctx, op)
 	if err == nil && len(ai.Conditions()) > 0 {
 		if err = a.checkMacaroonCaveats(op, relation, sourceModelUUID, offerUUID); err == nil {

--- a/apiserver/common/crossmodel/mock_test.go
+++ b/apiserver/common/crossmodel/mock_test.go
@@ -27,7 +27,7 @@ func (m *mockBakery) ExpireStorageAfter(time.Duration) (authentication.Expirable
 	return m, nil
 }
 
-func (m *mockBakery) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+func (m *mockBakery) Auth(_ context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
 	return m.Bakery.Checker.Auth(mss...)
 }
 

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -28,6 +28,7 @@ var sendMetrics = func(ctx context.Context, st metricsender.ModelBackend) error 
 	}
 
 	err = metricsender.SendMetrics(
+		ctx,
 		st,
 		metricsender.DefaultSenderFactory()(meteringURL),
 		clock.WallClock,

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -769,7 +769,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -787,6 +787,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 	}
 
 	results, err := secrets.RemoveSecretsForAgent(
+		context.Background(),
 		removeState, adminConfigGetter,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
@@ -828,7 +829,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -846,6 +847,7 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 	}
 
 	results, err := secrets.RemoveSecretsForAgent(
+		context.Background(),
 		removeState, adminConfigGetter,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
@@ -896,7 +898,7 @@ func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -914,6 +916,7 @@ func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
 	}
 
 	results, err := secrets.RemoveSecretsForAgent(
+		context.Background(),
 		removeState, adminConfigGetter,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
@@ -966,7 +969,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -1044,7 +1047,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -43,6 +43,7 @@ type MachinerAPI struct {
 
 // NewMachinerAPIForState creates a new instance of the Machiner API.
 func NewMachinerAPIForState(
+	ctx context.Context,
 	ctrlSt, st *state.State,
 	controllerConfigService ControllerConfigService,
 	cloudService common.CloudService,
@@ -57,7 +58,7 @@ func NewMachinerAPIForState(
 		return authorizer.AuthOwner, nil
 	}
 
-	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(context.Background(), st, cloudService, getCanAccess)
+	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(ctx, st, cloudService, getCanAccess)
 	if err != nil {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}

--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -44,6 +44,7 @@ func (s *machinerSuite) SetUpTest(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	// Create a machiner API for machine 1.
 	machiner, err := machine.NewMachinerAPIForState(
+		context.Background(),
 		st,
 		st,
 		s.ControllerServiceFactory(c).ControllerConfig(),
@@ -60,6 +61,7 @@ func (s *machinerSuite) TestMachinerFailsWithNonMachineAgentUser(c *gc.C) {
 	anAuthorizer.Tag = names.NewUnitTag("ubuntu/1")
 	st := s.ControllerModel(c).State()
 	aMachiner, err := machine.NewMachinerAPIForState(
+		context.Background(),
 		st,
 		st,
 		s.ControllerServiceFactory(c).ControllerConfig(),

--- a/apiserver/facades/agent/machine/register.go
+++ b/apiserver/facades/agent/machine/register.go
@@ -15,18 +15,19 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Machiner", 5, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
-		return newMachinerAPI(ctx) // Adds RecordAgentHostAndStartTime.
+		return newMachinerAPI(stdCtx, ctx) // Adds RecordAgentHostAndStartTime.
 	}, reflect.TypeOf((*MachinerAPI)(nil)))
 }
 
 // newMachinerAPI creates a new instance of the Machiner API.
-func newMachinerAPI(ctx facade.Context) (*MachinerAPI, error) {
+func newMachinerAPI(stdCtx context.Context, ctx facade.Context) (*MachinerAPI, error) {
 	systemState, err := ctx.StatePool().SystemState()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	serviceFactory := ctx.ServiceFactory()
 	return NewMachinerAPIForState(
+		stdCtx,
 		systemState,
 		ctx.State(),
 		serviceFactory.ControllerConfig(),

--- a/apiserver/facades/agent/metricsender/metricsender.go
+++ b/apiserver/facades/agent/metricsender/metricsender.go
@@ -77,7 +77,7 @@ func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireform
 // SendMetrics will send any unsent metrics
 // over the MetricSender interface in batches
 // no larger than batchSize.
-func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchSize int, transmitVendorMetrics bool) error {
+func SendMetrics(ctx context.Context, st ModelBackend, sender MetricSender, clock clock.Clock, batchSize int, transmitVendorMetrics bool) error {
 	metricsManager, err := st.MetricsManager()
 	if err != nil {
 		return errors.Trace(err)
@@ -111,7 +111,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 				wireData = append(wireData, ToWire(m, modelName))
 			}
 		}
-		response, err := sender.Send(context.Background(), wireData)
+		response, err := sender.Send(ctx, wireData)
 		if err != nil {
 			logger.Errorf("%+v", err)
 			if incErr := metricsManager.IncrementConsecutiveErrors(); incErr != nil {

--- a/apiserver/facades/agent/metricsender/metricsender_test.go
+++ b/apiserver/facades/agent/metricsender/metricsender_test.go
@@ -4,6 +4,7 @@
 package metricsender_test
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -120,7 +121,7 @@ func (s *MetricSenderSuite) TestSendMetricsFromNewModel(c *gc.C) {
 	f2.MakeMetric(c, &factory.MetricParams{Unit: credUnit, Time: &now})
 	f2.MakeMetric(c, &factory.MetricParams{Unit: meteredUnit, Time: &now})
 	f2.MakeMetric(c, &factory.MetricParams{Unit: credUnit, Sent: true, Time: &now})
-	err = metricsender.SendMetrics(TestSenderBackend{st, model}, &sender, clock, 10, true)
+	err = metricsender.SendMetrics(context.Background(), TestSenderBackend{st, model}, &sender, clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -143,7 +144,7 @@ func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -170,7 +171,7 @@ func (s *MetricSenderSuite) TestSendingHandlesModelMeterStatus(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -194,7 +195,7 @@ func (s *MetricSenderSuite) TestSendingHandlesEmptyModelMeterStatus(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 2)
@@ -223,7 +224,7 @@ func (s *MetricSenderSuite) TestSendMetricsAbort(c *gc.C) {
 
 	// Send 4 batches per POST.
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 4, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 4, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 4)
 
@@ -257,7 +258,7 @@ func (s *MetricSenderSuite) TestHoldMetrics(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, false)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 1)
@@ -287,7 +288,7 @@ func (s *MetricSenderSuite) TestHoldMetricsSetsMeterStatus(c *gc.C) {
 	f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: true, Time: &now})
 
 	st := s.ControllerModel(c).State()
-	err = metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, false)
+	err = metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sender.Data, gc.HasLen, 1)
 	c.Assert(sender.Data[0], gc.HasLen, 1)
@@ -318,7 +319,7 @@ func (s *MetricSenderSuite) TestSendBulkMetrics(c *gc.C) {
 	}
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, &sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(sender.Data, gc.HasLen, 10)
@@ -340,7 +341,7 @@ func (s *MetricSenderSuite) TestDontSendWithNopSender(c *gc.C) {
 	}
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, metricsender.NopSender{}, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, metricsender.NopSender{}, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	sent, err := st.CountOfSentMetrics()
 	c.Assert(err, jc.ErrorIsNil)
@@ -359,7 +360,7 @@ func (s *MetricSenderSuite) TestFailureIncrementsConsecutiveFailures(c *gc.C) {
 	}
 
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 1, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 1, true)
 	c.Assert(err, gc.ErrorMatches, "something went wrong")
 	mm, err := st.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -380,7 +381,7 @@ func (s *MetricSenderSuite) TestFailuresResetOnSuccessfulSend(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		f.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
 	}
-	err = metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, metricsender.NopSender{}, s.clock, 10, true)
+	err = metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, metricsender.NopSender{}, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err = st.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/metricsender/sender_test.go
+++ b/apiserver/facades/agent/metricsender/sender_test.go
@@ -4,6 +4,7 @@
 package metricsender_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -77,7 +78,7 @@ func (s *SenderSuite) TestHTTPSender(c *gc.C) {
 	}
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(receiverChan, gc.HasLen, metricCount)
@@ -162,7 +163,7 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 		}
 		sender := metricsender.DefaultSenderFactory()("http://example.com")
 		st := s.ControllerModel(c).State()
-		err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+		err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 		c.Assert(err, gc.ErrorMatches, test.expectedErr)
 		for _, batch := range batches {
 			m, err := st.MetricBatch(batch.UUID())
@@ -194,7 +195,7 @@ func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err = metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err = metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err = s.unit.GetMeterStatus()
@@ -243,7 +244,7 @@ func (s *SenderSuite) TestMeterStatusInvalid(c *gc.C) {
 
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := unit1.GetMeterStatus()
@@ -269,7 +270,7 @@ func (s *SenderSuite) TestGracePeriodResponse(c *gc.C) {
 	defer cleanup()
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := st.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -286,7 +287,7 @@ func (s *SenderSuite) TestNegativeGracePeriodResponse(c *gc.C) {
 	defer cleanup()
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := st.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
@@ -303,7 +304,7 @@ func (s *SenderSuite) TestZeroGracePeriodResponse(c *gc.C) {
 	defer cleanup()
 	sender := metricsender.DefaultSenderFactory()("http://example.com")
 	st := s.ControllerModel(c).State()
-	err := metricsender.SendMetrics(TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
+	err := metricsender.SendMetrics(context.Background(), TestSenderBackend{st, s.ControllerModel(c)}, sender, s.clock, 10, true)
 	c.Assert(err, jc.ErrorIsNil)
 	mm, err := st.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -148,7 +148,7 @@ func NewProvisionerAPI(stdCtx stdcontext.Context, ctx facade.Context) (*Provisio
 	if isCaasModel {
 		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, serviceFactory.Cloud(), serviceFactory.Credential())
 	} else {
-		env, err = environs.GetEnviron(stdcontext.Background(), configGetter, environs.New)
+		env, err = environs.GetEnviron(stdCtx, configGetter, environs.New)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -156,7 +156,7 @@ func NewProvisionerAPI(stdCtx stdcontext.Context, ctx facade.Context) (*Provisio
 	storageProviderRegistry := stateenvirons.NewStorageProviderRegistry(env)
 
 	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(
-		stdcontext.Background(), st, serviceFactory.Cloud(), getCanModify)
+		stdCtx, st, serviceFactory.Cloud(), getCanModify)
 	if err != nil {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -4,6 +4,7 @@
 package secretsmanager
 
 import (
+	"context"
 	"testing"
 
 	"github.com/juju/clock"
@@ -43,7 +44,7 @@ func NewTestAPI(
 	backendConfigGetter commonsecrets.BackendConfigGetter,
 	adminConfigGetter commonsecrets.BackendAdminConfigGetter,
 	drainConfigGetter commonsecrets.BackendDrainConfigGetter,
-	remoteClientGetter func(uri *coresecrets.URI) (CrossModelSecretsClient, error),
+	remoteClientGetter func(ctx context.Context, uri *coresecrets.URI) (CrossModelSecretsClient, error),
 	crossModelState CrossModelState,
 	authTag names.Tag,
 	clock clock.Clock,

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -62,13 +62,13 @@ func NewSecretManagerAPI(stdCtx context.Context, ctx facade.Context) (*SecretsMa
 	}
 	cloudService := serviceFactory.Cloud()
 	credentialSerivce := serviceFactory.Credential()
-	secretBackendConfigGetter := func(backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
+	secretBackendConfigGetter := func(stdCtx context.Context, backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
 		return secrets.BackendConfigInfo(stdCtx, secrets.SecretsModel(model), cloudService, credentialSerivce, backendIDs, wantAll, ctx.Auth().GetAuthTag(), leadershipChecker)
 	}
-	secretBackendAdminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	secretBackendAdminConfigGetter := func(stdCtx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return secrets.AdminBackendConfigInfo(stdCtx, secrets.SecretsModel(model), cloudService, credentialSerivce)
 	}
-	secretBackendDrainConfigGetter := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+	secretBackendDrainConfigGetter := func(stdCtx context.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		return secrets.DrainBackendConfigInfo(stdCtx, backendID, secrets.SecretsModel(model), cloudService, credentialSerivce, ctx.Auth().GetAuthTag(), leadershipChecker)
 	}
 	controllerAPI := common.NewControllerConfigAPI(
@@ -76,7 +76,7 @@ func NewSecretManagerAPI(stdCtx context.Context, ctx facade.Context) (*SecretsMa
 		serviceFactory.ControllerConfig(),
 		serviceFactory.ExternalController(),
 	)
-	remoteClientGetter := func(uri *coresecrets.URI) (CrossModelSecretsClient, error) {
+	remoteClientGetter := func(stdCtx context.Context, uri *coresecrets.URI) (CrossModelSecretsClient, error) {
 		info, err := controllerAPI.ControllerAPIInfoForModels(stdCtx, params.Entities{Entities: []params.Entity{{
 			Tag: names.NewModelTag(uri.SourceUUID).String(),
 		}}})

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -84,7 +84,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.clock = testclock.NewClock(time.Now())
 
-	backendConfigGetter := func(backendIds []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(_ context.Context, backendIds []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
 		// wantAll is for 3.1 compatibility only.
 		if wantAll {
 			return nil, errors.NotSupportedf("wantAll")
@@ -104,7 +104,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 			},
 		}, nil
 	}
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -120,7 +120,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 			},
 		}, nil
 	}
-	drainConfigGetter := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+	drainConfigGetter := func(_ context.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -136,7 +136,7 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 			},
 		}, nil
 	}
-	remoteClientGetter := func(uri *coresecrets.URI) (secretsmanager.CrossModelSecretsClient, error) {
+	remoteClientGetter := func(_ context.Context, uri *coresecrets.URI) (secretsmanager.CrossModelSecretsClient, error) {
 		return s.remoteClient, nil
 	}
 

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -20,12 +20,12 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("StorageProvisioner", 4, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV4(ctx)
+		return newFacadeV4(stdCtx, ctx)
 	}, reflect.TypeOf((*StorageProvisionerAPIv4)(nil)))
 }
 
 // newFacadeV4 provides the signature required for facade registration.
-func newFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
+func newFacadeV4(stdCtx context.Context, ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 	st := ctx.State()
 	model, err := st.Model()
 	if err != nil {
@@ -47,6 +47,7 @@ func newFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 		return nil, errors.Trace(err)
 	}
 	return NewStorageProvisionerAPIv4(
+		stdCtx,
 		backend,
 		storageBackend,
 		serviceFactory.ControllerConfig(),

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -56,6 +56,7 @@ type StorageProvisionerAPIv4 struct {
 
 // NewStorageProvisionerAPIv4 creates a new server-side StorageProvisioner v3 facade.
 func NewStorageProvisionerAPIv4(
+	ctx context.Context,
 	st Backend,
 	sb StorageBackend,
 	controllerConfigService ControllerConfigService,
@@ -72,7 +73,7 @@ func NewStorageProvisionerAPIv4(
 	// Cache the controller UUID so that we can use it later on.
 	// The controller UUID is a readonly property of the controller	config,
 	// so we don't need to refetch it for every request.
-	controllerConfig, err := controllerConfigService.ControllerConfig(context.Background())
+	controllerConfig, err := controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -68,6 +68,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
 	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		context.Background(),
 		backend,
 		storageBackend,
 		s.ControllerServiceFactory(c).ControllerConfig(),

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
@@ -67,6 +67,7 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
 	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		context.Background(),
 		backend,
 		storageBackend,
 		s.ControllerServiceFactory(c).ControllerConfig(),

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -41,6 +41,7 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = storageprovisioner.NewStorageProvisionerAPIv4(
+		context.Background(),
 		backend,
 		storageBackend,
 		s.ControllerServiceFactory(c).ControllerConfig(),

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2595,7 +2595,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 
 	// TODO - do in txn once we have support for that
 	if len(changes.SecretCreates) > 0 {
-		result, err := u.SecretsManagerAPI.CreateSecrets(context.Background(), params.CreateSecretArgs{Args: changes.SecretCreates})
+		result, err := u.SecretsManagerAPI.CreateSecrets(ctx, params.CreateSecretArgs{Args: changes.SecretCreates})
 		if err == nil {
 			var errorStrings []string
 			for _, r := range result.Results {
@@ -2612,7 +2612,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 		}
 	}
 	if len(changes.SecretUpdates) > 0 {
-		result, err := u.SecretsManagerAPI.UpdateSecrets(context.Background(), params.UpdateSecretArgs{Args: changes.SecretUpdates})
+		result, err := u.SecretsManagerAPI.UpdateSecrets(ctx, params.UpdateSecretArgs{Args: changes.SecretUpdates})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2630,7 +2630,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 		}
 	}
 	if len(changes.SecretGrants) > 0 {
-		result, err := u.SecretsManagerAPI.SecretsGrant(context.Background(), params.GrantRevokeSecretArgs{Args: changes.SecretGrants})
+		result, err := u.SecretsManagerAPI.SecretsGrant(ctx, params.GrantRevokeSecretArgs{Args: changes.SecretGrants})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2639,7 +2639,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 		}
 	}
 	if len(changes.SecretRevokes) > 0 {
-		result, err := u.SecretsManagerAPI.SecretsRevoke(context.Background(), params.GrantRevokeSecretArgs{Args: changes.SecretRevokes})
+		result, err := u.SecretsManagerAPI.SecretsRevoke(ctx, params.GrantRevokeSecretArgs{Args: changes.SecretRevokes})
 		if err == nil {
 			err = result.Combine()
 		}
@@ -2648,7 +2648,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 		}
 	}
 	if len(changes.SecretDeletes) > 0 {
-		result, err := u.SecretsManagerAPI.RemoveSecrets(context.Background(), params.DeleteSecretArgs{Args: changes.SecretDeletes})
+		result, err := u.SecretsManagerAPI.RemoveSecrets(ctx, params.DeleteSecretArgs{Args: changes.SecretDeletes})
 		if err == nil {
 			err = result.Combine()
 		}

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -370,7 +370,7 @@ func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params
 	}
 
 	// Various checks of the resolved charm against the arg provided.
-	dt, rcErrs := v.resolvedCharmValidation(resolvedCharm, arg)
+	dt, rcErrs := v.resolvedCharmValidation(ctx, resolvedCharm, arg)
 	if len(rcErrs) > 0 {
 		errs = append(errs, rcErrs...)
 	}
@@ -423,7 +423,7 @@ func validateAndParseAttachStorage(input []string, numUnits int) ([]names.Storag
 	return attachStorage, errs
 }
 
-func (v *deployFromRepositoryValidator) resolvedCharmValidation(resolvedCharm charm.Charm, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
+func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Context, resolvedCharm charm.Charm, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	errs := make([]error, 0)
 
 	var cons constraints.Value
@@ -473,7 +473,7 @@ func (v *deployFromRepositoryValidator) resolvedCharmValidation(resolvedCharm ch
 	}
 
 	// Enforce "assumes" requirements if the feature flag is enabled.
-	if err := assertCharmAssumptions(context.Background(), resolvedCharm.Meta().Assumes, v.model, v.cloudService, v.credentialService, v.state.ControllerConfig); err != nil {
+	if err := assertCharmAssumptions(ctx, resolvedCharm.Meta().Assumes, v.model, v.cloudService, v.credentialService, v.state.ControllerConfig); err != nil {
 		if !errors.Is(err, errors.NotSupported) || !arg.Force {
 			errs = append(errs, err)
 		}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -721,7 +721,7 @@ func (s *validatorSuite) TestResolvedCharmValidationSubordinate(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		NumUnits: intptr(1),
 	}
-	dt, err := s.getValidator().resolvedCharmValidation(ch, arg)
+	dt, err := s.getValidator().resolvedCharmValidation(context.Background(), ch, arg)
 	c.Assert(err, gc.HasLen, 0)
 	c.Assert(dt.numUnits, gc.Equals, 0)
 }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -258,7 +258,7 @@ func (c *Client) FindTools(ctx stdcontext.Context, args params.FindToolsParams) 
 	}
 
 	list, err := c.api.toolsFinder.FindAgents(
-		stdcontext.Background(),
+		ctx,
 		common.FindAgentsParams{
 			Number:       args.Number,
 			MajorVersion: args.MajorVersion,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -86,6 +86,7 @@ var LatestAPI = newControllerAPIv11
 // NewControllerAPI creates a new api server endpoint for operations
 // on a controller.
 func NewControllerAPI(
+	ctx context.Context,
 	st *state.State,
 	pool *state.StatePool,
 	authorizer facade.Authorizer,
@@ -240,6 +241,7 @@ func (c *ControllerAPI) dashboardConnectionInfoForCAAS(
 // dashboardConnectionInforForIAAS returns a dashboard connection for a Juju
 // dashboard deployed on IAAS.
 func (c *ControllerAPI) dashboardConnectionInfoForIAAS(
+	ctx context.Context,
 	appName string,
 	appSettings map[string]interface{},
 ) (*params.DashboardConnectionSSHTunnel, error) {
@@ -269,7 +271,7 @@ func (c *ControllerAPI) dashboardConnectionInfoForIAAS(
 		return nil, errors.Trace(err)
 	}
 	modelName := model.Name()
-	ctrCfg, err := c.controllerConfigService.ControllerConfig(context.Background())
+	ctrCfg, err := c.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -325,6 +327,7 @@ func (c *ControllerAPI) DashboardConnectionInfo(ctx context.Context) (params.Das
 
 			if model.Type() != state.ModelTypeCAAS {
 				sshConnection, err := c.dashboardConnectionInfoForIAAS(
+					ctx,
 					related.ApplicationName,
 					appSettings)
 				rval.SSHConnection = sshConnection
@@ -809,13 +812,13 @@ func (c *ControllerAPI) ConfigSet(ctx context.Context, args params.ControllerCon
 		return errors.Trace(err)
 	}
 	// Write Controller Config to DQLite.
-	if err := c.controllerConfigService.UpdateControllerConfig(context.Background(), args.Config, nil); err != nil {
+	if err := c.controllerConfigService.UpdateControllerConfig(ctx, args.Config, nil); err != nil {
 		return errors.Trace(err)
 	}
 	// TODO(thumper): add a version to controller config to allow for
 	// simultaneous updates and races in publishing, potentially across
 	// HA servers.
-	cfg, err := c.controllerConfigService.ControllerConfig(context.Background())
+	cfg, err := c.controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -995,7 +998,7 @@ func makeModelInfo(ctx context.Context, st, ctlrSt *state.State, controllerConfi
 	}
 	controllerVersion, _ := controllerConfig.AgentVersion()
 
-	coreConf, err := controllerConfigService.ControllerConfig(context.Background())
+	coreConf, err := controllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return empty, userList{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -131,7 +131,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		MultiwatcherFactory_: multiWatcherWorker,
 		ServiceFactory_:      s.ControllerServiceFactory(c),
 	}
-	controller, err := controller.LatestAPI(s.context)
+	controller, err := controller.LatestAPI(context.Background(), s.context)
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = controller
 
@@ -147,7 +147,7 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewUnitTag("mysql/0"),
 	}
-	endPoint, err := controller.LatestAPI(facadetest.Context{
+	endPoint, err := controller.LatestAPI(context.Background(), facadetest.Context{
 		State_:          s.State,
 		Resources_:      s.resources,
 		Auth_:           anAuthoriser,
@@ -329,6 +329,7 @@ func (s *controllerSuite) TestModelConfigFromNonController(c *gc.C) {
 		AdminTag: s.Owner,
 	}
 	controller, err := controller.NewControllerAPIv11(
+		context.Background(),
 		facadetest.Context{
 			State_:          st,
 			StatePool_:      s.StatePool,
@@ -360,6 +361,7 @@ func (s *controllerSuite) TestControllerConfigFromNonController(c *gc.C) {
 
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.Owner}
 	controller, err := controller.NewControllerAPIv11(
+		context.Background(),
 		facadetest.Context{
 			State_:          st,
 			Resources_:      common.NewResources(),
@@ -911,12 +913,14 @@ func (s *controllerSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPIv11(facadetest.Context{
-		State_:          s.State,
-		Resources_:      s.resources,
-		Auth_:           anAuthoriser,
-		ServiceFactory_: s.ControllerServiceFactory(c),
-	})
+	endpoint, err := controller.NewControllerAPIv11(
+		context.Background(),
+		facadetest.Context{
+			State_:          s.State,
+			Resources_:      s.resources,
+			Auth_:           anAuthoriser,
+			ServiceFactory_: s.ControllerServiceFactory(c),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.ModifyControllerAccessRequest{
 		Changes: []params.ModifyControllerAccess{{
@@ -997,12 +1001,14 @@ func (s *controllerSuite) TestConfigSetRequiresSuperUser(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: user.Tag(),
 	}
-	endpoint, err := controller.NewControllerAPIv11(facadetest.Context{
-		State_:          s.State,
-		Resources_:      s.resources,
-		Auth_:           anAuthoriser,
-		ServiceFactory_: s.ControllerServiceFactory(c),
-	})
+	endpoint, err := controller.NewControllerAPIv11(
+		context.Background(),
+		facadetest.Context{
+			State_:          s.State,
+			Resources_:      s.resources,
+			Auth_:           anAuthoriser,
+			ServiceFactory_: s.ControllerServiceFactory(c),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = endpoint.ConfigSet(stdcontext.Background(), params.ControllerConfigSet{Config: map[string]interface{}{
@@ -1171,12 +1177,14 @@ func (s *controllerSuite) TestWatchAllModelSummariesByNonAdmin(c *gc.C) {
 	anAuthoriser := apiservertesting.FakeAuthorizer{
 		Tag: names.NewLocalUserTag("bob"),
 	}
-	endPoint, err := controller.LatestAPI(facadetest.Context{
-		State_:          s.State,
-		Resources_:      s.resources,
-		Auth_:           anAuthoriser,
-		ServiceFactory_: s.ControllerServiceFactory(c),
-	})
+	endPoint, err := controller.LatestAPI(
+		context.Background(),
+		facadetest.Context{
+			State_:          s.State,
+			Resources_:      s.resources,
+			Auth_:           anAuthoriser,
+			ServiceFactory_: s.ControllerServiceFactory(c),
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = endPoint.WatchAllModelSummaries(stdcontext.Background())

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -61,6 +61,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 		Tag: jujutesting.AdminUser,
 	}
 	testController, err := controller.NewControllerAPIv11(
+		context.Background(),
 		facadetest.Context{
 			State_:          s.ControllerModel(c).State(),
 			StatePool_:      s.StatePool(),

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -13,12 +13,12 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Controller", 11, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
-		return newControllerAPIv11(ctx)
+		return newControllerAPIv11(stdCtx, ctx)
 	}, reflect.TypeOf((*ControllerAPI)(nil)))
 }
 
 // newControllerAPIv11 creates a new ControllerAPIv11
-func newControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
+func newControllerAPIv11(stdCtx context.Context, ctx facade.Context) (*ControllerAPI, error) {
 	var (
 		st             = ctx.State()
 		authorizer     = ctx.Auth()
@@ -31,6 +31,7 @@ func newControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
 	)
 
 	return NewControllerAPI(
+		stdCtx,
 		st,
 		pool,
 		authorizer,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -439,7 +439,7 @@ Please choose a different model name.
 		}
 	}()
 
-	broker, err := m.getBroker(context.Background(), environs.OpenParams{
+	broker, err := m.getBroker(ctx, environs.OpenParams{
 		ControllerUUID: controllerConfig.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,
@@ -496,7 +496,7 @@ func (m *ModelManagerAPI) newModel(
 	}
 
 	// Create the Environ.
-	env, err := environs.New(context.Background(), environs.OpenParams{
+	env, err := environs.New(ctx, environs.OpenParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -137,7 +137,7 @@ func (s *modelUpgradeSuite) newFacade(c *gc.C) *modelupgrader.ModelUpgraderAPI {
 		func(docker.ImageRepoDetails) (registry.Registry, error) {
 			return s.registryProvider, nil
 		},
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(stdcontext.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return s.cloudSpec.CloudSpec, nil
 		},
 		s.upgradeService,

--- a/apiserver/facades/client/secrets/package_test.go
+++ b/apiserver/facades/client/secrets/package_test.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/juju/names/v5"
@@ -26,9 +27,9 @@ func NewTestAPI(
 	authorizer facade.Authorizer,
 	secretsState SecretsState,
 	secretsConsumer SecretsConsumer,
-	adminBackendConfigGetter func() (*provider.ModelBackendConfigInfo, error),
-	backendConfigGetterForUserSecretsWrite func(backendID string) (*provider.ModelBackendConfigInfo, error),
-	backendGetter func(*provider.ModelBackendConfig) (provider.SecretsBackend, error),
+	adminBackendConfigGetter func(ctx context.Context) (*provider.ModelBackendConfigInfo, error),
+	backendConfigGetterForUserSecretsWrite func(ctx context.Context, backendID string) (*provider.ModelBackendConfigInfo, error),
+	backendGetter func(context.Context, *provider.ModelBackendConfig) (provider.SecretsBackend, error),
 ) (*SecretsAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm

--- a/apiserver/facades/client/secrets/register.go
+++ b/apiserver/facades/client/secrets/register.go
@@ -49,23 +49,23 @@ func newSecretsAPI(context facade.Context) (*SecretsAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	adminBackendConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	adminBackendConfigGetter := func(ctx stdcontext.Context) (*provider.ModelBackendConfigInfo, error) {
 		return secrets.AdminBackendConfigInfo(
-			stdcontext.Background(), secrets.SecretsModel(model),
+			ctx, secrets.SecretsModel(model),
 			serviceFactory.Cloud(), serviceFactory.Credential(),
 		)
 	}
-	backendConfigGetterForUserSecretsWrite := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetterForUserSecretsWrite := func(ctx stdcontext.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		// User secrets are owned by the model.
 		authTag := model.ModelTag()
 		return secrets.BackendConfigInfo(
-			stdcontext.Background(), secrets.SecretsModel(model),
+			ctx, secrets.SecretsModel(model),
 			serviceFactory.Cloud(), serviceFactory.Credential(),
 			[]string{backendID}, false, authTag, leadershipChecker,
 		)
 	}
 
-	backendGetter := func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+	backendGetter := func(ctx stdcontext.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 		p, err := provider.Provider(cfg.BackendType)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -43,7 +43,7 @@ type SecretsSuite struct {
 
 var _ = gc.Suite(&SecretsSuite{})
 
-func adminBackendConfigGetter() (*provider.ModelBackendConfigInfo, error) {
+func adminBackendConfigGetter(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 	return &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
 		Configs: map[string]provider.ModelBackendConfig{
@@ -69,8 +69,8 @@ func adminBackendConfigGetter() (*provider.ModelBackendConfigInfo, error) {
 	}, nil
 }
 
-func backendConfigGetterForUserSecretsWrite(c *gc.C) func(backendID string) (*provider.ModelBackendConfigInfo, error) {
-	return func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+func backendConfigGetterForUserSecretsWrite(c *gc.C) func(_ context.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
+	return func(_ context.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		c.Assert(backendID, gc.Equals, "backend-id")
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
@@ -140,7 +140,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		},
@@ -301,7 +301,7 @@ func (s *SecretsSuite) TestCreateSecretsEmptyData(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -369,7 +369,7 @@ func (s *SecretsSuite) assertCreateSecrets(c *gc.C, isInternal bool, finalStepFa
 	}
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -504,7 +504,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI, isInte
 	}
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -585,7 +585,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -613,7 +613,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelAdmin(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -639,7 +639,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelOwned(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -685,7 +685,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -712,7 +712,7 @@ func (s *SecretsSuite) TestRemoveSecretNotFound(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -755,7 +755,7 @@ func (s *SecretsSuite) TestGrantSecret(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -805,7 +805,7 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})
@@ -864,7 +864,7 @@ func (s *SecretsSuite) TestRevokeSecret(c *gc.C) {
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretsState, s.secretConsumer,
 		adminBackendConfigGetter, backendConfigGetterForUserSecretsWrite(c),
-		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+		func(_ context.Context, cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 			c.Assert(cfg.Config, jc.DeepEquals, provider.ConfigAttrs{"foo": cfg.BackendType})
 			return s.secretsBackend, nil
 		})

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -111,7 +111,7 @@ func (a *API) ModelOperatorProvisioningInfo(ctx context.Context) (params.ModelOp
 				modelConfig.Name()))
 	}
 
-	apiAddresses, err := a.APIAddresses(context.Background())
+	apiAddresses, err := a.APIAddresses(ctx)
 	if err != nil && apiAddresses.Error != nil {
 		err = apiAddresses.Error
 	}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -610,7 +610,7 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 			},
 		},
 	}
-	results, err := s.api.WatchOfferStatus(args)
+	results, err := s.api.WatchOfferStatus(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -715,7 +715,7 @@ func (s *mockBakeryService) NewMacaroon(ctx context.Context, version bakery.Vers
 	return bakery.NewLegacyMacaroon(mac)
 }
 
-func (s *mockBakeryService) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+func (s *mockBakeryService) Auth(_ context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
 	s.MethodCall(s, "Auth", mss)
 	checker := bakery.NewChecker(bakery.CheckerParams{
 		OpsAuthorizer:    mockAuthorizer{},

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -68,7 +68,7 @@ func (m *mockBakery) ExpireStorageAfter(_ time.Duration) (authentication.Expirab
 	return m, nil
 }
 
-func (m *mockBakery) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+func (m *mockBakery) Auth(_ context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
 	return m.Bakery.Checker.Auth(mss...)
 }
 
@@ -105,7 +105,7 @@ func (s *CrossModelSecretsSuite) setup(c *gc.C) *gomock.Controller {
 	secretsStateGetter := func(modelUUID string) (crossmodelsecrets.SecretsState, crossmodelsecrets.SecretsConsumer, func() bool, error) {
 		return s.secretsState, s.secretsConsumer, func() bool { return false }, nil
 	}
-	backendConfigGetter := func(modelUUID string) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(_ context.Context, modelUUID string) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "active-id",
 			Configs: map[string]provider.ModelBackendConfig{

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -21,22 +21,22 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("CrossModelSecrets", 1, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
-		return newStateCrossModelSecretsAPI(ctx)
+		return newStateCrossModelSecretsAPI(stdCtx, ctx)
 	}, reflect.TypeOf((*CrossModelSecretsAPI)(nil)))
 }
 
 // newStateCrossModelSecretsAPI creates a new server-side CrossModelSecrets API facade
 // backed by global state.
-func newStateCrossModelSecretsAPI(ctx facade.Context) (*CrossModelSecretsAPI, error) {
+func newStateCrossModelSecretsAPI(stdCtx context.Context, ctx facade.Context) (*CrossModelSecretsAPI, error) {
 	authCtxt := ctx.Resources().Get("offerAccessAuthContext").(*common.ValueResource).Value
-	secretBackendConfigGetter := func(modelUUID string) (*provider.ModelBackendConfigInfo, error) {
+	secretBackendConfigGetter := func(stdCtx context.Context, modelUUID string) (*provider.ModelBackendConfigInfo, error) {
 		model, closer, err := ctx.StatePool().GetModel(modelUUID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		defer closer.Release()
 		return secrets.AdminBackendConfigInfo(
-			context.Background(), secrets.SecretsModel(model), ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential())
+			stdCtx, secrets.SecretsModel(model), ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential())
 	}
 	secretInfoGetter := func(modelUUID string) (SecretsState, SecretsConsumer, func() bool, error) {
 		st, err := ctx.StatePool().Get(modelUUID)

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -79,8 +79,8 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 func (s *firewallerSuite) TestFirewallerFailsWithNonControllerUser(c *gc.C) {
 	defer s.ctrl.Finish()
 
-	constructor := func(context facade.Context) error {
-		_, err := firewaller.NewFirewallerAPIV7(context)
+	constructor := func(ctx facade.Context) error {
+		_, err := firewaller.NewFirewallerAPIV7(ctx)
 		return err
 	}
 	s.testFirewallerFailsWithNonControllerUser(c, constructor)

--- a/apiserver/facades/controller/metricsmanager/metricsmanager.go
+++ b/apiserver/facades/controller/metricsmanager/metricsmanager.go
@@ -228,7 +228,7 @@ func (api *MetricsManagerAPI) SendMetrics(ctx context.Context, args params.Entit
 		if err != nil {
 			return result, errors.Trace(err)
 		}
-		err = metricsender.SendMetrics(modelBackend{modelState, model}, api.sender, api.clock, maxBatchesPerSend, txVendorMetrics)
+		err = metricsender.SendMetrics(ctx, modelBackend{modelState, model}, api.sender, api.clock, maxBatchesPerSend, txVendorMetrics)
 		if err != nil {
 			err = errors.Annotatef(err, "failed to send metrics for %s", tag)
 			logger.Warningf("%v", err)

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -49,7 +49,7 @@ type API struct {
 	authorizer              facade.Authorizer
 	resources               facade.Resources
 	presence                facade.Presence
-	environscloudspecGetter func(names.ModelTag) (environscloudspec.CloudSpec, error)
+	environscloudspecGetter func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error)
 	leadership              leadership.Reader
 	credentialService       common.CredentialService
 	upgradeService          UpgradeService
@@ -68,7 +68,7 @@ func NewAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 	presence facade.Presence,
-	environscloudspecGetter func(names.ModelTag) (environscloudspec.CloudSpec, error),
+	environscloudspecGetter func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error),
 	leadership leadership.Reader,
 	credentialService common.CredentialService,
 	upgradeService UpgradeService,

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -613,7 +613,7 @@ func (s *Suite) makeAPI() (*migrationmaster.API, error) {
 		s.resources,
 		s.authorizer,
 		&stubPresence{},
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) { return s.cloudSpec, nil },
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) { return s.cloudSpec, nil },
 		stubLeadership{},
 		s.credentialService,
 		s.upgradeService,

--- a/apiserver/facades/controller/undertaker/register.go
+++ b/apiserver/facades/controller/undertaker/register.go
@@ -32,12 +32,12 @@ func newUndertakerFacade(ctx facade.Context) (*UndertakerAPI, error) {
 	}
 	cloudService := ctx.ServiceFactory().Cloud()
 	credentialService := ctx.ServiceFactory().Credential()
-	secretsBackendsGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	secretsBackendsGetter := func(ctx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		model, err := st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return secrets.AdminBackendConfigInfo(context.Background(), secrets.SecretsModel(model), cloudService, credentialService)
+		return secrets.AdminBackendConfigInfo(ctx, secrets.SecretsModel(model), cloudService, credentialService)
 	}
 	cloudSpecAPI := cloudspec.NewCloudSpec(
 		ctx.Resources(),

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -98,7 +98,7 @@ func (u *UndertakerAPI) ProcessDyingModel(ctx context.Context) error {
 
 // RemoveModel removes any records of this model from Juju.
 func (u *UndertakerAPI) RemoveModel(ctx context.Context) error {
-	secretBackendCfg, err := u.secretBackendConfigGetter()
+	secretBackendCfg, err := u.secretBackendConfigGetter(ctx)
 	if err != nil {
 		return errors.Annotate(err, "getting secrets backends config")
 	}

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -45,7 +45,7 @@ func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, modelName str
 	s.secrets = &mockSecrets{}
 	s.PatchValue(&undertaker.GetProvider, func(string) (provider.SecretBackendProvider, error) { return s.secrets, nil })
 
-	secretBackendConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	secretBackendConfigGetter := func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -74,7 +74,7 @@ func (s *undertakerSuite) TestNoPerms(c *gc.C) {
 			st,
 			nil,
 			authorizer,
-			func() (*provider.ModelBackendConfigInfo, error) {
+			func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 				return nil, errors.NotImplemented
 			},
 			nil,

--- a/apiserver/facades/controller/usersecrets/package_test.go
+++ b/apiserver/facades/controller/usersecrets/package_test.go
@@ -4,6 +4,7 @@
 package usersecrets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/juju/names/v5"
@@ -29,7 +30,7 @@ func NewTestAPI(
 	controllerUUID string,
 	modelUUID string,
 	secretsState SecretsState,
-	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error),
+	backendConfigGetter func(ctx context.Context) (*provider.ModelBackendConfigInfo, error),
 ) (*UserSecretsManager, error) {
 	if !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm

--- a/apiserver/facades/controller/usersecrets/register.go
+++ b/apiserver/facades/controller/usersecrets/register.go
@@ -34,9 +34,9 @@ func NewUserSecretsManager(context facade.Context) (*UserSecretsManager, error) 
 	}
 
 	serviceFactory := context.ServiceFactory()
-	backendConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(ctx stdcontext.Context) (*provider.ModelBackendConfigInfo, error) {
 		return secrets.AdminBackendConfigInfo(
-			stdcontext.Background(), secrets.SecretsModel(model),
+			ctx, secrets.SecretsModel(model),
 			serviceFactory.Cloud(), serviceFactory.Credential(),
 		)
 	}

--- a/apiserver/facades/controller/usersecrets/secrets.go
+++ b/apiserver/facades/controller/usersecrets/secrets.go
@@ -28,7 +28,7 @@ type UserSecretsManager struct {
 	modelUUID      string
 
 	secretsState        SecretsState
-	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error)
+	backendConfigGetter func(context.Context) (*provider.ModelBackendConfigInfo, error)
 }
 
 // WatchRevisionsToPrune returns a watcher for notifying when:

--- a/apiserver/facades/controller/usersecrets/secrets_test.go
+++ b/apiserver/facades/controller/usersecrets/secrets_test.go
@@ -61,7 +61,7 @@ func (s *userSecretsSuite) setup(c *gc.C) *gomock.Controller {
 	s.facade, err = usersecrets.NewTestAPI(
 		s.authorizer, s.resources, s.authTag,
 		coretesting.ControllerTag.Id(), coretesting.ModelTag.Id(), s.state,
-		func() (*provider.ModelBackendConfigInfo, error) {
+		func(_ context.Context) (*provider.ModelBackendConfigInfo, error) {
 			return &provider.ModelBackendConfigInfo{
 				ActiveID: "backend-id",
 				Configs: map[string]provider.ModelBackendConfig{

--- a/apiserver/facades/controller/usersecretsdrain/drain_test.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain_test.go
@@ -4,6 +4,8 @@
 package usersecretsdrain_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -36,7 +38,7 @@ func (s *drainSuite) setup(c *gc.C) *gomock.Controller {
 	s.authorizer.EXPECT().AuthController().Return(true)
 	s.secretsState = mocks.NewMockSecretsState(ctrl)
 
-	backendConfigGetter := func(backendIds []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(_ context.Context, backendIds []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
 		// wantAll is for 3.1 compatibility only.
 		if wantAll {
 			return nil, errors.NotSupportedf("wantAll")
@@ -57,7 +59,7 @@ func (s *drainSuite) setup(c *gc.C) *gomock.Controller {
 		}, nil
 	}
 
-	drainConfigGetter := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+	drainConfigGetter := func(_ context.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -84,7 +86,7 @@ func (s *drainSuite) setup(c *gc.C) *gomock.Controller {
 func (s *drainSuite) TestGetSecretBackendConfigs(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.facade.GetSecretBackendConfigs(params.SecretBackendArgs{
+	result, err := s.facade.GetSecretBackendConfigs(context.Background(), params.SecretBackendArgs{
 		BackendIDs: []string{"backend-id"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -108,7 +110,7 @@ func (s *drainSuite) TestGetSecretBackendConfigs(c *gc.C) {
 func (s *drainSuite) TestGetSecretContentInvalidArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +128,7 @@ func (s *drainSuite) TestGetSecretContentInternal(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -151,7 +153,7 @@ func (s *drainSuite) TestGetSecretContentExternal(c *gc.C) {
 		}, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -189,7 +191,7 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoInternal(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretRevisionContentInfo(params.SecretRevisionArg{
+	results, err := s.facade.GetSecretRevisionContentInfo(context.Background(), params.SecretRevisionArg{
 		URI:       uri.String(),
 		Revisions: []int{666},
 	})
@@ -212,7 +214,7 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoExternal(c *gc.C) {
 		}, nil,
 	)
 
-	results, err := s.facade.GetSecretRevisionContentInfo(params.SecretRevisionArg{
+	results, err := s.facade.GetSecretRevisionContentInfo(context.Background(), params.SecretRevisionArg{
 		URI:       uri.String(),
 		Revisions: []int{666},
 	})

--- a/apiserver/facades/controller/usersecretsdrain/register.go
+++ b/apiserver/facades/controller/usersecretsdrain/register.go
@@ -36,7 +36,6 @@ func newUserSecretsDrainAPI(context facade.Context) (*SecretsDrainAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ctx := stdcontext.Background()
 	serviceFactory := context.ServiceFactory()
 	cloudService := serviceFactory.Cloud()
 	credentialSerivce := serviceFactory.Credential()
@@ -56,13 +55,13 @@ func newUserSecretsDrainAPI(context facade.Context) (*SecretsDrainAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	secretBackendConfigGetter := func(backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
+	secretBackendConfigGetter := func(ctx stdcontext.Context, backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
 		return commonsecrets.BackendConfigInfo(
 			ctx, commonsecrets.SecretsModel(model), cloudService, credentialSerivce,
 			backendIDs, wantAll, authTag, leadershipChecker,
 		)
 	}
-	secretBackendDrainConfigGetter := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
+	secretBackendDrainConfigGetter := func(ctx stdcontext.Context, backendID string) (*provider.ModelBackendConfigInfo, error) {
 		return commonsecrets.DrainBackendConfigInfo(
 			ctx, backendID, commonsecrets.SecretsModel(model),
 			cloudService, credentialSerivce,

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -43,7 +43,7 @@ func GetEnvironAndCloud(ctx context.Context, st EnvironConfigGetter, newEnviron 
 			err, "retrieving cloud spec for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}
 
-	env, err := newEnviron(context.TODO(), OpenParams{
+	env, err := newEnviron(ctx, OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
 	})

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -131,4 +131,4 @@ type ModelPresence interface {
 	AgentStatus(agent string) (presence.Status, error)
 }
 
-type environsCloudSpecGetter func(names.ModelTag) (environscloudspec.CloudSpec, error)
+type environsCloudSpecGetter func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error)

--- a/internal/migration/precheck.go
+++ b/internal/migration/precheck.go
@@ -406,7 +406,7 @@ func (ctx *precheckSource) checkModel(stdCtx context.Context) error {
 		}
 	}
 
-	cloudspec, err := ctx.environscloudspecGetter(names.NewModelTag(model.UUID()))
+	cloudspec, err := ctx.environscloudspecGetter(stdCtx, names.NewModelTag(model.UUID()))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -44,7 +44,7 @@ func sourcePrecheck(backend migration.PrecheckBackend, credentialService migrati
 	return migration.SourcePrecheck(
 		context.Background(),
 		backend, allAlivePresence(), allAlivePresence(),
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return environscloudspec.CloudSpec{Type: "lxd"}, nil
 		},
 		credentialService,
@@ -62,7 +62,7 @@ func (s *SourcePrecheckSuite) TestSuccess(c *gc.C) {
 	err := migration.SourcePrecheck(
 		context.Background(),
 		backend, allAlivePresence(), allAlivePresence(),
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return environscloudspec.CloudSpec{Type: "lxd"}, nil
 		},
 		&fakeCredentialService{},
@@ -125,7 +125,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	err := migration.SourcePrecheck(
 		context.Background(),
 		backend, allAlivePresence(), allAlivePresence(),
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return cloudSpec.CloudSpec, nil
 		},
 		&fakeCredentialService{},
@@ -153,7 +153,7 @@ func (s *SourcePrecheckSuite) TestTargetController2Failed(c *gc.C) {
 	err := migration.SourcePrecheck(
 		context.Background(),
 		backend, allAlivePresence(), allAlivePresence(),
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return environscloudspec.CloudSpec{Type: "lxd"}, nil
 		},
 		&fakeCredentialService{},
@@ -263,7 +263,7 @@ func (s *SourcePrecheckSuite) TestDownMachineAgent(c *gc.C) {
 	err := migration.SourcePrecheck(
 		context.Background(),
 		backend, modelPresence, controllerPresence,
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return environscloudspec.CloudSpec{Type: "foo"}, nil
 		},
 		&fakeCredentialService{},
@@ -406,7 +406,7 @@ func (s *SourcePrecheckSuite) TestUnitLost(c *gc.C) {
 	err := migration.SourcePrecheck(
 		context.Background(),
 		backend, modelPresence, controllerPresence,
-		func(names.ModelTag) (environscloudspec.CloudSpec, error) {
+		func(context.Context, names.ModelTag) (environscloudspec.CloudSpec, error) {
 			return environscloudspec.CloudSpec{Type: "foo"}, nil
 		},
 		&fakeCredentialService{},


### PR DESCRIPTION
PR https://github.com/juju/juju/pull/16741  went through the apiserver facades and replaces the `context.TODO()` occurrences with the proper context passed to the facade methods. However, there was an issue with creating secrets artefacts in the facade set up - the wrong context was being used. This PR fixes that.

Also, there were places where `context.Background()` was being used in the same wrong way as the already fixed up `context.TODO()`. These are now also fixed. Hopefully that's the last of the fixes needed for the apiserver layer.

There's still a few to fix in other packages.

## QA steps

I deployed `juju-qa-dummy-source` and `juju-qa-dummy-sink` in different models and cross model related them (offer dummy source).
Then I ran juju exec to create and share a secret on the dummy-source app. Then juju exec on dummy-sink to read the secret. Without the fixes in this PR, that would result in a context expired error.

## Links

**Jira card:** JUJU-5243

