### PR TITLE
Update Sqlair dependency

### DIFF
--- a/domain/autocert/state/state.go
+++ b/domain/autocert/state/state.go
@@ -15,11 +15,9 @@ import (
 	"github.com/juju/juju/domain"
 )
 
-// ExternalController represents a single row from the database when
-// external_controller is joined with external_controller_address and
-// external_model.
+// Autocert is a named certificate.
 type Autocert struct {
-	// Name is the autocert cache name (primary key).
+	// Name is the autocert name. It uniquely identifies the certificate.
 	Name string `db:"name"`
 
 	// Data represents the binary (encoded) contents of the autocert.
@@ -72,7 +70,7 @@ func (st *State) Get(ctx context.Context, name string) ([]byte, error) {
 	}
 
 	q := `
-SELECT (name, data) AS &Autocert.*
+SELECT (name, data) AS (&Autocert.*)
 FROM   autocert_cache 
 WHERE  name = $M.name`
 	s, err := sqlair.Prepare(q, Autocert{}, sqlair.M{})

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -380,10 +380,10 @@ func (st *State) loadCloudCredentials(ctx context.Context, tx *sqlair.TX, name, 
 SELECT (cc.uuid, cc.name,
        cc.revoked, cc.invalid, 
        cc.invalid_reason, 
-       cc.owner_uuid) AS &Credential.*,
+       cc.owner_uuid) AS (&Credential.*),
        auth_type.type AS &AuthType.*,
        cloud.name AS &Cloud.*,
-       (cc_attr.key, cc_attr.value) AS &credentialAttribute.*
+       (cc_attr.key, cc_attr.value) AS (&credentialAttribute.*)
 FROM   cloud_credential cc
        JOIN auth_type ON cc.auth_type_id = auth_type.id
        JOIN cloud ON cc.cloud_uuid = cloud.uuid

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -44,7 +44,7 @@ func (st *State) Controller(
 SELECT (ctrl.uuid,
        alias,
        ca_cert,
-       address) as &ExternalController.*,
+       address) as (&ExternalController.*),
        model.uuid as &ExternalController.model
 FROM   external_controller AS ctrl
        LEFT JOIN external_model AS model
@@ -87,7 +87,7 @@ func (st *State) ControllersForModels(ctx context.Context, modelUUIDs ...string)
 SELECT (ctrl.uuid,  
        ctrl.alias,
        ctrl.ca_cert,
-       addrs.address) as &ExternalController.*,
+       addrs.address) as (&ExternalController.*),
        model.uuid as &ExternalController.model
 FROM   external_controller AS ctrl	
        LEFT JOIN external_model AS model

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -79,7 +79,7 @@ func (st *State) SetControllerReady(ctx context.Context, upgradeUUID domainupgra
 	}
 
 	lookForReadyNodeQuery := `
-SELECT  (controller_node_id) AS &infoControllerNode.*
+SELECT  controller_node_id AS &infoControllerNode.controller_node_id
 FROM    upgrade_info_controller_node
 WHERE   upgrade_info_uuid = $M.info_uuid
 AND     controller_node_id = $M.controller_id;
@@ -214,7 +214,7 @@ WHERE uuid = ?
 }
 
 // SetDBUpgradeCompleted marks the database upgrade as completed
-func (st State) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
+func (st *State) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -249,7 +249,7 @@ AND state_type_id = $M.from_state;`
 }
 
 // SetDBUpgradeFailed marks the database upgrade as failed
-func (st State) SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
+func (st *State) SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -296,7 +296,7 @@ func (st *State) SetControllerDone(ctx context.Context, upgradeUUID domainupgrad
 	}
 
 	lookForDoneNodesQuery := `
-SELECT (controller_node_id, node_upgrade_completed_at) AS &infoControllerNode.*
+SELECT (controller_node_id, node_upgrade_completed_at) AS (&infoControllerNode.*)
 FROM   upgrade_info_controller_node
 WHERE  upgrade_info_uuid = $M.info_uuid
 AND    controller_node_id = $M.controller_id;`

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
 	github.com/canonical/pebble v1.7.0
-	github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c
+	github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSH
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
 github.com/canonical/pebble v1.7.0 h1:VG7KcgEJ0eWq6JYnGWKQlWcyxZqqNdoiD+p8Dul19b8=
 github.com/canonical/pebble v1.7.0/go.mod h1:bROzibw902Vastd13S/H48BrVAjEUKnlRXv3ZIoFcPE=
-github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c h1:xeaBPftOYj0W/GsLZ5W97oE9Xq4hEd+NeKtor24reKA=
-github.com/canonical/sqlair v0.0.0-20230707154306-6f89ebb4ac5c/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1 h1:KVwWWsaiasTOHKQc0f3rxWxuMDTjkhsUnVBnRXf9YVM=
+github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=

--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -153,7 +153,7 @@ func (w *Pruner) prune() (map[string]int64, error) {
 		return nil, errors.Trace(err)
 	}
 
-	query, err := sqlair.Prepare(`SELECT (uuid) AS &Model.* FROM model_list;`, Model{})
+	query, err := sqlair.Prepare(`SELECT uuid AS &Model.uuid FROM model_list;`, Model{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -225,12 +225,12 @@ type ChangeLog struct {
 }
 
 var (
-	selectWitnessQuery = sqlair.MustPrepare(`SELECT (controller_id, lower_bound, updated_at) AS &Watermark.* FROM change_log_witness;`, Watermark{})
+	selectWitnessQuery = sqlair.MustPrepare(`SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;`, Watermark{})
 
 	// TODO (stickupkid): This needs to be swapped out for the following query
 	// once we have a way to use functions in columns.
 	// SELECT COUNT(*) AS &Result.count FROM change_log WHERE created_at > $M.created_at LIMIT $M.limit;
-	selectChangeLogQuery = sqlair.MustPrepare(`SELECT (id) AS &ChangeLog.* FROM change_log WHERE created_at > $M.created_at LIMIT $M.limit;`, ChangeLog{}, sqlair.M{})
+	selectChangeLogQuery = sqlair.MustPrepare(`SELECT id AS &ChangeLog.id FROM change_log WHERE created_at > $M.created_at LIMIT $M.limit;`, ChangeLog{}, sqlair.M{})
 )
 
 func (w *Pruner) locateLowestWatermark(ctx context.Context, tx *sqlair.TX, namespace string) (Watermark, error) {

--- a/internal/worker/changestreampruner/worker_test.go
+++ b/internal/worker/changestreampruner/worker_test.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	time "time"
+	"time"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	coredatabase "github.com/juju/juju/core/database"
@@ -519,7 +519,7 @@ VALUES ($M.id, 4, 2, 0, $M.created_at);
 
 func (s *workerSuite) expectChangeLogWitnesses(c *gc.C, runner coredatabase.TxnRunner, watermarks []Watermark) {
 	query, err := sqlair.Prepare(`
-SELECT (controller_id, lower_bound, updated_at) AS &Watermark.* FROM change_log_witness;
+SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;
 `, Watermark{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -539,7 +539,7 @@ SELECT (controller_id, lower_bound, updated_at) AS &Watermark.* FROM change_log_
 
 func (s *workerSuite) expectChangeLogItems(c *gc.C, runner coredatabase.TxnRunner, amount, lowerBound, upperBound int) {
 	query, err := sqlair.Prepare(`
-SELECT (id, edit_type_id, namespace_id, changed, created_at) AS &ChangeLogItem.* FROM change_log;
+SELECT (id, edit_type_id, namespace_id, changed, created_at) AS (&ChangeLogItem.*) FROM change_log;
 	`, ChangeLogItem{})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Update Sqlair dependency to use the latest `HEAD`.

Parentheses-enclosed fields now need symmetrical parentheses around targets represented by `AS`. A few statements needed updating accordingly.

Sundry housekeeping:
- Consistent pointer receivers in _upgrate/state_.
- Copy/paste comment whoopsie in _autocert/state_.

## QA steps

- Bootstrap and deploy a model.
- Check for errors in both the model and controller logs.

## Links

**Jira card:** [JUJU-5258](https://warthogs.atlassian.net/browse/JUJU-5258)

[JUJU-5258]: https://warthogs.atlassian.net/browse/JUJU-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ