### PR TITLE
Weave the proper context through k8s and machine environ apis

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -652,7 +652,7 @@ func (b *AgentBootstrap) initControllerCloudService(
 		// this should never happen.
 		return errors.Errorf("environ %T does not implement ServiceManager interface", env)
 	}
-	svc, err := broker.GetService(k8sconstants.JujuControllerStackName, true)
+	svc, err := broker.GetService(ctx, k8sconstants.JujuControllerStackName, true)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -639,7 +639,7 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	addrs := info.Addrs[:]
 
 	if info.Proxier != nil {
-		if err := info.Proxier.Start(); err != nil {
+		if err := info.Proxier.Start(ctx); err != nil {
 			return nil, errors.Annotate(err, "starting proxy for api connection")
 		}
 		logger.Debugf("starting proxier for connection")

--- a/api/client/modelupgrader/upgrader.go
+++ b/api/client/modelupgrader/upgrader.go
@@ -80,7 +80,7 @@ func (c *Client) UpgradeModel(
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS.
-func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary) (tools.List, error) {
+func (c *Client) UploadTools(_ context.Context, r io.ReadSeeker, vers version.Binary) (tools.List, error) {
 	req, err := http.NewRequest("POST", fmt.Sprintf("/tools?binaryVersion=%s", vers), r)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create upload request")

--- a/api/client/modelupgrader/upgrader_test.go
+++ b/api/client/modelupgrader/upgrader_test.go
@@ -115,6 +115,7 @@ func (s *UpgradeModelSuite) TestUploadTools(c *gc.C) {
 	client := modelupgrader.NewClient(apiCaller)
 
 	result, err := client.UploadTools(
+		context.Background(),
 		nil, version.MustParseBinary("2.9.100-ubuntu-amd64"),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/controller/caasoperatorupgrader/client.go
+++ b/api/controller/caasoperatorupgrader/client.go
@@ -34,13 +34,13 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 }
 
 // Upgrade upgrades the operator for the specified agent tag to v.
-func (c *Client) Upgrade(agentTag string, v version.Number) error {
+func (c *Client) Upgrade(ctx context.Context, agentTag string, v version.Number) error {
 	var result params.ErrorResult
 	arg := params.KubernetesUpgradeArg{
 		AgentTag: agentTag,
 		Version:  v,
 	}
-	if err := c.facade.FacadeCall(context.TODO(), "UpgradeOperator", arg, &result); err != nil {
+	if err := c.facade.FacadeCall(ctx, "UpgradeOperator", arg, &result); err != nil {
 		return errors.Trace(err)
 	}
 	if result.Error != nil {

--- a/api/controller/caasoperatorupgrader/client_test.go
+++ b/api/controller/caasoperatorupgrader/client_test.go
@@ -4,6 +4,8 @@
 package caasoperatorupgrader_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -41,7 +43,7 @@ func (s *provisionerSuite) TestUpgrader(c *gc.C) {
 		}
 		return nil
 	})
-	err := client.Upgrade("application-foo", version.MustParse("6.6.6"))
+	err := client.Upgrade(context.Background(), "application-foo", version.MustParse("6.6.6"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
 }

--- a/api/testing/fakeserver.go
+++ b/api/testing/fakeserver.go
@@ -19,7 +19,7 @@ func FakeAPIServer(root interface{}) net.Conn {
 	serverCodec := jsoncodec.NewNet(c1)
 	serverRPC := rpc.NewConn(serverCodec, nil)
 	serverRPC.Serve(root, nil, nil)
-	serverRPC.Start(context.TODO())
+	serverRPC.Start(context.Background())
 	go func() {
 		<-serverRPC.Dead()
 		serverRPC.Close()

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -57,17 +57,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -150,7 +150,7 @@ func DrainBackendConfigInfo(
 	if !ok {
 		return nil, errors.Errorf("missing secret backend %q", backendID)
 	}
-	backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, true)
+	backendCfg, err := backendConfigInfo(ctx, model, backendID, &cfg, authTag, leadershipChecker, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -193,7 +193,7 @@ func BackendConfigInfo(
 		if !ok {
 			return nil, errors.Errorf("missing secret backend %q", backendID)
 		}
-		backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, false)
+		backendCfg, err := backendConfigInfo(ctx, model, backendID, &cfg, authTag, leadershipChecker, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -203,6 +203,7 @@ func BackendConfigInfo(
 }
 
 func backendConfigInfo(
+	ctx context.Context,
 	model Model, backendID string, adminCfg *provider.ModelBackendConfig,
 	authTag names.Tag, leadershipChecker leadership.Checker, forDrain bool,
 ) (*provider.ModelBackendConfig, error) {
@@ -271,7 +272,7 @@ func backendConfigInfo(
 	}
 
 	logger.Debugf("secrets for %v:\nowned: %v\nconsumed:%v", authTag.String(), ownedRevisions, readRevisions)
-	cfg, err := p.RestrictedConfig(adminCfg, forDrain, authTag, ownedRevisions[backendID], readRevisions[backendID])
+	cfg, err := p.RestrictedConfig(ctx, adminCfg, forDrain, authTag, ownedRevisions[backendID], readRevisions[backendID])
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -603,7 +604,7 @@ func RemoveUserSecrets(
 					return errors.Trace(err)
 				}
 			}
-			if err := p.CleanupSecrets(&cfg, authTag, revs); err != nil {
+			if err := p.CleanupSecrets(ctx, &cfg, authTag, revs); err != nil {
 				return errors.Trace(err)
 			}
 			return nil

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -299,7 +299,7 @@ func (s *secretsSuite) assertBackendConfigInfoLeaderUnit(c *gc.C, wanted []strin
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(context.Background(), &adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
 	info, err := secrets.BackendConfigInfo(context.Background(), model, cloudService, credentialService, wanted, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
@@ -412,7 +412,7 @@ func (s *secretsSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-3"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(context.Background(), &adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
 	info, err := secrets.BackendConfigInfo(context.Background(), model, cloudService, credentialService, []string{"backend-id"}, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
@@ -525,7 +525,7 @@ func (s *secretsSuite) TestDrainBackendConfigInfo(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-3"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, true, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(context.Background(), &adminCfg, true, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
 	info, err := secrets.DrainBackendConfigInfo(context.Background(), "backend-id", model, cloudService, credentialService, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
@@ -617,7 +617,7 @@ func (s *secretsSuite) TestBackendConfigInfoAppTagLogin(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, appTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(context.Background(), &adminCfg, false, appTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
 	info, err := secrets.BackendConfigInfo(context.Background(), model, cloudService, credentialService, []string{"backend-id"}, false, appTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
@@ -965,6 +965,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 	mockprovider.EXPECT().NewBackend(cfg).Return(backend, nil)
 	backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	mockprovider.EXPECT().CleanupSecrets(
+		gomock.Any(),
 		cfg, names.NewUserTag("foo"),
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
@@ -1043,6 +1044,7 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 	mockprovider.EXPECT().NewBackend(cfg).Return(backend, nil)
 	backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	mockprovider.EXPECT().CleanupSecrets(
+		gomock.Any(),
 		cfg, names.NewUserTag("foo"),
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -344,7 +344,7 @@ func (f *toolsFinder) findMatchingAgents(ctx context.Context, args FindAgentsPar
 		majorVersion = args.MajorVersion
 		minorVersion = args.MinorVersion
 	}
-	simplestreamsList, err := envtoolsFindTools(ss,
+	simplestreamsList, err := envtoolsFindTools(ctx, ss,
 		env, majorVersion, minorVersion, streams, filter,
 	)
 	if len(storageList) == 0 && err != nil {

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -342,7 +342,7 @@ func (s *findToolsSuite) TestFindToolsMatchMajor(c *gc.C) {
 			Version: version.MustParseBinary("123.456.1-windows-alpha"),
 		},
 	}
-	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, streams []string, filter coretools.Filter) (coretools.List, error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, streams []string, filter coretools.Filter) (coretools.List, error) {
 		c.Assert(major, gc.Equals, 123)
 		c.Assert(minor, gc.Equals, 456)
 		c.Assert(streams, gc.DeepEquals, []string{"released"})
@@ -404,7 +404,7 @@ func (s *findToolsSuite) TestFindToolsRequestAgentStream(c *gc.C) {
 			Version: version.MustParseBinary("123.456.1-windows-alpha"),
 		},
 	}
-	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, streams []string, filter coretools.Filter) (coretools.List, error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, streams []string, filter coretools.Filter) (coretools.List, error) {
 		c.Assert(major, gc.Equals, 123)
 		c.Assert(minor, gc.Equals, 456)
 		c.Assert(streams, gc.DeepEquals, []string{"pretend"})
@@ -451,7 +451,7 @@ func (s *findToolsSuite) TestFindToolsRequestAgentStream(c *gc.C) {
 func (s *findToolsSuite) TestFindToolsNotFound(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		return nil, errors.NotFoundf("tools")
 	})
 
@@ -503,7 +503,7 @@ func (s *findToolsSuite) TestFindToolsExactNotInStorage(c *gc.C) {
 func (s *findToolsSuite) testFindToolsExact(c *gc.C, inStorage bool, develVersion bool) {
 	var called bool
 	current := coretesting.CurrentVersion()
-	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		c.Assert(filter.Number, gc.Equals, jujuversion.Current)
 		c.Assert(filter.OSType, gc.Equals, current.Release)
@@ -538,7 +538,7 @@ func (s *findToolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	var called bool
-	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
+	s.PatchValue(common.EnvtoolsFindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		return nil, errors.NotFoundf("tools")
 	})

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	provider "github.com/juju/juju/internal/secrets/provider"
@@ -55,17 +56,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -98,18 +99,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -105,7 +105,7 @@ type APIBase struct {
 }
 
 type CaasBrokerInterface interface {
-	ValidateStorageClass(config map[string]interface{}) error
+	ValidateStorageClass(ctx context.Context, config map[string]interface{}) error
 	Version() (*version.Number, error)
 }
 
@@ -482,7 +482,7 @@ func (c caasDeployParams) precheck(
 			return errors.Errorf(
 				"the %q storage pool requires a provider type of %q, not %q", poolName, k8sconstants.StorageProviderType, sp.Provider)
 		}
-		if err := caasBroker.ValidateStorageClass(sp.Attributes); err != nil {
+		if err := caasBroker.ValidateStorageClass(ctx, sp.Attributes); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1660,7 +1660,7 @@ func (s *ApplicationSuite) TestDeployMinDeploymentVersionTooHigh(c *gc.C) {
 	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil)
 
 	s.expectDefaultK8sModelConfig()
-	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any()).Return(nil)
+	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any(), gomock.Any()).Return(nil)
 	s.storagePoolManager.EXPECT().Get("k8s-operator-storage").Return(storage.NewConfig(
 		"k8s-operator-storage",
 		k8sconstants.StorageProviderType,
@@ -1865,7 +1865,7 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultOperatorStorageClass(c *gc.
 	ch := s.expectDefaultCharm(ctrl)
 	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil)
 	s.expectDefaultK8sModelConfig()
-	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any()).Return(nil)
+	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any(), gomock.Any()).Return(nil)
 	s.storagePoolManager.EXPECT().Get("k8s-operator-storage").Return(nil, errors.NotFoundf("pool"))
 	s.registry.EXPECT().StorageProvider(storage.ProviderType("k8s-operator-storage")).Return(nil, errors.NotFoundf(`provider type "k8s-operator-storage"`))
 
@@ -1925,7 +1925,7 @@ func (s *ApplicationSuite) TestDeployCAASModelInvalidStorage(c *gc.C) {
 		k8sconstants.StorageProviderType,
 		map[string]interface{}{"foo": "bar"}),
 	)
-	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any()).Return(errors.NotFoundf("storage class"))
+	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any(), gomock.Any()).Return(errors.NotFoundf("storage class"))
 
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
@@ -1962,7 +1962,7 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultStorageClass(c *gc.C) {
 		k8sconstants.StorageProviderType,
 		map[string]interface{}{"foo": "bar"}),
 	)
-	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any()).Return(nil)
+	s.caasBroker.EXPECT().ValidateStorageClass(gomock.Any(), gomock.Any()).Return(nil)
 
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -927,17 +927,17 @@ func (m *MockCaasBrokerInterface) EXPECT() *MockCaasBrokerInterfaceMockRecorder 
 }
 
 // ValidateStorageClass mocks base method.
-func (m *MockCaasBrokerInterface) ValidateStorageClass(arg0 map[string]any) error {
+func (m *MockCaasBrokerInterface) ValidateStorageClass(arg0 context.Context, arg1 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateStorageClass", arg0)
+	ret := m.ctrl.Call(m, "ValidateStorageClass", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateStorageClass indicates an expected call of ValidateStorageClass.
-func (mr *MockCaasBrokerInterfaceMockRecorder) ValidateStorageClass(arg0 any) *gomock.Call {
+func (mr *MockCaasBrokerInterfaceMockRecorder) ValidateStorageClass(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStorageClass", reflect.TypeOf((*MockCaasBrokerInterface)(nil).ValidateStorageClass), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStorageClass", reflect.TypeOf((*MockCaasBrokerInterface)(nil).ValidateStorageClass), arg0, arg1)
 }
 
 // Version mocks base method.

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -230,7 +230,7 @@ func (c *ControllerAPI) dashboardConnectionInfoForCAAS(
 		return nil, errors.NotFoundf("dashboard port in charm config")
 	}
 
-	proxier, err := caasBroker.ProxyToApplication(applicationName, fmt.Sprint(port))
+	proxier, err := caasBroker.ProxyToApplication(ctx, applicationName, fmt.Sprint(port))
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/modelconfig/mocks/secretsprovider.go
+++ b/apiserver/facades/client/modelconfig/mocks/secretsprovider.go
@@ -57,17 +57,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secretbackends/mocks/provider_mock.go
+++ b/apiserver/facades/client/secretbackends/mocks/provider_mock.go
@@ -57,17 +57,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secrets/mocks/secretsbackend.go
+++ b/apiserver/facades/client/secrets/mocks/secretsbackend.go
@@ -138,17 +138,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -181,18 +181,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -496,6 +496,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI, isInte
 		s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-1").Return(nil)
 		s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-2").Return(nil)
 		s.provider.EXPECT().CleanupSecrets(
+			gomock.Any(),
 			cfg, names.NewUserTag("foo"),
 			provider.SecretRevisions{uri.ID: set.NewStrings("rev-1", "rev-2")},
 		).Return(nil)
@@ -579,6 +580,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
+		gomock.Any(),
 		cfg, names.NewUserTag("foo"),
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
@@ -679,6 +681,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
+		gomock.Any(),
 		cfg, names.NewUserTag("foo"),
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -286,5 +286,5 @@ func (facade *Facade) getExecSecretToken(ctx stdcontext.Context, cloudSpec envir
 	if err != nil {
 		return "", errors.Annotate(err, "failed to open kubernetes client")
 	}
-	return broker.GetSecretToken(k8sprovider.ExecRBACResourceName)
+	return broker.GetSecretToken(ctx, k8sprovider.ExecRBACResourceName)
 }

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -405,7 +405,7 @@ func (s *facadeSuite) assertModelCredentialForSSH(c *gc.C, f func(authorizer *mo
 		model.EXPECT().Type().Return(state.ModelTypeCAAS),
 		backend.EXPECT().CloudSpec(gomock.Any()).Return(cloudSpec, nil),
 		model.EXPECT().Config().Return(nil, nil),
-		broker.EXPECT().GetSecretToken(k8sprovider.ExecRBACResourceName).Return("token", nil),
+		broker.EXPECT().GetSecretToken(gomock.Any(), k8sprovider.ExecRBACResourceName).Return("token", nil),
 	)
 	facade, err := sshclient.InternalFacade(backend, nil, authorizer,
 		func(_ context.Context, arg environs.OpenParams) (sshclient.Broker, error) {

--- a/apiserver/facades/client/sshclient/mocks/state_mock.go
+++ b/apiserver/facades/client/sshclient/mocks/state_mock.go
@@ -237,16 +237,16 @@ func (m *MockBroker) EXPECT() *MockBrokerMockRecorder {
 }
 
 // GetSecretToken mocks base method.
-func (m *MockBroker) GetSecretToken(arg0 string) (string, error) {
+func (m *MockBroker) GetSecretToken(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretToken", arg0)
+	ret := m.ctrl.Call(m, "GetSecretToken", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretToken indicates an expected call of GetSecretToken.
-func (mr *MockBrokerMockRecorder) GetSecretToken(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) GetSecretToken(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), arg0, arg1)
 }

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -36,7 +36,7 @@ type Model interface {
 
 // Broker is a subset of caas broker.
 type Broker interface {
-	GetSecretToken(name string) (string, error)
+	GetSecretToken(ctx context.Context, name string) (string, error)
 }
 
 // SSHMachine specifies the methods on State.Machine of interest to

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -55,7 +55,7 @@ func (api *API) UpgradeOperator(ctx context.Context, arg params.KubernetesUpgrad
 	}
 
 	api.logger.Debugf("upgrading caas agent for %s", tag)
-	err = api.broker.Upgrade(arg.AgentTag, arg.Version)
+	err = api.broker.Upgrade(ctx, arg.AgentTag, arg.Version)
 	if err != nil {
 		return serverErr(err), nil
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -92,7 +92,7 @@ type mockBroker struct {
 	testing.Stub
 }
 
-func (m *mockBroker) Upgrade(app string, vers version.Number) error {
+func (m *mockBroker) Upgrade(_ context.Context, app string, vers version.Number) error {
 	m.AddCall("Upgrade", app, vers)
 	return nil
 }

--- a/apiserver/facades/controller/secretbackendmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/controller/secretbackendmanager/mocks/secretsprovider.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	provider "github.com/juju/juju/internal/secrets/provider"
@@ -55,17 +56,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -98,18 +99,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/controller/usersecrets/mocks/secretsbackend.go
+++ b/apiserver/facades/controller/usersecrets/mocks/secretsbackend.go
@@ -138,17 +138,17 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 *provider.ModelBackendConfig, arg1 names.Tag, arg2 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupSecrets indicates an expected call of CleanupSecrets.
-func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) CleanupSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupSecrets", reflect.TypeOf((*MockSecretBackendProvider)(nil).CleanupSecrets), arg0, arg1, arg2, arg3)
 }
 
 // Initialise mocks base method.
@@ -181,18 +181,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/controller/usersecrets/secrets_test.go
+++ b/apiserver/facades/controller/usersecrets/secrets_test.go
@@ -128,6 +128,7 @@ func (s *userSecretsSuite) TestDeleteRevisionsAutoPruneEnabled(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
+		gomock.Any(),
 		cfg, names.NewUserTag("foo"),
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -243,7 +243,7 @@ func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	proxier, err := connInfo.ConnectionProxyInfo()
+	proxier, err := connInfo.ConnectionProxyInfo(ctx)
 	if errors.Is(err, errors.NotFound) {
 		return &payload, nil
 	}

--- a/apiserver/registration_environs_mock_test.go
+++ b/apiserver/registration_environs_mock_test.go
@@ -10,6 +10,7 @@
 package apiserver_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	proxy "github.com/juju/juju/internal/proxy"
@@ -40,16 +41,16 @@ func (m *MockConnectorInfo) EXPECT() *MockConnectorInfoMockRecorder {
 }
 
 // ConnectionProxyInfo mocks base method.
-func (m *MockConnectorInfo) ConnectionProxyInfo() (proxy.Proxier, error) {
+func (m *MockConnectorInfo) ConnectionProxyInfo(arg0 context.Context) (proxy.Proxier, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectionProxyInfo")
+	ret := m.ctrl.Call(m, "ConnectionProxyInfo", arg0)
 	ret0, _ := ret[0].(proxy.Proxier)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectionProxyInfo indicates an expected call of ConnectionProxyInfo.
-func (mr *MockConnectorInfoMockRecorder) ConnectionProxyInfo() *gomock.Call {
+func (mr *MockConnectorInfoMockRecorder) ConnectionProxyInfo(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectionProxyInfo", reflect.TypeOf((*MockConnectorInfo)(nil).ConnectionProxyInfo))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectionProxyInfo", reflect.TypeOf((*MockConnectorInfo)(nil).ConnectionProxyInfo), arg0)
 }

--- a/apiserver/registration_proxy_mock_test.go
+++ b/apiserver/registration_proxy_mock_test.go
@@ -10,6 +10,7 @@
 package apiserver_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -81,17 +82,17 @@ func (mr *MockProxierMockRecorder) RawConfig() *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockProxier) Start() error {
+func (m *MockProxier) Start(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockProxierMockRecorder) Start() *gomock.Call {
+func (mr *MockProxierMockRecorder) Start(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProxier)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProxier)(nil).Start), arg0)
 }
 
 // Stop mocks base method.

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -68,7 +68,7 @@ func (s *registrationSuite) assertRegisterNoProxy(c *gc.C, hasProxy bool) {
 		return nil, errors.NotSupportedf("proxier")
 	})
 	if hasProxy {
-		environ.EXPECT().ConnectionProxyInfo().Return(proxier, nil)
+		environ.EXPECT().ConnectionProxyInfo(gomock.Any()).Return(proxier, nil)
 		proxier.EXPECT().RawConfig().Return(rawConfig, nil)
 		proxier.EXPECT().Type().Return("kubernetes-port-forward")
 	}

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -242,7 +242,7 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 	}
 
 	ss := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
-	exactTools, err := envtools.FindExactTools(ss, env, v.Number, v.Release, v.Arch)
+	exactTools, err := envtools.FindExactTools(ctx, ss, env, v.Number, v.Release, v.Arch)
 	if err != nil {
 		return err
 	}

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -4,6 +4,7 @@
 package clientconfig
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -26,13 +27,13 @@ var logger = loggo.GetLogger("juju.caas.kubernetes.clientconfig")
 type K8sCredentialResolver func(string, *clientcmdapi.Config, string) (*clientcmdapi.Config, error)
 
 // GetJujuAdminServiceAccountResolver returns a function for ensuring juju admin service account created with admin cluster role binding setup.
-func GetJujuAdminServiceAccountResolver(clock jujuclock.Clock) K8sCredentialResolver {
+func GetJujuAdminServiceAccountResolver(ctx context.Context, clock jujuclock.Clock) K8sCredentialResolver {
 	return func(credentialUID string, config *clientcmdapi.Config, contextName string) (*clientcmdapi.Config, error) {
 		clientset, err := newK8sClientSet(config, contextName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return ensureJujuAdminServiceAccount(clientset, credentialUID, config, contextName, clock)
+		return ensureJujuAdminServiceAccount(ctx, clientset, credentialUID, config, contextName, clock)
 	}
 }
 

--- a/caas/kubernetes/clientconfig/plugins_test.go
+++ b/caas/kubernetes/clientconfig/plugins_test.go
@@ -4,6 +4,7 @@
 package clientconfig_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -157,7 +158,7 @@ func (s *k8sRawClientSuite) TestEnsureJujuAdminServiceAccount(c *gc.C) {
 	errChan := make(chan error)
 	cfgOutChan := make(chan *clientcmdapi.Config)
 	go func() {
-		cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(s.k8sClient, s.UID, cfg, contextName, s.clock)
+		cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(context.Background(), s.k8sClient, s.UID, cfg, contextName, s.clock)
 		errChan <- err
 		cfgOutChan <- cfgOut
 	}()
@@ -276,7 +277,7 @@ func (s *k8sRawClientSuite) TestEnsureJujuServiceAdminAccountIdempotent(c *gc.C)
 		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), s.name, metav1.GetOptions{}).Times(1).
 			Return(&sa, nil),
 	)
-	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(s.k8sClient, s.UID, cfg, contextName, s.clock)
+	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(context.Background(), s.k8sClient, s.UID, cfg, contextName, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	authName := cfg.Contexts[contextName].AuthInfo
 	updatedAuthInfo := cfgOut.AuthInfos[authName]
@@ -383,7 +384,7 @@ func (s *k8sRawClientSuite) TestEnsureJujuServiceAdminAccount2ndUpdate(c *gc.C) 
 		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), &newSaWithSecretUpdated, metav1.UpdateOptions{}).Times(1).
 			Return(nil, nil),
 	)
-	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(s.k8sClient, s.UID, cfg, contextName, s.clock)
+	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(context.Background(), s.k8sClient, s.UID, cfg, contextName, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	authName := cfg.Contexts[contextName].AuthInfo
 	updatedAuthInfo := cfgOut.AuthInfos[authName]
@@ -420,7 +421,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateClusterRole(c *gc.C) {
 		s.mockClusterRoles.EXPECT().Create(gomock.Any(), cr, metav1.CreateOptions{}).Times(1).
 			Return(cr, nil),
 	)
-	crOut, cleanUps, err := clientconfig.GetOrCreateClusterRole(cr.ObjectMeta, s.k8sClient.RbacV1().ClusterRoles())
+	crOut, cleanUps, err := clientconfig.GetOrCreateClusterRole(context.Background(), cr.ObjectMeta, s.k8sClient.RbacV1().ClusterRoles())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(crOut, jc.DeepEquals, cr)
 	c.Assert(len(cleanUps), jc.DeepEquals, 1)
@@ -429,7 +430,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateClusterRole(c *gc.C) {
 		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, metav1.GetOptions{}).Times(1).
 			Return(cr, nil),
 	)
-	crOut, cleanUps, err = clientconfig.GetOrCreateClusterRole(cr.ObjectMeta, s.k8sClient.RbacV1().ClusterRoles())
+	crOut, cleanUps, err = clientconfig.GetOrCreateClusterRole(context.Background(), cr.ObjectMeta, s.k8sClient.RbacV1().ClusterRoles())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(crOut, jc.DeepEquals, cr)
 	c.Assert(len(cleanUps), jc.DeepEquals, 0)
@@ -455,7 +456,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateServiceAccount(c *gc.C) {
 		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), s.name, metav1.GetOptions{}).Times(1).
 			Return(sa, nil),
 	)
-	saOut, cleanUps, err := clientconfig.GetOrCreateServiceAccount(sa.ObjectMeta, s.k8sClient.CoreV1().ServiceAccounts(s.namespace))
+	saOut, cleanUps, err := clientconfig.GetOrCreateServiceAccount(context.Background(), sa.ObjectMeta, s.k8sClient.CoreV1().ServiceAccounts(s.namespace))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saOut, jc.DeepEquals, sa)
 	c.Assert(len(cleanUps), jc.DeepEquals, 1)
@@ -464,7 +465,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateServiceAccount(c *gc.C) {
 		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), s.name, metav1.GetOptions{}).Times(1).
 			Return(sa, nil),
 	)
-	saOut, cleanUps, err = clientconfig.GetOrCreateServiceAccount(sa.ObjectMeta, s.k8sClient.CoreV1().ServiceAccounts(s.namespace))
+	saOut, cleanUps, err = clientconfig.GetOrCreateServiceAccount(context.Background(), sa.ObjectMeta, s.k8sClient.CoreV1().ServiceAccounts(s.namespace))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saOut, jc.DeepEquals, sa)
 	c.Assert(len(cleanUps), jc.DeepEquals, 0)
@@ -524,7 +525,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateClusterRoleBinding(c *gc.C) {
 			Return(clusterRoleBinding, nil),
 	)
 	clusterRoleBindingOut, cleanUps, err := clientconfig.GetOrCreateClusterRoleBinding(
-		clusterRoleBinding.ObjectMeta, sa, cr, s.k8sClient.RbacV1().ClusterRoleBindings(),
+		context.Background(), clusterRoleBinding.ObjectMeta, sa, cr, s.k8sClient.RbacV1().ClusterRoleBindings(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRoleBindingOut, jc.DeepEquals, clusterRoleBinding)
@@ -537,7 +538,7 @@ func (s *k8sRawClientSuite) TestGetOrCreateClusterRoleBinding(c *gc.C) {
 			Return(clusterRoleBinding, nil),
 	)
 	clusterRoleBindingOut, cleanUps, err = clientconfig.GetOrCreateClusterRoleBinding(
-		clusterRoleBinding.ObjectMeta, sa, cr, s.k8sClient.RbacV1().ClusterRoleBindings(),
+		context.Background(), clusterRoleBinding.ObjectMeta, sa, cr, s.k8sClient.RbacV1().ClusterRoleBindings(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRoleBindingOut, jc.DeepEquals, clusterRoleBinding)
@@ -564,7 +565,7 @@ func (s *k8sRawClientSuite) TestRemoveJujuAdminServiceAccount(c *gc.C) {
 		).Times(1).Return(nil),
 	)
 
-	err := clientconfig.RemoveJujuAdminServiceAccount(s.k8sClient, s.UID)
+	err := clientconfig.RemoveJujuAdminServiceAccount(context.Background(), s.k8sClient, s.UID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/caas/kubernetes/metadata.go
+++ b/caas/kubernetes/metadata.go
@@ -4,6 +4,8 @@
 package kubernetes
 
 import (
+	"context"
+
 	"github.com/juju/collections/set"
 	storagev1 "k8s.io/api/storage/v1"
 )
@@ -43,7 +45,7 @@ const (
 // ClusterMetadataChecker provides an API to query cluster metadata.
 type ClusterMetadataChecker interface {
 	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
-	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
+	GetClusterMetadata(ctx context.Context, storageClass string) (result *ClusterMetadata, err error)
 }
 
 // ClusterMetadata defines metadata about a cluster.

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -240,7 +241,7 @@ func (s *BaseSuite) setupBroker(
 	})
 
 	var err error
-	s.broker, err = provider.NewK8sBroker(controllerUUID, s.k8sRestConfig, s.cfg, s.getNamespace(), newK8sClientFunc, newK8sRestFunc,
+	s.broker, err = provider.NewK8sBroker(context.Background(), controllerUUID, s.k8sRestConfig, s.cfg, s.getNamespace(), newK8sClientFunc, newK8sRestFunc,
 		watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
 	if expectErr == "" {
 		c.Assert(err, jc.ErrorIsNil)
@@ -548,7 +549,7 @@ func (s *fakeClientSuite) setupBroker(
 	})
 
 	var err error
-	s.broker, err = provider.NewK8sBroker(coretesting.ControllerTag.Id(), s.k8sRestConfig, s.cfg, s.getNamespace(), newK8sClientFunc, newK8sRestFunc,
+	s.broker, err = provider.NewK8sBroker(context.Background(), coretesting.ControllerTag.Id(), s.k8sRestConfig, s.cfg, s.getNamespace(), newK8sClientFunc, newK8sRestFunc,
 		watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner, getKubeConfigDir func() (stri
 	return k8sCloud, err
 }
 
-func attemptMicroK8sCredential(cmdRunner CommandRunner, getKubeConfigDir func() (string, error)) (jujucloud.Credential, error) {
+func attemptMicroK8sCredential(ctx context.Context, cmdRunner CommandRunner, getKubeConfigDir func() (string, error)) (jujucloud.Credential, error) {
 	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner, getKubeConfigDir)
 	if err != nil {
 		return jujucloud.Credential{}, err
@@ -62,7 +63,7 @@ func attemptMicroK8sCredential(cmdRunner CommandRunner, getKubeConfigDir func() 
 	}
 
 	context := k8sConfig.Contexts[contextName]
-	resolver := clientconfig.GetJujuAdminServiceAccountResolver(jujuclock.WallClock)
+	resolver := clientconfig.GetJujuAdminServiceAccountResolver(ctx, jujuclock.WallClock)
 	conf, err := resolver(k8s.K8sCloudMicrok8s, k8sConfig, contextName)
 	if err != nil {
 		return jujucloud.Credential{}, errors.Annotate(err, "resolving microk8s credentials")

--- a/caas/kubernetes/provider/connection.go
+++ b/caas/kubernetes/provider/connection.go
@@ -18,9 +18,9 @@ import (
 // ProxyToApplication attempts to construct a Juju proxier for use in proxying
 // connections to the specified application. This assume the presence of a
 // corresponding service for the application.
-func (k *kubernetesClient) ProxyToApplication(appName, remotePort string) (proxy.Proxier, error) {
+func (k *kubernetesClient) ProxyToApplication(ctx context.Context, appName, remotePort string) (proxy.Proxier, error) {
 	svc, err := findServiceForApplication(
-		context.TODO(),
+		ctx,
 		k.client().CoreV1().Services(k.namespace),
 		appName,
 		k.IsLegacyLabels())
@@ -60,6 +60,7 @@ func (k *kubernetesClient) ProxyToApplication(appName, remotePort string) (proxy
 	}
 
 	return k8sproxy.GetProxy(
+		ctx,
 		proxyName,
 		config,
 		k.client().CoreV1().ServiceAccounts(k.GetCurrentNamespace()),
@@ -69,8 +70,9 @@ func (k *kubernetesClient) ProxyToApplication(appName, remotePort string) (proxy
 
 // ConnectionProxyInfo provides the means for getting a proxier onto a Juju
 // controller deployed in this provider.
-func (k *kubernetesClient) ConnectionProxyInfo() (proxy.Proxier, error) {
+func (k *kubernetesClient) ConnectionProxyInfo(ctx context.Context) (proxy.Proxier, error) {
 	p, err := k8sproxy.GetControllerProxy(
+		ctx,
 		getBootstrapResourceName(k8sconstants.JujuControllerStackName, proxyResourceName),
 		k.k8sCfgUnlocked.Host,
 		k.client().CoreV1().ConfigMaps(k.GetCurrentNamespace()),

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -83,7 +83,7 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 		}, meta.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+	c.Assert(controllerUpgrade(context.Background(), appName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
 
 	ss, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).
 		Get(context.Background(), appName, meta.GetOptions{})
@@ -98,7 +98,7 @@ func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {
 	var (
 		appName = k8sconstants.JujuControllerStackName
 	)
-	err := controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker)
+	err := controllerUpgrade(context.Background(), appName, version.MustParse("9.9.9"), s.broker)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -95,7 +96,7 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 
 func (s *credentialsSuite) TestRegisterCredentialsNotMicrok8s(c *gc.C) {
 	p := provider.NewProviderCredentials(credentialGetterFunc(builtinCloudRet{}))
-	credentials, err := p.RegisterCredentials(cloud.Cloud{})
+	credentials, err := p.RegisterCredentials(context.Background(), cloud.Cloud{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 0)
 }
@@ -110,7 +111,7 @@ func (s *credentialsSuite) TestRegisterCredentialsMicrok8s(c *gc.C) {
 			},
 		),
 	)
-	credentials, err := p.RegisterCredentials(defaultK8sCloud)
+	credentials, err := p.RegisterCredentials(context.Background(), defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
 	c.Assert(credentials[k8s.K8sCloudMicrok8s], gc.DeepEquals, &cloud.CloudCredential{

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -19,11 +19,11 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 )
 
-func (k *kubernetesClient) listCustomResourceDefinitions(selector k8slabels.Selector) ([]apiextensionsv1.CustomResourceDefinition, error) {
+func (k *kubernetesClient) listCustomResourceDefinitions(ctx context.Context, selector k8slabels.Selector) ([]apiextensionsv1.CustomResourceDefinition, error) {
 	listOps := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	list, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), listOps)
+	list, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(ctx, listOps)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -33,8 +33,8 @@ func (k *kubernetesClient) listCustomResourceDefinitions(selector k8slabels.Sele
 	return list.Items, nil
 }
 
-func (k *kubernetesClient) deleteCustomResourceDefinitions(selector k8slabels.Selector) error {
-	err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().DeleteCollection(context.TODO(), metav1.DeleteOptions{
+func (k *kubernetesClient) deleteCustomResourceDefinitions(ctx context.Context, selector k8slabels.Selector) error {
+	err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().DeleteCollection(ctx, metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{
 		LabelSelector: selector.String(),
@@ -45,8 +45,8 @@ func (k *kubernetesClient) deleteCustomResourceDefinitions(selector k8slabels.Se
 	return errors.Trace(err)
 }
 
-func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) error {
-	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
+func (k *kubernetesClient) deleteCustomResources(ctx context.Context, selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) error {
+	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{
 		// CRDs might be provisioned by another application/charm from a different model.
 	})
 	if err != nil {
@@ -62,7 +62,7 @@ func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensio
 			if err != nil {
 				return errors.Trace(err)
 			}
-			err = crdClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{
+			err = crdClient.DeleteCollection(ctx, metav1.DeleteOptions{
 				PropagationPolicy: constants.DefaultPropagationPolicy(),
 			}, metav1.ListOptions{
 				LabelSelector: selector.String(),
@@ -75,8 +75,8 @@ func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensio
 	return nil
 }
 
-func (k *kubernetesClient) listCustomResources(selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) (out []unstructured.Unstructured, err error) {
-	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
+func (k *kubernetesClient) listCustomResources(ctx context.Context, selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) (out []unstructured.Unstructured, err error) {
+	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{
 		// CRDs might be provisioned by another application/charm from a different model.
 	})
 	if err != nil {
@@ -92,7 +92,7 @@ func (k *kubernetesClient) listCustomResources(selectorGetter func(apiextensions
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			list, err := crdClient.List(context.TODO(), metav1.ListOptions{
+			list, err := crdClient.List(ctx, metav1.ListOptions{
 				LabelSelector: selector.String(),
 			})
 			if err != nil && !k8serrors.IsNotFound(err) {

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"context"
 	"os"
 
 	"github.com/juju/errors"
@@ -53,8 +54,8 @@ func cloudGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujuclo
 	}
 }
 
-func credentialGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujucloud.Credential, error) {
-	return func(provider.CommandRunner) (jujucloud.Credential, error) {
+func credentialGetterFunc(args builtinCloudRet) func(context.Context, provider.CommandRunner) (jujucloud.Credential, error) {
+	return func(context.Context, provider.CommandRunner) (jujucloud.Credential, error) {
 		return args.credential, args.err
 	}
 }
@@ -64,7 +65,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 		dummyRunner{},
 		credentialGetterFunc(builtin),
 		cloudGetterFunc(builtin),
-		func(environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) {
+		func(context.Context, environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) {
 			return &fakeK8sClusterMetadataChecker{}, nil
 		},
 	)

--- a/caas/kubernetes/provider/events.go
+++ b/caas/kubernetes/provider/events.go
@@ -44,11 +44,11 @@ const (
 	BackOffPullImage        = "BackOff"
 )
 
-func (k *kubernetesClient) getEvents(objName string, objKind string) ([]core.Event, error) {
+func (k *kubernetesClient) getEvents(ctx context.Context, objName string, objKind string) ([]core.Event, error) {
 	if k.namespace == "" {
 		return nil, errNoNamespace
 	}
-	return resources.ListEventsForObject(context.TODO(), k.client(), k.namespace, objName, objKind)
+	return resources.ListEventsForObject(ctx, k.client(), k.namespace, objName, objKind)
 }
 
 func (k *kubernetesClient) watchEvents(objName string, objKind string) (watcher.NotifyWatcher, error) {

--- a/caas/kubernetes/provider/exec/copy_test.go
+++ b/caas/kubernetes/provider/exec/copy_test.go
@@ -6,6 +6,7 @@ package exec_test
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -197,7 +198,7 @@ func (s *execSuite) TestCopyToPod(c *gc.C) {
 	cancel := make(<-chan struct{}, 1)
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- s.execClient.Copy(params, cancel)
+		errChan <- s.execClient.Copy(context.Background(), params, cancel)
 	}()
 	select {
 	case err := <-errChan:
@@ -297,7 +298,7 @@ func (s *execSuite) TestCopyFromPod(c *gc.C) {
 	cancel := make(<-chan struct{})
 	errChan := make(chan error)
 	go func() {
-		errChan <- s.execClient.Copy(params, cancel)
+		errChan <- s.execClient.Copy(context.Background(), params, cancel)
 	}()
 	select {
 	case err := <-errChan:

--- a/caas/kubernetes/provider/exec/export_test.go
+++ b/caas/kubernetes/provider/exec/export_test.go
@@ -4,6 +4,7 @@
 package exec
 
 import (
+	"context"
 	"os"
 
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -17,8 +18,8 @@ var (
 	RandomString                 = &randomString
 )
 
-func (ep *ExecParams) Validate(podGetter typedcorev1.PodInterface) error {
-	return ep.validate(podGetter)
+func (ep *ExecParams) Validate(ctx context.Context, podGetter typedcorev1.PodInterface) error {
+	return ep.validate(ctx, podGetter)
 }
 
 func (fr *FileResource) Validate() error {

--- a/caas/kubernetes/provider/exec/status.go
+++ b/caas/kubernetes/provider/exec/status.go
@@ -4,6 +4,7 @@
 package exec
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -53,11 +54,11 @@ type ContainerStatus struct {
 
 // Status returns information about a Pod including the status
 // of each container.
-func (c client) Status(params StatusParams) (*Status, error) {
+func (c client) Status(ctx context.Context, params StatusParams) (*Status, error) {
 	if err := params.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	pod, err := getValidatedPod(c.podGetter, params.PodName)
+	pod, err := getValidatedPod(ctx, c.podGetter, params.PodName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/exec/status_test.go
+++ b/caas/kubernetes/provider/exec/status_test.go
@@ -4,6 +4,7 @@
 package exec_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -53,7 +54,7 @@ func (s *statusSuite) TestStatus(c *gc.C) {
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 
-	status, err := s.execClient.Status(params)
+	status, err := s.execClient.Status(context.Background(), params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, &exec.Status{
 		PodName: "gitlab-k8s-0",
@@ -100,7 +101,7 @@ func (s *statusSuite) TestStatusInit(c *gc.C) {
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 
-	status, err := s.execClient.Status(params)
+	status, err := s.execClient.Status(context.Background(), params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, &exec.Status{
 		PodName: "gitlab-k8s-0",
@@ -147,7 +148,7 @@ func (s *statusSuite) TestStatusEphemeral(c *gc.C) {
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 
-	status, err := s.execClient.Status(params)
+	status, err := s.execClient.Status(context.Background(), params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.DeepEquals, &exec.Status{
 		PodName: "gitlab-k8s-0",
@@ -178,7 +179,7 @@ func (s *statusSuite) TestStatusPodNotFound(c *gc.C) {
 			Return(&core.PodList{}, nil),
 	)
 
-	status, err := s.execClient.Status(params)
+	status, err := s.execClient.Status(context.Background(), params)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	c.Assert(status, gc.IsNil)
 }

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -101,16 +101,16 @@ func toCaaSStorageProvisioner(sc *storagev1.StorageClass) *kubernetes.StoragePro
 // ValidateCloudEndpoint returns nil if the current model can talk to the kubernetes
 // endpoint.  Used as validation during model upgrades.
 // Implements environs.CloudEndpointChecker
-func (k *kubernetesClient) ValidateCloudEndpoint(_ environscontext.ProviderCallContext) error {
-	_, err := k.GetClusterMetadata("")
+func (k *kubernetesClient) ValidateCloudEndpoint(ctx environscontext.ProviderCallContext) error {
+	_, err := k.GetClusterMetadata(ctx, "")
 	return errors.Trace(err)
 }
 
 // GetClusterMetadata implements ClusterMetadataChecker. If a nominated storage
 // class is provided
-func (k *kubernetesClient) GetClusterMetadata(nominatedStorageClass string) (*kubernetes.ClusterMetadata, error) {
+func (k *kubernetesClient) GetClusterMetadata(ctx context.Context, nominatedStorageClass string) (*kubernetes.ClusterMetadata, error) {
 	return GetClusterMetadata(
-		context.TODO(),
+		ctx,
 		nominatedStorageClass,
 		k.client().CoreV1().Nodes(),
 		k.client().StorageV1().StorageClasses(),
@@ -135,7 +135,7 @@ func GetClusterMetadata(
 	}
 
 	// We may have the workload storage but still need to look for operator storage.
-	storageClasses, err := storageClassI.List(context.TODO(), v1.ListOptions{})
+	storageClasses, err := storageClassI.List(ctx, v1.ListOptions{})
 	if err != nil {
 		return nil, errors.Annotate(err, "listing storage classes")
 	}

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -59,32 +59,32 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	}
 	bridge := &modelOperatorBrokerBridge{
 		client: m.client,
-		ensureConfigMap: func(cm *core.ConfigMap) ([]func(), error) {
+		ensureConfigMap: func(ctx context.Context, cm *core.ConfigMap) ([]func(), error) {
 			ensureConfigMapCalled = true
 			_, err := m.client.CoreV1().ConfigMaps(namespace).Create(context.Background(), cm, meta.CreateOptions{})
 			return nil, err
 		},
-		ensureDeployment: func(d *apps.Deployment) ([]func(), error) {
+		ensureDeployment: func(ctx context.Context, d *apps.Deployment) ([]func(), error) {
 			ensureDeploymentCalled = true
 			_, err := m.client.AppsV1().Deployments(namespace).Create(context.Background(), d, meta.CreateOptions{})
 			return nil, err
 		},
-		ensureRole: func(r *rbac.Role) ([]func(), error) {
+		ensureRole: func(ctx context.Context, r *rbac.Role) ([]func(), error) {
 			ensureRoleCalled = true
 			_, err := m.client.RbacV1().Roles(namespace).Create(context.Background(), r, meta.CreateOptions{})
 			return nil, err
 		},
-		ensureRoleBinding: func(rb *rbac.RoleBinding) ([]func(), error) {
+		ensureRoleBinding: func(ctx context.Context, rb *rbac.RoleBinding) ([]func(), error) {
 			ensureRoleBindingCalled = true
 			_, err := m.client.RbacV1().RoleBindings(namespace).Create(context.Background(), rb, meta.CreateOptions{})
 			return nil, err
 		},
-		ensureServiceAccount: func(sa *core.ServiceAccount) ([]func(), error) {
+		ensureServiceAccount: func(ctx context.Context, sa *core.ServiceAccount) ([]func(), error) {
 			ensureServiceAccountCalled = true
 			_, err := m.client.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, meta.CreateOptions{})
 			return nil, err
 		},
-		ensureService: func(s *core.Service) ([]func(), error) {
+		ensureService: func(ctx context.Context, s *core.Service) ([]func(), error) {
 			ensureServiceCalled = true
 			_, err := m.client.CoreV1().Services(namespace).Create(context.Background(), s, meta.CreateOptions{})
 			return nil, err
@@ -116,7 +116,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 
 	errChan := make(chan error)
 	go func() {
-		errChan <- ensureModelOperator(modelUUID, agentPath, m.clock, &config, bridge)
+		errChan <- ensureModelOperator(context.Background(), modelUUID, agentPath, m.clock, &config, bridge)
 	}()
 
 	select {

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -4,7 +4,8 @@
 package provider
 
 import (
-	"github.com/juju/names/v5"
+	"context"
+
 	"github.com/juju/version/v2"
 	"k8s.io/client-go/kubernetes"
 )
@@ -36,10 +37,12 @@ func (u *upgradeCAASModelOperatorBridge) IsLegacyLabels() bool {
 }
 
 func modelOperatorUpgrade(
+	ctx context.Context,
 	operatorName string,
 	vers version.Number,
 	broker UpgradeCAASModelOperatorBroker) error {
 	return upgradeDeployment(
+		ctx,
 		operatorName,
 		"",
 		vers,
@@ -51,11 +54,11 @@ func (u *upgradeCAASModelOperatorBridge) Namespace() string {
 	return u.namespaceFn()
 }
 
-func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version.Number) error {
+func (k *kubernetesClient) upgradeModelOperator(ctx context.Context, vers version.Number) error {
 	broker := &upgradeCAASModelOperatorBridge{
 		clientFn:    k.client,
 		namespaceFn: k.GetCurrentNamespace,
 		isLegacyFn:  k.IsLegacyLabels,
 	}
-	return modelOperatorUpgrade(modelOperatorName, vers, broker)
+	return modelOperatorUpgrade(ctx, modelOperatorName, vers, broker)
 }

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -81,7 +81,7 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 		}, v1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(modelOperatorUpgrade(operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+	c.Assert(modelOperatorUpgrade(context.Background(), operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
 	de, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).
 		Get(context.Background(), operatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -4,6 +4,8 @@
 package provider_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
@@ -78,7 +80,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 func (s *providerSuite) TestOpen(c *gc.C) {
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 	config := fakeConfig(c)
-	broker, err := s.provider.Open(environs.OpenParams{
+	broker, err := s.provider.Open(context.Background(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: config,
 	})
@@ -106,7 +108,7 @@ func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
-	_, err := s.provider.Open(environs.OpenParams{
+	_, err := s.provider.Open(context.Background(), environs.OpenParams{
 		Cloud:  spec,
 		Config: fakeConfig(c),
 	})

--- a/caas/kubernetes/provider/proxy/proxier.go
+++ b/caas/kubernetes/provider/proxy/proxier.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"context"
 	"net"
 	"net/url"
 
@@ -99,7 +100,7 @@ func (p *Proxier) Port() string {
 	return p.tunnel.LocalPort
 }
 
-func (p *Proxier) Start() (err error) {
+func (p *Proxier) Start(ctx context.Context) (err error) {
 	tunnel, err := kubernetes.NewTunnelForConfig(
 		&p.restConfig,
 		kubernetes.TunnelKindServices,
@@ -116,7 +117,7 @@ func (p *Proxier) Start() (err error) {
 	defer func() {
 		err = errors.Annotate(err, "connecting k8s proxy")
 	}()
-	err = p.tunnel.ForwardPort()
+	err = p.tunnel.ForwardPort(ctx)
 	urlErr, ok := errors.Cause(err).(*url.Error)
 	if !ok {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/rbac_test.go
+++ b/caas/kubernetes/provider/rbac_test.go
@@ -4,6 +4,8 @@
 package provider_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -95,7 +97,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -181,7 +183,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -258,7 +260,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -335,7 +337,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }

--- a/caas/kubernetes/provider/resources.go
+++ b/caas/kubernetes/provider/resources.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -24,7 +23,7 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	modelLabel := fmt.Sprintf("%v==%v", tags.JujuModel, k.modelUUID)
 
 	pods := k.client().CoreV1().Pods(k.namespace)
-	podsList, err := pods.List(context.TODO(), v1.ListOptions{
+	podsList, err := pods.List(ctx, v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
 	if err != nil {
@@ -32,13 +31,13 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	}
 	for _, p := range podsList.Items {
 		p.Labels[tags.JujuController] = controllerUUID
-		if _, err := pods.Update(context.TODO(), &p, v1.UpdateOptions{}); err != nil {
+		if _, err := pods.Update(ctx, &p, v1.UpdateOptions{}); err != nil {
 			return errors.Annotatef(err, "updating labels for pod %q", p.Name)
 		}
 	}
 
 	pvcs := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
-	pvcList, err := pvcs.List(context.TODO(), v1.ListOptions{
+	pvcList, err := pvcs.List(ctx, v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
 	if err != nil {
@@ -46,13 +45,13 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	}
 	for _, pvc := range pvcList.Items {
 		pvc.Labels[tags.JujuController] = controllerUUID
-		if _, err := pvcs.Update(context.TODO(), &pvc, v1.UpdateOptions{}); err != nil {
+		if _, err := pvcs.Update(ctx, &pvc, v1.UpdateOptions{}); err != nil {
 			return errors.Annotatef(err, "updating labels for pvc %q", pvc.Name)
 		}
 	}
 
 	pvs := k.client().CoreV1().PersistentVolumes()
-	pvList, err := pvs.List(context.TODO(), v1.ListOptions{
+	pvList, err := pvs.List(ctx, v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
 	if err != nil {
@@ -60,13 +59,13 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	}
 	for _, pv := range pvList.Items {
 		pv.Labels[tags.JujuController] = controllerUUID
-		if _, err := pvs.Update(context.TODO(), &pv, v1.UpdateOptions{}); err != nil {
+		if _, err := pvs.Update(ctx, &pv, v1.UpdateOptions{}); err != nil {
 			return errors.Annotatef(err, "updating labels for pvc %q", pv.Name)
 		}
 	}
 
 	sSets := k.client().AppsV1().StatefulSets(k.namespace)
-	ssList, err := sSets.List(context.TODO(), v1.ListOptions{
+	ssList, err := sSets.List(ctx, v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
 	if err != nil {
@@ -74,13 +73,13 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	}
 	for _, ss := range ssList.Items {
 		ss.Labels[tags.JujuController] = controllerUUID
-		if _, err := sSets.Update(context.TODO(), &ss, v1.UpdateOptions{}); err != nil {
+		if _, err := sSets.Update(ctx, &ss, v1.UpdateOptions{}); err != nil {
 			return errors.Annotatef(err, "updating labels for stateful set %q", ss.Name)
 		}
 	}
 
 	deployments := k.client().AppsV1().Deployments(k.namespace)
-	dList, err := deployments.List(context.TODO(), v1.ListOptions{
+	dList, err := deployments.List(ctx, v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
 	if err != nil {
@@ -88,7 +87,7 @@ func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, c
 	}
 	for _, d := range dList.Items {
 		d.Labels[tags.JujuController] = controllerUUID
-		if _, err := deployments.Update(context.TODO(), &d, v1.UpdateOptions{}); err != nil {
+		if _, err := deployments.Update(ctx, &d, v1.UpdateOptions{}); err != nil {
 			return errors.Annotatef(err, "updating labels for deployment %q", d.Name)
 		}
 	}

--- a/caas/kubernetes/provider/secrets_test.go
+++ b/caas/kubernetes/provider/secrets_test.go
@@ -52,7 +52,7 @@ func (s *secretsSuite) TestGetSecretToken(c *gc.C) {
 	_, err := s.mockSecrets.Create(context.Background(), secret, v1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	out, err := s.broker.GetSecretToken("secret-1")
+	out, err := s.broker.GetSecretToken(context.Background(), "secret-1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, "token")
 

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -44,11 +44,11 @@ func updateStrategyForStatefulSet(strategy specs.UpdateStrategy) (o apps.Statefu
 	return o, nil
 }
 
-func (k *kubernetesClient) createStatefulSet(spec *apps.StatefulSet) (*apps.StatefulSet, error) {
+func (k *kubernetesClient) createStatefulSet(ctx context.Context, spec *apps.StatefulSet) (*apps.StatefulSet, error) {
 	if k.namespace == "" {
 		return nil, errNoNamespace
 	}
-	out, err := k.client().AppsV1().StatefulSets(k.namespace).Create(context.TODO(), spec, v1.CreateOptions{})
+	out, err := k.client().AppsV1().StatefulSets(k.namespace).Create(ctx, spec, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("stateful set %q", spec.GetName())
 	}
@@ -58,11 +58,11 @@ func (k *kubernetesClient) createStatefulSet(spec *apps.StatefulSet) (*apps.Stat
 	return out, errors.Trace(err)
 }
 
-func (k *kubernetesClient) getStatefulSet(name string) (*apps.StatefulSet, error) {
+func (k *kubernetesClient) getStatefulSet(ctx context.Context, name string) (*apps.StatefulSet, error) {
 	if k.namespace == "" {
 		return nil, errNoNamespace
 	}
-	out, err := k.client().AppsV1().StatefulSets(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
+	out, err := k.client().AppsV1().StatefulSets(k.namespace).Get(ctx, name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("stateful set %q", name)
 	}
@@ -70,11 +70,11 @@ func (k *kubernetesClient) getStatefulSet(name string) (*apps.StatefulSet, error
 }
 
 // deleteStatefulSet deletes a statefulset resource.
-func (k *kubernetesClient) deleteStatefulSet(name string) error {
+func (k *kubernetesClient) deleteStatefulSet(ctx context.Context, name string) error {
 	if k.namespace == "" {
 		return errNoNamespace
 	}
-	err := k.client().AppsV1().StatefulSets(k.namespace).Delete(context.TODO(), name, v1.DeleteOptions{
+	err := k.client().AppsV1().StatefulSets(k.namespace).Delete(ctx, name, v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	})
 	if k8serrors.IsNotFound(err) {

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -40,8 +40,8 @@ func HasLabels(src, has labels.Set) bool {
 
 // IsLegacyModelLabels checks to see if the provided model is running on an older
 // labeling scheme or a newer one.
-func IsLegacyModelLabels(namespace, model string, namespaceI core.NamespaceInterface) (bool, error) {
-	ns, err := namespaceI.Get(context.TODO(), namespace, meta.GetOptions{})
+func IsLegacyModelLabels(ctx context.Context, namespace, model string, namespaceI core.NamespaceInterface) (bool, error) {
+	ns, err := namespaceI.Get(ctx, namespace, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -103,7 +103,7 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 		_, err := l.client.CoreV1().Namespaces().Create(context.Background(), test.Namespace, meta.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
-		legacy, err := utils.IsLegacyModelLabels(test.Namespace.Name, test.Model, l.client.CoreV1().Namespaces())
+		legacy, err := utils.IsLegacyModelLabels(context.Background(), test.Namespace.Name, test.Model, l.client.CoreV1().Namespaces())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(legacy, gc.Equals, test.IsLegacy)
 	}

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -80,17 +80,17 @@ func (mr *MockBrokerMockRecorder) AdoptResources(arg0, arg1, arg2 any) *gomock.C
 }
 
 // AnnotateUnit mocks base method.
-func (m *MockBroker) AnnotateUnit(arg0, arg1 string, arg2 names.UnitTag) error {
+func (m *MockBroker) AnnotateUnit(arg0 context.Context, arg1, arg2 string, arg3 names.UnitTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AnnotateUnit indicates an expected call of AnnotateUnit.
-func (mr *MockBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockBroker)(nil).AnnotateUnit), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockBroker)(nil).AnnotateUnit), arg0, arg1, arg2, arg3)
 }
 
 // Application mocks base method.
@@ -123,17 +123,17 @@ func (mr *MockBrokerMockRecorder) Bootstrap(arg0, arg1, arg2 any) *gomock.Call {
 }
 
 // CheckCloudCredentials mocks base method.
-func (m *MockBroker) CheckCloudCredentials() error {
+func (m *MockBroker) CheckCloudCredentials(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckCloudCredentials")
+	ret := m.ctrl.Call(m, "CheckCloudCredentials", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckCloudCredentials indicates an expected call of CheckCloudCredentials.
-func (mr *MockBrokerMockRecorder) CheckCloudCredentials() *gomock.Call {
+func (mr *MockBrokerMockRecorder) CheckCloudCredentials(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCloudCredentials", reflect.TypeOf((*MockBroker)(nil).CheckCloudCredentials))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCloudCredentials", reflect.TypeOf((*MockBroker)(nil).CheckCloudCredentials), arg0)
 }
 
 // Config mocks base method.
@@ -222,46 +222,46 @@ func (mr *MockBrokerMockRecorder) DestroyController(arg0, arg1 any) *gomock.Call
 }
 
 // EnsureImageRepoSecret mocks base method.
-func (m *MockBroker) EnsureImageRepoSecret(arg0 docker.ImageRepoDetails) error {
+func (m *MockBroker) EnsureImageRepoSecret(arg0 context.Context, arg1 docker.ImageRepoDetails) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureImageRepoSecret", arg0)
+	ret := m.ctrl.Call(m, "EnsureImageRepoSecret", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureImageRepoSecret indicates an expected call of EnsureImageRepoSecret.
-func (mr *MockBrokerMockRecorder) EnsureImageRepoSecret(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) EnsureImageRepoSecret(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureImageRepoSecret", reflect.TypeOf((*MockBroker)(nil).EnsureImageRepoSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureImageRepoSecret", reflect.TypeOf((*MockBroker)(nil).EnsureImageRepoSecret), arg0, arg1)
 }
 
 // EnsureModelOperator mocks base method.
-func (m *MockBroker) EnsureModelOperator(arg0, arg1 string, arg2 *caas.ModelOperatorConfig) error {
+func (m *MockBroker) EnsureModelOperator(arg0 context.Context, arg1, arg2 string, arg3 *caas.ModelOperatorConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureModelOperator", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureModelOperator", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureModelOperator indicates an expected call of EnsureModelOperator.
-func (mr *MockBrokerMockRecorder) EnsureModelOperator(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) EnsureModelOperator(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureModelOperator", reflect.TypeOf((*MockBroker)(nil).EnsureModelOperator), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureModelOperator", reflect.TypeOf((*MockBroker)(nil).EnsureModelOperator), arg0, arg1, arg2, arg3)
 }
 
 // EnsureSecretAccessToken mocks base method.
-func (m *MockBroker) EnsureSecretAccessToken(arg0 names.Tag, arg1, arg2, arg3 []string) (string, error) {
+func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 names.Tag, arg2, arg3, arg4 []string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureSecretAccessToken indicates an expected call of EnsureSecretAccessToken.
-func (mr *MockBrokerMockRecorder) EnsureSecretAccessToken(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) EnsureSecretAccessToken(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).EnsureSecretAccessToken), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).EnsureSecretAccessToken), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetJujuSecret mocks base method.
@@ -280,63 +280,63 @@ func (mr *MockBrokerMockRecorder) GetJujuSecret(arg0, arg1 any) *gomock.Call {
 }
 
 // GetSecretToken mocks base method.
-func (m *MockBroker) GetSecretToken(arg0 string) (string, error) {
+func (m *MockBroker) GetSecretToken(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretToken", arg0)
+	ret := m.ctrl.Call(m, "GetSecretToken", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretToken indicates an expected call of GetSecretToken.
-func (mr *MockBrokerMockRecorder) GetSecretToken(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) GetSecretToken(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), arg0, arg1)
 }
 
 // GetService mocks base method.
-func (m *MockBroker) GetService(arg0 string, arg1 bool) (*caas.Service, error) {
+func (m *MockBroker) GetService(arg0 context.Context, arg1 string, arg2 bool) (*caas.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetService", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*caas.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetService indicates an expected call of GetService.
-func (mr *MockBrokerMockRecorder) GetService(arg0, arg1 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) GetService(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockBroker)(nil).GetService), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockBroker)(nil).GetService), arg0, arg1, arg2)
 }
 
 // ModelOperator mocks base method.
-func (m *MockBroker) ModelOperator() (*caas.ModelOperatorConfig, error) {
+func (m *MockBroker) ModelOperator(arg0 context.Context) (*caas.ModelOperatorConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelOperator")
+	ret := m.ctrl.Call(m, "ModelOperator", arg0)
 	ret0, _ := ret[0].(*caas.ModelOperatorConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelOperator indicates an expected call of ModelOperator.
-func (mr *MockBrokerMockRecorder) ModelOperator() *gomock.Call {
+func (mr *MockBrokerMockRecorder) ModelOperator(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelOperator", reflect.TypeOf((*MockBroker)(nil).ModelOperator))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelOperator", reflect.TypeOf((*MockBroker)(nil).ModelOperator), arg0)
 }
 
 // ModelOperatorExists mocks base method.
-func (m *MockBroker) ModelOperatorExists() (bool, error) {
+func (m *MockBroker) ModelOperatorExists(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelOperatorExists")
+	ret := m.ctrl.Call(m, "ModelOperatorExists", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelOperatorExists indicates an expected call of ModelOperatorExists.
-func (mr *MockBrokerMockRecorder) ModelOperatorExists() *gomock.Call {
+func (mr *MockBrokerMockRecorder) ModelOperatorExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelOperatorExists", reflect.TypeOf((*MockBroker)(nil).ModelOperatorExists))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelOperatorExists", reflect.TypeOf((*MockBroker)(nil).ModelOperatorExists), arg0)
 }
 
 // PrecheckInstance mocks base method.
@@ -382,32 +382,32 @@ func (mr *MockBrokerMockRecorder) Provider() *gomock.Call {
 }
 
 // ProxyToApplication mocks base method.
-func (m *MockBroker) ProxyToApplication(arg0, arg1 string) (proxy.Proxier, error) {
+func (m *MockBroker) ProxyToApplication(arg0 context.Context, arg1, arg2 string) (proxy.Proxier, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProxyToApplication", arg0, arg1)
+	ret := m.ctrl.Call(m, "ProxyToApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(proxy.Proxier)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProxyToApplication indicates an expected call of ProxyToApplication.
-func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyToApplication", reflect.TypeOf((*MockBroker)(nil).ProxyToApplication), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyToApplication", reflect.TypeOf((*MockBroker)(nil).ProxyToApplication), arg0, arg1, arg2)
 }
 
 // RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 names.Tag) error {
+func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0)
+	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveSecretAccessToken indicates an expected call of RemoveSecretAccessToken.
-func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0, arg1)
 }
 
 // SaveJujuSecret mocks base method.
@@ -470,46 +470,46 @@ func (mr *MockBrokerMockRecorder) StorageProviderTypes() *gomock.Call {
 }
 
 // Units mocks base method.
-func (m *MockBroker) Units(arg0 string) ([]caas.Unit, error) {
+func (m *MockBroker) Units(arg0 context.Context, arg1 string) ([]caas.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Units", arg0)
+	ret := m.ctrl.Call(m, "Units", arg0, arg1)
 	ret0, _ := ret[0].([]caas.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Units indicates an expected call of Units.
-func (mr *MockBrokerMockRecorder) Units(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) Units(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockBroker)(nil).Units), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockBroker)(nil).Units), arg0, arg1)
 }
 
 // Upgrade mocks base method.
-func (m *MockBroker) Upgrade(arg0 string, arg1 version.Number) error {
+func (m *MockBroker) Upgrade(arg0 context.Context, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockBrokerMockRecorder) Upgrade(arg0, arg1 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) Upgrade(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockBroker)(nil).Upgrade), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockBroker)(nil).Upgrade), arg0, arg1, arg2)
 }
 
 // ValidateStorageClass mocks base method.
-func (m *MockBroker) ValidateStorageClass(arg0 map[string]any) error {
+func (m *MockBroker) ValidateStorageClass(arg0 context.Context, arg1 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateStorageClass", arg0)
+	ret := m.ctrl.Call(m, "ValidateStorageClass", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateStorageClass indicates an expected call of ValidateStorageClass.
-func (mr *MockBrokerMockRecorder) ValidateStorageClass(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) ValidateStorageClass(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStorageClass", reflect.TypeOf((*MockBroker)(nil).ValidateStorageClass), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStorageClass", reflect.TypeOf((*MockBroker)(nil).ValidateStorageClass), arg0, arg1)
 }
 
 // Version mocks base method.

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -177,7 +177,7 @@ type AddCAASCommand struct {
 	eks        bool
 	k8sCluster k8sCluster
 
-	adminServiceAccountResolver func(jujuclock.Clock) clientconfig.K8sCredentialResolver
+	adminServiceAccountResolver func(stdcontext.Context, jujuclock.Clock) clientconfig.K8sCredentialResolver
 	cloudMetadataStore          CloudMetadataStore
 	credentialStoreAPI          CredentialStoreAPI
 	newClientConfigReader       func(string) (clientconfig.ClientConfigFunc, error)
@@ -499,7 +499,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		}
 	}
 
-	k8sConfig, err = c.adminServiceAccountResolver(c.clock)(
+	k8sConfig, err = c.adminServiceAccountResolver(ctx, c.clock)(
 		credentialUID,
 		k8sConfig,
 		k8sCtxName,
@@ -847,7 +847,7 @@ func (c *AddCAASCommand) getClusterMetadataFunc(ctx *cmd.Context) provider.GetCl
 		result := make(chan *k8s.ClusterMetadata, 1)
 		errChan := make(chan error, 1)
 		go func() {
-			clusterMetadata, err := storageParams.MetadataChecker.GetClusterMetadata(storageParams.WorkloadStorage)
+			clusterMetadata, err := storageParams.MetadataChecker.GetClusterMetadata(ctx, storageParams.WorkloadStorage)
 			if err != nil {
 				errChan <- err
 			} else {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -170,7 +170,7 @@ type fakeK8sClusterMetadataChecker struct {
 	existingSC bool
 }
 
-func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
+func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(ctx context.Context, storageClass string) (result *k8s.ClusterMetadata, err error) {
 	results := api.MethodCall(api, "GetClusterMetadata")
 	return results[0].(*k8s.ClusterMetadata), jujutesting.TypeAssertError(results[1])
 }
@@ -374,7 +374,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 		func() (caas.AddCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(_ jujuclock.Clock) clientconfig.K8sCredentialResolver {
+		func(_ context.Context, _ jujuclock.Clock) clientconfig.K8sCredentialResolver {
 			return func(_ string, c *clientcmdapi.Config, _ string) (*clientcmdapi.Config, error) {
 				return c, nil
 			}

--- a/cmd/juju/caas/credential.go
+++ b/cmd/juju/caas/credential.go
@@ -4,6 +4,7 @@
 package caas
 
 import (
+	"context"
 	"encoding/hex"
 	"math/rand"
 
@@ -70,7 +71,7 @@ func decideCredentialUID(store credentialGetter, cloudName, credentialName strin
 	return credUID, nil
 }
 
-func cleanUpCredentialRBAC(cloud jujucloud.Cloud, credential jujucloud.Credential) error {
+func cleanUpCredentialRBAC(ctx context.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) error {
 	attr := credential.Attributes()
 	if attr == nil {
 		return nil
@@ -88,6 +89,6 @@ func cleanUpCredentialRBAC(cloud jujucloud.Cloud, credential jujucloud.Credentia
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = clientconfig.RemoveCredentialRBACResources(restConfig, credUID)
+	err = clientconfig.RemoveCredentialRBACResources(ctx, restConfig, credUID)
 	return errors.Trace(err)
 }

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -5,6 +5,7 @@ package caas
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	jujuclock "github.com/juju/clock"
@@ -23,7 +24,7 @@ func NewAddCAASCommandForTest(
 	credentialStoreAPI CredentialStoreAPI,
 	store jujuclient.ClientStore,
 	addCloudAPIFunc func() (AddCloudAPI, error),
-	adminServiceAccountResolver func(jujuclock.Clock) clientconfig.K8sCredentialResolver,
+	adminServiceAccountResolver func(context.Context, jujuclock.Clock) clientconfig.K8sCredentialResolver,
 	brokerGetter BrokerGetter,
 	k8sCluster k8sCluster,
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -4,6 +4,7 @@
 package caas
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/v3"
@@ -112,7 +113,7 @@ func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	if c.ControllerName != "" && c.Client { // TODO(caas): only do RBAC cleanup for removing from both client and controller to less complexity.
-		if err := cleanUpCredentialRBACResources(c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
+		if err := cleanUpCredentialRBACResources(ctxt, c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -144,6 +145,7 @@ func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 }
 
 func cleanUpCredentialRBACResources(
+	ctx context.Context,
 	cloudName string,
 	cloudMetadataStore CloudMetadataStore, credentialStoreAPI credentialGetter,
 ) error {
@@ -167,7 +169,7 @@ func cleanUpCredentialRBACResources(
 		return nil
 	}
 	for _, credential := range cloudCredentials.AuthCredentials {
-		if err := cleanUpCredentialRBAC(pCloud, credential); err != nil {
+		if err := cleanUpCredentialRBAC(ctx, pCloud, credential); err != nil {
 			logger.Warningf("unable to remove RBAC resources for credential %q", credential.Label)
 		}
 	}

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -270,7 +270,7 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 			return errors.Trace(err)
 		}
 
-		if _, err := broker.GetClusterMetadata(""); err != nil {
+		if _, err := broker.GetClusterMetadata(ctx, ""); err != nil {
 			return errors.Annotate(err, "unable to update k8s cluster because the cluster is not accessible")
 		}
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -813,7 +813,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	defer ctx.StopInterruptNotify(interrupted)
 
 	var cancel context.CancelFunc
-	stdCtx, cancel := context.WithTimeout(context.Background(), bootstrapCfg.bootstrap.BootstrapTimeout)
+	stdCtx, cancel := context.WithTimeout(ctx, bootstrapCfg.bootstrap.BootstrapTimeout)
 
 	defer func() {
 		// If the context is an error state, then don't continue on processing
@@ -1118,7 +1118,7 @@ func (c *bootstrapCommand) controllerDataRefresher(
 	} else if env, ok := environ.(caas.ServiceManager); ok {
 		// CAAS.
 		var svc *caas.Service
-		svc, err = env.GetService(k8sconstants.JujuControllerStackName, false)
+		svc, err = env.GetService(callCtx, k8sconstants.JujuControllerStackName, false)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1134,7 +1134,7 @@ func (c *bootstrapCommand) controllerDataRefresher(
 
 	var proxier proxy.Proxier
 	if conInfo, ok := environ.(environs.ConnectorInfo); ok {
-		proxier, err = conInfo.ConnectionProxyInfo()
+		proxier, err = conInfo.ConnectionProxyInfo(callCtx)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1206,7 +1206,7 @@ func createImageMetadata(c *gc.C) (string, []*imagemetadata.ImageMetadata) {
 	c.Assert(err, jc.ErrorIsNil)
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 	base := corebase.MustParseBaseFromString("ubuntu@22.04")
-	err = imagemetadata.MergeAndWriteMetadata(ss, base, im, cloudSpec, sourceStor)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, base, im, cloudSpec, sourceStor)
 	c.Assert(err, jc.ErrorIsNil)
 	return sourceDir, im
 }
@@ -2339,7 +2339,7 @@ clouds:
 // checkTools check if the environment contains the passed envtools.
 func checkTools(c *gc.C, env environs.Environ, expected []version.Binary) {
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	list, err := envtools.FindTools(ss,
+	list, err := envtools.FindTools(context.Background(), ss,
 		env, jujuversion.Current.Major, jujuversion.Current.Minor, []string{"released"}, coretools.Filter{})
 	c.Check(err, jc.ErrorIsNil)
 	c.Logf("found: " + list.String())

--- a/cmd/juju/commands/mocks/modelupgrader_mock.go
+++ b/cmd/juju/commands/mocks/modelupgrader_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -71,16 +72,16 @@ func (mr *MockModelUpgraderAPIMockRecorder) UpgradeModel(arg0, arg1, arg2, arg3,
 }
 
 // UploadTools mocks base method.
-func (m *MockModelUpgraderAPI) UploadTools(arg0 io.ReadSeeker, arg1 version.Binary) (tools.List, error) {
+func (m *MockModelUpgraderAPI) UploadTools(arg0 context.Context, arg1 io.ReadSeeker, arg2 version.Binary) (tools.List, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadTools", arg0, arg1)
+	ret := m.ctrl.Call(m, "UploadTools", arg0, arg1, arg2)
 	ret0, _ := ret[0].(tools.List)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UploadTools indicates an expected call of UploadTools.
-func (mr *MockModelUpgraderAPIMockRecorder) UploadTools(arg0, arg1 any) *gomock.Call {
+func (mr *MockModelUpgraderAPIMockRecorder) UploadTools(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTools", reflect.TypeOf((*MockModelUpgraderAPI)(nil).UploadTools), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTools", reflect.TypeOf((*MockModelUpgraderAPI)(nil).UploadTools), arg0, arg1, arg2)
 }

--- a/cmd/juju/commands/mocks/synctool_mock.go
+++ b/cmd/juju/commands/mocks/synctool_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -56,16 +57,16 @@ func (mr *MockSyncToolAPIMockRecorder) Close() *gomock.Call {
 }
 
 // UploadTools mocks base method.
-func (m *MockSyncToolAPI) UploadTools(arg0 io.ReadSeeker, arg1 version.Binary) (tools.List, error) {
+func (m *MockSyncToolAPI) UploadTools(arg0 context.Context, arg1 io.ReadSeeker, arg2 version.Binary) (tools.List, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadTools", arg0, arg1)
+	ret := m.ctrl.Call(m, "UploadTools", arg0, arg1, arg2)
 	ret0, _ := ret[0].(tools.List)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UploadTools indicates an expected call of UploadTools.
-func (mr *MockSyncToolAPIMockRecorder) UploadTools(arg0, arg1 any) *gomock.Call {
+func (mr *MockSyncToolAPIMockRecorder) UploadTools(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTools", reflect.TypeOf((*MockSyncToolAPI)(nil).UploadTools), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTools", reflect.TypeOf((*MockSyncToolAPI)(nil).UploadTools), arg0, arg1, arg2)
 }

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 
@@ -98,7 +99,7 @@ func (c *syncAgentBinaryCommand) Init(args []string) error {
 // SyncToolAPI provides an interface with a subset of the
 // modelupgrader.Client API. This exists to enable mocking.
 type SyncToolAPI interface {
-	UploadTools(r io.ReadSeeker, v version.Binary) (coretools.List, error)
+	UploadTools(ctx context.Context, r io.ReadSeeker, v version.Binary) (coretools.List, error)
 	Close() error
 }
 
@@ -156,7 +157,7 @@ func (c *syncAgentBinaryCommand) Run(ctx *cmd.Context) (resultErr error) {
 		adaptor := syncToolAPIAdaptor{api}
 		sctx.TargetToolsUploader = adaptor
 	}
-	return block.ProcessBlockedError(syncTools(sctx), block.BlockChange)
+	return block.ProcessBlockedError(syncTools(ctx, sctx), block.BlockChange)
 }
 
 // syncToolAPIAdaptor implements sync.ToolsFinder and
@@ -166,7 +167,7 @@ type syncToolAPIAdaptor struct {
 	SyncToolAPI
 }
 
-func (s syncToolAPIAdaptor) UploadTools(toolsDir, stream string, tools *coretools.Tools, data []byte) error {
-	_, err := s.SyncToolAPI.UploadTools(bytes.NewReader(data), tools.Version)
+func (s syncToolAPIAdaptor) UploadTools(ctx context.Context, toolsDir, stream string, tools *coretools.Tools, data []byte) error {
+	_, err := s.SyncToolAPI.UploadTools(ctx, bytes.NewReader(data), tools.Version)
 	return err
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -242,7 +242,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 			version.Zero,
 			errors.NotFoundf("available agent tool, upload required"),
 		),
-		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), builtVersion).Return(nil, nil),
+		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), gomock.Any(), builtVersion).Return(nil, nil),
 		s.modelUpgrader.EXPECT().UpgradeModel(
 			coretesting.ModelTag.Id(), builtVersion.Number,
 			"", false, false,
@@ -504,7 +504,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithBuildAgent(c *gc.C) {
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
 		s.controllerAPI.EXPECT().ModelConfig().Return(cfg, nil),
-		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), builtVersion).Return(nil, nil),
+		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), gomock.Any(), builtVersion).Return(nil, nil),
 		s.modelUpgrader.EXPECT().UpgradeModel(
 			coretesting.ModelTag.Id(), builtVersion.Number,
 			"", false, false,

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -76,8 +76,8 @@ func WaitForAgentInitialisation(
 	isCAASController bool,
 	controllerName string,
 ) (err error) {
-	if ctx.Context().Err() != nil {
-		return errors.Errorf("unable to contact api server: (%v)", ctx.Context().Err())
+	if ctx.Err() != nil {
+		return errors.Errorf("unable to contact api server: (%v)", ctx.Err())
 	}
 
 	// Make a best effort to find the new controller address so we can print it.
@@ -97,7 +97,7 @@ func WaitForAgentInitialisation(
 		Clock:    clock.WallClock,
 		Attempts: bootstrapReadyPollCount,
 		Delay:    bootstrapReadyPollDelay,
-		Stop:     ctx.Context().Done(),
+		Stop:     ctx.Done(),
 		NotifyFunc: func(lastErr error, attempts int) {
 			apiAttempts = attempts
 		},

--- a/cmd/juju/dashboard/dashboard.go
+++ b/cmd/juju/dashboard/dashboard.go
@@ -152,7 +152,7 @@ func (c *dashboardCommand) Run(ctx *cmd.Context) error {
 			return errors.Annotatef(err, "unsupported proxy type %q for dashboard", res.Proxier.Type())
 		}
 
-		runner = tunnelProxyRunner(tunnelProxy)
+		runner = tunnelProxyRunner(ctx, tunnelProxy)
 	} else if res.SSHTunnel != nil {
 		runner = tunnelSSHRunner(*res.SSHTunnel, c.port, c.embeddedSSHCmd)
 	} else {
@@ -249,9 +249,9 @@ func tunnelSSHRunner(
 	}
 }
 
-func tunnelProxyRunner(p proxy.TunnelProxier) connectionRunner {
+func tunnelProxyRunner(ctx context.Context, p proxy.TunnelProxier) connectionRunner {
 	return func(ctx context.Context, callBack urlCallBack) error {
-		if err := p.Start(); err != nil {
+		if err := p.Start(ctx); err != nil {
 			return errors.Annotate(err, "starting tunnel proxy")
 		}
 		defer p.Stop()

--- a/cmd/juju/ssh/mocks/k8s_exec_mock.go
+++ b/cmd/juju/ssh/mocks/k8s_exec_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	exec "github.com/juju/juju/caas/kubernetes/provider/exec"
@@ -41,31 +42,31 @@ func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 }
 
 // Copy mocks base method.
-func (m *MockExecutor) Copy(arg0 exec.CopyParams, arg1 <-chan struct{}) error {
+func (m *MockExecutor) Copy(arg0 context.Context, arg1 exec.CopyParams, arg2 <-chan struct{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Copy", arg0, arg1)
+	ret := m.ctrl.Call(m, "Copy", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Copy indicates an expected call of Copy.
-func (mr *MockExecutorMockRecorder) Copy(arg0, arg1 any) *gomock.Call {
+func (mr *MockExecutorMockRecorder) Copy(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockExecutor)(nil).Copy), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockExecutor)(nil).Copy), arg0, arg1, arg2)
 }
 
 // Exec mocks base method.
-func (m *MockExecutor) Exec(arg0 exec.ExecParams, arg1 <-chan struct{}) error {
+func (m *MockExecutor) Exec(arg0 context.Context, arg1 exec.ExecParams, arg2 <-chan struct{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exec", arg0, arg1)
+	ret := m.ctrl.Call(m, "Exec", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Exec indicates an expected call of Exec.
-func (mr *MockExecutorMockRecorder) Exec(arg0, arg1 any) *gomock.Call {
+func (mr *MockExecutorMockRecorder) Exec(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockExecutor)(nil).Exec), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockExecutor)(nil).Exec), arg0, arg1, arg2)
 }
 
 // NameSpace mocks base method.
@@ -97,16 +98,16 @@ func (mr *MockExecutorMockRecorder) RawClient() *gomock.Call {
 }
 
 // Status mocks base method.
-func (m *MockExecutor) Status(arg0 exec.StatusParams) (*exec.Status, error) {
+func (m *MockExecutor) Status(arg0 context.Context, arg1 exec.StatusParams) (*exec.Status, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status", arg0)
+	ret := m.ctrl.Call(m, "Status", arg0, arg1)
 	ret0, _ := ret[0].(*exec.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockExecutorMockRecorder) Status(arg0 any) *gomock.Call {
+func (mr *MockExecutorMockRecorder) Status(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockExecutor)(nil).Status), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockExecutor)(nil).Status), arg0, arg1)
 }

--- a/cmd/juju/ssh/mocks/package_mock.go
+++ b/cmd/juju/ssh/mocks/package_mock.go
@@ -13,6 +13,7 @@ import (
 	io "io"
 	os "os"
 	reflect "reflect"
+	time "time"
 
 	charm "github.com/juju/charm/v12"
 	api "github.com/juju/juju/api"
@@ -50,6 +51,49 @@ func NewMockContext(ctrl *gomock.Controller) *MockContext {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
+}
+
+// Deadline mocks base method.
+func (m *MockContext) Deadline() (time.Time, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deadline")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// Deadline indicates an expected call of Deadline.
+func (mr *MockContextMockRecorder) Deadline() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deadline", reflect.TypeOf((*MockContext)(nil).Deadline))
+}
+
+// Done mocks base method.
+func (m *MockContext) Done() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Done")
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// Done indicates an expected call of Done.
+func (mr *MockContextMockRecorder) Done() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockContext)(nil).Done))
+}
+
+// Err mocks base method.
+func (m *MockContext) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err.
+func (mr *MockContextMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockContext)(nil).Err))
 }
 
 // GetStderr mocks base method.
@@ -116,6 +160,20 @@ func (m *MockContext) StopInterruptNotify(arg0 chan<- os.Signal) {
 func (mr *MockContextMockRecorder) StopInterruptNotify(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInterruptNotify", reflect.TypeOf((*MockContext)(nil).StopInterruptNotify), arg0)
+}
+
+// Value mocks base method.
+func (m *MockContext) Value(arg0 any) any {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Value", arg0)
+	ret0, _ := ret[0].(any)
+	return ret0
+}
+
+// Value indicates an expected call of Value.
+func (mr *MockContextMockRecorder) Value(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockContext)(nil).Value), arg0)
 }
 
 // MockLeaderAPI is a mock of LeaderAPI interface.

--- a/cmd/juju/ssh/ssh_container.go
+++ b/cmd/juju/ssh/ssh_container.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -226,6 +227,7 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 
 // Context defines methods for command context.
 type Context interface {
+	context.Context
 	InterruptNotify(c chan<- os.Signal)
 	StopInterruptNotify(c chan<- os.Signal)
 	GetStdout() io.Writer
@@ -247,6 +249,7 @@ func (c *sshContainer) ssh(ctx Context, enablePty bool, target *resolvedTarget) 
 		}
 	}
 	return c.execClient.Exec(
+		ctx,
 		k8sexec.ExecParams{
 			PodName:       target.entity,
 			ContainerName: c.container,
@@ -300,7 +303,7 @@ func (c *sshContainer) copy(ctx Context) error {
 
 	cancel, stop := getInterruptAbortChan(ctx)
 	defer stop()
-	return c.execClient.Copy(k8sexec.CopyParams{Src: srcSpec, Dest: destSpec}, cancel)
+	return c.execClient.Copy(ctx, k8sexec.CopyParams{Src: srcSpec, Dest: destSpec}, cancel)
 }
 
 func (c *sshContainer) expandSCPArg(arg string) (o k8sexec.FileResource, err error) {

--- a/cmd/juju/ssh/ssh_container_test.go
+++ b/cmd/juju/ssh/ssh_container_test.go
@@ -5,6 +5,7 @@ package ssh_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"time"
 
@@ -309,8 +310,8 @@ func (s *sshContainerSuite) TestSSHNoContainerSpecified(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, arg k8sexec.ExecParams, cancel <-chan struct{}) error {
 				mc := jc.NewMultiChecker()
 				mc.AddExpr(`_.Env`, jc.Ignore)
 				c.Check(arg, mc, k8sexec.ExecParams{
@@ -346,8 +347,8 @@ func (s *sshContainerSuite) TestSSHWithContainerSpecified(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, arg k8sexec.ExecParams, cancel <-chan struct{}) error {
 				mc := jc.NewMultiChecker()
 				mc.AddExpr(`_.Env`, jc.Ignore)
 				c.Check(arg, mc, k8sexec.ExecParams{
@@ -388,8 +389,8 @@ func (s *sshContainerSuite) TestSSHCancelled(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, arg k8sexec.ExecParams, cancel <-chan struct{}) error {
 				mc := jc.NewMultiChecker()
 				mc.AddExpr(`_.Env`, jc.Ignore)
 				c.Check(arg, mc, k8sexec.ExecParams{
@@ -491,7 +492,7 @@ func (s *sshContainerSuite) TestCopyFromWorkloadPod(c *gc.C) {
 			}, nil),
 
 		ctx.EXPECT().InterruptNotify(gomock.Any()),
-		s.execClient.EXPECT().Copy(k8sexec.CopyParams{
+		s.execClient.EXPECT().Copy(gomock.Any(), k8sexec.CopyParams{
 			Src:  k8sexec.FileResource{Path: "/home/ubuntu/", PodName: "mariadb-k8s-0", ContainerName: "charm"},
 			Dest: k8sexec.FileResource{Path: "./file1"},
 		}, gomock.Any()).
@@ -521,7 +522,7 @@ func (s *sshContainerSuite) TestCopyToWorkloadPod(c *gc.C) {
 			}, nil),
 
 		ctx.EXPECT().InterruptNotify(gomock.Any()),
-		s.execClient.EXPECT().Copy(k8sexec.CopyParams{
+		s.execClient.EXPECT().Copy(gomock.Any(), k8sexec.CopyParams{
 			Src:  k8sexec.FileResource{Path: "./file1"},
 			Dest: k8sexec.FileResource{Path: "/home/ubuntu/", PodName: "mariadb-k8s-0", ContainerName: "charm"},
 		}, gomock.Any()).
@@ -555,7 +556,7 @@ func (s *sshContainerSuite) TestCopyToWorkloadPodWithContainerSpecified(c *gc.C)
 			}, nil),
 
 		ctx.EXPECT().InterruptNotify(gomock.Any()),
-		s.execClient.EXPECT().Copy(k8sexec.CopyParams{
+		s.execClient.EXPECT().Copy(gomock.Any(), k8sexec.CopyParams{
 			Src:  k8sexec.FileResource{Path: "./file1"},
 			Dest: k8sexec.FileResource{Path: "/home/ubuntu/", PodName: "mariadb-k8s-0", ContainerName: "container1"},
 		}, gomock.Any()).
@@ -607,8 +608,8 @@ func (s *sshContainerSuite) TestSSHWithTerm(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, arg k8sexec.ExecParams, cancel <-chan struct{}) error {
 				c.Check(arg, jc.DeepEquals, k8sexec.ExecParams{
 					PodName:  "mariadb-k8s-0",
 					Env:      []string{"TERM=foobar-256color"},
@@ -653,8 +654,8 @@ func (s *sshContainerSuite) TestSSHWithTermNoTTY(c *gc.C) {
 		ctx.EXPECT().GetStdout().Return(buffer),
 		ctx.EXPECT().GetStderr().Return(buffer),
 		ctx.EXPECT().GetStdin().Return(buffer),
-		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(arg k8sexec.ExecParams, cancel <-chan struct{}) error {
+		s.execClient.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, arg k8sexec.ExecParams, cancel <-chan struct{}) error {
 				c.Check(arg, jc.DeepEquals, k8sexec.ExecParams{
 					PodName:  "mariadb-k8s-0",
 					Env:      nil,

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -157,7 +157,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 
 	agentTools := envtesting.PrimeTools(c, store, s.DataDir, "released", vers)
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	err = envtools.MergeAndWriteMetadata(ss, store, "released", "released", coretools.List{agentTools}, envtools.DoNotWriteMirrors)
+	err = envtools.MergeAndWriteMetadata(context.Background(), ss, store, "released", "released", coretools.List{agentTools}, envtools.DoNotWriteMirrors)
 	c.Assert(err, jc.ErrorIsNil)
 
 	tools1, err := agenttools.ChangeAgentTools(s.DataDir, tag.String(), vers)

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -281,7 +281,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 				OSType: coreos.HostOSTypeName(),
 			}
 			ss := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
-			_, toolsErr := envtools.FindTools(ss, env, -1, -1, streams, filter)
+			_, toolsErr := envtools.FindTools(ctx, ss, env, -1, -1, streams, filter)
 			if toolsErr == nil {
 				logger.Infof("agent binaries are available, upgrade will occur after bootstrap")
 			}

--- a/cmd/plugins/juju-metadata/generateagents.go
+++ b/cmd/plugins/juju-metadata/generateagents.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/v3"
@@ -134,7 +135,7 @@ func (c *generateAgentsCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		toolsList, err = envtools.FindToolsForCloud(ss, makeDataSources(ss, source), simplestreams.CloudSpec{}, []string{c.stream}, -1, -1, coretools.Filter{})
+		toolsList, err = envtools.FindToolsForCloud(context, ss, makeDataSources(ss, source), simplestreams.CloudSpec{}, []string{c.stream}, -1, -1, coretools.Filter{})
 	}
 	if err != nil {
 		return errors.Trace(err)
@@ -148,7 +149,7 @@ func (c *generateAgentsCommand) Run(context *cmd.Context) error {
 	if c.public {
 		writeMirrors = envtools.WriteMirrors
 	}
-	return errors.Trace(mergeAndWriteMetadata(ss, targetStorage, c.stream, c.stream, c.clean, toolsList, writeMirrors))
+	return errors.Trace(mergeAndWriteMetadata(context, ss, targetStorage, c.stream, c.stream, c.clean, toolsList, writeMirrors))
 }
 
 func makeDataSources(ss *simplestreams.Simplestreams, urls ...string) []simplestreams.DataSource {
@@ -170,10 +171,10 @@ func makeDataSources(ss *simplestreams.Simplestreams, urls ...string) []simplest
 // This is essentially the same as tools.MergeAndWriteMetadata, but also
 // resolves metadata for existing agents by fetching them and computing
 // size/sha256 locally.
-func mergeAndWriteMetadata(ss envtools.SimplestreamsFetcher,
+func mergeAndWriteMetadata(ctx context.Context, ss envtools.SimplestreamsFetcher,
 	stor storage.Storage, toolsDir, stream string, clean bool, toolsList coretools.List, writeMirrors envtools.ShouldWriteMirrors,
 ) error {
-	existing, err := envtools.ReadAllMetadata(ss, stor)
+	existing, err := envtools.ReadAllMetadata(ctx, ss, stor)
 	if err != nil {
 		return err
 	}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -257,7 +257,7 @@ func (c *imageMetadataCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	fetcher := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
-	err = imagemetadata.MergeAndWriteMetadata(fetcher, base, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(ctx, fetcher, base, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
 	if err != nil {
 		return errors.Errorf("image metadata files could not be created: %v", err)
 	}

--- a/cmd/plugins/juju-metadata/validateagentsmetadata.go
+++ b/cmd/plugins/juju-metadata/validateagentsmetadata.go
@@ -220,7 +220,7 @@ func (c *validateAgentsMetadataCommand) Run(context *cmd.Context) error {
 	}
 	params.Stream = c.stream
 
-	versions, resolveInfo, err := tools.ValidateToolsMetadata(ss, &tools.ToolsMetadataLookupParams{
+	versions, resolveInfo, err := tools.ValidateToolsMetadata(context, ss, &tools.ToolsMetadataLookupParams{
 		MetadataLookupParams: *params,
 		Version:              c.exactVersion,
 		Major:                c.major,

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -172,7 +172,7 @@ func (c *validateImageMetadataCommand) Run(ctx *cmd.Context) error {
 	}
 
 	fetcher := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
-	images, resolveInfo, err := imagemetadata.ValidateImageMetadata(fetcher, params)
+	images, resolveInfo, err := imagemetadata.ValidateImageMetadata(ctx, fetcher, params)
 	if err != nil {
 		if resolveInfo != nil {
 			metadata := map[string]interface{}{

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -91,7 +92,7 @@ func (s *ValidateImageMetadataSuite) makeLocalMetadata(id, region string, base c
 		return err
 	}
 	ss := simplestreams.NewSimpleStreams(sstestings.TestDataSourceFactory())
-	err = imagemetadata.MergeAndWriteMetadata(ss, base, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, base, []*imagemetadata.ImageMetadata{im}, &cloudSpec, targetStorage)
 	if err != nil {
 		return err
 	}

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
-	envcontext "github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/instances"
 )
 
@@ -115,7 +115,7 @@ func checkCAASModelCredential(ctx stdcontext.Context, brokerParams environs.Open
 		return nil, errors.Trace(err)
 	}
 
-	if err = broker.CheckCloudCredentials(); err != nil {
+	if err = broker.CheckCloudCredentials(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return nil, nil

--- a/domain/credential/service/modelcredential_test.go
+++ b/domain/credential/service/modelcredential_test.go
@@ -488,7 +488,7 @@ func (m *mockCaasBroker) Namespaces() ([]string, error) {
 	return m.namespacesFunc()
 }
 
-func (m *mockCaasBroker) CheckCloudCredentials() error {
+func (m *mockCaasBroker) CheckCloudCredentials(_ context.Context) error {
 	// The k8s provider implements this via a list namespaces call to the cluster
 	_, err := m.namespacesFunc()
 	return err

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -135,6 +135,7 @@ type BootstrapLogger interface {
 // it is being invoked.
 type BootstrapContext interface {
 	BootstrapLogger
+	context.Context
 
 	// InterruptNotify starts watching for interrupt signals
 	// on behalf of the caller, sending them to the supplied
@@ -150,7 +151,4 @@ type BootstrapContext interface {
 	// ShouldVerifyCredentials indicates whether the caller's cloud
 	// credentials should be verified.
 	ShouldVerifyCredentials() bool
-
-	// Context is the context.Context value for this bootstrap command.
-	Context() context.Context
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -104,7 +104,7 @@ func (s *bootstrapSuite) TestBootstrapNeedsSettings(c *gc.C) {
 	env := newEnviron("bar", noKeysDefined, nil)
 	s.setDummyStorage(c, env)
 
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext,
 		bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
@@ -114,7 +114,7 @@ func (s *bootstrapSuite) TestBootstrapNeedsSettings(c *gc.C) {
 
 	controllerCfg := coretesting.FakeControllerConfig()
 	delete(controllerCfg, "ca-cert")
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig: controllerCfg,
 			AdminSecret:      "admin-secret",
@@ -123,14 +123,14 @@ func (s *bootstrapSuite) TestBootstrapNeedsSettings(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "validating bootstrap parameters: controller configuration has no ca-cert")
 
 	controllerCfg = coretesting.FakeControllerConfig()
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig: controllerCfg,
 			AdminSecret:      "admin-secret",
 		})
 	c.Assert(err, gc.ErrorMatches, "validating bootstrap parameters: empty ca-private-key")
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        controllerCfg,
 			AdminSecret:             "admin-secret",
@@ -143,7 +143,7 @@ func (s *bootstrapSuite) TestBootstrapNeedsSettings(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapTestingOptions(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:           coretesting.FakeControllerConfig(),
 			AdminSecret:                "admin-secret",
@@ -159,7 +159,7 @@ func (s *bootstrapSuite) TestBootstrapTestingOptions(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapEmptyConstraints(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -181,7 +181,7 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	s.setDummyStorage(c, env)
 	bootstrapCons := constraints.MustParse("cores=3 mem=7G")
 	modelCons := constraints.MustParse("cores=2 mem=4G")
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -199,7 +199,7 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapWithStoragePools(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -231,7 +231,7 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -254,7 +254,7 @@ func (s *bootstrapSuite) TestBootstrapFallbackBootstrapSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -275,7 +275,7 @@ func (s *bootstrapSuite) TestBootstrapForcedBootstrapSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -299,7 +299,7 @@ func (s *bootstrapSuite) TestBootstrapWithInvalidBootstrapBase(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -319,7 +319,7 @@ func (s *bootstrapSuite) TestBootstrapWithInvalidBootstrapSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -334,7 +334,7 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	placement := "directive"
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -375,7 +375,7 @@ func (s *bootstrapSuite) assertFinalizePodBootstrapConfig(c *gc.C, serviceType, 
 		ControllerExternalIPs:      externalIps,
 		ExtraAgentValuesForTesting: map[string]string{"foo": "bar"},
 	}
-	err = bootstrap.FinalizePodBootstrapConfig(envtesting.BootstrapTODOContext(c), podConfig, params, modelCfg)
+	err = bootstrap.FinalizePodBootstrapConfig(envtesting.BootstrapTestContext(c), podConfig, params, modelCfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(podConfig.Bootstrap.ControllerModelConfig, jc.DeepEquals, modelCfg)
 	c.Assert(podConfig.Bootstrap.ControllerServiceType, gc.Equals, serviceType)
@@ -407,7 +407,7 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	bootstrapCons := constraints.MustParse("arch=amd64")
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -446,7 +446,7 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToExistingProviderSupport
 	// Bootstrap should succeed with no failures as constraints validator used internally
 	// would have both provider supported architectures and architectures retrieved from images metadata.
 	bootstrapCons := constraints.MustParse(fmt.Sprintf("arch=%v", data.architecture))
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -529,7 +529,7 @@ func (s *bootstrapSuite) TestBootstrapAddsArchFromImageToProviderWithNoSupported
 	// Bootstrap should succeed with no failures as constraints validator used internally
 	// would have both provider supported architectures and architectures retrieved from images metadata.
 	bootstrapCons := constraints.MustParse(fmt.Sprintf("arch=%v", data.architecture))
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -629,11 +629,11 @@ func (s *bootstrapSuite) TestBootstrapLocalTools(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.CentOS })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:      "admin-secret",
 			CAPrivateKey:     coretesting.CAKey,
@@ -657,11 +657,11 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsMismatchingOS(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Windows })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:      "admin-secret",
 			CAPrivateKey:     coretesting.CAKey,
@@ -682,11 +682,11 @@ func (s *bootstrapSuite) TestBootstrapLocalToolsDifferentLinuxes(c *gc.C) {
 
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.GenericLinux })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:      "admin-secret",
 			CAPrivateKey:     coretesting.CAKey,
@@ -708,13 +708,13 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		c.Fatal("should not call FindTools if BuildAgent is specified")
 		return nil, errors.NotFoundf("tools")
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			BuildAgent:       true,
 			AdminSecret:      "admin-secret",
@@ -755,7 +755,7 @@ func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientAr
 	s.PatchValue(&arch.HostArch, func() string { return clientArch })
 	toolsArch := clientArch
 	findToolsOk := false
-	s.PatchValue(bootstrap.FindTools, func(_ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
 		c.Assert(filter.Arch, gc.Equals, toolsArch)
 		c.Assert(filter.OSType, gc.Equals, "ubuntu")
 		findToolsOk = true
@@ -770,7 +770,7 @@ func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientAr
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "admin-secret",
 			CAPrivateKey:            coretesting.CAKey,
@@ -796,12 +796,12 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 	// Patch out HostArch and FindTools to allow the test to pass on other architectures,
 	// such as s390.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-stream": "proposed"})
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:      "admin-secret",
 			CAPrivateKey:     coretesting.CAKey,
@@ -818,12 +818,12 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 
 func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"development": true})
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			AdminSecret:      "admin-secret",
@@ -947,7 +947,7 @@ func createImageMetadataForArch(c *gc.C, arch string) (dir string, _ []*imagemet
 	c.Assert(err, jc.ErrorIsNil)
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 	base := corebase.MustParseBaseFromString("ubuntu@16.04")
-	err = imagemetadata.MergeAndWriteMetadata(ss, base, im, cloudSpec, sourceStor)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, base, im, cloudSpec, sourceStor)
 	c.Assert(err, jc.ErrorIsNil)
 	return sourceDir, im
 }
@@ -998,7 +998,7 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapMetadataDirNonexistend(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	nonExistentFileName := "/tmp/TestBootstrapMetadataDirNonexistend"
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -1098,7 +1098,7 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 		CloudCredential:         &credential,
 		SupportedBootstrapBases: supportedJujuBases,
 	}
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env, s.callContext, args)
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env, s.callContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.instanceConfig, gc.NotNil)
@@ -1114,7 +1114,7 @@ func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 	s.PatchEnvironment("JUJU_STREAMS_PUBLICKEY_FILE", path)
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             "admin-secret",
@@ -1145,7 +1145,7 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 	}
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:          coretesting.FakeControllerConfig(),
 			ControllerInheritedConfig: map[string]interface{}{"ftp-proxy": "http://proxy"},
@@ -1243,7 +1243,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, cli
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			AdminSecret:      "admin-secret",
@@ -1323,13 +1323,13 @@ func (s *bootstrapSuite) TestAvailableToolsInvalidArch(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string {
 		return arch.S390X
 	})
-	s.PatchValue(bootstrap.FindTools, func(envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		c.Fatal("find packaged tools should not be called")
 		return nil, errors.New("unexpected")
 	})
 
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			BuildAgent:       true,
 			AdminSecret:      "admin-secret",
@@ -1351,7 +1351,7 @@ func (s *bootstrapSuite) TestAvailableToolsInvalidArch(c *gc.C) {
 
 func (s *bootstrapSuite) TestTargetSeriesOverride(c *gc.C) {
 	env := newBootstrapEnvironWithHardwareDetection("foo", "artful", "amd64", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
 			CAPrivateKey:            coretesting.CAKey,
@@ -1364,7 +1364,7 @@ func (s *bootstrapSuite) TestTargetSeriesOverride(c *gc.C) {
 
 func (s *bootstrapSuite) TestTargetArchOverride(c *gc.C) {
 	env := newBootstrapEnvironWithHardwareDetection("foo", "bionic", "riscv", useDefaultKeys, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
 			CAPrivateKey:            coretesting.CAKey,
@@ -1395,7 +1395,7 @@ func (s *bootstrapSuite) TestTargetSeriesAndArchOverridePriority(c *gc.C) {
 	envtesting.UploadFakeTools(c, stor, "released", "released")
 
 	env := newBootstrapEnvironWithHardwareDetection("foo", "haiku", "riscv", useDefaultKeys, nil)
-	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err = bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
 			CAPrivateKey:            coretesting.CAKey,

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -133,10 +133,10 @@ func PrepareController(
 	}
 	if isCAASController {
 		details.ModelType = model.CAAS
-		env, err = caas.Open(ctx.Context(), p, openParams)
+		env, err = caas.Open(ctx, p, openParams)
 	} else {
 		details.ModelType = model.IAAS
-		env, err = environs.Open(ctx.Context(), p, openParams)
+		env, err = environs.Open(ctx, p, openParams)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -55,7 +55,7 @@ func (s *PrepareSuite) assertPrepare(c *gc.C, skipVerify bool) {
 	cfg, err := config.New(config.NoDefaults, baselineAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	controllerStore := jujuclient.NewMemStore()
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	controllerCfg := controller.Config{
 		controller.ControllerUUIDKey:       testing.ControllerTag.Id(),
 		controller.CACertKey:               testing.CACert,

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -4,6 +4,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -60,6 +61,7 @@ func validateUploadAllowed(env environs.ConfigGetter, toolsArch *string, toolsBa
 
 // findPackagedTools returns a list of tools for in simplestreams.
 func findPackagedTools(
+	ctx context.Context,
 	env environs.BootstrapEnviron,
 	ss envtools.SimplestreamsFetcher,
 	vers *version.Number,
@@ -76,7 +78,7 @@ func findPackagedTools(
 		}
 	}
 	logger.Infof("looking for bootstrap agent binaries: version=%v", vers)
-	toolsList, findToolsErr := findBootstrapTools(env, ss, vers, arch, base)
+	toolsList, findToolsErr := findBootstrapTools(ctx, env, ss, vers, arch, base)
 	logger.Infof("found %d packaged agent binaries", len(toolsList))
 	if findToolsErr != nil {
 		return nil, findToolsErr
@@ -106,7 +108,7 @@ func locallyBuildableTools() (buildable coretools.List, _ version.Number, _ erro
 // which it would be reasonable to launch an environment's first machine,
 // given the supplied constraints. If a specific agent version is not requested,
 // all tools matching the current major.minor version are chosen.
-func findBootstrapTools(env environs.BootstrapEnviron, ss envtools.SimplestreamsFetcher, vers *version.Number, arch *string, base *corebase.Base) (list coretools.List, err error) {
+func findBootstrapTools(ctx context.Context, env environs.BootstrapEnviron, ss envtools.SimplestreamsFetcher, vers *version.Number, arch *string, base *corebase.Base) (list coretools.List, err error) {
 	// Construct a tools filter.
 	cliVersion := jujuversion.Current
 	var filter coretools.Filter
@@ -121,5 +123,5 @@ func findBootstrapTools(env environs.BootstrapEnviron, ss envtools.Simplestreams
 		filter.Number = *vers
 	}
 	streams := envtools.PreferredStreams(vers, env.Config().Development(), env.Config().AgentStream())
-	return findTools(ss, env, cliVersion.Major, cliVersion.Minor, streams, filter)
+	return findTools(ctx, ss, env, cliVersion.Major, cliVersion.Minor, streams, filter)
 }

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -4,6 +4,7 @@
 package imagedownloads
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"sort"
@@ -81,6 +82,7 @@ func (m *Metadata) DownloadURL(baseURL string) (*url.URL, error) {
 // Fetch gets product results as Metadata from the provided datasources, given
 // some constraints and an optional filter function.
 func Fetch(
+	ctx context.Context,
 	fetcher imagemetadata.SimplestreamsFetcher,
 	src []simplestreams.DataSource,
 	cons *imagemetadata.ImageConstraint,
@@ -98,7 +100,7 @@ func Fetch(
 		},
 	}
 
-	items, resolveInfo, err := fetcher.GetMetadata(src, params)
+	items, resolveInfo, err := fetcher.GetMetadata(ctx, src, params)
 	if err != nil {
 		return nil, resolveInfo, err
 	}
@@ -158,7 +160,7 @@ func validateArgs(arch, release, stream, ftype string) error {
 //   - File image type.
 //
 // src exists to pass in a data source for testing.
-func One(fetcher imagemetadata.SimplestreamsFetcher, arch, release, stream, ftype string, src func() simplestreams.DataSource) (*Metadata, error) {
+func One(ctx context.Context, fetcher imagemetadata.SimplestreamsFetcher, arch, release, stream, ftype string, src func() simplestreams.DataSource) (*Metadata, error) {
 	if err := validateArgs(arch, release, stream, ftype); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -177,7 +179,7 @@ func One(fetcher imagemetadata.SimplestreamsFetcher, arch, release, stream, ftyp
 		return nil, errors.Trace(err)
 	}
 
-	md, _, err := Fetch(fetcher, ds, limit, Filter(ftype))
+	md, _, err := Fetch(ctx, fetcher, ds, limit, Filter(ftype))
 	if err != nil {
 		// It doesn't appear that arch is vetted anywhere else so we can wind
 		// up with empty results if someone requests any arch with valid series

--- a/environs/imagedownloads/simplestreams_test.go
+++ b/environs/imagedownloads/simplestreams_test.go
@@ -4,6 +4,7 @@
 package imagedownloads_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,7 +81,7 @@ func (*Suite) TestFetchManyDefaultFilter(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)
+	got, resolveInfo, err := Fetch(context.Background(), ss, tds, constraints, nil)
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(got), jc.DeepEquals, 27)
@@ -107,7 +108,7 @@ func (*Suite) TestFetchManyDefaultFilterAndCustomImageDownloadURL(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)
+	got, resolveInfo, err := Fetch(context.Background(), ss, tds, constraints, nil)
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(got), jc.DeepEquals, 27)
@@ -134,7 +135,7 @@ func (*Suite) TestFetchSingleDefaultFilter(c *gc.C) {
 			Arches:   []string{"ppc64el"},
 			Releases: []string{"16.04"},
 		}}
-	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)
+	got, resolveInfo, err := Fetch(context.Background(), ss, tds, constraints, nil)
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(got), jc.DeepEquals, 8)
@@ -157,7 +158,7 @@ func (*Suite) TestFetchOneWithFilter(c *gc.C) {
 			Arches:   []string{"ppc64el"},
 			Releases: []string{"16.04"},
 		}}
-	got, resolveInfo, err := Fetch(ss, tds, constraints, Filter("disk1.img"))
+	got, resolveInfo, err := Fetch(context.Background(), ss, tds, constraints, Filter("disk1.img"))
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(got), jc.DeepEquals, 1)
@@ -184,7 +185,7 @@ func (*Suite) TestFetchManyWithFilter(c *gc.C) {
 			Arches:   []string{"amd64", "arm64", "ppc64el"},
 			Releases: []string{"16.04"},
 		}}
-	got, resolveInfo, err := Fetch(ss, tds, constraints, Filter("disk1.img"))
+	got, resolveInfo, err := Fetch(context.Background(), ss, tds, constraints, Filter("disk1.img"))
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(got), jc.DeepEquals, 3)
@@ -206,7 +207,7 @@ func (*Suite) TestOneAmd64XenialTarGz(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
-	got, err := One(ss, "amd64", "16.04", "", "tar.gz", newTestDataSourceFunc(ts.URL))
+	got, err := One(context.Background(), ss, "amd64", "16.04", "", "tar.gz", newTestDataSourceFunc(ts.URL))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(got, jc.DeepEquals, &Metadata{
 		Arch:    "amd64",
@@ -223,7 +224,7 @@ func (*Suite) TestOneArm64JammyImg(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
-	got, err := One(ss, "arm64", "22.04", "released", "disk1.img", newTestDataSourceFunc(ts.URL))
+	got, err := One(context.Background(), ss, "arm64", "22.04", "released", "disk1.img", newTestDataSourceFunc(ts.URL))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(got, jc.DeepEquals, &Metadata{
 		Arch:    "arm64",
@@ -240,7 +241,7 @@ func (*Suite) TestOneArm64FocalImg(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
-	got, err := One(ss, "arm64", "20.04", "released", "disk1.img", newTestDataSourceFunc(ts.URL))
+	got, err := One(context.Background(), ss, "arm64", "20.04", "released", "disk1.img", newTestDataSourceFunc(ts.URL))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(got, jc.DeepEquals, &Metadata{
 		Arch:    "arm64",
@@ -271,7 +272,7 @@ func (*Suite) TestOneErrors(c *gc.C) {
 	defer ts.Close()
 	for i, test := range table {
 		c.Logf("test % 1d: %s\n", i+1, test.description)
-		_, err := One(ss, test.arch, test.version, test.stream, test.ftype, newTestDataSourceFunc(ts.URL))
+		_, err := One(context.Background(), ss, test.arch, test.version, test.stream, test.ftype, newTestDataSourceFunc(ts.URL))
 		c.Check(err, gc.ErrorMatches, test.errorMatch)
 	}
 }

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -4,6 +4,8 @@
 package imagemetadata_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -40,7 +42,7 @@ func assertFetch(c *gc.C, ss *simplestreams.Simplestreams, stor storage.Storage,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
-	metadata, _, err := imagemetadata.Fetch(ss, []simplestreams.DataSource{dataSource}, cons)
+	metadata, _, err := imagemetadata.Fetch(context.Background(), ss, []simplestreams.DataSource{dataSource}, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, len(ids))
 	for i, id := range ids {
@@ -64,7 +66,7 @@ func (s *generateSuite) TestWriteMetadata(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, im, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, im, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	metadata := testing.ParseMetadataFromDir(c, dir)
 	c.Assert(metadata, gc.HasLen, 1)
@@ -90,7 +92,7 @@ func (s *generateSuite) TestWriteMetadataMergeOverwriteSameArch(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	newImageMetadata := []*imagemetadata.ImageMetadata{
 		{
@@ -104,7 +106,7 @@ func (s *generateSuite) TestWriteMetadataMergeOverwriteSameArch(c *gc.C) {
 			Version: testVersion,
 		},
 	}
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	metadata := testing.ParseMetadataFromDir(c, dir)
 	c.Assert(metadata, gc.HasLen, 2)
@@ -133,7 +135,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentSeries(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	newImageMetadata := []*imagemetadata.ImageMetadata{
 		{
@@ -148,7 +150,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentSeries(c *gc.C) {
 		},
 	}
 	base := corebase.MustParseBaseFromString("ubuntu@12.04")
-	err = imagemetadata.MergeAndWriteMetadata(ss, base, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, base, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	metadata := testing.ParseMetadataFromDir(c, dir)
 	c.Assert(metadata, gc.HasLen, 3)
@@ -179,7 +181,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentRegion(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	newImageMetadata := []*imagemetadata.ImageMetadata{
 		{
@@ -197,7 +199,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentRegion(c *gc.C) {
 		Region:   "region2",
 		Endpoint: "endpoint2",
 	}
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	metadata := testing.ParseMetadataFromDir(c, dir)
 	c.Assert(metadata, gc.HasLen, 3)
@@ -232,7 +234,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentVirtType(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	newImageMetadata := []*imagemetadata.ImageMetadata{
 		{
@@ -242,7 +244,7 @@ func (s *generateSuite) TestWriteMetadataMergeDifferentVirtType(c *gc.C) {
 			VirtType: "lxd",
 		},
 	}
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
 	foundMetadata := testing.ParseMetadataFromDir(c, dir)
@@ -275,7 +277,7 @@ func (s *generateSuite) TestWriteIndexRegionOnce(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 	newImageMetadata := []*imagemetadata.ImageMetadata{
 		{
@@ -285,7 +287,7 @@ func (s *generateSuite) TestWriteIndexRegionOnce(c *gc.C) {
 			VirtType: "lxd",
 		},
 	}
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
 	foundIndex, _ := testing.ParseIndexMetadataFromStorage(c, targetStorage)
@@ -310,7 +312,7 @@ func (s *generateSuite) TestWriteDistinctIndexRegions(c *gc.C) {
 	dir := c.MkDir()
 	targetStorage, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, existingImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedCloudSpecs := []simplestreams.CloudSpec{*cloudSpec}
@@ -327,7 +329,7 @@ func (s *generateSuite) TestWriteDistinctIndexRegions(c *gc.C) {
 		Region:   "region2",
 		Endpoint: "endpoint2",
 	}
-	err = imagemetadata.MergeAndWriteMetadata(ss, testBase, newImageMetadata, cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, testBase, newImageMetadata, cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 
 	foundIndex, _ := testing.ParseIndexMetadataFromStorage(c, targetStorage)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -4,6 +4,7 @@
 package imagemetadata
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -225,7 +226,7 @@ func (im *ImageMetadata) productId() string {
 // server.
 type SimplestreamsFetcher interface {
 	NewDataSource(simplestreams.Config) simplestreams.DataSource
-	GetMetadata([]simplestreams.DataSource, simplestreams.GetMetadataParams) ([]interface{}, *simplestreams.ResolveInfo, error)
+	GetMetadata(context.Context, []simplestreams.DataSource, simplestreams.GetMetadataParams) ([]interface{}, *simplestreams.ResolveInfo, error)
 }
 
 // Fetch returns a list of images for the specified cloud matching the
@@ -233,7 +234,7 @@ type SimplestreamsFetcher interface {
 // which has a file is the one used.
 // Signed data is preferred, but if there is no signed data available and
 // onlySigned is false, then unsigned data is used.
-func Fetch(fetcher SimplestreamsFetcher, sources []simplestreams.DataSource, cons *ImageConstraint) ([]*ImageMetadata, *simplestreams.ResolveInfo, error) {
+func Fetch(ctx context.Context, fetcher SimplestreamsFetcher, sources []simplestreams.DataSource, cons *ImageConstraint) ([]*ImageMetadata, *simplestreams.ResolveInfo, error) {
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   currentStreamsVersion,
 		LookupConstraint: cons,
@@ -244,7 +245,7 @@ func Fetch(fetcher SimplestreamsFetcher, sources []simplestreams.DataSource, con
 		},
 	}
 
-	items, resolveInfo, err := fetcher.GetMetadata(sources, params)
+	items, resolveInfo, err := fetcher.GetMetadata(ctx, sources, params)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -5,6 +5,7 @@ package imagemetadata_test
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -327,7 +328,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		// Add invalid datasource and check later that resolveInfo is correct.
 		invalidSource := sstesting.InvalidDataSource(s.RequireSigned)
-		images, resolveInfo, err := imagemetadata.Fetch(ss,
+		images, resolveInfo, err := imagemetadata.Fetch(context.Background(), ss,
 			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint)
 		if !c.Check(err, jc.ErrorIsNil) {
 			continue
@@ -425,7 +426,7 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 		Arches:   []string{"amd64"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	images, resolveInfo, err := imagemetadata.Fetch(ss, []simplestreams.DataSource{signedSource}, imageConstraint)
+	images, resolveInfo, err := imagemetadata.Fetch(context.Background(), ss, []simplestreams.DataSource{signedSource}, imageConstraint)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(images), gc.Equals, 1)
 	c.Assert(images[0].Id, gc.Equals, "ami-123456")
@@ -456,7 +457,7 @@ func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	imagemetadata.SetSigningPublicKey(s.origKey)
-	_, _, err = imagemetadata.Fetch(ss, []simplestreams.DataSource{signedSource}, imageConstraint)
+	_, _, err = imagemetadata.Fetch(context.Background(), ss, []simplestreams.DataSource{signedSource}, imageConstraint)
 	c.Assert(err, gc.ErrorMatches, "cannot read index data.*")
 }
 

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path"
@@ -50,6 +51,7 @@ func ParseIndexMetadataFromStorage(c *gc.C, stor storage.StorageReader) (*simple
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 	indexRef, err := ss.GetIndexWithFormat(
+		context.Background(),
 		source, indexPath, "index:1.0", mirrorsPath, requireSigned, simplestreams.CloudSpec{}, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(indexRef.Indexes, gc.HasLen, 1)

--- a/environs/imagemetadata/validation.go
+++ b/environs/imagemetadata/validation.go
@@ -4,6 +4,7 @@
 package imagemetadata
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -13,7 +14,7 @@ import (
 
 // ValidateImageMetadata attempts to load image metadata for the specified cloud attributes and stream
 // and returns any image ids found, or an error if the metadata could not be loaded.
-func ValidateImageMetadata(fetcher SimplestreamsFetcher, params *simplestreams.MetadataLookupParams) ([]string, *simplestreams.ResolveInfo, error) {
+func ValidateImageMetadata(ctx context.Context, fetcher SimplestreamsFetcher, params *simplestreams.MetadataLookupParams) ([]string, *simplestreams.ResolveInfo, error) {
 	if params.Release == "" {
 		return nil, nil, fmt.Errorf("required parameter series not specified")
 	}
@@ -38,7 +39,7 @@ func ValidateImageMetadata(fetcher SimplestreamsFetcher, params *simplestreams.M
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	matchingImages, resolveInfo, err := Fetch(fetcher, params.Sources, imageConstraint)
+	matchingImages, resolveInfo, err := Fetch(ctx, fetcher, params.Sources, imageConstraint)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -4,6 +4,7 @@
 package imagemetadata_test
 
 import (
+	"context"
 	"path"
 	"path/filepath"
 
@@ -40,7 +41,7 @@ func (s *ValidateSuite) makeLocalMetadata(c *gc.C, ss *simplestreams.Simplestrea
 	}
 	targetStorage, err := filestorage.NewFileStorageWriter(s.metadataDir)
 	c.Assert(err, jc.ErrorIsNil)
-	err = imagemetadata.MergeAndWriteMetadata(ss, base, metadata, &cloudSpec, targetStorage)
+	err = imagemetadata.MergeAndWriteMetadata(context.Background(), ss, base, metadata, &cloudSpec, targetStorage)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -62,7 +63,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, ss *simplestreams.Simplestreams, st
 		Sources: []simplestreams.DataSource{
 			sstesting.VerifyDefaultCloudDataSource("test", utils.MakeFileURL(metadataPath))},
 	}
-	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(ss, params)
+	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(imageIds, gc.DeepEquals, []string{"1234"})
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
@@ -92,7 +93,7 @@ func (s *ValidateSuite) assertNoMatch(c *gc.C, ss *simplestreams.Simplestreams, 
 		Sources: []simplestreams.DataSource{
 			sstesting.VerifyDefaultCloudDataSource("test", "file://"+s.metadataDir)},
 	}
-	_, _, err := imagemetadata.ValidateImageMetadata(ss, params)
+	_, _, err := imagemetadata.ValidateImageMetadata(context.Background(), ss, params)
 	c.Assert(err, gc.Not(gc.IsNil))
 }
 

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -28,7 +28,7 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package testing -destination testing/package_mock.go -write_package_comment=false github.com/juju/juju/environs EnvironProvider,CloudEnvironProvider,ProviderSchema,ProviderCredentials,FinalizeCredentialContext,FinalizeCloudContext,CloudFinalizer,CloudDetector,CloudRegionDetector,ModelConfigUpgrader,ConfigGetter,CloudDestroyer,Environ,InstancePrechecker,Firewaller,InstanceTagger,InstanceTypesFetcher,Upgrader,UpgradeStep,DefaultConstraintsChecker,ProviderCredentialsRegister,RequestFinalizeCredential,NetworkingEnviron
 
 type ConnectorInfo interface {
-	ConnectionProxyInfo() (proxy.Proxier, error)
+	ConnectionProxyInfo(ctx stdcontext.Context) (proxy.Proxier, error)
 }
 
 // A EnvironProvider represents a computing and storage provider
@@ -214,6 +214,8 @@ type FinalizeCredentialParams struct {
 // to provide a means of interacting with the user when finalizing
 // a cloud definition.
 type FinalizeCloudContext interface {
+	stdcontext.Context
+
 	// Verbosef will write the formatted string to Stderr if the
 	// verbose flag is true, and to the logger if not.
 	Verbosef(string, ...interface{})

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -139,7 +139,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	ctx := stdcontext.WithValue(stdcontext.TODO(), bootstrap.SimplestreamsFetcherContextKey, ss)
+	ctx := stdcontext.WithValue(stdcontext.Background(), bootstrap.SimplestreamsFetcherContextKey, ss)
 	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
 	t.ProviderCallContext = envcontext.WithoutCredentialInvalidator(ctx)
 }
@@ -237,7 +237,7 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInstances, gc.Not(gc.HasLen), 0)
 
-	e2 := t.Open(c, t.BootstrapContext.Context(), e.Config())
+	e2 := t.Open(c, t.BootstrapContext, e.Config())
 	controllerInstances2, err := e2.ControllerInstances(t.ProviderCallContext, t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInstances2, gc.Not(gc.HasLen), 0)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -69,7 +69,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, cfg.AgentStream(), cfg.AgentStream())
-	err = bootstrap.Bootstrap(ctx, env, envcontext.WithoutCredentialInvalidator(ctx.Context()), bootstrap.BootstrapParams{
+	err = bootstrap.Bootstrap(ctx, env, envcontext.WithoutCredentialInvalidator(ctx), bootstrap.BootstrapParams{
 		ControllerConfig:        controllerCfg,
 		AdminSecret:             "admin-secret",
 		CAPrivateKey:            testing.CAKey,
@@ -168,7 +168,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	_, err = store.ControllerByName("controller-name")
 	c.Assert(err, jc.ErrorIsNil)
 
-	callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
+	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	err = environs.Destroy("controller-name", e, callCtx, store)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/environs/simplestreams/fetchdata_test.go
+++ b/environs/simplestreams/fetchdata_test.go
@@ -5,6 +5,7 @@ package simplestreams_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	jc "github.com/juju/testing/checkers"
@@ -130,14 +131,14 @@ func (s *fetchDataSuite) setupDataSource(key string) {
 }
 
 func (s *fetchDataSuite) assertFetchData(c *gc.C) {
-	data, _, err := simplestreams.FetchData(s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
+	data, _, err := simplestreams.FetchData(context.Background(), s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert([]byte(s.expectedData), gc.DeepEquals, data)
 	s.source.CheckCallNames(c, s.expectedCalls...)
 }
 
 func (s *fetchDataSuite) assertFetchDataFail(c *gc.C, msg string) {
-	data, _, err := simplestreams.FetchData(s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
+	data, _, err := simplestreams.FetchData(context.Background(), s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
 	c.Assert(err, gc.ErrorMatches, msg)
 	c.Assert(data, gc.IsNil)
 	s.source.CheckCallNames(c, s.expectedCalls...)

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -4,6 +4,7 @@
 package simplestreams_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -344,7 +345,7 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	}
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	items, resolveInfo, err := ss.GetMetadata(sources, params)
+	items, resolveInfo, err := ss.GetMetadata(context.Background(), sources, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(items, gc.HasLen, 0)
 	c.Assert(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
@@ -496,7 +497,7 @@ func (s *simplestreamsSuite) TestGetMirrorMetadata(c *gc.C) {
 		}
 		ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 		indexRef, err := ss.GetIndexWithFormat(
-			s.Source, s.IndexPath(), sstesting.Index_v1,
+			context.Background(), s.Source, s.IndexPath(), sstesting.Index_v1,
 			simplestreams.MirrorsPath("v1"), s.RequireSigned, cloud, params)
 		if !c.Check(err, jc.ErrorIsNil) {
 			continue

--- a/environs/simplestreams/testing/stub.go
+++ b/environs/simplestreams/testing/stub.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"io"
 
 	"github.com/juju/testing"
@@ -50,31 +51,31 @@ func (s *StubDataSource) Description() string {
 	return s.DescriptionFunc()
 }
 
-// Description implements simplestreams.DataSource.
-func (s *StubDataSource) Fetch(path string) (io.ReadCloser, string, error) {
+// Fetch implements simplestreams.DataSource.
+func (s *StubDataSource) Fetch(ctx context.Context, path string) (io.ReadCloser, string, error) {
 	s.MethodCall(s, "Fetch", path)
 	return s.FetchFunc(path)
 }
 
-// Description implements simplestreams.DataSource.
+// URL implements simplestreams.DataSource.
 func (s *StubDataSource) URL(path string) (string, error) {
 	s.MethodCall(s, "URL", path)
 	return s.URLFunc(path)
 }
 
-// Description implements simplestreams.DataSource.
+// PublicSigningKey implements simplestreams.DataSource.
 func (s *StubDataSource) PublicSigningKey() string {
 	s.MethodCall(s, "PublicSigningKey")
 	return s.PublicSigningKeyFunc()
 }
 
-// Description implements simplestreams.DataSource.
+// Priority implements simplestreams.DataSource.
 func (s *StubDataSource) Priority() int {
 	s.MethodCall(s, "Priority")
 	return s.PriorityFunc()
 }
 
-// Description implements simplestreams.DataSource.
+// RequireSigned implements simplestreams.DataSource.
 func (s *StubDataSource) RequireSigned() bool {
 	s.MethodCall(s, "RequireSigned")
 	return s.RequireSignedFunc()

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -6,6 +6,7 @@ package testing
 // Provides a TestDataSuite which creates and provides http access to sample simplestreams metadata.
 
 import (
+	stdcontext "context"
 	"fmt"
 	"io"
 	"net/http"
@@ -732,6 +733,7 @@ func (s *LocalLiveSimplestreamsSuite) GetIndexRef(format string) (*simplestreams
 	}
 	ss := simplestreams.NewSimpleStreams(TestDataSourceFactory())
 	return ss.GetIndexWithFormat(
+		stdcontext.Background(),
 		s.Source, s.IndexPath(),
 		format,
 		simplestreams.MirrorsPath(s.StreamsVersion),
@@ -781,7 +783,7 @@ func (s *LocalLiveSimplestreamsSuite) TestGetProductsPathInvalidProductSpec(c *g
 func (s *LocalLiveSimplestreamsSuite) AssertGetMetadata(c *gc.C) *simplestreams.CloudMetadata {
 	indexRef, err := s.GetIndexRef(Index_v1)
 	c.Assert(err, jc.ErrorIsNil)
-	metadata, err := indexRef.GetCloudMetadataWithFormat(s.ValidConstraint, Product_v1, s.RequireSigned)
+	metadata, err := indexRef.GetCloudMetadataWithFormat(stdcontext.Background(), s.ValidConstraint, Product_v1, s.RequireSigned)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata.Format, gc.Equals, Product_v1)
 	c.Assert(len(metadata.Products) > 0, jc.IsTrue)

--- a/environs/storage/storage.go
+++ b/environs/storage/storage.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path"
@@ -103,7 +104,7 @@ func (s *storageSimpleStreamsDataSource) Description() string {
 }
 
 // Fetch is defined in simplestreams.DataSource.
-func (s *storageSimpleStreamsDataSource) Fetch(path string) (io.ReadCloser, string, error) {
+func (s *storageSimpleStreamsDataSource) Fetch(_ context.Context, path string) (io.ReadCloser, string, error) {
 	relpath := s.relpath(path)
 	dataURL := relpath
 	fullURL, err := s.storage.URL(relpath)

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	stdtesting "testing"
@@ -46,7 +47,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
 	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA, false)
-	rc, url, err := ds.Fetch("foo/bar/data.txt")
+	rc, url, err := ds.Fetch(context.Background(), "foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
 	c.Assert(url, gc.Equals, s.baseURL+"/foo/bar/data.txt")
@@ -59,7 +60,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
 	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
-	rc, url, err := ds.Fetch("foo/bar/data.txt")
+	rc, url, err := ds.Fetch(context.Background(), "foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
 	c.Assert(url, gc.Equals, s.baseURL+"/base/foo/bar/data.txt")
@@ -71,7 +72,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 func (s *datasourceSuite) TestFetchWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
 	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
-	_, _, err := ds.Fetch("foo/bar/data.txt")
+	_, _, err := ds.Fetch(context.Background(), "foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(stor.getName, gc.Equals, "base/foo/bar/data.txt")
 	c.Assert(stor.invokeCount, gc.Equals, 10)

--- a/environs/sync/simplestreams_mock_test.go
+++ b/environs/sync/simplestreams_mock_test.go
@@ -10,6 +10,7 @@
 package sync_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	simplestreams "github.com/juju/juju/environs/simplestreams"
@@ -40,9 +41,9 @@ func (m *MockSimplestreamsFetcher) EXPECT() *MockSimplestreamsFetcherMockRecorde
 }
 
 // GetMetadata mocks base method.
-func (m *MockSimplestreamsFetcher) GetMetadata(arg0 []simplestreams.DataSource, arg1 simplestreams.GetMetadataParams) ([]any, *simplestreams.ResolveInfo, error) {
+func (m *MockSimplestreamsFetcher) GetMetadata(arg0 context.Context, arg1 []simplestreams.DataSource, arg2 simplestreams.GetMetadataParams) ([]any, *simplestreams.ResolveInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetMetadata", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]any)
 	ret1, _ := ret[1].(*simplestreams.ResolveInfo)
 	ret2, _ := ret[2].(error)
@@ -50,9 +51,9 @@ func (m *MockSimplestreamsFetcher) GetMetadata(arg0 []simplestreams.DataSource, 
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockSimplestreamsFetcherMockRecorder) GetMetadata(arg0, arg1 any) *gomock.Call {
+func (mr *MockSimplestreamsFetcherMockRecorder) GetMetadata(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockSimplestreamsFetcher)(nil).GetMetadata), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockSimplestreamsFetcher)(nil).GetMetadata), arg0, arg1, arg2)
 }
 
 // NewDataSource mocks base method.

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	environscmd "github.com/juju/juju/environs/cmd"
-	envcontext "github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	"github.com/juju/juju/provider/common"
@@ -46,6 +46,6 @@ func BootstrapContext(ctx context.Context, c *gc.C) environs.BootstrapContext {
 	return environscmd.BootstrapContext(ctx, cmdtesting.Context(c))
 }
 
-func BootstrapTODOContext(c *gc.C) environs.BootstrapContext {
-	return BootstrapContext(context.TODO(), c)
+func BootstrapTestContext(c *gc.C) environs.BootstrapContext {
+	return BootstrapContext(context.Background(), c)
 }

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -10,6 +10,7 @@ import (
 	context "context"
 	io "io"
 	reflect "reflect"
+	time "time"
 
 	jsonschema "github.com/juju/jsonschema"
 	cloud "github.com/juju/juju/cloud"
@@ -500,6 +501,63 @@ func NewMockFinalizeCloudContext(ctrl *gomock.Controller) *MockFinalizeCloudCont
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFinalizeCloudContext) EXPECT() *MockFinalizeCloudContextMockRecorder {
 	return m.recorder
+}
+
+// Deadline mocks base method.
+func (m *MockFinalizeCloudContext) Deadline() (time.Time, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deadline")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// Deadline indicates an expected call of Deadline.
+func (mr *MockFinalizeCloudContextMockRecorder) Deadline() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deadline", reflect.TypeOf((*MockFinalizeCloudContext)(nil).Deadline))
+}
+
+// Done mocks base method.
+func (m *MockFinalizeCloudContext) Done() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Done")
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// Done indicates an expected call of Done.
+func (mr *MockFinalizeCloudContextMockRecorder) Done() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockFinalizeCloudContext)(nil).Done))
+}
+
+// Err mocks base method.
+func (m *MockFinalizeCloudContext) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err.
+func (mr *MockFinalizeCloudContextMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockFinalizeCloudContext)(nil).Err))
+}
+
+// Value mocks base method.
+func (m *MockFinalizeCloudContext) Value(arg0 any) any {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Value", arg0)
+	ret0, _ := ret[0].(any)
+	return ret0
+}
+
+// Value indicates an expected call of Value.
+func (mr *MockFinalizeCloudContextMockRecorder) Value(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockFinalizeCloudContext)(nil).Value), arg0)
 }
 
 // Verbosef mocks base method.

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -111,7 +111,7 @@ func PrimeTools(c *gc.C, stor storage.Storage, dataDir, toolsDir string, vers ve
 	agentTools, err := uploadFakeToolsVersion(stor, toolsDir, vers)
 	c.Assert(err, jc.ErrorIsNil)
 	client := http.NewClient()
-	resp, err := client.Get(context.TODO(), agentTools.URL)
+	resp, err := client.Get(context.Background(), agentTools.URL)
 	c.Assert(err, jc.ErrorIsNil)
 	defer resp.Body.Close()
 	err = agenttools.UnpackTools(dataDir, agentTools, resp.Body)
@@ -174,7 +174,7 @@ func UploadFakeToolsVersions(store storage.Storage, toolsDir, stream string, ver
 		}
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	if err := envtools.MergeAndWriteMetadata(ss, store, toolsDir, stream, agentTools, envtools.DoNotWriteMirrors); err != nil {
+	if err := envtools.MergeAndWriteMetadata(context.Background(), ss, store, toolsDir, stream, agentTools, envtools.DoNotWriteMirrors); err != nil {
 		return nil, err
 	}
 	err := SignTestTools(store)

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -159,14 +160,14 @@ func (t *ToolsMetadata) productId() (string, error) {
 // server.
 type SimplestreamsFetcher interface {
 	NewDataSource(simplestreams.Config) simplestreams.DataSource
-	GetMetadata([]simplestreams.DataSource, simplestreams.GetMetadataParams) ([]interface{}, *simplestreams.ResolveInfo, error)
+	GetMetadata(context.Context, []simplestreams.DataSource, simplestreams.GetMetadataParams) ([]interface{}, *simplestreams.ResolveInfo, error)
 }
 
 // Fetch returns a list of tools for the specified cloud matching the constraint.
 // The base URL locations are as specified - the first location which has a file is the one used.
 // Signed data is preferred, but if there is no signed data available and onlySigned is false,
 // then unsigned data is used.
-func Fetch(ss SimplestreamsFetcher, sources []simplestreams.DataSource, cons *ToolsConstraint,
+func Fetch(ctx context.Context, ss SimplestreamsFetcher, sources []simplestreams.DataSource, cons *ToolsConstraint,
 ) ([]*ToolsMetadata, *simplestreams.ResolveInfo, error) {
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   currentStreamsVersion,
@@ -178,7 +179,7 @@ func Fetch(ss SimplestreamsFetcher, sources []simplestreams.DataSource, cons *To
 			ValueTemplate:   ToolsMetadata{},
 		},
 	}
-	items, resolveInfo, err := ss.GetMetadata(sources, params)
+	items, resolveInfo, err := ss.GetMetadata(ctx, sources, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -348,13 +349,13 @@ func MergeMetadata(tmlist1, tmlist2 []*ToolsMetadata) ([]*ToolsMetadata, error) 
 }
 
 // ReadMetadata returns the tools metadata from the given storage for the specified stream.
-func ReadMetadata(ss SimplestreamsFetcher, store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
+func ReadMetadata(ctx context.Context, ss SimplestreamsFetcher, store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
 	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, simplestreams.EXISTING_CLOUD_DATA, false)
 	toolsConstraint, err := makeToolsConstraint(simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
 	if err != nil {
 		return nil, err
 	}
-	metadata, _, err := Fetch(ss, []simplestreams.DataSource{dataSource}, toolsConstraint)
+	metadata, _, err := Fetch(ctx, ss, []simplestreams.DataSource{dataSource}, toolsConstraint)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, err
 	}
@@ -366,10 +367,10 @@ var AllMetadataStreams = []string{ReleasedStream, ProposedStream, TestingStream,
 
 // ReadAllMetadata returns the tools metadata from the given storage for all streams.
 // The result is a map of metadata slices, keyed on stream.
-func ReadAllMetadata(ss SimplestreamsFetcher, store storage.StorageReader) (map[string][]*ToolsMetadata, error) {
+func ReadAllMetadata(ctx context.Context, ss SimplestreamsFetcher, store storage.StorageReader) (map[string][]*ToolsMetadata, error) {
 	streamMetadata := make(map[string][]*ToolsMetadata)
 	for _, stream := range AllMetadataStreams {
-		metadata, err := ReadMetadata(ss, store, stream)
+		metadata, err := ReadMetadata(ctx, ss, store, stream)
 		if err != nil {
 			return nil, err
 		}
@@ -505,8 +506,8 @@ const (
 // MergeAndWriteMetadata reads the existing metadata from storage (if any),
 // and merges it with metadata generated from the given tools list. The
 // resulting metadata is written to storage.
-func MergeAndWriteMetadata(ss SimplestreamsFetcher, store storage.Storage, toolsDir, stream string, tools coretools.List, writeMirrors ShouldWriteMirrors) error {
-	existing, err := ReadAllMetadata(ss, store)
+func MergeAndWriteMetadata(ctx context.Context, ss SimplestreamsFetcher, store storage.Storage, toolsDir, stream string, tools coretools.List, writeMirrors ShouldWriteMirrors) error {
+	existing, err := ReadAllMetadata(ctx, ss, store)
 	if err != nil {
 		return err
 	}

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -5,6 +5,7 @@ package testing
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -115,7 +116,7 @@ func makeTools(c *gc.C, metadataDir, stream string, versionStrings []string, wit
 	c.Assert(err, jc.ErrorIsNil)
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	err = tools.MergeAndWriteMetadata(ss, store, stream, stream, toolsList, false)
+	err = tools.MergeAndWriteMetadata(context.Background(), ss, store, stream, stream, toolsList, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Sign metadata
@@ -153,6 +154,7 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 	indexRef, err := ss.GetIndexWithFormat(
+		context.Background(),
 		source, indexPath, "index:1.0", mirrorsPath, requireSigned, simplestreams.CloudSpec{}, params)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -13,6 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	corebase "github.com/juju/juju/core/base"
@@ -179,7 +180,7 @@ func (s *SimpleStreamsToolsSuite) TestFindTools(c *gc.C) {
 		custom := s.uploadCustom(c, test.custom...)
 		public := s.uploadPublic(c, test.public...)
 		streams := envtools.PreferredStreams(&jujuversion.Current, s.env.Config().Development(), s.env.Config().AgentStream())
-		actual, err := envtools.FindTools(ss, s.env, test.major, test.minor, streams, coretools.Filter{})
+		actual, err := envtools.FindTools(context.Background(), ss, s.env, test.major, test.minor, streams, coretools.Filter{})
 		if test.err != nil {
 			if len(actual) > 0 {
 				c.Logf(actual.String())
@@ -209,7 +210,7 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	logger.SetLogLevel(loggo.TRACE)
 
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	_, err := envtools.FindTools(ss,
+	_, err := envtools.FindTools(context.Background(), ss,
 		s.env, 1, -1, []string{"released"}, coretools.Filter{Number: version.Number{Major: 1, Minor: 2, Patch: 3}})
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	// This is slightly overly prescriptive, but feel free to change or add
@@ -274,7 +275,7 @@ func (s *SimpleStreamsToolsSuite) TestFindExactTools(c *gc.C) {
 		s.reset(c, nil)
 		custom := s.uploadCustom(c, test.custom...)
 		public := s.uploadPublic(c, test.public...)
-		actual, err := envtools.FindExactTools(ss, s.env, test.seek.Number, test.seek.Release, test.seek.Arch)
+		actual, err := envtools.FindExactTools(context.Background(), ss, s.env, test.seek.Number, test.seek.Release, test.seek.Arch)
 		if test.err == nil {
 			if !c.Check(err, jc.ErrorIsNil) {
 				continue
@@ -357,7 +358,7 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsWithStreamFallback(c *gc.C) {
 			"proposed": test.proposed,
 			"released": test.released,
 		})
-		actual, err := envtools.FindTools(ss,
+		actual, err := envtools.FindTools(context.Background(), ss,
 			s.env, test.major, test.minor, test.streams, coretools.Filter{})
 		if test.err != nil {
 			if len(actual) > 0 {

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -35,7 +35,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 			"agent-metadata-url": toolsMetadataURL,
 		})
 	}
-	env, err := bootstrap.PrepareController(false, envtesting.BootstrapTODOContext(c),
+	env, err := bootstrap.PrepareController(false, envtesting.BootstrapTestContext(c),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -4,6 +4,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/version/v2"
@@ -22,7 +23,7 @@ type ToolsMetadataLookupParams struct {
 
 // ValidateToolsMetadata attempts to load tools metadata for the specified cloud attributes and returns
 // any tools versions found, or an error if the metadata could not be loaded.
-func ValidateToolsMetadata(ss SimplestreamsFetcher, params *ToolsMetadataLookupParams) ([]string, *simplestreams.ResolveInfo, error) {
+func ValidateToolsMetadata(ctx context.Context, ss SimplestreamsFetcher, params *ToolsMetadataLookupParams) ([]string, *simplestreams.ResolveInfo, error) {
 	if len(params.Sources) == 0 {
 		return nil, nil, fmt.Errorf("required parameter sources not specified")
 	}
@@ -55,7 +56,7 @@ func ValidateToolsMetadata(ss SimplestreamsFetcher, params *ToolsMetadataLookupP
 			Arches:   params.Architectures,
 		})
 	}
-	matchingTools, resolveInfo, err := Fetch(ss, params.Sources, toolsConstraint)
+	matchingTools, resolveInfo, err := Fetch(ctx, ss, params.Sources, toolsConstraint)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -4,6 +4,7 @@
 package tools
 
 import (
+	"context"
 	"path"
 
 	jc "github.com/juju/testing/checkers"
@@ -68,7 +69,7 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 		},
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	versions, resolveInfo, err := ValidateToolsMetadata(ss, params)
+	versions, resolveInfo, err := ValidateToolsMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(versions, gc.DeepEquals, []string{"1.11.2-ubuntu-amd64"})
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
@@ -94,7 +95,7 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 		},
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	versions, resolveInfo, err := ValidateToolsMetadata(ss, params)
+	versions, resolveInfo, err := ValidateToolsMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(versions, gc.DeepEquals, []string{"1.11.2-ubuntu-amd64"})
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
@@ -119,7 +120,7 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 			Sources:       []simplestreams.DataSource{s.dataSource}},
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	versions, resolveInfo, err := ValidateToolsMetadata(ss, params)
+	versions, resolveInfo, err := ValidateToolsMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(versions, gc.DeepEquals, []string{"1.11.2-ubuntu-amd64"})
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
@@ -143,7 +144,7 @@ func (s *ValidateSuite) TestNoMatch(c *gc.C) {
 			Sources:       []simplestreams.DataSource{s.dataSource}},
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	_, _, err := ValidateToolsMetadata(ss, params)
+	_, _, err := ValidateToolsMetadata(context.Background(), ss, params)
 	c.Assert(err, gc.Not(gc.IsNil))
 }
 
@@ -160,6 +161,6 @@ func (s *ValidateSuite) TestStreamsNoMatch(c *gc.C) {
 			Sources:       []simplestreams.DataSource{s.dataSource}},
 	}
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	_, _, err := ValidateToolsMetadata(ss, params)
+	_, _, err := ValidateToolsMetadata(context.Background(), ss, params)
 	c.Assert(err, gc.Not(gc.IsNil))
 }

--- a/internal/container/kvm/sync.go
+++ b/internal/container/kvm/sync.go
@@ -4,6 +4,7 @@
 package kvm
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -43,7 +44,7 @@ func (p syncParams) One() (*imagedownloads.Metadata, error) {
 	if err := p.exists(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return imagedownloads.One(p.fetcher, p.arch, p.version, p.stream, p.fType, p.srcFunc)
+	return imagedownloads.One(context.TODO(), p.fetcher, p.arch, p.version, p.stream, p.fType, p.srcFunc)
 }
 
 func (p syncParams) exists() error {

--- a/internal/database/testing/dqlitesuite.go
+++ b/internal/database/testing/dqlitesuite.go
@@ -96,7 +96,7 @@ func (s *DqliteSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.dqlite.Ready(context.TODO())
+	err = s.dqlite.Ready(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.trackedDB, s.db = s.OpenDB(c)

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -166,7 +166,7 @@ type ToolsDownloader interface {
 // ToolsUploader defines a single method that is used to upload tools
 // to the target controller in a migration.
 type ToolsUploader interface {
-	UploadTools(io.ReadSeeker, version.Binary) (tools.List, error)
+	UploadTools(context.Context, io.ReadSeeker, version.Binary) (tools.List, error)
 }
 
 // ResourceDownloader defines the interface for downloading resources
@@ -319,7 +319,7 @@ func uploadTools(config UploadBinariesConfig) error {
 		}
 		defer cleanup()
 
-		if _, err := config.ToolsUploader.UploadTools(content, v); err != nil {
+		if _, err := config.ToolsUploader.UploadTools(context.TODO(), content, v); err != nil {
 			return errors.Annotate(err, "cannot upload agent binaries")
 		}
 	}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -305,7 +305,7 @@ type fakeUploader struct {
 	reassignCharmURL bool
 }
 
-func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary) (tools.List, error) {
+func (f *fakeUploader) UploadTools(_ context.Context, r io.ReadSeeker, v version.Binary) (tools.List, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3,6 +3,8 @@
 
 package proxy
 
+import "context"
+
 // Proxier describes an implemntation of an object that is capable of performing
 // connection proxying. Typically an implementation will support this interface
 // and one of the more specific types of proxy's below. Proxy's should be
@@ -11,7 +13,7 @@ package proxy
 type Proxier interface {
 	// Start starts the lifecycle of the proxy. Proxy's should have their start
 	// method called before operating with the proxy.
-	Start() error
+	Start(ctx context.Context) error
 
 	// Stop stops the proxy after a call to Start(). Proxy's should be
 	// considered single use. This call should only ever be made once.

--- a/internal/proxy/testing/proxy.go
+++ b/internal/proxy/testing/proxy.go
@@ -3,6 +3,8 @@
 
 package testing
 
+import "context"
+
 type MockProxier struct {
 	// See Proxier interface
 	RawConfigFn func() (map[string]interface{}, error)
@@ -40,7 +42,7 @@ func (mp *MockProxier) RawConfig() (map[string]interface{}, error) {
 	return mp.RawConfigFn()
 }
 
-func (mp *MockProxier) Start() error {
+func (mp *MockProxier) Start(_ context.Context) error {
 	if mp.StartFn == nil {
 		return nil
 	}

--- a/internal/secrets/provider/juju/provider.go
+++ b/internal/secrets/provider/juju/provider.go
@@ -4,6 +4,8 @@
 package juju
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/internal/secrets/provider"
@@ -39,7 +41,7 @@ func (p jujuProvider) CleanupModel(*provider.ModelBackendConfig) error {
 }
 
 // CleanupSecrets is not used.
-func (p jujuProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
+func (p jujuProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
 	return nil
 }
 
@@ -52,7 +54,7 @@ func BuiltInConfig() provider.BackendConfig {
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p jujuProvider) RestrictedConfig(
-	adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	ctx context.Context, adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	return &provider.BackendConfig{
 		BackendType: BackendType,

--- a/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
+++ b/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
@@ -57,18 +57,18 @@ func (mr *MockBrokerMockRecorder) DeleteJujuSecret(arg0, arg1 any) *gomock.Call 
 }
 
 // EnsureSecretAccessToken mocks base method.
-func (m *MockBroker) EnsureSecretAccessToken(arg0 names.Tag, arg1, arg2, arg3 []string) (string, error) {
+func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 names.Tag, arg2, arg3, arg4 []string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureSecretAccessToken indicates an expected call of EnsureSecretAccessToken.
-func (mr *MockBrokerMockRecorder) EnsureSecretAccessToken(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) EnsureSecretAccessToken(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).EnsureSecretAccessToken), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).EnsureSecretAccessToken), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetJujuSecret mocks base method.
@@ -87,17 +87,17 @@ func (mr *MockBrokerMockRecorder) GetJujuSecret(arg0, arg1 any) *gomock.Call {
 }
 
 // RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 names.Tag) error {
+func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0)
+	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveSecretAccessToken indicates an expected call of RemoveSecretAccessToken.
-func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0, arg1)
 }
 
 // SaveJujuSecret mocks base method.

--- a/internal/secrets/provider/kubernetes/provider.go
+++ b/internal/secrets/provider/kubernetes/provider.go
@@ -77,7 +77,7 @@ func (p k8sProvider) getBroker(cfg *provider.ModelBackendConfig) (Broker, clouds
 }
 
 // CleanupSecrets removes rules of the role associated with the removed secrets.
-func (p k8sProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
+func (p k8sProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
 	if tag == nil {
 		// This should never happen.
 		// Because this method is used for uniter facade only.
@@ -90,7 +90,7 @@ func (p k8sProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag names.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = broker.EnsureSecretAccessToken(tag, nil, nil, removed.RevisionIDs())
+	_, err = broker.EnsureSecretAccessToken(ctx, tag, nil, nil, removed.RevisionIDs())
 	return errors.Trace(err)
 }
 
@@ -130,6 +130,7 @@ func IsBuiltInName(backendName string) bool {
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p k8sProvider) RestrictedConfig(
+	ctx context.Context,
 	adminCfg *provider.ModelBackendConfig, forDrain bool, consumer names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	logger.Tracef("getting k8s backend config for %q, owned %v, read %v", consumer, owned, read)
@@ -142,7 +143,7 @@ func (p k8sProvider) RestrictedConfig(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	token, err := broker.EnsureSecretAccessToken(consumer, owned.RevisionIDs(), read.RevisionIDs(), nil)
+	token, err := broker.EnsureSecretAccessToken(ctx, consumer, owned.RevisionIDs(), read.RevisionIDs(), nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/secrets/provider/kubernetes/provider_test.go
+++ b/internal/secrets/provider/kubernetes/provider_test.go
@@ -44,7 +44,7 @@ func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud
 	s.PatchEnvironment("KUBERNETES_SERVICE_PORT", "8888")
 
 	broker.EXPECT().EnsureSecretAccessToken(
-		tag, []string{"owned-rev-1"}, []string{"read-rev-1", "read-rev-2"}, nil,
+		gomock.Any(), tag, []string{"owned-rev-1"}, []string{"read-rev-1", "read-rev-2"}, nil,
 	).Return("token", nil)
 
 	p, err := provider.Provider(kubernetes.BackendType)
@@ -64,7 +64,7 @@ func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud
 		},
 	}
 
-	backendCfg, err := p.RestrictedConfig(adminCfg, false, tag,
+	backendCfg, err := p.RestrictedConfig(context.Background(), adminCfg, false, tag,
 		provider.SecretRevisions{"owned-a": set.NewStrings("owned-rev-1")},
 		provider.SecretRevisions{"read-b": set.NewStrings("read-rev-1", "read-rev-2")},
 	)
@@ -121,11 +121,11 @@ func (s *providerSuite) TestCleanupSecrets(c *gc.C) {
 
 	gomock.InOrder(
 		broker.EXPECT().EnsureSecretAccessToken(
-			tag, nil, nil, []string{"rev-1", "rev-2"},
+			gomock.Any(), tag, nil, nil, []string{"rev-1", "rev-2"},
 		).Return("token", nil),
 	)
 
-	err = p.CleanupSecrets(adminCfg, tag, provider.SecretRevisions{"removed": set.NewStrings("rev-1", "rev-2")})
+	err = p.CleanupSecrets(context.Background(), adminCfg, tag, provider.SecretRevisions{"removed": set.NewStrings("rev-1", "rev-2")})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/secrets/provider/provider.go
+++ b/internal/secrets/provider/provider.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -74,7 +75,7 @@ type SecretBackendProvider interface {
 
 	// CleanupSecrets removes any ACLs / resources associated
 	// with the removed secrets.
-	CleanupSecrets(cfg *ModelBackendConfig, tag names.Tag, removed SecretRevisions) error
+	CleanupSecrets(ctx context.Context, cfg *ModelBackendConfig, tag names.Tag, removed SecretRevisions) error
 
 	// CleanupModel removes any secrets / ACLs / resources
 	// associated with the model config.
@@ -83,7 +84,7 @@ type SecretBackendProvider interface {
 	// RestrictedConfig returns the config needed to create a
 	// secrets backend client restricted to manage the specified
 	// owned secrets and read shared secrets for the given entity tag.
-	RestrictedConfig(adminCfg *ModelBackendConfig, forDrain bool, tag names.Tag, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
+	RestrictedConfig(ctx context.Context, adminCfg *ModelBackendConfig, forDrain bool, tag names.Tag, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
 
 	// NewBackend creates a secrets backend client using the
 	// specified model config.

--- a/internal/secrets/provider/vault/provider.go
+++ b/internal/secrets/provider/vault/provider.go
@@ -140,7 +140,7 @@ func (p vaultProvider) CleanupModel(cfg *provider.ModelBackendConfig) (err error
 }
 
 // CleanupSecrets removes policies associated with the removed secrets.
-func (p vaultProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
+func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
 	modelPath := modelPathPrefix(cfg.ModelName, cfg.ModelUUID)
 	client, err := p.newBackend(modelPath, &cfg.BackendConfig)
 	if err != nil {
@@ -161,7 +161,6 @@ func (p vaultProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag name
 		return false
 	}
 
-	ctx := context.Background()
 	policies, err := sys.ListPoliciesWithContext(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -183,7 +182,7 @@ func (p vaultProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag name
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p vaultProvider) RestrictedConfig(
-	adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	ctx context.Context, adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	adminUser := tag == nil
 	// Get an admin backend client so we can set up the policies.
@@ -194,7 +193,6 @@ func (p vaultProvider) RestrictedConfig(
 	}
 	sys := backend.client.Sys()
 
-	ctx := context.Background()
 	var policies []string
 	if forDrain {
 		// For drain worker, we need to be able to update a secret.

--- a/internal/secrets/provider/vault/provider_test.go
+++ b/internal/secrets/provider/vault/provider_test.go
@@ -4,6 +4,7 @@
 package vault_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -101,7 +102,7 @@ func (s *providerSuite) TestBackendConfigBadClient(c *gc.C) {
 			},
 		},
 	}
-	_, err = p.RestrictedConfig(adminCfg, false, nil, nil, nil)
+	_, err = p.RestrictedConfig(context.Background(), adminCfg, false, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -151,7 +152,7 @@ func (s *providerSuite) TestBackendConfigAdmin(c *gc.C) {
 			},
 		},
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, false, nil, nil, nil)
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, false, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -226,7 +227,7 @@ func (s *providerSuite) TestBackendConfigNonAdmin(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, false, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, false, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -311,7 +312,7 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, true, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }

--- a/internal/worker/caasadmission/controller.go
+++ b/internal/worker/caasadmission/controller.go
@@ -4,6 +4,7 @@
 package caasadmission
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -70,7 +71,7 @@ func (c *Controller) makeLoop(
 		defer mux.RemoveHandler(http.MethodPost, path)
 
 		logger.Infof("ensuring model k8s webhook configurations")
-		admissionCleanup, err := admissionCreator.EnsureMutatingWebhookConfiguration()
+		admissionCleanup, err := admissionCreator.EnsureMutatingWebhookConfiguration(context.TODO())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/worker/caasadmission/controller_test.go
+++ b/internal/worker/caasadmission/controller_test.go
@@ -4,6 +4,7 @@
 package caasadmission_test
 
 import (
+	"context"
 	"net/http"
 	"sync"
 
@@ -60,7 +61,7 @@ func (s *ControllerSuite) TestControllerStartup(c *gc.C) {
 		},
 	}
 	creator := &dummyAdmissionCreator{
-		EnsureMutatingWebhookConfigurationFunc: func() (func(), error) {
+		EnsureMutatingWebhookConfigurationFunc: func(_ context.Context) (func(), error) {
 			waitGroup.Done()
 			return func() { waitGroup.Done() }, nil
 		},
@@ -118,7 +119,7 @@ func (s *ControllerSuite) TestControllerStartupAdmissionError(c *gc.C) {
 	waitGroup.Add(1)
 	mux := &dummyMux{}
 	creator := &dummyAdmissionCreator{
-		EnsureMutatingWebhookConfigurationFunc: func() (func(), error) {
+		EnsureMutatingWebhookConfigurationFunc: func(_ context.Context) (func(), error) {
 			waitGroup.Done()
 			return func() {}, errors.NewNotValid(nil, "not valid")
 		},

--- a/internal/worker/caasadmission/manifold.go
+++ b/internal/worker/caasadmission/manifold.go
@@ -4,6 +4,8 @@
 package caasadmission
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -31,7 +33,7 @@ type K8sBroker interface {
 	// cleanup function that will destroy the webhook configuration from k8s
 	// when called and a subsequent error if there was a problem. If error is
 	// not nil then no other return values should be considered valid.
-	EnsureMutatingWebhookConfiguration(*admission.MutatingWebhookConfiguration) (func(), error)
+	EnsureMutatingWebhookConfiguration(context.Context, *admission.MutatingWebhookConfiguration) (func(), error)
 
 	// IsLegacyLabels reports if the k8s broker requires legacy labels to be
 	// used for the broker model/namespace

--- a/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	caas "github.com/juju/juju/caas"
@@ -41,17 +42,17 @@ func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 }
 
 // AnnotateUnit mocks base method.
-func (m *MockCAASBroker) AnnotateUnit(arg0, arg1 string, arg2 names.UnitTag) error {
+func (m *MockCAASBroker) AnnotateUnit(arg0 context.Context, arg1, arg2 string, arg3 names.UnitTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AnnotateUnit indicates an expected call of AnnotateUnit.
-func (mr *MockCAASBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCAASBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockCAASBroker)(nil).AnnotateUnit), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockCAASBroker)(nil).AnnotateUnit), arg0, arg1, arg2, arg3)
 }
 
 // Application mocks base method.
@@ -69,16 +70,16 @@ func (mr *MockCAASBrokerMockRecorder) Application(arg0, arg1 any) *gomock.Call {
 }
 
 // Units mocks base method.
-func (m *MockCAASBroker) Units(arg0 string) ([]caas.Unit, error) {
+func (m *MockCAASBroker) Units(arg0 context.Context, arg1 string) ([]caas.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Units", arg0)
+	ret := m.ctrl.Call(m, "Units", arg0, arg1)
 	ret0, _ := ret[0].([]caas.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Units indicates an expected call of Units.
-func (mr *MockCAASBrokerMockRecorder) Units(arg0 any) *gomock.Call {
+func (mr *MockCAASBrokerMockRecorder) Units(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockCAASBroker)(nil).Units), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockCAASBroker)(nil).Units), arg0, arg1)
 }

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -408,7 +408,7 @@ func updateState(appName string, app caas.Application, lastReportedStatus map[st
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			err = broker.AnnotateUnit(appName, unitInfo.ProviderId, unit)
+			err = broker.AnnotateUnit(context.TODO(), appName, unitInfo.ProviderId, unit)
 			if errors.Is(err, errors.NotFound) {
 				continue
 			} else if err != nil {

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -228,8 +228,8 @@ func (s *OpsSuite) TestUpdateState(c *gc.C) {
 		unitFacade.EXPECT().UpdateApplicationService(updateServiceArg).Return(nil),
 		app.EXPECT().Units().Return(units, nil),
 		facade.EXPECT().UpdateUnits(updateUnitsArg).Return(appUnitInfo, nil),
-		broker.EXPECT().AnnotateUnit("test", "a", names.NewUnitTag("test/0")).Return(nil),
-		broker.EXPECT().AnnotateUnit("test", "b", names.NewUnitTag("test/1")).Return(nil),
+		broker.EXPECT().AnnotateUnit(gomock.Any(), "test", "a", names.NewUnitTag("test/0")).Return(nil),
+		broker.EXPECT().AnnotateUnit(gomock.Any(), "test", "b", names.NewUnitTag("test/1")).Return(nil),
 	)
 
 	lastReportedStatus := map[string]status.StatusInfo{

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -12,6 +12,7 @@
 package caasapplicationprovisioner
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -71,8 +72,8 @@ type CAASProvisionerFacade interface {
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
 	Application(string, caas.DeploymentType) caas.Application
-	AnnotateUnit(appName string, podName string, unit names.UnitTag) error
-	Units(appName string) ([]caas.Unit, error)
+	AnnotateUnit(ctx context.Context, appName string, podName string, unit names.UnitTag) error
+	Units(ctx context.Context, appName string) ([]caas.Unit, error)
 }
 
 // Runner exposes functionalities of a worker.Runner.

--- a/internal/worker/caasmodelconfigmanager/mocks/broker_mock.go
+++ b/internal/worker/caasmodelconfigmanager/mocks/broker_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	docker "github.com/juju/juju/internal/docker"
@@ -40,15 +41,15 @@ func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 }
 
 // EnsureImageRepoSecret mocks base method.
-func (m *MockCAASBroker) EnsureImageRepoSecret(arg0 docker.ImageRepoDetails) error {
+func (m *MockCAASBroker) EnsureImageRepoSecret(arg0 context.Context, arg1 docker.ImageRepoDetails) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureImageRepoSecret", arg0)
+	ret := m.ctrl.Call(m, "EnsureImageRepoSecret", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureImageRepoSecret indicates an expected call of EnsureImageRepoSecret.
-func (mr *MockCAASBrokerMockRecorder) EnsureImageRepoSecret(arg0 any) *gomock.Call {
+func (mr *MockCAASBrokerMockRecorder) EnsureImageRepoSecret(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureImageRepoSecret", reflect.TypeOf((*MockCAASBroker)(nil).EnsureImageRepoSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureImageRepoSecret", reflect.TypeOf((*MockCAASBroker)(nil).EnsureImageRepoSecret), arg0, arg1)
 }

--- a/internal/worker/caasmodelconfigmanager/worker_test.go
+++ b/internal/worker/caasmodelconfigmanager/worker_test.go
@@ -4,6 +4,7 @@
 package caasmodelconfigmanager_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -175,7 +176,7 @@ func (s *workerSuite) TestWorkerTokenRefreshRequired(c *gc.C) {
 			})
 			return o
 		}),
-		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any()).DoAndReturn(func(i docker.ImageRepoDetails) error {
+		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, i docker.ImageRepoDetails) error {
 			c.Check(i, gc.DeepEquals, s.CAASImageRepo(c))
 			return nil
 		}),
@@ -183,7 +184,7 @@ func (s *workerSuite) TestWorkerTokenRefreshRequired(c *gc.C) {
 		s.reg.EXPECT().ShouldRefreshAuth().Return(true, time.Duration(0)),
 		s.reg.EXPECT().RefreshAuth().Return(nil),
 		s.reg.EXPECT().ImageRepoDetails().Return(refreshed),
-		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any()).DoAndReturn(func(i docker.ImageRepoDetails) error {
+		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, i docker.ImageRepoDetails) error {
 			c.Check(i, gc.DeepEquals, refreshed)
 			close(done)
 			return nil
@@ -238,7 +239,7 @@ func (s *workerSuite) TestWorkerTokenRefreshNotRequiredThenRetry(c *gc.C) {
 			})
 			return o
 		}),
-		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any()).DoAndReturn(func(i docker.ImageRepoDetails) error {
+		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, i docker.ImageRepoDetails) error {
 			c.Check(i, gc.DeepEquals, s.CAASImageRepo(c))
 			return nil
 		}),
@@ -252,7 +253,7 @@ func (s *workerSuite) TestWorkerTokenRefreshNotRequiredThenRetry(c *gc.C) {
 		}),
 		s.reg.EXPECT().RefreshAuth().Return(nil),
 		s.reg.EXPECT().ImageRepoDetails().Return(s.CAASImageRepo(c)),
-		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any()).DoAndReturn(func(i docker.ImageRepoDetails) error {
+		s.broker.EXPECT().EnsureImageRepoSecret(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, i docker.ImageRepoDetails) error {
 			c.Check(i, gc.DeepEquals, s.CAASImageRepo(c))
 			close(done)
 			return nil

--- a/internal/worker/caasupgrader/mock_test.go
+++ b/internal/worker/caasupgrader/mock_test.go
@@ -4,6 +4,8 @@
 package caasupgrader_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	"github.com/juju/version/v2"
 
@@ -37,7 +39,7 @@ type mockOperatorUpgrader struct {
 	testing.Stub
 }
 
-func (m *mockOperatorUpgrader) Upgrade(appName string, vers version.Number) error {
+func (m *mockOperatorUpgrader) Upgrade(_ context.Context, appName string, vers version.Number) error {
 	m.AddCall("Upgrade", appName, vers)
 	return nil
 }

--- a/internal/worker/caasupgrader/upgrader.go
+++ b/internal/worker/caasupgrader/upgrader.go
@@ -4,6 +4,7 @@
 package caasupgrader
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -42,7 +43,7 @@ type UpgraderClient interface {
 }
 
 type CAASOperatorUpgrader interface {
-	Upgrade(agentTag string, v version.Number) error
+	Upgrade(ctx context.Context, agentTag string, v version.Number) error
 }
 
 // Config contains the items the worker needs to start.
@@ -163,7 +164,7 @@ func (u *Upgrader) loop() error {
 			direction = "downgrade"
 		}
 		logger.Debugf("%s requested for %v from %v to %v", direction, u.tag, jujuversion.Current, wantVersion)
-		err = u.operatorUpgrader.Upgrade(u.tag.String(), wantVersion)
+		err = u.operatorUpgrader.Upgrade(context.TODO(), u.tag.String(), wantVersion)
 		if err != nil {
 			return errors.Annotatef(
 				err, "requesting upgrade for %v from %v to %v", u.tag.String(), jujuversion.Current, wantVersion)

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -396,7 +396,7 @@ type uploadWrapper struct {
 }
 
 // UploadTools prepends the model UUID to the args passed to the migration client.
-func (w *uploadWrapper) UploadTools(r io.ReadSeeker, vers version.Binary) (tools.List, error) {
+func (w *uploadWrapper) UploadTools(_ context.Context, r io.ReadSeeker, vers version.Binary) (tools.List, error) {
 	return w.client.UploadTools(w.modelUUID, r, vers)
 }
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -177,7 +179,7 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 	}
 	streams := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	possibleTools, err := tools.FindTools(ss, env, -1, -1, streams, filter)
+	possibleTools, err := tools.FindTools(context.Background(), ss, env, -1, -1, streams, filter)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -253,7 +255,7 @@ func SetImageMetadata(env environs.Environ, fetcher imagemetadata.SimplestreamsF
 	if err != nil {
 		return errors.Trace(err)
 	}
-	imageMetadata, _, err := imagemetadata.Fetch(fetcher, sources, imageConstraint)
+	imageMetadata, _, err := imagemetadata.Fetch(context.Background(), fetcher, sources, imageConstraint)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -205,7 +205,7 @@ func (env *azureEnviron) initEnviron(ctx stdcontext.Context) error {
 // PrepareForBootstrap is part of the Environ interface.
 func (env *azureEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, _ string) error {
 	if ctx.ShouldVerifyCredentials() {
-		callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
+		callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 		if err := verifyCredentials(env, callCtx); err != nil {
 			return errors.Trace(err)
 		}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1437,7 +1437,7 @@ const resourceGroupName = "juju-testmodel-deadbeef"
 func (s *environSuite) TestBootstrap(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
@@ -1471,7 +1471,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
@@ -1504,7 +1504,7 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender, testing.Attrs{"network": "mynetwork"})
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
@@ -1541,7 +1541,7 @@ func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.createSenderWithUnauthorisedStatusCode(c)
@@ -1568,7 +1568,7 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = append(s.sender, s.resourceSKUsSender())
@@ -1619,7 +1619,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender, testing.Attrs{"resource-group-name": "foo"})
 
 	s.sender = append(s.sender, s.resourceSKUsSender())
@@ -1671,7 +1671,7 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -30,7 +30,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	envcontext "github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/models"
@@ -288,7 +288,7 @@ func BootstrapInstance(
 		}
 
 		select {
-		case <-ctx.Context().Done():
+		case <-ctx.Done():
 			return nil, nil, nil, errors.Annotate(err, "starting controller (cancelled)")
 		default:
 		}
@@ -458,7 +458,7 @@ var FinishBootstrap = func(
 
 	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig)
 	addr, err := WaitSSH(
-		ctx.Context(),
+		ctx,
 		ctx.GetStderr(),
 		client,
 		GetCheckNonceCommand(instanceConfig),

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -153,7 +153,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 	env.startInstance = startInstance
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapConstraints:     checkCons,
@@ -200,7 +200,7 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 		startInstance: fakeStartInstance,
 		config:        fakeMinimalConfig(c),
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	bootstrapSeries := jujuversion.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -221,7 +221,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidSeries(c *gc.C) {
 		startInstance: fakeStartInstance,
 		config:        fakeMinimalConfig(c),
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	bootstrapSeries := "spock"
 	availableTools := fakeAvailableTools()
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -240,7 +240,7 @@ func (s *BootstrapSuite) TestBootstrapFallbackSeries(c *gc.C) {
 		startInstance: fakeStartInstance,
 		config:        fakeMinimalConfig(c),
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	bootstrapSeries := ""
 	availableTools := fakeAvailableTools()
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -261,7 +261,7 @@ func (s *BootstrapSuite) TestBootstrapSeriesWithForce(c *gc.C) {
 		startInstance: fakeStartInstance,
 		config:        fakeMinimalConfig(c),
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	bootstrapSeries := "xenial"
 	availableTools := fakeAvailableTools()
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -298,7 +298,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 		return nil, nil, nil, errors.New("bloop")
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -338,7 +338,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 		return nil, nil, nil, errors.New("bloop")
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -380,7 +380,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 		return nil, nil, nil, errors.New("bloop")
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -425,7 +425,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 		return nil, nil, nil, errors.New("bloop")
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -468,7 +468,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 		return nil, nil, nil, environs.ZoneIndependentError(errors.New("bloop"))
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -494,7 +494,7 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 		},
 	}
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -524,7 +524,7 @@ func (s *BootstrapSuite) TestStartInstanceRootDisk(c *gc.C) {
 		startInstance: startInstance,
 		config:        fakeMinimalConfig(c),
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	availableTools := fakeAvailableTools()
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
@@ -697,7 +697,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 			return []instances.Instance{inst}, nil
 		},
 	}
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	bootstrapSeries := jujuversion.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -160,7 +160,7 @@ func (e *environ) Name() string {
 // PrepareForBootstrap is part of the Environ interface.
 func (e *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
 	// Cannot really invalidate a credential here since nothing is bootstrapped yet.
-	callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
+	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	if ctx.ShouldVerifyCredentials() {
 		if err := verifyCredentials(e.ec2Client, callCtx); err != nil {
 			return err

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -42,7 +42,7 @@ func (s *vpcSuite) SetUpTest(c *gc.C) {
 func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapTODOContext(c))
+	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapTestContext(c))
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 
 	s.stubAPI.CheckCallNames(c, "DescribeVpcsWithContext")
@@ -50,7 +50,7 @@ func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {
 
 func (s *vpcSuite) TestValidateBootstrapVPCCredentialError(c *gc.C) {
 	s.stubAPI.SetErrors(fmt.Errorf("%w: AWS failed!", common.ErrorCredentialNotValid))
-	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapTODOContext(c))
+	err := validateBootstrapVPC(s.stubAPI, s.cloudCallCtx, "region", anyVPCID, false, envtesting.BootstrapTestContext(c))
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 	c.Check(err, jc.ErrorIs, common.ErrorCredentialNotValid)
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -269,8 +269,8 @@ func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.Tests.SetUpTest(c)
 
 	t.Tests.BootstrapContext = bootstrapContextWithClientFunc(c, bootstrapClientFunc(t.client), bootstrapIAMClientFunc(t.iamClient))
-	t.Tests.ProviderCallContext = envcontext.WithoutCredentialInvalidator(t.Tests.BootstrapContext.Context())
-	t.callCtx = envcontext.WithoutCredentialInvalidator(t.Tests.BootstrapContext.Context())
+	t.Tests.ProviderCallContext = envcontext.WithoutCredentialInvalidator(t.Tests.BootstrapContext)
+	t.callCtx = envcontext.WithoutCredentialInvalidator(t.Tests.BootstrapContext)
 	t.useIAMRole = false
 }
 
@@ -593,7 +593,7 @@ func (t *localServerSuite) TestDestroyControllerModelDeleteSecurityGroupInsisten
 
 func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyError(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
-	hostedEnv, err := environs.New(t.BootstrapContext.Context(), environs.OpenParams{
+	hostedEnv, err := environs.New(t.BootstrapContext, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: env.Config(),
 	})
@@ -620,7 +620,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 		"firewall-mode": "global",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(t.BootstrapContext.Context(), environs.OpenParams{
+	env, err := environs.New(t.BootstrapContext, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: cfg,
 	})
@@ -1907,7 +1907,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	params.Endpoint = "http://foo"
 	params.Sources, err = environs.ImageMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
-	image_ids, _, err := imagemetadata.ValidateImageMetadata(ss, params)
+	image_ids, _, err := imagemetadata.ValidateImageMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(image_ids)
 	c.Assert(image_ids, gc.DeepEquals, []string{"ami-02204133", "ami-02204135", "ami-02204139"})
@@ -2294,7 +2294,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := environs.New(s.BootstrapContext.Context(), environs.OpenParams{
+	env, err := environs.New(s.BootstrapContext, environs.OpenParams{
 		Cloud:          s.CloudSpec(),
 		Config:         cfg,
 		ControllerUUID: coretesting.ControllerTag.Id(),

--- a/provider/equinix/environ_network_test.go
+++ b/provider/equinix/environ_network_test.go
@@ -99,8 +99,8 @@ func (s *networkSuite) TestListIPsByProjectIDAndRegion(c *gc.C) {
 		cl.ProjectIPs = projectIP
 		return cl
 	})
-	ctx := envtesting.BootstrapTODOContext(c)
-	env, err := environs.Open(ctx.Context(), s.provider, environs.OpenParams{
+	ctx := envtesting.BootstrapTestContext(c)
+	env, err := environs.Open(ctx, s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: makeTestModelConfig(c),
 	})
@@ -302,8 +302,8 @@ func (s *networkSuite) TestNetworkInterfaces(c *gc.C) {
 		cl.ProjectIPs = projectIP
 		return cl
 	})
-	ctx := envtesting.BootstrapTODOContext(c)
-	env, err := environs.Open(ctx.Context(), s.provider, environs.OpenParams{
+	ctx := envtesting.BootstrapTestContext(c)
+	env, err := environs.Open(ctx, s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: makeTestModelConfig(c),
 	})

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -110,7 +110,7 @@ var (
 	bootstrap  = common.Bootstrap
 )
 
-func newEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ, error) {
+func newEnviron(ctx stdcontext.Context, cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ, error) {
 	ecfg, err := newConfig(cfg, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
@@ -127,7 +127,7 @@ func newEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ
 		ecfg:      ecfg,
 		namespace: namespace,
 	}
-	if err = e.SetCloudSpec(stdcontext.TODO(), cloud); err != nil {
+	if err = e.SetCloudSpec(ctx, cloud); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -76,7 +76,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	}
 	s.FakeCommon.BSFinalizer = finalizer
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
@@ -97,7 +97,7 @@ func (s *environSuite) TestBootstrapInvalidCredentialError(c *gc.C) {
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 	}
-	_, err := s.Env.Bootstrap(envtesting.BootstrapTODOContext(c), s.CallCtx, params)
+	_, err := s.Env.Bootstrap(envtesting.BootstrapTestContext(c), s.CallCtx, params)
 	c.Check(err, gc.NotNil)
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
@@ -120,7 +120,7 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 	}
 	s.FakeCommon.BSFinalizer = finalizer
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig:         config,
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
@@ -149,7 +149,7 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 }
 
 func (s *environSuite) TestBootstrapCommon(c *gc.C) {
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -38,11 +38,11 @@ func (environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
+func (environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := newEnviron(args.Cloud, args.Config)
+	env, err := newEnviron(ctx, args.Cloud, args.Config)
 	return env, errors.Trace(err)
 }
 

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -62,6 +62,7 @@ type environ struct {
 }
 
 func newEnviron(
+	ctx stdcontext.Context,
 	p *environProvider,
 	spec environscloudspec.CloudSpec,
 	cfg *config.Config,
@@ -86,7 +87,7 @@ func newEnviron(
 	}
 	env.base = common.DefaultProvider{Env: env}
 
-	err = env.SetCloudSpec(stdcontext.TODO(), spec)
+	err = env.SetCloudSpec(ctx, spec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -112,7 +112,7 @@ func (s *environSuite) TestBootstrapAPI(c *gc.C) {
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	}
-	callCtx := envcontext.WithoutCredentialInvalidator(ctx.Context())
+	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	_, err := s.Env.Bootstrap(ctx, callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -144,11 +144,12 @@ func (*environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := p.validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
 	env, err := newEnviron(
+		ctx,
 		p,
 		args.Cloud,
 		args.Config,

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -277,7 +277,7 @@ func (s *providerSuite) TestFinalizeCloud(c *gc.C) {
 	server.EXPECT().LocalBridgeName().Return("lxdbr0")
 	deps.factory.EXPECT().LocalServerAddress().Return("1.2.3.4:1234", nil)
 
-	var ctx mockContext
+	ctx := mockContext{Context: context.Background()}
 	out, err := finalizer.FinalizeCloud(&ctx, cloud.Cloud{
 		Name:      "localhost",
 		Type:      "lxd",
@@ -311,7 +311,7 @@ func (s *providerSuite) TestFinalizeCloudWithRemoteProvider(c *gc.C) {
 	deps := s.createProvider(ctrl)
 	finalizer := deps.provider.(environs.CloudFinalizer)
 
-	var ctx mockContext
+	ctx := mockContext{Context: context.Background()}
 	out, err := finalizer.FinalizeCloud(&ctx, cloud.Cloud{
 		Name:      "nuc8",
 		Type:      "lxd",
@@ -616,6 +616,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
 }
 
 type mockContext struct {
+	context.Context
 	jtesting.Stub
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -111,7 +111,7 @@ var _ environs.Networking = (*maasEnviron)(nil)
 // the capabilities of a MAAS installation.
 type Capabilities = func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error)
 
-func NewEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config, getCaps Capabilities) (*maasEnviron, error) {
+func NewEnviron(ctx stdcontext.Context, cloud environscloudspec.CloudSpec, cfg *config.Config, getCaps Capabilities) (*maasEnviron, error) {
 	if getCaps == nil {
 		getCaps = getCapabilities
 	}
@@ -125,7 +125,7 @@ func NewEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config, getCaps C
 	if err := env.SetConfig(cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := env.SetCloudSpec(stdcontext.TODO(), cloud); err != nil {
+	if err := env.SetCloudSpec(ctx, cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -59,12 +59,12 @@ func (EnvironProvider) Version() int {
 	return 0
 }
 
-func (EnvironProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
+func (EnvironProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := NewEnviron(args.Cloud, args.Config, nil)
+	env, err := NewEnviron(ctx, args.Cloud, args.Config, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating MAAS environ")
 	}

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"math/rand"
@@ -82,7 +83,7 @@ func (suite *maasEnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) {
 	attrs := coretesting.FakeConfig().Merge(maasEnvAttrs)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	return NewEnviron(cloud, cfg, nil)
+	return NewEnviron(context.Background(), cloud, cfg, nil)
 }
 
 func (suite *maasEnvironSuite) TestNewEnvironWithController(c *gc.C) {
@@ -696,7 +697,7 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             jujutesting.AdminSecret,
@@ -720,7 +721,7 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             jujutesting.AdminSecret,
@@ -744,7 +745,7 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             jujutesting.AdminSecret,
@@ -2398,7 +2399,7 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	}
 
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             jujutesting.AdminSecret,
@@ -2537,7 +2538,7 @@ func (suite *maasEnvironSuite) TestDestroy(c *gc.C) {
 func (suite *maasEnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron(c, newFakeController())
 	vers := version.MustParse("1.2.3")
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
@@ -2558,7 +2559,7 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachineError = gomaasapi.NewNoMatchError("oops")
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
 			AdminSecret:             jujutesting.AdminSecret,

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi/v2"
@@ -61,7 +63,7 @@ func (suite *maasSuite) makeEnviron(c *gc.C, controller gomaasapi.Controller) *m
 	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := NewEnviron(cloud, cfg, nil)
+	env, err := NewEnviron(context.Background(), cloud, cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 	return env

--- a/provider/oci/environ_integration_test.go
+++ b/provider/oci/environ_integration_test.go
@@ -336,7 +336,7 @@ func (s *environSuite) TestPrepareForBootstrap(c *gc.C) {
 		gomock.Any(), gomock.Any()).Return(
 		ociIdentity.ListAvailabilityDomainsResponse{}, errors.New("got error"))
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	err := s.env.PrepareForBootstrap(ctx, "controller-1")
 	c.Assert(err, gc.IsNil)
 
@@ -910,7 +910,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 	s.setupStartInstanceExpectations(true, true, gomock.Any())
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
@@ -930,7 +930,7 @@ func (s *environSuite) TestBootstrapFlexibleShape(c *gc.C) {
 	// By setting the constraint cpu-cores=32, we are selecting the
 	// VM.Standard3.Flex shape defined in listShapesResponse(), which has
 	// 32 maximum CPUs.
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
@@ -958,7 +958,7 @@ func (s *environSuite) TestBootstrapNoAllocatePublicIP(c *gc.C) {
 
 	s.setupStartInstanceExpectations(true, false, noPublicIPMatcher{})
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
@@ -988,7 +988,7 @@ func (s *environSuite) TestBootstrapNoMatchingTools(c *gc.C) {
 	s.setupListRouteTableExpectations(vcnId, machineTags, 0)
 	s.setupListSubnetsExpectations(vcnId, "fakeRouteTableId", machineTags, 0)
 
-	ctx := envtesting.BootstrapTODOContext(c)
+	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1911,7 +1911,7 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	params.Sources, err = environs.ImageMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
 	params.Release = "13.04"
-	imageIDs, _, err := imagemetadata.ValidateImageMetadata(ss, params)
+	imageIDs, _, err := imagemetadata.ValidateImageMetadata(context.Background(), ss, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(imageIDs, jc.SameContents, []string{"id-y"})
 }
@@ -2628,7 +2628,7 @@ func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	c.Assert(attrs["auth-url"].(string)[:8], gc.Equals, "https://")
 	env, err := bootstrap.PrepareController(
 		false,
-		envtesting.BootstrapTODOContext(c),
+		envtesting.BootstrapTestContext(c),
 		jujuclient.NewMemStore(),
 		prepareParams(attrs, s.cred),
 	)
@@ -2734,7 +2734,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	}
 
 	// Read from the Config entry's image-metadata-url
-	contentReader, imageURL, err := mappedSources["image-metadata-url"].Fetch(custom)
+	contentReader, imageURL, err := mappedSources["image-metadata-url"].Fetch(context.Background(), custom)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
 	content, err := io.ReadAll(contentReader)
@@ -2743,7 +2743,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	c.Check(imageURL[:8], gc.Equals, "https://")
 
 	// Check the entry we got from keystone
-	contentReader, imageURL, err = mappedSources["keystone catalog"].Fetch(metadata)
+	contentReader, imageURL, err = mappedSources["keystone catalog"].Fetch(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
 	content, err = io.ReadAll(contentReader)
@@ -2794,7 +2794,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSourcesWithCertificate
 	}
 
 	// Check the entry we got from keystone
-	contentReader, imageURL, err := mappedSources["keystone catalog"].Fetch(metadata)
+	contentReader, imageURL, err := mappedSources["keystone catalog"].Fetch(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
 	content, err := io.ReadAll(contentReader)
@@ -2842,7 +2842,7 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Read from the Config entry's agent-metadata-url
-	contentReader, metadataURL, err := sources[0].Fetch(custom)
+	contentReader, metadataURL, err := sources[0].Fetch(context.Background(), custom)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
 	content, err := io.ReadAll(contentReader)
@@ -2852,7 +2852,7 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 
 	// Check the entry we got from keystone
 	// Now fetch the data, and verify the contents.
-	contentReader, metadataURL, err = sources[1].Fetch(keystoneContainer + "/" + keystone)
+	contentReader, metadataURL, err = sources[1].Fetch(context.Background(), keystoneContainer+"/"+keystone)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
 	content, err = io.ReadAll(contentReader)
@@ -3754,7 +3754,7 @@ func (s *noNeutronSuite) TestSupport(c *gc.C) {
 	// For testing, we create a storage instance to which is uploaded tools and image metadata.
 	_, err = bootstrap.PrepareController(
 		false,
-		envtesting.BootstrapTODOContext(c),
+		envtesting.BootstrapTestContext(c),
 		jujuclient.NewMemStore(),
 		prepareParams(attrs, s.cred),
 	)
@@ -3853,7 +3853,7 @@ func (s *noSwiftSuite) SetUpTest(c *gc.C) {
 
 	env, err := bootstrap.PrepareController(
 		false,
-		envtesting.BootstrapTODOContext(c),
+		envtesting.BootstrapTestContext(c),
 		jujuclient.NewMemStore(),
 		prepareParams(attrs, s.cred),
 	)
@@ -3905,7 +3905,7 @@ func bootstrapEnv(c *gc.C, env environs.Environ) error {
 }
 
 func bootstrapEnvWithConstraints(c *gc.C, env environs.Environ, cons constraints.Value) error {
-	return bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
+	return bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
 		envcontext.WithoutCredentialInvalidator(context.Background()),
 		bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -4,6 +4,8 @@
 package vsphere
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
@@ -31,7 +33,7 @@ func init() {
 	simplestreams.RegisterStructTags(OvaFileMetadata{})
 }
 
-func findImageMetadata(env environs.Environ, arch string, series string) (*OvaFileMetadata, error) {
+func findImageMetadata(ctx context.Context, env environs.Environ, arch string, series string) (*OvaFileMetadata, error) {
 	vers, err := imagemetadata.ImageRelease(series)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -49,7 +51,7 @@ func findImageMetadata(env environs.Environ, arch string, series string) (*OvaFi
 		return nil, errors.Trace(err)
 	}
 
-	matchingImages, err := imageMetadataFetch(sources, ic)
+	matchingImages, err := imageMetadataFetch(ctx, sources, ic)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -60,7 +62,7 @@ func findImageMetadata(env environs.Environ, arch string, series string) (*OvaFi
 	return matchingImages[0], nil
 }
 
-func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint) ([]*OvaFileMetadata, error) {
+func imageMetadataFetch(ctx context.Context, sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint) ([]*OvaFileMetadata, error) {
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   imagemetadata.StreamsVersionV1,
 		LookupConstraint: cons,
@@ -71,7 +73,7 @@ func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.
 		},
 	}
 	ss := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
-	items, _, err := ss.GetMetadata(sources, params)
+	items, _, err := ss.GetMetadata(ctx, sources, params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -181,7 +181,7 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	img, err := findImageMetadata(v.env, arch, series)
+	img, err := findImageMetadata(ctx, v.env, arch, series)
 	if err != nil {
 		return nil, "", environs.ZoneIndependentError(err)
 	}


### PR DESCRIPTION
This PR weaves the passed context through the environ and kubernetes packages.

There was fallout in some other areas; eg the workers which call into the newly updated k8s apis use a `context.TODO()` for now. Similarly, 1 or 2 api clients needed to take a context in order to satisfy an updated interface. 

This is largely mechanical - lots of small changes to add a context to a method signature, or to use the context that was available but hitherto ignored. The k8s package was particularly affected as many methods needed a context but didn't have one passed in yet. There was also a bit of cleanup because the k8s bootstrap infrastructure was storing a context and using it instead of using one via the method signatures.

The remaining places to fix are the api client methods and the workers.

## QA steps

bootstrap both machine and k8s controllers and deploy a charm

## Links


**Jira card:** JUJU-5243

