### PR TITLE
Add GetAllUsers func to user service

### DIFF
--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -49,6 +49,11 @@ type State interface {
 	// returned.
 	GetUserByName(context.Context, string) (user.User, error)
 
+	// GetAllUsers will retrieve all users from the database where the user is
+	// active and has not been removed. If no users exist an empty slice will be
+	// returned.
+	GetAllUsers(context.Context) ([]user.User, error)
+
 	// RemoveUser marks the user as removed. This obviates the ability of a user
 	// to function, but keeps the user retaining provenance, i.e. auditing.
 	// RemoveUser will also remove any credentials and activation codes for the
@@ -147,6 +152,15 @@ func (s *Service) GetUserByName(
 		return user.User{}, errors.Annotatef(err, "getting user %q", name)
 	}
 
+	return usr, nil
+}
+
+// GetAllUsers will return all users that have not been removed.
+func (s *Service) GetAllUsers(ctx context.Context) ([]user.User, error) {
+	usr, err := s.st.GetAllUsers(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting all users")
+	}
 	return usr, nil
 }
 

--- a/domain/user/service/state_mock_test.go
+++ b/domain/user/service/state_mock_test.go
@@ -110,6 +110,21 @@ func (mr *MockStateMockRecorder) EnableUserAuthentication(arg0, arg1 any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableUserAuthentication", reflect.TypeOf((*MockState)(nil).EnableUserAuthentication), arg0, arg1)
 }
 
+// GetAllUsers mocks base method.
+func (m *MockState) GetAllUsers(arg0 context.Context) ([]user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllUsers", arg0)
+	ret0, _ := ret[0].([]user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllUsers indicates an expected call of GetAllUsers.
+func (mr *MockStateMockRecorder) GetAllUsers(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockState)(nil).GetAllUsers), arg0)
+}
+
 // GetUser mocks base method.
 func (m *MockState) GetUser(arg0 context.Context, arg1 user.UUID) (user.User, error) {
 	m.ctrl.T.Helper()

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -411,6 +411,47 @@ WHERE uuid = ?
 	c.Check(removed, gc.Equals, true)
 }
 
+// TestGetAllUsers asserts that we can get all users from the database.
+func (s *stateSuite) TestGetAllUsers(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add admin1 user.
+	adminUUID1, err := user.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	adminUser1 := user.User{
+		Name:        "admin1",
+		DisplayName: "admin1",
+	}
+	err = st.AddUser(context.Background(), adminUUID1, adminUser1, adminUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add admin1 user.
+	adminUUID2, err := user.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	adminUser2 := user.User{
+		Name:        "admin2",
+		DisplayName: "admin2",
+	}
+	err = st.AddUser(context.Background(), adminUUID2, adminUser2, adminUUID2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get all users.
+	users, err := st.GetAllUsers(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(users, gc.HasLen, 2)
+
+	c.Check(users[0].Name, gc.Equals, adminUser1.Name)
+	c.Check(users[0].DisplayName, gc.Equals, adminUser1.DisplayName)
+	c.Check(users[0].CreatorUUID, gc.Equals, adminUUID1)
+	c.Check(users[0].CreatedAt, gc.NotNil)
+
+	c.Check(users[1].Name, gc.Equals, adminUser2.Name)
+	c.Check(users[1].DisplayName, gc.Equals, adminUser2.DisplayName)
+	c.Check(users[1].CreatorUUID, gc.Equals, adminUUID2)
+	c.Check(users[1].CreatedAt, gc.NotNil)
+}
+
 // TestSetPasswordHash asserts that we can set a password hash for a user.
 func (s *stateSuite) TestSetPasswordHash(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())


### PR DESCRIPTION
This PR adds GetAllUsers function to state and service layers in the user
domain and the unit-tests. We need this function in `usermanager` facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
go test github.com/juju/juju/domain/user/state/... -gocheck.v
go test github.com/juju/juju/domain/user/service/... -gocheck.v
```

## Links

**Jira card:** [JUJU-5274](https://warthogs.atlassian.net/browse/JUJU-5274)



[JUJU-5274]: https://warthogs.atlassian.net/browse/JUJU-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ