### PR TITLE
Remove facade context attributes

### DIFF
--- a/api/agent/instancemutater/instancemutater_test.go
+++ b/api/agent/instancemutater/instancemutater_test.go
@@ -4,7 +4,6 @@
 package instancemutater_test
 
 import (
-	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -90,7 +89,6 @@ func (s *instanceMutaterSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.fCaller = mocks.NewMockFacadeCaller(ctrl)
 	s.apiCaller = mocks.NewMockAPICaller(ctrl)
-	s.apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	return ctrl
 }

--- a/api/agent/instancemutater/mocks/caller_mock.go
+++ b/api/agent/instancemutater/mocks/caller_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/agent/provisioner/mocks/caller_mock.go
+++ b/api/agent/provisioner/mocks/caller_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -4,8 +4,6 @@
 package provisioner_test
 
 import (
-	"context"
-
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -37,7 +35,6 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) setupCaller(ctrl *gomock.Controller) *mocks.MockAPICaller {
 	caller := mocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Provisioner").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	return caller
 }
 
@@ -713,7 +710,6 @@ func (s *provisionerContainerSuite) SetUpTest(_ *gc.C) {
 func (s *provisionerContainerSuite) setupCaller(ctrl *gomock.Controller) *mocks.MockAPICaller {
 	caller := mocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Provisioner").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	return caller
 }
 

--- a/api/agent/secretsdrain/client_test.go
+++ b/api/agent/secretsdrain/client_test.go
@@ -4,8 +4,6 @@
 package secretsdrain_test
 
 import (
-	"context"
-
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -26,7 +24,6 @@ func (s *secretsDrainSuite) TestNewClient(c *gc.C) {
 
 	apiCaller := mocks.NewMockAPICaller(ctrl)
 	apiCaller.EXPECT().BestFacadeVersion("SecretsDrain").Return(1)
-	apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	client := secretsdrain.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)

--- a/api/agent/secretsdrain/mocks/facade_mock.go
+++ b/api/agent/secretsdrain/mocks/facade_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/agent/unitassigner/unitassigner_test.go
+++ b/api/agent/unitassigner/unitassigner_test.go
@@ -103,10 +103,6 @@ func (*fakeAssignCaller) BestFacadeVersion(facade string) int {
 	return 1
 }
 
-func (*fakeAssignCaller) Context() context.Context {
-	return context.Background()
-}
-
 type fakeWatchCaller struct {
 	base.APICaller
 	sync.Mutex

--- a/api/agent/uniter/payload_test.go
+++ b/api/agent/uniter/payload_test.go
@@ -427,10 +427,6 @@ func (s *stubFacade) APICall(ctx context.Context, objType string, version int, i
 	return nil
 }
 
-func (s *stubFacade) Context() context.Context {
-	return context.Background()
-}
-
 type unitMethods struct{}
 
 func (m unitMethods) Handler(name string) (func(target, response interface{}), bool) {

--- a/api/agent/uniter/resource_test.go
+++ b/api/agent/uniter/resource_test.go
@@ -47,7 +47,7 @@ func (s *ResourcesFacadeClientSuite) TestGetResource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cl.HTTPDoer = s.api
 
-	info, content, err := cl.GetResource("spam")
+	info, content, err := cl.GetResource(context.Background(), "spam")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "Do", "GetResourceInfo")
@@ -60,7 +60,7 @@ func (s *ResourcesFacadeClientSuite) TestUnitDoer(c *gc.C) {
 	req, err := http.NewRequest("GET", "/resources/eggs", body)
 	c.Assert(err, jc.ErrorIsNil)
 	var resp *http.Response
-	doer := uniter.NewUnitHTTPClient(context.Background(), s.api, "spam/1")
+	doer := uniter.NewUnitHTTPClient(s.api, "spam/1")
 
 	err = doer.Do(context.Background(), req, &resp)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,10 +88,6 @@ func (s *stubAPI) setResource(info resources.Resource, reader io.ReadCloser) {
 	s.ReturnDo = &http.Response{
 		Body: reader,
 	}
-}
-
-func (s *stubAPI) Context() context.Context {
-	return context.Background()
 }
 
 func (s *stubAPI) BestFacadeVersion(_ string) int {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1229,7 +1229,7 @@ func (s *apiclientSuite) TestLoginCapturesCLIArgs(c *gc.C) {
 		Broken:        broken,
 		Closed:        make(chan struct{}),
 	})
-	err := testConn.Login(names.NewUserTag("fred"), "secret", "", nil)
+	err := testConn.Login(context.Background(), names.NewUserTag("fred"), "secret", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	calls := conn.stub.Calls()
@@ -1247,7 +1247,7 @@ func (s *apiclientSuite) TestConnectStreamRequiresSlashPathPrefix(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
 
-	reader, err := conn.ConnectStream("foo", nil)
+	reader, err := conn.ConnectStream(context.Background(), "foo", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot make API path from non-slash-prefixed path "foo"`)
 	c.Assert(reader, gc.Equals, nil)
 }
@@ -1260,7 +1260,7 @@ func (s *apiclientSuite) TestConnectStreamErrorBadConnection(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	reader, err := conn.ConnectStream("/", nil)
+	reader, err := conn.ConnectStream(context.Background(), "/", nil)
 	c.Assert(err, gc.ErrorMatches, "bad connection")
 	c.Assert(reader, gc.IsNil)
 }
@@ -1273,7 +1273,7 @@ func (s *apiclientSuite) TestConnectStreamErrorNoData(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	reader, err := conn.ConnectStream("/", nil)
+	reader, err := conn.ConnectStream(context.Background(), "/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to read initial response: EOF")
 	c.Assert(reader, gc.IsNil)
 }
@@ -1286,7 +1286,7 @@ func (s *apiclientSuite) TestConnectStreamErrorBadData(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	reader, err := conn.ConnectStream("/", nil)
+	reader, err := conn.ConnectStream(context.Background(), "/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to unmarshal initial response: .*")
 	c.Assert(reader, gc.IsNil)
 }
@@ -1300,7 +1300,7 @@ func (s *apiclientSuite) TestConnectStreamErrorReadError(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	reader, err := conn.ConnectStream("/", nil)
+	reader, err := conn.ConnectStream(context.Background(), "/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to read initial response: bad read")
 	c.Assert(reader, gc.IsNil)
 }
@@ -1320,7 +1320,7 @@ func (s *apiclientSuite) TestConnectControllerStreamRejectsRelativePaths(c *gc.C
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	reader, err := conn.ConnectControllerStream("foo", nil, nil)
+	reader, err := conn.ConnectControllerStream(context.Background(), "foo", nil, nil)
 	c.Assert(err, gc.ErrorMatches, `path "foo" is not absolute`)
 	c.Assert(reader, gc.IsNil)
 }
@@ -1329,7 +1329,7 @@ func (s *apiclientSuite) TestConnectControllerStreamRejectsModelPaths(c *gc.C) {
 	info := s.APIInfo()
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
-	reader, err := conn.ConnectControllerStream("/model/foo", nil, nil)
+	reader, err := conn.ConnectControllerStream(context.Background(), "/model/foo", nil, nil)
 	c.Assert(err, gc.ErrorMatches, `path "/model/foo" is model-specific`)
 	c.Assert(reader, gc.IsNil)
 }
@@ -1345,7 +1345,7 @@ func (s *apiclientSuite) TestConnectControllerStreamAppliesHeaders(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	_, err = conn.ConnectControllerStream("/something", nil, headers)
+	_, err = conn.ConnectControllerStream(context.Background(), "/something", nil, headers)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(catcher.Headers().Get("thomas"), gc.Equals, "cromwell")
 	c.Assert(catcher.Headers().Get("anne"), gc.Equals, "boleyn")
@@ -1361,7 +1361,7 @@ func (s *apiclientSuite) TestConnectStreamWithoutLogin(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	_, err = conn.ConnectStream("/path", nil)
+	_, err = conn.ConnectStream(context.Background(), "/path", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot use ConnectStream without logging in`)
 }
 
@@ -1435,7 +1435,7 @@ func (s *apiclientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	conn, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	_, err = conn.ConnectStream("/path", nil)
+	_, err = conn.ConnectStream(context.Background(), "/path", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	connectURL, err := url.Parse(catcher.Location())
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/base/caller_test.go
+++ b/api/base/caller_test.go
@@ -4,8 +4,6 @@
 package base_test
 
 import (
-	"context"
-
 	"github.com/juju/testing"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -28,7 +26,7 @@ func (s *apiCallerSuite) TestNewFacadeCaller(c *gc.C) {
 
 	facade := base.NewFacadeCaller(s.apiCaller, "Foo")
 	c.Assert(facade, gc.NotNil)
-	c.Check(facade.(Tracer).Tracer(), gc.Equals, coretrace.NoopTracer{})
+	c.Check(facade.(Tracer).Tracer(), gc.IsNil)
 }
 
 func (s *apiCallerSuite) TestNewFacadeCallerWithTracer(c *gc.C) {
@@ -44,7 +42,6 @@ func (s *apiCallerSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 	s.apiCaller = mocks.NewMockAPICaller(ctrl)
 	s.apiCaller.EXPECT().BestFacadeVersion("Foo").Return(1)
-	s.apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	return ctrl
 }

--- a/api/base/clientfacade.go
+++ b/api/base/clientfacade.go
@@ -3,10 +3,6 @@
 
 package base
 
-import (
-	coretrace "github.com/juju/juju/core/trace"
-)
-
 // APICallCloser is the same as APICaller, but also provides a Close() method
 // for when we are done with this connection.
 type APICallCloser interface {
@@ -45,15 +41,10 @@ var _ ClientFacade = (*clientFacade)(nil)
 // It is expected that most client-facing facades will embed a ClientFacade and
 // will use a FacadeCaller so this function returns both.
 func NewClientFacade(caller APICallCloser, facadeName string, options ...Option) (ClientFacade, FacadeCaller) {
-	// Derive the context from the API caller context if it's available. The
-	// default will be a noop tracer if none is found.
-	tracer, _ := coretrace.TracerFromContext(caller.Context())
-
 	fc := facadeCaller{
 		facadeName:  facadeName,
 		bestVersion: caller.BestFacadeVersion(facadeName),
 		caller:      caller,
-		tracer:      tracer,
 	}
 	for _, option := range options {
 		fc = option(fc)

--- a/api/base/mocks/caller_mock.go
+++ b/api/base/mocks/caller_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/base/mocks/clientfacade_mock.go
+++ b/api/base/mocks/clientfacade_mock.go
@@ -101,47 +101,33 @@ func (mr *MockAPICallCloserMockRecorder) Close() *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICallCloser) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICallCloser) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallCloserMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallCloserMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICallCloser) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICallCloser) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallCloserMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallCloserMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICallCloser) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallCloserMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICallCloser)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -37,10 +37,6 @@ func (APICallerFunc) ModelTag() (names.ModelTag, bool) {
 	return names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d"), true
 }
 
-func (APICallerFunc) Context() context.Context {
-	return context.Background()
-}
-
 func (APICallerFunc) Close() error {
 	return nil
 }
@@ -57,11 +53,11 @@ func (APICallerFunc) BakeryClient() base.MacaroonDischarger {
 	panic("no bakery client available in this test")
 }
 
-func (APICallerFunc) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+func (APICallerFunc) ConnectStream(_ context.Context, path string, attrs url.Values) (base.Stream, error) {
 	return nil, errors.NotImplementedf("stream connection")
 }
 
-func (APICallerFunc) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
+func (APICallerFunc) ConnectControllerStream(_ context.Context, path string, attrs url.Values, headers http.Header) (base.Stream, error) {
 	return nil, errors.NotImplementedf("controller stream connection")
 }
 

--- a/api/client/backups/download.go
+++ b/api/client/backups/download.go
@@ -4,6 +4,7 @@
 package backups
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -19,7 +20,7 @@ type downloadParams struct {
 }
 
 // Download returns an io.ReadCloser for the given backup id.
-func (c *Client) Download(filename string) (io.ReadCloser, error) {
+func (c *Client) Download(ctx context.Context, filename string) (io.ReadCloser, error) {
 	httpClient, err := c.st.HTTPClient()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -27,7 +28,7 @@ func (c *Client) Download(filename string) (io.ReadCloser, error) {
 
 	var resp *http.Response
 	err = httpClient.Call(
-		c.st.Context(),
+		ctx,
 		&downloadParams{
 			Body: params.BackupsDownloadArgs{
 				ID: filename,

--- a/api/client/backups/download_test.go
+++ b/api/client/backups/download_test.go
@@ -32,10 +32,9 @@ func (s *downloadSuite) TestDownload(c *gc.C) {
 	httpClient := &httprequest.Client{BaseURL: srv.URL}
 
 	s.apiCaller.EXPECT().HTTPClient().Return(httpClient, nil)
-	s.apiCaller.EXPECT().Context().Return(context.Background())
 
 	client := s.newClient()
-	rdr, err := client.Download("/path/to/backup")
+	rdr, err := client.Download(context.Background(), "/path/to/backup")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = rdr.Close() }()
 

--- a/api/client/charms/downloader.go
+++ b/api/client/charms/downloader.go
@@ -16,17 +16,16 @@ import (
 
 // CharmOpener provides the OpenCharm method.
 type CharmOpener interface {
-	OpenCharm(curl string) (io.ReadCloser, error)
+	OpenCharm(ctx context.Context, curl string) (io.ReadCloser, error)
 }
 
 type charmOpener struct {
-	ctx        context.Context
 	httpClient http.HTTPDoer
 }
 
-func (s *charmOpener) OpenCharm(curl string) (io.ReadCloser, error) {
+func (s *charmOpener) OpenCharm(ctx context.Context, curl string) (io.ReadCloser, error) {
 	uri, query := openCharmArgs(curl)
-	return http.OpenURI(s.ctx, s.httpClient, uri, query)
+	return http.OpenURI(ctx, s.httpClient, uri, query)
 }
 
 // NewCharmOpener returns a charm opener for the specified caller.
@@ -36,7 +35,6 @@ func NewCharmOpener(apiConn base.APICaller) (CharmOpener, error) {
 		return nil, errors.Trace(err)
 	}
 	return &charmOpener{
-		ctx:        apiConn.Context(),
 		httpClient: httpClient,
 	}, nil
 }

--- a/api/client/charms/downloader_test.go
+++ b/api/client/charms/downloader_test.go
@@ -37,7 +37,6 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.Background()).MinTimes(1)
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).MinTimes(1)
 
 	charmData := "charmdatablob"
@@ -53,7 +52,7 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 
 	opener, err := charms.NewCharmOpener(mockCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	reader, err := opener.OpenCharm("ch:mycharm")
+	reader, err := opener.OpenCharm(context.Background(), "ch:mycharm")
 
 	defer reader.Close()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client/charms/localcharmclient_test.go
+++ b/api/client/charms/localcharmclient_test.go
@@ -4,7 +4,6 @@
 package charms_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -339,7 +338,6 @@ func testMinVer(t minverTest, c *gc.C) {
 		Doer:    mockHttpDoer,
 	}
 
-	mockCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	mockCaller.EXPECT().HTTPClient().Return(reqClient, nil).AnyTimes()
 	mockFacadeCaller.EXPECT().RawAPICaller().Return(mockCaller).AnyTimes()
 

--- a/api/client/client/client.go
+++ b/api/client/client/client.go
@@ -209,17 +209,17 @@ func (c *Client) AbortCurrentUpgrade() error {
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS.
-func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (tools.List, error) {
+func (c *Client) UploadTools(ctx context.Context, r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (tools.List, error) {
 	endpoint := fmt.Sprintf("/tools?binaryVersion=%s&series=%s", vers, strings.Join(additionalSeries, ","))
 	contentType := "application/x-tar-gz"
 	var resp params.ToolsResult
-	if err := c.httpPost(r, endpoint, contentType, &resp); err != nil {
+	if err := c.httpPost(ctx, r, endpoint, contentType, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return resp.ToolsList, nil
 }
 
-func (c *Client) httpPost(content io.ReadSeeker, endpoint, contentType string, response interface{}) error {
+func (c *Client) httpPost(ctx context.Context, content io.ReadSeeker, endpoint, contentType string, response interface{}) error {
 	req, err := http.NewRequest("POST", endpoint, content)
 	if err != nil {
 		return errors.Annotate(err, "cannot create upload request")
@@ -232,7 +232,7 @@ func (c *Client) httpPost(content io.ReadSeeker, endpoint, contentType string, r
 		return errors.Trace(err)
 	}
 
-	if err := httpClient.Do(c.facade.RawAPICaller().Context(), req, response); err != nil {
+	if err := httpClient.Do(ctx, req, response); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/api/client/modelupgrader/mocks/apibase_mock.go
+++ b/api/client/modelupgrader/mocks/apibase_mock.go
@@ -101,47 +101,33 @@ func (mr *MockAPICallCloserMockRecorder) Close() *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICallCloser) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICallCloser) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallCloserMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallCloserMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICallCloser) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICallCloser) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallCloserMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallCloserMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICallCloser) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallCloserMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICallCloser)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICallCloser)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/client/modelupgrader/upgrader.go
+++ b/api/client/modelupgrader/upgrader.go
@@ -80,7 +80,7 @@ func (c *Client) UpgradeModel(
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS.
-func (c *Client) UploadTools(_ context.Context, r io.ReadSeeker, vers version.Binary) (tools.List, error) {
+func (c *Client) UploadTools(ctx context.Context, r io.ReadSeeker, vers version.Binary) (tools.List, error) {
 	req, err := http.NewRequest("POST", fmt.Sprintf("/tools?binaryVersion=%s", vers), r)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create upload request")
@@ -94,7 +94,7 @@ func (c *Client) UploadTools(_ context.Context, r io.ReadSeeker, vers version.Bi
 		return nil, errors.Trace(err)
 	}
 
-	if err := httpClient.Do(c.facade.RawAPICaller().Context(), req, &resp); err != nil {
+	if err := httpClient.Do(ctx, req, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return resp.ToolsList, nil

--- a/api/client/modelupgrader/upgrader_test.go
+++ b/api/client/modelupgrader/upgrader_test.go
@@ -35,7 +35,6 @@ func (s *UpgradeModelSuite) TestAbortModelUpgrade(c *gc.C) {
 	apiCaller := mocks.NewMockAPICallCloser(ctrl)
 
 	apiCaller.EXPECT().BestFacadeVersion("ModelUpgrader").Return(1)
-	apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	apiCaller.EXPECT().APICall(
 		gomock.Any(),
 		"ModelUpgrader", 1, "", "AbortModelUpgrade",
@@ -55,7 +54,6 @@ func (s *UpgradeModelSuite) TestUpgradeModel(c *gc.C) {
 	apiCaller := mocks.NewMockAPICallCloser(ctrl)
 
 	apiCaller.EXPECT().BestFacadeVersion("ModelUpgrader").Return(1)
-	apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	apiCaller.EXPECT().APICall(
 		gomock.Any(),
 		"ModelUpgrader", 1, "", "UpgradeModel",
@@ -109,7 +107,6 @@ func (s *UpgradeModelSuite) TestUploadTools(c *gc.C) {
 
 	apiCaller.EXPECT().BestFacadeVersion("ModelUpgrader").Return(1)
 	apiCaller.EXPECT().HTTPClient().Return(&httprequest.Client{Doer: doer}, nil)
-	apiCaller.EXPECT().Context().Return(ctx).AnyTimes()
 	doer.EXPECT().Do(req).Return(resp, nil)
 
 	client := modelupgrader.NewClient(apiCaller)

--- a/api/client/resources/client.go
+++ b/api/client/resources/client.go
@@ -109,7 +109,7 @@ func newListResourcesArgs(applications []string) (params.ListResourcesArgs, erro
 }
 
 // Upload sends the provided resource blob up to Juju.
-func (c Client) Upload(application, name, filename, pendingID string, reader io.ReadSeeker) error {
+func (c Client) Upload(ctx context.Context, application, name, filename, pendingID string, reader io.ReadSeeker) error {
 	uReq, err := NewUploadRequest(application, name, filename, reader)
 	if err != nil {
 		return errors.Trace(err)
@@ -123,7 +123,7 @@ func (c Client) Upload(application, name, filename, pendingID string, reader io.
 	}
 
 	var response params.UploadResult // ignored
-	if err := c.httpClient.Do(c.facade.RawAPICaller().Context(), req, &response); err != nil {
+	if err := c.httpClient.Do(ctx, req, &response); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -224,7 +224,7 @@ func newAddPendingResourcesArgsV2(tag names.ApplicationTag, chID CharmID, resour
 // pendingID first, then it uses the client.Upload to actually send it.
 // Pending resources IDs are required for resources uploaded before
 // AddApplication has been called.
-func (c Client) UploadPendingResource(application string, res charmresource.Resource, filename string, reader io.ReadSeeker) (pendingID string, err error) {
+func (c Client) UploadPendingResource(ctx context.Context, application string, res charmresource.Resource, filename string, reader io.ReadSeeker) (pendingID string, err error) {
 	if !names.IsValidApplication(application) {
 		return "", errors.Errorf("invalid application %q", application)
 	}
@@ -241,7 +241,7 @@ func (c Client) UploadPendingResource(application string, res charmresource.Reso
 	if reader == nil {
 		return pendingID, nil
 	}
-	return pendingID, c.Upload(application, res.Name, filename, pendingID, reader)
+	return pendingID, c.Upload(ctx, application, res.Name, filename, pendingID, reader)
 }
 
 func resolveErrors(errs []error) error {

--- a/api/client/subnets/subnets_test.go
+++ b/api/client/subnets/subnets_test.go
@@ -4,8 +4,6 @@
 package subnets_test
 
 import (
-	"context"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -30,7 +28,6 @@ func (s *SubnetsSuite) TestNewAPISuccess(c *gc.C) {
 
 	apiCaller := basemocks.NewMockAPICallCloser(ctrl)
 	apiCaller.EXPECT().BestFacadeVersion("Subnets").Return(4)
-	apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	api := subnets.NewAPI(apiCaller)
 	c.Check(api, gc.NotNil)

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -109,7 +109,7 @@ func StreamDebugLog(ctx context.Context, source base.StreamConnector, args Debug
 	// Prepare URL query attributes.
 	attrs := args.URLQuery()
 
-	connection, err := source.ConnectStream("/log", attrs)
+	connection, err := source.ConnectStream(ctx, "/log", attrs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/common/stream/stream.go
+++ b/api/common/stream/stream.go
@@ -4,6 +4,8 @@
 package stream
 
 import (
+	"context"
+
 	"github.com/google/go-querystring/query"
 	"github.com/juju/errors"
 
@@ -12,12 +14,12 @@ import (
 
 // Open opens a streaming connection to the endpoint path that conforms
 // to the provided config.
-func Open(conn base.StreamConnector, path string, cfg interface{}) (base.Stream, error) {
+func Open(ctx context.Context, conn base.StreamConnector, path string, cfg interface{}) (base.Stream, error) {
 	attrs, err := query.Values(cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to generate URL query from config")
 	}
-	stream, err := conn.ConnectStream(path, attrs)
+	stream, err := conn.ConnectStream(ctx, path, attrs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot connect to %s", path)
 	}

--- a/api/connection_test.go
+++ b/api/connection_test.go
@@ -4,6 +4,7 @@
 package api_test
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/juju/errors"
@@ -88,7 +89,7 @@ func (s *connectionSuite) apiConnection() api.Connection {
 
 func (s *connectionSuite) TestAPIHostPortsAlwaysIncludesTheConnection(c *gc.C) {
 	apiConn := s.apiConnection()
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	hostPortList := apiConn.APIHostPorts()
@@ -131,7 +132,7 @@ func (s *connectionSuite) TestAPIHostPortsDoesNotIncludeConnectionProxy(c *gc.C)
 		Closed:        make(chan struct{}),
 		Proxier:       proxytest.NewMockTunnelProxier(),
 	})
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	hostPortList := apiConn.APIHostPorts()
@@ -148,7 +149,7 @@ func (s *connectionSuite) TestTags(c *gc.C) {
 	modelTag, ok := apiConn.ModelTag()
 	c.Check(ok, jc.IsTrue)
 	c.Assert(modelTag, jc.DeepEquals, coretesting.ModelTag)
-	err := apiConn.Login(jujutesting.AdminUser, jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), jujutesting.AdminUser, jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Now that we've logged in, ModelTag should still be the same.
 	modelTag, ok = apiConn.ModelTag()
@@ -160,7 +161,7 @@ func (s *connectionSuite) TestTags(c *gc.C) {
 
 func (s *connectionSuite) TestLoginSetsControllerAccess(c *gc.C) {
 	apiConn := s.apiConnection()
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiConn.ControllerAccess(), gc.Equals, "superuser")
 }
@@ -201,7 +202,7 @@ func (s *connectionSuite) TestLoginToMigratedModel(c *gc.C) {
 		Broken:        broken,
 		Closed:        make(chan struct{}),
 	})
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 
 	redirErr, ok := errors.Cause(err).(*api.RedirectError)
 	c.Assert(ok, gc.Equals, true)
@@ -217,7 +218,7 @@ func (s *connectionSuite) TestLoginToMigratedModel(c *gc.C) {
 
 func (s *connectionSuite) TestBestFacadeVersion(c *gc.C) {
 	apiConn := s.apiConnection()
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(apiConn.BestFacadeVersion("Client"), gc.Equals, 6)
 }
@@ -293,7 +294,7 @@ func (s *connectionSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {
 		Broken:        broken,
 		Closed:        make(chan struct{}),
 	})
-	err := apiConn.Login(names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
+	err := apiConn.Login(context.Background(), names.NewUserTag("admin"), jujutesting.AdminSecret, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	hostPorts := apiConn.APIHostPorts()
 	// We should have rotate the server we connected to as the first item,

--- a/api/controller/controller/http_test.go
+++ b/api/controller/controller/http_test.go
@@ -4,7 +4,6 @@
 package controller_test
 
 import (
-	"context"
 	"net/url"
 
 	"github.com/juju/names/v5"
@@ -30,11 +29,6 @@ func (*httpAPICallCloser) ModelTag() (names.ModelTag, bool) {
 // BestFacadeVersion implements base.APICallCloser.
 func (*httpAPICallCloser) BestFacadeVersion(facade string) int {
 	return 42
-}
-
-// BestFacadeVersion implements base.APICallCloser.
-func (*httpAPICallCloser) Context() context.Context {
-	return context.Background()
 }
 
 // HTTPClient implements base.APICallCloser. The returned HTTP client can be

--- a/api/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -100,7 +100,7 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChange(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	err = client.PublishRelationChange(params.RemoteRelationChangeEvent{
+	err = client.PublishRelationChange(context.Background(), params.RemoteRelationChangeEvent{
 		RelationToken: "token",
 		DepartedUnits: []int{1},
 		Macaroons:     macaroon.Slice{mac},
@@ -112,7 +112,7 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChange(c *gc.C) {
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
-	err = client.PublishRelationChange(params.RemoteRelationChangeEvent{
+	err = client.PublishRelationChange(context.Background(), params.RemoteRelationChangeEvent{
 		RelationToken: "token",
 		DepartedUnits: []int{1},
 		Macaroons:     macaroon.Slice{different},
@@ -150,7 +150,7 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChangeDischargeRequired(c 
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	err := client.PublishRelationChange(params.RemoteRelationChangeEvent{
+	err := client.PublishRelationChange(context.Background(), params.RemoteRelationChangeEvent{
 		RelationToken: "token",
 		DepartedUnits: []int{1},
 	})
@@ -190,7 +190,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
+	result, err := client.RegisterRemoteRelations(context.Background(), params.RegisterRemoteRelationArg{
 		RelationToken: "token",
 		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{mac},
@@ -204,7 +204,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
-	result, err = client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
+	result, err = client.RegisterRemoteRelations(context.Background(), params.RegisterRemoteRelationArg{
 		RelationToken: "token",
 		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{different},
@@ -227,7 +227,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err := client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{})
+	_, err := client.RegisterRemoteRelations(context.Background(), params.RegisterRemoteRelationArg{})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 
@@ -259,7 +259,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationDischargeRequired(c
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelationArg{
+	result, err := client.RegisterRemoteRelations(context.Background(), params.RegisterRemoteRelationArg{
 		RelationToken: "token",
 		OfferUUID:     "offer-uuid"})
 	c.Check(err, jc.ErrorIsNil)
@@ -302,6 +302,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 	}
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
 	_, err = client.WatchRelationChanges(
+		context.Background(),
 		remoteRelationToken,
 		"app-token",
 		macaroon.Slice{mac},
@@ -313,6 +314,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
 	_, err = client.WatchRelationChanges(
+		context.Background(),
 		remoteRelationToken,
 		"app-token",
 		macaroon.Slice{different},
@@ -357,7 +359,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChangesDischargeRequired(c *
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchRelationChanges("token", "app-token", nil)
+	_, err := client.WatchRelationChanges(context.Background(), "token", "app-token", nil)
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(dischargeMac, gc.HasLen, 1)
@@ -392,7 +394,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
+	_, err = client.WatchRelationSuspendedStatus(context.Background(), params.RemoteEntityArg{
 		Token:         remoteRelationToken,
 		Macaroons:     macaroon.Slice{mac},
 		BakeryVersion: bakery.LatestVersion,
@@ -403,7 +405,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
-	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
+	_, err = client.WatchRelationSuspendedStatus(context.Background(), params.RemoteEntityArg{
 		Token:         remoteRelationToken,
 		Macaroons:     macaroon.Slice{different},
 		BakeryVersion: bakery.LatestVersion,
@@ -444,7 +446,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatusDischargeRequired(c *g
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchRelationSuspendedStatus(params.RemoteEntityArg{Token: "token"})
+	_, err := client.WatchRelationSuspendedStatus(context.Background(), params.RemoteEntityArg{Token: "token"})
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(dischargeMac, gc.HasLen, 1)
@@ -481,7 +483,7 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChange(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	err = client.PublishIngressNetworkChange(params.IngressNetworksChangeEvent{
+	err = client.PublishIngressNetworkChange(context.Background(), params.IngressNetworksChangeEvent{
 		RelationToken: "token",
 		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{mac},
 		BakeryVersion: bakery.LatestVersion,
@@ -492,7 +494,7 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChange(c *gc.C) {
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
-	err = client.PublishIngressNetworkChange(params.IngressNetworksChangeEvent{
+	err = client.PublishIngressNetworkChange(context.Background(), params.IngressNetworksChangeEvent{
 		RelationToken: "token",
 		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{different},
 		BakeryVersion: bakery.LatestVersion,
@@ -529,7 +531,7 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChangeDischargeRequi
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	err := client.PublishIngressNetworkChange(params.IngressNetworksChangeEvent{
+	err := client.PublishIngressNetworkChange(context.Background(), params.IngressNetworksChangeEvent{
 		RelationToken: "token",
 		Networks:      []string{"1.2.3.4/32"}})
 	c.Check(callCount, gc.Equals, 2)
@@ -568,7 +570,7 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelation(c *gc.C) 
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err = client.WatchEgressAddressesForRelation(relation)
+	_, err = client.WatchEgressAddressesForRelation(context.Background(), relation)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
 	// cached and override the passed in macaroon.
@@ -578,7 +580,7 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelation(c *gc.C) 
 	rel2 := relation
 	rel2.Macaroons = macaroon.Slice{different}
 	rel2.BakeryVersion = bakery.LatestVersion
-	_, err = client.WatchEgressAddressesForRelation(rel2)
+	_, err = client.WatchEgressAddressesForRelation(context.Background(), rel2)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
 }
@@ -616,7 +618,7 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelationDischargeR
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchEgressAddressesForRelation(params.RemoteEntityArg{Token: "token"})
+	_, err := client.WatchEgressAddressesForRelation(context.Background(), params.RemoteEntityArg{Token: "token"})
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(dischargeMac, gc.HasLen, 1)
@@ -651,7 +653,7 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err = client.WatchOfferStatus(params.OfferArg{
+	_, err = client.WatchOfferStatus(context.Background(), params.OfferArg{
 		OfferUUID:     offerUUID,
 		Macaroons:     macaroon.Slice{mac},
 		BakeryVersion: bakery.LatestVersion,
@@ -662,7 +664,7 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("offer-uuid", macaroon.Slice{mac})
-	_, err = client.WatchOfferStatus(params.OfferArg{
+	_, err = client.WatchOfferStatus(context.Background(), params.OfferArg{
 		OfferUUID:     offerUUID,
 		Macaroons:     macaroon.Slice{different},
 		BakeryVersion: bakery.LatestVersion,
@@ -703,7 +705,7 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatusDischargeRequired(c *gc.C
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchOfferStatus(params.OfferArg{OfferUUID: "offer-uuid"})
+	_, err := client.WatchOfferStatus(context.Background(), params.OfferArg{OfferUUID: "offer-uuid"})
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(dischargeMac, gc.HasLen, 1)
@@ -739,14 +741,14 @@ func (s *CrossModelRelationsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 		return nil
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
-	_, err = client.WatchConsumedSecretsChanges(appToken, relToken, mac)
+	_, err = client.WatchConsumedSecretsChanges(context.Background(), appToken, relToken, mac)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
 	// cached and override the passed in macaroon.
 	different, err := jujutesting.NewMacaroon("different")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert(relToken, macaroon.Slice{mac})
-	_, err = client.WatchConsumedSecretsChanges(appToken, relToken, different)
+	_, err = client.WatchConsumedSecretsChanges(context.Background(), appToken, relToken, different)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
 }
@@ -783,7 +785,7 @@ func (s *CrossModelRelationsSuite) TestWatchConsumedSecretsChangesDischargeRequi
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelrelations.NewClientWithCache(callerWithBakery, s.cache)
-	_, err := client.WatchConsumedSecretsChanges("app-token", "rel-token", nil)
+	_, err := client.WatchConsumedSecretsChanges(context.Background(), "app-token", "rel-token", nil)
 	c.Check(callCount, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(dischargeMac, gc.HasLen, 1)

--- a/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -4,6 +4,7 @@
 package crossmodelsecrets_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -84,7 +85,7 @@ func (s *CrossControllerSuite) TestGetRemoteSecretContentInfo(c *gc.C) {
 		return nil
 	})
 	client := crossmodelsecrets.NewClient(apiCaller)
-	content, backend, latestRevision, draining, err := client.GetRemoteSecretContentInfo(uri, 665, true, true, "token", 666, macs)
+	content, backend, latestRevision, draining, err := client.GetRemoteSecretContentInfo(context.Background(), uri, 665, true, true, "token", 666, macs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(latestRevision, gc.Equals, 666)
 	c.Assert(draining, jc.IsTrue)
@@ -118,7 +119,7 @@ func (s *CrossControllerSuite) TestControllerInfoError(c *gc.C) {
 		return nil
 	})
 	client := crossmodelsecrets.NewClient(apiCaller)
-	content, backend, _, _, err := client.GetRemoteSecretContentInfo(coresecrets.NewURI(), 665, false, false, "token", 666, nil)
+	content, backend, _, _, err := client.GetRemoteSecretContentInfo(context.Background(), coresecrets.NewURI(), 665, false, false, "token", 666, nil)
 	c.Assert(err, gc.ErrorMatches, "attempt count exceeded: boom")
 	c.Assert(content, gc.IsNil)
 	c.Assert(backend, gc.IsNil)

--- a/api/controller/machineundertaker/undertaker_test.go
+++ b/api/controller/machineundertaker/undertaker_test.go
@@ -4,8 +4,6 @@
 package machineundertaker_test
 
 import (
-	"context"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -348,8 +346,4 @@ func (c *fakeAPICaller) ModelTag() (names.ModelTag, bool) {
 
 func (c *fakeAPICaller) BestFacadeVersion(string) int {
 	return 0
-}
-
-func (c *fakeAPICaller) Context() context.Context {
-	return context.Background()
 }

--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -236,7 +236,7 @@ func (c *Client) ProcessRelations(controllerAlias string) error {
 }
 
 // OpenResource downloads the named resource for an application.
-func (c *Client) OpenResource(application, name string) (io.ReadCloser, error) {
+func (c *Client) OpenResource(ctx context.Context, application, name string) (io.ReadCloser, error) {
 	httpClient, err := c.httpClientFactory()
 	if err != nil {
 		return nil, errors.Annotate(err, "unable to create HTTP client")
@@ -245,7 +245,7 @@ func (c *Client) OpenResource(application, name string) (io.ReadCloser, error) {
 	uri := fmt.Sprintf("/applications/%s/resources/%s", application, name)
 	var resp *http.Response
 	if err := httpClient.Get(
-		c.caller.RawAPICaller().Context(),
+		ctx,
 		uri, &resp); err != nil {
 		return nil, errors.Annotate(err, "unable to retrieve resource")
 	}

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -424,7 +424,7 @@ func setupFakeHTTP() (*migrationmaster.Client, *fakeDoer) {
 
 func (s *ClientSuite) TestOpenResource(c *gc.C) {
 	client, doer := setupFakeHTTP()
-	r, err := client.OpenResource("app", "blob")
+	r, err := client.OpenResource(context.Background(), "app", "blob")
 	c.Assert(err, jc.ErrorIsNil)
 	checkReader(c, r, "resourceful")
 	c.Check(doer.method, gc.Equals, "GET")
@@ -630,11 +630,7 @@ func (fakeConnector) BestFacadeVersion(string) int {
 	return 0
 }
 
-func (fakeConnector) Context() context.Context {
-	return context.Background()
-}
-
-func (c fakeConnector) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+func (c fakeConnector) ConnectStream(_ context.Context, path string, attrs url.Values) (base.Stream, error) {
 	*c.path = path
 	*c.attrs = attrs
 	return nil, errors.New("colonel abrams")
@@ -648,10 +644,6 @@ type fakeHTTPCaller struct {
 
 func (fakeHTTPCaller) BestFacadeVersion(string) int {
 	return 0
-}
-
-func (r *fakeHTTPCaller) Context() context.Context {
-	return context.Background()
 }
 
 func (c fakeHTTPCaller) HTTPClient() (*httprequest.Client, error) {

--- a/api/controller/pubsub/pubsub.go
+++ b/api/controller/pubsub/pubsub.go
@@ -4,6 +4,8 @@
 package pubsub
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/base"
@@ -30,8 +32,8 @@ func NewAPI(connector base.StreamConnector) *API {
 
 // OpenMessageWriter returns a new message writer interface value which must
 // be closed when finished with.
-func (api *API) OpenMessageWriter() (MessageWriter, error) {
-	conn, err := api.connector.ConnectStream("/pubsub", nil)
+func (api *API) OpenMessageWriter(ctx context.Context) (MessageWriter, error) {
+	conn, err := api.connector.ConnectStream(ctx, "/pubsub", nil)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot connect to /pubsub")
 	}

--- a/api/controller/pubsub/pubsub_test.go
+++ b/api/controller/pubsub/pubsub_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/url"
@@ -28,7 +29,7 @@ func (s *PubSubSuite) TestNewAPI(c *gc.C) {
 		c: c,
 	}
 	a := apipubsub.NewAPI(conn)
-	w, err := a.OpenMessageWriter()
+	w, err := a.OpenMessageWriter(context.Background())
 	c.Assert(err, gc.IsNil)
 
 	msg := new(params.PubSubMessage)
@@ -49,7 +50,7 @@ func (s *PubSubSuite) TestNewAPIWriteLogError(c *gc.C) {
 		connectError: errors.New("foo"),
 	}
 	a := apipubsub.NewAPI(conn)
-	w, err := a.OpenMessageWriter()
+	w, err := a.OpenMessageWriter(context.Background())
 	c.Assert(err, gc.ErrorMatches, "cannot connect to /pubsub: foo")
 	c.Assert(w, gc.Equals, nil)
 }
@@ -60,7 +61,7 @@ func (s *PubSubSuite) TestNewAPIWriteError(c *gc.C) {
 		writeError: errors.New("foo"),
 	}
 	a := apipubsub.NewAPI(conn)
-	w, err := a.OpenMessageWriter()
+	w, err := a.OpenMessageWriter(context.Background())
 	c.Assert(err, gc.IsNil)
 	defer w.Close()
 
@@ -79,7 +80,7 @@ type mockConnector struct {
 	closeCount int
 }
 
-func (c *mockConnector) ConnectStream(path string, values url.Values) (base.Stream, error) {
+func (c *mockConnector) ConnectStream(_ context.Context, path string, values url.Values) (base.Stream, error) {
 	c.c.Assert(path, gc.Equals, "/pubsub")
 	c.c.Assert(values, gc.HasLen, 0)
 	if c.connectError != nil {

--- a/api/controller/usersecretsdrain/client_test.go
+++ b/api/controller/usersecretsdrain/client_test.go
@@ -4,8 +4,6 @@
 package usersecretsdrain_test
 
 import (
-	"context"
-
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -26,7 +24,6 @@ func (s *userSecretsdrainSuite) TestNewClient(c *gc.C) {
 
 	apiCaller := mocks.NewMockAPICaller(ctrl)
 	apiCaller.EXPECT().BestFacadeVersion("UserSecretsDrain").Return(1)
-	apiCaller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	client := usersecretsdrain.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)

--- a/api/controller/usersecretsdrain/mocks/facade_mock.go
+++ b/api/controller/usersecretsdrain/mocks/facade_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/api/http/http.go
+++ b/api/http/http.go
@@ -28,17 +28,16 @@ type HTTPDoer interface {
 
 // URIOpener provides the OpenURI method.
 type URIOpener interface {
-	OpenURI(uri string, query url.Values) (io.ReadCloser, error)
+	OpenURI(ctx context.Context, uri string, query url.Values) (io.ReadCloser, error)
 }
 
 type uriOpener struct {
-	ctx        context.Context
 	httpClient HTTPDoer
 }
 
 // OpenURI performs a GET on a Juju HTTP endpoint returning the specified blob.
-func (o *uriOpener) OpenURI(uri string, query url.Values) (io.ReadCloser, error) {
-	return OpenURI(o.ctx, o.httpClient, uri, query)
+func (o *uriOpener) OpenURI(ctx context.Context, uri string, query url.Values) (io.ReadCloser, error) {
+	return OpenURI(ctx, o.httpClient, uri, query)
 }
 
 // NewURIOpener returns a URI opener for the api caller.
@@ -48,7 +47,6 @@ func NewURIOpener(apiConn base.APICaller) (URIOpener, error) {
 		return nil, errors.Trace(err)
 	}
 	return &uriOpener{
-		ctx:        apiConn.Context(),
 		httpClient: httpClient,
 	}, nil
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -277,7 +277,7 @@ type Connection interface {
 
 	// These are a bit off -- ServerVersion is apparently not known until after
 	// Login()? Maybe evidence of need for a separate AuthenticatedConnection..?
-	Login(name names.Tag, password, nonce string, ms []macaroon.Slice) error
+	Login(ctx context.Context, name names.Tag, password, nonce string, ms []macaroon.Slice) error
 	ServerVersion() (version.Number, bool)
 
 	// APICaller provides the facility to make API calls directly.

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -4,6 +4,7 @@
 package logsender
 
 import (
+	"context"
 	"io"
 	"net/url"
 
@@ -34,11 +35,11 @@ func NewAPI(connector base.StreamConnector) *API {
 
 // LogWriter returns a new log writer interface value
 // which must be closed when finished with.
-func (api *API) LogWriter() (LogWriter, error) {
+func (api *API) LogWriter(ctx context.Context) (LogWriter, error) {
 	attrs := make(url.Values)
 	// Version 1 does ping/pong handling.
 	attrs.Set("version", "1")
-	conn, err := api.connector.ConnectStream("/logsink", attrs)
+	conn, err := api.connector.ConnectStream(ctx, "/logsink", attrs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot connect to /logsink")
 	}

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -4,6 +4,7 @@
 package logsender_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/url"
@@ -30,7 +31,7 @@ func (s *LogSenderSuite) TestNewAPI(c *gc.C) {
 		c: c,
 	}
 	a := logsender.NewAPI(conn)
-	w, err := a.LogWriter()
+	w, err := a.LogWriter(context.Background())
 	c.Assert(err, gc.IsNil)
 
 	msg := new(params.LogRecord)
@@ -51,7 +52,7 @@ func (s *LogSenderSuite) TestNewAPIWriteLogError(c *gc.C) {
 		connectError: errors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
-	w, err := a.LogWriter()
+	w, err := a.LogWriter(context.Background())
 	c.Assert(err, gc.ErrorMatches, "cannot connect to /logsink: foo")
 	c.Assert(w, gc.Equals, nil)
 }
@@ -62,7 +63,7 @@ func (s *LogSenderSuite) TestNewAPIWriteError(c *gc.C) {
 		writeError: errors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
-	w, err := a.LogWriter()
+	w, err := a.LogWriter(context.Background())
 	c.Assert(err, gc.IsNil)
 
 	err = w.WriteLog(new(params.LogRecord))
@@ -78,7 +79,7 @@ func (s *LogSenderSuite) TestNewAPIReadError(c *gc.C) {
 		writeError: errors.New("closed yo"),
 	}
 	a := logsender.NewAPI(conn)
-	w, err := a.LogWriter()
+	w, err := a.LogWriter(context.Background())
 	c.Assert(err, gc.IsNil)
 	select {
 	case <-conn.closed:
@@ -103,7 +104,7 @@ type mockConnector struct {
 	closed       chan bool
 }
 
-func (c *mockConnector) ConnectStream(path string, values url.Values) (base.Stream, error) {
+func (c *mockConnector) ConnectStream(_ context.Context, path string, values url.Values) (base.Stream, error) {
 	c.c.Assert(path, gc.Equals, "/logsink")
 	c.c.Assert(values, jc.DeepEquals, url.Values{
 		"version": []string{"1"},

--- a/api/logstream/logstream.go
+++ b/api/logstream/logstream.go
@@ -4,6 +4,7 @@
 package logstream
 
 import (
+	"context"
 	"io"
 	"sync"
 
@@ -38,8 +39,8 @@ type LogStream struct {
 
 // Open opens a websocket to the API's /logstream endpoint and returns
 // a stream of log records from that connection.
-func Open(conn base.StreamConnector, cfg params.LogStreamConfig, controllerUUID string) (*LogStream, error) {
-	wsStream, err := stream.Open(conn, "/logstream", &cfg)
+func Open(ctx context.Context, conn base.StreamConnector, cfg params.LogStreamConfig, controllerUUID string) (*LogStream, error) {
+	wsStream, err := stream.Open(ctx, conn, "/logstream", &cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/logstream/logstream_test.go
+++ b/api/logstream/logstream_test.go
@@ -4,6 +4,7 @@
 package logstream_test
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -38,7 +39,7 @@ func (s *LogReaderSuite) TestOpenFullConfig(c *gc.C) {
 		Sink: "spam",
 	}
 
-	_, err := logstream.Open(conn, cfg, cUUID)
+	_, err := logstream.Open(context.Background(), conn, cfg, cUUID)
 	c.Assert(err, gc.IsNil)
 
 	stub.CheckCallNames(c, "ConnectStream")
@@ -55,7 +56,7 @@ func (s *LogReaderSuite) TestOpenError(c *gc.C) {
 	stub.SetErrors(failure)
 	var cfg params.LogStreamConfig
 
-	_, err := logstream.Open(conn, cfg, cUUID)
+	_, err := logstream.Open(context.Background(), conn, cfg, cUUID)
 
 	c.Check(err, gc.ErrorMatches, "cannot connect to /logstream: foo")
 	stub.CheckCallNames(c, "ConnectStream")
@@ -85,7 +86,7 @@ func (s *LogReaderSuite) TestNextOneRecord(c *gc.C) {
 	jsonReader.ReturnReadJSON = logsCh
 	conn.ReturnConnectStream = jsonReader
 	var cfg params.LogStreamConfig
-	stream, err := logstream.Open(conn, cfg, cUUID)
+	stream, err := logstream.Open(context.Background(), conn, cfg, cUUID)
 	c.Assert(err, gc.IsNil)
 	stub.ResetCalls()
 
@@ -150,7 +151,7 @@ func (s *LogReaderSuite) TestNextError(c *gc.C) {
 	failure := errors.New("an error")
 	stub.SetErrors(nil, failure)
 	var cfg params.LogStreamConfig
-	stream, err := logstream.Open(conn, cfg, cUUID)
+	stream, err := logstream.Open(context.Background(), conn, cfg, cUUID)
 	c.Assert(err, gc.IsNil)
 
 	var nextErr error
@@ -175,7 +176,7 @@ func (s *LogReaderSuite) TestClose(c *gc.C) {
 	jsonReader := mockStream{stub: stub}
 	conn.ReturnConnectStream = jsonReader
 	var cfg params.LogStreamConfig
-	stream, err := logstream.Open(conn, cfg, cUUID)
+	stream, err := logstream.Open(context.Background(), conn, cfg, cUUID)
 	c.Assert(err, gc.IsNil)
 	stub.ResetCalls()
 
@@ -196,7 +197,7 @@ type mockConnector struct {
 	ReturnConnectStream base.Stream
 }
 
-func (c *mockConnector) ConnectStream(path string, values url.Values) (base.Stream, error) {
+func (c *mockConnector) ConnectStream(_ context.Context, path string, values url.Values) (base.Stream, error) {
 	c.stub.AddCall("ConnectStream", path, values)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -42,7 +42,6 @@ var _ = gc.Suite(&watcherSuite{})
 
 func setupWatcher[T any](c *gc.C, caller *apimocks.MockAPICaller, facadeName string) (string, chan T) {
 	caller.EXPECT().BestFacadeVersion(facadeName).Return(666).AnyTimes()
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	// Initial event.
 	eventCh := make(chan T)
 
@@ -75,7 +74,6 @@ func (s *watcherSuite) TestWatchMachine(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Machiner").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, _ := setupWatcher[any](c, caller, "NotifyWatcher")
 
@@ -111,7 +109,6 @@ func (s *watcherSuite) TestNotifyWatcherStopsWithPendingSend(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Machiner").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, _ := setupWatcher[any](c, caller, "NotifyWatcher")
 
@@ -145,7 +142,6 @@ func (s *watcherSuite) TestWatchUnits(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Deployer").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, eventCh := setupWatcher[*params.StringsWatchResult](c, caller, "StringsWatcher")
 
@@ -187,7 +183,6 @@ func (s *watcherSuite) TestStringsWatcherStopsWithPendingSend(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("Deployer").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, _ := setupWatcher[*params.StringsWatchResult](c, caller, "StringsWatcher")
 
@@ -218,7 +213,6 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("StorageProvisioner").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, eventCh := setupWatcher[*params.MachineStorageIdsWatchResult](c, caller, "VolumeAttachmentsWatcher")
 
@@ -293,7 +287,6 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, eventCh := setupWatcher[*params.RelationLifeSuspendedStatusWatchResult](c, caller, "RelationStatusWatcher")
 
@@ -318,7 +311,7 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "CrossModelRelations", 666, "", "WatchRelationsSuspendedStatus", args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
 	client := crossmodelrelations.NewClient(&apicloser{caller})
-	w, err := client.WatchRelationSuspendedStatus(arg)
+	w, err := client.WatchRelationSuspendedStatus(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -368,7 +361,6 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666)
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	watcherID, eventCh := setupWatcher[*params.OfferStatusWatchResult](c, caller, "OfferStatusWatcher")
 
@@ -400,7 +392,7 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "CrossModelRelations", 666, "", "WatchOfferStatus", args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
 	client := crossmodelrelations.NewClient(&apicloser{caller})
-	w, err := client.WatchOfferStatus(arg)
+	w, err := client.WatchOfferStatus(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -516,7 +508,6 @@ func (s *watcherSuite) TestSecretsRotationWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("SecretsManager").Return(666).AnyTimes()
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	client := secretsmanager.NewClient(caller)
 	s.assertSecretsTriggerWatcher(c, caller, "WatchSecretsRotationChanges", client.WatchSecretsRotationChanges)
@@ -528,7 +519,6 @@ func (s *watcherSuite) TestSecretsRevisionsExpiryWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("SecretsManager").Return(666).AnyTimes()
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	client := secretsmanager.NewClient(caller)
 	s.assertSecretsTriggerWatcher(c, caller, "WatchSecretRevisionsExpiryChanges", client.WatchSecretRevisionsExpiryChanges)
@@ -540,7 +530,6 @@ func (s *watcherSuite) TestCrossModelSecretsRevisionWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("CrossModelRelations").Return(666).AnyTimes()
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	watcherID, eventCh := setupWatcher[*params.SecretRevisionWatchResult](c, caller, "SecretsRevisionWatcher")
 
 	mac, err := jujutesting.NewMacaroon("apimac")
@@ -563,7 +552,7 @@ func (s *watcherSuite) TestCrossModelSecretsRevisionWatcher(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "CrossModelRelations", 666, "", "WatchConsumedSecretsChanges", args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
 	client := crossmodelrelations.NewClient(&apicloser{caller})
-	w, err := client.WatchConsumedSecretsChanges("app-token", "rel-token", mac)
+	w, err := client.WatchConsumedSecretsChanges(context.Background(), "app-token", "rel-token", mac)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -615,7 +604,6 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 
 	caller := apimocks.NewMockAPICaller(ctrl)
 	caller.EXPECT().BestFacadeVersion("MigrationMinion").Return(666).AnyTimes()
-	caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	watcherID, eventCh := setupWatcher[*params.MigrationStatus](c, caller, "MigrationStatusWatcher")
 
 	initialResult := params.NotifyWatchResult{

--- a/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
@@ -112,9 +113,9 @@ func (m *MockCrossModelSecretsClient) EXPECT() *MockCrossModelSecretsClientMockR
 }
 
 // GetRemoteSecretContentInfo mocks base method.
-func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.URI, arg1 int, arg2, arg3 bool, arg4 string, arg5 int, arg6 macaroon.Slice) (*secrets0.ContentParams, *provider.ModelBackendConfig, int, bool, error) {
+func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3, arg4 bool, arg5 string, arg6 int, arg7 macaroon.Slice) (*secrets0.ContentParams, *provider.ModelBackendConfig, int, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRemoteSecretContentInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "GetRemoteSecretContentInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(*secrets0.ContentParams)
 	ret1, _ := ret[1].(*provider.ModelBackendConfig)
 	ret2, _ := ret[2].(int)
@@ -124,9 +125,9 @@ func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.U
 }
 
 // GetRemoteSecretContentInfo indicates an expected call of GetRemoteSecretContentInfo.
-func (mr *MockCrossModelSecretsClientMockRecorder) GetRemoteSecretContentInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockCrossModelSecretsClientMockRecorder) GetRemoteSecretContentInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteSecretContentInfo", reflect.TypeOf((*MockCrossModelSecretsClient)(nil).GetRemoteSecretContentInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteSecretContentInfo", reflect.TypeOf((*MockCrossModelSecretsClient)(nil).GetRemoteSecretContentInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // GetSecretAccessScope mocks base method.

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -29,7 +29,7 @@ import (
 
 // CrossModelSecretsClient gets secret content from a cross model controller.
 type CrossModelSecretsClient interface {
-	GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, refresh, peek bool, appToken string, unitId int, macs macaroon.Slice) (*secrets.ContentParams, *secretsprovider.ModelBackendConfig, int, bool, error)
+	GetRemoteSecretContentInfo(ctx context.Context, uri *coresecrets.URI, revision int, refresh, peek bool, appToken string, unitId int, macs macaroon.Slice) (*secrets.ContentParams, *secretsprovider.ModelBackendConfig, int, bool, error)
 	GetSecretAccessScope(uri *coresecrets.URI, appToken string, unitId int) (string, error)
 }
 
@@ -520,7 +520,7 @@ func (s *SecretsManagerAPI) getRemoteSecretContent(ctx context.Context, uri *cor
 	}
 
 	macs := macaroon.Slice{mac}
-	content, backend, latestRevision, draining, err := extClient.GetRemoteSecretContentInfo(uri, wantRevision, refresh, peek, token, unitId, macs)
+	content, backend, latestRevision, draining, err := extClient.GetRemoteSecretContentInfo(ctx, uri, wantRevision, refresh, peek, token, unitId, macs)
 	if err != nil {
 		return nil, nil, false, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1304,7 +1304,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(gomock.Any(), uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1370,7 +1370,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(gomock.Any(), uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1441,7 +1441,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, true, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(gomock.Any(), uri, 665, true, false, "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1510,7 +1510,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 0, true, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(gomock.Any(), uri, 0, true, false, "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",

--- a/apiserver/macaroon_test.go
+++ b/apiserver/macaroon_test.go
@@ -286,7 +286,7 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 
 	// Then check that ConnectStream works OK and that it doesn't need
 	// to discharge again.
-	conn, err := client.ConnectStream("/path", nil)
+	conn, err := client.ConnectStream(context.Background(), "/path", nil)
 	c.Assert(err, gc.IsNil)
 	defer conn.Close()
 	connectURL, err := url.Parse(catcher.Location())
@@ -322,7 +322,7 @@ func (s *macaroonLoginSuite) TestConnectStreamFailedDischarge(c *gc.C) {
 	// the actual debug-log endpoint will return an error).
 	dischargeError = true
 	logArgs := url.Values{"noTail": []string{"true"}}
-	conn, err := client.ConnectStream("/log", logArgs)
+	conn, err := client.ConnectStream(context.Background(), "/log", logArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
 	conn.Close()
@@ -331,7 +331,7 @@ func (s *macaroonLoginSuite) TestConnectStreamFailedDischarge(c *gc.C) {
 	// and try again. The login should fail.
 	jar.Clear()
 
-	conn, err = client.ConnectStream("/log", logArgs)
+	conn, err = client.ConnectStream(context.Background(), "/log", logArgs)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 	c.Assert(conn, gc.IsNil)
 }
@@ -382,7 +382,7 @@ func (s *macaroonLoginSuite) TestConnectStreamWithDischargedMacaroons(c *gc.C) {
 	info2.Macaroons = dischargedMacaroons
 
 	client2 := s.OpenAPI(c, info2, nil)
-	conn, err := client2.ConnectStream("/path", nil)
+	conn, err := client2.ConnectStream(context.Background(), "/path", nil)
 	c.Assert(err, gc.IsNil)
 	defer conn.Close()
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -624,6 +624,7 @@ func (s *CAASDeploySuite) TestDevices(c *gc.C) {
 		},
 	)
 	s.DeployResources = func(
+		_ context.Context,
 		applicationID string,
 		chID resources.CharmID,
 		filesAndRevisions map[string]string,
@@ -1177,6 +1178,7 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) modelcmd.ModelCommand {
 			return fakeAPI, nil
 		},
 		DeployResources: func(
+			_ context.Context,
 			applicationID string,
 			chID resources.CharmID,
 			filesAndRevisions map[string]string,
@@ -1279,10 +1281,6 @@ func (f *fakeDeployAPI) BestFacadeVersion(facade string) int {
 func (f *fakeDeployAPI) APICall(ctx context.Context, objType string, version int, id, request string, params, response interface{}) error {
 	results := f.MethodCall(f, "APICall", objType, version, id, request, params, response)
 	return jujutesting.TypeAssertError(results[0])
-}
-
-func (f *fakeDeployAPI) Context() context.Context {
-	return context.Background()
 }
 
 func (f *fakeDeployAPI) Client() *apiclient.Client {

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -113,7 +113,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 
 	// Deploying bundles does not allow the use force, it's expected that the
 	// bundle is correct and therefore the charms are also.
-	if err := bundleDeploy(d.defaultCharmSchema, bundleData, spec); err != nil {
+	if err := bundleDeploy(ctx, d.defaultCharmSchema, bundleData, spec); err != nil {
 		return errors.Annotate(err, "cannot deploy bundle")
 	}
 	return nil

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -93,7 +93,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNotFoundCharmHub(c *gc.C) 
 		},
 	}
 
-	err := bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err := bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "no-such": bundle not found`)
 }
 
@@ -169,7 +169,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccessWithModelConstraint
 	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpecWithConstraints(constraints.MustParse("arch=arm64")))
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpecWithConstraints(constraints.MustParse("arch=arm64")))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "20.04")
@@ -251,7 +251,7 @@ func (s *BundleDeployRepositorySuite) TestDeployAddCharmHasBase(c *gc.C) {
 	bundleData, err := charm.ReadBundleData(strings.NewReader(multiApplicationBundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 3)
 	s.assertDeployArgs(c, fullGatewayURL.String(), "istio-ingressgateway", "ubuntu", "20.04")
@@ -439,7 +439,7 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccessWithRevis
 	bundleData, err := charm.ReadBundleData(strings.NewReader(kubernetesCharmhubGitlabBundleWithRevision))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, fullGitlabCurl.String(), "gitlab", "ubuntu", "20.04")
@@ -846,6 +846,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleResources(c *gc.C) {
 
 	spec := s.bundleDeploySpec()
 	spec.deployResources = func(
+		_ context.Context,
 		_ string,
 		_ resources.CharmID,
 		filesAndRevisions map[string]string,
@@ -899,6 +900,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSpecifyResources(c *gc.C) 
 
 	spec := s.bundleDeploySpec()
 	spec.deployResources = func(
+		_ context.Context,
 		_ string,
 		_ resources.CharmID,
 		filesAndRevisions map[string]string,
@@ -1654,7 +1656,7 @@ machines:
 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(quickBundle))
 	c.Assert(err, jc.ErrorIsNil)
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, gc.ErrorMatches, `cannot create machine for holding wp unit: invalid container type "bad"`)
 }
 
@@ -1898,7 +1900,7 @@ relations:
 	bundleData, err := charm.ReadBundleData(strings.NewReader(bundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "20.04")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "20.04")
@@ -1966,7 +1968,7 @@ relations:
 	bundleData, err := charm.ReadBundleData(strings.NewReader(bundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "20.04")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "20.04")
@@ -2047,7 +2049,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithEndpointBindings(c *gc
 	bundleDeploymentSpec := s.bundleDeploySpec()
 	bundleDeploymentSpec.knownSpaceNames = set.NewStrings("alpha", "beta")
 
-	err = bundleDeploy(charm.CharmHub, bundleData, bundleDeploymentSpec)
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, bundleDeploymentSpec)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2064,7 +2066,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidEndpointBinding
 	bundleDeploymentSpec := s.bundleDeploySpec()
 	bundleDeploymentSpec.knownSpaceNames = set.NewStrings("alpha")
 
-	err = bundleDeploy(charm.CharmHub, bundleData, bundleDeploymentSpec)
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, bundleDeploymentSpec)
 	c.Assert(err, gc.ErrorMatches, `space "beta" not found`)
 }
 
@@ -2090,7 +2092,9 @@ func (s *BundleDeployRepositorySuite) bundleDeploySpec() bundleDeploySpec {
 }
 
 func (s *BundleDeployRepositorySuite) bundleDeploySpecWithConstraints(cons constraints.Value) bundleDeploySpec {
-	deployResourcesFunc := func(_ string,
+	deployResourcesFunc := func(
+		_ context.Context,
+		_ string,
 		_ resources.CharmID,
 		_ map[string]string,
 		_ map[string]charmresource.Meta,
@@ -2189,7 +2193,6 @@ func (s *BundleDeployRepositorySuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.deployerAPI = mocks.NewMockDeployerAPI(ctrl)
 	s.deployerAPI.EXPECT().BestFacadeVersion("Resources").Return(666).AnyTimes()
-	s.deployerAPI.EXPECT().Context().Return(context.Background()).AnyTimes()
 	s.deployerAPI.EXPECT().BestFacadeVersion("Charms").Return(666).AnyTimes()
 	s.deployerAPI.EXPECT().HTTPClient().Return(&httprequest.Client{}, nil).AnyTimes()
 	s.bundleResolver = mocks.NewMockResolver(ctrl)
@@ -2215,7 +2218,7 @@ func (s *BundleDeployRepositorySuite) runDeployWithSpec(c *gc.C, bundle string, 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(bundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bundleDeploy(charm.CharmHub, bundleData, spec)
+	err = bundleDeploy(context.Background(), charm.CharmHub, bundleData, spec)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -123,6 +123,7 @@ func (d *deployCharm) deploy(
 	}
 
 	ids, err := d.deployResources(
+		ctx,
 		applicationName,
 		resources.CharmID{
 			URL:    id.URL,
@@ -410,7 +411,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// No localPendingResources should exist if a dry-run.
-	uploadErr := c.uploadExistingPendingResources(info.Name, localPendingResources, deployAPI,
+	uploadErr := c.uploadExistingPendingResources(ctx, info.Name, localPendingResources, deployAPI,
 		c.model.Filesystem())
 	if uploadErr != nil {
 		ctx.Errorf("Unable to upload resources for %v, consider using --attach-resource. \n %v",

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -5,6 +5,7 @@ package deployer
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
@@ -112,7 +113,7 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *gc.C) 
 			OS: "ubuntu"},
 	}
 
-	repoCharm.uploadExistingPendingResources = func(appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
+	repoCharm.uploadExistingPendingResources = func(_ context.Context, appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
 		c.Assert(appName, gc.Equals, dInfo.Name)
 		return nil
 	}
@@ -161,7 +162,7 @@ func (s *charmSuite) TestDeployFromRepositoryCharmAppNameVSCharmName(c *gc.C) {
 			OS: "ubuntu"},
 	}
 
-	repoCharm.uploadExistingPendingResources = func(appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
+	repoCharm.uploadExistingPendingResources = func(_ context.Context, appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
 		c.Assert(appName, gc.Equals, dInfo.Name)
 		return nil
 	}
@@ -198,7 +199,7 @@ func (s *charmSuite) TestDeployFromRepositoryErrorNoUploadResources(c *gc.C) {
 		Stdout: writer,
 	}
 
-	repoCharm.uploadExistingPendingResources = func(appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
+	repoCharm.uploadExistingPendingResources = func(_ context.Context, appName string, pendingResources []application.PendingResourceUpload, conn base.APICallCloser, filesystem modelcmd.Filesystem) error {
 		c.Fatalf("Do not upload pending resources if errors")
 		return nil
 	}
@@ -213,6 +214,7 @@ func (s *charmSuite) newDeployCharm() *deployCharm {
 	return &deployCharm{
 		configOptions: s.configFlag,
 		deployResources: func(
+			context.Context,
 			string,
 			resources.CharmID,
 			map[string]string,

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -397,6 +397,7 @@ func (s *deployerSuite) makeBundleDir(c *gc.C, content string) string {
 func (s *deployerSuite) newDeployerFactory() DeployerFactory {
 	dep := DeployerDependencies{
 		DeployResources: func(
+			context.Context,
 			string,
 			resources.CharmID,
 			map[string]string,

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -231,33 +231,33 @@ func (mr *MockDeployerAPIMockRecorder) Close() *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockDeployerAPI) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockDeployerAPI) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockDeployerAPIMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockDeployerAPIMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockDeployerAPI)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockDeployerAPI)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockDeployerAPI) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockDeployerAPI) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockDeployerAPIMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockDeployerAPIMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockDeployerAPI)(nil).ConnectStream), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockDeployerAPI)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // Consume mocks base method.
@@ -273,20 +273,6 @@ func (m *MockDeployerAPI) Consume(arg0 crossmodel.ConsumeApplicationArgs) (strin
 func (mr *MockDeployerAPIMockRecorder) Consume(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Consume", reflect.TypeOf((*MockDeployerAPI)(nil).Consume), arg0)
-}
-
-// Context mocks base method.
-func (m *MockDeployerAPI) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockDeployerAPIMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockDeployerAPI)(nil).Context))
 }
 
 // Deploy mocks base method.

--- a/cmd/juju/application/deployer/resource.go
+++ b/cmd/juju/application/deployer/resource.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"strconv"
 
 	charmresource "github.com/juju/charm/v12/resource"
@@ -18,6 +19,7 @@ import (
 
 // DeployResourcesFunc is the function type of DeployResources.
 type DeployResourcesFunc func(
+	ctx context.Context,
 	applicationID string,
 	chID resources.CharmID,
 	filesAndRevisions map[string]string,
@@ -30,6 +32,7 @@ type DeployResourcesFunc func(
 // creates pending resource metadata for the all resource mentioned in the
 // metadata. It returns a map of resource name to pending resource IDs.
 func DeployResources(
+	ctx context.Context,
 	applicationID string,
 	chID resources.CharmID,
 	filesAndRevisions map[string]string,
@@ -60,7 +63,7 @@ func DeployResources(
 		}
 	}
 
-	ids, err = resourcecmd.DeployResources(resourcecmd.DeployResourcesArgs{
+	ids, err = resourcecmd.DeployResources(ctx, resourcecmd.DeployResourcesArgs{
 		ApplicationID:  applicationID,
 		CharmID:        chID,
 		ResourceValues: filenames,
@@ -88,7 +91,7 @@ func (cl *deployClient) AddPendingResources(applicationID string, chID resources
 	})
 }
 
-type UploadExistingPendingResourcesFunc func(appName string,
+type UploadExistingPendingResourcesFunc func(ctx context.Context, appName string,
 	pendingResources []application.PendingResourceUpload,
 	conn base.APICallCloser,
 	filesystem modelcmd.Filesystem) error
@@ -99,6 +102,7 @@ type UploadExistingPendingResourcesFunc func(appName string,
 // Called after AddApplication so no pending resource IDs are
 // necessary, see juju attach for more examples.
 func UploadExistingPendingResources(
+	ctx context.Context,
 	appName string,
 	pendingResources []application.PendingResourceUpload,
 	conn base.APICallCloser,
@@ -123,7 +127,7 @@ func UploadExistingPendingResources(
 			return errors.Annotatef(openResErr, "unable to open resource %v", pendingResUpload.Name)
 		}
 
-		uploadErr := resourceApiClient.Upload(appName,
+		uploadErr := resourceApiClient.Upload(ctx, appName,
 			pendingResUpload.Name, pendingResUpload.Filename, "", r)
 
 		if uploadErr != nil {

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -630,10 +630,6 @@ func (r *mockAPIRoot) BestFacadeVersion(name string) int {
 	return 42
 }
 
-func (r *mockAPIRoot) Context() context.Context {
-	return context.Background()
-}
-
 func (r *mockAPIRoot) APICall(ctx context.Context, objType string, version int, id, request string, params, response interface{}) error {
 	call := objType + "." + request
 	r.stub.AddCall(call, version, params)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -453,7 +454,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		URL:    curl,
 		Origin: origin,
 	}
-	resourceIDs, err := c.upgradeResources(apiRoot, chID)
+	resourceIDs, err := c.upgradeResources(ctx, apiRoot, chID)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -569,6 +570,7 @@ func (c *refreshCommand) parseBindFlag(apiRoot base.APICallCloser) error {
 // TODO(axw) apiRoot is passed in here because DeployResources requires it,
 // DeployResources should accept a resource-specific client instead.
 func (c *refreshCommand) upgradeResources(
+	ctx context.Context,
 	apiRoot base.APICallCloser,
 	chID application.CharmID,
 ) (map[string]string, error) {
@@ -599,6 +601,7 @@ func (c *refreshCommand) upgradeResources(
 	// Note: the validity of user-supplied resources to be uploaded will be
 	// checked further down the stack.
 	ids, err := c.DeployResources(
+		ctx,
 		c.ApplicationName,
 		resources.CharmID{
 			URL:    chID.URL,

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -102,6 +102,7 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 	s.testPlatform = corecharm.MustParsePlatform(fmt.Sprintf("%s/%s/%s", arch.DefaultArchitecture, s.testBase.OS, s.testBase.Channel))
 
 	s.deployResources = func(
+		_ context.Context,
 		applicationID string,
 		chID resources.CharmID,
 		filesAndRevisions map[string]string,

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -5,6 +5,7 @@ package backups
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"text/template"
 	"time"
@@ -26,7 +27,7 @@ type APIClient interface {
 	// Create sends an RPC request to create a new backup.
 	Create(notes string, noDownload bool) (*params.BackupsMetadataResult, error)
 	// Download pulls the backup archive file.
-	Download(filename string) (io.ReadCloser, error)
+	Download(ctx context.Context, filename string) (io.ReadCloser, error)
 }
 
 // CommandBase is the base type for backups sub-commands.

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -149,7 +149,7 @@ func (c *createCommand) decideFilename(ctx *cmd.Context, filename string, timest
 }
 
 func (c *createCommand) download(ctx *cmd.Context, client APIClient, copyFrom string, archiveFilename string) error {
-	resultArchive, err := client.Download(copyFrom)
+	resultArchive, err := client.Download(ctx, copyFrom)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -78,7 +78,7 @@ func (c *downloadCommand) Run(ctx *cmd.Context) error {
 	defer client.Close()
 
 	// Download the archive.
-	resultArchive, err := client.Download(c.RemoteFilename)
+	resultArchive, err := client.Download(ctx, c.RemoteFilename)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -5,6 +5,7 @@ package backups_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -197,7 +198,7 @@ func (c *fakeAPIClient) Create(notes string, noDownload bool) (*params.BackupsMe
 	return createResult, nil
 }
 
-func (c *fakeAPIClient) Download(id string) (io.ReadCloser, error) {
+func (c *fakeAPIClient) Download(_ context.Context, id string) (io.ReadCloser, error) {
 	c.calls = append(c.calls, "Download")
 	c.args = append(c.args, id)
 	if c.err != nil {

--- a/cmd/juju/resource/stub_test.go
+++ b/cmd/juju/resource/stub_test.go
@@ -4,6 +4,7 @@
 package resource_test
 
 import (
+	"context"
 	"io"
 
 	charmresource "github.com/juju/charm/v12/resource"
@@ -35,7 +36,7 @@ type stubAPIClient struct {
 	resources resources.ApplicationResources
 }
 
-func (s *stubAPIClient) Upload(application, name, filename, pendingID string, resource io.ReadSeeker) error {
+func (s *stubAPIClient) Upload(_ context.Context, application, name, filename, pendingID string, resource io.ReadSeeker) error {
 	s.stub.AddCall("Upload", application, name, filename, pendingID, resource)
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/internal/upgradesteps/api_mock_test.go
+++ b/internal/upgradesteps/api_mock_test.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/caasapplicationprovisioner/manifold_test.go
+++ b/internal/worker/caasapplicationprovisioner/manifold_test.go
@@ -4,8 +4,6 @@
 package caasapplicationprovisioner_test
 
 import (
-	"context"
-
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -113,10 +111,6 @@ type mockAPICaller struct {
 
 func (*mockAPICaller) BestFacadeVersion(facade string) int {
 	return 1
-}
-
-func (*mockAPICaller) Context() context.Context {
-	return context.Background()
 }
 
 func (*mockAPICaller) ModelTag() (names.ModelTag, bool) {

--- a/internal/worker/caasfirewaller/mocks/api_base_mock.go
+++ b/internal/worker/caasfirewaller/mocks/api_base_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/containerbroker/mocks/base_mock.go
+++ b/internal/worker/containerbroker/mocks/base_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -4,6 +4,7 @@
 package firewaller_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -356,7 +357,7 @@ func (s *firewallerBaseSuite) newFirewaller(c *gc.C, ctrl *gomock.Controller) wo
 		EnvironIPV6CIDRSupport: s.withIpv6,
 		FirewallerAPI:          s.firewaller,
 		RemoteRelationsApi:     s.remoteRelations,
-		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
+		NewCrossModelFacadeFunc: func(context.Context, *api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
 		Clock:              s.clock,
@@ -1216,7 +1217,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 		Macaroons:       macaroon.Slice{mac},
 		BakeryVersion:   bakery.LatestVersion,
 	}
-	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(event).DoAndReturn(func(_ params.IngressNetworksChangeEvent) error {
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
 		published <- true
 		return nil
 	})
@@ -1232,7 +1233,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *gc.C)
 	// Trigger watcher for unit on the consuming app (leave the relation scope).
 	event.IngressRequired = false
 	event.Networks = []string{}
-	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(event).DoAndReturn(func(_ params.IngressNetworksChangeEvent) error {
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
 		published <- true
 		return nil
 	})
@@ -1267,7 +1268,7 @@ func (s *InstanceModeSuite) TestRemoteRelationWorkerError(c *gc.C) {
 		Macaroons:       macaroon.Slice{mac},
 		BakeryVersion:   bakery.LatestVersion,
 	}
-	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(event).DoAndReturn(func(_ params.IngressNetworksChangeEvent) error {
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
 		published <- true
 		return errors.New("fail")
 	})
@@ -1280,7 +1281,7 @@ func (s *InstanceModeSuite) TestRemoteRelationWorkerError(c *gc.C) {
 	case <-published:
 	}
 
-	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(event).DoAndReturn(func(_ params.IngressNetworksChangeEvent) error {
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
 		published <- true
 		return nil
 	})
@@ -1355,7 +1356,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *gc.C)
 		Token:     "rel-token",
 		Macaroons: macaroon.Slice{mac},
 	}
-	s.crossmodelFirewaller.EXPECT().WatchEgressAddressesForRelation(arg).DoAndReturn(func(_ params.RemoteEntityArg) (watcher.StringsWatcher, error) {
+	s.crossmodelFirewaller.EXPECT().WatchEgressAddressesForRelation(gomock.Any(), arg).DoAndReturn(func(_ context.Context, _ params.RemoteEntityArg) (watcher.StringsWatcher, error) {
 		watched <- true
 		return remoteEgressWatch, nil
 	})
@@ -1442,7 +1443,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressRejected(c *gc.C) {
 		Macaroons:       macaroon.Slice{mac},
 		BakeryVersion:   bakery.LatestVersion,
 	}
-	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(event).DoAndReturn(func(_ params.IngressNetworksChangeEvent) error {
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
 		return &params.Error{Code: params.CodeForbidden, Message: "error"}
 	})
 	s.firewaller.EXPECT().SetRelationStatus(relTag.Id(), relation.Error, "error").DoAndReturn(func(string, relation.Status, string) error {
@@ -2282,7 +2283,7 @@ func (s *NoneModeSuite) TestStopImmediately(c *gc.C) {
 		EnvironIPV6CIDRSupport: s.withIpv6,
 		FirewallerAPI:          s.firewaller,
 		RemoteRelationsApi:     s.remoteRelations,
-		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
+		NewCrossModelFacadeFunc: func(context.Context, *api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
 		Clock:         s.clock,

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -48,8 +48,8 @@ type FirewallerAPI interface {
 // CrossModelFirewallerFacade exposes firewaller functionality on the
 // remote offering model to a worker.
 type CrossModelFirewallerFacade interface {
-	PublishIngressNetworkChange(params.IngressNetworksChangeEvent) error
-	WatchEgressAddressesForRelation(details params.RemoteEntityArg) (watcher.StringsWatcher, error)
+	PublishIngressNetworkChange(stdcontext.Context, params.IngressNetworksChangeEvent) error
+	WatchEgressAddressesForRelation(ctx stdcontext.Context, details params.RemoteEntityArg) (watcher.StringsWatcher, error)
 }
 
 // CrossModelFirewallerFacadeCloser implements CrossModelFirewallerFacade

--- a/internal/worker/firewaller/mocks/facade_mocks.go
+++ b/internal/worker/firewaller/mocks/facade_mocks.go
@@ -398,32 +398,32 @@ func (mr *MockCrossModelFirewallerFacadeCloserMockRecorder) Close() *gomock.Call
 }
 
 // PublishIngressNetworkChange mocks base method.
-func (m *MockCrossModelFirewallerFacadeCloser) PublishIngressNetworkChange(arg0 params.IngressNetworksChangeEvent) error {
+func (m *MockCrossModelFirewallerFacadeCloser) PublishIngressNetworkChange(arg0 context.Context, arg1 params.IngressNetworksChangeEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublishIngressNetworkChange", arg0)
+	ret := m.ctrl.Call(m, "PublishIngressNetworkChange", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PublishIngressNetworkChange indicates an expected call of PublishIngressNetworkChange.
-func (mr *MockCrossModelFirewallerFacadeCloserMockRecorder) PublishIngressNetworkChange(arg0 any) *gomock.Call {
+func (mr *MockCrossModelFirewallerFacadeCloserMockRecorder) PublishIngressNetworkChange(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishIngressNetworkChange", reflect.TypeOf((*MockCrossModelFirewallerFacadeCloser)(nil).PublishIngressNetworkChange), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishIngressNetworkChange", reflect.TypeOf((*MockCrossModelFirewallerFacadeCloser)(nil).PublishIngressNetworkChange), arg0, arg1)
 }
 
 // WatchEgressAddressesForRelation mocks base method.
-func (m *MockCrossModelFirewallerFacadeCloser) WatchEgressAddressesForRelation(arg0 params.RemoteEntityArg) (watcher.Watcher[[]string], error) {
+func (m *MockCrossModelFirewallerFacadeCloser) WatchEgressAddressesForRelation(arg0 context.Context, arg1 params.RemoteEntityArg) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchEgressAddressesForRelation", arg0)
+	ret := m.ctrl.Call(m, "WatchEgressAddressesForRelation", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchEgressAddressesForRelation indicates an expected call of WatchEgressAddressesForRelation.
-func (mr *MockCrossModelFirewallerFacadeCloserMockRecorder) WatchEgressAddressesForRelation(arg0 any) *gomock.Call {
+func (mr *MockCrossModelFirewallerFacadeCloserMockRecorder) WatchEgressAddressesForRelation(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchEgressAddressesForRelation", reflect.TypeOf((*MockCrossModelFirewallerFacadeCloser)(nil).WatchEgressAddressesForRelation), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchEgressAddressesForRelation", reflect.TypeOf((*MockCrossModelFirewallerFacadeCloser)(nil).WatchEgressAddressesForRelation), arg0, arg1)
 }
 
 // MockEnvironFirewaller is a mock of EnvironFirewaller interface.

--- a/internal/worker/firewaller/shim.go
+++ b/internal/worker/firewaller/shim.go
@@ -4,6 +4,8 @@
 package firewaller
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/worker/v3"
@@ -68,7 +70,7 @@ func NewWorker(cfg Config) (worker.Worker, error) {
 func crossmodelFirewallerFacadeFunc(
 	connectionFunc apicaller.NewExternalControllerConnectionFunc,
 ) newCrossModelFacadeFunc {
-	return func(apiInfo *api.Info) (CrossModelFirewallerFacadeCloser, error) {
+	return func(ctx context.Context, apiInfo *api.Info) (CrossModelFirewallerFacadeCloser, error) {
 		apiInfo.Tag = names.NewUserTag(api.AnonymousUsername)
 		conn, err := connectionFunc(apiInfo)
 		if err != nil {

--- a/internal/worker/instancemutater/mocks/base_mock.go
+++ b/internal/worker/instancemutater/mocks/base_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/logforwarder/logforwarder.go
+++ b/internal/worker/logforwarder/logforwarder.go
@@ -4,6 +4,7 @@
 package logforwarder
 
 import (
+	"context"
 	"io"
 	"sync"
 
@@ -29,7 +30,7 @@ type LogStream interface {
 }
 
 // LogStreamFn is a function that opens a log stream.
-type LogStreamFn func(_ base.APICaller, _ params.LogStreamConfig, controllerUUID string) (LogStream, error)
+type LogStreamFn func(_ context.Context, _ base.APICaller, _ params.LogStreamConfig, controllerUUID string) (LogStream, error)
 
 // SendCloser is responsible for sending log records to a log sink.
 type SendCloser interface {
@@ -202,7 +203,7 @@ func (lf *LogForwarder) loop() error {
 					// TODO(wallyworld) - this should be configurable via lf.args.LogForwardConfig
 					MaxLookbackRecords: 100,
 				}
-				stream, err = lf.args.OpenLogStream(lf.args.Caller, streamCfg, lf.args.ControllerUUID)
+				stream, err = lf.args.OpenLogStream(context.TODO(), lf.args.Caller, streamCfg, lf.args.ControllerUUID)
 				if err != nil {
 					lf.catacomb.Kill(errors.Annotate(err, "creating log stream"))
 					break

--- a/internal/worker/logforwarder/logforwarder_test.go
+++ b/internal/worker/logforwarder/logforwarder_test.go
@@ -93,7 +93,7 @@ func (s *LogForwarderSuite) newLogForwarderArgsWithAPI(
 			}
 			return sink, nil
 		},
-		OpenLogStream: func(_ base.APICaller, _ params.LogStreamConfig, controllerUUID string) (logforwarder.LogStream, error) {
+		OpenLogStream: func(_ context.Context, _ base.APICaller, _ params.LogStreamConfig, controllerUUID string) (logforwarder.LogStream, error) {
 			c.Assert(controllerUUID, gc.Equals, "feebdaed-2f18-4fd2-967d-db9663db7bea")
 			return stream, nil
 		},
@@ -236,10 +236,6 @@ type mockCaller struct {
 
 func (*mockCaller) APICall(ctx context.Context, objType string, version int, id, request string, params, response interface{}) error {
 	return nil
-}
-
-func (*mockCaller) Context() context.Context {
-	return context.Background()
 }
 
 func (*mockCaller) BestFacadeVersion(facade string) int {

--- a/internal/worker/logforwarder/manifold.go
+++ b/internal/worker/logforwarder/manifold.go
@@ -4,6 +4,8 @@
 package logforwarder
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -45,8 +47,8 @@ type ManifoldConfig struct {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	openLogStream := config.OpenLogStream
 	if openLogStream == nil {
-		openLogStream = func(caller base.APICaller, cfg params.LogStreamConfig, controllerUUID string) (LogStream, error) {
-			return logstream.Open(caller, cfg, controllerUUID)
+		openLogStream = func(ctx context.Context, caller base.APICaller, cfg params.LogStreamConfig, controllerUUID string) (LogStream, error) {
+			return logstream.Open(ctx, caller, cfg, controllerUUID)
 		}
 	}
 

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -4,6 +4,7 @@
 package logsender
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -19,7 +20,7 @@ const loggerName = "juju.worker.logsender"
 
 // LogSenderAPI provides a log writer.
 type LogSenderAPI interface {
-	LogWriter() (logsender.LogWriter, error)
+	LogWriter(ctx context.Context) (logsender.LogWriter, error)
 }
 
 // New starts a logsender worker which reads log message structs from
@@ -35,7 +36,7 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 		sender := make(chan logsender.LogWriter)
 		errChan := make(chan error)
 		go func() {
-			logWriter, err := logSenderAPI.LogWriter()
+			logWriter, err := logSenderAPI.LogWriter(context.TODO())
 			if err != nil {
 				select {
 				case errChan <- err:

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -4,6 +4,7 @@
 package logsender_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -31,7 +32,7 @@ type logsenderAPI struct {
 	writer *mocks.MockLogWriter
 }
 
-func (s logsenderAPI) LogWriter() (apilogsender.LogWriter, error) {
+func (s logsenderAPI) LogWriter(_ context.Context) (apilogsender.LogWriter, error) {
 	return s.writer, nil
 }
 

--- a/internal/worker/metrics/sender/manifold_test.go
+++ b/internal/worker/metrics/sender/manifold_test.go
@@ -155,11 +155,11 @@ func (s *stubAPICaller) ModelTag() (names.ModelTag, bool) {
 	return names.NewModelTag("foobar"), true
 }
 
-func (s *stubAPICaller) ConnectStream(string, url.Values) (base.Stream, error) {
+func (s *stubAPICaller) ConnectStream(context.Context, string, url.Values) (base.Stream, error) {
 	panic("should not be called")
 }
 
-func (s *stubAPICaller) ConnectControllerStream(string, url.Values, http.Header) (base.Stream, error) {
+func (s *stubAPICaller) ConnectControllerStream(context.Context, string, url.Values, http.Header) (base.Stream, error) {
 	panic("should not be called")
 }
 
@@ -169,10 +169,6 @@ func (s *stubAPICaller) HTTPClient() (*httprequest.Client, error) {
 
 func (s *stubAPICaller) RootHTTPClient() (*httprequest.Client, error) {
 	panic("should not be called")
-}
-
-func (s *stubAPICaller) Context() context.Context {
-	return context.Background()
 }
 
 func (s *stubAPICaller) BakeryClient() base.MacaroonDischarger {

--- a/internal/worker/migrationmaster/validate_test.go
+++ b/internal/worker/migrationmaster/validate_test.go
@@ -4,6 +4,8 @@
 package migrationmaster_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -82,7 +84,7 @@ func validConfig() migrationmaster.Config {
 		Guard:           struct{ fortress.Guard }{},
 		Facade:          struct{ migrationmaster.Facade }{},
 		APIOpen:         func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
-		UploadBinaries:  func(migration.UploadBinariesConfig) error { return nil },
+		UploadBinaries:  func(context.Context, migration.UploadBinariesConfig) error { return nil },
 		CharmDownloader: struct{ migration.CharmDownloader }{},
 		ToolsDownloader: struct{ migration.ToolsDownloader }{},
 		Clock:           struct{ clock.Clock }{},

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -1474,10 +1474,6 @@ func (c *stubConnection) APICall(ctx context.Context, objType string, _ int, _, 
 	return errors.New("unexpected API call")
 }
 
-func (c *stubConnection) Context() context.Context {
-	return context.Background()
-}
-
 func (c *stubConnection) Client() *apiclient.Client {
 	// This is kinda crappy but the *Client doesn't have to be
 	// functional...
@@ -1493,7 +1489,7 @@ func (c *stubConnection) ControllerTag() names.ControllerTag {
 	return c.controllerTag
 }
 
-func (c *stubConnection) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
+func (c *stubConnection) ConnectControllerStream(_ context.Context, path string, attrs url.Values, headers http.Header) (base.Stream, error) {
 	c.stub.AddCall("ConnectControllerStream", path, attrs, headers)
 	if c.streamErr != nil {
 		return nil, c.streamErr
@@ -1501,8 +1497,8 @@ func (c *stubConnection) ConnectControllerStream(path string, attrs url.Values, 
 	return c.logStream, nil
 }
 
-func makeStubUploadBinaries(stub *jujutesting.Stub) func(migration.UploadBinariesConfig) error {
-	return func(config migration.UploadBinariesConfig) error {
+func makeStubUploadBinaries(stub *jujutesting.Stub) func(context.Context, migration.UploadBinariesConfig) error {
+	return func(_ context.Context, config migration.UploadBinariesConfig) error {
 		stub.AddCall(
 			"UploadBinaries",
 			config.Charms,
@@ -1518,7 +1514,7 @@ func makeStubUploadBinaries(stub *jujutesting.Stub) func(migration.UploadBinarie
 
 // nullUploadBinaries is a UploadBinaries variant which is intended to
 // not get called.
-func nullUploadBinaries(migration.UploadBinariesConfig) error {
+func nullUploadBinaries(context.Context, migration.UploadBinariesConfig) error {
 	panic("should not get called")
 }
 

--- a/internal/worker/provisioner/container_initialisation_test.go
+++ b/internal/worker/provisioner/container_initialisation_test.go
@@ -4,7 +4,6 @@
 package provisioner
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -95,7 +94,6 @@ func (s *containerSetupSuite) TestContainerManagerConfigError(c *gc.C) {
 		gomock.Any(),
 		"Provisioner", 666, "", "ContainerManagerConfig", params.ContainerManagerConfigParams{Type: "lxd"}, gomock.Any()).Return(
 		errors.New("boom"))
-	s.caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	cs := s.setUpContainerSetup(c, instance.LXD)
 	abort := make(chan struct{})
@@ -166,7 +164,6 @@ func (s *containerSetupSuite) expectContainerManagerConfig(cType instance.Contai
 		gomock.Any(),
 		"Provisioner", 666, "", "ContainerManagerConfig", params.ContainerManagerConfigParams{Type: cType}, gomock.Any(),
 	).SetArg(6, resultSource).MinTimes(1)
-	s.caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 }
 
 type credentialAPIForTest struct{}

--- a/internal/worker/provisioner/containerworker_test.go
+++ b/internal/worker/provisioner/containerworker_test.go
@@ -4,7 +4,6 @@
 package provisioner_test
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -118,7 +117,6 @@ func (s *containerWorkerSuite) TestContainerSetupAndProvisionerErrWatcherClose(c
 	s.initialiser = testing.NewMockInitialiser(ctrl)
 	s.caller = apimocks.NewMockAPICaller(ctrl)
 	s.caller.EXPECT().BestFacadeVersion("Provisioner").Return(0).AnyTimes()
-	s.caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	s.stringsWatcher = mocks.NewMockStringsWatcher(ctrl)
 	s.machine = provisionermocks.NewMockMachineProvisioner(ctrl)
 	s.manager = testing.NewMockManager(ctrl)
@@ -195,7 +193,6 @@ func (s *containerWorkerSuite) patch(c *gc.C) *gomock.Controller {
 	s.caller.EXPECT().BestFacadeVersion("Provisioner").Return(0).AnyTimes()
 	s.caller.EXPECT().BestFacadeVersion("NotifyWatcher").Return(0).AnyTimes()
 	s.caller.EXPECT().BestFacadeVersion("StringsWatcher").Return(0).AnyTimes()
-	s.caller.EXPECT().Context().Return(context.Background()).AnyTimes()
 	s.stringsWatcher = mocks.NewMockStringsWatcher(ctrl)
 	s.machine = provisionermocks.NewMockMachineProvisioner(ctrl)
 	s.manager = testing.NewMockManager(ctrl)

--- a/internal/worker/provisioner/mocks/base_mock.go
+++ b/internal/worker/provisioner/mocks/base_mock.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/proxyupdater/manifold_test.go
+++ b/internal/worker/proxyupdater/manifold_test.go
@@ -4,8 +4,6 @@
 package proxyupdater_test
 
 import (
-	"context"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/proxy"
@@ -153,10 +151,6 @@ type dummyAPICaller struct {
 
 func (*dummyAPICaller) BestFacadeVersion(_ string) int {
 	return 42
-}
-
-func (*dummyAPICaller) Context() context.Context {
-	return context.Background()
 }
 
 type dummyWorker struct {

--- a/internal/worker/pubsub/messagewriter.go
+++ b/internal/worker/pubsub/messagewriter.go
@@ -4,6 +4,7 @@
 package pubsub
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -33,13 +34,13 @@ var dialOpts = api.DialOpts{
 
 // NewMessageWriter will connect to the remote defined by the info,
 // and return a MessageWriter.
-func NewMessageWriter(info *api.Info) (MessageWriter, error) {
+func NewMessageWriter(ctx context.Context, info *api.Info) (MessageWriter, error) {
 	conn, err := api.Open(info, dialOpts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	a := pubsubapi.NewAPI(conn)
-	writer, err := a.OpenMessageWriter()
+	writer, err := a.OpenMessageWriter(ctx)
 	if err != nil {
 		conn.Close()
 		return nil, errors.Trace(err)

--- a/internal/worker/pubsub/remoteserver.go
+++ b/internal/worker/pubsub/remoteserver.go
@@ -4,6 +4,7 @@
 package pubsub
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -42,7 +43,7 @@ type remoteServer struct {
 	info   *api.Info
 	logger Logger
 
-	newWriter  func(*api.Info) (MessageWriter, error)
+	newWriter  func(context.Context, *api.Info) (MessageWriter, error)
 	connection MessageWriter
 
 	hub   *pubsub.StructuredHub
@@ -70,7 +71,7 @@ type RemoteServerConfig struct {
 
 	// APIInfo is initially populated with the addresses of the target machine.
 	APIInfo   *api.Info
-	NewWriter func(*api.Info) (MessageWriter, error)
+	NewWriter func(context.Context, *api.Info) (MessageWriter, error)
 }
 
 // NewRemoteServer creates a new RemoteServer that will connect to the remote
@@ -229,7 +230,7 @@ func (r *remoteServer) connect() bool {
 	_ = retry.Call(retry.CallArgs{
 		Func: func() error {
 			r.logger.Debugf("open api to %s: %v", r.target, r.info.Addrs)
-			conn, err := r.newWriter(r.info)
+			conn, err := r.newWriter(context.TODO(), r.info)
 			if err != nil {
 				r.logger.Tracef("unable to get message writer for %s, reconnecting... : %v\n%s", r.target, err, errors.ErrorStack(err))
 				return errors.Trace(err)

--- a/internal/worker/pubsub/remoteserver_test.go
+++ b/internal/worker/pubsub/remoteserver_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -310,7 +311,7 @@ func (f *fakeConnectionOpener) getWriter() *messageWriter {
 	return f.writer
 }
 
-func (f *fakeConnectionOpener) newWriter(info *api.Info) (psworker.MessageWriter, error) {
+func (f *fakeConnectionOpener) newWriter(_ context.Context, info *api.Info) (psworker.MessageWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 	if f.callback != nil {

--- a/internal/worker/pubsub/subscriber.go
+++ b/internal/worker/pubsub/subscriber.go
@@ -4,6 +4,7 @@
 package pubsub
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -31,7 +32,7 @@ type WorkerConfig struct {
 	Logger Logger
 
 	APIInfo   *api.Info
-	NewWriter func(*api.Info) (MessageWriter, error)
+	NewWriter func(context.Context, *api.Info) (MessageWriter, error)
 	NewRemote func(RemoteServerConfig) (RemoteServer, error)
 }
 

--- a/internal/worker/pubsub/subscriber_test.go
+++ b/internal/worker/pubsub/subscriber_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -85,7 +86,7 @@ func (*WorkerConfigSuite) TestValidate(c *gc.C) {
 				APIInfo: &api.Info{
 					Addrs: []string{"localhost"},
 				},
-				NewWriter: func(*api.Info) (psworker.MessageWriter, error) {
+				NewWriter: func(context.Context, *api.Info) (psworker.MessageWriter, error) {
 					return &messageWriter{}, nil
 				},
 			},
@@ -99,7 +100,7 @@ func (*WorkerConfigSuite) TestValidate(c *gc.C) {
 				APIInfo: &api.Info{
 					Addrs: []string{"localhost"},
 				},
-				NewWriter: func(*api.Info) (psworker.MessageWriter, error) {
+				NewWriter: func(context.Context, *api.Info) (psworker.MessageWriter, error) {
 					return &messageWriter{}, nil
 				},
 				NewRemote: func(psworker.RemoteServerConfig) (psworker.RemoteServer, error) {
@@ -152,7 +153,7 @@ func (s *SubscriberSuite) SetUpTest(c *gc.C) {
 			CACert: "fake as",
 			Tag:    tag,
 		},
-		NewWriter: func(*api.Info) (psworker.MessageWriter, error) {
+		NewWriter: func(context.Context, *api.Info) (psworker.MessageWriter, error) {
 			return &messageWriter{}, nil
 		},
 		NewRemote: s.remotes.new,

--- a/internal/worker/remoterelations/mock_test.go
+++ b/internal/worker/remoterelations/mock_test.go
@@ -4,6 +4,7 @@
 package remoterelations_test
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/errors"
@@ -278,7 +279,7 @@ func (m *mockRemoteRelationsFacade) Close() error {
 	return nil
 }
 
-func (m *mockRemoteRelationsFacade) PublishRelationChange(change params.RemoteRelationChangeEvent) error {
+func (m *mockRemoteRelationsFacade) PublishRelationChange(_ context.Context, change params.RemoteRelationChangeEvent) error {
 	m.stub.MethodCall(m, "PublishRelationChange", change)
 	if err := m.stub.NextErr(); err != nil {
 		return err
@@ -286,7 +287,7 @@ func (m *mockRemoteRelationsFacade) PublishRelationChange(change params.RemoteRe
 	return nil
 }
 
-func (m *mockRemoteRelationsFacade) RegisterRemoteRelations(relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error) {
+func (m *mockRemoteRelationsFacade) RegisterRemoteRelations(_ context.Context, relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error) {
 	m.stub.MethodCall(m, "RegisterRemoteRelations", relations)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
@@ -312,7 +313,7 @@ func (m *mockRemoteRelationsFacade) remoteRelationWatcher(key string) (*mockRemo
 	return w, ok
 }
 
-func (m *mockRemoteRelationsFacade) WatchRelationChanges(relationToken string, appToken string, mac macaroon.Slice) (apiwatcher.RemoteRelationWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchRelationChanges(_ context.Context, relationToken string, appToken string, mac macaroon.Slice) (apiwatcher.RemoteRelationWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchRelationChanges", relationToken, appToken, mac)
@@ -337,7 +338,7 @@ func (m *mockRemoteRelationsFacade) secretsRevisionWatcher(key string) (*mockSec
 	return w, ok
 }
 
-func (m *mockRemoteRelationsFacade) WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchRelationSuspendedStatus(_ context.Context, arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchRelationSuspendedStatus", arg.Token, arg.Macaroons)
@@ -348,7 +349,7 @@ func (m *mockRemoteRelationsFacade) WatchRelationSuspendedStatus(arg params.Remo
 	return m.relationsStatusWatchers[arg.Token], nil
 }
 
-func (m *mockRemoteRelationsFacade) WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchOfferStatus(_ context.Context, arg params.OfferArg) (watcher.OfferStatusWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchOfferStatus", arg.OfferUUID, arg.Macaroons)
@@ -360,7 +361,7 @@ func (m *mockRemoteRelationsFacade) WatchOfferStatus(arg params.OfferArg) (watch
 }
 
 // RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
-func (m *mockRemoteRelationsFacade) RelationUnitSettings(relationUnits []params.RemoteRelationUnit) ([]params.SettingsResult, error) {
+func (m *mockRemoteRelationsFacade) RelationUnitSettings(_ context.Context, relationUnits []params.RemoteRelationUnit) ([]params.SettingsResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "RelationUnitSettings", relationUnits)
@@ -376,7 +377,7 @@ func (m *mockRemoteRelationsFacade) RelationUnitSettings(relationUnits []params.
 	return result, nil
 }
 
-func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(appToken, relToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
+func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(_ context.Context, appToken, relToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "WatchConsumedSecretsChanges", appToken, relToken, mac)

--- a/internal/worker/remoterelations/remoterelations.go
+++ b/internal/worker/remoterelations/remoterelations.go
@@ -4,6 +4,7 @@
 package remoterelations
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -45,11 +46,11 @@ type RemoteModelRelationsFacadeCloser interface {
 type RemoteModelRelationsFacade interface {
 	// RegisterRemoteRelations sets up the remote model to participate
 	// in the specified relations.
-	RegisterRemoteRelations(relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error)
+	RegisterRemoteRelations(_ context.Context, relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error)
 
 	// PublishRelationChange publishes relation changes to the
 	// model hosting the remote application involved in the relation.
-	PublishRelationChange(params.RemoteRelationChangeEvent) error
+	PublishRelationChange(context.Context, params.RemoteRelationChangeEvent) error
 
 	// WatchRelationChanges returns a watcher that notifies of changes
 	// to the units in the remote model for the relation with the
@@ -57,19 +58,19 @@ type RemoteModelRelationsFacade interface {
 	// the case where we're talking to a v1 API and the client needs
 	// to convert RelationUnitsChanges into RemoteRelationChangeEvents
 	// as they come in.
-	WatchRelationChanges(relationToken, applicationToken string, macs macaroon.Slice) (apiwatcher.RemoteRelationWatcher, error)
+	WatchRelationChanges(_ context.Context, relationToken, applicationToken string, macs macaroon.Slice) (apiwatcher.RemoteRelationWatcher, error)
 
 	// WatchRelationSuspendedStatus starts a RelationStatusWatcher for watching the
 	// relations of each specified application in the remote model.
-	WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
+	WatchRelationSuspendedStatus(_ context.Context, arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
 
 	// WatchOfferStatus starts an OfferStatusWatcher for watching the status
 	// of the specified offer in the remote model.
-	WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatcher, error)
+	WatchOfferStatus(_ context.Context, arg params.OfferArg) (watcher.OfferStatusWatcher, error)
 
 	// WatchConsumedSecretsChanges starts a watcher for any changes to secrets
 	// consumed by the specified application.
-	WatchConsumedSecretsChanges(applicationToken, relationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error)
+	WatchConsumedSecretsChanges(ctx context.Context, applicationToken, relationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.

--- a/internal/worker/s3caller/api_mocks.go
+++ b/internal/worker/s3caller/api_mocks.go
@@ -161,47 +161,33 @@ func (mr *MockConnectionMockRecorder) Close() *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockConnection) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockConnection) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockConnectionMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockConnectionMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockConnection)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockConnection)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockConnection) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockConnection) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockConnectionMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockConnectionMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockConnection)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockConnection) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockConnectionMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockConnection)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockConnection)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // ControllerAccess mocks base method.
@@ -304,17 +290,17 @@ func (mr *MockConnectionMockRecorder) IsProxied() *gomock.Call {
 }
 
 // Login mocks base method.
-func (m *MockConnection) Login(arg0 names.Tag, arg1, arg2 string, arg3 []macaroon.Slice) error {
+func (m *MockConnection) Login(arg0 context.Context, arg1 names.Tag, arg2, arg3 string, arg4 []macaroon.Slice) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Login", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Login indicates an expected call of Login.
-func (mr *MockConnectionMockRecorder) Login(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockConnectionMockRecorder) Login(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockConnection)(nil).Login), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockConnection)(nil).Login), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ModelTag mocks base method.

--- a/internal/worker/storageprovisioner/manifold_machine_test.go
+++ b/internal/worker/storageprovisioner/manifold_machine_test.go
@@ -134,7 +134,3 @@ func (f *fakeAPIConn) APICall(ctx context.Context, objType string, version int, 
 func (*fakeAPIConn) BestFacadeVersion(facade string) int {
 	return 42
 }
-
-func (*fakeAPIConn) Context() context.Context {
-	return context.Background()
-}

--- a/internal/worker/uniter/runner/context/mocks/resource_mock.go
+++ b/internal/worker/uniter/runner/context/mocks/resource_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -41,9 +42,9 @@ func (m *MockOpenedResourceClient) EXPECT() *MockOpenedResourceClientMockRecorde
 }
 
 // GetResource mocks base method.
-func (m *MockOpenedResourceClient) GetResource(arg0 string) (resources.Resource, io.ReadCloser, error) {
+func (m *MockOpenedResourceClient) GetResource(arg0 context.Context, arg1 string) (resources.Resource, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResource", arg0)
+	ret := m.ctrl.Call(m, "GetResource", arg0, arg1)
 	ret0, _ := ret[0].(resources.Resource)
 	ret1, _ := ret[1].(io.ReadCloser)
 	ret2, _ := ret[2].(error)
@@ -51,7 +52,7 @@ func (m *MockOpenedResourceClient) GetResource(arg0 string) (resources.Resource,
 }
 
 // GetResource indicates an expected call of GetResource.
-func (mr *MockOpenedResourceClientMockRecorder) GetResource(arg0 any) *gomock.Call {
+func (mr *MockOpenedResourceClientMockRecorder) GetResource(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockOpenedResourceClient)(nil).GetResource), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockOpenedResourceClient)(nil).GetResource), arg0, arg1)
 }

--- a/internal/worker/uniter/runner/context/resources/context.go
+++ b/internal/worker/uniter/runner/context/resources/context.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,12 +25,12 @@ type ResourcesHookContext struct {
 // not been uploaded yet then errors.NotFound is returned.
 //
 // Note that the downloaded file is checked for correctness.
-func (ctx *ResourcesHookContext) DownloadResource(name string) (filePath string, _ error) {
+func (ctx *ResourcesHookContext) DownloadResource(stdCtx context.Context, name string) (filePath string, _ error) {
 	// TODO(katco): Potential race-condition: two commands running at
 	// once. Solve via collision using os.Mkdir() with a uniform
 	// temp dir name (e.g. "<resourcesDir>/.<res name>.download")?
 
-	remote, err := OpenResource(name, ctx.Client)
+	remote, err := OpenResource(stdCtx, name, ctx.Client)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/context/resources/context_test.go
+++ b/internal/worker/uniter/runner/context/resources/context_test.go
@@ -4,6 +4,7 @@
 package resources_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -37,14 +38,14 @@ func (s *ContextSuite) TestDownloadOutOfDate(c *gc.C) {
 	resourceDir := c.MkDir()
 	client := mocks.NewMockOpenedResourceClient(ctrl)
 
-	client.EXPECT().GetResource("spam").Return(info, reader, nil)
+	client.EXPECT().GetResource(gomock.Any(), "spam").Return(info, reader, nil)
 
 	ctx := resources.ResourcesHookContext{
 		Client:       client,
 		ResourcesDir: resourceDir,
 		Logger:       coretesting.NoopLogger{},
 	}
-	path, err := ctx.DownloadResource("spam")
+	path, err := ctx.DownloadResource(context.Background(), "spam")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "Read", "Read", "Close")
@@ -66,14 +67,14 @@ func (s *ContextSuite) TestContextDownloadUpToDate(c *gc.C) {
 
 	client := mocks.NewMockOpenedResourceClient(ctrl)
 
-	client.EXPECT().GetResource("spam").Return(info, reader, nil)
+	client.EXPECT().GetResource(gomock.Any(), "spam").Return(info, reader, nil)
 
 	ctx := resources.ResourcesHookContext{
 		Client:       client,
 		ResourcesDir: resourceDir,
 		Logger:       coretesting.NoopLogger{},
 	}
-	path, err := ctx.DownloadResource("spam")
+	path, err := ctx.DownloadResource(context.Background(), "spam")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "Close")

--- a/internal/worker/uniter/runner/context/resources/resource.go
+++ b/internal/worker/uniter/runner/context/resources/resource.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	charmresource "github.com/juju/charm/v12/resource"
@@ -20,7 +21,7 @@ import (
 type OpenedResourceClient interface {
 	// GetResource returns the resource info and content for the given
 	// name (and unit-implied application).
-	GetResource(resourceName string) (resources.Resource, io.ReadCloser, error)
+	GetResource(ctx context.Context, resourceName string) (resources.Resource, io.ReadCloser, error)
 }
 
 // OpenedResource wraps the resource info and reader returned
@@ -31,8 +32,8 @@ type OpenedResource struct {
 }
 
 // OpenResource opens the identified resource using the provided client.
-func OpenResource(name string, client OpenedResourceClient) (*OpenedResource, error) {
-	info, reader, err := client.GetResource(name)
+func OpenResource(ctx context.Context, name string, client OpenedResourceClient) (*OpenedResource, error) {
+	info, reader, err := client.GetResource(ctx, name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/context/resources/resource_test.go
+++ b/internal/worker/uniter/runner/context/resources/resource_test.go
@@ -4,6 +4,7 @@
 package resources_test
 
 import (
+	"context"
 	"io"
 
 	"github.com/juju/testing"
@@ -34,9 +35,9 @@ func (s *OpenedResourceSuite) TestOpenResource(c *gc.C) {
 
 	client := mocks.NewMockOpenedResourceClient(ctrl)
 	info, reader := newResource(c, s.stub, "spam", "some data")
-	client.EXPECT().GetResource("spam").Return(info, reader, nil)
+	client.EXPECT().GetResource(gomock.Any(), "spam").Return(info, reader, nil)
 
-	opened, err := resources.OpenResource("spam", client)
+	opened, err := resources.OpenResource(context.Background(), "spam", client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(opened, jc.DeepEquals, &resources.OpenedResource{
 		Resource:   info,
@@ -66,9 +67,9 @@ func (s *OpenedResourceSuite) TestDockerImage(c *gc.C) {
 	client := mocks.NewMockOpenedResourceClient(ctrl)
 	jsonContent := `{"ImageName":"image-name","Username":"docker-registry","Password":"secret"}`
 	info, reader := newDockerResource(c, s.stub, "spam", jsonContent)
-	client.EXPECT().GetResource("spam").Return(info, reader, nil)
+	client.EXPECT().GetResource(gomock.Any(), "spam").Return(info, reader, nil)
 
-	opened, err := resources.OpenResource("spam", client)
+	opened, err := resources.OpenResource(context.Background(), "spam", client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(opened.Path, gc.Equals, "content.yaml")
 	content := opened.Content()

--- a/internal/worker/uniter/runner/jujuc/context.go
+++ b/internal/worker/uniter/runner/jujuc/context.go
@@ -4,6 +4,7 @@
 package jujuc
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -325,7 +326,7 @@ type ContextStorage interface {
 type ContextResources interface {
 	// DownloadResource downloads the named resource and returns
 	// the path to which it was downloaded.
-	DownloadResource(name string) (filePath string, _ error)
+	DownloadResource(ctx context.Context, name string) (filePath string, _ error)
 }
 
 // ContextPayloads exposes the functionality needed by the

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/resources.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/resources.go
@@ -3,13 +3,15 @@
 
 package jujuctesting
 
+import "context"
+
 // ContextResources is a test double for jujuc.ContextResources.
 type ContextResources struct {
 	contextBase
 }
 
 // DownloadResource implements jujuc.ContextResources.
-func (c *ContextRelations) DownloadResource(resourceName string) (string, error) {
+func (c *ContextRelations) DownloadResource(_ context.Context, resourceName string) (string, error) {
 	c.stub.AddCall("DownloadResource", resourceName)
 	return "/path/to/" + resourceName, nil
 }

--- a/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -209,18 +210,18 @@ func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0 any) *gomock.Call 
 }
 
 // DownloadResource mocks base method.
-func (m *MockContext) DownloadResource(arg0 string) (string, error) {
+func (m *MockContext) DownloadResource(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadResource", arg0)
+	ret := m.ctrl.Call(m, "DownloadResource", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DownloadResource indicates an expected call of DownloadResource.
-func (mr *MockContextMockRecorder) DownloadResource(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) DownloadResource(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadResource", reflect.TypeOf((*MockContext)(nil).DownloadResource), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadResource", reflect.TypeOf((*MockContext)(nil).DownloadResource), arg0, arg1)
 }
 
 // FlushPayloads mocks base method.

--- a/internal/worker/uniter/runner/jujuc/resource-get.go
+++ b/internal/worker/uniter/runner/jujuc/resource-get.go
@@ -85,7 +85,7 @@ func (c *ResourceGetCmd) Init(args []string) error {
 
 // Run implements cmd.Command.
 func (c ResourceGetCmd) Run(ctx *cmd.Context) error {
-	filePath, err := c.ctx.DownloadResource(c.resourceName)
+	filePath, err := c.ctx.DownloadResource(ctx, c.resourceName)
 	if err != nil {
 		return errors.Annotate(err, "could not download resource")
 	}

--- a/internal/worker/uniter/runner/jujuc/resource-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/resource-get_test.go
@@ -46,7 +46,7 @@ func (s *ResourceGetCmdSuite) TestRun(c *gc.C) {
 
 	const expected = "/var/lib/juju/agents/unit-foo-1/resources/spam/a-file.tgz"
 	hctx := mocks.NewMockContext(ctrl)
-	hctx.EXPECT().DownloadResource("spam").Return(expected, nil)
+	hctx.EXPECT().DownloadResource(gomock.Any(), "spam").Return(expected, nil)
 
 	com, err := jujuc.NewCommand(hctx, "resource-get")
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *ResourceGetCmdSuite) TestRunDownloadFailure(c *gc.C) {
 	defer ctrl.Finish()
 
 	hctx := mocks.NewMockContext(ctrl)
-	hctx.EXPECT().DownloadResource("spam").Return("", errors.New("<failure>"))
+	hctx.EXPECT().DownloadResource(gomock.Any(), "spam").Return("", errors.New("<failure>"))
 
 	com, err := jujuc.NewCommand(hctx, "resource-get")
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/jujuc/restricted.go
+++ b/internal/worker/uniter/runner/jujuc/restricted.go
@@ -4,6 +4,7 @@
 package jujuc
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v12"
@@ -146,7 +147,7 @@ func (*RestrictedContext) AddUnitStorage(map[string]params.StorageConstraints) e
 }
 
 // DownloadResource implements hooks.Context.
-func (ctx *RestrictedContext) DownloadResource(name string) (filePath string, _ error) {
+func (ctx *RestrictedContext) DownloadResource(_ context.Context, name string) (filePath string, _ error) {
 	return "", ErrRestrictedContext
 }
 

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -19,7 +20,7 @@ import (
 	network "github.com/juju/juju/core/network"
 	payloads "github.com/juju/juju/core/payloads"
 	secrets "github.com/juju/juju/core/secrets"
-	context "github.com/juju/juju/internal/worker/uniter/runner/context"
+	context0 "github.com/juju/juju/internal/worker/uniter/runner/context"
 	jujuc "github.com/juju/juju/internal/worker/uniter/runner/jujuc"
 	params "github.com/juju/juju/rpc/params"
 	loggo "github.com/juju/loggo"
@@ -51,10 +52,10 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 }
 
 // ActionData mocks base method.
-func (m *MockContext) ActionData() (*context.ActionData, error) {
+func (m *MockContext) ActionData() (*context0.ActionData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActionData")
-	ret0, _ := ret[0].(*context.ActionData)
+	ret0, _ := ret[0].(*context0.ActionData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -226,18 +227,18 @@ func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0 any) *gomock.Call 
 }
 
 // DownloadResource mocks base method.
-func (m *MockContext) DownloadResource(arg0 string) (string, error) {
+func (m *MockContext) DownloadResource(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadResource", arg0)
+	ret := m.ctrl.Call(m, "DownloadResource", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DownloadResource indicates an expected call of DownloadResource.
-func (mr *MockContextMockRecorder) DownloadResource(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) DownloadResource(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadResource", reflect.TypeOf((*MockContext)(nil).DownloadResource), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadResource", reflect.TypeOf((*MockContext)(nil).DownloadResource), arg0, arg1)
 }
 
 // Flush mocks base method.
@@ -416,7 +417,7 @@ func (mr *MockContextMockRecorder) HookStorage() *gomock.Call {
 }
 
 // HookVars mocks base method.
-func (m *MockContext) HookVars(arg0 context.Paths, arg1 bool, arg2 context.Environmenter) ([]string, error) {
+func (m *MockContext) HookVars(arg0 context0.Paths, arg1 bool, arg2 context0.Environmenter) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HookVars", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
@@ -804,7 +805,7 @@ func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2 any) *gomoc
 }
 
 // SetProcess mocks base method.
-func (m *MockContext) SetProcess(arg0 context.HookProcess) {
+func (m *MockContext) SetProcess(arg0 context0.HookProcess) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetProcess", arg0)
 }

--- a/internal/worker/upgradesteps/api_mock_test.go
+++ b/internal/worker/upgradesteps/api_mock_test.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.

--- a/internal/worker/upgradestepsmachine/api_mock_test.go
+++ b/internal/worker/upgradestepsmachine/api_mock_test.go
@@ -87,47 +87,33 @@ func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 any) *gomock.Call {
 }
 
 // ConnectControllerStream mocks base method.
-func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+func (m *MockAPICaller) ConnectControllerStream(arg0 context.Context, arg1 string, arg2 url.Values, arg3 http.Header) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream.
-func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2, arg3)
 }
 
 // ConnectStream mocks base method.
-func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+func (m *MockAPICaller) ConnectStream(arg0 context.Context, arg1 string, arg2 url.Values) (base.Stream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
+	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConnectStream indicates an expected call of ConnectStream.
-func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
-}
-
-// Context mocks base method.
-func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
-	return ret0
-}
-
-// Context indicates an expected call of Context.
-func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1, arg2)
 }
 
 // HTTPClient mocks base method.


### PR DESCRIPTION
Various api related structs stored a context on an attribute. This PR removes said attributes and instead updates the various methods where the context is needed to take it as an argument.

There was a lot of gomock and mechanical test fallout - these are in separate commits.

5007a8745dd1ab600d237add4d1f8e176c23b8c8 is the gomock changes
https://github.com/juju/juju/pull/16756/commits/4c2e81e1f4f86d0833f5642665b67b568e222e15 is the mechanical test changes to add `context.Background()` etc to the api calls being used.

The actual changes are in commit https://github.com/juju/juju/pull/16756/commits/af2138879a6bf161bb49e472d3915bd8e815cb0a.

Note we now start out with a nil tracer on the facade struct - if you want a tracer, you need to use `WithTracer()`. This is the same behaviour as we had since we used to just start with a no op tracer anyway as the now deleted context attribute was just a `context.Background()`.

There's still a lot more to do, but this cleans up a fairly significant wart.

## QA steps

bootstrap
deploy juju-qa-dummy-source and juju-qa-dummy-sink in different models and cross model relate
ensure it all works

## Links

**Jira card:** JUJU-5243

