### PR TITLE
Ensure goroutines do not leak

### DIFF
--- a/internal/changestream/eventmultiplexer/package_test.go
+++ b/internal/changestream/eventmultiplexer/package_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	time "time"
 
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -23,6 +24,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package eventmultiplexer -destination clock_mock_test.go github.com/juju/clock Clock,Timer
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 

--- a/internal/changestream/stream/package_test.go
+++ b/internal/changestream/stream/package_test.go
@@ -84,8 +84,11 @@ func (s *baseSuite) expectAfter() chan<- time.Time {
 	return ch
 }
 
-func (s *baseSuite) expectAfterAnyTimes(done chan struct{}) {
+func (s *baseSuite) expectAfterAnyTimes() {
 	s.clock.EXPECT().After(defaultWaitTermTimeout).Return(make(chan time.Time)).AnyTimes()
+}
+
+func (s *baseSuite) expectBackoffAnyTimes(done chan struct{}) {
 	s.clock.EXPECT().After(gomock.Any()).DoAndReturn(func(d time.Duration) <-chan time.Time {
 		ch := make(chan time.Time)
 		go func() {

--- a/internal/changestream/stream/package_test.go
+++ b/internal/changestream/stream/package_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	time "time"
 
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -21,6 +22,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package stream -destination clock_mock_test.go github.com/juju/clock Clock,Timer
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 
@@ -81,12 +84,16 @@ func (s *baseSuite) expectAfter() chan<- time.Time {
 	return ch
 }
 
-func (s *baseSuite) expectAfterAnyTimes() {
+func (s *baseSuite) expectAfterAnyTimes(done chan struct{}) {
 	s.clock.EXPECT().After(defaultWaitTermTimeout).Return(make(chan time.Time)).AnyTimes()
 	s.clock.EXPECT().After(gomock.Any()).DoAndReturn(func(d time.Duration) <-chan time.Time {
 		ch := make(chan time.Time)
 		go func() {
-			ch <- time.Now()
+			select {
+			case ch <- time.Now():
+			case <-done:
+				return
+			}
 		}()
 		return ch
 	}).AnyTimes()

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -85,9 +85,12 @@ func (s *streamSuite) TestNoData(c *gc.C) {
 func (s *streamSuite) TestOneChange(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -121,9 +124,12 @@ func (s *streamSuite) TestOneChange(c *gc.C) {
 func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -174,9 +180,12 @@ func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithEmptyResults(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -210,9 +219,12 @@ func (s *streamSuite) TestOneChangeWithEmptyResults(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithClosedAbort(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -250,9 +262,12 @@ func (s *streamSuite) TestOneChangeWithClosedAbort(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -290,9 +305,12 @@ func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithTermDoneAfterKill(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -375,9 +393,12 @@ func (s *streamSuite) TestOneChangeWithTimeoutCausesWorkerToBounce(c *gc.C) {
 func (s *streamSuite) TestMultipleTerms(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -423,6 +444,9 @@ func (s *streamSuite) TestMultipleTermsAllEmpty(c *gc.C) {
 	s.expectClock()
 	s.expectMetrics()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	var duration int64
 	s.clock.EXPECT().After(defaultWaitTermTimeout).Return(make(chan time.Time)).AnyTimes()
 	s.clock.EXPECT().After(gomock.Any()).DoAndReturn(func(d time.Duration) <-chan time.Time {
@@ -433,7 +457,10 @@ func (s *streamSuite) TestMultipleTermsAllEmpty(c *gc.C) {
 
 		ch := make(chan time.Time)
 		go func() {
-			ch <- time.Now()
+			select {
+			case ch <- time.Now():
+			case <-done:
+			}
 		}()
 		return ch
 	}).AnyTimes()
@@ -475,9 +502,12 @@ func (s *streamSuite) TestMultipleTermsAllEmpty(c *gc.C) {
 func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -552,8 +582,11 @@ func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -613,8 +646,11 @@ func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -664,8 +700,11 @@ func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -730,8 +769,11 @@ func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -806,8 +848,11 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) 
 func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -877,8 +922,11 @@ func constructWatermark(start, finish int) string {
 func (s *streamSuite) TestReport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -973,8 +1021,11 @@ func (s *streamSuite) TestReport(c *gc.C) {
 func (s *streamSuite) TestWatermarkWrite(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -1034,8 +1085,11 @@ func (s *streamSuite) TestWatermarkWrite(c *gc.C) {
 func (s *streamSuite) TestWatermarkWriteIsIgnored(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -1095,8 +1149,11 @@ func (s *streamSuite) TestWatermarkWriteIsIgnored(c *gc.C) {
 func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes()
+	s.expectAfterAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -85,12 +85,9 @@ func (s *streamSuite) TestNoData(c *gc.C) {
 func (s *streamSuite) TestOneChange(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -129,7 +126,8 @@ func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -185,7 +183,8 @@ func (s *streamSuite) TestOneChangeWithEmptyResults(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -219,12 +218,9 @@ func (s *streamSuite) TestOneChangeWithEmptyResults(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithClosedAbort(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -262,12 +258,9 @@ func (s *streamSuite) TestOneChangeWithClosedAbort(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -305,12 +298,9 @@ func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *gc.C) {
 func (s *streamSuite) TestOneChangeWithTermDoneAfterKill(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -398,7 +388,8 @@ func (s *streamSuite) TestMultipleTerms(c *gc.C) {
 
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -502,12 +493,9 @@ func (s *streamSuite) TestMultipleTermsAllEmpty(c *gc.C) {
 func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -582,11 +570,8 @@ func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -646,11 +631,8 @@ func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -700,11 +682,8 @@ func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -769,11 +748,8 @@ func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -848,11 +824,8 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) 
 func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
-	defer close(done)
-
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -926,7 +899,8 @@ func (s *streamSuite) TestReport(c *gc.C) {
 	defer close(done)
 
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -1025,7 +999,8 @@ func (s *streamSuite) TestWatermarkWrite(c *gc.C) {
 	defer close(done)
 
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -1089,7 +1064,8 @@ func (s *streamSuite) TestWatermarkWriteIsIgnored(c *gc.C) {
 	defer close(done)
 
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()
@@ -1153,7 +1129,8 @@ func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *gc.C) {
 	defer close(done)
 
 	s.expectAnyLogs()
-	s.expectAfterAnyTimes(done)
+	s.expectAfterAnyTimes()
+	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
 	s.expectMetrics()

--- a/internal/database/app/dqlite_linux.go
+++ b/internal/database/app/dqlite_linux.go
@@ -7,8 +7,11 @@ package app
 
 import (
 	"crypto/tls"
+	"sync"
+
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
+	"github.com/juju/errors"
 )
 
 // Option can be used to tweak app parameters.
@@ -67,9 +70,69 @@ func WithTracing(level client.LogLevel) Option {
 //
 // It takes care of starting a dqlite node and registering a dqlite Go SQL
 // driver.
-type App = app.App
+type App struct {
+	*app.App
+
+	closer *onceError
+}
 
 // New creates a new application node.
 func New(dir string, options ...Option) (*App, error) {
-	return app.New(dir, options...)
+	app, err := app.New(dir, options...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &App{
+		App:    app,
+		closer: &onceError{},
+	}, nil
+}
+
+// Close will close the application.
+// This will close it exactly once. Any subsequent calls will return the same
+// error.
+func (a *App) Close() error {
+	return a.closer.Do(func() error {
+		return a.App.Close()
+	})
+
+}
+
+// onceError is an object that will perform exactly one action.
+type onceError struct {
+	once  sync.Once
+	mutex sync.Mutex
+	err   error
+}
+
+// Do calls the function f if and only if Do is being called for the
+// first time for this instance of Once. In other words, given
+//
+//	var once Once
+//
+// if once.Do(f) is called multiple times, only the first call will invoke f,
+// even if f has a different value in each invocation. A new instance of
+// Once is required for each function to execute.
+//
+// If f panics, Do considers it to have returned; future calls of Do return
+// without calling f.
+func (o *onceError) Do(f func() error) error {
+	// Attempt to get the error without invoking f.
+	o.mutex.Lock()
+	if o.err != nil {
+		o.mutex.Unlock()
+		return o.err
+	}
+
+	// We need to invoke f at least once. We'll hold onto the lock until
+	// we're done. This should ensure there isn't a race between the first
+	// invocation of f and the return of the error.
+	defer o.mutex.Unlock()
+
+	// Do the work.
+	o.once.Do(func() {
+		o.err = f()
+	})
+
+	return o.err
 }

--- a/internal/database/app/dqlite_linux_test.go
+++ b/internal/database/app/dqlite_linux_test.go
@@ -1,0 +1,49 @@
+//go:build dqlite && linux
+
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type onceErrorSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&onceErrorSuite{})
+
+func (s *onceErrorSuite) TestDoWithNil(c *gc.C) {
+	var oe onceError
+	err := oe.Do(func() error {
+		return nil
+	})
+	c.Assert(err, gc.IsNil)
+
+	var called bool
+	err = oe.Do(func() error {
+		called = true
+		return nil
+	})
+	c.Assert(err, gc.IsNil)
+	c.Check(called, jc.IsFalse)
+}
+
+func (s *onceErrorSuite) TestDoWithError(c *gc.C) {
+	var oe onceError
+	err := oe.Do(func() error {
+		return fmt.Errorf("boom")
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+
+	err = oe.Do(func() error {
+		return fmt.Errorf("blah")
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}

--- a/internal/database/app/package_test.go
+++ b/internal/database/app/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package app
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/worker/bootstrap/package_test.go
+++ b/internal/worker/bootstrap/package_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
 	"github.com/juju/utils/v3"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -22,6 +23,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package bootstrap -destination bootstrap_mock_test.go github.com/juju/juju/internal/worker/bootstrap ControllerConfigService,FlagService,ObjectStoreGetter,LegacyState,HTTPClient
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 

--- a/internal/worker/changestream/package_test.go
+++ b/internal/worker/changestream/package_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -19,6 +20,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package changestream -destination metrics_mock_test.go github.com/prometheus/client_golang/prometheus Registerer
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 

--- a/internal/worker/changestreampruner/package_test.go
+++ b/internal/worker/changestreampruner/package_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -21,6 +22,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package changestreampruner -destination worker_mock_test.go github.com/juju/worker/v4 Worker
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 

--- a/internal/worker/dbaccessor/package_test.go
+++ b/internal/worker/dbaccessor/package_test.go
@@ -12,6 +12,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -25,6 +26,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -package dbaccessor -destination metrics_mock_test.go github.com/prometheus/client_golang/prometheus Registerer
 
 func TestPackage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 
@@ -137,6 +140,16 @@ func (s *baseSuite) newWorkerWithDB(c *gc.C, db TrackedDB) worker.Worker {
 type dbBaseSuite struct {
 	domaintesting.ControllerSuite
 	baseSuite
+}
+
+func (s *dbBaseSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
+	s.baseSuite.SetUpTest(c)
+}
+
+func (s *dbBaseSuite) TearDownTest(c *gc.C) {
+	s.ControllerSuite.TearDownTest(c)
+	s.baseSuite.TearDownTest(c)
 }
 
 func ensureStartup(c *gc.C, w *dbWorker) {

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -133,15 +133,8 @@ func (s *integrationSuite) TearDownTest(c *gc.C) {
 	if s.db != nil {
 		s.db.Close()
 	}
-
-	// We can't for what ever reason call s.DqliteSuite.TearDownTest here
-	// because it will cause a segfault. The workaround is to close the
-	// db directly.
-	if db := s.DB(); db != nil {
-		db.Close()
-	}
-
 	s.dqliteAppIntegrationSuite.TearDownTest(c)
+	s.DqliteSuite.TearDownTest(c)
 }
 
 func (s *integrationSuite) TestWorkerSetsNodeIDAndAddress(c *gc.C) {


### PR DESCRIPTION
Now that we've added goroutine leak detection, we can start using it in test suites. This should ensure that we're correctly cleaning up workers when we kill them.

This did catch a lot of tests that were leaking, so it's nice to clean up those directly. This should ensure that our tests don't become bogged down and that repeated runs are possible.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

That tests pass.

## Links

**Jira card:** JUJU-5277

