### PR TITLE
Add support for noble

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -65,6 +65,7 @@ var ubuntuVersions = []string{
 	"22.10",
 	"23.04",
 	"23.10",
+	"24.04",
 }
 
 var controllerCfg = controller.Config{

--- a/core/base/supported.go
+++ b/core/base/supported.go
@@ -274,6 +274,7 @@ const (
 	Kinetic SeriesName = "kinetic"
 	Lunar   SeriesName = "lunar"
 	Mantic  SeriesName = "mantic"
+	Noble   SeriesName = "noble"
 )
 
 var ubuntuSeries = map[SeriesName]seriesVersion{
@@ -381,6 +382,12 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 	Mantic: {
 		WorkloadType: ControllerWorkloadType,
 		Version:      "23.10",
+	},
+	Noble: {
+		WorkloadType: ControllerWorkloadType,
+		Version:      "24.04",
+		LTS:          true,
+		ESMSupported: true,
 	},
 }
 

--- a/core/base/supportedbases_test.go
+++ b/core/base/supportedbases_test.go
@@ -35,6 +35,7 @@ func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
 			MustParseBaseFromString("kubernetes@kubernetes"),
 			MustParseBaseFromString("ubuntu@20.04/stable"),
 			MustParseBaseFromString("ubuntu@22.04/stable"),
+			MustParseBaseFromString("ubuntu@24.04/stable"),
 		},
 	}, {
 		name:          "requested base",
@@ -47,6 +48,7 @@ func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
 			MustParseBaseFromString("kubernetes@kubernetes"),
 			MustParseBaseFromString("ubuntu@20.04/stable"),
 			MustParseBaseFromString("ubuntu@22.04/stable"),
+			MustParseBaseFromString("ubuntu@24.04/stable"),
 		},
 	}, {
 		name:          "invalid base",

--- a/core/base/supportedseries_linux_test.go
+++ b/core/base/supportedseries_linux_test.go
@@ -58,6 +58,7 @@ func (s *SupportedSeriesLinuxSuite) TestUbuntuSeriesVersion(c *gc.C) {
 		{"eoan", "19.10"},
 		{"focal", "20.04"},
 		{"jammy", "22.04"},
+		{"noble", "24.04"},
 	}
 	for _, v := range isUbuntuTests {
 		ver, err := UbuntuSeriesVersion(v.series)
@@ -80,6 +81,6 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"centos7", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
+		"centos7", "centos9", "focal", "genericlinux", "jammy", "kubernetes", "noble",
 	})
 }

--- a/core/base/supportedseries_test.go
+++ b/core/base/supportedseries_test.go
@@ -36,10 +36,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"noble", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"noble", "jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -52,10 +52,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"noble", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"noble", "jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -68,10 +68,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"noble", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"noble", "jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -84,10 +84,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"noble", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"noble", "jammy", "focal", "centos9", "centos7", "genericlinux", "kubernetes"})
 }
 
 var getOSFromSeriesTests = []struct {
@@ -271,10 +271,16 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 			WorkloadType: ControllerWorkloadType,
 			Version:      "23.10",
 		},
+		Noble: {
+			WorkloadType: ControllerWorkloadType,
+			Version:      "24.04",
+			LTS:          true,
+			ESMSupported: true,
+		},
 	}
 
 	result := ubuntuVersions(nil, nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "focal": "20.04", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "jammy": "22.04", "kinetic": "22.10", "lunar": "23.04", "mantic": "23.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "focal": "20.04", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "jammy": "22.04", "kinetic": "22.10", "lunar": "23.04", "mantic": "23.10", "noble": "24.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(boolPtr(true), boolPtr(true), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
@@ -286,16 +292,16 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 	c.Check(result, gc.DeepEquals, map[string]string{})
 
 	result = ubuntuVersions(boolPtr(false), boolPtr(true), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "trusty": "14.04", "xenial": "16.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "noble": "24.04", "trusty": "14.04", "xenial": "16.04"})
 
 	result = ubuntuVersions(boolPtr(true), nil, ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
 
 	result = ubuntuVersions(boolPtr(false), nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "mantic": "23.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "mantic": "23.10", "noble": "24.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(nil, boolPtr(true), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04", "trusty": "14.04", "xenial": "16.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04", "noble": "24.04", "trusty": "14.04", "xenial": "16.04"})
 
 	result = ubuntuVersions(nil, boolPtr(false), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "mantic": "23.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -46,6 +46,7 @@ var ubuntuVersions = []string{
 	"22.10",
 	"23.04",
 	"23.10",
+	"24.04",
 }
 
 func makeBases(os string, vers []string) []state.Base {


### PR DESCRIPTION
Add `noble` to the list of allowed bases. The default is still `jammy`.

## QA steps

bootstrap and check jammy is the default
bootstrap with `--bootstrap-series=noble`

as above with add-machine

## Documentation changes

We'll want to ensure `noble` is mentioned when it goes GA.

## Links

**Jira card:** JUJU-5283

