### PR TITLE
Fix k8s permissions to allow cross model secrets to work with rbac

### DIFF
--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -24,7 +24,7 @@ import (
 	"github.com/juju/juju/secrets/provider"
 )
 
-type backendConfigGetter func(string) (*provider.ModelBackendConfigInfo, error)
+type backendConfigGetter func(modelUUID, backendID string, consumer names.Tag) (*provider.ModelBackendConfigInfo, error)
 type secretStateGetter func(modelUUID string) (SecretsState, SecretsConsumer, func() bool, error)
 
 // CrossModelSecretsAPI provides access to the CrossModelSecrets API facade.
@@ -225,7 +225,7 @@ func (s *CrossModelSecretsAPI) getSecretContent(arg params.GetRemoteSecretConten
 	if err != nil || content.ValueRef == nil {
 		return content, nil, latestRevision, errors.Trace(err)
 	}
-	backend, err := s.getBackend(uri.SourceUUID, content.ValueRef.BackendID)
+	backend, err := s.getBackend(uri.SourceUUID, content.ValueRef.BackendID, consumer)
 	return content, backend, latestRevision, errors.Trace(err)
 }
 
@@ -255,8 +255,8 @@ func (s *CrossModelSecretsAPI) updateConsumedRevision(secretsState SecretsState,
 	return md.LatestRevision, nil
 }
 
-func (s *CrossModelSecretsAPI) getBackend(modelUUID string, backendID string) (*params.SecretBackendConfigResult, error) {
-	cfgInfo, err := s.backendConfigGetter(modelUUID)
+func (s *CrossModelSecretsAPI) getBackend(modelUUID string, backendID string, consumer names.Tag) (*params.SecretBackendConfigResult, error) {
+	cfgInfo, err := s.backendConfigGetter(modelUUID, backendID, consumer)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -103,7 +103,9 @@ func (s *CrossModelSecretsSuite) setup(c *gc.C) *gomock.Controller {
 	secretsStateGetter := func(modelUUID string) (crossmodelsecrets.SecretsState, crossmodelsecrets.SecretsConsumer, func() bool, error) {
 		return s.secretsState, s.secretsConsumer, func() bool { return false }, nil
 	}
-	backendConfigGetter := func(modelUUID string) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(modelUUID, backendID string, consumer names.Tag) (*provider.ModelBackendConfigInfo, error) {
+		c.Assert(backendID, gc.Equals, "backend-id")
+		c.Assert(consumer.String(), gc.Equals, "unit-remote-app-666")
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "active-id",
 			Configs: map[string]provider.ModelBackendConfig{

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
@@ -27,13 +28,19 @@ func Register(registry facade.FacadeRegistry) {
 // backed by global state.
 func newStateCrossModelSecretsAPI(ctx facade.Context) (*CrossModelSecretsAPI, error) {
 	authCtxt := ctx.Resources().Get("offerAccessAuthContext").(common.ValueResource).Value
-	secretBackendConfigGetter := func(modelUUID string) (*provider.ModelBackendConfigInfo, error) {
+
+	leadershipChecker, err := ctx.LeadershipChecker()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	secretBackendConfigGetter := func(modelUUID, backendID string, consumer names.Tag) (*provider.ModelBackendConfigInfo, error) {
 		model, closer, err := ctx.StatePool().GetModel(modelUUID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		defer closer.Release()
-		return secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
+		return secrets.BackendConfigInfo(secrets.SecretsModel(model), []string{backendID}, false, consumer, leadershipChecker)
 	}
 	secretInfoGetter := func(modelUUID string) (SecretsState, SecretsConsumer, func() bool, error) {
 		st, err := ctx.StatePool().Get(modelUUID)

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -265,6 +265,12 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 			APIGroups: []string{"*"},
 			Resources: []string{"*"},
 		}}
+	} else {
+		appClusterRole.Rules = []rbacv1.PolicyRule{{
+			Verbs:     []string{"get", "list"},
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+		}}
 	}
 	appClusterRoleBinding := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/caas/kubernetes/provider/application/trust.go
+++ b/caas/kubernetes/provider/application/trust.go
@@ -50,7 +50,15 @@ var fullAccessApplicationNamespaceRules = []rbacv1.PolicyRule{
 	},
 }
 
-var defaultApplicationClusterRules []rbacv1.PolicyRule
+var defaultApplicationClusterRules = []rbacv1.PolicyRule{
+	{
+		// TODO - these are only needed to determine legacy labels or not.
+		// We need to migrate away from legacy labels.
+		APIGroups: []string{""},
+		Resources: []string{"namespaces"},
+		Verbs:     []string{"get", "list"},
+	},
+}
 
 var fullAccessApplicationClusterRules = []rbacv1.PolicyRule{
 	{

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -129,5 +129,14 @@ func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
 	})
 	clusterRole, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(clusterRole.Rules, gc.HasLen, 0)
+	c.Assert(clusterRole.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+		},
+	})
 }


### PR DESCRIPTION
With cross model secrets, there's a facade on the target controller `controller/crossmodelsecrets` which gets the config to access the secret on k8s and passes it back to the consuming model. But the logic only called `AdminBackendConfigInfo` and not `BackendConfigInfo`. Just calling `AdminBackendConfigInfo` does not set up the necessary role bindings. The non cross model case uses `BackendConfigInfo` and so should the cross model case.

Separately, when creating the default (non trusted) rules for the app service account, we need to include the ability to get ans list namespaces, or else we'll see errors in the logs when the k8s provider tries to query the namespace to see if legacy labels are used. These rules can be removed when we move off legacy labels.

## QA steps

See reproducer in the bug link.

## Links

https://bugs.launchpad.net/juju/+bug/2046484

**Jira card:** JUJU-5284

