### PR TITLE
Remove a log line left in for debug in cmr auth

### DIFF
--- a/apiserver/common/crossmodel/bakery.go
+++ b/apiserver/common/crossmodel/bakery.go
@@ -267,7 +267,6 @@ func (o *OfferBakery) CreateDischargeMacaroon(
 		requiredSourceModelUUID, username, requiredOffer, requiredRelation,
 		permission.ConsumeAccess,
 	)
-	logger.Criticalf("authYaml: %s", authYaml)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
A `log.Critical()` was accidentally left in the code for debugging; this PR removes it.