### PR TITLE
Store cmr macaroon discharge endpoint on the context

### DIFF
--- a/apiserver/common/crossmodel/mocks/crossmodel_mock.go
+++ b/apiserver/common/crossmodel/mocks/crossmodel_mock.go
@@ -51,47 +51,19 @@ func (m *MockOfferBakeryInterface) EXPECT() *MockOfferBakeryInterfaceMockRecorde
 	return m.recorder
 }
 
-// Bakery mocks base method.
-func (m *MockOfferBakeryInterface) Bakery() authentication.ExpirableStorageBakery {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bakery")
-	ret0, _ := ret[0].(authentication.ExpirableStorageBakery)
-	return ret0
-}
-
-// Bakery indicates an expected call of Bakery.
-func (mr *MockOfferBakeryInterfaceMockRecorder) Bakery() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bakery", reflect.TypeOf((*MockOfferBakeryInterface)(nil).Bakery))
-}
-
-// Clock mocks base method.
-func (m *MockOfferBakeryInterface) Clock() clock.Clock {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clock")
-	ret0, _ := ret[0].(clock.Clock)
-	return ret0
-}
-
-// Clock indicates an expected call of Clock.
-func (mr *MockOfferBakeryInterfaceMockRecorder) Clock() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clock", reflect.TypeOf((*MockOfferBakeryInterface)(nil).Clock))
-}
-
 // CreateDischargeMacaroon mocks base method.
-func (m *MockOfferBakeryInterface) CreateDischargeMacaroon(arg0 context.Context, arg1 string, arg2, arg3 map[string]string, arg4 bakery.Op, arg5 bakery.Version) (*bakery.Macaroon, error) {
+func (m *MockOfferBakeryInterface) CreateDischargeMacaroon(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 bakery.Op, arg6 bakery.Version) (*bakery.Macaroon, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDischargeMacaroon", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateDischargeMacaroon", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*bakery.Macaroon)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateDischargeMacaroon indicates an expected call of CreateDischargeMacaroon.
-func (mr *MockOfferBakeryInterfaceMockRecorder) CreateDischargeMacaroon(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockOfferBakeryInterfaceMockRecorder) CreateDischargeMacaroon(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDischargeMacaroon", reflect.TypeOf((*MockOfferBakeryInterface)(nil).CreateDischargeMacaroon), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDischargeMacaroon", reflect.TypeOf((*MockOfferBakeryInterface)(nil).CreateDischargeMacaroon), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // GetConsumeOfferCaveats mocks base method.
@@ -123,11 +95,12 @@ func (mr *MockOfferBakeryInterfaceMockRecorder) InferDeclaredFromMacaroon(arg0, 
 }
 
 // RefreshDischargeURL mocks base method.
-func (m *MockOfferBakeryInterface) RefreshDischargeURL(arg0 string) error {
+func (m *MockOfferBakeryInterface) RefreshDischargeURL(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshDischargeURL", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RefreshDischargeURL indicates an expected call of RefreshDischargeURL.
@@ -136,16 +109,44 @@ func (mr *MockOfferBakeryInterfaceMockRecorder) RefreshDischargeURL(arg0 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshDischargeURL", reflect.TypeOf((*MockOfferBakeryInterface)(nil).RefreshDischargeURL), arg0)
 }
 
-// SetClock mocks base method.
-func (m *MockOfferBakeryInterface) SetClock(arg0 clock.Clock) {
+// getBakery mocks base method.
+func (m *MockOfferBakeryInterface) getBakery() authentication.ExpirableStorageBakery {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClock", arg0)
+	ret := m.ctrl.Call(m, "getBakery")
+	ret0, _ := ret[0].(authentication.ExpirableStorageBakery)
+	return ret0
 }
 
-// SetClock indicates an expected call of SetClock.
-func (mr *MockOfferBakeryInterfaceMockRecorder) SetClock(arg0 any) *gomock.Call {
+// getBakery indicates an expected call of getBakery.
+func (mr *MockOfferBakeryInterfaceMockRecorder) getBakery() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClock", reflect.TypeOf((*MockOfferBakeryInterface)(nil).SetClock), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getBakery", reflect.TypeOf((*MockOfferBakeryInterface)(nil).getBakery))
+}
+
+// getClock mocks base method.
+func (m *MockOfferBakeryInterface) getClock() clock.Clock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getClock")
+	ret0, _ := ret[0].(clock.Clock)
+	return ret0
+}
+
+// getClock indicates an expected call of getClock.
+func (mr *MockOfferBakeryInterfaceMockRecorder) getClock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getClock", reflect.TypeOf((*MockOfferBakeryInterface)(nil).getClock))
+}
+
+// setClock mocks base method.
+func (m *MockOfferBakeryInterface) setClock(arg0 clock.Clock) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "setClock", arg0)
+}
+
+// setClock indicates an expected call of setClock.
+func (mr *MockOfferBakeryInterfaceMockRecorder) setClock(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setClock", reflect.TypeOf((*MockOfferBakeryInterface)(nil).setClock), arg0)
 }
 
 // MockBackend is a mock of Backend interface.

--- a/apiserver/common/crossmodel/package_test.go
+++ b/apiserver/common/crossmodel/package_test.go
@@ -22,14 +22,10 @@ func TestAll(t *testing.T) {
 	gc.TestingT(t)
 }
 
-func (o *OfferBakery) DischargeURL() string {
-	return o.accessEndpoint
-}
-
 func (o *OfferBakery) SetBakery(bakery authentication.ExpirableStorageBakery) {
 	o.bakery = bakery
 }
 
 func (o *AuthContext) SetClock(clk clock.Clock) {
-	o.offerBakery.SetClock(clk)
+	o.offerBakery.setClock(clk)
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -139,9 +139,9 @@ bootstrap() {
 
 		juju_add_model "${model}" "${cloud}" "${bootstrapped_name}" "${output}"
 		name="${bootstrapped_name}"
-		BOOTSTRAPPED_CLOUD=$(juju show-model controller | yq -o=j | jq -r '.[] | .cloud')
+		BOOTSTRAPPED_CLOUD=$(juju show-model controller | yq -j | jq -r '.[] | .cloud')
 		export BOOTSTRAPPED_CLOUD
-		BOOTSTRAPPED_CLOUD_REGION=$(juju show-model controller | yq -o=j | jq -r '.[] | (.cloud + "/" + .region)')
+		BOOTSTRAPPED_CLOUD_REGION=$(juju show-model controller | yq -j | jq -r '.[] | (.cloud + "/" + .region)')
 		export BOOTSTRAPPED_CLOUD_REGION
 	else
 		local cloud_region

--- a/tests/suites/cli/display_clouds.sh
+++ b/tests/suites/cli/display_clouds.sh
@@ -82,7 +82,7 @@ EOF
 	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju clouds --client --format=json | jq -S 'with_entries(select(
 	                                                  .value.defined != "built-in")) | with_entries((select(.value.defined == "local")
 	                                                  | del(.value.defined) |  del(.value.description)))')
-	EXPECTED=$(echo "${CLOUDS}" | yq -o=j | jq -S '.[] | del(.clouds) | .[] |= ({endpoint} as $endpoint | .[] |= walk(
+	EXPECTED=$(echo "${CLOUDS}" | yq -j | jq -S '.[] | del(.clouds) | .[] |= ({endpoint} as $endpoint | .[] |= walk(
                                                   (objects | select(contains($endpoint))) |= del(.endpoint)
                                                 ))')
 	if [ "${CLOUD_LIST}" != "${EXPECTED}" ]; then
@@ -90,7 +90,7 @@ EOF
 		exit 1
 	fi
 
-	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format yaml --client | yq -o=j | jq -S 'with_entries((select(.value!= null)))')
+	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format yaml --client | yq -j | jq -S 'with_entries((select(.value!= null)))')
 	EXPECTED=$(
 		cat <<'EOF' | jq -S
 	{

--- a/tests/suites/metrics/metrics.sh
+++ b/tests/suites/metrics/metrics.sh
@@ -13,7 +13,7 @@ run_smoke_test() {
 
 	attempt=0
 	while true; do
-		OUT=$(juju metrics metered/0 --format yaml | yq -o=j | jq -r '.[]')
+		OUT=$(juju metrics metered/0 --format yaml | yq -j | jq -r '.[]')
 		if [[ -n ${OUT} ]]; then
 			break
 		fi


### PR DESCRIPTION
https://github.com/juju/juju/pull/16686 fixed an issue supporting discharge of cross model macaroons against a JAAS endpoint. However, the implementation moved the discharge endpoint from the auth context to the bakery, which resulted in the possibility of a mismatch between the endpoint used and the cert address.

This PR fixes that by (again) storing the discharge endpoint on the auth context - the context is copied each time the endpoint is updated. Before the original PR, the endpoint was also duplicated on the authenticator but this is unnecessary since the authenticator has a copy of the context (containing the endpoint).

The bakery interface had some package scoped methods unexported as well (don't like exporting things unless needed).

Also, the the ci scripts we were using `yq -o=j ...` but modern versions of `yq` just need `yq -j ...`

## QA steps

run the model_migration_saas_common test on google cloud

`===> [ ✔ ] Success: model migration saas common (775s)`