### PR TITLE
Add auth to charm upload S3 endpoint

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -984,9 +984,15 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:    modelCharmsHTTPHandler,
 		authorizer: modelCharmsUploadAuthorizer,
 	}, {
+		// GET has no authorizer
 		pattern: charmsObjectsRoutePrefix,
-		methods: []string{"GET", "PUT"},
+		methods: []string{"GET"},
 		handler: modelObjectsCharmsHTTPHandler,
+	}, {
+		pattern:    charmsObjectsRoutePrefix,
+		methods:    []string{"PUT"},
+		handler:    modelObjectsCharmsHTTPHandler,
+		authorizer: modelCharmsUploadAuthorizer,
 	}}
 	if srv.registerIntrospectionHandlers != nil {
 		add := func(subpath string, h http.Handler) {


### PR DESCRIPTION
This was missed off in a previous PR, where these endpoints were initially added https://github.com/juju/juju/pull/16750

Now this endpoint matches the previous endpoint authoriser
See https://github.com/juju/juju/blob/3.4/apiserver/apiserver.go#L886-L896

This endpoint is an upgraded version of the `/model/:modeluuid/charms/` endpoint. This endpoint has an authoriser for POST operations, but nothing for GET. This should be replicated by the new endpoint, as no changes in authorisation were intended

## Bug Reproducer

It is a little difficult to demonstrate this bug, since only users upload local charms to Juju. In fact, if something else attempts to upload a charm, we fail later anyway with a similar 'unathorised' error

However, it can be demonstrated using this diff:
https://pastebin.canonical.com/p/p3rFytMqj9/
Here, we hack our client to pretend to be sending requests as `machine-0` instead of a user, and we hack the server to skip authentication.

In this situation, if we attempt to upload a local charm, we should fail gracefully.

Apply the diff to the head of 3.4, compile juju with `make install` and run:
```
$ juju bootstrap lxd lxd
$ juju add-model
$ juju add-machine # We are pretending to be machine-0, so it must exist
$ juju deploy ~/charms/ubuntu
ERROR Put https://10.219.211.226:17070/model-69247d43-84eb-4d29-8c7d-1e97e82eee7c/charms/ubuntu-f4acd42: authorization failed: tag kind machine not valid
```

Look in `juju debug-log -m controller` and you will see:
```
machine-0: 16:42:11 ERROR juju.apiserver returning error from POST /model-4b70d1ca-9df6-43bd-86de-900849a0ef05/charms/ubuntu-f4acd42?%3Amodeluuid=4b70d1ca-9df6-43bd-86de-900849a0ef05&%3Aobject=ubuntu-f4acd42&arch=&name=ubuntu&revision=0&schema=local&series=jammy: [{github.com/juju/juju/apiserver.(*CharmsHTTPHandler).ServeHTTP:76: } {github.com/juju/juju/apiserver.(*CharmsHTTPHandler).ServeHTTP:68: cannot upload charm} {github.com/juju/juju/apiserver.(*charmsHandler).ServePost:111: } {github.com/juju/juju/apiserver.checkPermissions:77: tag kind machine not valid}]
```

This shows that request is being processed by the handler, which throws the above error itself. Not good!

Repeat the above steps, applying the diff to this PR. You will see the same error when deploying, but no error in debug-log. This indicates the Juju apiserver endpoint authoriser has successfully realised this request is not authorised, and exits early before the handler is started 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Add a panic after line 48 in `localcharmputters.go` https://github.com/juju/juju/blob/3.4/api/client/charms/localcharmputters.go#L48 and compile Juju

This ensures that we successfully use the new s3-compatible endpoint.

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ~/charms/ubuntu
(verify charm deploys + goes to active)
```