### PR TITLE
Use RootHTTPClient in migrationtarget client

### DIFF
--- a/api/controller/migrationtarget/client.go
+++ b/api/controller/migrationtarget/client.go
@@ -29,8 +29,8 @@ import (
 // NewClient returns a new Client based on an existing API connection.
 func NewClient(caller base.APICaller) *Client {
 	return &Client{
-		caller:            base.NewFacadeCaller(caller, "MigrationTarget"),
-		httpClientFactory: caller.HTTPClient,
+		caller:                base.NewFacadeCaller(caller, "MigrationTarget"),
+		httpRootClientFactory: caller.RootHTTPClient,
 	}
 }
 
@@ -38,8 +38,8 @@ func NewClient(caller base.APICaller) *Client {
 // used by the migrationmaster worker when talking to the target
 // controller during a migration.
 type Client struct {
-	caller            base.FacadeCaller
-	httpClientFactory func() (*httprequest.Client, error)
+	caller                base.FacadeCaller
+	httpRootClientFactory func() (*httprequest.Client, error)
 }
 
 // BestFacadeVersion returns the best supported facade version
@@ -202,8 +202,8 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(params.MigrationModelHTTPHeader, modelUUID)
 
-	// The returned httpClient sets the base url to /model/<uuid> if it can.
-	httpClient, err := c.httpClientFactory()
+	// The returned httpClient sets the base url to the controller api root
+	httpClient, err := c.httpRootClientFactory()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -368,7 +368,7 @@ func (fakeHTTPCaller) BestFacadeVersion(string) int {
 	return 0
 }
 
-func (c fakeHTTPCaller) HTTPClient() (*httprequest.Client, error) {
+func (c fakeHTTPCaller) RootHTTPClient() (*httprequest.Client, error) {
 	return c.httpClient, c.err
 }
 


### PR DESCRIPTION
All the apiserver endpoints for migration are scoped to the server root (i.e /migrate/blah instead of /model/:modeluuid/migrate/balh). See apiserver/apiserver.go

However, the migrationtarget client uses an http client which attempts to prefix urls with "/model/:modeluuid". It seems this fails and we rely on this failing

This works, but is confusing and potentially delicate. I suspect this was only done because this was the only HTTPClient available at the time.

Use the newly made available RootHTTPClient instead to avoid this misdirection

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
juju bootstrap lxd lxd-dst
juju bootstrap lxd lxd-src
juju add-model m 
juju deploy ubuntu ubu-ch
juju deploy ~/charms/ubuntu ubu-local
(wait until deployed)
juju migrate m lxd-dst
(verify migration is successful)
```
Repeat this, but bootstraping `lxd-src` with Juju 3.3