### PR TITLE
Add terraform provider for juju smoke test workflow.

### DIFF
--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -1,0 +1,92 @@
+name: "Terraform Provider for Juju Smoke"
+on:
+  push:
+    branches: [2.9, 3.*]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/terraform-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  smoke:
+    name: Terraform Smoke
+    runs-on: [self-hosted, linux, x64, aws, xlarge]
+    if: github.event.pull_request.draft == false
+    steps:
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        set -euxo pipefail
+        echo "/snap/bin" >> $GITHUB_PATH
+        sudo DEBIAN_FRONTEND=noninteractive apt install -y expect
+
+    - name: Checkout juju
+      uses: actions/checkout@v3
+
+    - name: Setup LXD
+      uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: setup env
+      shell: bash
+      run: |
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+    - name: Install local Juju
+      shell: bash
+      run: |
+        make go-install
+
+    - name: Bootstrap Juju - localhost
+      shell: bash
+      run: |
+        set -euxo pipefail
+            
+        juju bootstrap localhost c \
+              --constraints "arch=$(go env GOARCH)"
+        juju version
+
+    - name: Find terraform provider for juju latest release
+      uses: actions/checkout@v3
+      with:
+        repository: 'juju/terraform-provider-juju'
+        #path: terraform-provider-juju
+        fetch-depth: 0
+
+    - name: Checkout terraform provider for juju latest release
+      run: |
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        git checkout $LATEST_TAG
+
+    - name: Set environment to configure provider for test
+      run: |
+        CONTROLLER=$(juju whoami --format yaml | yq .controller)
+        echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+        echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+        echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+        echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+        juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: Run terraform provider for juju ACC tests
+      shell: bash
+      env:
+        TF_ACC: "1"
+        TEST_CLOUD: lxd
+      run: |
+        go mod download
+        go test -timeout 40m -v -cover ./internal/provider/


### PR DESCRIPTION
Ensure that we test apiserver changes for 2.9 and 3.x against the lastest terraform provider for juju release.

There is currently a bug for add model in juju 3.3, and possibly juju 3.4. ```Error: interface conversion: interface {} is nil, not string``` It's expected the terraform tests will be successful against 2.9 -> 3.2. 

The terraform provider for juju tests will be run. These are actually live acceptance tests. Currently we will only run with LXD as a cloud, the tests can also be run against MicroK8S in the future. The alternative would be to write plan terraform plans for test and keep updating them in the juju repo.

This suite is implement as a GitHub action rather than within the juju integration test suites as it's easier to do when dealing with 2 different repositories.

Once this test is stable, it should become required.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Successful GitHub action run for new workflow



## Links

 JUJU-4554

