### PR TITLE
Improve Merge/Upgrade Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Build"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,7 +1,7 @@
 name: "Client Tests"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,7 +1,7 @@
 name: "Generate"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,7 @@
 name: "Licenses"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,7 +1,7 @@
 name: "Migrate"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   migrate:
     name: migrate from ${{ matrix.channel }} via ${{ matrix.client }} client
+    timeout-minutes: 30
     runs-on: [self-hosted, linux, arm64, aws, xlarge]
     if: github.event.pull_request.draft == false
     strategy:
@@ -85,7 +86,7 @@ jobs:
           juju switch controller
           juju wait-for application controller
 
-      - name: Migrate default model to 3.x controller
+      - name: Migrate model to target controller
         run: |
           # Determine which Juju client to use
           JUJU='juju'

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install Juju ${{ matrix.channel }}
         run: |
+          mkdir -p ~/.local/share/juju
           if [[ ${{ matrix.channel }} == '2.9/stable' ]]; then
             sudo snap install juju --classic --channel ${{ matrix.channel }}
           else

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   migrate:
     name: migrate from ${{ matrix.channel }} via ${{ matrix.client }} client
-    runs-on: [self-hosted, linux, arm64, aws, large]
+    runs-on: [self-hosted, linux, arm64, aws, xlarge]
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   migrate:
-    name: 2.9-to-3.x via ${{ matrix.client }} client
+    name: migrate from ${{ matrix.channel }} via ${{ matrix.client }} client
     runs-on: [self-hosted, linux, arm64, aws, large]
     if: github.event.pull_request.draft == false
     strategy:
@@ -27,8 +27,8 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
-        channel: ["2.9/stable"]
-        client: ['2.9', '3.x']
+        channel: ["2.9/stable", "3.1/stable"]
+        client: ['source', 'target']
 
     steps:
       - name: Checkout code
@@ -47,62 +47,61 @@ jobs:
 
       - name: Setup LXD
         if: matrix.cloud == 'lxd'
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
 
-      - name: Install Juju 2.9
+      - name: Install Juju ${{ matrix.channel }}
         run: |
-          sudo snap install juju --classic --channel ${{ matrix.channel }}
+          if [[ ${{ matrix.channel }} == '2.9/stable' ]]; then
+            sudo snap install juju --classic --channel ${{ matrix.channel }}
+          else
+            sudo snap install juju --channel ${{ matrix.channel }}
+          fi
 
-      - name: Bootstrap a 2.9 controller and model
+      - name: Bootstrap a ${{ matrix.channel }} controller and model
         run: |
           /snap/bin/juju version
-          /snap/bin/juju bootstrap lxd test29 --constraints "arch=$(go env GOARCH)"
+          /snap/bin/juju bootstrap lxd source-controller --constraints "arch=$(go env GOARCH)"
           /snap/bin/juju add-model test-migrate
           /snap/bin/juju set-model-constraints arch=$(go env GOARCH)
           /snap/bin/juju deploy ubuntu
-          
-          # TODO: use juju-restore
-          # TODO: add users/permissions/models and test that those migrate over
 
-      - name: Upgrade client to 3.x
+      - name: Install target juju client
         run: |
           make go-install &>/dev/null
 
-      - name: Bootstrap 3.x controller
+      - name: Bootstrap target controller
         run: |
           juju version
-          juju bootstrap lxd test3x --constraints "arch=$(go env GOARCH)"
+          juju bootstrap lxd target-controller --constraints "arch=$(go env GOARCH)"
           juju switch controller
           juju wait-for application controller
-
-        # TODO: create backup and juju restore
 
       - name: Migrate default model to 3.x controller
         run: |
           # Determine which Juju client to use
           JUJU='juju'
-          if [[ ${{ matrix.client }} == '2.9' ]]; then
+          if [[ ${{ matrix.client }} == 'source' ]]; then
             JUJU='/snap/bin/juju'
           fi
           
-          $JUJU switch test29
+          $JUJU switch source-controller
           
           # Ensure application is fully deployed
           # We have to use the old client to speak to the new controller, as
           # this is blocked otherwise.
-          /snap/bin/juju wait-for application ubuntu
+          $JUJU wait-for application ubuntu
 
           # Wait a few secs for the machine status to update
           # so that migration prechecks pass.
           sleep 10
 
           $JUJU version
-          $JUJU migrate test-migrate test3x
+          $JUJU migrate test-migrate target-controller
 
       - name: Check the migration was successful
         run: |
           set -x
-          juju switch test3x
+          juju switch target-controller
           
           # Wait for 'test-migrate' model to come through
           attempt=0

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -49,6 +49,14 @@ jobs:
         if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
 
+      - name: Wait for LXD
+        if: matrix.cloud == 'lxd'
+        run: |
+          while ! ip link show lxdbr0; do
+            echo "Waiting for lxdbr0..."
+            sleep 10
+          done
+
       - name: Install Juju ${{ matrix.channel }}
         run: |
           mkdir -p ~/.local/share/juju

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,6 +35,14 @@ jobs:
       if: matrix.cloud == 'localhost'
       uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
 
+    - name: Wait for LXD
+      if: matrix.cloud == 'localhost'
+      run: |
+        while ! ip link show lxdbr0; do
+          echo "Waiting for lxdbr0..."
+          sleep 10
+        done
+
     - name: Setup Docker Mirror
       shell: bash
       run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,7 +1,7 @@
 name: "Smoke"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,7 +1,7 @@
 name: "Snapcraft"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -37,6 +37,13 @@ jobs:
 
     - name: Setup LXD
       uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
+  
+    - name: Wait for LXD
+      run: |
+        while ! ip link show lxdbr0; do
+          echo "Waiting for lxdbr0..."
+          sleep 10
+        done
 
     - name: Set up Go
       if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,7 +1,7 @@
 name: "Static Analysis"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3, main]
+    branches: [2.*, 3.*, 4.*, main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 #   paths:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Mirror docker images required for juju bootstrap
         if: matrix.cloud == 'microk8s'
         env:
-          SOURCE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
+          SOURCE_JUJU_VERSION: ${{ steps.vars.outputs.source-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -148,14 +148,14 @@ jobs:
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${SOURCE_JUJU_TAG}
+            FROM docker.io/jujusolutions/jujud-operator:${SOURCE_JUJU_VERSION}
           
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
+          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
           
           DOCKER_USERNAME=${DOCKER_REGISTRY}/test-repo make seed-repository
 
@@ -220,8 +220,7 @@ jobs:
       - name: Build jujud image
         if: matrix.cloud == 'microk8s'
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
-          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
+          TARGET_JUJU_VERSION: ${{ steps.vars.outputs.target-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -231,26 +230,14 @@ jobs:
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${UPSTREAM_JUJU_TAG}
+            FROM docker.io/jujusolutions/jujud-operator:${TARGET_JUJU_VERSION}
           
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
-          
-          BUILD_TEMP=$(mktemp -d)
-          cp ~/certs/ca.crt $BUILD_TEMP/
-          cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
-          
-            COPY ca.crt /usr/local/share/ca-certificates/ca.crt
-          
-            RUN update-ca-certificates
-          EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
+          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
 
       - name: Preflight
         shell: bash
@@ -262,8 +249,7 @@ jobs:
       - name: Test upgrade controller
         shell: bash
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
-          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
+          TARGET_JUJU_VERSION: ${{ steps.vars.outputs.target-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -271,7 +257,7 @@ jobs:
           if [[ $OUTPUT == 'no upgrades available' ]]; then
             exit 1
           fi
-          .github/verify-agent-version.sh ${MODEL_TYPE_${{ matrix.cloud }}} ${UPSTREAM_JUJU_TAG}
+          .github/verify-agent-version.sh ${MODEL_TYPE_${{ matrix.cloud }}} ${TARGET_JUJU_VERSION}
           
           PANIC=$(juju debug-log --replay --no-tail -m controller | grep "panic" || true)
           if [ "$PANIC" != "" ]; then
@@ -285,7 +271,7 @@ jobs:
       - name: Test upgrade model
         shell: bash
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
+          TARGET_JUJU_VERSION: ${{ steps.vars.outputs.target-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -300,7 +286,7 @@ jobs:
           attempt=0
           while true; do
             UPDATED=$((juju show-model m --format=json || echo "") | jq -r '.m."agent-version"')
-            if [[ $UPDATED == $UPSTREAM_JUJU_TAG* ]]; then
+            if [[ $UPDATED == $TARGET_JUJU_VERSION* ]]; then
               break
             fi
             sleep 10

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,7 +1,7 @@
 name: "Upgrade"
 on:
   push:
-    branches: [2.9, 3.1, 3.2, 3.3]
+    branches: [3.*]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -34,59 +34,57 @@ jobs:
       CHARM_localhost: apache2
       CHARM_microk8s: prometheus-k8s
       DOCKER_REGISTRY: 10.152.183.69
-      RUN_TEST: RUN
       UPGRADE_FLAGS_localhost: --build-agent
       UPGRADE_FLAGS_microk8s: --agent-stream=develop
       MODEL_TYPE_localhost: iaas
       MODEL_TYPE_microk8s: caas
 
     steps:
-      - name: Install Dependencies
-        if: env.RUN_TEST == 'RUN'
-        shell: bash
-        run: |
-          set -euxo pipefail
-          sudo snap install juju --channel=3.2/stable
-          mkdir -p ~/.local/share
-          echo "/snap/bin" >> $GITHUB_PATH
-
       - name: Checkout
-        if: env.RUN_TEST == 'RUN'
         uses: actions/checkout@v3
 
       - name: Setup LXD
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'localhost'
+        if: matrix.cloud == 'localhost'
         uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
 
       - name: Set some variables
-        if: env.RUN_TEST == 'RUN'
         run: |
           set -euxo pipefail
           
-          echo "base-juju-version=$(juju version | cut -d '-' -f 1)" >> $GITHUB_OUTPUT
-          upstreamJujuVersion=$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
-          echo "upstream-juju-version=${upstreamJujuVersion}" >> $GITHUB_OUTPUT
-          currentStableChannel="$(echo $upstreamJujuVersion | cut -d'.' -f1,2)/stable"
-          currentStableVersion=$(snap info juju | yq ".channels[\"$currentStableChannel\"]" | cut -d' ' -f1)
-          echo "current-stable-juju-version=$currentStableVersion" >> $GITHUB_OUTPUT
+          targetJujuVersion=$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
+          jujuSnapChannel="$(echo $targetJujuVersion | cut -d'.' -f1,2)/stable"
+          sourceJujuVersion=$(snap info juju | yq ".channels[\"$jujuSnapChannel\"]" | cut -d' ' -f1)
+
+          echo "juju-snap-channel=${jujuSnapChannel}" >> $GITHUB_OUTPUT
+          echo "target-juju-version=${targetJujuVersion}" >> $GITHUB_OUTPUT
+          echo "source-juju-version=${sourceJujuVersion}" >> $GITHUB_OUTPUT
           echo "juju-db-version=4.4" >> $GITHUB_OUTPUT
         id: vars
 
       - name: Set up Go
-        if: env.RUN_TEST == 'RUN'
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: setup env
+      - name: Setup Environment
         shell: bash
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
+      - name: Install Juju
+        shell: bash
+        env:
+          JUJU_SNAP_CHANNEL: ${{ steps.vars.outputs.juju-snap-channel }}
+        run: |
+          set -euxo pipefail
+          sudo snap install juju --channel=${JUJU_SNAP_CHANNEL}
+          mkdir -p ~/.local/share
+          echo "/snap/bin" >> $GITHUB_PATH
+
       - name: Setup Docker Mirror
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         shell: bash
         run: |
           (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
@@ -95,7 +93,7 @@ jobs:
           docker system info
 
       - name: Setup k8s
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
         with:
           channel: "1.28-strict/stable"
@@ -103,7 +101,7 @@ jobs:
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
       - name: Setup local caas registry
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         run: |
           set -euxo pipefail
           
@@ -133,9 +131,9 @@ jobs:
           curl https://${DOCKER_REGISTRY}/v2/
 
       - name: Mirror docker images required for juju bootstrap
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         env:
-          BASE_JUJU_TAG: ${{ steps.vars.outputs.base-juju-version }}
+          SOURCE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
           JUJU_DB_TAG: ${{ steps.vars.outputs.juju-db-version }}
           CHARM_BASE: ubuntu-20.04
         run: |
@@ -145,14 +143,14 @@ jobs:
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${BASE_JUJU_TAG}
+            FROM docker.io/jujusolutions/jujud-operator:${SOURCE_JUJU_TAG}
           
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
           
             RUN update-ca-certificates
           EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${BASE_JUJU_TAG}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${BASE_JUJU_TAG}
+          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
+          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
           
           docker pull docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}
           docker tag docker.io/jujusolutions/juju-db:${JUJU_DB_TAG} ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
@@ -163,7 +161,7 @@ jobs:
           docker push ${DOCKER_REGISTRY}/test-repo/charm-base:${CHARM_BASE}
 
       - name: Bootstrap Juju - localhost
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'localhost'
+        if: matrix.cloud == 'localhost'
         shell: bash
         run: |
           set -euxo pipefail
@@ -177,7 +175,7 @@ jobs:
           juju status
 
       - name: Bootstrap Juju - microk8s
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
 
         # TODO: Enabling developer-mode is a bit of a hack to get this working for now.
         # Ideally, we would mock our own simplestream, similar to Jenkins, to select
@@ -198,7 +196,6 @@ jobs:
           juju status
 
       - name: Deploy some applications
-        if: env.RUN_TEST == 'RUN'
         shell: bash
         run: |
           set -euxo pipefail
@@ -216,17 +213,16 @@ jobs:
           $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.cloud }}}.sh 30
 
       - name: Update Juju
-        if: env.RUN_TEST == 'RUN'
         shell: bash
         run: |
           sudo snap remove juju --purge
           make go-install
 
       - name: Build jujud image
-        if: env.RUN_TEST == 'RUN' && matrix.cloud == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
-          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.current-stable-juju-version }}
+          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
+          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -258,7 +254,6 @@ jobs:
           docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
 
       - name: Preflight
-        if: env.RUN_TEST == 'RUN'
         shell: bash
         run: |
           set -euxo pipefail
@@ -266,11 +261,10 @@ jobs:
           juju version
 
       - name: Test upgrade controller
-        if: env.RUN_TEST == 'RUN'
         shell: bash
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
-          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.current-stable-juju-version }}
+          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
+          CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -290,10 +284,9 @@ jobs:
           $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.cloud }}}.sh 30
 
       - name: Test upgrade model
-        if: env.RUN_TEST == 'RUN'
         shell: bash
         env:
-          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
+          UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.target-juju-version }}
         run: |
           set -euxo pipefail
           
@@ -329,7 +322,6 @@ jobs:
           $GITHUB_WORKSPACE/.github/verify-${CHARM_${{ matrix.cloud }}}.sh 30
 
       - name: Wrap up
-        if: env.RUN_TEST == 'RUN'
         run: |
           set -euxo pipefail
           

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -22,9 +22,10 @@ permissions:
 
 jobs:
 
-  Upgrade:
+  upgrade:
     name: Upgrade
     runs-on: [self-hosted, linux, x64, aws, xlarge]
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Setup LXD
         if: matrix.cloud == 'localhost'
         uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
+    
+      - name: Wait for LXD
+        if: matrix.cloud == 'localhost'
+        run: |
+          while ! ip link show lxdbr0; do
+            echo "Waiting for lxdbr0..."
+            sleep 10
+          done
 
       - name: Set some variables
         run: |

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -58,7 +58,6 @@ jobs:
           echo "juju-snap-channel=${jujuSnapChannel}" >> $GITHUB_OUTPUT
           echo "target-juju-version=${targetJujuVersion}" >> $GITHUB_OUTPUT
           echo "source-juju-version=${sourceJujuVersion}" >> $GITHUB_OUTPUT
-          echo "juju-db-version=4.4" >> $GITHUB_OUTPUT
         id: vars
 
       - name: Set up Go
@@ -134,8 +133,6 @@ jobs:
         if: matrix.cloud == 'microk8s'
         env:
           SOURCE_JUJU_TAG: ${{ steps.vars.outputs.source-juju-version }}
-          JUJU_DB_TAG: ${{ steps.vars.outputs.juju-db-version }}
-          CHARM_BASE: ubuntu-20.04
         run: |
           set -euxo pipefail
           
@@ -152,13 +149,7 @@ jobs:
           docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
           docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_TAG}
           
-          docker pull docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}
-          docker tag docker.io/jujusolutions/juju-db:${JUJU_DB_TAG} ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
-          docker push ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
-          
-          docker pull docker.io/jujusolutions/charm-base:${CHARM_BASE}
-          docker tag docker.io/jujusolutions/charm-base:${CHARM_BASE} ${DOCKER_REGISTRY}/test-repo/charm-base:${CHARM_BASE}
-          docker push ${DOCKER_REGISTRY}/test-repo/charm-base:${CHARM_BASE}
+          DOCKER_USERNAME=${DOCKER_REGISTRY}/test-repo make seed-repository
 
       - name: Bootstrap Juju - localhost
         if: matrix.cloud == 'localhost'

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -144,23 +144,4 @@ func (s *StateTrackerSuite) TestReport(c *gc.C) {
 	// txn-watcher report and the system state.
 	c.Check(report, gc.HasLen, 3)
 	c.Check(report["pool-size"], gc.Equals, 0)
-
-	// Calling Report increments the request count in the system
-	// state's hubwatcher stats, so zero that out before comparing.
-	removeRequestCount := func(report map[string]interface{}) map[string]interface{} {
-		next := report
-		for _, p := range []string{"system", "workers", "txnlog", "report"} {
-			child, ok := next[p]
-			if !ok {
-				c.Fatalf("couldn't find system.workers.txnlog.report")
-			}
-			next = child.(map[string]interface{})
-		}
-		delete(next, "request-count")
-		return report
-	}
-	report = removeRequestCount(report)
-	c.Check(removeRequestCount(s.stateTracker.Report()), gc.DeepEquals, report)
-	c.Check(removeRequestCount(s.stateTracker.Report()), gc.DeepEquals, report)
-	c.Check(removeRequestCount(s.stateTracker.Report()), gc.DeepEquals, report)
 }


### PR DESCRIPTION
Various changes to the migrate and upgrade jobs to improve how they run.
- Jobs that use LXD wait for the lxdbr0 network interface to exist before trying to bootstrap lxd.
- The migrate job now runs for 2.9 and 3.1 as source controller. Both the source and target client versions are tested.
- The upgrade job has been cleaned up.

*NOTE*:
- `Migrate / migrate from 2.9/stable via target client` fails due to 2.9.47 not being released yet.
- `Upgrade / Upgrade (microk8s)` fails due to a bug with how dqlite is configured. It tries to bind to the old pod ip, from the previous pod before the upgrade.

Also includes a fix for a flaky test in the worker/state tests, which was written with the old txn watcher in mind, but this test shouldn't be concerned about the sstxn watcher implementation.

## QA steps

Look at action results.

## Documentation changes

N/A

## Links

N/A