### PR TITLE
Create corresponding S3-compatible migrate endpoint for charms

### DIFF
--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
@@ -201,37 +200,37 @@ func (s *ClientSuite) TestCheckMachines(c *gc.C) {
 
 func (s *ClientSuite) TestUploadCharm(c *gc.C) {
 	const charmBody = "charming"
-	curl := charm.MustParseURL("ch:foo-2")
-	doer := newFakeDoer(c, params.CharmsResponse{
-		CharmURL: curl.String(),
-	})
+	curl := "ch:foo-2"
+	charmRef := "foo-abcdef0"
+	doer := newFakeDoer(c, "", map[string]string{"Juju-Curl": curl})
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
 	client := migrationtarget.NewClient(caller)
-	outCurl, err := client.UploadCharm("uuid", curl, strings.NewReader(charmBody))
+	outCurl, err := client.UploadCharm("uuid", curl, charmRef, strings.NewReader(charmBody))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outCurl, gc.DeepEquals, curl)
-	c.Assert(doer.method, gc.Equals, "POST")
-	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=&name=foo&revision=2&schema=ch&series=")
+	c.Assert(doer.method, gc.Equals, "PUT")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms/foo-abcdef0")
+	c.Assert(doer.headers.Get("Juju-Curl"), gc.Equals, curl)
 	c.Assert(doer.body, gc.Equals, charmBody)
 }
 
 func (s *ClientSuite) TestUploadCharmHubCharm(c *gc.C) {
 	const charmBody = "charming"
-	curl := charm.MustParseURL("ch:s390x/bionic/juju-qa-test-15")
-	doer := newFakeDoer(c, params.CharmsResponse{
-		CharmURL: curl.String(),
-	})
+	curl := "ch:s390x/bionic/juju-qa-test-15"
+	charmRef := "juju-qa-test-abcdef0"
+	doer := newFakeDoer(c, "", map[string]string{"Juju-Curl": curl})
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
 	client := migrationtarget.NewClient(caller)
-	outCurl, err := client.UploadCharm("uuid", curl, strings.NewReader(charmBody))
+	outCurl, err := client.UploadCharm("uuid", curl, charmRef, strings.NewReader(charmBody))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outCurl, gc.DeepEquals, curl)
-	c.Assert(doer.method, gc.Equals, "POST")
-	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=s390x&name=juju-qa-test&revision=15&schema=ch&series=bionic")
+	c.Assert(doer.method, gc.Equals, "PUT")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms/juju-qa-test-abcdef0")
+	c.Assert(doer.headers.Get("Juju-Curl"), gc.Equals, curl)
 	c.Assert(doer.body, gc.Equals, charmBody)
 }
 
@@ -241,7 +240,7 @@ func (s *ClientSuite) TestUploadTools(c *gc.C) {
 	someTools := &tools.Tools{Version: vers}
 	doer := newFakeDoer(c, params.ToolsResult{
 		ToolsList: []*tools.Tools{someTools},
-	})
+	}, nil)
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
@@ -261,7 +260,7 @@ func (s *ClientSuite) TestUploadTools(c *gc.C) {
 
 func (s *ClientSuite) TestUploadResource(c *gc.C) {
 	const resourceBody = "resourceful"
-	doer := newFakeDoer(c, "")
+	doer := newFakeDoer(c, "", nil)
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
@@ -280,7 +279,7 @@ func (s *ClientSuite) TestUploadResource(c *gc.C) {
 
 func (s *ClientSuite) TestSetUnitResource(c *gc.C) {
 	const resourceBody = "resourceful"
-	doer := newFakeDoer(c, "")
+	doer := newFakeDoer(c, "", nil)
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
@@ -298,7 +297,7 @@ func (s *ClientSuite) TestSetUnitResource(c *gc.C) {
 }
 
 func (s *ClientSuite) TestPlaceholderResource(c *gc.C) {
-	doer := newFakeDoer(c, "")
+	doer := newFakeDoer(c, "", nil)
 	caller := &fakeHTTPCaller{
 		httpClient: &httprequest.Client{Doer: doer},
 	}
@@ -376,7 +375,7 @@ func (r *fakeHTTPCaller) Context() context.Context {
 	return context.Background()
 }
 
-func newFakeDoer(c *gc.C, respBody interface{}) *fakeDoer {
+func newFakeDoer(c *gc.C, respBody interface{}, respHeaders map[string]string) *fakeDoer {
 	body, err := json.Marshal(respBody)
 	c.Assert(err, jc.ErrorIsNil)
 	resp := &http.Response{
@@ -385,6 +384,9 @@ func newFakeDoer(c *gc.C, respBody interface{}) *fakeDoer {
 	}
 	resp.Header = make(http.Header)
 	resp.Header.Add("Content-Type", "application/json")
+	for k, v := range respHeaders {
+		resp.Header.Set(k, v)
+	}
 	return &fakeDoer{
 		response: resp,
 	}
@@ -393,14 +395,16 @@ func newFakeDoer(c *gc.C, respBody interface{}) *fakeDoer {
 type fakeDoer struct {
 	response *http.Response
 
-	method string
-	url    string
-	body   string
+	method  string
+	url     string
+	body    string
+	headers http.Header
 }
 
 func (d *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 	d.method = req.Method
 	d.url = req.URL.String()
+	d.headers = req.Header
 
 	// If the body is nil, don't do anything about reading the req.Body
 	// The underlying net http go library deals with nil bodies for requests,

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -830,6 +830,11 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		PostHandler: migrateCharmsHandler.ServePost,
 		GetHandler:  migrateCharmsHandler.ServeUnsupported,
 	}
+	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
+		PutHandler:          modelObjectsCharmsHandler.ServePut,
+		GetHandler:          modelObjectsCharmsHandler.ServeUnsupported,
+		LegacyCharmsHandler: migrateCharmsHTTPHandler,
+	}
 	migrateToolsUploadHandler := &toolsUploadHandler{
 		ctxt:          httpCtxt,
 		stateAuthFunc: httpCtxt.stateForMigrationImporting,
@@ -912,8 +917,13 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:    backupHandler,
 		authorizer: controllerAdminAuthorizer,
 	}, {
+		// Legacy migration endpoint. Used by Juju 3.3 and prior
 		pattern:    "/migrate/charms",
 		handler:    migrateCharmsHTTPHandler,
+		authorizer: controllerAdminAuthorizer,
+	}, {
+		pattern:    "/migrate/charms/:object",
+		handler:    migrateObjectsCharmsHTTPHandler,
 		authorizer: controllerAdminAuthorizer,
 	}, {
 		pattern:    "/migrate/tools",

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -58,6 +58,10 @@ type objectsCharmHandler struct {
 	ctxt httpContext
 }
 
+func (h *objectsCharmHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request) error {
+	return errors.Trace(emitUnsupportedMethodErr(r.Method))
+}
+
 // ServeGet serves the GET method for the S3 API. This is the equivalent of the
 // `GetObject` method in the AWS S3 API.
 // Since juju's objects (S3) API only acts as a shim, this method will only

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v12"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -401,8 +400,8 @@ func (w *uploadWrapper) UploadTools(r io.ReadSeeker, vers version.Binary) (tools
 }
 
 // UploadCharm prepends the model UUID to the args passed to the migration client.
-func (w *uploadWrapper) UploadCharm(curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
-	return w.client.UploadCharm(w.modelUUID, curl, content)
+func (w *uploadWrapper) UploadCharm(curl string, charmRef string, content io.ReadSeeker) (string, error) {
+	return w.client.UploadCharm(w.modelUUID, curl, charmRef, content)
 }
 
 // UploadResource prepends the model UUID to the args passed to the migration client.


### PR DESCRIPTION
We recently added an S3-compatible endpoint to upload local charms to replace/deprecate the old charms handler.
https://github.com/juju/juju/pull/16750

We recently added an S3-compatible endpoint to upload local charms to
replace/deprecate the old charms handler.

This is working towards the eventual aim of treating charm url as an
opaque string, so we can remove series from it. In this respect, the
important chance is that the api interface now treats charm url as an
opaque string (in a header), even if (at the moment) we parse it at the
other end

The /migrate/charms endpoint also uses this handler. So, as before, create a new endpoint for migrating charms which uses the new handler. This takes us a step closer to deprectaing this handler

As a consequence, re-write the controller api to upload charms during migrations to use the new endpoint.

NOTE since we can only migrate forward versions, we can drop the old UploadCharm api client method as we do not need backwards compatibility

This means we drop another instance of reading Series from charm.URL, and even go as far as treating the charm url as an opaque string

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Integration tests

Ensure migration related integration tests pass
```
SHORT_GIT_COMMIT="9097338" JUJU_VERSION="3.4-rc1" JUJU_BUILD_NUMBER="0" ./main.sh -v -c aws -p ec2 -s 'test_model_config,test_model_multi,test_model_metrics,test_model_destroy,test_model_status' model
```

## QA steps

Repeat the following steps, bootstraping `lxd-src` from
- This PR
- branch 3.3 HEAD

(`lxd-dst` should always be bootstrapped from this PR)

```
juju bootstrap lxd lxd-dst
juju bootstrap lxd lxd-src
juju add-model m
juju deploy ubuntu ubu-ch
juju deploy ~/charms/ubuntu ubu-local
juju migrate m lxd-dst
(verify the migration is done successfully)
```