### PR TITLE
Namespace the file objectstore

### DIFF
--- a/internal/objectstore/fileobjectstore.go
+++ b/internal/objectstore/fileobjectstore.go
@@ -20,6 +20,10 @@ import (
 	"github.com/juju/juju/core/objectstore"
 )
 
+const (
+	defaultFileDirectory = "objectstore"
+)
+
 type opType int
 
 const (
@@ -54,7 +58,7 @@ type fileObjectStore struct {
 // NewFileObjectStore returns a new object store worker based on the file
 // storage.
 func NewFileObjectStore(ctx context.Context, namespace, rootPath string, metadataService objectstore.ObjectStoreMetadata, claimer Claimer, logger Logger, clock clock.Clock) (TrackedObjectStore, error) {
-	path := filepath.Join(rootPath, namespace)
+	path := filepath.Join(rootPath, defaultFileDirectory, namespace)
 
 	s := &fileObjectStore{
 		baseObjectStore: baseObjectStore{

--- a/internal/objectstore/fileobjectstore_test.go
+++ b/internal/objectstore/fileobjectstore_test.go
@@ -77,7 +77,7 @@ func (s *FileObjectStoreSuite) TestGetMetadataAndFileFound(c *gc.C) {
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, filepath.Join(path, namespace), fileName, "some content")
+	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store, err := NewFileObjectStore(context.Background(), namespace, path, s.service, s.claimer, jujutesting.NewCheckLogger(c), clock.WallClock)
 	c.Assert(err, gc.IsNil)
@@ -102,7 +102,7 @@ func (s *FileObjectStoreSuite) TestGetMetadataAndFileNotFoundThenFound(c *gc.C) 
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, filepath.Join(path, namespace), fileName, "some content")
+	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store, err := NewFileObjectStore(context.Background(), namespace, path, s.service, s.claimer, jujutesting.NewCheckLogger(c), clock.WallClock)
 	c.Assert(err, gc.IsNil)
@@ -131,7 +131,7 @@ func (s *FileObjectStoreSuite) TestGetMetadataAndFileFoundWithIncorrectSize(c *g
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, filepath.Join(path, namespace), fileName, "some content")
+	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store, err := NewFileObjectStore(context.Background(), namespace, path, s.service, s.claimer, jujutesting.NewCheckLogger(c), clock.WallClock)
 	c.Assert(err, gc.IsNil)
@@ -537,12 +537,12 @@ func (s *FileObjectStoreSuite) calculateHash(c *gc.C, contents string) string {
 }
 
 func (s *FileObjectStoreSuite) expectFileDoesNotExist(c *gc.C, path, namespace, hash string) {
-	_, err := os.Stat(filepath.Join(path, namespace, hash))
+	_, err := os.Stat(filepath.Join(path, defaultFileDirectory, namespace, hash))
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 }
 
 func (s *FileObjectStoreSuite) expectFileDoesExist(c *gc.C, path, namespace, hash string) {
-	_, err := os.Stat(filepath.Join(path, namespace, hash))
+	_, err := os.Stat(filepath.Join(path, defaultFileDirectory, namespace, hash))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -554,4 +554,8 @@ func (s *FileObjectStoreSuite) expectClaim(hash string, num int) {
 
 func (s *FileObjectStoreSuite) expectRelease(hash string, num int) {
 	s.claimer.EXPECT().Release(gomock.Any(), hash).Return(nil).Times(num)
+}
+
+func (s *FileObjectStoreSuite) filePath(path, namespace string) string {
+	return filepath.Join(path, defaultFileDirectory, namespace)
 }


### PR DESCRIPTION
To prevent cluttering up /var/lib/juju, we should suffix the root path with a name (objectstore in this case).

This came up when doing some final testing on file backed object storage.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent --config="object-store-type=file"
$ juju add-model default
$ juju deploy ubuntu
``` 

## Links

**Jira card:** JUJU-5328

