### PR TITLE
Remove redundant base -> series -> base in local charm deploy

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -263,6 +263,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 type localCharm struct {
 	deployCharm
 	curl *charm.URL
+	base corebase.Base
 	ch   charm.Charm
 }
 
@@ -287,12 +288,8 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 		return errors.Trace(err)
 	}
 
-	base, err := corebase.GetBaseFromSeries(l.curl.Series)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	platform := utils.MakePlatform(l.constraints, base, l.modelConstraints)
+	platform := utils.MakePlatform(l.constraints, l.base, l.modelConstraints)
+	// Local charms don't need a channel.
 	origin, err := utils.MakeOrigin(charm.Local, curl.Revision, charm.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)
@@ -302,7 +299,6 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 	l.id = application.CharmID{
 		URL:    curl,
 		Origin: origin,
-		// Local charms don't need a channel.
 	}
 	return l.deploy(ctx, deployAPI)
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -571,6 +571,7 @@ func (dk *localCharmDeployerKind) CreateDeployer(d factory) (Deployer, error) {
 	return &localCharm{
 		deployCharm: d.newDeployCharm(),
 		curl:        dk.curl,
+		base:        dk.base,
 		ch:          dk.ch,
 	}, err
 }


### PR DESCRIPTION
Originally, when deploying a local charm, we would configure and use a baseSelector from core/charm to calculate a base.

We then pass that base into NewCharmAtPath, which converts this base into a series to construct a charm url.

https://github.com/juju/juju/blob/b16a7028fbf04c2934e16813bb7a8b36210f661a/cmd/juju/application/deployer/deployer.go#L234-L240

Then, we would pass that curl into localCharm and in it's PrepareAndDeploy we would get this series and convert back into a base.

https://github.com/juju/juju/blob/b16a7028fbf04c2934e16813bb7a8b36210f661a/cmd/juju/application/deployer/charm.go#L290-L293

Instead, pass the original base into localCharm for it to use ther this means:
1) We can drop a call to GetBaseFromSeries
2) We can drop a occurence of reading Series from charm.URL

NOTE:
A priori we cannot say that NewCharmAtPath will return a charmurl with series matching the provided base. It may reject the user's request and use something else.

However, this is not a concern because the base we pass in was selected from BaseSelector, so we know we can trust this base.

NOTE 2:
It seems we do not test any of the structs extending deployCharm. It seems their only responsibility is to configure implementation details for deployCharm before calling deployCharm. If I'm wrong here, I would appreciate a pointer to where/how it would be appropriate to test this change

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ cat ~/chams/ubuntu/manifest.yaml
bases:
- architectures:
  - amd64
  - arm
  - arm64
  - i386
  - ppc64
  channel: '20.04'
  name: ubuntu
- architectures:
  - amd64
  - arm
  - arm64
  - i386
  - ppc64
  channel: '22.04'
  name: ubuntu

$ juju deploy ~/charms/ubuntu
Located local charm "ubuntu", revision 0
Deploying "ubuntu" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ~/charms/ubuntu ubuntu2 --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubuntu2" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable

$ juju deploy ~/charms/ubuntu ubuntu3 --series focal
WARNING series flag is deprecated, use --base instead
Located local charm "ubuntu", revision 1
Deploying "ubuntu3" from local charm "ubuntu", revision 1 on ubuntu@20.04/stable

$ juju deploy ~/charms/ubuntu ubuntu2 --base ubuntu@18.04
ERROR ubuntu is not available on the following base: ubuntu@18.04/stable

$ juju deploy ~/charms/ubuntu ubuntu2 --base ubuntu@18.04 --force
ERROR ubuntu is not available on the following base: ubuntu@18.04/stable
```
then check all successful deploys deploy to the correct OS

```
$ cat ~/chams/ubuntu-jammy/manifest.yaml
bases:
- architectures:
  - amd64
  - arm
  - arm64
  - i386
  - ppc64
  channel: '22.04'
  name: ubuntu

$ juju deploy ~/charms/ubuntu-jammy ubuntu1
Located local charm "ubuntu", revision 0
Deploying "ubuntu1" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ~/charms/ubuntu-jammy ubuntu2 --base ubuntu@20.04
ERROR base "ubuntu@20.04/stable" is not supported, supported bases are: ubuntu@22.04

$ juju deploy ~/charms/ubuntu-jammy ubuntu2 --base ubuntu@20.04 --force
Located local charm "ubuntu", revision 0
Deploying "ubuntu2" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable
```
