### PR TITLE
Event Watcher

### DIFF
--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -39,6 +39,7 @@ type Context struct {
 	CharmhubHTTPClient_    facade.HTTPClient
 	ServiceFactory_        servicefactory.ServiceFactory
 	ControllerDB_          changestream.WatchableDB
+	EventWatcher_          changestream.EventWatcher
 	ObjectStore_           objectstore.ObjectStore
 	ControllerObjectStore_ objectstore.ObjectStore
 	Logger_                loggo.Logger
@@ -176,6 +177,10 @@ func (context Context) ServiceFactory() servicefactory.ServiceFactory {
 // ControllerDB implements facade.Context.
 func (context Context) ControllerDB() (changestream.WatchableDB, error) {
 	return context.ControllerDB_, nil
+}
+
+func (context Context) EventWatcher() (changestream.EventWatcher, error) {
+	return context.EventWatcher_, nil
 }
 
 // MachineTag returns the current machine tag.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -71,6 +71,7 @@ type Context interface {
 	ControllerDBGetter
 	ServiceFactory
 	ObjectStoreFactory
+	EventWatcher
 	Logger
 
 	// Auth represents information about the connected client. You
@@ -164,6 +165,13 @@ type ControllerDBGetter interface {
 type ServiceFactory interface {
 	// ServiceFactory returns the services factory for the current model.
 	ServiceFactory() servicefactory.ServiceFactory
+}
+
+// EventWatcher defines an interface for listening to changes from the database.
+type EventWatcher interface {
+	// EventWatcher returns a event watcher that can be used to listen to
+	// changes from the database.
+	EventWatcher() (changestream.EventWatcher, error)
 }
 
 // ObjectStoreFactory defines an interface for accessing the object store.

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -824,6 +824,11 @@ func (ctx *facadeContext) ServiceFactory() servicefactory.ServiceFactory {
 	return ctx.r.serviceFactory
 }
 
+func (ctx *facadeContext) EventWatcher() (changestream.EventWatcher, error) {
+	db, err := ctx.r.shared.dbGetter.GetWatchableDB(ctx.r.state.ModelUUID())
+	return db, errors.Trace(err)
+}
+
 // Tracer returns the tracer for the current model.
 func (ctx *facadeContext) Tracer() trace.Tracer {
 	return ctx.r.tracer

--- a/core/changestream/eventsource_test.go
+++ b/core/changestream/eventsource_test.go
@@ -59,4 +59,5 @@ func (s *changestreamSuite) setupMocks(c *gc.C) *gomock.Controller {
 type stubWatchableDB struct {
 	database.TxnRunner
 	EventSource
+	EventWatcher
 }

--- a/internal/changestream/eventwatcher/eventwatcher.go
+++ b/internal/changestream/eventwatcher/eventwatcher.go
@@ -1,0 +1,303 @@
+package eventwatcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/juju/retry"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/catacomb"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/core/changestream"
+)
+
+const (
+	defaultUnsubscribeTimeout = time.Second
+)
+
+var (
+	// The backoff strategy is used to back-off when we get no changes
+	// from the database. This is used to prevent the worker from polling
+	// the database too frequently and allow us to attempt to coalesce
+	// changes when there is less activity.
+	backOffStrategy = retry.ExpBackoff(time.Millisecond*10, time.Millisecond*250, 1.5, false)
+)
+
+// Logger represents the logging methods called.
+type Logger interface {
+	Errorf(message string, args ...interface{})
+	Infof(message string, args ...interface{})
+	Debugf(message string, args ...interface{})
+	Tracef(message string, args ...interface{})
+	IsTraceEnabled() bool
+}
+
+type Watcher interface {
+	worker.Worker
+	Changes() <-chan []changestream.ChangeEvent
+	Unsubscribe()
+}
+
+// EventWatcher takes an EventSource and allows you to watch all the events
+// that are emitted from it. All the events are run asynchronously to prevent
+// blocking the caller.
+type EventWatcher struct {
+	catacomb catacomb.Catacomb
+	source   changestream.EventSource
+
+	clock  clock.Clock
+	logger Logger
+
+	watcherRunner  *worker.Runner
+	addRequests    chan chan Watcher
+	removeRequests chan string
+}
+
+// New returns a new EventWatcher.
+func New(source changestream.EventSource, clock clock.Clock, logger Logger) (*EventWatcher, error) {
+	w := &EventWatcher{
+		source:         source,
+		clock:          clock,
+		logger:         logger,
+		addRequests:    make(chan chan Watcher),
+		removeRequests: make(chan string),
+		watcherRunner: worker.NewRunner(worker.RunnerParams{
+			Clock: clock,
+			IsFatal: func(err error) bool {
+				return false
+			},
+			RestartDelay: time.Second * 10,
+			Logger:       logger,
+		}),
+	}
+
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Kill stops the event watcher.
+func (e *EventWatcher) Kill() {
+	e.catacomb.Kill(nil)
+}
+
+// Wait waits for the event watcher to stop.
+func (e *EventWatcher) Wait() error {
+	return e.catacomb.Wait()
+}
+
+// Watch returns a Watcher that can be used to watch for events.
+func (e *EventWatcher) Watch() (changestream.Watcher, error) {
+	request := make(chan Watcher)
+	select {
+	case <-e.catacomb.Dying():
+		return nil, changestream.ErrWatcherDying
+	case e.addRequests <- request:
+	}
+
+	select {
+	case <-e.catacomb.Dying():
+		return nil, changestream.ErrWatcherDying
+	case watchable := <-request:
+		return watchable, nil
+	}
+}
+
+func (w *EventWatcher) loop() error {
+	sub, err := w.source.Subscribe()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Ensure that we unsubscribe from the source when we are done.
+	defer sub.Unsubscribe()
+
+	ctx, cancel := w.scopedContext()
+	defer cancel()
+
+	events := make([][]changestream.ChangeEvent, 0)
+
+	var id int
+	var attempt int
+	var overflow []string
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case changes := <-sub.Changes():
+			w.logger.Tracef("received %d changes", len(changes))
+
+			events = append(events, changes)
+
+		case <-sub.Done():
+			return nil
+
+		case res := <-w.addRequests:
+			id++
+			namespace := fmt.Sprintf("watchable-%d", id)
+
+			if err := w.watcherRunner.StartWorker(namespace, func() (worker.Worker, error) {
+				return newWatchable(namespace, w.removeRequests), nil
+			}); err != nil {
+				return errors.Trace(err)
+			}
+
+			worker, err := w.watcherRunner.Worker(namespace, ctx.Done())
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			select {
+			case <-w.catacomb.Dying():
+				return w.catacomb.ErrDying()
+			case res <- worker.(Watcher):
+			}
+
+		case namespace := <-w.removeRequests:
+			if err := w.watcherRunner.StopWorker(namespace); err != nil && !errors.Is(err, errors.NotFound) {
+				return errors.Trace(err)
+			}
+			// Remove the namespace from the overflow list, it's pointless
+			// attempting to dispatch to it if it's gone.
+			var names []string
+			for _, name := range overflow {
+				if name == namespace {
+					continue
+				}
+				names = append(names, name)
+			}
+			overflow = names
+
+		default:
+			if len(events) == 0 {
+				attempt++
+				select {
+				case <-w.catacomb.Dying():
+					return w.catacomb.ErrDying()
+				case <-w.clock.After(backOffStrategy(0, attempt)):
+					continue
+				}
+			}
+
+			// We have some events.
+			attempt = 0
+
+			// We allow for 100 milliseconds to process the events. If those
+			// events are not processed within that time, we will try again
+			// later.
+			local, localCancel := context.WithTimeout(ctx, time.Millisecond*100)
+
+			// We have overflow names to dispatch to, so use them, before
+			// falling back to the worker runner.
+			var names []string
+			if len(overflow) > 0 {
+				names = overflow
+			} else {
+				names = w.watcherRunner.WorkerNames()
+			}
+
+			var dispatched []string
+			for _, name := range names {
+				worker, err := w.watcherRunner.Worker(name, local.Done())
+				if err != nil {
+					if errors.Is(err, errors.NotFound) {
+						// If the worker is not found, then we can continue.
+						// Likely from the overflowed names.
+						continue
+					}
+					localCancel()
+					return errors.Trace(err)
+				}
+
+				watchable := worker.(*watchable)
+				watchable.dispatch(events[0])
+
+				dispatched = append(dispatched, name)
+			}
+
+			// Work out the overflow names to dispatch to. This can happen if
+			// we didn't dispatch to all the workers.
+			overflow = set.NewStrings(names...).Difference(set.NewStrings(dispatched...)).Values()
+
+			// If the overflowed names are empty, then we can remove the first
+			// event and continue.
+			if len(overflow) == 0 {
+				events = events[1:]
+			}
+
+			localCancel()
+		}
+	}
+}
+
+// scopedContext returns a context that is in the scope of the worker lifetime.
+// It returns a cancellable context that is cancelled when the action has
+// completed.
+func (w *EventWatcher) scopedContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return w.catacomb.Context(ctx), cancel
+}
+
+type watchable struct {
+	tomb      tomb.Tomb
+	changes   chan []changestream.ChangeEvent
+	namespace string
+	unsub     chan<- string
+}
+
+func newWatchable(namespace string, unsub chan<- string) *watchable {
+	w := &watchable{
+		namespace: namespace,
+		unsub:     unsub,
+	}
+	w.tomb.Go(w.loop)
+
+	return w
+}
+
+// Kill stops the event watcher.
+func (w *watchable) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait waits for the event watcher to stop.
+func (w *watchable) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *watchable) Changes() <-chan []changestream.ChangeEvent {
+	return w.changes
+}
+
+func (w *watchable) Unsubscribe() {
+	select {
+	case <-w.tomb.Dying():
+	case w.unsub <- w.namespace:
+	case <-time.After(defaultUnsubscribeTimeout):
+	}
+}
+
+func (w *watchable) loop() error {
+	<-w.tomb.Dying()
+	return tomb.ErrDying
+}
+
+func (w *watchable) dispatch(events []changestream.ChangeEvent) {
+	w.tomb.Go(func() error {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case w.changes <- events:
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
The event watcher dispatches events for the apiserver watch methods. This is to replace the multiwatcher setup. Instead the idea there will be one event watcher for every db. The reason for all of this machinary is to prevent adding back pressure to the underlying event stream. The event watcher will dispatch all the events asynchronously. It will then be upto the api to consume the events at their leasure.

The major difference between this and the multiwatcher, is that there is no backing store. You only get events from when you subscribed and in the future. If the api disconnects and reconnects, they'll get only the new events, no historicals.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

