### PR TITLE
Introduces a new model table to describe agent information.

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -36,6 +36,7 @@ func ControllerDDL() *schema.Schema {
 		changeLogTriggersForTable("external_controller", "uuid", tableExternalController),
 		modelListSchema,
 		modelMetadataSchema,
+		modelAgentSchema,
 		controllerConfigSchema,
 		changeLogTriggersForTable("controller_config", "key", tableControllerConfig),
 		controllerNodeTable,
@@ -357,7 +358,6 @@ CREATE TABLE model_metadata (
     model_type_id         INT,
     name                  TEXT NOT NULL,
     owner_uuid            TEXT NOT NULL,
-
     CONSTRAINT            fk_model_metadata_model
         FOREIGN KEY           (model_uuid)
         REFERENCES            model_list(uuid),
@@ -381,6 +381,26 @@ CREATE TABLE model_metadata (
 CREATE UNIQUE INDEX idx_model_metadata_name_owner
 ON model_metadata (name, owner_uuid);
 `)
+}
+
+func modelAgentSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE model_agent (
+    model_uuid TEXT PRIMARY KEY,
+
+    -- previous_version describes the agent version that was in use before the
+    -- the current target_version.
+    previous_version TEXT NOT NULL,
+
+    -- target_version describes the desired agent version that should be
+    -- being run in this model. It should not be considered "the" version that
+    -- is being run for every agent as each agent needs to upgrade to this
+    -- version.
+    target_version TEXT NOT NULL,
+    CONSTRAINT            fk_model_agent_model
+        FOREIGN KEY           (model_uuid)
+        REFERENCES            model_list(uuid)
+);`)
 }
 
 func controllerConfigSchema() schema.Patch {

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -79,6 +79,7 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 
 		// Model migration
 		"model_migration",
+		"model_agent",
 		"model_migration_status",
 		"model_migration_user",
 		"model_migration_minion_sync",


### PR DESCRIPTION
Introduces agent version to dqlite models.
    
With this commit we are adding a new model agent table that will drive
the information around what agents are running for a model. Specificly
at the moment we are concerned with describing the agent version that
model should be running.
    
Previously this has been kept in model config as a special case read only
attribute that has a lot of logic about when it can and can't be changed.
    
By making it a first class citizen of a models metadata we can treat it
properly and remove a lot of complexity out of modelconfig. It also
allows us to not use the controllers model as a special case for sources
of default information.
    
This is a placeholder commit to introduce the table into the schema.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

At the moment this is just a DDL change. A simple bootstrap is all that is needed for testing to make sure it succeeds.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5063

