### PR TITLE
Wires up user correlation for models in DQlite.

### DIFF
--- a/api/package_test.go
+++ b/api/package_test.go
@@ -46,6 +46,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/status",
 		"core/trace",
+		"core/user",
 		"core/watcher",
 		"domain/credential", // Imported by environs/envcontext.
 		"environs/envcontext",

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -72,6 +72,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/status",
 		"core/trace",
 		"core/upgrade",
+		"core/user",
 		"core/watcher",
 		"domain/credential",
 		"environs/cloudspec",

--- a/cmd/containeragent/unit/package_test.go
+++ b/cmd/containeragent/unit/package_test.go
@@ -115,6 +115,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/snap",
 		"core/status",
+		"core/user",
 		"core/watcher",
 		"downloader",
 		"environs",

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	coreos "github.com/juju/juju/core/os"
+	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -63,8 +64,6 @@ var (
 )
 
 type BootstrapAgentFunc func(agentbootstrap.AgentBootstrapArgs) (*agentbootstrap.AgentBootstrap, error)
-
-const adminUserName = "admin"
 
 // BootstrapCommand represents a jujud bootstrap command.
 type BootstrapCommand struct {
@@ -371,7 +370,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		// We shouldn't attempt to dial peers until we have some.
 		dialOpts.Direct = true
 
-		adminTag := names.NewLocalUserTag(adminUserName)
+		adminTag := names.NewLocalUserTag(coreuser.AdminUserName)
 		bootstrap, err := c.BootstrapAgent(agentbootstrap.AgentBootstrapArgs{
 			AgentConfig:               agentConfig,
 			BootstrapEnviron:          env,

--- a/core/model/defaults.go
+++ b/core/model/defaults.go
@@ -1,7 +1,9 @@
-// Copyright 2023 Canonical Ltd.
+// Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package model
+
+import "github.com/juju/juju/core/user"
 
 const (
 	// ControllerModelName is the name given to the model that hosts the Juju
@@ -10,8 +12,8 @@ const (
 	// logic to ask questions and calculate defaults in Juju.
 	ControllerModelName = "controller"
 
-	// ControllerModelOwner is the name of the owner that is assigned to the
-	// controller model. This is a static value that we ue for every Juju
-	// deployment.
-	ControllerModelOwner = "admin"
+	// ControllerModelOwnerUsername is the user name of the owner that is
+	// assigned to the controller model. This is a static value that we use for
+	// every Juju deployment.
+	ControllerModelOwnerUsername = user.AdminUserName
 )

--- a/core/multiwatcher/package_test.go
+++ b/core/multiwatcher/package_test.go
@@ -31,6 +31,7 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/instance",
 		"core/life",
 		"core/model",
+		"core/user",
 		"core/network",
 		"core/permission",
 		"core/status",

--- a/core/user/defaults.go
+++ b/core/user/defaults.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+const (
+	// AdminUsername is the default username that we give to the default admin
+	// user that is created as part of every Juju bootstrap.
+	AdminUserName = "admin"
+)

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -44,6 +44,8 @@ func NewService(st State) *Service {
 // - modelerrors.AlreadyExists: When the model uuid is already in use or a model
 // with the same name and owner already exists.
 // - errors.NotFound: When the cloud, cloud region, or credential do not exist.
+// - [github.com/juju/juju/domain/user/errors.NotFound] when the owner of the
+// mode cannot be found.
 func (s *Service) CreateModel(
 	ctx context.Context,
 	args model.ModelCreationArgs,

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3"
 
+	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
 )
 
@@ -32,9 +33,8 @@ type ModelCreationArgs struct {
 	// Must not be empty for a valid struct.
 	Name string
 
-	// Owner is the name of the owner for the model.
-	// Must not be empty for a valid struct.
-	Owner string
+	// Owner is the uuid of the user that owns this model in the Juju controller.
+	Owner user.UUID
 
 	// Type is the type of the model.
 	// Type must satisfy IsValid() for a valid struct.
@@ -87,8 +87,8 @@ func (m ModelCreationArgs) Validate() error {
 	if m.Name == "" {
 		return fmt.Errorf("%w name cannot be empty", errors.NotValid)
 	}
-	if m.Owner == "" {
-		return fmt.Errorf("%w owner cannot be empty", errors.NotValid)
+	if err := m.Owner.Validate(); err != nil {
+		return fmt.Errorf("%w owner: %w", errors.NotValid, err)
 	}
 	if !m.Type.IsValid() {
 		return fmt.Errorf("%w model type of %q", errors.NotSupported, m.Type)

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
 )
 
@@ -51,6 +52,8 @@ func (s *typesSuite) TestUUIDValidate(c *gc.C) {
 }
 
 func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
+	userUUID, err := user.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
 	tests := []struct {
 		Args    ModelCreationArgs
 		ErrTest error
@@ -60,7 +63,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "",
-				Owner:       "wallyworld-ipv6",
+				Owner:       userUUID,
 				Type:        TypeCAAS,
 			},
 			ErrTest: errors.NotValid,
@@ -80,7 +83,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
-				Owner:       "wallyworld-ipv6",
+				Owner:       userUUID,
 				Type:        Type("ipv6-only"),
 			},
 			ErrTest: errors.NotSupported,
@@ -90,7 +93,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Cloud:       "",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
-				Owner:       "wallyworld-ipv6",
+				Owner:       userUUID,
 				Type:        TypeIAAS,
 			},
 			ErrTest: errors.NotValid,
@@ -100,7 +103,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Cloud:       "my-cloud",
 				CloudRegion: "",
 				Name:        "my-awesome-model",
-				Owner:       "wallyworld-ipv6",
+				Owner:       userUUID,
 				Type:        TypeIAAS,
 			},
 			ErrTest: nil,
@@ -113,7 +116,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 					Owner: "wallyworld",
 				},
 				Name:  "my-awesome-model",
-				Owner: "wallyworld-ipv6",
+				Owner: userUUID,
 				Type:  TypeIAAS,
 			},
 			ErrTest: errors.NotValid,
@@ -123,7 +126,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
-				Owner:       "wallyworld-ipv6",
+				Owner:       userUUID,
 				Type:        TypeIAAS,
 			},
 			ErrTest: nil,
@@ -138,7 +141,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 					Name:  "mycred",
 				},
 				Name:  "my-awesome-model",
-				Owner: "wallyworld-ipv6",
+				Owner: userUUID,
 				Type:  TypeIAAS,
 			},
 			ErrTest: nil,

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -373,9 +373,9 @@ CREATE TABLE model_metadata (
     CONSTRAINT            fk_model_metadata_model_type_id
         FOREIGN KEY           (model_type_id)
         REFERENCES            model_type(id)
---    CONSTRAINT            fk_model_metadata_XXXX
---        FOREIGN KEY           (owner_uuid)
---        REFERENCES            XXXX(uuid)
+    CONSTRAINT            fk_model_metadata_owner_uuid
+        FOREIGN KEY           (owner_uuid)
+        REFERENCES            user(uuid)
 );
 
 CREATE UNIQUE INDEX idx_model_metadata_name_owner


### PR DESCRIPTION
Until now we haven't had any strong referential integrity for model owners onto the user table. Now that the user DDL has been established this sets up the checks and test to assert that when adding a model the owner exists and is a valid user in the system (not removed).

As part of this PR I have also wired up the bootstrap process to set the admin user as the owner of the controller model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run unit tests under `service` and `state` in the model domain package.

Also bootstrap a controller to lxd and make sure it succeeds with no error output around creating the controller model.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5345

