### PR TITLE
Remove legacy fallback case

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -417,18 +417,7 @@ func (a *API) resolveOneCharm(arg params.ResolveCharmWithChannel) params.Resolve
 	}
 
 	result.Origin = archOrigin
-
-	switch {
-	case resultURL.Series != "" && len(resolvedBases) == 0:
-		base, err := base.GetBaseFromSeries(resultURL.Series)
-		if err != nil {
-			result.Error = apiservererrors.ServerError(err)
-			return result
-		}
-		result.SupportedBases = []params.Base{{Name: base.OS, Channel: base.Channel.String()}}
-	default:
-		result.SupportedBases = transform.Slice(resolvedBases, convertCharmBase)
-	}
+	result.SupportedBases = transform.Slice(resolvedBases, convertCharmBase)
 
 	return result
 }


### PR DESCRIPTION
This case, where we fallback to the series in a charm's url, is a fallback case for charmstore charms from before charm series was included in charm metadata

We stopped supporting such charms a long time ago. We will failure earlier for such charms.

Remove this case. As a side effect, we remove a reference to the Series attribute in of charm URL

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu ubu1
juju deploy ubuntu ubu2 --base ubuntu@20.04
```