### PR TITLE
Change signature for GetUserByAuth to use name and password

### DIFF
--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -53,10 +53,10 @@ type State interface {
 	// usererrors.NotFound will be returned.
 	GetUserByName(ctx context.Context, name string) (user.User, error)
 
-	// GetUserWithAuth will retrieve the user with checking authentication information
-	// specified by UUID from the database. If the user does not exist
+	// GetUserByAuth will retrieve the user with checking authentication information
+	// specified by name and password from the database. If the user does not exist
 	// an error that satisfies usererrors.NotFound will be returned.
-	GetUserWithAuth(context.Context, user.UUID, string) (user.User, error)
+	GetUserByAuth(context.Context, string, string) (user.User, error)
 
 	// RemoveUser marks the user as removed. This obviates the ability of a user
 	// to function, but keeps the user retaining provenance, i.e. auditing.
@@ -176,22 +176,23 @@ func (s *Service) GetUserByName(
 }
 
 // GetUserWithAuth will find and return the user with UUID. If there is no
-// user for the UUID then an error that satisfies usererrors.NotFound will
-// be returned.
+// user for the name and password, then an error that satisfies
+// usererrors.NotFound will be returned. If supplied with an invalid user name
+// then an error that satisfies usererrors.UsernameNotValid will be returned.
 //
 // GetUserWithAuth will not return users that have been previously removed.
 func (s *Service) GetUserWithAuth(
 	ctx context.Context,
-	uuid user.UUID,
+	name string,
 	password string,
 ) (user.User, error) {
-	if err := uuid.Validate(); err != nil {
-		return user.User{}, errors.Annotatef(usererrors.UUIDNotValid, "validating uuid %q", uuid)
+	if err := ValidateUsername(name); err != nil {
+		return user.User{}, errors.Annotatef(err, "validating username %q", name)
 	}
 
-	usr, err := s.st.GetUserWithAuth(ctx, uuid, password)
+	usr, err := s.st.GetUserByAuth(ctx, name, password)
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user for uuid %q", uuid)
+		return user.User{}, errors.Annotatef(err, "getting user %q", name)
 	}
 
 	return usr, nil
@@ -199,7 +200,7 @@ func (s *Service) GetUserWithAuth(
 
 // ValidateUsername takes a user name and validates that the user name is
 // conformant to our regex rules defined in usernameValidationRegex. If a
-// user name is not valid an error is returned that satisfies
+// user name is not valid, an error is returned that satisfies
 // usererrors.UsernameNotValid.
 //
 // User names must be one or more runes long, can contain any unicode rune from

--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -175,13 +175,13 @@ func (s *Service) GetUserByName(
 	return usr, nil
 }
 
-// GetUserWithAuth will find and return the user with UUID. If there is no
+// GetUserByAuth will find and return the user with UUID. If there is no
 // user for the name and password, then an error that satisfies
 // usererrors.NotFound will be returned. If supplied with an invalid user name
 // then an error that satisfies usererrors.UsernameNotValid will be returned.
 //
-// GetUserWithAuth will not return users that have been previously removed.
-func (s *Service) GetUserWithAuth(
+// GetUserByAuth will not return users that have been previously removed.
+func (s *Service) GetUserByAuth(
 	ctx context.Context,
 	name string,
 	password string,

--- a/domain/user/service/service_test.go
+++ b/domain/user/service/service_test.go
@@ -1162,7 +1162,7 @@ func (s *serviceSuite) TestGetUserByAuth(c *gc.C) {
 	err = s.service().SetPassword(context.Background(), uuid, password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	user, err := s.service().GetUserWithAuth(context.Background(), mockState[uuid].name, "password")
+	user, err := s.service().GetUserByAuth(context.Background(), mockState[uuid].name, "password")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.Name, gc.Equals, "Jürgen.test")
 	c.Assert(user.DisplayName, gc.Equals, "Old mate 👍")

--- a/domain/user/service/state_mock_test.go
+++ b/domain/user/service/state_mock_test.go
@@ -140,6 +140,21 @@ func (mr *MockStateMockRecorder) GetUser(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockState)(nil).GetUser), arg0, arg1)
 }
 
+// GetUserByAuth mocks base method.
+func (m *MockState) GetUserByAuth(arg0 context.Context, arg1, arg2 string) (user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserByAuth", arg0, arg1, arg2)
+	ret0, _ := ret[0].(user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserByAuth indicates an expected call of GetUserByAuth.
+func (mr *MockStateMockRecorder) GetUserByAuth(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByAuth", reflect.TypeOf((*MockState)(nil).GetUserByAuth), arg0, arg1, arg2)
+}
+
 // GetUserByName mocks base method.
 func (m *MockState) GetUserByName(arg0 context.Context, arg1 string) (user.User, error) {
 	m.ctrl.T.Helper()
@@ -153,21 +168,6 @@ func (m *MockState) GetUserByName(arg0 context.Context, arg1 string) (user.User,
 func (mr *MockStateMockRecorder) GetUserByName(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByName", reflect.TypeOf((*MockState)(nil).GetUserByName), arg0, arg1)
-}
-
-// GetUserWithAuth mocks base method.
-func (m *MockState) GetUserWithAuth(arg0 context.Context, arg1 user.UUID, arg2 string) (user.User, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserWithAuth", arg0, arg1, arg2)
-	ret0, _ := ret[0].(user.User)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserWithAuth indicates an expected call of GetUserWithAuth.
-func (mr *MockStateMockRecorder) GetUserWithAuth(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserWithAuth", reflect.TypeOf((*MockState)(nil).GetUserWithAuth), arg0, arg1, arg2)
 }
 
 // RemoveUser mocks base method.

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -260,13 +260,13 @@ JOIN user_password ON user.uuid = user_password.user_uuid
 WHERE user.name = $M.name AND removed = false
 `
 
-		selectGetUserWithAuthStmt, err := sqlair.Prepare(getUserWithAuthQuery, User{}, sqlair.M{})
+		selectGetUserByAuthStmt, err := sqlair.Prepare(getUserWithAuthQuery, User{}, sqlair.M{})
 		if err != nil {
 			return errors.Annotate(err, "preparing select getUserWithAuth query")
 		}
 
 		var result User
-		err = tx.Query(ctx, selectGetUserWithAuthStmt, sqlair.M{"name": name}).Get(&result)
+		err = tx.Query(ctx, selectGetUserByAuthStmt, sqlair.M{"name": name}).Get(&result)
 		if err != nil && errors.Is(err, sql.ErrNoRows) {
 			return errors.Annotatef(usererrors.NotFound, "%q", name)
 		} else if err != nil {

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -425,9 +425,8 @@ func (s *stateSuite) TestGetUserWithAuthInfoByName(c *gc.C) {
 	c.Check(u.Disabled, gc.Equals, false)
 }
 
-// TestGetUserWithAuth asserts that we can get a user with auth info from the
-// database.
-func (s *stateSuite) TestGetUserWithAuth(c *gc.C) {
+// TestGetUserByAuth asserts that we can get a user by auth from the database.
+func (s *stateSuite) TestGetUserByAuth(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	// Add admin user with password hash.
@@ -448,13 +447,40 @@ func (s *stateSuite) TestGetUserWithAuth(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get the user.
-	u, err := st.GetUserWithAuth(context.Background(), adminUUID, "password")
+	u, err := st.GetUserByAuth(context.Background(), adminUser.Name, "password")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(u.Name, gc.Equals, "admin")
 	c.Check(u.DisplayName, gc.Equals, "admin")
 	c.Check(u.CreatorUUID, gc.Equals, adminUUID)
 	c.Check(u.CreatedAt, gc.NotNil)
+}
+
+// TestGetUserByAuthWrongPassword asserts that we get an error when we try to
+// get a user by auth with the wrong password.
+func (s *stateSuite) TestGetUserByAuthWrongPassword(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Add admin user with password hash.
+	adminUUID, err := user.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	adminUser := user.User{
+		Name:        "admin",
+		DisplayName: "admin",
+	}
+
+	salt, err := auth.NewSalt()
+	c.Assert(err, jc.ErrorIsNil)
+
+	passwordHash, err := auth.HashPassword(auth.NewPassword("password"), salt)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.AddUserWithPasswordHash(context.Background(), adminUUID, adminUser, adminUUID, passwordHash, salt)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get the user.
+	_, err = st.GetUserByAuth(context.Background(), adminUser.Name, "wrongPassword")
+	c.Assert(err, jc.ErrorIs, usererrors.Unauthorized)
 }
 
 // TestRemoveUser asserts that we can remove a user from the database.

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -456,9 +456,9 @@ func (s *stateSuite) TestGetUserByAuth(c *gc.C) {
 	c.Check(u.CreatedAt, gc.NotNil)
 }
 
-// TestGetUserByAuthWrongPassword asserts that we get an error when we try to
+// TestGetUserByAuthUnauthorized asserts that we get an error when we try to
 // get a user by auth with the wrong password.
-func (s *stateSuite) TestGetUserByAuthWrongPassword(c *gc.C) {
+func (s *stateSuite) TestGetUserByAuthUnauthorized(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	// Add admin user with password hash.
@@ -481,6 +481,17 @@ func (s *stateSuite) TestGetUserByAuthWrongPassword(c *gc.C) {
 	// Get the user.
 	_, err = st.GetUserByAuth(context.Background(), "admin", "wrongPassword")
 	c.Assert(err, jc.ErrorIs, usererrors.Unauthorized)
+}
+
+// TestGetUserByAutUnexcitingUser asserts that we get an error when we try to
+// get a user by auth that does not exist.
+func (s *stateSuite) TestGetUserByAutUnexcitingUser(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// Get the user.
+	_, err := st.GetUserByAuth(context.Background(), "admin", "password")
+	c.Assert(err, jc.ErrorIs, usererrors.Unauthorized)
+
 }
 
 // TestRemoveUser asserts that we can remove a user from the database.

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -447,7 +447,7 @@ func (s *stateSuite) TestGetUserByAuth(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get the user.
-	u, err := st.GetUserByAuth(context.Background(), adminUser.Name, "password")
+	u, err := st.GetUserByAuth(context.Background(), "admin", "password")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(u.Name, gc.Equals, "admin")
@@ -464,10 +464,6 @@ func (s *stateSuite) TestGetUserByAuthWrongPassword(c *gc.C) {
 	// Add admin user with password hash.
 	adminUUID, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	adminUser := user.User{
-		Name:        "admin",
-		DisplayName: "admin",
-	}
 
 	salt, err := auth.NewSalt()
 	c.Assert(err, jc.ErrorIsNil)
@@ -475,11 +471,15 @@ func (s *stateSuite) TestGetUserByAuthWrongPassword(c *gc.C) {
 	passwordHash, err := auth.HashPassword(auth.NewPassword("password"), salt)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.AddUserWithPasswordHash(context.Background(), adminUUID, adminUser, adminUUID, passwordHash, salt)
+	err = st.AddUserWithPasswordHash(
+		context.Background(), adminUUID,
+		"admin", "admin",
+		adminUUID, passwordHash, salt,
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get the user.
-	_, err = st.GetUserByAuth(context.Background(), adminUser.Name, "wrongPassword")
+	_, err = st.GetUserByAuth(context.Background(), "admin", "wrongPassword")
 	c.Assert(err, jc.ErrorIs, usererrors.Unauthorized)
 }
 


### PR DESCRIPTION
This PR involves modifying the signature of the GetUserByAuth function to accept a username and password as parameters.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
 go test github.com/juju/juju/domain/user/state/... -gocheck.v
 go test github.com/juju/juju/domain/user/service/... -gocheck.v
```

## Links

**Jira card:** [JUJU-5346](https://warthogs.atlassian.net/browse/JUJU-5346)



[JUJU-5346]: https://warthogs.atlassian.net/browse/JUJU-5346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ