### PR TITLE
Always verify result exists when looking for map entries.

### DIFF
--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -85,7 +85,14 @@ func (c ModelConfigCreator) NewModelConfig(
 		// Juju:juju-system-key
 		if parsedKey.Comment == config.JujuSystemKey {
 			// If found, add this key to the attrs.
-			prevAuthKeys := attrs[config.AuthorizedKeysKey].(string)
+			authorizedKeysValue, ok := attrs[config.AuthorizedKeysKey]
+			if !ok {
+				continue
+			}
+			prevAuthKeys, ok := authorizedKeysValue.(string)
+			if !ok {
+				continue
+			}
 			attrs[config.AuthorizedKeysKey] = config.ConcatAuthKeys(prevAuthKeys, key)
 			break
 		}


### PR DESCRIPTION
Getting a value from a map and converting it to a string without verifying the value exists first can cause a panic:
 "interface conversion: interface {} is nil, not string"

There was a juju bug seen in the terraform provider for juju where add model for 3.3.x and 3.4 controllers failed with the string above. Looking at tracing in the controller led to the issue:

```
2024-01-23 19:42:17 CRITICAL juju.rpc server.go:557 panic running request {MethodCaller:0xc000960150 transformErrors:0x3a773a0 hdr:{RequestId:2 Request:{Type:ModelManager Version:9 Id: Action:CreateModel} Error: ErrorCode: ErrorInfo:map[] Version:1}} with arg {Name:east-two OwnerTag:user-admin Config:map[] CloudTag: CloudRegion: CloudCredentialTag:}: interface conversion: interface {} is nil, not string
goroutine 6178 [running]:
runtime/debug.Stack()
        /snap/go/10489/src/runtime/debug/stack.go:24 +0x5e
github.com/juju/juju/rpc.(*Conn).runRequest.func1()
        /home/heather/work/src/github.com/juju/juju/rpc/server.go:558 +0x6e
panic({0x6862080?, 0xc000961d70?})
        /snap/go/10489/src/runtime/panic.go:914 +0x21f
github.com/juju/juju/controller/modelmanager.ModelConfigCreator.NewModelConfig({0x7889d60, 0xc001040268}, {{0xc002a81171, 0x3}, {0xc002a81161, 0x9}, {0xc0029ede20, 0x9}, {0xc00141eb58, 0x18}, ...}, ...)
        /home/heather/work/src/github.com/juju/juju/controller/modelmanager/createmodel.go:88 +0x552
github.com/juju/juju/apiserver/facades/client/modelmanager.(*ModelManagerAPI).newModelConfig(0xc000f042c0, {{0xc002a81171, 0x3}, {0xc002a81161, 0x9}, {0xc0029ede20, 0x9}, {0xc00141eb58, 0x18}, {0x0, ...}, ...}, ...)
        /home/heather/work/src/github.com/juju/juju/apiserver/facades/client/modelmanager/modelmanager.go:184 +0x359
github.com/juju/juju/apiserver/facades/client/modelmanager.(*ModelManagerAPI).newModel(_, {{0xc002a81171, 0x3}, {0xc002a81161, 0x9}, {0xc0029ede20, 0x9}, {0xc00141eb58, 0x18}, {0x0, ...}, ...}, ...)
....
```

Updated the code block to handle both cases, where authorized-keys exists and does not. Both should yield attrs which include the juju-system-key in the authorized-keys.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Fixes errors in https://github.com/juju/juju/actions/workflows/terraform-smoke.yml for 3.3 and 3.4 branches. Fixing this bug has uncovered a different failure in the terraform smoke tests for juju 3.3 and 3.4 Can also be seen as resolved with reproduction steps in [bug 384](https://github.com/juju/terraform-provider-juju/issues/385). 

```
# create a controller
$ juju bootstrap localhost terraform

# install terraform if you haven't already
$ sudo snap install terraform

# setup an area to use terraform
$ mkdir /tmp/terraform-test
$ cd !$


# Copy the following terraform plan to a `plan.tf` file in /tmp/terraform-test
$ cat > plans.tf << EOF
terraform {
  required_providers {
    juju = {
      version = ">=0.10.1"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testing" {
  name = "teasing"
}

resource "juju_application" "ubuntu" {
  model = juju_model.testing.name
  charm {
    name = "ubuntu"
  }
}
EOF

# Run the plan
$ terraform init  && terraform plan && terraform apply -auto-approve

# A model called testing which a single unit of the ubuntu application should be created.

# Find the lxc machine name for the ubuntu unit, use lxc exec to go there.
$ juju switch testing
$ juju status
$ lxd exec <juju-xxxxx-0> - bash -

# Validate that the "juju-system-key" has been place on the machine, thus not causing a regression.
$ grep "juju-system-key" /home/ubuntu/.ssh/authorized_keys
```


## Links
JUJU-5330
https://github.com/juju/terraform-provider-juju/issues/385

