### PR TITLE
Replace slice queries with SQLair queries in network/state

### DIFF
--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -41,17 +41,16 @@ func (st *State) AddSpace(
 		return errors.Trace(err)
 	}
 
-	insertSpaceStmt, err := sqlair.Prepare(
-		`INSERT INTO space (uuid, name) VALUES ($Space.uuid, $Space.name)`, Space{},
-	)
+	insertSpaceStmt, err := sqlair.Prepare(`
+INSERT INTO space (uuid, name) 
+VALUES ($Space.uuid, $Space.name)`, Space{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	insertProviderStmt, err := sqlair.Prepare(
-		`INSERT INTO provider_space (provider_id, space_uuid) VALUES ($ProviderSpace.provider_id, $ProviderSpace.space_uuid)`,
-		ProviderSpace{},
-	)
+	insertProviderStmt, err := sqlair.Prepare(`
+INSERT INTO provider_space (provider_id, space_uuid)
+VALUES ($ProviderSpace.provider_id, $ProviderSpace.space_uuid)`, ProviderSpace{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -84,8 +83,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair
 		// that are of a type on which the space can be set.
 
 		var nonSettableSubnets []Subnet
-		err := tx.Query(ctx, checkInputSubnetsStmt, subnetIDsInS).GetAll(&nonSettableSubnets)
-		if err != nil {
+		if err := tx.Query(ctx, checkInputSubnetsStmt, subnetIDsInS).GetAll(&nonSettableSubnets); err != nil {
 			return errors.Annotatef(err, "checking if there are fan subnets for space %q", uuid)
 		}
 

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -14,7 +14,6 @@ import (
 	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain"
-	"github.com/juju/juju/internal/database"
 )
 
 // State represents a type for interacting with the underlying state.
@@ -42,85 +41,92 @@ func (st *State) AddSpace(
 		return errors.Trace(err)
 	}
 
-	insertSpaceStmt := `
-INSERT INTO space (uuid, name)
-VALUES (?, ?)`
+	insertSpaceStmt, err := sqlair.Prepare(
+		`INSERT INTO space (uuid, name) VALUES ($Space.uuid, $Space.name)`, Space{},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	insertProviderStmt := `
-INSERT INTO provider_space (provider_id, space_uuid)
-VALUES (?, ?)`
+	insertProviderStmt, err := sqlair.Prepare(
+		`INSERT INTO provider_space (provider_id, space_uuid) VALUES ($ProviderSpace.provider_id, $ProviderSpace.space_uuid)`,
+		ProviderSpace{},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	subnetBinds, subnetVals := database.SliceToPlaceholder(subnetIDs)
-	findFanSubnetsStmt := fmt.Sprintf(`
-SELECT subject_subnet_uuid
+	findFanSubnetsStmt, err := sqlair.Prepare(`
+SELECT subject_subnet_uuid AS &Subnet.uuid
 FROM   subnet_association
-WHERE  association_type_id = 0 AND associated_subnet_uuid IN (%s)`, subnetBinds)
+WHERE  association_type_id = 0 AND associated_subnet_uuid IN ($S[:])`, sqlair.S{}, Subnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	checkInputSubnetsStmt := fmt.Sprintf(`
-SELECT uuid
+	checkInputSubnetsStmt, err := sqlair.Prepare(`
+SELECT &Subnet.uuid
 FROM   subnet
 JOIN   subnet_type
 ON     subnet.subnet_type_id = subnet_type.id
-WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN (%s)`, subnetBinds)
+WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair.S{}, Subnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// We must first check on the provided subnet ids to validate
 		// that are of a type on which the space can be set.
-		nonSettableSubnets, err := tx.QueryContext(ctx, checkInputSubnetsStmt, subnetVals...)
+
+		subnetIDsInS := sqlair.S{}
+		for _, sid := range subnetIDs {
+			subnetIDsInS = append(subnetIDsInS, sid)
+		}
+
+		var nonSettableSubnets []Subnet
+		err := tx.Query(ctx, checkInputSubnetsStmt, subnetIDsInS).GetAll(&nonSettableSubnets)
 		if err != nil {
 			return errors.Annotatef(err, "checking if there are fan subnets for space %q", uuid)
 		}
-		defer func() { _ = nonSettableSubnets.Close() }()
 		// If any row is returned we must fail with the returned fan
 		// subnet uuids.
-		uniqueErrorSubnetUUIDs := make(map[string]string)
-		var nonSettableUUIDs []string
-		for nonSettableSubnets.Next() {
-			var fanSubnetID string
-			err = nonSettableSubnets.Scan(&fanSubnetID)
-			if err != nil {
-				return errors.Trace(err)
+		if len(nonSettableSubnets) > 0 {
+			uniqueErrorSubnetUUIDs := make(map[string]string)
+			var nonSettableUUIDs []string
+			for _, nonSettableSubnet := range nonSettableSubnets {
+				fanSubnetID := nonSettableSubnet.UUID
+				if _, ok := uniqueErrorSubnetUUIDs[fanSubnetID]; !ok {
+					uniqueErrorSubnetUUIDs[fanSubnetID] = fanSubnetID
+					nonSettableUUIDs = append(nonSettableUUIDs, fanSubnetID)
+				}
 			}
-			if _, ok := uniqueErrorSubnetUUIDs[fanSubnetID]; !ok {
-				uniqueErrorSubnetUUIDs[fanSubnetID] = fanSubnetID
-				nonSettableUUIDs = append(nonSettableUUIDs, fanSubnetID)
-			}
-		}
-		if len(nonSettableUUIDs) > 0 {
 			return errors.Errorf(
 				"cannot set space for FAN subnet UUIDs %q - it is always inherited from underlay", nonSettableUUIDs)
 		}
 
-		if _, err := tx.ExecContext(ctx, insertSpaceStmt, uuid, name); err != nil {
+		if err := tx.Query(ctx, insertSpaceStmt, Space{UUID: uuid, Name: name}).Run(); err != nil {
 			return errors.Annotatef(err, "inserting space uuid %q into space table", uuid)
 		}
 		if providerID != "" {
-			if _, err := tx.ExecContext(ctx, insertProviderStmt, providerID, uuid); err != nil {
+			if err := tx.Query(ctx, insertProviderStmt, ProviderSpace{ProviderId: providerID, SpaceUUID: uuid}).Run(); err != nil {
 				return errors.Annotatef(err, "inserting provider id %q into provider_space table", providerID)
 			}
 		}
 
 		// Retrieve the fan overlays (if any) of the passed subnet ids.
-		rows, err := tx.QueryContext(ctx, findFanSubnetsStmt, subnetVals...)
+		var fanSubnets []Subnet
+		err = tx.Query(ctx, findFanSubnetsStmt, subnetIDsInS).GetAll(&fanSubnets)
 		if err != nil {
 			return errors.Annotatef(err, "retrieving the fan subnets for space %q", uuid)
 		}
-		defer func() { _ = rows.Close() }()
 		// Append the fan subnet (unique) ids (if any) to the provided
 		// subnet ids.
 		uniqueFanSubnetIDs := make(map[string]string)
-		for rows.Next() {
-			var fanSubnetID string
-			err = rows.Scan(&fanSubnetID)
-			if err != nil {
-				return errors.Trace(err)
+		for _, fanSubnet := range fanSubnets {
+			if _, ok := uniqueFanSubnetIDs[fanSubnet.UUID]; !ok {
+				uniqueFanSubnetIDs[fanSubnet.UUID] = fanSubnet.UUID
+				subnetIDs = append(subnetIDs, fanSubnet.UUID)
 			}
-			if _, ok := uniqueFanSubnetIDs[fanSubnetID]; !ok {
-				uniqueFanSubnetIDs[fanSubnetID] = fanSubnetID
-			}
-		}
-		for _, fanSubnetID := range uniqueFanSubnetIDs {
-			subnetIDs = append(subnetIDs, fanSubnetID)
 		}
 
 		// Update all subnets (including their fan overlays) to include

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -124,8 +124,8 @@ VALUES ($ProviderNetworkSubnet.provider_network_uuid, $ProviderNetworkSubnet.sub
 	if subnetType == subnetTypeFanOverlaySegment {
 		// Retrieve the underlay subnet uuid.
 		var underlaySubnet Subnet
-		err := tx.Query(ctx, retrieveUnderlaySubnetUUIDStmt, Subnet{CIDR: subnetInfo.FanInfo.FanLocalUnderlay}).Get(&underlaySubnet)
-		if err != nil {
+
+		if err := tx.Query(ctx, retrieveUnderlaySubnetUUIDStmt, Subnet{CIDR: subnetInfo.FanInfo.FanLocalUnderlay}).Get(&underlaySubnet); err != nil {
 			return errors.Annotatef(err, "retrieving underlay subnet %q for subnet %q", subnetInfo.FanInfo.FanLocalUnderlay, uuid)
 		}
 		// Add the association of the underlay and the newly
@@ -194,8 +194,8 @@ VALUES ($M.availability_zone_uuid, $M.subnet_uuid)`, sqlair.M{})
 	for _, az := range subnet.AvailabilityZones {
 		// Retrieve the availability zone.
 		m := sqlair.M{}
-		err := tx.Query(ctx, retrieveAvailabilityZoneStmt, sqlair.M{"name": az}).Get(m)
-		if err != nil && err != sql.ErrNoRows {
+
+		if err := tx.Query(ctx, retrieveAvailabilityZoneStmt, sqlair.M{"name": az}).Get(m); err != nil && err != sqlair.ErrNoRows {
 			return errors.Annotatef(err, "retrieving availability zone %q for subnet %q", az, subnetUUID)
 		}
 		azUUIDStr, _ := m["uuid"]
@@ -394,8 +394,8 @@ WHERE  uuid = $M.uuid;`, sqlair.M{})
 	}
 
 	var outcome sqlair.Outcome
-	err = tx.Query(ctx, updateSubnetSpaceIDStmt, sqlair.M{"space_uuid": spaceID, "uuid": uuid}).Get(&outcome)
-	if err != nil {
+
+	if err = tx.Query(ctx, updateSubnetSpaceIDStmt, sqlair.M{"space_uuid": spaceID, "uuid": uuid}).Get(&outcome); err != nil {
 		return errors.Trace(err)
 	}
 	affected, err := outcome.Result().RowsAffected()

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -194,8 +194,8 @@ VALUES ($M.availability_zone_uuid, $M.subnet_uuid)`, sqlair.M{})
 	for _, az := range subnet.AvailabilityZones {
 		// Retrieve the availability zone.
 		m := sqlair.M{}
-
-		if err := tx.Query(ctx, retrieveAvailabilityZoneStmt, sqlair.M{"name": az}).Get(m); err != nil && err != sqlair.ErrNoRows {
+		err := tx.Query(ctx, retrieveAvailabilityZoneStmt, sqlair.M{"name": az}).Get(m)
+		if err != nil && err != sql.ErrNoRows {
 			return errors.Annotatef(err, "retrieving availability zone %q for subnet %q", az, subnetUUID)
 		}
 		azUUIDStr, _ := m["uuid"]

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -28,7 +28,7 @@ func (st *State) UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo
 		return errors.Trace(err)
 	}
 
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		for _, subnet := range subnets {
 			err := updateSubnetSpaceID(
 				ctx,
@@ -55,13 +55,13 @@ func (st *State) UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo
 	})
 }
 
-func addSubnet(ctx context.Context, tx *sql.Tx, uuid string, subnet network.SubnetInfo) error {
+func addSubnet(ctx context.Context, tx *sqlair.TX, uuid string, subnetInfo network.SubnetInfo) error {
 	var subnetType int
-	if subnet.FanInfo != nil {
+	if subnetInfo.FanInfo != nil {
 		subnetType = subnetTypeFanOverlaySegment
 	}
-	spaceUUIDValue := subnet.SpaceID
-	if subnet.SpaceID == "" {
+	spaceUUIDValue := subnetInfo.SpaceID
+	if subnetInfo.SpaceID == "" {
 		spaceUUIDValue = network.AlphaSpaceId
 	}
 	pnUUID, err := utils.NewUUID()
@@ -69,111 +69,137 @@ func addSubnet(ctx context.Context, tx *sql.Tx, uuid string, subnet network.Subn
 		return errors.Trace(err)
 	}
 
-	insertSubnetStmt := `
+	insertSubnetStmt, err := sqlair.Prepare(`
 INSERT INTO subnet (uuid, cidr, vlan_tag, space_uuid, subnet_type_id)
-VALUES (?, ?, ?, ?, ?)`
-	insertSubnetAssociationStmt := `
+VALUES ($Subnet.uuid, $Subnet.cidr, $Subnet.vlan_tag, $Subnet.space_uuid, $Subnet.subnet_type_id)`, Subnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertSubnetAssociationStmt, err := sqlair.Prepare(`
 INSERT INTO subnet_association (subject_subnet_uuid, associated_subnet_uuid, association_type_id)
-VALUES (?, ?, 0)` // For the moment the only allowed association is 'overlay_of' and therefore its ID is hard-coded here.
-	retrieveUnderlaySubnetUUIDStmt := `
-SELECT uuid
+VALUES ($M.subject_subnet_uuid, $M.associated_subnet_uuid, 0)`, sqlair.M{}) // For the moment the only allowed association is 'overlay_of' and therefore its ID is hard-coded here.
+	if err != nil {
+		return errors.Trace(err)
+	}
+	retrieveUnderlaySubnetUUIDStmt, err := sqlair.Prepare(`
+SELECT &Subnet.uuid
 FROM   subnet
-WHERE  cidr = ?`
-	insertSubnetProviderIDStmt := `
+WHERE  cidr = $Subnet.cidr`, Subnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertSubnetProviderIDStmt, err := sqlair.Prepare(`
 INSERT INTO provider_subnet (provider_id, subnet_uuid)
-VALUES (?, ?)`
-	insertSubnetProviderNetworkIDStmt := `
+VALUES ($ProviderSubnet.provider_id, $ProviderSubnet.subnet_uuid)`, ProviderSubnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertSubnetProviderNetworkIDStmt, err := sqlair.Prepare(`
 INSERT INTO provider_network (uuid, provider_network_id)
-VALUES (?, ?)`
-	insertSubnetProviderNetworkSubnetStmt := `
+VALUES ($ProviderNetwork.uuid, $ProviderNetwork.provider_network_id)`, ProviderNetwork{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertSubnetProviderNetworkSubnetStmt, err := sqlair.Prepare(`
 INSERT INTO provider_network_subnet (provider_network_uuid, subnet_uuid)
-VALUES (?, ?)`
+VALUES ($ProviderNetworkSubnet.provider_network_uuid, $ProviderNetworkSubnet.subnet_uuid)`, ProviderNetworkSubnet{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 	// Add the subnet entity.
-	if _, err := tx.ExecContext(
+	if err := tx.Query(
 		ctx,
 		insertSubnetStmt,
-		uuid,
-		subnet.CIDR,
-		subnet.VLANTag,
-		spaceUUIDValue,
-		subnetType,
-	); err != nil {
+		Subnet{
+			UUID:       uuid,
+			CIDR:       subnetInfo.CIDR,
+			VLANtag:    subnetInfo.VLANTag,
+			SpaceUUID:  spaceUUIDValue,
+			SubnetType: subnetType,
+		},
+	).Run(); err != nil {
 		return errors.Trace(err)
 	}
 
 	if subnetType == subnetTypeFanOverlaySegment {
 		// Retrieve the underlay subnet uuid.
-		var underlaySubnetUUID string
-		row := tx.QueryRowContext(ctx, retrieveUnderlaySubnetUUIDStmt, subnet.FanInfo.FanLocalUnderlay)
-		if err := row.Scan(&underlaySubnetUUID); err != nil {
-			return errors.Annotatef(err, "retrieving underlay subnet %q for subnet %q", subnet.FanInfo.FanLocalUnderlay, uuid)
+		var underlaySubnet Subnet
+		err := tx.Query(ctx, retrieveUnderlaySubnetUUIDStmt, Subnet{CIDR: subnetInfo.FanInfo.FanLocalUnderlay}).Get(&underlaySubnet)
+		if err != nil {
+			return errors.Annotatef(err, "retrieving underlay subnet %q for subnet %q", subnetInfo.FanInfo.FanLocalUnderlay, uuid)
 		}
 		// Add the association of the underlay and the newly
 		// created subnet to the associations table.
-		if _, err := tx.ExecContext(
+		if err := tx.Query(
 			ctx,
 			insertSubnetAssociationStmt,
-			uuid,
-			underlaySubnetUUID,
-		); err != nil {
-			return errors.Annotatef(err, "inserting subnet association between underlay %q and subnet %q", subnet.FanInfo.FanLocalUnderlay, uuid)
+			sqlair.M{"subject_subnet_uuid": uuid, "associated_subnet_uuid": underlaySubnet.UUID},
+		).Run(); err != nil {
+			return errors.Annotatef(err, "inserting subnet association between underlay %q and subnet %q", subnetInfo.FanInfo.FanLocalUnderlay, uuid)
 		}
 	}
 	// Add the subnet uuid to the provider ids table.
-	if _, err := tx.ExecContext(
+	if err := tx.Query(
 		ctx,
 		insertSubnetProviderIDStmt,
-		subnet.ProviderId,
-		uuid,
-	); err != nil {
-		return errors.Annotatef(err, "inserting provider id %q for subnet %q", subnet.ProviderId, uuid)
+		ProviderSubnet{SubnetUUID: uuid, ProviderNetworkId: subnetInfo.ProviderId},
+	).Run(); err != nil {
+		return errors.Annotatef(err, "inserting provider id %q for subnet %q", subnetInfo.ProviderId, uuid)
 	}
-	// Add the subnet and provider network uuids to the
-	// provider_network_subnet table.
-	if _, err := tx.ExecContext(
+	// Add the provider network id and its uuid to the
+	// provider_network table.
+	if err := tx.Query(
 		ctx,
 		insertSubnetProviderNetworkIDStmt,
-		pnUUID.String(),
-		subnet.ProviderNetworkId,
-	); err != nil {
-		return errors.Annotatef(err, "inserting provider network id %q for subnet %q", subnet.ProviderNetworkId, uuid)
+		ProviderNetwork{ProviderNetworkUUID: pnUUID.String(), ProviderNetworkId: subnetInfo.ProviderNetworkId},
+	).Run(); err != nil {
+		return errors.Annotatef(err, "inserting provider network id %q for subnet %q", subnetInfo.ProviderNetworkId, uuid)
 	}
 	// Insert the providerNetworkUUID into provider network to
 	// subnets mapping table.
-	if _, err := tx.ExecContext(
+	if err := tx.Query(
 		ctx,
 		insertSubnetProviderNetworkSubnetStmt,
-		pnUUID.String(),
-		uuid,
-	); err != nil {
-		return errors.Annotatef(err, "inserting association between provider network id %q and subnet %q", subnet.ProviderNetworkId, uuid)
+		ProviderNetworkSubnet{SubnetUUID: uuid, ProviderNetworkUUID: pnUUID.String()},
+	).Run(); err != nil {
+		return errors.Annotatef(err, "inserting association between provider network id %q and subnet %q", subnetInfo.ProviderNetworkId, uuid)
 	}
 
-	return addAvailabilityZones(ctx, tx, uuid, subnet)
+	return addAvailabilityZones(ctx, tx, uuid, subnetInfo)
 }
 
 // addAvailabilityZones adds the availability zones of a subnet if they don't exist, and
 // update the availability_zone_subnet table with the subnet's id.
-func addAvailabilityZones(ctx context.Context, tx *sql.Tx, subnetUUID string, subnet network.SubnetInfo) error {
-	retrieveAvailabilityZoneStmt := `
-SELECT uuid
+func addAvailabilityZones(ctx context.Context, tx *sqlair.TX, subnetUUID string, subnet network.SubnetInfo) error {
+	retrieveAvailabilityZoneStmt, err := sqlair.Prepare(`
+SELECT &M.uuid
 FROM   availability_zone
-WHERE  name = ?`
-	insertAvailabilityZoneStmt := `
+WHERE  name = $M.name`, sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertAvailabilityZoneStmt, err := sqlair.Prepare(`
 INSERT INTO availability_zone (uuid, name)
-VALUES (?, ?)`
-	insertAvailabilityZoneSubnetStmt := `
+VALUES ($M.uuid, $M.name)`, sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertAvailabilityZoneSubnetStmt, err := sqlair.Prepare(`
 INSERT INTO availability_zone_subnet (availability_zone_uuid, subnet_uuid)
-VALUES (?, ?)`
+VALUES ($M.availability_zone_uuid, $M.subnet_uuid)`, sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	for _, az := range subnet.AvailabilityZones {
 		// Retrieve the availability zone.
-		var azUUIDStr string
-		row := tx.QueryRowContext(ctx, retrieveAvailabilityZoneStmt, az)
-		err := row.Scan(&azUUIDStr)
+		m := sqlair.M{}
+		err := tx.Query(ctx, retrieveAvailabilityZoneStmt, sqlair.M{"name": az}).Get(m)
 		if err != nil && err != sql.ErrNoRows {
 			return errors.Annotatef(err, "retrieving availability zone %q for subnet %q", az, subnetUUID)
 		}
+		azUUIDStr, _ := m["uuid"]
+
 		// If it doesn't exist, add the availability zone.
 		if errors.Is(err, sql.ErrNoRows) {
 			azUUID, err := utils.NewUUID()
@@ -181,23 +207,21 @@ VALUES (?, ?)`
 				return errors.Annotatef(err, "generating UUID for availability zone %q for subnet %q", az, subnetUUID)
 			}
 			azUUIDStr = azUUID.String()
-			if _, err := tx.ExecContext(
+			if err := tx.Query(
 				ctx,
 				insertAvailabilityZoneStmt,
-				azUUIDStr,
-				az,
-			); err != nil {
+				sqlair.M{"uuid": azUUIDStr, "name": az},
+			).Run(); err != nil {
 				return errors.Annotatef(err, "inserting availability zone %q for subnet %q", az, subnetUUID)
 			}
 		}
 		// Add the subnet id along with the az uuid into the
 		// availability_zone_subnet mapping table.
-		if _, err := tx.ExecContext(
+		if err := tx.Query(
 			ctx,
 			insertAvailabilityZoneSubnetStmt,
-			azUUIDStr,
-			subnetUUID,
-		); err != nil {
+			sqlair.M{"availability_zone_uuid": azUUIDStr, "subnet_uuid": subnetUUID},
+		).Run(); err != nil {
 			return errors.Annotatef(err, "inserting availability zone %q association with subnet %q", az, subnetUUID)
 		}
 	}
@@ -215,7 +239,7 @@ func (st *State) AddSubnet(
 	}
 
 	return errors.Trace(
-		db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			return addSubnet(ctx, tx, subnet.ID.String(), subnet)
 		}),
 	)
@@ -357,20 +381,24 @@ func (st *State) GetSubnetsByCIDR(
 
 func updateSubnetSpaceID(
 	ctx context.Context,
-	tx *sql.Tx,
+	tx *sqlair.TX,
 	uuid string,
 	spaceID string,
 ) error {
-	q := `
+	updateSubnetSpaceIDStmt, err := sqlair.Prepare(`
 UPDATE subnet
-SET    space_uuid = ?
-WHERE  uuid = ?;`
-
-	rows, err := tx.ExecContext(ctx, q, spaceID, uuid)
+SET    space_uuid = $M.space_uuid
+WHERE  uuid = $M.uuid;`, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
-	affected, err := rows.RowsAffected()
+
+	var outcome sqlair.Outcome
+	err = tx.Query(ctx, updateSubnetSpaceIDStmt, sqlair.M{"space_uuid": spaceID, "uuid": uuid}).Get(&outcome)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	affected, err := outcome.Result().RowsAffected()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -392,7 +420,7 @@ func (st *State) UpdateSubnet(
 		return errors.Trace(err)
 	}
 
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return updateSubnetSpaceID(ctx, tx, uuid, spaceID)
 	})
 }

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -9,6 +9,62 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
+// Subnet represents a single row from the subnet table.
+type Subnet struct {
+	// UUID is the subnet's UUID.
+	UUID string `db:"uuid"`
+	// CIDR of the network, in 123.45.67.89/24 format.
+	CIDR string `db:"cidr"`
+	// VLANtag is the subnet's vlan tag.
+	VLANtag int `db:"vlan_tag"`
+	// SpaceUUID is the space UUID.
+	SpaceUUID string `db:"space_uuid"`
+	// SubnetType indicates if the subnet is a fan overlay or a base subnet.
+	SubnetType int `db:"subnet_type_id"`
+}
+
+// ProviderSubnet represents a single row from the provider_subnet table.
+type ProviderSubnet struct {
+	// SubnetUUID is the UUID of the subnet.
+	SubnetUUID string `db:"subnet_uuid"`
+	// ProviderNetworkId is the provider ID of the network
+	// containing this subnet.
+	ProviderNetworkId network.Id `db:"provider_id"`
+}
+
+// ProviderNetwork represents a single row from the provider_network table.
+type ProviderNetwork struct {
+	// ProviderNetworkUUID is the provider network UUID.
+	ProviderNetworkUUID string `db:"uuid"`
+	// ProviderNetworkId is the provider ID of the network.
+	// containing this subnet.
+	ProviderNetworkId network.Id `db:"provider_network_id"`
+}
+
+// ProviderNetworkSubnet represents a single row from the provider_network_subnet mapping table.
+type ProviderNetworkSubnet struct {
+	// SubnetUUID is the UUID of the subnet.
+	SubnetUUID string `db:"subnet_uuid"`
+	// ProviderNetworkUUID is the provider network UUID.
+	ProviderNetworkUUID string `db:"provider_network_uuid"`
+}
+
+// Space represents a single row from the space table.
+type Space struct {
+	// Name is the space name.
+	Name string `db:"name"`
+	// UUID is the unique ID of the space.
+	UUID string `db:"uuid"`
+}
+
+// ProviderSpace represents a single row from the provider_space table.
+type ProviderSpace struct {
+	// SpaceUUID is the unique ID of the space.
+	SpaceUUID string `db:"space_uuid"`
+	// ProviderId is a provider-specific subnet ID.
+	ProviderId network.Id `db:"provider_id"`
+}
+
 // SpaceSubnetRow represents a single row from the database when
 // space is joined with provider_space, subnet, subnet_type,
 // subnet_association, subject_subnet_type_uuid, subnet_association_type,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
 	github.com/canonical/pebble v1.7.0
-	github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1
+	github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSH
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
 github.com/canonical/pebble v1.7.0 h1:VG7KcgEJ0eWq6JYnGWKQlWcyxZqqNdoiD+p8Dul19b8=
 github.com/canonical/pebble v1.7.0/go.mod h1:bROzibw902Vastd13S/H48BrVAjEUKnlRXv3ZIoFcPE=
-github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1 h1:KVwWWsaiasTOHKQc0f3rxWxuMDTjkhsUnVBnRXf9YVM=
-github.com/canonical/sqlair v0.0.0-20240105130237-d0535bc071d1/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42 h1:s0eal/q/KeSKTZNYbkoJ1V3SSoUuhx+GCqoNN0zooto=
+github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
With SQLair now supporting slice inputs queries that used `database.SliceToPlaceholder` can be replaced with SQLair queries. The PR affects this change in `domain/network/state`.

Changing the transaction from `StdTxn` to `Txn` has the knock on effect that other queries in the same tx must also use SQLair. A lot of the other queries do not benefit from SQLair ergonomics however upcoming SQLair roadmap items such as support for INSERT statements and support for basic types will allow them to in subsequent changes.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~- [] Go unit tests, with comments saying what you're testing~
~- [] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
`go test github.com/juju/juju/domain/network/state/... -gocheck.v`
<!-- Describe steps to verify that the change works. -->

## Documentation changes
N/A
<!-- How it affects user workflow (CLI or API). -->



