### PR TITLE
Remove series from charm url when adding charms in bundles

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -817,7 +817,6 @@ func (s *DeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 	}
 
 	deployURL := *inURL
-	deployURL.Series = "jammy"
 
 	dArgs := application.DeployArgs{
 		CharmID: application.CharmID{
@@ -2559,9 +2558,6 @@ func withCharmDeployableWithDevicesAndStorage(
 	devices map[string]devices.Constraints,
 ) {
 	deployURL := *url
-	if deployURL.Series == "" {
-		deployURL.Series = "jammy"
-	}
 	fallbackCons := constraints.MustParse("arch=amd64")
 	platform := apputils.MakePlatform(constraints.Value{}, base, fallbackCons)
 	origin, _ := apputils.MakeOrigin(charm.Schema(url.Schema), url.Revision, charm.Channel{}, platform)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -608,9 +608,9 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 
 	// Ensure that we use the architecture from the add charm change params.
 	var cons constraints.Value
-	if change.Params.Architecture != "" {
+	if chParams.Architecture != "" {
 		cons = constraints.Value{
-			Arch: &change.Params.Architecture,
+			Arch: &chParams.Architecture,
 		}
 	}
 
@@ -624,8 +624,8 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	}
 
 	revision := -1
-	if change.Params.Revision != nil && *change.Params.Revision >= 0 {
-		revision = *change.Params.Revision
+	if chParams.Revision != nil && *chParams.Revision >= 0 {
+		revision = *chParams.Revision
 	}
 
 	platform := utils.MakePlatform(cons, base, h.modelConstraints)
@@ -662,11 +662,6 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	selectedSeries, err := corebase.GetSeriesFromBase(selectedBase)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	url = url.WithSeries(selectedSeries)
 	resolvedOrigin.Base = selectedBase
 	logger.Tracef("Using channel %s from %v to deploy %v", resolvedOrigin.Base, supportedBases, url)
 

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -101,8 +101,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccess(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("ch:focal/mysql")
-	wordpressCurl := charm.MustParseURL("ch:focal/wordpress")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -148,9 +148,9 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccessWithModelConstraint
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl, err := charm.ParseURL("focal/mysql")
+	mysqlCurl, err := charm.ParseURL("mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	wordpressCurl, err := charm.ParseURL("focal/wordpress")
+	wordpressCurl, err := charm.ParseURL("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	chUnits := []charmUnit{
 		{
@@ -267,8 +267,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mariadbCurl := charm.MustParseURL("ch:jammy/mariadb-k8s")
-	gitlabCurl := charm.MustParseURL("ch:jammy/gitlab-k8s")
+	mariadbCurl := charm.MustParseURL("ch:mariadb-k8s")
+	gitlabCurl := charm.MustParseURL("ch:gitlab-k8s")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"kubernetes"},
@@ -510,8 +510,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleStorage(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("ch:jammy/mysql")
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -634,9 +634,8 @@ func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL) *c
 			return curl, origin, []corebase.Base{base}, nil
 		}).Times(3)
 
-	fullCurl := curl.WithSeries("focal")
 	s.deployerAPI.EXPECT().AddCharm(
-		fullCurl,
+		curl,
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		false,
 	).DoAndReturn(
@@ -646,15 +645,15 @@ func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL) *c
 		})
 
 	charmInfo := &apicharms.CharmInfo{
-		Revision: fullCurl.Revision,
-		URL:      fullCurl.String(),
+		Revision: curl.Revision,
+		URL:      curl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"kubernetes"},
 		},
 	}
-	s.expectCharmInfo(fullCurl.String(), charmInfo)
+	s.expectCharmInfo(curl.String(), charmInfo)
 	s.expectDeploy()
-	return fullCurl
+	return curl
 }
 
 const kubernetesBitcoinBundle = `
@@ -676,8 +675,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundle(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	bitcoinCurl := charm.MustParseURL("ch:focal/bitcoin-miner")
-	dashboardCurl := charm.MustParseURL("ch:focal/dashboard4miner")
+	bitcoinCurl := charm.MustParseURL("ch:bitcoin-miner")
+	dashboardCurl := charm.MustParseURL("ch:dashboard4miner")
 	chUnits := []charmUnit{
 		{
 			curl:                 bitcoinCurl,
@@ -737,8 +736,8 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("ch:jammy/mysql")
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -759,10 +758,10 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 
 	if !dryRun {
 		s.expectAddCharm(false)
-		s.expectCharmInfo("ch:jammy/mysql", &apicharms.CharmInfo{URL: mysqlCurl.String(), Meta: &charm.Meta{}})
+		s.expectCharmInfo("ch:mysql", &apicharms.CharmInfo{URL: mysqlCurl.String(), Meta: &charm.Meta{}})
 		s.expectSetCharm(c, "mysql")
 		s.expectAddCharm(false)
-		s.expectCharmInfo("ch:jammy/wordpress", &apicharms.CharmInfo{URL: wordpressCurl.String(), Meta: &charm.Meta{}})
+		s.expectCharmInfo("ch:wordpress", &apicharms.CharmInfo{URL: wordpressCurl.String(), Meta: &charm.Meta{}})
 		s.expectSetCharm(c, "wordpress")
 	}
 
@@ -838,7 +837,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleResources(c *gc.C) {
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -891,7 +890,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSpecifyResources(c *gc.C) 
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("ch:focal/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -968,7 +967,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	s.expectResolveCharm(nil)
 	s.expectResolveCharm(nil)
 
-	mysqlCurl := charm.MustParseURL("ch:jammy/mysql")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
 	s.expectAddCharm(false)
 	s.expectSetCharm(c, "mysql")
 	charmInfo := &apicharms.CharmInfo{
@@ -979,7 +978,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	}
 	s.expectCharmInfo(mysqlCurl.String(), charmInfo)
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectAddCharm(false)
 	s.expectSetCharm(c, "wordpress")
 	wpCharmInfo := &apicharms.CharmInfo{
@@ -1048,9 +1047,9 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNewRelations(c *gc.C) {
 	s.expectAddCharm(false)
 	s.expectAddCharm(false)
 	s.expectAddCharm(false)
-	s.expectCharmInfo("ch:jammy/mysql", &apicharms.CharmInfo{Meta: &charm.Meta{}})
-	s.expectCharmInfo("ch:jammy/varnish", &apicharms.CharmInfo{Meta: &charm.Meta{}})
-	s.expectCharmInfo("ch:jammy/wordpress", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectCharmInfo("ch:mysql", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectCharmInfo("ch:varnish", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectCharmInfo("ch:wordpress", &apicharms.CharmInfo{Meta: &charm.Meta{}})
 	s.expectSetCharm(c, "mysql")
 	s.expectSetCharm(c, "wordpress")
 	s.expectDeploy()
@@ -1082,7 +1081,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNewRelations(c *gc.C) {
 const machineUnitPlacementBundle = `
       applications:
           wordpress:
-              charm: ch:focal/wordpress
+              charm: ch:wordpress
               num_units: 2
               to:
                   - 1
@@ -1090,7 +1089,7 @@ const machineUnitPlacementBundle = `
               options:
                   blog-title: these are the voyages
           mysql:
-              charm: ch:focal/mysql
+              charm: ch:mysql
               num_units: 2
               to:
                   - lxd:wordpress/0
@@ -1171,7 +1170,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMachineAttributes(c *gc.C)
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -1207,7 +1206,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleTwiceScaleUp(c *gc.C) {
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
 
-	djangoCurl := charm.MustParseURL("ch:focal/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharmWithBases([]string{"ubuntu@22.04", "ubuntu@20.04"}, nil)
 	s.expectAddCharm(false)
 	s.expectAddCharm(false)
@@ -1256,7 +1255,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: wordpressCurl.Revision,
@@ -1277,7 +1276,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 		{Entity: &params.UnitInfo{Name: "wordpress/1", MachineId: "1"}},
 	}, nil)
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
@@ -1327,7 +1326,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddContainer("0", "0/lxd/1", "", "lxd")
 	s.expectAddContainer("1", "1/lxd/1", "", "lxd")
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		URL: wordpressCurl.String(),
@@ -1341,7 +1340,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddOneUnit("wordpress", "0/lxd/0", "0")
 	s.expectAddOneUnit("wordpress", "1/lxd/0", "1")
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		URL: djangoCurl.String(),
@@ -1409,7 +1408,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddContainer("0", "0/kvm/0", "20.04", "kvm")
 
 	// Setup for mem charm
-	memCurl := charm.MustParseURL("ch:focal/mem")
+	memCurl := charm.MustParseURL("ch:mem")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: memCurl.Revision,
@@ -1426,7 +1425,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddOneUnit("mem", "2", "2")
 
 	// Setup for django charm
-	djangoCurl := charm.MustParseURL("ch:focal/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
@@ -1445,7 +1444,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddOneUnit("django", "0/kvm/0", "4")
 
 	// Setup for rails charm
-	railsCurl := charm.MustParseURL("ch:focal/rails")
+	railsCurl := charm.MustParseURL("ch:rails")
 	s.expectResolveCharm(nil)
 	charmInfo3 := &apicharms.CharmInfo{
 		Revision: railsCurl.Revision,
@@ -1485,7 +1484,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSwitch(c *gc.C) {
 
 	s.expectGetAnnotationsEmpty()
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
 	charmInfo := &apicharms.CharmInfo{
@@ -1498,7 +1497,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSwitch(c *gc.C) {
 	s.expectSetCharm(c, "django")
 	s.expectDeploy()
 
-	railsCurl := charm.MustParseURL("ch:jammy/rails")
+	railsCurl := charm.MustParseURL("ch:rails")
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
 	rCharmInfo := &apicharms.CharmInfo{
@@ -1543,8 +1542,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotations(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
-	memCurl := charm.MustParseURL("ch:jammy/mem")
+	djangoCurl := charm.MustParseURL("ch:django")
+	memCurl := charm.MustParseURL("ch:mem")
 	chUnits := []charmUnit{
 		{
 			curl:                 memCurl,
@@ -1598,8 +1597,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotationsChanges(c *gc.C
 	s.expectWatchAll()
 	s.expectResolveCharmWithBases([]string{"ubuntu@18.04", "ubuntu@22.04", "ubuntu@16.04"}, nil)
 	s.expectAddCharm(false)
-	s.expectCharmInfo("ch:jammy/django", &apicharms.CharmInfo{
-		URL:  "ch:jammy/django",
+	s.expectCharmInfo("ch:django", &apicharms.CharmInfo{
+		URL:  "ch:django",
 		Meta: &charm.Meta{},
 	})
 
@@ -1638,7 +1637,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleInvalidMachineContainerTyp
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectAddCharm(false)
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
@@ -1686,7 +1685,7 @@ func (s *BundleDeployRepositorySuite) testDeployBundleUnitPlacedToMachines(c *gc
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectAddCharm(false)
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
@@ -1761,7 +1760,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"jammy", "focal"},
@@ -1797,10 +1796,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C)
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
-	mysqlCurl := charm.MustParseURL("ch:jammy/mysql")
-	pgresCurl := charm.MustParseURL("ch:jammy/postgres")
-	varnishCurl := charm.MustParseURL("ch:jammy/varnish")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	pgresCurl := charm.MustParseURL("ch:postgres")
+	varnishCurl := charm.MustParseURL("ch:varnish")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"jammy", "focal"},
@@ -1836,10 +1835,10 @@ applications:
         charm: ch:mysql
         num_units: 1
     postgres:
-        charm: ch:focal/postgres
+        charm: ch:postgres
         num_units: 1
     varnish:
-        charm: ch:focal/varnish
+        charm: ch:varnish
         num_units: 1
 relations:
     - ["wordpress:db", "mysql:server"]
@@ -1879,8 +1878,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("local:jammy/mysql-1")
-	wordpressCurl := charm.MustParseURL("local:jammy/wordpress-3")
+	mysqlCurl := charm.MustParseURL("local:mysql-1")
+	wordpressCurl := charm.MustParseURL("local:wordpress-3")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -1949,8 +1948,8 @@ func (s *BundleDeployRepositorySuite) assertDeployBundleLocalPathInvalidSeriesWi
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("local:jammy/mysql-1")
-	wordpressCurl := charm.MustParseURL("local:jammy/wordpress-3")
+	mysqlCurl := charm.MustParseURL("local:mysql-1")
+	wordpressCurl := charm.MustParseURL("local:wordpress-3")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -2053,7 +2052,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithEndpointBindings(c *gc
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	grafanaCurl, err := charm.ParseURL("ch:jammy/grafana")
+	grafanaCurl, err := charm.ParseURL("ch:grafana")
 	c.Assert(err, jc.ErrorIsNil)
 	chUnits := []charmUnit{{
 		curl:                 grafanaCurl,


### PR DESCRIPTION
When we calculate the base to use for a charm, as well as adding the base to the origin, we also used to convert it to a series and include it in the charm url

However, this charm url series is never read. It was only included as a legacy fallback option for charms which we have not supported for a long time

Drop the series from the charm url. This is part of an effort to remove Series from the charmurl in general, as part of work to stop using series and to use bases instead across our codebase

As a flyby, refactor some simple inconsistant variable usage

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Run integration tests
```
./main.sh -v -c aws -p ec2 deploy test_deploy_bundles
```

Model migration tests
```
SHORT_GIT_COMMIT="4e76c05" JUJU_VERSION="3.4-rc1" JUJU_BUILD_NUMBER="0" ./main.sh -v -c aws -p ec2 -s 'test_model_config,test_model_multi,test_model_metrics,test_model_destroy,test_model_status' model
```

### Deploy some common bundles
```
$ juju deploy charmed-kubernetes
```
```
$ juju deploy cos-lite --trust
```
& check applications become active & ready

### Check exported bundles can be deployed correctly
```
$ juju add-model m
$ juju deploy ubuntu ubu1 --base ubuntu@22.04
$ juju deploy ubuntu ubu2 --base ubuntu@20.04
$ juju export-bundle > bundle.bundle
$ cat bundle.bundle
default-base: ubuntu@22.04/stable
applications:
  ubu1:
    charm: ubuntu
    channel: stable
    revision: 24
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
  ubu2:
    charm: ubuntu
    channel: stable
    revision: 24
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
    base: ubuntu@20.04/stable

$ juju add-model m
$ juju deploy ./bundle.bundle
(wait)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m2     lxd         localhost/localhost  3.4-beta1  unsupported  13:15:32Z

App   Version  Status   Scale  Charm   Channel  Rev  Exposed  Message
ubu1           waiting      1  ubuntu  stable    24  no       agent initialising
ubu2           waiting      1  ubuntu  stable    24  no       agent initialising

Unit     Workload  Agent      Machine  Public address  Ports  Message
ubu1/0*  waiting   executing  0        10.219.211.10          agent initialising
ubu2/0*  waiting   executing  1        10.219.211.98          agent initialising

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.10  juju-812d1f-0  ubuntu@22.04      Running
1        started  10.219.211.98  juju-812d1f-1  ubuntu@20.04      Running
```

### Deploy a bundle without any base/series data in applications
(make sure to include a local charm)

```
$ cat bundle.bundle
applications:
  ubu1:
    charm: ubuntu
    channel: stable
    num_units: 1
    to:
    - "0"
  ubu2:
    charm: /home/jack/charms/ubuntu
    channel: stable
    num_units: 1
    to:
    - "1"
machines:
  "0": {}
  "1":
    base: ubuntu@20.04

$ juju deploy ./bundle.bundle
(wait)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc1.1  unsupported  21:04:05Z

App   Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu1  22.04    active      1  ubuntu  stable    24  no       
ubu2  20.04    active      1  ubuntu             0  no       

Unit     Workload  Agent  Machine  Public address  Ports  Message
ubu1/0*  active    idle   0        10.219.211.131         
ubu2/0*  active    idle   1        10.219.211.22          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.131  juju-49261f-0  ubuntu@22.04      Running
1        started  10.219.211.22   juju-49261f-1  ubuntu@20.04      Running
```

### Check charms can be refreshed (with 3.5 and 3.1 clients)

Ensure a juju-qa-test charm is present at `~/charms/juju-qa-test`

```
$ juju add-model m
$ cat bundle.yaml
applications:
  juju-qa-test:
    charm: juju-qa-test
    num_units: 1
    revision: 23
    channel: latest/stable

$ juju deploy ./bundle.yaml
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.5-beta1.1  unsupported  13:39:12Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   23  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/2*  active    idle   3        10.219.211.224         hello

Machine  State    Address         Inst id        Base          AZ  Message
3        started  10.219.211.224  juju-35f954-3  ubuntu@22.04      Running
```

Repeat the following steps with a client built from this version of Juju in this PR, and the `3.5` branch, and the `3.1` branch

```
$ juju refresh juju-qa-test
Added charm-hub charm "juju-qa-test", revision 25 in channel stable, to the model
no change to endpoint in space "alpha": info

$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.5-beta1.1  unsupported  13:40:06Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/2*  active    idle   3        10.219.211.224         hello

Machine  State    Address         Inst id        Base          AZ  Message
3        started  10.219.211.224  juju-35f954-3  ubuntu@22.04      Running
```

### Model migration

Run integration tests above

#### Force a failed migration
Apply the following diff and build Juju to force a failed migration
```
diff --git a/version/version.go b/version/version.go
index ad63f83629..e0260696c5 100644
--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "3.4-rc1"
+const version = "3.4-rc2"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.
diff --git a/worker/migrationmaster/worker.go b/worker/migrationmaster/worker.go
index 30462cd221..5b81620674 100644
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -512,6 +512,7 @@ func (w *Worker) doVALIDATION(status coremigration.MigrationStatus) (coremigrati
                w.setErrorStatus("model activation failed, %v", err)
                return coremigration.ABORT, nil
        }
+       panic("oop")
        return coremigration.SUCCESS, nil
 }
```

```
$ juju bootstrap lxd lxd-dst
$ juju bootstrap lxd lxd
$ juju add-model m 
$ juju deploy ubuntu ubu-ch
$ juju deploy ubuntu ubu-local
(wait)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp 
m      lxd         localhost/localhost  3.4-rc2.1  unsupported  13:55:26Z  

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.162         
ubu-local/0*  active    idle   1        10.219.211.78          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.162  juju-aaf05a-0  ubuntu@22.04      Running
1        started  10.219.211.78   juju-aaf05a-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst
(wait)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp  Notes
m      lxd         localhost/localhost  3.4-rc2.1  unsupported  13:55:26Z  migrating: aborted, removing model from target controller: model activation failed, migration mode for the model is n...

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.162         
ubu-local/0*  active    idle   1        10.219.211.78          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.162  juju-aaf05a-0  ubuntu@22.04      Running
1        started  10.219.211.78   juju-aaf05a-1  ubuntu@22.04      Running

$ juju refresh ubu-ch --channel edge # verify can still refresh
(wait)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp  Notes
m      lxd         localhost/localhost  3.4-rc2.1  unsupported  13:55:26Z  migrating: aborted, removing model from target controller: model activation failed, migration mode for the model is n...

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.162         
ubu-local/0*  active    idle   1        10.219.211.78          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.162  juju-aaf05a-0  ubuntu@22.04      Running
1        started  10.219.211.78   juju-aaf05a-1  ubuntu@22.04      Running
```

### Check machines can be upgraded with charms

```
$ juju add-model m
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    base: ubuntu@20.04

$ juju deploy ./bundle.yaml
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc1  unsupported  14:09:59Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.183         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.183  juju-e2e10d-0  ubuntu@20.04      Running

$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 prepare ubuntu@22.04

$ juju ssh 0 do-release-upgrade
...
$ juju upgrade-machine 0 complete
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc1  unsupported  14:18:43Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.183         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.183  juju-e2e10d-0  ubuntu@22.04      series upgrade completed: success

$ juju set-application-base ubuntu ubuntu@22.04
$ juju add-unit ubuntu
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc1  unsupported  14:19:48Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu           active      2  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.183         
ubuntu/1   active    idle   1        10.219.211.171         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.183  juju-e2e10d-0  ubuntu@22.04      series upgrade completed: success
1        started  10.219.211.171  juju-e2e10d-1  ubuntu@22.04      Running
```

### Verify new client can interact with pre-existing charms

Build juju from 3.5 (and repeat with 3.1) main branch
```
$ juju add-model m
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    base: ubuntu@20.04

$ juju deploy ./bundle.yaml
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc2  unsupported  16:25:49Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.51          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.51  juju-728aee-0  ubuntu@20.04      Running
```

Build juju client from this PR & edit `bundle.yaml` such that:
```
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 2

$ juju deploy ./bundle.yaml
Executing changes:
- upload charm ubuntu from charm-hub with architecture=amd64
- set constraints for ubuntu to ""
- add unit ubuntu/1 to new machine 1
Deploy of bundle completed.

(wait)
$  juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc2  unsupported  16:30:12Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu           active      2  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.51          
ubuntu/1   active    idle   1        10.219.211.29          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.51  juju-728aee-0  ubuntu@20.04      Running
1        started  10.219.211.29  juju-728aee-1  ubuntu@20.04      Running
```

### Verify base client can interact with charms deployed from here

Build juju from this PR
```
$ juju add-model m
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    base: ubuntu@20.04

$ juju deploy ./bundle.yaml
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc2  unsupported  16:25:49Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.51          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.51  juju-728aee-0  ubuntu@20.04      Running
```

Build juju client from 3.5 (and repeat with 3.1) main branch & edit `bundle.yaml` such that:
```
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 2

$ juju deploy ./bundle.yaml
Executing changes:
- upload charm ubuntu from charm-hub with architecture=amd64
- set constraints for ubuntu to ""
- add unit ubuntu/1 to new machine 1
Deploy of bundle completed.

(wait)
$  juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      lxd         localhost/localhost  3.4-rc2  unsupported  16:30:12Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu           active      2  ubuntu  stable    24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.51          
ubuntu/1   active    idle   1        10.219.211.29          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.51  juju-728aee-0  ubuntu@20.04      Running
1        started  10.219.211.29  juju-728aee-1  ubuntu@20.04      Running
```