### PR TITLE
[SQLair] Replace slice queries in domain/modelconfig/state

### DIFF
--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/errors"
@@ -184,6 +185,9 @@ func (st *State) UpdateModelConfig(
 DELETE FROM model_config
 WHERE key IN ($S[:])
 `[1:], sqlair.S{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	upsertStmt, err := sqlair.Prepare(`
 INSERT INTO model_config (key, value) VALUES ($M.key, $M.value)
@@ -191,6 +195,9 @@ ON CONFLICT(key) DO UPDATE
 SET value = excluded.value
 WHERE key = excluded.key
 `[1:], sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if len(removeAttrsSlice) != 0 {

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
-
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/sqlair"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
@@ -58,10 +59,7 @@ func (st *State) ModelConfigHasAttributes(
 		return rval, errors.Trace(err)
 	}
 
-	attrsSlice := make(sqlair.S, len(attrs), len(attrs))
-	for i, attr := range attrs {
-		attrsSlice[i] = attr
-	}
+	attrsSlice := sqlair.S(transform.Slice(attrs, func(s string) any { return any(s) }))
 	stmt, err := sqlair.Prepare(`
 SELECT &Key.key FROM model_config WHERE key IN ($S[:])
 `, sqlair.S{}, Key{})
@@ -177,10 +175,7 @@ func (st *State) UpdateModelConfig(
 		return errors.Trace(err)
 	}
 
-	removeAttrsSlice := make(sqlair.S, len(removeAttrs), len(removeAttrs))
-	for i, removeAttr := range removeAttrs {
-		removeAttrsSlice[i] = removeAttr
-	}
+	removeAttrsSlice := sqlair.S(transform.Slice(removeAttrs, func(s string) any { return any(s) }))
 	deleteStmt, err := sqlair.Prepare(`
 DELETE FROM model_config
 WHERE key IN ($S[:])


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Replace queries using `database.SliceToPlaceholder` with SQLair slice queries. The PR affects this change in domain/modelconfig/state.

Because all queries in each transaction need to be changed to SQLair queries the upsert query in `UpsertModelConfig` is changed from a bulk insert to a for loop of single row inserts. SQLair does not yet support bulk inserts but it is on the roadmap, this can be changed back once that feature is in. It is also an option to wait before making the switch to SQLair in modelconfig/state until bulk inserts are supported. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
`go test github.com/juju/juju/domain/modelconfig/state/... -gocheck.v`
<!-- Describe steps to verify that the change works. -->

## Documentation changes
N/A
<!-- How it affects user workflow (CLI or API). -->

