### PR TITLE
add dot-minikube interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,7 @@ apps:
       - dot-google
       - dot-kubernetes
       - dot-maas
+      - dot-minikube
       - dot-openstack
       - dot-oracle
       # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
@@ -524,6 +525,11 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.maasrc
+
+  dot-minikube:
+    interface: personal-files
+    read:
+      - $HOME/.minikube
 
   dot-oracle:
     interface: personal-files


### PR DESCRIPTION
Minikube creates its files in $HOME/.minikube, and the ".minikube" part is hard-coded, according to https://minikube.sigs.k8s.io/docs/handbook/config/#exclusive-environment-tunings. as a result, when running `juju clouds` on a machine with minikube installed, juju detects the minikube cloud but unable to access files in the .minikube folder due to the strict confinement.

A work around that I had to do was to set MINIKUBE_HOME to $HOME/.aws/.minikube which will be much simpler with a "dot-minikube" interface.

This PR is a very minor change that adds the dot-minikube interface

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2051154

