### PR TITLE
FailAction for ActionNotAvailable

### DIFF
--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -139,7 +139,7 @@ func (f *factory) NewAction(actionId string) (Operation, error) {
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, charmrunner.ErrActionNotAvailable
 	} else if params.IsCodeActionNotAvailable(err) {
-		return nil, charmrunner.ErrActionNotAvailable
+		return f.NewFailAction(actionId)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -243,9 +243,9 @@ func (s *FactorySuite) TestNewResignLeadershipString(c *gc.C) {
 
 func (s *FactorySuite) TestNewActionNotAvailable(c *gc.C) {
 	s.actionErr = &params.Error{Code: "action no longer available"}
-	rnr, err := s.factory.NewAction("666")
-	c.Assert(rnr, gc.IsNil)
+	op, err := s.factory.NewAction("666")
 	c.Assert(err, gc.Equals, charmrunner.ErrActionNotAvailable)
+	c.Check(op.String(), gc.Equals, "fail action "+someActionId)
 }
 
 func (s *FactorySuite) TestNewActionUnauthorised(c *gc.C) {


### PR DESCRIPTION
When we run "exec -u unit -- sudo reboot", it can't be completed as literally machine is rebooted.
After rebooting, any further command is not working and db.actionnotifications.find() show me the reboot action forever. This changes makes not available action fail. so uniter can take command further.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

https://bugs.launchpad.net/juju/+bug/2012861
