### PR TITLE
Support minikube env folder on juju snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,7 @@ apps:
       - dot-google
       - dot-kubernetes
       - dot-maas
+      - dot-minikube
       - dot-openstack
       - dot-oracle
       # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
@@ -178,6 +179,11 @@ plugs:
     read:
       - $HOME/.maasrc
 
+  dot-minikube:
+    interface: personal-files
+    read:
+      - $HOME/.minikube
+
   dot-oracle:
     interface: personal-files
     read:
@@ -187,3 +193,4 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.novarc
+


### PR DESCRIPTION
Adds dot-minikube plug to support minikube env folder in the home directory by default.


## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~


## Links


**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2051154

**Jira card:** JUJU-5352

