### PR TITLE
Add change_log_namespace entries for storage tables

### DIFF
--- a/domain/schema/changelog.go
+++ b/domain/schema/changelog.go
@@ -65,7 +65,7 @@ CREATE TABLE change_log_witness (
 }
 
 // changeLogTriggersForTable is a helper function to generate the necessary
-// triggers for a table to have it's crud operations tracked in the schemas
+// triggers for a table to have its CRUD operations tracked in the schema's
 // change_log table.
 func changeLogTriggersForTable(table, columnName string, namespaceID tableNamespaceID) func() schema.Patch {
 	return func() schema.Patch {

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -10,7 +10,7 @@ import (
 type tableNamespaceID int
 
 const (
-	tableExternalController tableNamespaceID = iota + 1
+	tableExternalController tableNamespaceID = iota
 	tableControllerNode
 	tableControllerConfig
 	tableModelMigrationStatus
@@ -54,12 +54,12 @@ func ControllerDDL() *schema.Schema {
 		userPermissionSchema,
 	}
 
-	schema := schema.New()
+	ctrlSchema := schema.New()
 	for _, fn := range patches {
-		schema.Add(fn())
+		ctrlSchema.Add(fn())
 	}
 
-	return schema
+	return ctrlSchema
 }
 
 func leaseSchema() schema.Patch {
@@ -118,17 +118,17 @@ func changeLogControllerNamespaces() schema.Patch {
 	// constants above.
 	return schema.MakePatch(`
 INSERT INTO change_log_namespace VALUES
-    (1, 'external_controller', 'external controller changes based on the UUID'),
-    (2, 'controller_node', 'controller node changes based on the controller ID'),
-    (3, 'controller_config', 'controller config changes based on the key'),
-    (4, 'model_migration_status', 'model migration status changes based on the UUID'),
-    (5, 'model_migration_minion_sync', 'model migration minion sync changes based on the UUID'),
-    (6, 'upgrade_info', 'upgrade info changes based on the UUID'),
-    (7, 'cloud', 'cloud changes based on the UUID'),
-    (8, 'cloud_credential', 'cloud credential changes based on the UUID'),
-    (9, 'autocert_cache', 'autocert cache changes based on the UUID'),
-    (10, 'upgrade_info_controller_node', 'upgrade info controller node changes based on the upgrade info UUID'),
-    (11, 'object_store_metadata_path', 'object store metadata path changes based on the path')
+    (0, 'external_controller', 'external controller changes based on the UUID'),
+    (1, 'controller_node', 'controller node changes based on the controller ID'),
+    (2, 'controller_config', 'controller config changes based on the key'),
+    (3, 'model_migration_status', 'model migration status changes based on the UUID'),
+    (4, 'model_migration_minion_sync', 'model migration minion sync changes based on the UUID'),
+    (5, 'upgrade_info', 'upgrade info changes based on the UUID'),
+    (6, 'cloud', 'cloud changes based on the UUID'),
+    (7, 'cloud_credential', 'cloud credential changes based on the UUID'),
+    (8, 'autocert_cache', 'autocert cache changes based on the UUID'),
+    (9, 'upgrade_info_controller_node', 'upgrade info controller node changes based on the upgrade info UUID'),
+    (10, 'object_store_metadata_path', 'object store metadata path changes based on the path')
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	tableModelConfig tableNamespaceID = iota + 1
+	tableModelConfig tableNamespaceID = iota
 	tableModelObjectStoreMetadata
 	tableBlockDeviceMachine
 	tableStorageAttachment
@@ -55,11 +55,11 @@ func ModelDDL() *schema.Schema {
 		annotationSchemaForTable("storage_filesystem"),
 	}
 
-	schema := schema.New()
+	modelSchema := schema.New()
 	for _, fn := range patches {
-		schema.Add(fn())
+		modelSchema.Add(fn())
 	}
-	return schema
+	return modelSchema
 }
 
 func annotationModel() schema.Patch {
@@ -106,9 +106,15 @@ func changeLogModelNamespace() schema.Patch {
 	// constants above.
 	return schema.MakePatch(`
 INSERT INTO change_log_namespace VALUES
-    (1, 'model_config', 'model config changes based on config key'),
-    (2, 'object_store_metadata_path', 'object store metadata path changes based on the path'),
-    (3, 'block_device', 'block device changes based on the machine uuid');
+    (0, 'model_config', 'Model configuration changes based on key'),
+    (1, 'object_store_metadata_path', 'Object store metadata path changes based on the path'),
+    (2, 'block_device', 'Block device changes based on the machine UUID'),
+    (3, 'storage_attachment', 'Storage attachment changes based on the storage instance UUID'),
+    (4, 'storage_filesystem', 'File system changes based on UUID'),
+    (5, 'storage_filesystem_attachment', 'File system attachment changes based on UUID'),
+    (6, 'storage_volume', 'Storage volume changes based on UUID'),
+    (7, 'storage_volume_attachment', 'Volume attachment changes based on UUID'),
+    (8, 'storage_volume_attachment_plan', 'Volume attachment plan changes based on UUID');
 `)
 }
 


### PR DESCRIPTION
This corrects an omission from #16764. 

It simply adds `change_log_namespace` entries for the new storage tables.

