### PR TITLE
Merge 3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,7 +591,7 @@ image-check: $(image_check_prereq)
 
 .PHONY: image-check-build
 image-check-build:
-	CLIENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" AGENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" make build
+	CLIENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" AGENT_PACKAGE_PLATFORMS="$(OCI_IMAGE_PLATFORMS)" make go-build
 
 .PHONY: image-check-build-skip
 image-check-build-skip:

--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -150,7 +150,7 @@ func (c *Client) GetSecretAccessScope(uri *coresecrets.URI, appToken string, uni
 }
 
 // GetRemoteSecretContentInfo gets secret content from a cross model controller.
-func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, refresh, peek bool, appToken string, unitId int, macs macaroon.Slice) (
+func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, refresh, peek bool, sourceControllerUUID, appToken string, unitId int, macs macaroon.Slice) (
 	*secrets.ContentParams, *provider.ModelBackendConfig, int, bool, error,
 ) {
 	if uri == nil {
@@ -158,13 +158,14 @@ func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, 
 	}
 
 	arg := params.GetRemoteSecretContentArg{
-		ApplicationToken: appToken,
-		UnitId:           unitId,
-		URI:              uri.String(),
-		Refresh:          refresh,
-		Peek:             peek,
-		Macaroons:        macs,
-		BakeryVersion:    bakery.LatestVersion,
+		SourceControllerUUID: sourceControllerUUID,
+		ApplicationToken:     appToken,
+		UnitId:               unitId,
+		URI:                  uri.String(),
+		Refresh:              refresh,
+		Peek:                 peek,
+		Macaroons:            macs,
+		BakeryVersion:        bakery.LatestVersion,
 	}
 	if revision > 0 {
 		arg.Revision = &revision

--- a/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -49,14 +49,15 @@ func (s *CrossControllerSuite) TestGetRemoteSecretContentInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "GetSecretContentInfo")
 		c.Check(arg, jc.DeepEquals, params.GetRemoteSecretContentArgs{
 			Args: []params.GetRemoteSecretContentArg{{
-				ApplicationToken: "token",
-				UnitId:           666,
-				Revision:         ptr(665),
-				Macaroons:        macs,
-				BakeryVersion:    3,
-				URI:              uri.String(),
-				Refresh:          true,
-				Peek:             true,
+				SourceControllerUUID: coretesting.ControllerTag.Id(),
+				ApplicationToken:     "token",
+				UnitId:               666,
+				Revision:             ptr(665),
+				Macaroons:            macs,
+				BakeryVersion:        3,
+				URI:                  uri.String(),
+				Refresh:              true,
+				Peek:                 true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretContentResults{})
@@ -84,7 +85,7 @@ func (s *CrossControllerSuite) TestGetRemoteSecretContentInfo(c *gc.C) {
 		return nil
 	})
 	client := crossmodelsecrets.NewClient(apiCaller)
-	content, backend, latestRevision, draining, err := client.GetRemoteSecretContentInfo(uri, 665, true, true, "token", 666, macs)
+	content, backend, latestRevision, draining, err := client.GetRemoteSecretContentInfo(uri, 665, true, true, coretesting.ControllerTag.Id(), "token", 666, macs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(latestRevision, gc.Equals, 666)
 	c.Assert(draining, jc.IsTrue)
@@ -118,7 +119,7 @@ func (s *CrossControllerSuite) TestControllerInfoError(c *gc.C) {
 		return nil
 	})
 	client := crossmodelsecrets.NewClient(apiCaller)
-	content, backend, _, _, err := client.GetRemoteSecretContentInfo(coresecrets.NewURI(), 665, false, false, "token", 666, nil)
+	content, backend, _, _, err := client.GetRemoteSecretContentInfo(coresecrets.NewURI(), 665, false, false, coretesting.ControllerTag.Id(), "token", 666, nil)
 	c.Assert(err, gc.ErrorMatches, "attempt count exceeded: boom")
 	c.Assert(content, gc.IsNil)
 	c.Assert(backend, gc.IsNil)

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -144,7 +144,7 @@ func DrainBackendConfigInfo(backendID string, model Model, authTag names.Tag, le
 	if !ok {
 		return nil, errors.Errorf("missing secret backend %q", backendID)
 	}
-	backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, true)
+	backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, true, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -160,7 +160,7 @@ func DrainBackendConfigInfo(backendID string, model Model, authTag names.Tag, le
 // owned by the agent, and read only those secrets shared with the agent.
 // The result includes config for all relevant backends, including the id
 // of the current active backend.
-func BackendConfigInfo(model Model, backendIDs []string, wantAll bool, authTag names.Tag, leadershipChecker leadership.Checker) (*provider.ModelBackendConfigInfo, error) {
+func BackendConfigInfo(model Model, sameController bool, backendIDs []string, wantAll bool, authTag names.Tag, leadershipChecker leadership.Checker) (*provider.ModelBackendConfigInfo, error) {
 	adminModelCfg, err := AdminBackendConfigInfo(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting configured secrets providers")
@@ -183,7 +183,7 @@ func BackendConfigInfo(model Model, backendIDs []string, wantAll bool, authTag n
 		if !ok {
 			return nil, errors.Errorf("missing secret backend %q", backendID)
 		}
-		backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, false)
+		backendCfg, err := backendConfigInfo(model, backendID, &cfg, authTag, leadershipChecker, sameController, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -194,7 +194,7 @@ func BackendConfigInfo(model Model, backendIDs []string, wantAll bool, authTag n
 
 func backendConfigInfo(
 	model Model, backendID string, adminCfg *provider.ModelBackendConfig,
-	authTag names.Tag, leadershipChecker leadership.Checker, forDrain bool,
+	authTag names.Tag, leadershipChecker leadership.Checker, sameController, forDrain bool,
 ) (*provider.ModelBackendConfig, error) {
 	p, err := GetProvider(adminCfg.BackendType)
 	if err != nil {
@@ -261,7 +261,7 @@ func backendConfigInfo(
 	}
 
 	logger.Debugf("secrets for %v:\nowned: %v\nconsumed:%v", authTag.String(), ownedRevisions, readRevisions)
-	cfg, err := p.RestrictedConfig(adminCfg, forDrain, authTag, ownedRevisions[backendID], readRevisions[backendID])
+	cfg, err := p.RestrictedConfig(adminCfg, sameController, forDrain, authTag, ownedRevisions[backendID], readRevisions[backendID])
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -291,9 +291,9 @@ func (s *secretsSuite) assertBackendConfigInfoLeaderUnit(c *gc.C, wanted []strin
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(&adminCfg, true, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
-	info, err := secrets.BackendConfigInfo(model, wanted, false, unitTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, true, wanted, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -402,9 +402,9 @@ func (s *secretsSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-3"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(&adminCfg, true, false, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
-	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, false, unitTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, true, []string{"backend-id"}, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -513,7 +513,7 @@ func (s *secretsSuite) TestDrainBackendConfigInfo(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-3"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, true, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(&adminCfg, true, true, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
 	info, err := secrets.DrainBackendConfigInfo("backend-id", model, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
@@ -603,9 +603,9 @@ func (s *secretsSuite) TestBackendConfigInfoAppTagLogin(c *gc.C) {
 				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
 			}}, nil),
 	)
-	p.EXPECT().RestrictedConfig(&adminCfg, false, appTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
+	p.EXPECT().RestrictedConfig(&adminCfg, true, false, appTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil)
 
-	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, false, appTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, true, []string{"backend-id"}, false, appTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -657,7 +657,7 @@ func (s *secretsSuite) TestBackendConfigInfoFailedInvalidAuthTag(c *gc.C) {
 		p.EXPECT().Initialise(gomock.Any()).Return(nil),
 	)
 
-	_, err := secrets.BackendConfigInfo(model, []string{"some-id"}, false, badTag, leadershipChecker)
+	_, err := secrets.BackendConfigInfo(model, true, []string{"some-id"}, false, badTag, leadershipChecker)
 	c.Assert(err, gc.ErrorMatches, `login as "user-foo" not supported`)
 }
 

--- a/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
@@ -112,9 +112,9 @@ func (m *MockCrossModelSecretsClient) EXPECT() *MockCrossModelSecretsClientMockR
 }
 
 // GetRemoteSecretContentInfo mocks base method.
-func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.URI, arg1 int, arg2, arg3 bool, arg4 string, arg5 int, arg6 macaroon.Slice) (*secrets0.ContentParams, *provider.ModelBackendConfig, int, bool, error) {
+func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.URI, arg1 int, arg2, arg3 bool, arg4, arg5 string, arg6 int, arg7 macaroon.Slice) (*secrets0.ContentParams, *provider.ModelBackendConfig, int, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRemoteSecretContentInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "GetRemoteSecretContentInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(*secrets0.ContentParams)
 	ret1, _ := ret[1].(*provider.ModelBackendConfig)
 	ret2, _ := ret[2].(int)
@@ -124,9 +124,9 @@ func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.U
 }
 
 // GetRemoteSecretContentInfo indicates an expected call of GetRemoteSecretContentInfo.
-func (mr *MockCrossModelSecretsClientMockRecorder) GetRemoteSecretContentInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockCrossModelSecretsClientMockRecorder) GetRemoteSecretContentInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteSecretContentInfo", reflect.TypeOf((*MockCrossModelSecretsClient)(nil).GetRemoteSecretContentInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteSecretContentInfo", reflect.TypeOf((*MockCrossModelSecretsClient)(nil).GetRemoteSecretContentInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // GetSecretAccessScope mocks base method.

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -98,18 +98,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -64,6 +64,7 @@ func NewTestAPI(
 		remoteClientGetter:  remoteClientGetter,
 		crossModelState:     crossModelState,
 		clock:               clock,
+		controllerUUID:      coretesting.ControllerTag.Id(),
 		modelUUID:           coretesting.ModelTag.Id(),
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -58,7 +58,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 	secretBackendConfigGetter := func(backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
-		return secrets.BackendConfigInfo(secrets.SecretsModel(model), backendIDs, wantAll, context.Auth().GetAuthTag(), leadershipChecker)
+		return secrets.BackendConfigInfo(secrets.SecretsModel(model), true, backendIDs, wantAll, context.Auth().GetAuthTag(), leadershipChecker)
 	}
 	secretBackendAdminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
 		return secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
@@ -106,6 +106,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		secretsTriggers:     context.State(),
 		secretsConsumer:     context.State(),
 		clock:               clock.WallClock,
+		controllerUUID:      context.State().ControllerUUID(),
 		modelUUID:           context.State().ModelUUID(),
 		backendConfigGetter: secretBackendConfigGetter,
 		adminConfigGetter:   secretBackendAdminConfigGetter,

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -30,7 +30,7 @@ var logger = loggo.GetLoggerWithLabels("juju.apiserver.secretsmanager", corelogg
 
 // CrossModelSecretsClient gets secret content from a cross model controller.
 type CrossModelSecretsClient interface {
-	GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, refresh, peek bool, appToken string, unitId int, macs macaroon.Slice) (*secrets.ContentParams, *secretsprovider.ModelBackendConfig, int, bool, error)
+	GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, refresh, peek bool, sourceControllerUUID, appToken string, unitId int, macs macaroon.Slice) (*secrets.ContentParams, *secretsprovider.ModelBackendConfig, int, bool, error)
 	GetSecretAccessScope(uri *coresecrets.URI, appToken string, unitId int) (string, error)
 }
 
@@ -44,6 +44,7 @@ type SecretsManagerAPI struct {
 	secretsConsumer   SecretsConsumer
 	authTag           names.Tag
 	clock             clock.Clock
+	controllerUUID    string
 	modelUUID         string
 
 	backendConfigGetter commonsecrets.BackendConfigGetter
@@ -518,7 +519,7 @@ func (s *SecretsManagerAPI) getRemoteSecretContent(uri *coresecrets.URI, refresh
 	}
 
 	macs := macaroon.Slice{mac}
-	content, backend, latestRevision, draining, err := extClient.GetRemoteSecretContentInfo(uri, wantRevision, refresh, peek, token, unitId, macs)
+	content, backend, latestRevision, draining, err := extClient.GetRemoteSecretContentInfo(uri, wantRevision, refresh, peek, s.controllerUUID, token, unitId, macs)
 	if err != nil {
 		return nil, nil, false, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1303,7 +1303,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, coretesting.ControllerTag.Id(), "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1369,7 +1369,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, false, false, coretesting.ControllerTag.Id(), "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1440,7 +1440,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, true, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 665, true, false, coretesting.ControllerTag.Id(), "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",
@@ -1509,7 +1509,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
 	s.crossModelState.EXPECT().GetMacaroon(scopeTag).Return(mac, nil)
 
-	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 0, true, false, "token", 0, macaroon.Slice{mac}).Return(
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(uri, 0, true, false, coretesting.ControllerTag.Id(), "token", 0, macaroon.Slice{mac}).Return(
 		&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id",

--- a/apiserver/facades/client/modelconfig/mocks/secretsprovider.go
+++ b/apiserver/facades/client/modelconfig/mocks/secretsprovider.go
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secretbackends/mocks/provider_mock.go
+++ b/apiserver/facades/client/secretbackends/mocks/provider_mock.go
@@ -100,18 +100,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secrets/mocks/secretsbackend.go
+++ b/apiserver/facades/client/secrets/mocks/secretsbackend.go
@@ -181,18 +181,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/client/secrets/register.go
+++ b/apiserver/facades/client/secrets/register.go
@@ -53,7 +53,7 @@ func newSecretsAPI(context facade.Context) (*SecretsAPI, error) {
 	backendConfigGetterForUserSecretsWrite := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
 		// User secrets are owned by the model.
 		authTag := model.ModelTag()
-		return secrets.BackendConfigInfo(secrets.SecretsModel(model), []string{backendID}, false, authTag, leadershipChecker)
+		return secrets.BackendConfigInfo(secrets.SecretsModel(model), true, []string{backendID}, false, authTag, leadershipChecker)
 	}
 
 	backendGetter := func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -106,7 +106,8 @@ func (s *CrossModelSecretsSuite) setup(c *gc.C) *gomock.Controller {
 	secretsStateGetter := func(modelUUID string) (crossmodelsecrets.SecretsState, crossmodelsecrets.SecretsConsumer, func() bool, error) {
 		return s.secretsState, s.secretsConsumer, func() bool { return false }, nil
 	}
-	backendConfigGetter := func(modelUUID, backendID string, consumer names.Tag) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(modelUUID string, sameController bool, backendID string, consumer names.Tag) (*provider.ModelBackendConfigInfo, error) {
+		c.Assert(sameController, jc.IsFalse)
 		c.Assert(backendID, gc.Equals, "backend-id")
 		c.Assert(consumer.String(), gc.Equals, "unit-remote-app-666")
 		return &provider.ModelBackendConfigInfo{
@@ -128,6 +129,7 @@ func (s *CrossModelSecretsSuite) setup(c *gc.C) *gomock.Controller {
 	s.facade, err = crossmodelsecrets.NewCrossModelSecretsAPI(
 		s.resources,
 		s.authContext,
+		coretesting.ControllerTag.Id(),
 		coretesting.ModelTag.Id(),
 		secretsStateGetter,
 		backendConfigGetter,
@@ -201,23 +203,25 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 
 	args := params.GetRemoteSecretContentArgs{
 		Args: []params.GetRemoteSecretContentArg{{
-			ApplicationToken: "token",
-			UnitId:           666,
-			BakeryVersion:    3,
-			Macaroons:        macaroon.Slice{mac.M()},
-			URI:              uri.String(),
-			Refresh:          true,
+			SourceControllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f666",
+			ApplicationToken:     "token",
+			UnitId:               666,
+			BakeryVersion:        3,
+			Macaroons:            macaroon.Slice{mac.M()},
+			URI:                  uri.String(),
+			Refresh:              true,
 		}, {
 			URI: coresecrets.NewURI().String(),
 		}, {
 			URI: uri.String(),
 		}, {
-			ApplicationToken: "token2",
-			UnitId:           666,
-			BakeryVersion:    3,
-			Macaroons:        macaroon.Slice{mac.M()},
-			URI:              uri.String(),
-			Refresh:          true,
+			SourceControllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f666",
+			ApplicationToken:     "token2",
+			UnitId:               666,
+			BakeryVersion:        3,
+			Macaroons:            macaroon.Slice{mac.M()},
+			URI:                  uri.String(),
+			Refresh:              true,
 		}},
 	}
 	results, err := s.facade.GetSecretContentInfo(args)

--- a/apiserver/facades/controller/secretbackendmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/controller/secretbackendmanager/mocks/secretsprovider.go
@@ -98,18 +98,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/controller/usersecrets/mocks/secretsbackend.go
+++ b/apiserver/facades/controller/usersecrets/mocks/secretsbackend.go
@@ -181,18 +181,18 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1 bool, arg2 names.Tag, arg3, arg4 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 *provider.ModelBackendConfig, arg1, arg2 bool, arg3 names.Tag, arg4, arg5 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*provider.BackendConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RestrictedConfig indicates an expected call of RestrictedConfig.
-func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockSecretBackendProviderMockRecorder) RestrictedConfig(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictedConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).RestrictedConfig), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Type mocks base method.

--- a/apiserver/facades/controller/usersecretsdrain/register.go
+++ b/apiserver/facades/controller/usersecretsdrain/register.go
@@ -50,7 +50,7 @@ func newUserSecretsDrainAPI(context facade.Context) (*SecretsDrainAPI, error) {
 	}
 
 	secretBackendConfigGetter := func(backendIDs []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
-		return commonsecrets.BackendConfigInfo(commonsecrets.SecretsModel(model), backendIDs, wantAll, authTag, leadershipChecker)
+		return commonsecrets.BackendConfigInfo(commonsecrets.SecretsModel(model), true, backendIDs, wantAll, authTag, leadershipChecker)
 	}
 	secretBackendDrainConfigGetter := func(backendID string) (*provider.ModelBackendConfigInfo, error) {
 		return commonsecrets.DrainBackendConfigInfo(backendID, commonsecrets.SecretsModel(model), authTag, leadershipChecker)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21505,6 +21505,9 @@
                         "revision": {
                             "type": "integer"
                         },
+                        "source-controller-uuid": {
+                            "type": "string"
+                        },
                         "unit-id": {
                             "type": "integer"
                         },
@@ -21514,6 +21517,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "source-controller-uuid",
                         "application-token",
                         "unit-id",
                         "uri"

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -467,6 +467,9 @@ type GetRemoteSecretContentArgs struct {
 
 // GetRemoteSecretContentArg holds ares for fetching a remote secret.
 type GetRemoteSecretContentArg struct {
+	// SourceControllerUUID is the UUID of the controller making this API call.
+	SourceControllerUUID string `json:"source-controller-uuid"`
+
 	// ApplicationToken is the application token on the remote model.
 	ApplicationToken string `json:"application-token"`
 

--- a/secrets/provider/juju/provider.go
+++ b/secrets/provider/juju/provider.go
@@ -52,7 +52,7 @@ func BuiltInConfig() provider.BackendConfig {
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p jujuProvider) RestrictedConfig(
-	adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	adminCfg *provider.ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	return &provider.BackendConfig{
 		BackendType: BackendType,

--- a/secrets/provider/kubernetes/provider.go
+++ b/secrets/provider/kubernetes/provider.go
@@ -130,7 +130,7 @@ func IsBuiltInName(backendName string) bool {
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p k8sProvider) RestrictedConfig(
-	adminCfg *provider.ModelBackendConfig, forDrain bool, consumer names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	adminCfg *provider.ModelBackendConfig, sameController, forDrain bool, consumer names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	logger.Tracef("getting k8s backend config for %q, owned %v, read %v", consumer, owned, read)
 
@@ -152,7 +152,7 @@ func (p k8sProvider) RestrictedConfig(
 	}
 	cloudSpec.Credential = &cred
 
-	if cloudSpec.IsControllerCloud {
+	if sameController && cloudSpec.IsControllerCloud {
 		// The cloudspec used for controller has a fake endpoint (address and port)
 		// because we ignore the endpoint and load the in-cluster credential instead.
 		// So we have to clean up the endpoint here for uniter to use.
@@ -163,6 +163,8 @@ func (p k8sProvider) RestrictedConfig(
 			logger.Tracef("patching endpoint to %q", cloudSpec.Endpoint)
 			cloudSpec.IsControllerCloud = false
 		}
+	} else {
+		cloudSpec.IsControllerCloud = false
 	}
 	return cloudSpecToBackendConfig(cloudSpec)
 }

--- a/secrets/provider/kubernetes/provider_test.go
+++ b/secrets/provider/kubernetes/provider_test.go
@@ -32,7 +32,7 @@ type providerSuite struct {
 
 var _ = gc.Suite(&providerSuite{})
 
-func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud bool) {
+func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud, sameController bool) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -64,7 +64,7 @@ func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud
 		},
 	}
 
-	backendCfg, err := p.RestrictedConfig(adminCfg, false, tag,
+	backendCfg, err := p.RestrictedConfig(adminCfg, sameController, false, tag,
 		provider.SecretRevisions{"owned-a": set.NewStrings("owned-rev-1")},
 		provider.SecretRevisions{"read-b": set.NewStrings("read-rev-1", "read-rev-2")},
 	)
@@ -78,19 +78,25 @@ func (s *providerSuite) assertRestrictedConfigWithTag(c *gc.C, isControllerCloud
 			"is-controller-cloud": isControllerCloud,
 		},
 	}
-	if isControllerCloud {
+	if isControllerCloud && sameController {
 		expected.Config["endpoint"] = "https://8.6.8.6:8888"
+		expected.Config["is-controller-cloud"] = false
+	} else {
 		expected.Config["is-controller-cloud"] = false
 	}
 	c.Assert(backendCfg, jc.DeepEquals, expected)
 }
 
 func (s *providerSuite) TestRestrictedConfigWithTag(c *gc.C) {
-	s.assertRestrictedConfigWithTag(c, false)
+	s.assertRestrictedConfigWithTag(c, false, false)
 }
 
 func (s *providerSuite) TestRestrictedConfigWithTagWithControllerCloud(c *gc.C) {
-	s.assertRestrictedConfigWithTag(c, true)
+	s.assertRestrictedConfigWithTag(c, true, true)
+}
+
+func (s *providerSuite) TestRestrictedConfigWithTagWithControllerCloudDifferentController(c *gc.C) {
+	s.assertRestrictedConfigWithTag(c, true, false)
 }
 
 func (s *providerSuite) TestCleanupSecrets(c *gc.C) {

--- a/secrets/provider/provider.go
+++ b/secrets/provider/provider.go
@@ -83,7 +83,7 @@ type SecretBackendProvider interface {
 	// RestrictedConfig returns the config needed to create a
 	// secrets backend client restricted to manage the specified
 	// owned secrets and read shared secrets for the given entity tag.
-	RestrictedConfig(adminCfg *ModelBackendConfig, forDrain bool, tag names.Tag, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
+	RestrictedConfig(adminCfg *ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
 
 	// NewBackend creates a secrets backend client using the
 	// specified model config.

--- a/secrets/provider/vault/provider.go
+++ b/secrets/provider/vault/provider.go
@@ -183,7 +183,7 @@ func (p vaultProvider) CleanupSecrets(cfg *provider.ModelBackendConfig, tag name
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p vaultProvider) RestrictedConfig(
-	adminCfg *provider.ModelBackendConfig, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	adminCfg *provider.ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	adminUser := tag == nil
 	// Get an admin backend client so we can set up the policies.

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -101,7 +101,7 @@ func (s *providerSuite) TestBackendConfigBadClient(c *gc.C) {
 			},
 		},
 	}
-	_, err = p.RestrictedConfig(adminCfg, false, nil, nil, nil)
+	_, err = p.RestrictedConfig(adminCfg, true, false, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -151,7 +151,7 @@ func (s *providerSuite) TestBackendConfigAdmin(c *gc.C) {
 			},
 		},
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, false, nil, nil, nil)
+	cfg, err := p.RestrictedConfig(adminCfg, true, false, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -226,7 +226,7 @@ func (s *providerSuite) TestBackendConfigNonAdmin(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, false, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+	cfg, err := p.RestrictedConfig(adminCfg, true, false, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -311,7 +311,7 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(adminCfg, true, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+	cfg, err := p.RestrictedConfig(adminCfg, true, true, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }


### PR DESCRIPTION
Merge 3.1

https://github.com/juju/juju/pull/16827 [from wallyworld/fix-cmr-k8s-secrets](https://github.com/juju/juju/commit/23aaaf083bbbf8163c49ce770e5c27d1e1d0bdd1)

All except one conflict were go mocks which were regenerated. The  remaining one was trivial.

```
# Conflicts:
#       apiserver/common/secrets/mocks/provider_mock.go
#       apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
#       apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
#       apiserver/facades/agent/secretsmanager/register.go
#       apiserver/facades/client/modelconfig/mocks/secretsprovider.go
#       apiserver/facades/client/secretbackends/mocks/provider_mock.go
#       apiserver/facades/controller/secretbackendmanager/mocks/secretsprovider.go
#       apiserver/facades/controller/usersecrets/mocks/secretsbackend.go
#
```