### PR TITLE
Ensure terraform juju smoke workflow does not run on main prs.

### DIFF
--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -4,6 +4,7 @@ on:
     branches: [2.9, 3.*]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches: [2.9, 3.*]
     paths:
       - '**.go'
       - 'go.mod'


### PR DESCRIPTION
Should have put the list of branches to run on in push AND pull_request. This test is currently not expected to succeed against juju 4.x as the terraform provider for juju does not support it today.
