### PR TITLE
Cherry pick forward s3 migration endpoint

### DIFF
--- a/api/controller/migrationtarget/client.go
+++ b/api/controller/migrationtarget/client.go
@@ -9,10 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
-	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -114,28 +112,24 @@ func (c *Client) Activate(modelUUID string, sourceInfo coremigration.SourceContr
 
 // UploadCharm sends the content to the API server using an HTTP post in order
 // to add the charm binary to the model specified.
-func (c *Client) UploadCharm(ctx context.Context, modelUUID string, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
-	args := url.Values{}
-	args.Add("name", curl.Name)
-	args.Add("schema", curl.Schema)
-	args.Add("arch", curl.Architecture)
-	args.Add("series", curl.Series)
-	args.Add("revision", strconv.Itoa(curl.Revision))
-
-	apiURI := url.URL{
-		Path:     "/migrate/charms",
-		RawQuery: args.Encode(),
-	}
+func (c *Client) UploadCharm(ctx context.Context, modelUUID string, curl string, charmRef string, content io.ReadSeeker) (string, error) {
+	apiURI := url.URL{Path: fmt.Sprintf("/migrate/charms/%s", charmRef)}
 
 	contentType := "application/zip"
-	var resp params.CharmsResponse
-	if err := c.httpPost(ctx, modelUUID, content, apiURI.String(), contentType, &resp); err != nil {
-		return nil, errors.Trace(err)
+	resp := &http.Response{}
+	// Add Juju-Curl header to Put operation. Juju 3.4 apiserver
+	// expects this header to be present, since we still need some
+	// of the values from the charm url.
+	headers := map[string]string{
+		"Juju-Curl": curl,
+	}
+	if err := c.httpPut(ctx, modelUUID, content, apiURI.String(), contentType, headers, &resp); err != nil {
+		return "", errors.Trace(err)
 	}
 
-	respCurl, err := charm.ParseURL(resp.CharmURL)
-	if err != nil {
-		return nil, errors.Annotatef(err, "bad charm URL in response")
+	respCurl := resp.Header.Get("Juju-Curl")
+	if respCurl == "" {
+		return "", errors.Errorf("response returned no charm URL")
 	}
 	return respCurl, nil
 }
@@ -146,7 +140,7 @@ func (c *Client) UploadTools(ctx context.Context, modelUUID string, r io.ReadSee
 	endpoint := fmt.Sprintf("/migrate/tools?binaryVersion=%s", vers)
 	contentType := "application/x-tar-gz"
 	var resp params.ToolsResult
-	if err := c.httpPost(ctx, modelUUID, r, endpoint, contentType, &resp); err != nil {
+	if err := c.httpPost(ctx, modelUUID, r, endpoint, contentType, nil, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return resp.ToolsList, nil
@@ -179,7 +173,7 @@ func (c *Client) SetUnitResource(ctx context.Context, modelUUID, unit string, re
 func (c *Client) resourcePost(ctx context.Context, modelUUID string, args url.Values, r io.ReadSeeker) error {
 	uri := "/migrate/resources?" + args.Encode()
 	contentType := "application/octet-stream"
-	err := c.httpPost(ctx, modelUUID, r, uri, contentType, nil)
+	err := c.httpPost(ctx, modelUUID, r, uri, contentType, nil, nil)
 	return errors.Trace(err)
 }
 
@@ -202,13 +196,24 @@ func makeResourceArgs(res resources.Resource) url.Values {
 	return args
 }
 
-func (c *Client) httpPost(ctx context.Context, modelUUID string, content io.ReadSeeker, endpoint, contentType string, response interface{}) error {
-	req, err := http.NewRequest("POST", endpoint, content)
+func (c *Client) httpPost(ctx context.Context, modelUUID string, content io.ReadSeeker, endpoint, contentType string, headers map[string]string, response interface{}) error {
+	return c.http(ctx, "POST", modelUUID, content, endpoint, contentType, headers, response)
+}
+
+func (c *Client) httpPut(ctx context.Context, modelUUID string, content io.ReadSeeker, endpoint, contentType string, headers map[string]string, response interface{}) error {
+	return c.http(ctx, "PUT", modelUUID, content, endpoint, contentType, headers, response)
+}
+
+func (c *Client) http(ctx context.Context, method, modelUUID string, content io.ReadSeeker, endpoint, contentType string, headers map[string]string, response interface{}) error {
+	req, err := http.NewRequest(method, endpoint, content)
 	if err != nil {
 		return errors.Annotate(err, "cannot create upload request")
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(params.MigrationModelHTTPHeader, modelUUID)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 
 	// The returned httpClient sets the base url to the controller api root
 	httpClient, err := c.httpRootClientFactory()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -847,6 +847,11 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		PostHandler: migrateCharmsHandler.ServePost,
 		GetHandler:  migrateCharmsHandler.ServeUnsupported,
 	}
+	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
+		ctxt:                httpCtxt,
+		objectStoreGetter:   srv.shared.objectStoreGetter,
+		LegacyCharmsHandler: migrateCharmsHTTPHandler,
+	}
 	migrateToolsUploadHandler := &toolsUploadHandler{
 		ctxt:          httpCtxt,
 		stateAuthFunc: httpCtxt.stateForMigrationImporting,
@@ -930,8 +935,13 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:    backupHandler,
 		authorizer: controllerAdminAuthorizer,
 	}, {
+		// Legacy migration endpoint. Used by Juju 3.3 and prior
 		pattern:    "/migrate/charms",
 		handler:    migrateCharmsHTTPHandler,
+		authorizer: controllerAdminAuthorizer,
+	}, {
+		pattern:    "/migrate/charms/:object",
+		handler:    migrateObjectsCharmsHTTPHandler,
 		authorizer: controllerAdminAuthorizer,
 	}, {
 		pattern:    "/migrate/tools",

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -5,6 +5,9 @@ package migration
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -159,7 +162,7 @@ type CharmDownloader interface {
 // CharmUploader defines a single method that is used to upload a
 // charm to the target controller in a migration.
 type CharmUploader interface {
-	UploadCharm(context.Context, *charm.URL, io.ReadSeeker) (*charm.URL, error)
+	UploadCharm(ctx context.Context, charmURL string, charmRef string, content io.ReadSeeker) (string, error)
 }
 
 // ToolsDownloader defines a single method that is used to download
@@ -274,6 +277,19 @@ func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err er
 	return tempFile, rmTempFile, nil
 }
 
+func hashArchive(archive io.ReadSeeker) (string, error) {
+	hash := sha256.New()
+	_, err := io.Copy(hash, archive)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	_, err = archive.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return hex.EncodeToString(hash.Sum(nil))[0:7], nil
+}
+
 func uploadCharms(ctx context.Context, config UploadBinariesConfig) error {
 	// It is critical that charms are uploaded in ascending charm URL
 	// order so that charm revisions end up the same in the target as
@@ -298,11 +314,17 @@ func uploadCharms(ctx context.Context, config UploadBinariesConfig) error {
 		if err != nil {
 			return errors.Annotate(err, "bad charm URL")
 		}
-		if usedCurl, err := config.CharmUploader.UploadCharm(ctx, curl, content); err != nil {
+		hash, err := hashArchive(content)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		charmRef := fmt.Sprintf("%s-%s", curl.Name, hash)
+
+		if usedCurl, err := config.CharmUploader.UploadCharm(ctx, charmURL, charmRef, content); err != nil {
 			return errors.Annotate(err, "cannot upload charm")
-		} else if usedCurl.String() != curl.String() {
+		} else if usedCurl != charmURL {
 			// The target controller shouldn't assign a different charm URL.
-			return errors.Errorf("charm %s unexpectedly assigned %s", curl, usedCurl)
+			return errors.Errorf("charm %s unexpectedly assigned %s", charmURL, usedCurl)
 		}
 	}
 	return nil

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -202,14 +202,21 @@ func (s *ImportSuite) TestBinariesMigration(c *gc.C) {
 	err := migration.UploadBinaries(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedCharms := []string{
+	expectedCurls := []string{
 		// Note ordering.
 		"ch:trusty/postgresql-42",
 		"local:trusty/magic-2",
 		"local:trusty/magic-10",
 	}
-	c.Assert(downloader.charms, jc.DeepEquals, expectedCharms)
-	c.Assert(uploader.charms, jc.DeepEquals, expectedCharms)
+	c.Assert(downloader.curls, jc.DeepEquals, expectedCurls)
+	c.Assert(uploader.curls, jc.DeepEquals, expectedCurls)
+
+	expectedRefs := []string{
+		"postgresql-a77196f",
+		"magic-d348864",
+		"magic-5f44d22",
+	}
+	c.Assert(uploader.charmRefs, jc.DeepEquals, expectedRefs)
 
 	c.Assert(downloader.uris, jc.SameContents, []string{
 		"/tools/0",
@@ -245,7 +252,7 @@ func (s *ImportSuite) TestWrongCharmURLAssigned(c *gc.C) {
 	}
 	err := migration.UploadBinaries(context.Background(), config)
 	c.Assert(err, gc.ErrorMatches,
-		"cannot upload charms: charm local:foo/bar-2 unexpectedly assigned local:foo/bar-1")
+		"cannot upload charms: charm local:foo/bar-2 unexpectedly assigned local:foo/bar-100")
 }
 
 func (s *ImportSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -271,13 +278,13 @@ func (i *fakeImporter) Import(model description.Model, controllerConfig controll
 }
 
 type fakeDownloader struct {
-	charms    []string
+	curls     []string
 	uris      []string
 	resources []string
 }
 
 func (d *fakeDownloader) OpenCharm(_ context.Context, curl string) (io.ReadCloser, error) {
-	d.charms = append(d.charms, curl)
+	d.curls = append(d.curls, curl)
 	// Return the charm URL string as the fake charm content
 	return io.NopCloser(bytes.NewReader([]byte(curl + " content"))), nil
 }
@@ -299,7 +306,8 @@ func (d *fakeDownloader) OpenResource(_ context.Context, app, name string) (io.R
 
 type fakeUploader struct {
 	tools            map[version.Binary]string
-	charms           []string
+	curls            []string
+	charmRefs        []string
 	resources        map[string]string
 	unitResources    []string
 	reassignCharmURL bool
@@ -314,21 +322,22 @@ func (f *fakeUploader) UploadTools(_ context.Context, r io.ReadSeeker, v version
 	return tools.List{&tools.Tools{Version: v}}, nil
 }
 
-func (f *fakeUploader) UploadCharm(_ context.Context, u *charm.URL, r io.ReadSeeker) (*charm.URL, error) {
+func (f *fakeUploader) UploadCharm(_ context.Context, curl string, charmRef string, r io.ReadSeeker) (string, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	if string(data) != u.String()+" content" {
-		panic(fmt.Sprintf("unexpected charm body for %s: %s", u.String(), data))
+	if string(data) != curl+" content" {
+		panic(fmt.Sprintf("unexpected charm body for %s: %s", curl, data))
 	}
-	f.charms = append(f.charms, u.String())
+	f.curls = append(f.curls, curl)
+	f.charmRefs = append(f.charmRefs, charmRef)
 
-	outU := *u
+	outU := curl
 	if f.reassignCharmURL {
-		outU.Revision--
+		outU = charm.MustParseURL(outU).WithRevision(100).String()
 	}
-	return &outU, nil
+	return outU, nil
 }
 
 func (f *fakeUploader) UploadResource(_ context.Context, res resources.Resource, r io.ReadSeeker) error {

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v12"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -401,8 +400,8 @@ func (w *uploadWrapper) UploadTools(ctx context.Context, r io.ReadSeeker, vers v
 }
 
 // UploadCharm prepends the model UUID to the args passed to the migration client.
-func (w *uploadWrapper) UploadCharm(ctx context.Context, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
-	return w.client.UploadCharm(ctx, w.modelUUID, curl, content)
+func (w *uploadWrapper) UploadCharm(ctx context.Context, curl string, charmRef string, content io.ReadSeeker) (string, error) {
+	return w.client.UploadCharm(ctx, w.modelUUID, curl, charmRef, content)
 }
 
 // UploadResource prepends the model UUID to the args passed to the migration client.


### PR DESCRIPTION
Cherry pick forward:

- https://github.com/juju/juju/pull/16796

Conflicts:
-   api/controller/migrationtarget/client.go
-   api/controller/migrationtarget/client_test.go
-   internal/migration/migration.go
-   internal/migration/migration_test.go
-   internal/worker/migrationmaster/worker.go


Conflicts were due to use of contexts in main and not 3.4.