### PR TITLE
undertaker RemoveModel() handles secrets config not found

### DIFF
--- a/apiserver/facades/controller/machineundertaker/backend.go
+++ b/apiserver/facades/controller/machineundertaker/backend.go
@@ -11,7 +11,7 @@ import (
 // Backend defines the methods the machine undertaker needs from
 // state.State.
 type Backend interface {
-	// AllRemovedMachines returns all of the machines which have been
+	// AllMachineRemovals returns all of the machines which have been
 	// marked for removal.
 	AllMachineRemovals() ([]string, error)
 


### PR DESCRIPTION
If a model destroy operation is interrupted and resumes, the model config may already be deleted. This PR handles that in the case of loading secrets backend config to use to delete model secrets.

## QA steps

Just a regression test - destroy a model

## Links

https://bugs.launchpad.net/juju/+bug/2050966

**Jira card:** JUJU-5356

