### PR TITLE
Wire up trace uniter hooks

### DIFF
--- a/internal/worker/meterstatus/connected.go
+++ b/internal/worker/meterstatus/connected.go
@@ -101,7 +101,7 @@ func (w *connectedStatusHandler) Handle(ctx context.Context) error {
 		w.config.Logger.Tracef("meter status (%q, %q) matches stored information (%q, %q), skipping", currentCode, currentInfo, w.st.Code, w.st.Info)
 		return nil
 	}
-	w.applyStatus(ctx, currentCode, currentInfo, ctx.Done())
+	w.applyStatus(ctx, currentCode, currentInfo)
 	w.st.Code, w.st.Info = currentCode, currentInfo
 	if err = w.config.StateReadWriter.Write(w.st); err != nil {
 		return errors.Annotate(err, "failed to record meter status worker state")
@@ -109,7 +109,7 @@ func (w *connectedStatusHandler) Handle(ctx context.Context) error {
 	return nil
 }
 
-func (w *connectedStatusHandler) applyStatus(ctx context.Context, code, info string, abort <-chan struct{}) {
+func (w *connectedStatusHandler) applyStatus(ctx context.Context, code, info string) {
 	w.config.Logger.Tracef("applying meter status change: %q (%q)", code, info)
-	w.config.Runner.RunHook(ctx, code, info, abort)
+	w.config.Runner.RunHook(ctx, code, info)
 }

--- a/internal/worker/meterstatus/context.go
+++ b/internal/worker/meterstatus/context.go
@@ -42,6 +42,7 @@ func newLimitedContext(config hookConfig) *limitedContext {
 
 // HookVars implements runner.Context.
 func (ctx *limitedContext) HookVars(
+	_ stdcontext.Context,
 	paths context.Paths,
 	remote bool,
 	envVars context.Environmenter,

--- a/internal/worker/meterstatus/context_test.go
+++ b/internal/worker/meterstatus/context_test.go
@@ -4,6 +4,8 @@
 package meterstatus_test
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3/keyvalues"
 	gc "gopkg.in/check.v1"
@@ -35,7 +37,7 @@ func (*dummyPaths) ComponentDir(name string) string { return "/dummy/" + name }
 func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	ctx := meterstatus.NewLimitedContext("u/0")
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false, context.NewRemoteEnvironmenter(
+	vars, err := ctx.HookVars(stdcontext.Background(), paths, false, context.NewRemoteEnvironmenter(
 		func() []string { return []string{} },
 		func(k string) string {
 			switch k {
@@ -75,7 +77,7 @@ func (s *ContextSuite) TestHookContextSetEnv(c *gc.C) {
 	}
 	ctx.SetEnvVars(setVars)
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false, context.NewRemoteEnvironmenter(
+	vars, err := ctx.HookVars(stdcontext.Background(), paths, false, context.NewRemoteEnvironmenter(
 		func() []string { return []string{} },
 		func(k string) string {
 			switch k {

--- a/internal/worker/meterstatus/manifold_test.go
+++ b/internal/worker/meterstatus/manifold_test.go
@@ -5,6 +5,7 @@ package meterstatus_test
 
 import (
 	"context"
+	stdcontext "context"
 	"sync"
 	"time"
 
@@ -256,7 +257,7 @@ type stubRunner struct {
 	ran  chan struct{}
 }
 
-func (r *stubRunner) RunHook(_ context.Context, code, info string, abort <-chan struct{}) {
+func (r *stubRunner) RunHook(ctx stdcontext.Context, code, info string) {
 	r.stub.MethodCall(r, "RunHook", code, info)
 	if r.ran != nil {
 		select {

--- a/internal/worker/metrics/collect/context.go
+++ b/internal/worker/metrics/collect/context.go
@@ -42,6 +42,7 @@ func newHookContext(config hookConfig) *hookContext {
 
 // HookVars implements runner.Context.
 func (ctx *hookContext) HookVars(
+	_ stdcontext.Context,
 	paths context.Paths,
 	remote bool,
 	envVars context.Environmenter,

--- a/internal/worker/metrics/collect/context_test.go
+++ b/internal/worker/metrics/collect/context_test.go
@@ -67,7 +67,7 @@ func (*dummyPaths) ComponentDir(name string) string { return "/dummy/" + name }
 func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	ctx := collect.NewHookContext("u/0", s.recorder)
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false, context.NewRemoteEnvironmenter(
+	vars, err := ctx.HookVars(stdcontext.Background(), paths, false, context.NewRemoteEnvironmenter(
 		func() []string { return []string{} },
 		func(k string) string {
 			switch k {

--- a/internal/worker/metrics/collect/manifold.go
+++ b/internal/worker/metrics/collect/manifold.go
@@ -283,24 +283,24 @@ type hookRunner struct {
 	logger Logger
 }
 
-func (h *hookRunner) do(stdCtx stdcontext.Context, recorder spool.MetricRecorder) error {
+func (h *hookRunner) do(ctx stdcontext.Context, recorder spool.MetricRecorder) error {
 	h.m.Lock()
 	defer h.m.Unlock()
 	h.logger.Debugf("recording metrics")
 
-	ctx := newHookContext(hookConfig{
+	hookContext := newHookContext(hookConfig{
 		unitName: h.unitTag,
 		recorder: recorder,
 		clock:    h.clock,
 		logger:   h.logger,
 	})
-	err := ctx.addJujuUnitsMetric()
+	err := hookContext.addJujuUnitsMetric()
 	if err != nil {
 		return errors.Annotatef(err, "error adding 'juju-units' metric")
 	}
 
-	r := runner.NewRunner(ctx, h.paths, nil)
-	handlerType, err := r.RunHook(stdCtx, string(hooks.CollectMetrics))
+	r := runner.NewRunner(hookContext, h.paths, nil)
+	handlerType, err := r.RunHook(ctx, string(hooks.CollectMetrics))
 	switch {
 	case charmrunner.IsMissingHookError(errors.Cause(err)):
 		fallthrough

--- a/internal/worker/uniter/operation/executor.go
+++ b/internal/worker/uniter/operation/executor.go
@@ -84,7 +84,7 @@ func (x *executor) State() State {
 
 // Run is part of the Executor interface.
 func (x *executor) Run(ctx context.Context, op Operation, remoteStateChange <-chan remotestate.Snapshot) (err error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
+	ctx, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
 		trace.StringAttr("executor.state", op.String()),
 		trace.StringAttr("executor.unit", x.unitName),
 	))
@@ -137,7 +137,7 @@ func (x *executor) Run(ctx context.Context, op Operation, remoteStateChange <-ch
 
 // Skip is part of the Executor interface.
 func (x *executor) Skip(ctx context.Context, op Operation) (err error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
+	ctx, span := trace.Start(ctx, trace.NameFromFunc(), trace.WithAttributes(
 		trace.StringAttr("executor.state", op.String()),
 		trace.StringAttr("executor.unit", x.unitName),
 	))

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -449,15 +449,15 @@ func (r *MockRunner) Context() runnercontext.Context {
 	return r.context
 }
 
-func (r *MockRunner) RunAction(_ context.Context, actionName string) (runner.HookHandlerType, error) {
+func (r *MockRunner) RunAction(ctx context.Context, actionName string) (runner.HookHandlerType, error) {
 	return runner.ExplicitHookHandler, r.MockRunAction.Call(actionName)
 }
 
-func (r *MockRunner) RunCommands(_ context.Context, commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
+func (r *MockRunner) RunCommands(ctx context.Context, commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
 	return r.MockRunCommands.Call(commands, runLocation)
 }
 
-func (r *MockRunner) RunHook(_ context.Context, hookName string) (runner.HookHandlerType, error) {
+func (r *MockRunner) RunHook(ctx context.Context, hookName string) (runner.HookHandlerType, error) {
 	r.Context().(*MockContext).setStatusCalled = r.MockRunHook.setStatusCalled
 	return runner.ExplicitHookHandler, r.MockRunHook.Call(hookName)
 }
@@ -475,7 +475,7 @@ func (r *MockActionWaitRunner) Context() runnercontext.Context {
 	return r.context
 }
 
-func (r *MockActionWaitRunner) RunAction(_ context.Context, actionName string) (runner.HookHandlerType, error) {
+func (r *MockActionWaitRunner) RunAction(ctx context.Context, actionName string) (runner.HookHandlerType, error) {
 	r.actionName = actionName
 	return runner.ExplicitHookHandler, <-r.actionChan
 }

--- a/internal/worker/uniter/runcommands/mock_test.go
+++ b/internal/worker/uniter/runcommands/mock_test.go
@@ -32,7 +32,7 @@ func (r *mockRunner) Context() runnercontext.Context {
 	return &mockRunnerContext{}
 }
 
-func (r *mockRunner) RunCommands(_ context.Context, commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+func (r *mockRunner) RunCommands(ctx context.Context, commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
 	return r.runCommands(commands, runLocation)
 }
 

--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -1413,6 +1413,7 @@ func (c *HookContext) HookVars(
 		vars = append(vars,
 			"JUJU_TRACE_ID="+scope.TraceID(),
 			"JUJU_SPAN_ID="+scope.SpanID(),
+			fmt.Sprintf("JUJU_TRACE_FLAGS=%d", scope.TraceFlags()),
 		)
 	}
 

--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/core/quota"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/worker/common/charmrunner"
 	"github.com/juju/juju/internal/worker/uniter/api"
@@ -50,6 +51,7 @@ type Context interface {
 	jujuc.Context
 	Id() string
 	HookVars(
+		ctx context.Context,
 		paths Paths,
 		remote bool,
 		env Environmenter) ([]string, error)
@@ -340,25 +342,25 @@ type HookContext struct {
 }
 
 // GetLogger returns a Logger for the specified module.
-func (ctx *HookContext) GetLogger(module string) loggo.Logger {
-	return ctx.logger.Root().Child(module)
+func (c *HookContext) GetLogger(module string) loggo.Logger {
+	return c.logger.Root().Child(module)
 }
 
 // GetCharmState returns a copy of the cached charm state.
 // Implements jujuc.HookContext.unitCharmStateContext, part of runner.Context.
-func (ctx *HookContext) GetCharmState() (map[string]string, error) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	if err := ctx.ensureCharmStateLoaded(); err != nil {
+func (c *HookContext) GetCharmState() (map[string]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureCharmStateLoaded(); err != nil {
 		return nil, err
 	}
 
-	if len(ctx.cachedCharmState) == 0 {
+	if len(c.cachedCharmState) == 0 {
 		return nil, nil
 	}
 
-	retVal := make(map[string]string, len(ctx.cachedCharmState))
-	for k, v := range ctx.cachedCharmState {
+	retVal := make(map[string]string, len(c.cachedCharmState))
+	for k, v := range c.cachedCharmState {
 		retVal[k] = v
 	}
 	return retVal, nil
@@ -366,14 +368,14 @@ func (ctx *HookContext) GetCharmState() (map[string]string, error) {
 
 // GetCharmStateValue returns the value of the given key.
 // Implements jujuc.HookContext.unitCharmStateContext, part of runner.Context.
-func (ctx *HookContext) GetCharmStateValue(key string) (string, error) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	if err := ctx.ensureCharmStateLoaded(); err != nil {
+func (c *HookContext) GetCharmStateValue(key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureCharmStateLoaded(); err != nil {
 		return "", err
 	}
 
-	value, ok := ctx.cachedCharmState[key]
+	value, ok := c.cachedCharmState[key]
 	if !ok {
 		return "", errors.NotFoundf("%q", key)
 	}
@@ -382,10 +384,10 @@ func (ctx *HookContext) GetCharmStateValue(key string) (string, error) {
 
 // SetCharmStateValue sets the key/value pair provided in the cache.
 // Implements jujuc.HookContext.unitCharmStateContext, part of runner.Context.
-func (ctx *HookContext) SetCharmStateValue(key, value string) error {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	if err := ctx.ensureCharmStateLoaded(); err != nil {
+func (c *HookContext) SetCharmStateValue(key, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureCharmStateLoaded(); err != nil {
 		return err
 	}
 
@@ -396,46 +398,46 @@ func (ctx *HookContext) SetCharmStateValue(key, value string) error {
 		return errors.Trace(err)
 	}
 
-	curValue, exists := ctx.cachedCharmState[key]
+	curValue, exists := c.cachedCharmState[key]
 	if exists && curValue == value {
 		return nil // no-op
 	}
 
-	ctx.cachedCharmState[key] = value
-	ctx.charmStateCacheDirty = true
+	c.cachedCharmState[key] = value
+	c.charmStateCacheDirty = true
 	return nil
 }
 
 // DeleteCharmStateValue deletes the key/value pair for the given key from
 // the cache.
 // Implements jujuc.HookContext.unitCharmStateContext, part of runner.Context.
-func (ctx *HookContext) DeleteCharmStateValue(key string) error {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	if err := ctx.ensureCharmStateLoaded(); err != nil {
+func (c *HookContext) DeleteCharmStateValue(key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureCharmStateLoaded(); err != nil {
 		return err
 	}
 
-	if _, exists := ctx.cachedCharmState[key]; !exists {
+	if _, exists := c.cachedCharmState[key]; !exists {
 		return nil // no-op
 	}
 
-	delete(ctx.cachedCharmState, key)
-	ctx.charmStateCacheDirty = true
+	delete(c.cachedCharmState, key)
+	c.charmStateCacheDirty = true
 	return nil
 }
 
 // ensureCharmStateLoaded retrieves and caches the unit's charm state from the
 // controller. The caller of this method must be holding the ctx mutex.
-func (ctx *HookContext) ensureCharmStateLoaded() error {
+func (c *HookContext) ensureCharmStateLoaded() error {
 	// NOTE: Assuming lock to be held!
-	if ctx.cachedCharmState != nil {
+	if c.cachedCharmState != nil {
 		return nil
 	}
 
 	// Load from controller
 	var charmState map[string]string
-	unitState, err := ctx.unit.State()
+	unitState, err := c.unit.State()
 	if err != nil {
 		return errors.Annotate(err, "loading unit state from database")
 	}
@@ -445,113 +447,113 @@ func (ctx *HookContext) ensureCharmStateLoaded() error {
 		charmState = unitState.CharmState
 	}
 
-	ctx.cachedCharmState = charmState
-	ctx.charmStateCacheDirty = false
+	c.cachedCharmState = charmState
+	c.charmStateCacheDirty = false
 	return nil
 }
 
 // RequestReboot will set the reboot flag to true on the machine agent
 // Implements jujuc.HookContext.ContextInstance, part of runner.Context.
-func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
+func (c *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
 	// Must set reboot priority first, because killing the hook
 	// process will trigger the completion of the hook. If killing
 	// the hook fails, then we can reset the priority.
-	ctx.setRebootPriority(priority)
+	c.setRebootPriority(priority)
 
 	var err error
 	if priority == jujuc.RebootNow {
 		// At this point, the hook should be running
-		err = ctx.killCharmHook()
+		err = c.killCharmHook()
 	}
 
 	switch err {
 	case nil, charmrunner.ErrNoProcess:
 		// ErrNoProcess almost certainly means we are running in debug hooks
 	default:
-		ctx.setRebootPriority(jujuc.RebootSkip)
+		c.setRebootPriority(jujuc.RebootSkip)
 	}
 	return err
 }
 
-func (ctx *HookContext) GetRebootPriority() jujuc.RebootPriority {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	return ctx.rebootPriority
+func (c *HookContext) GetRebootPriority() jujuc.RebootPriority {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rebootPriority
 }
 
-func (ctx *HookContext) setRebootPriority(priority jujuc.RebootPriority) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	ctx.rebootPriority = priority
+func (c *HookContext) setRebootPriority(priority jujuc.RebootPriority) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rebootPriority = priority
 }
 
-func (ctx *HookContext) GetProcess() HookProcess {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	return ctx.process
+func (c *HookContext) GetProcess() HookProcess {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.process
 }
 
 // SetProcess implements runner.Context.
-func (ctx *HookContext) SetProcess(process HookProcess) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-	ctx.process = process
+func (c *HookContext) SetProcess(process HookProcess) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.process = process
 }
 
 // Id returns an integer which uniquely identifies the relation.
 // Implements jujuc.HookContext.ContextRelation, part of runner.Context.
-func (ctx *HookContext) Id() string {
-	return ctx.id
+func (c *HookContext) Id() string {
+	return c.id
 }
 
 // UnitName returns the executing unit's name.
 // UnitName implements jujuc.HookContext.ContextUnit, part of runner.Context.
-func (ctx *HookContext) UnitName() string {
-	return ctx.unitName
+func (c *HookContext) UnitName() string {
+	return c.unitName
 }
 
 // ModelType of the context we are running in.
 // SetProcess implements runner.Context.
-func (ctx *HookContext) ModelType() model.ModelType {
-	return ctx.modelType
+func (c *HookContext) ModelType() model.ModelType {
+	return c.modelType
 }
 
 // UnitStatus will return the status for the current Unit.
 // Implements jujuc.HookContext.ContextStatus, part of runner.Context.
-func (ctx *HookContext) UnitStatus(stdCtx context.Context) (*jujuc.StatusInfo, error) {
-	if ctx.status == nil {
+func (c *HookContext) UnitStatus(ctx context.Context) (*jujuc.StatusInfo, error) {
+	if c.status == nil {
 		var err error
-		unitStatus, err := ctx.unit.UnitStatus(stdCtx)
+		unitStatus, err := c.unit.UnitStatus(ctx)
 		if err != nil {
 			return nil, err
 		}
-		ctx.status = &jujuc.StatusInfo{
+		c.status = &jujuc.StatusInfo{
 			Status: unitStatus.Status,
 			Info:   unitStatus.Info,
 			Data:   unitStatus.Data,
 		}
 	}
-	return ctx.status, nil
+	return c.status, nil
 }
 
 // ApplicationStatus returns the status for the application and all the units on
 // the application to which this context unit belongs, only if this unit is
 // the leader.
 // Implements jujuc.HookContext.ContextStatus, part of runner.Context.
-func (ctx *HookContext) ApplicationStatus(stdCtx context.Context) (jujuc.ApplicationStatusInfo, error) {
+func (c *HookContext) ApplicationStatus(ctx context.Context) (jujuc.ApplicationStatusInfo, error) {
 	var err error
-	isLeader, err := ctx.IsLeader()
+	isLeader, err := c.IsLeader()
 	if err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Annotatef(err, "cannot determine leadership")
 	}
 	if !isLeader {
 		return jujuc.ApplicationStatusInfo{}, ErrIsNotLeader
 	}
-	app, err := ctx.unit.Application(stdCtx)
+	app, err := c.unit.Application(ctx)
 	if err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Trace(err)
 	}
-	appStatus, err := app.Status(ctx.unit.Name())
+	appStatus, err := app.Status(c.unit.Name())
 	if err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Trace(err)
 	}
@@ -579,10 +581,10 @@ func (ctx *HookContext) ApplicationStatus(stdCtx context.Context) (jujuc.Applica
 
 // SetUnitStatus will set the given status for this unit.
 // Implements jujuc.HookContext.ContextStatus, part of runner.Context.
-func (ctx *HookContext) SetUnitStatus(stdCtx context.Context, unitStatus jujuc.StatusInfo) error {
-	ctx.hasRunStatusSet = true
-	ctx.logger.Tracef("[WORKLOAD-STATUS] %s: %s", unitStatus.Status, unitStatus.Info)
-	return ctx.unit.SetUnitStatus(stdCtx,
+func (c *HookContext) SetUnitStatus(ctx context.Context, unitStatus jujuc.StatusInfo) error {
+	c.hasRunStatusSet = true
+	c.logger.Tracef("[WORKLOAD-STATUS] %s: %s", unitStatus.Status, unitStatus.Info)
+	return c.unit.SetUnitStatus(ctx,
 		status.Status(unitStatus.Status),
 		unitStatus.Info,
 		unitStatus.Data,
@@ -591,9 +593,9 @@ func (ctx *HookContext) SetUnitStatus(stdCtx context.Context, unitStatus jujuc.S
 
 // SetAgentStatus will set the given status for this unit's agent.
 // Implements jujuc.HookContext.ContextStatus, part of runner.Context.
-func (ctx *HookContext) SetAgentStatus(agentStatus jujuc.StatusInfo) error {
-	ctx.logger.Tracef("[AGENT-STATUS] %s: %s", agentStatus.Status, agentStatus.Info)
-	return ctx.unit.SetAgentStatus(
+func (c *HookContext) SetAgentStatus(agentStatus jujuc.StatusInfo) error {
+	c.logger.Tracef("[AGENT-STATUS] %s: %s", agentStatus.Status, agentStatus.Info)
+	return c.unit.SetAgentStatus(
 		status.Status(agentStatus.Status),
 		agentStatus.Info,
 		agentStatus.Data,
@@ -603,9 +605,9 @@ func (ctx *HookContext) SetAgentStatus(agentStatus jujuc.StatusInfo) error {
 // SetApplicationStatus will set the given status to the application to which this
 // unit's belong, only if this unit is the leader.
 // Implements jujuc.HookContext.ContextStatus, part of runner.Context.
-func (ctx *HookContext) SetApplicationStatus(stdCtx context.Context, applicationStatus jujuc.StatusInfo) error {
-	ctx.logger.Tracef("[APPLICATION-STATUS] %s: %s", applicationStatus.Status, applicationStatus.Info)
-	isLeader, err := ctx.IsLeader()
+func (c *HookContext) SetApplicationStatus(ctx context.Context, applicationStatus jujuc.StatusInfo) error {
+	c.logger.Tracef("[APPLICATION-STATUS] %s: %s", applicationStatus.Status, applicationStatus.Info)
+	isLeader, err := c.IsLeader()
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine leadership")
 	}
@@ -613,12 +615,12 @@ func (ctx *HookContext) SetApplicationStatus(stdCtx context.Context, application
 		return ErrIsNotLeader
 	}
 
-	app, err := ctx.unit.Application(stdCtx)
+	app, err := c.unit.Application(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return app.SetStatus(
-		ctx.unit.Name(),
+		c.unit.Name(),
 		status.Status(applicationStatus.Status),
 		applicationStatus.Info,
 		applicationStatus.Data,
@@ -626,97 +628,97 @@ func (ctx *HookContext) SetApplicationStatus(stdCtx context.Context, application
 }
 
 // HasExecutionSetUnitStatus implements runner.Context.
-func (ctx *HookContext) HasExecutionSetUnitStatus() bool {
-	return ctx.hasRunStatusSet
+func (c *HookContext) HasExecutionSetUnitStatus() bool {
+	return c.hasRunStatusSet
 }
 
 // ResetExecutionSetUnitStatus implements runner.Context.
-func (ctx *HookContext) ResetExecutionSetUnitStatus() {
-	ctx.hasRunStatusSet = false
+func (c *HookContext) ResetExecutionSetUnitStatus() {
+	c.hasRunStatusSet = false
 }
 
 // PublicAddress fetches the executing unit's public address if it has
 // not yet been retrieved.
 // The cached value is returned, or an error if it is not available.
-func (ctx *HookContext) PublicAddress() (string, error) {
-	if ctx.publicAddress == "" {
+func (c *HookContext) PublicAddress() (string, error) {
+	if c.publicAddress == "" {
 		var err error
-		if ctx.publicAddress, err = ctx.unit.PublicAddress(); err != nil && !params.IsCodeNoAddressSet(err) {
+		if c.publicAddress, err = c.unit.PublicAddress(); err != nil && !params.IsCodeNoAddressSet(err) {
 			return "", errors.Trace(err)
 		}
 	}
 
-	if ctx.publicAddress == "" {
+	if c.publicAddress == "" {
 		return "", errors.NotFoundf("public address")
 	}
-	return ctx.publicAddress, nil
+	return c.publicAddress, nil
 }
 
 // PrivateAddress returns the executing unit's private address or an
 // error if it is not available.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) PrivateAddress() (string, error) {
-	if ctx.privateAddress == "" {
+func (c *HookContext) PrivateAddress() (string, error) {
+	if c.privateAddress == "" {
 		return "", errors.NotFoundf("private address")
 	}
-	return ctx.privateAddress, nil
+	return c.privateAddress, nil
 }
 
 // AvailabilityZone returns the executing unit's availability zone or an error
 // if it was not found (or is not available).
 // Implements jujuc.HookContext.ContextInstance, part of runner.Context.
-func (ctx *HookContext) AvailabilityZone() (string, error) {
-	if ctx.availabilityZone == "" {
+func (c *HookContext) AvailabilityZone() (string, error) {
+	if c.availabilityZone == "" {
 		return "", errors.NotFoundf("availability zone")
 	}
-	return ctx.availabilityZone, nil
+	return c.availabilityZone, nil
 }
 
 // StorageTags returns a list of tags for storage instances
 // attached to the unit or an error if they are not available.
 // Implements jujuc.HookContext.ContextStorage, part of runner.Context.
-func (ctx *HookContext) StorageTags() ([]names.StorageTag, error) {
+func (c *HookContext) StorageTags() ([]names.StorageTag, error) {
 	// Comparing to nil on purpose here to cache an empty slice.
-	if ctx.storageTags != nil {
-		return ctx.storageTags, nil
+	if c.storageTags != nil {
+		return c.storageTags, nil
 	}
-	attachmentIds, err := ctx.uniter.UnitStorageAttachments(ctx.unit.Tag())
+	attachmentIds, err := c.uniter.UnitStorageAttachments(c.unit.Tag())
 	if err != nil {
 		return nil, err
 	}
 	// N.B. zero-length non-nil slice on purpose.
-	ctx.storageTags = make([]names.StorageTag, 0)
+	c.storageTags = make([]names.StorageTag, 0)
 	for _, attachmentId := range attachmentIds {
 		storageTag, err := names.ParseStorageTag(attachmentId.StorageTag)
 		if err != nil {
 			return nil, err
 		}
-		ctx.storageTags = append(ctx.storageTags, storageTag)
+		c.storageTags = append(c.storageTags, storageTag)
 	}
-	return ctx.storageTags, nil
+	return c.storageTags, nil
 }
 
 // HookStorage returns the storage attachment associated
 // the executing hook if it was found, and an error if it
 // was not found or is not available.
 // Implements jujuc.HookContext.ContextStorage, part of runner.Context.
-func (ctx *HookContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+func (c *HookContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
 	emptyTag := names.StorageTag{}
-	if ctx.storageTag == emptyTag {
+	if c.storageTag == emptyTag {
 		return nil, errors.NotFound
 	}
-	return ctx.Storage(ctx.storageTag)
+	return c.Storage(c.storageTag)
 }
 
 // Storage returns the ContextStorageAttachment with the supplied
 // tag if it was found, and an error if it was not found or is not
 // available to the context.
 // Implements jujuc.HookContext.ContextStorage, part of runner.Context.
-func (ctx *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, error) {
-	if ctxStorageAttachment, ok := ctx.storageAttachmentCache[tag]; ok {
+func (c *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, error) {
+	if ctxStorageAttachment, ok := c.storageAttachmentCache[tag]; ok {
 		return ctxStorageAttachment, nil
 	}
-	attachment, err := ctx.uniter.StorageAttachment(tag, ctx.unit.Tag())
+	attachment, err := c.uniter.StorageAttachment(tag, c.unit.Tag())
 	if err != nil {
 		return nil, err
 	}
@@ -725,23 +727,23 @@ func (ctx *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorageAttac
 		kind:     storage.StorageKind(attachment.Kind),
 		location: attachment.Location,
 	}
-	ctx.storageAttachmentCache[tag] = ctxStorageAttachment
+	c.storageAttachmentCache[tag] = ctxStorageAttachment
 	return ctxStorageAttachment, nil
 }
 
 // AddUnitStorage saves storage constraints in the context.
 // Implements jujuc.HookContext.ContextStorage, part of runner.Context.
-func (ctx *HookContext) AddUnitStorage(cons map[string]params.StorageConstraints) error {
+func (c *HookContext) AddUnitStorage(cons map[string]params.StorageConstraints) error {
 	// All storage constraints are accumulated before context is flushed.
-	if ctx.storageAddConstraints == nil {
-		ctx.storageAddConstraints = make(
+	if c.storageAddConstraints == nil {
+		c.storageAddConstraints = make(
 			map[string][]params.StorageConstraints,
 			len(cons))
 	}
 	for storage, newConstraints := range cons {
 		// Multiple calls for the same storage are accumulated as well.
-		ctx.storageAddConstraints[storage] = append(
-			ctx.storageAddConstraints[storage],
+		c.storageAddConstraints[storage] = append(
+			c.storageAddConstraints[storage],
 			newConstraints)
 	}
 	return nil
@@ -749,65 +751,65 @@ func (ctx *HookContext) AddUnitStorage(cons map[string]params.StorageConstraints
 
 // OpenPortRange marks the supplied port range for opening.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) OpenPortRange(endpointName string, portRange network.PortRange) error {
-	return ctx.portRangeChanges.OpenPortRange(endpointName, portRange)
+func (c *HookContext) OpenPortRange(endpointName string, portRange network.PortRange) error {
+	return c.portRangeChanges.OpenPortRange(endpointName, portRange)
 }
 
 // ClosePortRange ensures the supplied port range is closed even when
 // the executing unit's application is exposed (unless it is opened
 // separately by a co- located unit).
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) ClosePortRange(endpointName string, portRange network.PortRange) error {
-	return ctx.portRangeChanges.ClosePortRange(endpointName, portRange)
+func (c *HookContext) ClosePortRange(endpointName string, portRange network.PortRange) error {
+	return c.portRangeChanges.ClosePortRange(endpointName, portRange)
 }
 
 // OpenedPortRanges returns all port ranges currently opened by this
 // unit on its assigned machine grouped by endpoint.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) OpenedPortRanges() network.GroupedPortRanges {
-	return ctx.portRangeChanges.OpenedUnitPortRanges()
+func (c *HookContext) OpenedPortRanges() network.GroupedPortRanges {
+	return c.portRangeChanges.OpenedUnitPortRanges()
 }
 
 // ConfigSettings returns the current application configuration of the executing unit.
 // Implements jujuc.HookContext.ContextUnit, part of runner.Context.
-func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
-	if ctx.configSettings == nil {
+func (c *HookContext) ConfigSettings() (charm.Settings, error) {
+	if c.configSettings == nil {
 		var err error
-		ctx.configSettings, err = ctx.unit.ConfigSettings()
+		c.configSettings, err = c.unit.ConfigSettings()
 		if err != nil {
 			return nil, err
 		}
 	}
 	result := charm.Settings{}
-	for name, value := range ctx.configSettings {
+	for name, value := range c.configSettings {
 		result[name] = value
 	}
 	return result, nil
 }
 
-func (ctx *HookContext) getSecretsBackend() (api.SecretsBackend, error) {
-	if ctx.secretsBackend != nil {
-		return ctx.secretsBackend, nil
+func (c *HookContext) getSecretsBackend() (api.SecretsBackend, error) {
+	if c.secretsBackend != nil {
+		return c.secretsBackend, nil
 	}
 	var err error
-	ctx.secretsBackend, err = ctx.secretsBackendGetter()
+	c.secretsBackend, err = c.secretsBackendGetter()
 	if err != nil {
 		return nil, err
 	}
-	return ctx.secretsBackend, nil
+	return c.secretsBackend, nil
 }
 
-func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.URI, error) {
-	mds, err := ctx.SecretMetadata()
+func (c *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.URI, error) {
+	mds, err := c.SecretMetadata()
 	if err != nil {
 		return nil, err
 	}
 	for ID, md := range mds {
-		if md.Label == label && md.Owner.Id() == ctx.unit.Tag().Id() {
+		if md.Label == label && md.Owner.Id() == c.unit.Tag().Id() {
 			return &coresecrets.URI{ID: ID}, nil
 		}
 	}
-	for _, md := range ctx.secretChanges.pendingCreates {
+	for _, md := range c.secretChanges.pendingCreates {
 		// Check if we have any pending create changes.
 		if md.Label == nil || md.URI == nil {
 			continue
@@ -816,7 +818,7 @@ func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.
 			return md.URI, nil
 		}
 	}
-	for _, md := range ctx.secretChanges.pendingUpdates {
+	for _, md := range c.secretChanges.pendingUpdates {
 		// Check if we have any pending label update changes.
 		if md.Label == nil || md.URI == nil {
 			continue
@@ -825,27 +827,27 @@ func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.
 			return md.URI, nil
 		}
 	}
-	return nil, errors.NotFoundf("secret owned by %q with label %q", ctx.unitName, label)
+	return nil, errors.NotFoundf("secret owned by %q with label %q", c.unitName, label)
 }
 
 // GetSecret returns the value of the specified secret.
-func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, peek bool) (coresecrets.SecretValue, error) {
+func (c *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, peek bool) (coresecrets.SecretValue, error) {
 	if uri == nil && label == "" {
 		return nil, errors.NotValidf("empty URI and label")
 	}
 	if uri != nil {
-		if v, got := ctx.getPendingSecretValue(uri, label, refresh, peek); got {
+		if v, got := c.getPendingSecretValue(uri, label, refresh, peek); got {
 			return v, nil
 		}
 	}
 	if label != "" {
-		if v, got := ctx.getPendingSecretValue(nil, label, refresh, peek); got {
+		if v, got := c.getPendingSecretValue(nil, label, refresh, peek); got {
 			return v, nil
 		}
 	}
 	if uri == nil && label != "" {
 		// try to resolve label to URI by looking up owned secrets.
-		ownedSecretURI, err := ctx.lookupOwnedSecretURIByLabel(label)
+		ownedSecretURI, err := c.lookupOwnedSecretURIByLabel(label)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return nil, err
 		}
@@ -855,7 +857,7 @@ func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, p
 			label = ""
 		}
 	}
-	backend, err := ctx.getSecretsBackend()
+	backend, err := c.getSecretsBackend()
 	if err != nil {
 		return nil, err
 	}
@@ -866,16 +868,16 @@ func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, p
 	return v, nil
 }
 
-func (ctx *HookContext) getPendingSecretValue(uri *coresecrets.URI, label string, refresh, peek bool) (coresecrets.SecretValue, bool) {
+func (c *HookContext) getPendingSecretValue(uri *coresecrets.URI, label string, refresh, peek bool) (coresecrets.SecretValue, bool) {
 	if uri == nil && label == "" {
 		return nil, false
 	}
-	for i, v := range ctx.secretChanges.pendingCreates {
+	for i, v := range c.secretChanges.pendingCreates {
 		if uri != nil && v.URI != nil && v.URI.ID == uri.ID {
 			if label != "" {
-				pending := ctx.secretChanges.pendingCreates[i]
+				pending := c.secretChanges.pendingCreates[i]
 				pending.Label = &label
-				ctx.secretChanges.pendingCreates[i] = pending
+				c.secretChanges.pendingCreates[i] = pending
 			}
 			// The initial value of the secret is not stored in the database yet.
 			return v.Value, true
@@ -889,22 +891,22 @@ func (ctx *HookContext) getPendingSecretValue(uri *coresecrets.URI, label string
 		return nil, false
 	}
 
-	for i, v := range ctx.secretChanges.pendingUpdates {
+	for i, v := range c.secretChanges.pendingUpdates {
 		if uri != nil && v.URI != nil && v.URI.ID == uri.ID {
 			if label != "" {
-				pending := ctx.secretChanges.pendingUpdates[i]
+				pending := c.secretChanges.pendingUpdates[i]
 				pending.Label = &label
-				ctx.secretChanges.pendingUpdates[i] = pending
+				c.secretChanges.pendingUpdates[i] = pending
 			}
 			if refresh {
-				ctx.secretChanges.pendingTrackLatest[v.URI.ID] = true
+				c.secretChanges.pendingTrackLatest[v.URI.ID] = true
 			}
 			// The new value of the secret is going to be updated to the database.
 			return v.Value, v.Value != nil && !v.Value.IsEmpty()
 		}
 		if label != "" && v.Label != nil && label == *v.Label {
 			if refresh {
-				ctx.secretChanges.pendingTrackLatest[v.URI.ID] = true
+				c.secretChanges.pendingTrackLatest[v.URI.ID] = true
 			}
 			// The new value of the secret is going to be updated to the database.
 			return v.Value, v.Value != nil && !v.Value.IsEmpty()
@@ -914,9 +916,9 @@ func (ctx *HookContext) getPendingSecretValue(uri *coresecrets.URI, label string
 }
 
 // CreateSecret creates a secret with the specified data.
-func (ctx *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets.URI, error) {
+func (c *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets.URI, error) {
 	if args.OwnerTag.Kind() == names.ApplicationTagKind {
-		isLeader, err := ctx.IsLeader()
+		isLeader, err := c.IsLeader()
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot determine leadership")
 		}
@@ -924,11 +926,11 @@ func (ctx *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets
 			return nil, ErrIsNotLeader
 		}
 	}
-	uris, err := ctx.secretsClient.CreateSecretURIs(1)
+	uris, err := c.secretsClient.CreateSecretURIs(1)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	err = ctx.secretChanges.create(uniter.SecretCreateArg{
+	err = c.secretChanges.create(uniter.SecretCreateArg{
 		SecretUpsertArg: uniter.SecretUpsertArg{
 			URI:          uris[0],
 			RotatePolicy: args.RotatePolicy,
@@ -946,10 +948,10 @@ func (ctx *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets
 }
 
 // UpdateSecret creates a secret with the specified data.
-func (ctx *HookContext) UpdateSecret(uri *coresecrets.URI, args *jujuc.SecretUpdateArgs) error {
-	md, ok := ctx.secretMetadata[uri.ID]
+func (c *HookContext) UpdateSecret(uri *coresecrets.URI, args *jujuc.SecretUpdateArgs) error {
+	md, ok := c.secretMetadata[uri.ID]
 	if ok && md.Owner.Kind() == names.ApplicationTagKind {
-		isLeader, err := ctx.IsLeader()
+		isLeader, err := c.IsLeader()
 		if err != nil {
 			return errors.Annotatef(err, "cannot determine leadership")
 		}
@@ -957,7 +959,7 @@ func (ctx *HookContext) UpdateSecret(uri *coresecrets.URI, args *jujuc.SecretUpd
 			return ErrIsNotLeader
 		}
 	}
-	ctx.secretChanges.update(uniter.SecretUpdateArg{
+	c.secretChanges.update(uniter.SecretUpdateArg{
 		SecretUpsertArg: uniter.SecretUpsertArg{
 			URI:          uri,
 			RotatePolicy: args.RotatePolicy,
@@ -972,10 +974,10 @@ func (ctx *HookContext) UpdateSecret(uri *coresecrets.URI, args *jujuc.SecretUpd
 }
 
 // RemoveSecret removes a secret with the specified uri.
-func (ctx *HookContext) RemoveSecret(uri *coresecrets.URI, revision *int) error {
-	md, ok := ctx.secretMetadata[uri.ID]
+func (c *HookContext) RemoveSecret(uri *coresecrets.URI, revision *int) error {
+	md, ok := c.secretMetadata[uri.ID]
 	if ok && md.Owner.Kind() == names.ApplicationTagKind {
-		isLeader, err := ctx.IsLeader()
+		isLeader, err := c.IsLeader()
 		if err != nil {
 			return errors.Annotatef(err, "cannot determine leadership")
 		}
@@ -983,15 +985,15 @@ func (ctx *HookContext) RemoveSecret(uri *coresecrets.URI, revision *int) error 
 			return ErrIsNotLeader
 		}
 	}
-	ctx.secretChanges.remove(uri, revision)
+	c.secretChanges.remove(uri, revision)
 	return nil
 }
 
 // SecretMetadata gets the secret ids and their labels and latest revisions created by the charm.
 // The result includes any pending updates.
-func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error) {
+func (c *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error) {
 	result := make(map[string]jujuc.SecretMetadata)
-	for _, c := range ctx.secretChanges.pendingCreates {
+	for _, c := range c.secretChanges.pendingCreates {
 		md := jujuc.SecretMetadata{
 			Owner:          c.OwnerTag,
 			LatestRevision: 1,
@@ -1010,11 +1012,11 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 		}
 		result[c.URI.ID] = md
 	}
-	for id, v := range ctx.secretMetadata {
-		if _, ok := ctx.secretChanges.pendingDeletes[id]; ok {
+	for id, v := range c.secretMetadata {
+		if _, ok := c.secretChanges.pendingDeletes[id]; ok {
 			continue
 		}
-		if u, ok := ctx.secretChanges.pendingUpdates[id]; ok {
+		if u, ok := c.secretChanges.pendingUpdates[id]; ok {
 			if u.Label != nil {
 				v.Label = *u.Label
 			}
@@ -1033,7 +1035,7 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 	for k, v := range result {
 		uri := &coresecrets.URI{ID: k}
 		var err error
-		if v.Access, err = ctx.secretChanges.secretGrantInfo(uri, v.Access...); err != nil {
+		if v.Access, err = c.secretChanges.secretGrantInfo(uri, v.Access...); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -1041,8 +1043,8 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 }
 
 // GrantSecret grants access to a specified secret.
-func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrantRevokeArgs) error {
-	secretMetadata, err := ctx.SecretMetadata()
+func (c *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrantRevokeArgs) error {
+	secretMetadata, err := c.SecretMetadata()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1051,7 +1053,7 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 		return errors.NotFoundf("secret %q", uri.ID)
 	}
 	if md.Owner.Kind() == names.ApplicationTagKind {
-		isLeader, err := ctx.IsLeader()
+		isLeader, err := c.IsLeader()
 		if err != nil {
 			return errors.Annotatef(err, "cannot determine leadership")
 		}
@@ -1094,15 +1096,15 @@ func (ctx *HookContext) GrantSecret(uri *coresecrets.URI, arg *jujuc.SecretGrant
 			return errors.NewNotValid(nil, "any unit level grants need to be revoked before granting access to the corresponding application")
 		}
 	}
-	ctx.secretChanges.grant(uniterArg)
+	c.secretChanges.grant(uniterArg)
 	return nil
 }
 
 // RevokeSecret revokes access to a specified secret.
-func (ctx *HookContext) RevokeSecret(uri *coresecrets.URI, args *jujuc.SecretGrantRevokeArgs) error {
-	md, ok := ctx.secretMetadata[uri.ID]
+func (c *HookContext) RevokeSecret(uri *coresecrets.URI, args *jujuc.SecretGrantRevokeArgs) error {
+	md, ok := c.secretMetadata[uri.ID]
 	if ok && md.Owner.Kind() == names.ApplicationTagKind {
-		isLeader, err := ctx.IsLeader()
+		isLeader, err := c.IsLeader()
 		if err != nil {
 			return errors.Annotatef(err, "cannot determine leadership")
 		}
@@ -1110,7 +1112,7 @@ func (ctx *HookContext) RevokeSecret(uri *coresecrets.URI, args *jujuc.SecretGra
 			return ErrIsNotLeader
 		}
 	}
-	ctx.secretChanges.revoke(uniter.SecretGrantRevokeArgs{
+	c.secretChanges.revoke(uniter.SecretGrantRevokeArgs{
 		URI:             uri,
 		ApplicationName: args.ApplicationName,
 		UnitName:        args.UnitName,
@@ -1121,73 +1123,73 @@ func (ctx *HookContext) RevokeSecret(uri *coresecrets.URI, args *jujuc.SecretGra
 
 // GoalState returns the goal state for the current unit.
 // Implements jujuc.HookContext.ContextUnit, part of runner.Context.
-func (ctx *HookContext) GoalState(stdCtx context.Context) (*application.GoalState, error) {
+func (c *HookContext) GoalState(ctx context.Context) (*application.GoalState, error) {
 	var err error
-	ctx.goalState, err = ctx.uniter.GoalState(stdCtx)
+	c.goalState, err = c.uniter.GoalState(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ctx.goalState, nil
+	return &c.goalState, nil
 }
 
 // CloudSpec return the cloud specification for the running unit's model.
 // Implements jujuc.HookContext.ContextUnit, part of runner.Context.
-func (ctx *HookContext) CloudSpec(stdCtx context.Context) (*params.CloudSpec, error) {
-	if ctx.modelType == model.CAAS {
+func (c *HookContext) CloudSpec(ctx context.Context) (*params.CloudSpec, error) {
+	if c.modelType == model.CAAS {
 		return nil, errors.NotSupportedf("credential-get on a %q model", model.CAAS)
 	}
 	var err error
-	ctx.cloudSpec, err = ctx.uniter.CloudSpec(stdCtx)
+	c.cloudSpec, err = c.uniter.CloudSpec(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return ctx.cloudSpec, nil
+	return c.cloudSpec, nil
 }
 
 // ActionParams simply returns the arguments to the Action.
 // Implements jujuc.ActionHookContext.actionHookContext, part of runner.Context.
-func (ctx *HookContext) ActionParams() (map[string]interface{}, error) {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) ActionParams() (map[string]interface{}, error) {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return nil, errors.New("not running an action")
 	}
-	return ctx.actionData.Params, nil
+	return c.actionData.Params, nil
 }
 
 // LogActionMessage logs a progress message for the Action.
 // Implements jujuc.ActionHookContext.actionHookContext, part of runner.Context.
-func (ctx *HookContext) LogActionMessage(message string) error {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) LogActionMessage(message string) error {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return errors.New("not running an action")
 	}
-	return ctx.unit.LogActionMessage(ctx.actionData.Tag, message)
+	return c.unit.LogActionMessage(c.actionData.Tag, message)
 }
 
 // SetActionMessage sets a message for the Action, usually an error message.
 // Implements jujuc.ActionHookContext.actionHookContext, part of runner.Context.
-func (ctx *HookContext) SetActionMessage(message string) error {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) SetActionMessage(message string) error {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return errors.New("not running an action")
 	}
-	ctx.actionData.ResultsMessage = message
+	c.actionData.ResultsMessage = message
 	return nil
 }
 
 // SetActionFailed sets the fail state of the action.
 // Implements jujuc.ActionHookContext.actionHookContext, part of runner.Context.
-func (ctx *HookContext) SetActionFailed() error {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) SetActionFailed() error {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return errors.New("not running an action")
 	}
-	ctx.actionData.Failed = true
+	c.actionData.Failed = true
 	return nil
 }
 
@@ -1196,50 +1198,50 @@ func (ctx *HookContext) SetActionFailed() error {
 // upon completion of the Action.  It returns an error if not called on an
 // Action-containing HookContext.
 // Implements jujuc.ActionHookContext.actionHookContext, part of runner.Context.
-func (ctx *HookContext) UpdateActionResults(keys []string, value interface{}) error {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) UpdateActionResults(keys []string, value interface{}) error {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return errors.New("not running an action")
 	}
-	addValueToMap(keys, value, ctx.actionData.ResultsMap)
+	addValueToMap(keys, value, c.actionData.ResultsMap)
 	return nil
 }
 
 // HookRelation returns the ContextRelation associated with the executing
 // hook if it was found, or an error if it was not found (or is not available).
 // Implements jujuc.RelationHookContext.relationHookContext, part of runner.Context.
-func (ctx *HookContext) HookRelation() (jujuc.ContextRelation, error) {
-	return ctx.Relation(ctx.relationId)
+func (c *HookContext) HookRelation() (jujuc.ContextRelation, error) {
+	return c.Relation(c.relationId)
 }
 
 // RemoteUnitName returns the name of the remote unit the hook execution
 // is associated with if it was found, and an error if it was not found or is not
 // available.
 // Implements jujuc.RelationHookContext.relationHookContext, part of runner.Context.
-func (ctx *HookContext) RemoteUnitName() (string, error) {
-	if ctx.remoteUnitName == "" {
+func (c *HookContext) RemoteUnitName() (string, error) {
+	if c.remoteUnitName == "" {
 		return "", errors.NotFoundf("remote unit")
 	}
-	return ctx.remoteUnitName, nil
+	return c.remoteUnitName, nil
 }
 
 // RemoteApplicationName returns the name of the remote application the hook execution
 // is associated with if it was found, and an error if it was not found or is not
 // available.
 // Implements jujuc.RelationHookContext.relationHookContext, part of runner.Context.
-func (ctx *HookContext) RemoteApplicationName() (string, error) {
-	if ctx.remoteApplicationName == "" {
+func (c *HookContext) RemoteApplicationName() (string, error) {
+	if c.remoteApplicationName == "" {
 		return "", errors.NotFoundf("saas application")
 	}
-	return ctx.remoteApplicationName, nil
+	return c.remoteApplicationName, nil
 }
 
 // Relation returns the relation with the supplied id if it was found, and
 // an error if it was not found or is not available.
 // Implements jujuc.HookContext.ContextRelations, part of runner.Context.
-func (ctx *HookContext) Relation(id int) (jujuc.ContextRelation, error) {
-	r, found := ctx.relations[id]
+func (c *HookContext) Relation(id int) (jujuc.ContextRelation, error) {
+	r, found := c.relations[id]
 	if !found {
 		return nil, errors.NotFoundf("relation")
 	}
@@ -1249,9 +1251,9 @@ func (ctx *HookContext) Relation(id int) (jujuc.ContextRelation, error) {
 // RelationIds returns the ids of all relations the executing unit is
 // currently participating in or an error if they are not available.
 // Implements jujuc.HookContext.ContextRelations, part of runner.Context.
-func (ctx *HookContext) RelationIds() ([]int, error) {
+func (c *HookContext) RelationIds() ([]int, error) {
 	ids := []int{}
-	for id := range ctx.relations {
+	for id := range c.relations {
 		ids = append(ids, id)
 	}
 	return ids, nil
@@ -1259,13 +1261,13 @@ func (ctx *HookContext) RelationIds() ([]int, error) {
 
 // AddMetric adds metrics to the hook context.
 // Implements jujuc.HookContext.ContextMetrics, part of runner.Context.
-func (ctx *HookContext) AddMetric(key, value string, created time.Time) error {
+func (c *HookContext) AddMetric(key, value string, created time.Time) error {
 	return errors.New("metrics not allowed in this context")
 }
 
 // AddMetricLabels adds metrics with labels to the hook context.
 // Implements jujuc.HookContext.ContextMetrics, part of runner.Context.
-func (ctx *HookContext) AddMetricLabels(key, value string, created time.Time, labels map[string]string) error {
+func (c *HookContext) AddMetricLabels(key, value string, created time.Time, labels map[string]string) error {
 	return errors.New("metrics not allowed in this context")
 }
 
@@ -1273,25 +1275,26 @@ func (ctx *HookContext) AddMetricLabels(key, value string, created time.Time, la
 // transitory; it exists to allow uniter and runner code to keep working as
 // it did; it should be considered deprecated, and not used by new clients.
 // Implements runner.Context.
-func (ctx *HookContext) ActionData() (*ActionData, error) {
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	if ctx.actionData == nil {
+func (c *HookContext) ActionData() (*ActionData, error) {
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	if c.actionData == nil {
 		return nil, errors.New("not running an action")
 	}
-	return ctx.actionData, nil
+	return c.actionData, nil
 }
 
 // HookVars returns an os.Environ-style list of strings necessary to run a hook
 // such that it can know what environment it's operating in, and can call back
 // into context.
 // Implements runner.Context.
-func (ctx *HookContext) HookVars(
+func (c *HookContext) HookVars(
+	ctx context.Context,
 	paths Paths,
 	remote bool,
 	env Environmenter,
 ) ([]string, error) {
-	vars := ctx.legacyProxySettings.AsEnvironmentValues()
+	vars := c.legacyProxySettings.AsEnvironmentValues()
 	vars = append(vars, ContextDependentEnvVars(env)...)
 
 	// TODO(thumper): as work on proxies progress, there will be additional
@@ -1299,77 +1302,77 @@ func (ctx *HookContext) HookVars(
 	vars = append(vars,
 		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
 		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
-		"JUJU_CONTEXT_ID="+ctx.id,
-		"JUJU_HOOK_NAME="+ctx.hookName,
+		"JUJU_CONTEXT_ID="+c.id,
+		"JUJU_HOOK_NAME="+c.hookName,
 		"JUJU_AGENT_SOCKET_ADDRESS="+paths.GetJujucClientSocket(remote).Address,
 		"JUJU_AGENT_SOCKET_NETWORK="+paths.GetJujucClientSocket(remote).Network,
-		"JUJU_UNIT_NAME="+ctx.unitName,
-		"JUJU_MODEL_UUID="+ctx.uuid,
-		"JUJU_MODEL_NAME="+ctx.modelName,
-		"JUJU_API_ADDRESSES="+strings.Join(ctx.apiAddrs, " "),
-		"JUJU_SLA="+ctx.slaLevel,
-		"JUJU_MACHINE_ID="+ctx.assignedMachineTag.Id(),
-		"JUJU_PRINCIPAL_UNIT="+ctx.principal,
-		"JUJU_AVAILABILITY_ZONE="+ctx.availabilityZone,
+		"JUJU_UNIT_NAME="+c.unitName,
+		"JUJU_MODEL_UUID="+c.uuid,
+		"JUJU_MODEL_NAME="+c.modelName,
+		"JUJU_API_ADDRESSES="+strings.Join(c.apiAddrs, " "),
+		"JUJU_SLA="+c.slaLevel,
+		"JUJU_MACHINE_ID="+c.assignedMachineTag.Id(),
+		"JUJU_PRINCIPAL_UNIT="+c.principal,
+		"JUJU_AVAILABILITY_ZONE="+c.availabilityZone,
 		"JUJU_VERSION="+version.Current.String(),
-		"CLOUD_API_VERSION="+ctx.cloudAPIVersion,
+		"CLOUD_API_VERSION="+c.cloudAPIVersion,
 		// Some of these will be empty, but that is fine, better
 		// to explicitly export them as empty.
-		"JUJU_CHARM_HTTP_PROXY="+ctx.jujuProxySettings.Http,
-		"JUJU_CHARM_HTTPS_PROXY="+ctx.jujuProxySettings.Https,
-		"JUJU_CHARM_FTP_PROXY="+ctx.jujuProxySettings.Ftp,
-		"JUJU_CHARM_NO_PROXY="+ctx.jujuProxySettings.NoProxy,
+		"JUJU_CHARM_HTTP_PROXY="+c.jujuProxySettings.Http,
+		"JUJU_CHARM_HTTPS_PROXY="+c.jujuProxySettings.Https,
+		"JUJU_CHARM_FTP_PROXY="+c.jujuProxySettings.Ftp,
+		"JUJU_CHARM_NO_PROXY="+c.jujuProxySettings.NoProxy,
 	)
 	if remote {
 		vars = append(vars,
 			"JUJU_AGENT_CA_CERT="+path.Join(paths.GetBaseDir(), caas.CACertFile),
 		)
 	}
-	if ctx.meterStatus != nil {
+	if c.meterStatus != nil {
 		vars = append(vars,
-			"JUJU_METER_STATUS="+ctx.meterStatus.code,
-			"JUJU_METER_INFO="+ctx.meterStatus.info,
+			"JUJU_METER_STATUS="+c.meterStatus.code,
+			"JUJU_METER_INFO="+c.meterStatus.info,
 		)
 
 	}
-	if r, err := ctx.HookRelation(); err == nil {
+	if r, err := c.HookRelation(); err == nil {
 		vars = append(vars,
 			"JUJU_RELATION="+r.Name(),
 			"JUJU_RELATION_ID="+r.FakeId(),
-			"JUJU_REMOTE_UNIT="+ctx.remoteUnitName,
-			"JUJU_REMOTE_APP="+ctx.remoteApplicationName,
+			"JUJU_REMOTE_UNIT="+c.remoteUnitName,
+			"JUJU_REMOTE_APP="+c.remoteApplicationName,
 		)
 
-		if ctx.departingUnitName != "" {
+		if c.departingUnitName != "" {
 			vars = append(vars,
-				"JUJU_DEPARTING_UNIT="+ctx.departingUnitName,
+				"JUJU_DEPARTING_UNIT="+c.departingUnitName,
 			)
 		}
 	} else if !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}
-	if ctx.actionData != nil {
+	if c.actionData != nil {
 		vars = append(vars,
-			"JUJU_ACTION_NAME="+ctx.actionData.Name,
-			"JUJU_ACTION_UUID="+ctx.actionData.Tag.Id(),
-			"JUJU_ACTION_TAG="+ctx.actionData.Tag.String(),
+			"JUJU_ACTION_NAME="+c.actionData.Name,
+			"JUJU_ACTION_UUID="+c.actionData.Tag.Id(),
+			"JUJU_ACTION_TAG="+c.actionData.Tag.String(),
 		)
 	}
-	if ctx.workloadName != "" {
-		vars = append(vars, "JUJU_WORKLOAD_NAME="+ctx.workloadName)
-		if ctx.noticeID != "" {
+	if c.workloadName != "" {
+		vars = append(vars, "JUJU_WORKLOAD_NAME="+c.workloadName)
+		if c.noticeID != "" {
 			vars = append(vars,
-				"JUJU_NOTICE_ID="+ctx.noticeID,
-				"JUJU_NOTICE_TYPE="+ctx.noticeType,
-				"JUJU_NOTICE_KEY="+ctx.noticeKey,
+				"JUJU_NOTICE_ID="+c.noticeID,
+				"JUJU_NOTICE_TYPE="+c.noticeType,
+				"JUJU_NOTICE_KEY="+c.noticeKey,
 			)
 		}
 	}
 
-	if ctx.baseUpgradeTarget != "" {
+	if c.baseUpgradeTarget != "" {
 		// We need to set both the base and the series for the hook. This until
 		// we migrate everything to use base.
-		b, err := corebase.ParseBaseFromString(ctx.baseUpgradeTarget)
+		b, err := corebase.ParseBaseFromString(c.baseUpgradeTarget)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1379,24 +1382,24 @@ func (ctx *HookContext) HookVars(
 		}
 
 		vars = append(vars,
-			"JUJU_TARGET_BASE="+ctx.baseUpgradeTarget,
+			"JUJU_TARGET_BASE="+c.baseUpgradeTarget,
 			"JUJU_TARGET_SERIES="+s,
 		)
 	}
 
-	if ctx.secretURI != "" {
+	if c.secretURI != "" {
 		vars = append(vars,
-			"JUJU_SECRET_ID="+ctx.secretURI,
-			"JUJU_SECRET_LABEL="+ctx.secretLabel,
+			"JUJU_SECRET_ID="+c.secretURI,
+			"JUJU_SECRET_LABEL="+c.secretLabel,
 		)
-		if ctx.secretRevision > 0 {
+		if c.secretRevision > 0 {
 			vars = append(vars,
-				"JUJU_SECRET_REVISION="+strconv.Itoa(ctx.secretRevision),
+				"JUJU_SECRET_REVISION="+strconv.Itoa(c.secretRevision),
 			)
 		}
 	}
 
-	if storage, err := ctx.HookStorage(); err == nil {
+	if storage, err := c.HookStorage(); err == nil {
 		vars = append(vars,
 			"JUJU_STORAGE_ID="+storage.Tag().Id(),
 			"JUJU_STORAGE_LOCATION="+storage.Location(),
@@ -1406,12 +1409,19 @@ func (ctx *HookContext) HookVars(
 		return nil, errors.Trace(err)
 	}
 
+	if scope := coretrace.SpanFromContext(ctx).Scope(); scope.TraceID() != "" {
+		vars = append(vars,
+			"JUJU_TRACE_ID="+scope.TraceID(),
+			"JUJU_SPAN_ID="+scope.SpanID(),
+		)
+	}
+
 	return append(vars, OSDependentEnvVars(paths, env)...), nil
 }
 
-func (ctx *HookContext) handleReboot(ctxErr error) error {
-	ctx.logger.Tracef("checking for reboot request")
-	rebootPriority := ctx.GetRebootPriority()
+func (c *HookContext) handleReboot(ctxErr error) error {
+	c.logger.Tracef("checking for reboot request")
+	rebootPriority := c.GetRebootPriority()
 	switch rebootPriority {
 	case jujuc.RebootSkip:
 		return ctxErr
@@ -1427,11 +1437,11 @@ func (ctx *HookContext) handleReboot(ctxErr error) error {
 
 	// Do a best-effort attempt to set the unit agent status; we don't care
 	// if it fails as we will request a reboot anyway.
-	if err := ctx.unit.SetAgentStatus(status.Rebooting, "", nil); err != nil {
-		ctx.logger.Errorf("updating agent status: %v", err)
+	if err := c.unit.SetAgentStatus(status.Rebooting, "", nil); err != nil {
+		c.logger.Errorf("updating agent status: %v", err)
 	}
 
-	if err := ctx.unit.RequestReboot(); err != nil {
+	if err := c.unit.RequestReboot(); err != nil {
 		return err
 	}
 
@@ -1439,9 +1449,9 @@ func (ctx *HookContext) handleReboot(ctxErr error) error {
 }
 
 // Prepare implements the runner.Context interface.
-func (ctx *HookContext) Prepare(stdCtx context.Context) error {
-	if ctx.actionData != nil {
-		err := ctx.uniter.ActionBegin(stdCtx, ctx.actionData.Tag)
+func (c *HookContext) Prepare(ctx context.Context) error {
+	if c.actionData != nil {
+		err := c.uniter.ActionBegin(ctx, c.actionData.Tag)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1450,31 +1460,31 @@ func (ctx *HookContext) Prepare(stdCtx context.Context) error {
 }
 
 // Flush implements the runner.Context interface.
-func (ctx *HookContext) Flush(stdCtx context.Context, process string, ctxErr error) error {
+func (c *HookContext) Flush(ctx context.Context, process string, ctxErr error) error {
 	// Apply the changes if no error reported while the hook was executing.
 	var flushErr error
 	if ctxErr == nil {
-		flushErr = ctx.doFlush(process)
+		flushErr = c.doFlush(process)
 	}
 
-	if ctx.actionData != nil {
+	if c.actionData != nil {
 		// While an Action is executing, errors may happen as part of
 		// its normal flow. We pass both potential action errors
 		// (ctxErr) and any flush errors to finalizeAction helper
 		// which will figure out if an error needs to be returned back
 		// to the uniter.
-		return ctx.finalizeAction(stdCtx, ctxErr, flushErr)
+		return c.finalizeAction(ctx, ctxErr, flushErr)
 	}
 
 	// TODO(gsamfira): Just for now, reboot will not be supported in actions.
 	if ctxErr == nil {
 		ctxErr = flushErr
 	}
-	return ctx.handleReboot(ctxErr)
+	return c.handleReboot(ctxErr)
 }
 
-func (ctx *HookContext) doFlush(process string) error {
-	b := uniter.NewCommitHookParamsBuilder(ctx.unit.Tag())
+func (c *HookContext) doFlush(process string) error {
+	b := uniter.NewCommitHookParamsBuilder(c.unit.Tag())
 
 	// When processing config changed hooks we need to ensure that the
 	// relation settings for the unit endpoints are up to date after
@@ -1483,40 +1493,40 @@ func (ctx *HookContext) doFlush(process string) error {
 		b.UpdateNetworkInfo()
 	}
 
-	if ctx.charmStateCacheDirty {
-		b.UpdateCharmState(ctx.cachedCharmState)
+	if c.charmStateCacheDirty {
+		b.UpdateCharmState(c.cachedCharmState)
 	}
 
-	for _, rctx := range ctx.relations {
-		unitSettings, appSettings := rctx.FinalSettings()
+	for _, rc := range c.relations {
+		unitSettings, appSettings := rc.FinalSettings()
 		if len(unitSettings)+len(appSettings) == 0 {
 			continue // no settings need updating
 		}
-		b.UpdateRelationUnitSettings(rctx.RelationTag().String(), unitSettings, appSettings)
+		b.UpdateRelationUnitSettings(rc.RelationTag().String(), unitSettings, appSettings)
 	}
 
-	for endpointName, portRanges := range ctx.portRangeChanges.pendingOpenRanges {
+	for endpointName, portRanges := range c.portRangeChanges.pendingOpenRanges {
 		for _, pr := range portRanges {
 			b.OpenPortRange(endpointName, pr)
 		}
 	}
-	for endpointName, portRanges := range ctx.portRangeChanges.pendingCloseRanges {
+	for endpointName, portRanges := range c.portRangeChanges.pendingCloseRanges {
 		for _, pr := range portRanges {
 			b.ClosePortRange(endpointName, pr)
 		}
 	}
 
-	if len(ctx.storageAddConstraints) > 0 {
-		b.AddStorage(ctx.storageAddConstraints)
+	if len(c.storageAddConstraints) > 0 {
+		b.AddStorage(c.storageAddConstraints)
 	}
 
 	// Before saving the secret metadata to Juju, save the content to an external
 	// backend (if configured) - we need the backend id to send to Juju.
 	// If the flush to Juju fails, we'll delete the external content.
 	var secretsBackend api.SecretsBackend
-	if ctx.secretChanges.haveContentUpdates() {
+	if c.secretChanges.haveContentUpdates() {
 		var err error
-		secretsBackend, err = ctx.getSecretsBackend()
+		secretsBackend, err = c.getSecretsBackend()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1531,7 +1541,7 @@ func (ctx *HookContext) doFlush(process string) error {
 		pendingRevokes     []uniter.SecretGrantRevokeArgs
 		pendingTrackLatest []string
 	)
-	for _, c := range ctx.secretChanges.pendingCreates {
+	for _, c := range c.secretChanges.pendingCreates {
 		ref, err := secretsBackend.SaveContent(c.URI, 1, c.Value)
 		if errors.Is(err, errors.NotSupported) {
 			pendingCreates = append(pendingCreates, c)
@@ -1545,7 +1555,7 @@ func (ctx *HookContext) doFlush(process string) error {
 		c.Value = nil
 		pendingCreates = append(pendingCreates, c)
 	}
-	for _, u := range ctx.secretChanges.pendingUpdates {
+	for _, u := range c.secretChanges.pendingUpdates {
 		// Juju checks that the current revision is stable when updating metadata so it's
 		// safe to increment here knowing the same value will be saved in Juju.
 		if u.Value.IsEmpty() {
@@ -1566,9 +1576,9 @@ func (ctx *HookContext) doFlush(process string) error {
 		pendingUpdates = append(pendingUpdates, u.SecretUpsertArg)
 	}
 
-	for _, d := range ctx.secretChanges.pendingDeletes {
+	for _, d := range c.secretChanges.pendingDeletes {
 		pendingDeletes = append(pendingDeletes, d)
-		md, ok := ctx.secretMetadata[d.URI.ID]
+		md, ok := c.secretMetadata[d.URI.ID]
 		if !ok {
 			continue
 		}
@@ -1578,7 +1588,7 @@ func (ctx *HookContext) doFlush(process string) error {
 		} else {
 			toDelete = []int{*d.Revision}
 		}
-		ctx.logger.Debugf("deleting secret %q provider ids: %v", d.URI.ID, toDelete)
+		c.logger.Debugf("deleting secret %q provider ids: %v", d.URI.ID, toDelete)
 		for _, rev := range toDelete {
 			if err := secretsBackend.DeleteContent(d.URI, rev); err != nil {
 				if errors.Is(err, errors.NotFound) {
@@ -1589,17 +1599,17 @@ func (ctx *HookContext) doFlush(process string) error {
 		}
 	}
 
-	for _, grants := range ctx.secretChanges.pendingGrants {
+	for _, grants := range c.secretChanges.pendingGrants {
 		for _, g := range grants {
 			pendingGrants = append(pendingGrants, g)
 		}
 	}
 
-	for _, revokes := range ctx.secretChanges.pendingRevokes {
+	for _, revokes := range c.secretChanges.pendingRevokes {
 		pendingRevokes = append(pendingRevokes, revokes...)
 	}
 
-	for uri := range ctx.secretChanges.pendingTrackLatest {
+	for uri := range c.secretChanges.pendingTrackLatest {
 		pendingTrackLatest = append(pendingTrackLatest, uri)
 	}
 
@@ -1613,15 +1623,15 @@ func (ctx *HookContext) doFlush(process string) error {
 	// Generate change request but skip its execution if no changes are pending.
 	commitReq, numChanges := b.Build()
 	if numChanges > 0 {
-		if err := ctx.unit.CommitHookChanges(commitReq); err != nil {
-			ctx.logger.Errorf("cannot apply changes: %v", err)
+		if err := c.unit.CommitHookChanges(commitReq); err != nil {
+			c.logger.Errorf("cannot apply changes: %v", err)
 		cleanupDone:
 			for _, secretId := range cleanups {
 				if err2 := secretsBackend.DeleteExternalContent(secretId); err2 != nil {
 					if errors.Is(err, errors.NotSupported) {
 						break cleanupDone
 					}
-					ctx.logger.Errorf("cannot cleanup secret %q: %v", secretId, err2)
+					c.logger.Errorf("cannot cleanup secret %q: %v", secretId, err2)
 				}
 			}
 			return errors.Trace(err)
@@ -1629,24 +1639,24 @@ func (ctx *HookContext) doFlush(process string) error {
 	}
 
 	// Call completed successfully; update local state
-	ctx.charmStateCacheDirty = false
+	c.charmStateCacheDirty = false
 	return nil
 }
 
 // finalizeAction passes back the final status of an Action hook to state.
 // It wraps any errors which occurred in normal behavior of the Action run;
 // only errors passed in unhandledErr will be returned.
-func (ctx *HookContext) finalizeAction(stdCtx context.Context, err, flushErr error) error {
+func (c *HookContext) finalizeAction(ctx context.Context, err, flushErr error) error {
 	// TODO (binary132): synchronize with gsamfira's reboot logic
-	ctx.actionDataMu.Lock()
-	defer ctx.actionDataMu.Unlock()
-	message := ctx.actionData.ResultsMessage
-	results := ctx.actionData.ResultsMap
-	tag := ctx.actionData.Tag
+	c.actionDataMu.Lock()
+	defer c.actionDataMu.Unlock()
+	message := c.actionData.ResultsMessage
+	results := c.actionData.ResultsMap
+	tag := c.actionData.Tag
 	actionStatus := params.ActionCompleted
-	if ctx.actionData.Failed {
+	if c.actionData.Failed {
 		select {
-		case <-ctx.actionData.Cancel:
+		case <-c.actionData.Cancel:
 			actionStatus = params.ActionAborted
 		default:
 			actionStatus = params.ActionFailed
@@ -1658,10 +1668,10 @@ func (ctx *HookContext) finalizeAction(stdCtx context.Context, err, flushErr err
 	if err != nil {
 		message = err.Error()
 		if charmrunner.IsMissingHookError(err) {
-			message = fmt.Sprintf("action not implemented on unit %q", ctx.unitName)
+			message = fmt.Sprintf("action not implemented on unit %q", c.unitName)
 		}
 		select {
-		case <-ctx.actionData.Cancel:
+		case <-c.actionData.Cancel:
 			actionStatus = params.ActionAborted
 		default:
 			actionStatus = params.ActionFailed
@@ -1685,26 +1695,26 @@ func (ctx *HookContext) finalizeAction(stdCtx context.Context, err, flushErr err
 		}
 	}
 
-	callErr := ctx.uniter.ActionFinish(stdCtx, tag, actionStatus, results, message)
+	callErr := c.uniter.ActionFinish(ctx, tag, actionStatus, results, message)
 	// Prevent the unit agent from looping if it's impossible to finalise the action.
 	if params.IsCodeNotFoundOrCodeUnauthorized(callErr) || params.IsCodeAlreadyExists(callErr) {
-		ctx.logger.Warningf("error finalising action %v: %v", tag.Id(), callErr)
+		c.logger.Warningf("error finalising action %v: %v", tag.Id(), callErr)
 		callErr = nil
 	}
 	return errors.Trace(callErr)
 }
 
 // killCharmHook tries to kill the current running charm hook.
-func (ctx *HookContext) killCharmHook() error {
-	proc := ctx.GetProcess()
+func (c *HookContext) killCharmHook() error {
+	proc := c.GetProcess()
 	if proc == nil {
 		// nothing to kill
 		return charmrunner.ErrNoProcess
 	}
-	ctx.logger.Infof("trying to kill context process %v", proc.Pid())
+	c.logger.Infof("trying to kill context process %v", proc.Pid())
 
-	tick := ctx.clock.After(0)
-	timeout := ctx.clock.After(30 * time.Second)
+	tick := c.clock.After(0)
+	timeout := c.clock.After(30 * time.Second)
 	for {
 		// We repeatedly try to kill the process until we fail; this is
 		// because we don't control the *Process, and our clients expect
@@ -1715,70 +1725,70 @@ func (ctx *HookContext) killCharmHook() error {
 		case <-tick:
 			err := proc.Kill()
 			if err != nil {
-				ctx.logger.Infof("kill returned: %s", err)
-				ctx.logger.Infof("assuming already killed")
+				c.logger.Infof("kill returned: %s", err)
+				c.logger.Infof("assuming already killed")
 				return nil
 			}
 		case <-timeout:
 			return errors.Errorf("failed to kill context process %v", proc.Pid())
 		}
-		ctx.logger.Infof("waiting for context process %v to die", proc.Pid())
-		tick = ctx.clock.After(100 * time.Millisecond)
+		c.logger.Infof("waiting for context process %v to die", proc.Pid())
+		tick = c.clock.After(100 * time.Millisecond)
 	}
 }
 
 // UnitWorkloadVersion returns the version of the workload reported by
 // the current unit.
 // Implements jujuc.HookContext.ContextVersion, part of runner.Context.
-func (ctx *HookContext) UnitWorkloadVersion(stdCtx context.Context) (string, error) {
-	return ctx.uniter.UnitWorkloadVersion(stdCtx, ctx.unit.Tag())
+func (c *HookContext) UnitWorkloadVersion(ctx context.Context) (string, error) {
+	return c.uniter.UnitWorkloadVersion(ctx, c.unit.Tag())
 }
 
 // SetUnitWorkloadVersion sets the current unit's workload version to
 // the specified value.
 // Implements jujuc.HookContext.ContextVersion, part of runner.Context.
-func (ctx *HookContext) SetUnitWorkloadVersion(stdCtx context.Context, version string) error {
-	return ctx.uniter.SetUnitWorkloadVersion(stdCtx, ctx.unit.Tag(), version)
+func (c *HookContext) SetUnitWorkloadVersion(ctx context.Context, version string) error {
+	return c.uniter.SetUnitWorkloadVersion(ctx, c.unit.Tag(), version)
 }
 
 // NetworkInfo returns the network info for the given bindings on the given relation.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+func (c *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
 	var relId *int
 	if relationId != -1 {
 		relId = &relationId
 	}
-	return ctx.unit.NetworkInfo(bindingNames, relId)
+	return c.unit.NetworkInfo(bindingNames, relId)
 }
 
 // WorkloadName returns the name of the container/workload for workload hooks.
-func (ctx *HookContext) WorkloadName() (string, error) {
-	if ctx.workloadName == "" {
+func (c *HookContext) WorkloadName() (string, error) {
+	if c.workloadName == "" {
 		return "", errors.NotFoundf("workload name")
 	}
-	return ctx.workloadName, nil
+	return c.workloadName, nil
 }
 
 // SecretURI returns the secret URI for secret hooks.
 // This is not yet used by any hook commands - it is exported
 // for tests to use.
-func (ctx *HookContext) SecretURI() (string, error) {
-	if ctx.secretURI == "" {
+func (c *HookContext) SecretURI() (string, error) {
+	if c.secretURI == "" {
 		return "", errors.NotFoundf("secret URI")
 	}
-	return ctx.secretURI, nil
+	return c.secretURI, nil
 }
 
 // SecretLabel returns the secret label for secret hooks.
 // This is not yet used by any hook commands - it is exported
 // for tests to use.
-func (ctx *HookContext) SecretLabel() string {
-	return ctx.secretLabel
+func (c *HookContext) SecretLabel() string {
+	return c.secretLabel
 }
 
 // SecretRevision returns the secret revision for secret hooks.
 // This is not yet used by any hook commands - it is exported
 // for tests to use.
-func (ctx *HookContext) SecretRevision() int {
-	return ctx.secretRevision
+func (c *HookContext) SecretRevision() int {
+	return c.secretRevision
 }

--- a/internal/worker/uniter/runner/context/env_test.go
+++ b/internal/worker/uniter/runner/context/env_test.go
@@ -4,6 +4,7 @@
 package context_test
 
 import (
+	stdcontext "context"
 	"sort"
 
 	"github.com/juju/names/v5"
@@ -50,7 +51,7 @@ func (s *EnvSuite) getPaths() (paths context.Paths, expectVars []string) {
 	}
 }
 
-func (s *EnvSuite) getContext(newProxyOnly bool, uniter api.UniterClient, unit context.HookUnit) (ctx *context.HookContext, expectVars []string) {
+func (s *EnvSuite) getHookContext(newProxyOnly bool, uniter api.UniterClient, unit context.HookUnit) (ctx *context.HookContext, expectVars []string) {
 	var (
 		legacyProxy proxy.Settings
 		jujuProxy   proxy.Settings
@@ -235,17 +236,17 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 		},
 	)
 
-	ctx, contextVars := s.getContext(false, state, unit)
+	hookContext, contextVars := s.getHookContext(false, state, unit)
 	paths, pathsVars := s.getPaths()
-	actualVars, err := ctx.HookVars(paths, false, environmenter)
+	actualVars, err := hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars)
 
-	relationVars := s.setDepartingRelation(ctx)
-	secretVars := s.setSecret(ctx)
-	storageVars := s.setStorage(ctx)
-	noticeVars := s.setNotice(ctx)
-	actualVars, err = ctx.HookVars(paths, false, environmenter)
+	relationVars := s.setDepartingRelation(hookContext)
+	secretVars := s.setSecret(hookContext)
+	storageVars := s.setStorage(hookContext)
+	noticeVars := s.setNotice(hookContext)
+	actualVars, err = hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars, relationVars, secretVars, storageVars, noticeVars)
 }
@@ -297,15 +298,15 @@ func (s *EnvSuite) TestEnvCentos(c *gc.C) {
 			},
 		)
 
-		ctx, contextVars := s.getContext(false, state, unit)
+		hookContext, contextVars := s.getHookContext(false, state, unit)
 		paths, pathsVars := s.getPaths()
-		actualVars, err := ctx.HookVars(paths, false, environmenter)
+		actualVars, err := hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, centosVars)
 
-		relationVars := s.setRelation(ctx)
-		secretVars := s.setSecret(ctx)
-		actualVars, err = ctx.HookVars(paths, false, environmenter)
+		relationVars := s.setRelation(hookContext)
+		secretVars := s.setSecret(hookContext)
+		actualVars, err = hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, centosVars, relationVars, secretVars)
 	}
@@ -350,15 +351,15 @@ func (s *EnvSuite) TestEnvGenericLinux(c *gc.C) {
 		},
 	)
 
-	ctx, contextVars := s.getContext(false, state, unit)
+	hookContext, contextVars := s.getHookContext(false, state, unit)
 	paths, pathsVars := s.getPaths()
-	actualVars, err := ctx.HookVars(paths, false, environmenter)
+	actualVars, err := hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars)
 
-	relationVars := s.setRelation(ctx)
-	secretVars := s.setSecret(ctx)
-	actualVars, err = ctx.HookVars(paths, false, environmenter)
+	relationVars := s.setRelation(hookContext)
+	secretVars := s.setSecret(hookContext)
+	actualVars, err = hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars, relationVars, secretVars)
 }
@@ -404,15 +405,15 @@ func (s *EnvSuite) TestHostEnv(c *gc.C) {
 		},
 	)
 
-	ctx, contextVars := s.getContext(false, state, unit)
+	hookContext, contextVars := s.getHookContext(false, state, unit)
 	paths, pathsVars := s.getPaths()
-	actualVars, err := ctx.HookVars(paths, false, environmenter)
+	actualVars, err := hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars, []string{"KUBERNETES_SERVICE=test"})
 
-	relationVars := s.setRelation(ctx)
-	secretVars := s.setSecret(ctx)
-	actualVars, err = ctx.HookVars(paths, false, environmenter)
+	relationVars := s.setRelation(hookContext)
+	secretVars := s.setSecret(hookContext)
+	actualVars, err = hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars, relationVars, secretVars, []string{"KUBERNETES_SERVICE=test"})
 }

--- a/internal/worker/uniter/runner/factory_test.go
+++ b/internal/worker/uniter/runner/factory_test.go
@@ -230,7 +230,7 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 			Params:     test.payload,
 			ResultsMap: map[string]interface{}{},
 		})
-		vars, err := ctx.HookVars(s.paths, false, context.NewRemoteEnvironmenter(
+		vars, err := ctx.HookVars(stdcontext.Background(), s.paths, false, context.NewRemoteEnvironmenter(
 			func() []string { return []string{} },
 			func(k string) string {
 				switch k {
@@ -313,7 +313,7 @@ func (s *FactorySuite) TestNewActionRunnerWithCancel(c *gc.C) {
 		ResultsMap: map[string]interface{}{},
 		Cancel:     cancel,
 	})
-	vars, err := ctx.HookVars(s.paths, false, context.NewRemoteEnvironmenter(
+	vars, err := ctx.HookVars(stdcontext.Background(), s.paths, false, context.NewRemoteEnvironmenter(
 		func() []string { return []string{} },
 		func(k string) string {
 			switch k {

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -417,18 +417,18 @@ func (mr *MockContextMockRecorder) HookStorage() *gomock.Call {
 }
 
 // HookVars mocks base method.
-func (m *MockContext) HookVars(arg0 context0.Paths, arg1 bool, arg2 context0.Environmenter) ([]string, error) {
+func (m *MockContext) HookVars(arg0 context.Context, arg1 context0.Paths, arg2 bool, arg3 context0.Environmenter) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HookVars", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HookVars", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HookVars indicates an expected call of HookVars.
-func (mr *MockContextMockRecorder) HookVars(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockContextMockRecorder) HookVars(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookVars", reflect.TypeOf((*MockContext)(nil).HookVars), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookVars", reflect.TypeOf((*MockContext)(nil).HookVars), arg0, arg1, arg2, arg3)
 }
 
 // Id mocks base method.

--- a/internal/worker/uniter/runner/runner_test.go
+++ b/internal/worker/uniter/runner/runner_test.go
@@ -251,6 +251,7 @@ func (ctx *MockContext) UnitName() string {
 }
 
 func (ctx *MockContext) HookVars(
+	_ stdcontext.Context,
 	paths context.Paths,
 	_ bool,
 	envVars context.Environmenter,


### PR DESCRIPTION
Adds the tracer to the env hooks. Passes over the trace and span ids.
Trace flags will have to be done later once #16575 has landed.

This facilitates the ability to trace from juju unit agents through
the charm code. By just adding the `JUJU_TRACE_ID` and `JUJU_SPAN_ID`
any language or framework can pick those up and work on a trace
using that as the parent.

Most of the code is just pushing `context.Context` everywhere.

## Sceenshot

From this, you can see it leaving the juju-unit and then being picked up
via the juju controller charm.

See: https://github.com/juju/juju-controller/pull/55

![Screenshot from 2024-01-29 11-37-45](https://github.com/juju/juju/assets/2562584/e90ef38f-d3a3-4370-87ae-35f9593290ae)



## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setting up tempo

It assumes that docker (docker-compose) is correctly installed:

```sh
$ git clone https://github.com/grafana/tempo.git
$ cd tempo/example/docker-compose/local
$ docker compose up -d
```

### Setting up juju-controller charm

```sh
$ cd <location of juju-controller charm>
$ git checkout <https://github.com/juju/juju-controller/pull/55>
$ charmcraft pack
```

### Bootstrapping

```sh
$ juju bootstrap lxd test --build-agent --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=192.168.0.60:4317" --config="open-telemetry-sample-ratio=1.0" --controller-charm-path=<location of juju-controller charm>/juju-controller_ubuntu-22.04-amd64-aarch64-arm64-s390x_ubuntu-20.04-amd64-aarch64-arm64-s390x.charm
```

## Links

**Jira card:** JUJU-[XXXX]