### PR TITLE
[SQLair] Replace slice queries in domain/cloud/state

### DIFF
--- a/domain/cloud/bootstrap/bootstrap.go
+++ b/domain/cloud/bootstrap/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
-
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"

--- a/domain/cloud/bootstrap/bootstrap.go
+++ b/domain/cloud/bootstrap/bootstrap.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/canonical/sqlair"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
@@ -20,7 +22,7 @@ import (
 // InsertCloud inserts the initial cloud during bootstrap.
 func InsertCloud(cloud cloud.Cloud) func(context.Context, database.TxnRunner) error {
 	return func(ctx context.Context, db database.TxnRunner) error {
-		return errors.Trace(db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			cloudUUID, err := uuid.NewUUID()
 			if err != nil {
 				return errors.Trace(err)

--- a/domain/cloud/bootstrap/bootstrap.go
+++ b/domain/cloud/bootstrap/bootstrap.go
@@ -21,11 +21,11 @@ import (
 // InsertCloud inserts the initial cloud during bootstrap.
 func InsertCloud(cloud cloud.Cloud) func(context.Context, database.TxnRunner) error {
 	return func(ctx context.Context, db database.TxnRunner) error {
+		cloudUUID, err := uuid.NewUUID()
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			cloudUUID, err := uuid.NewUUID()
-			if err != nil {
-				return errors.Trace(err)
-			}
 			if err := state.CreateCloud(ctx, tx, cloudUUID.String(), cloud); err != nil {
 				return errors.Annotate(err, "creating bootstrap cloud")
 			}

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -6,8 +6,9 @@ package state
 import (
 	"context"
 	"database/sql"
-	stderrors "errors"
 	"fmt"
+
+	"github.com/juju/collections/transform"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
@@ -199,46 +200,49 @@ func (st *State) UpdateCloudDefaults(
 		return errors.Trace(err)
 	}
 
-	selectStmt := "SELECT uuid FROM cloud WHERE name = ?"
+	selectStmt, err := sqlair.Prepare("SELECT &Cloud.uuid FROM cloud WHERE name = $Cloud.name", Cloud{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	deleteBinds, deleteVals := database.SliceToPlaceholder(removeAttrs)
-	deleteStmt := fmt.Sprintf(`
+	deleteStmt, err := sqlair.Prepare(`
 DELETE FROM  cloud_defaults
-WHERE        key IN (%s)
-AND          cloud_uuid = ?;
-`, deleteBinds)
+WHERE        key IN ($Attrs[:])
+AND          cloud_uuid = $Cloud.uuid;
+`, Attrs{}, Cloud{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	upsertStmt := fmt.Sprintf(`
+	upsertStmt, err := sqlair.Prepare(`
 INSERT INTO cloud_defaults (cloud_uuid, key, value) 
-VALUES %s 
+VALUES ($CloudDefaults.cloud_uuid, $CloudDefaults.key, $CloudDefaults.value)
 ON CONFLICT(cloud_uuid, key) DO UPDATE
     SET value = excluded.value
     WHERE cloud_uuid = excluded.cloud_uuid
     AND key = excluded.key;
-`, database.MakeBindArgs(3, len(updateAttrs)))
+`, CloudDefaults{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		var uuid string
-		row := tx.QueryRowContext(ctx, selectStmt, cloudName)
-		if err := row.Scan(&uuid); err == sql.ErrNoRows {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		cloud := Cloud{Name: cloudName}
+		err := tx.Query(ctx, selectStmt, cloud).Get(&cloud)
+		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("cloud %q %w%w", cloudName, errors.NotFound, errors.Hide(err))
 		} else if err != nil {
 			return fmt.Errorf("fetching cloud %q: %w", cloudName, err)
 		}
 
-		if len(deleteVals) > 0 {
-			_, err := tx.ExecContext(ctx, deleteStmt, append(deleteVals, uuid)...)
-			if err != nil {
+		if len(removeAttrs) > 0 {
+			if err := tx.Query(ctx, deleteStmt, Attrs(removeAttrs), cloud).Run(); err != nil {
 				return fmt.Errorf("removing cloud default keys for %q: %w", cloudName, err)
 			}
 		}
 
-		if len(updateAttrs) > 0 {
-			values := make([]any, 0, len(updateAttrs)*3)
-			for k, v := range updateAttrs {
-				values = append(values, uuid, k, v)
-			}
-			_, err := tx.ExecContext(ctx, upsertStmt, values...)
+		for k, v := range updateAttrs {
+			err := tx.Query(ctx, upsertStmt, CloudDefaults{ID: cloud.ID, Key: k, Value: v}).Run()
 			if database.IsErrConstraintNotNull(err) {
 				return fmt.Errorf("missing cloud %q %w%w", cloudName, errors.NotValid, errors.Hide(err))
 			} else if err != nil {
@@ -265,41 +269,37 @@ func (st *State) CloudAllRegionDefaults(
 		return defaults, fmt.Errorf("getting database instance for cloud region defaults: %w", err)
 	}
 
-	stmt := `
-SELECT  cloud_region.name,
+	stmt, err := sqlair.Prepare(`
+SELECT  (cloud_region.name,
         cloud_region_defaults.key,
-        cloud_region_defaults.value
+        cloud_region_defaults.value)
+		AS (&CloudRegionDefaultValue.*)
 FROM    cloud_region_defaults
         INNER JOIN cloud_region
             ON cloud_region.uuid = cloud_region_defaults.region_uuid
         INNER JOIN cloud
             ON cloud_region.cloud_uuid = cloud.uuid
-WHERE   cloud.name = ?
-`
+WHERE   cloud.name = $Cloud.name
+`, CloudRegionDefaultValue{}, Cloud{})
+	if err != nil {
+		return defaults, errors.Trace(err)
+	}
 
-	return defaults, db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := tx.QueryContext(ctx, stmt, cloudName)
-		if err != nil {
+	return defaults, db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+
+		var regionDefaultValues []CloudRegionDefaultValue
+
+		if err := tx.Query(ctx, stmt, Cloud{Name: cloudName}).GetAll(&regionDefaultValues); err != nil {
 			return fmt.Errorf("fetching cloud %q region defaults: %w", cloudName, err)
 		}
-		defer rows.Close()
 
-		var regionName, key, value string
-		for rows.Next() {
-			if err := rows.Scan(&regionName, &key, &value); err != nil {
-				return fmt.Errorf(
-					"compiling cloud %q region %q defaults: %w",
-					cloudName,
-					regionName,
-					stderrors.Join(err, rows.Err()),
-				)
-			}
-			store, has := defaults[regionName]
+		for _, regionDefaultValue := range regionDefaultValues {
+			store, has := defaults[regionDefaultValue.Name]
 			if !has {
 				store = map[string]string{}
-				defaults[regionName] = store
+				defaults[regionDefaultValue.Name] = store
 			}
-			store[key] = value
+			store[regionDefaultValue.Key] = regionDefaultValue.Value
 		}
 		return nil
 	})
@@ -322,43 +322,49 @@ func (st *State) UpdateCloudRegionDefaults(
 		return errors.Trace(err)
 	}
 
-	selectStmt := `
-SELECT  cloud_region.uuid
+	selectStmt, err := sqlair.Prepare(`
+SELECT  cloud_region.uuid AS &CloudRegion.uuid
 FROM    cloud_region
         INNER JOIN cloud
             ON cloud_region.cloud_uuid = cloud.uuid
-WHERE   cloud.name = ?
-AND     cloud_region.name = ?;
-`
+WHERE   cloud.name = $Cloud.name
+AND     cloud_region.name = $CloudRegion.name;
+`, CloudRegion{}, Cloud{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	deleteBinds, deleteVals := database.SliceToPlaceholder(removeAttrs)
-	deleteStmt := fmt.Sprintf(`
+	deleteStmt, err := sqlair.Prepare(`
 DELETE FROM  cloud_region_defaults
-WHERE        key IN (%s)
-AND          region_uuid = ?;
-`, deleteBinds)
+WHERE        key IN ($Attrs[:])
+AND          region_uuid = $CloudRegion.uuid;
+`, Attrs{}, CloudRegion{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	upsertStmt := fmt.Sprintf(`
+	upsertStmt, err := sqlair.Prepare(`
 INSERT INTO cloud_region_defaults (region_uuid, key, value)
-VALUES %s
+VALUES ($CloudRegionDefaults.region_uuid, $CloudRegionDefaults.key, $CloudRegionDefaults.value) 
 ON CONFLICT(region_uuid, key) DO UPDATE
     SET value = excluded.value
     WHERE region_uuid = excluded.region_uuid
     AND key = excluded.key;
-`, database.MakeBindArgs(3, len(updateAttrs)))
+`, CloudRegionDefaults{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		var uuid string
-		row := tx.QueryRowContext(ctx, selectStmt, cloudName, regionName)
-		if err := row.Scan(&uuid); err == sql.ErrNoRows {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		cloudRegion := CloudRegion{Name: regionName}
+		if err := tx.Query(ctx, selectStmt, Cloud{Name: cloudName}, cloudRegion).Get(&cloudRegion); errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("cloud %q region %q %w%w", cloudName, regionName, errors.NotFound, errors.Hide(err))
 		} else if err != nil {
 			return fmt.Errorf("fetching cloud %q region %q: %w", cloudName, regionName, err)
 		}
 
-		if len(deleteVals) > 0 {
-			_, err := tx.ExecContext(ctx, deleteStmt, append(deleteVals, uuid)...)
-			if err != nil {
+		if len(removeAttrs) > 0 {
+			if err := tx.Query(ctx, deleteStmt, cloudRegion, append(Attrs(removeAttrs), cloudRegion.ID)).Run(); err != nil {
 				return fmt.Errorf(
 					"removing cloud %q region %q default keys: %w",
 					cloudName,
@@ -368,12 +374,8 @@ ON CONFLICT(region_uuid, key) DO UPDATE
 			}
 		}
 
-		if len(updateAttrs) > 0 {
-			values := make([]any, 0, len(updateAttrs)*3)
-			for k, v := range updateAttrs {
-				values = append(values, uuid, k, v)
-			}
-			_, err := tx.ExecContext(ctx, upsertStmt, values...)
+		for k, v := range updateAttrs {
+			err := tx.Query(ctx, upsertStmt, CloudRegionDefaults{ID: cloudRegion.ID, Key: k, Value: v}).Run()
 			if database.IsErrConstraintNotNull(err) {
 				return fmt.Errorf(
 					"missing region %q for cloud %q %w%w",
@@ -581,14 +583,18 @@ func (st *State) UpsertCloud(ctx context.Context, cloud cloud.Cloud) error {
 		return errors.Trace(err)
 	}
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	selectUUIDStmt, err := sqlair.Prepare("SELECT &Cloud.uuid FROM cloud WHERE name = $Cloud.name", Cloud{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Get the cloud UUID - either existing or make a new one.
-		var cloudUUID string
-		row := tx.QueryRowContext(ctx, "SELECT uuid FROM cloud WHERE name = ?", cloud.Name)
-		err := row.Scan(&cloudUUID)
-		if err != nil && err != sql.ErrNoRows {
+		dbCloud := Cloud{Name: cloud.Name}
+		err := tx.Query(ctx, selectUUIDStmt, dbCloud).Get(&dbCloud)
+		if err != nil && err != sqlair.ErrNoRows {
 			return errors.Trace(err)
 		}
+		cloudUUID := dbCloud.ID
 		if err != nil {
 			cloudUUID = uuid.MustNewUUID().String()
 		}
@@ -617,7 +623,7 @@ func (st *State) UpsertCloud(ctx context.Context, cloud cloud.Cloud) error {
 
 // CreateCloud saves the specified cloud.
 // Exported for use in the related cloud bootstrap package.
-func CreateCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud cloud.Cloud) error {
+func CreateCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud cloud.Cloud) error {
 	if err := upsertCloud(ctx, tx, cloudUUID, cloud); err != nil {
 		return errors.Annotatef(err, "updating cloud %s", cloudUUID)
 	}
@@ -633,30 +639,30 @@ func CreateCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud cloud.
 	return nil
 }
 
-func upsertCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud cloud.Cloud) error {
+func upsertCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud cloud.Cloud) error {
 	dbCloud, err := dbCloudFromCloud(ctx, tx, cloudUUID, cloud)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	q := `
-INSERT INTO cloud (uuid, name, cloud_type_id, endpoint, identity_endpoint, storage_endpoint, skip_tls_verify)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+	insertCloudStmt, err := sqlair.Prepare(`
+INSERT INTO cloud (uuid, name, cloud_type_id, endpoint,
+                   identity_endpoint, storage_endpoint,
+                   skip_tls_verify)
+VALUES ($Cloud.uuid, $Cloud.name, $Cloud.cloud_type_id, $Cloud.endpoint, 
+        $Cloud.identity_endpoint, $Cloud.storage_endpoint,
+        $Cloud.skip_tls_verify)
 ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
                                 endpoint=excluded.endpoint,
                                 identity_endpoint=excluded.identity_endpoint,
                                 storage_endpoint=excluded.storage_endpoint,
-                                skip_tls_verify=excluded.skip_tls_verify;`
+                                skip_tls_verify=excluded.skip_tls_verify;
+`, Cloud{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	_, err = tx.ExecContext(ctx, q,
-		dbCloud.ID,
-		dbCloud.Name,
-		dbCloud.TypeID,
-		dbCloud.Endpoint,
-		dbCloud.IdentityEndpoint,
-		dbCloud.StorageEndpoint,
-		dbCloud.SkipTLSVerify,
-	)
+	err = tx.Query(ctx, insertCloudStmt, dbCloud).Run()
 	if database.IsErrConstraintCheck(err) {
 		return fmt.Errorf("%w cloud name cannot be empty%w", errors.NotValid, errors.Hide(err))
 	} else if err != nil {
@@ -667,36 +673,33 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 
 // loadAuthTypes reads the cloud auth type values and ids
 // into a map for easy lookup.
-func loadAuthTypes(ctx context.Context, tx *sql.Tx) (map[string]int, error) {
+func loadAuthTypes(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
 	var dbAuthTypes = map[string]int{}
 
-	rows, err := tx.QueryContext(ctx, "SELECT id, type FROM auth_type")
-	if err != nil && err != sql.ErrNoRows {
+	stmt, err := sqlair.Prepare("SELECT &AuthType.* FROM auth_type", AuthType{})
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	for rows.Next() {
-		var (
-			id    int
-			value string
-		)
-		if err := rows.Scan(&id, &value); err != nil {
-			return nil, errors.Trace(err)
-		}
-		dbAuthTypes[value] = id
+	var authTypes []AuthType
+	err = tx.Query(ctx, stmt).GetAll(&authTypes)
+	if err != nil && err != sqlair.ErrNoRows {
+		return nil, errors.Trace(err)
 	}
-	return dbAuthTypes, rows.Err()
+	for _, authType := range authTypes {
+		dbAuthTypes[authType.Type] = authType.ID
+	}
+	return dbAuthTypes, nil
 }
 
-func updateAuthTypes(ctx context.Context, tx *sql.Tx, cloudUUID string, authTypes cloud.AuthTypes) error {
+func updateAuthTypes(ctx context.Context, tx *sqlair.TX, cloudUUID string, authTypes cloud.AuthTypes) error {
 	dbAuthTypes, err := loadAuthTypes(ctx, tx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// First validate the passed in auth types.
-	var authTypeIds = make([]int, len(authTypes))
+	var authTypeIds = make(AuthTypeIds, len(authTypes))
 	for i, a := range authTypes {
 		id, ok := dbAuthTypes[string(a)]
 		if !ok {
@@ -705,97 +708,115 @@ func updateAuthTypes(ctx context.Context, tx *sql.Tx, cloudUUID string, authType
 		authTypeIds[i] = id
 	}
 
-	authTypeIdsBinds, authTypeIdsAnyVals := database.SliceToPlaceholder(authTypeIds)
-
 	// Delete auth types no longer in the list.
-	deleteQuery := fmt.Sprintf(`
+	deleteQuery, err := sqlair.Prepare(`
 DELETE FROM  cloud_auth_type
-WHERE        cloud_uuid = ?
-AND          auth_type_id NOT IN (%s)
-`, authTypeIdsBinds)
-
-	args := append([]any{cloudUUID}, authTypeIdsAnyVals...)
-	if _, err := tx.ExecContext(ctx, deleteQuery, args...); err != nil {
+WHERE        cloud_uuid = $M.cloud_uuid
+AND          auth_type_id NOT IN ($AuthTypeIds[:])
+`, authTypeIds, sqlair.M{})
+	if err != nil {
 		return errors.Trace(err)
 	}
 
-	insertQuery := `
+	if err := tx.Query(ctx, deleteQuery, authTypeIds, sqlair.M{"cloud_uuid": cloudUUID}).Run(); err != nil {
+		return errors.Trace(err)
+	}
+
+	insertStmt, err := sqlair.Prepare(`
 INSERT INTO cloud_auth_type (cloud_uuid, auth_type_id)
-VALUES (?, ?)
+VALUES ($CloudAuthType.cloud_uuid, $CloudAuthType.auth_type_id)
 ON CONFLICT(cloud_uuid, auth_type_id) DO NOTHING;
-	`
+	`, CloudAuthType{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, a := range authTypeIds {
-		if _, err := tx.ExecContext(ctx, insertQuery, cloudUUID, a); err != nil {
+		cloudAuthType := CloudAuthType{CloudUUID: cloudUUID, AuthTypeID: a}
+		if err := tx.Query(ctx, insertStmt, cloudAuthType).Run(); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func updateCACerts(ctx context.Context, tx *sql.Tx, cloudUUID string, certs []string) error {
+func updateCACerts(ctx context.Context, tx *sqlair.TX, cloudUUID string, certs []string) error {
 	// Delete any existing ca certs - we just delete them all rather
 	// than keeping existing ones as the cert values are long strings.
-	deleteQuery := `
+	deleteQuery, err := sqlair.Prepare(`
 DELETE FROM  cloud_ca_cert
-WHERE        cloud_uuid = ?
-`
-
-	if _, err := tx.ExecContext(ctx, deleteQuery, cloudUUID); err != nil {
+WHERE        cloud_uuid = $M.cloud_uuid
+`, sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	insertQuery, err := sqlair.Prepare(`
+INSERT INTO cloud_ca_cert (cloud_uuid, ca_cert)
+VALUES ($CloudCACert.cloud_uuid, $CloudCACert.ca_cert)
+`, CloudCACert{})
+	if err != nil {
 		return errors.Trace(err)
 	}
 
-	insertQuery := `
-INSERT INTO cloud_ca_cert (cloud_uuid, ca_cert)
-VALUES (?, ?)
-`
-	for _, cert := range certs {
+	if err := tx.Query(ctx, deleteQuery, sqlair.M{"cloud_uuid": cloudUUID}).Run(); err != nil {
+		return errors.Trace(err)
+	}
 
-		if _, err := tx.ExecContext(ctx, insertQuery, cloudUUID, cert); err != nil {
+	for _, cert := range certs {
+		cloudCACert := CloudCACert{CloudUUID: cloudUUID, CACert: cert}
+		if err := tx.Query(ctx, insertQuery, cloudCACert).Run(); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func updateRegions(ctx context.Context, tx *sql.Tx, cloudUUID string, regions []cloud.Region) error {
-	regionNamesBinds, regionNames := database.SliceToPlaceholderTransform(
-		regions, func(r cloud.Region) any {
-			return r.Name
-		},
-	)
+func updateRegions(ctx context.Context, tx *sqlair.TX, cloudUUID string, regions []cloud.Region) error {
+	regionNames := RegionNames(transform.Slice(regions, func(r cloud.Region) string { return r.Name }))
 
-	// Delete any regions no longer in the list.
-	deleteQuery := fmt.Sprintf(`
+	deleteQuery, err := sqlair.Prepare(`
 DELETE FROM  cloud_region
-WHERE        cloud_uuid = ?
-AND          name NOT IN (%s)
-`, regionNamesBinds)
-
-	args := append([]any{cloudUUID}, regionNames...)
-	if _, err := tx.ExecContext(ctx, deleteQuery, args...); err != nil {
+WHERE        cloud_uuid = $M.cloud_uuid
+AND          name NOT IN ($RegionNames[:])
+`, RegionNames{}, sqlair.M{})
+	if err != nil {
 		return errors.Trace(err)
 	}
 
-	insertQuery := `
-INSERT INTO cloud_region (uuid, cloud_uuid, name, endpoint, identity_endpoint, storage_endpoint)
-VALUES (?, ?, ?, ?, ?, ?)
+	insertQuery, err := sqlair.Prepare(`
+INSERT INTO cloud_region (uuid, cloud_uuid, name,
+                          endpoint, identity_endpoint,
+                          storage_endpoint)
+VALUES ($CloudRegion.uuid, $CloudRegion.cloud_uuid, $CloudRegion.name, 
+        $CloudRegion.endpoint, $CloudRegion.identity_endpoint, 
+        $CloudRegion.storage_endpoint)
 ON CONFLICT(cloud_uuid, name) DO UPDATE SET name=excluded.name,
                                             endpoint=excluded.endpoint,
                                             identity_endpoint=excluded.identity_endpoint,
                                             storage_endpoint=excluded.storage_endpoint
-`
-	for _, r := range regions {
+`, CloudRegion{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-		if _, err := tx.ExecContext(ctx, insertQuery, uuid.MustNewUUID().String(), cloudUUID,
-			r.Name, r.Endpoint, r.IdentityEndpoint, r.StorageEndpoint,
-		); err != nil {
+	// Delete any regions no longer in the list.
+	if err := tx.Query(ctx, deleteQuery, sqlair.M{"cloud_uuid": cloudUUID}, regionNames).Run(); err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, r := range regions {
+		cloudRegion := CloudRegion{ID: uuid.MustNewUUID().String(),
+			CloudUUID: cloudUUID, Name: r.Name, Endpoint: r.Endpoint,
+			IdentityEndpoint: r.IdentityEndpoint,
+			StorageEndpoint:  r.StorageEndpoint}
+		if err := tx.Query(ctx, insertQuery, cloudRegion).Run(); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func dbCloudFromCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud cloud.Cloud) (*Cloud, error) {
+func dbCloudFromCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud cloud.Cloud) (*Cloud, error) {
 	cld := &Cloud{
 		ID:                cloudUUID,
 		Name:              cloud.Name,
@@ -806,9 +827,13 @@ func dbCloudFromCloud(ctx context.Context, tx *sql.Tx, cloudUUID string, cloud c
 		IsControllerCloud: cloud.IsControllerCloud,
 	}
 
-	row := tx.QueryRowContext(ctx, "SELECT id FROM cloud_type WHERE type = ?", cloud.Type)
-	err := row.Scan(&cld.TypeID)
-	if err == sql.ErrNoRows {
+	selectCloudIDstmt, err := sqlair.Prepare("SELECT id AS &Cloud.cloud_type_id FROM cloud_type WHERE type = $CloudType.type", Cloud{}, CloudType{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cloudType := CloudType{Type: cloud.Type}
+	err = tx.Query(ctx, selectCloudIDstmt, cloudType).Get(cld)
+	if err == sqlair.ErrNoRows {
 		return nil, errors.NotValidf("cloud type %q", cloud.Type)
 	}
 	if err != nil {

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -8,9 +8,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/juju/collections/transform"
-
 	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
@@ -454,9 +453,13 @@ FROM   cloud
 		}
 		cld, ok := clouds[dbCloud.ID]
 		if !ok {
+			cloudType, ok := m["cloud_type"].(string)
+			if !ok {
+				return nil, fmt.Errorf("error getting cloud type from database")
+			}
 			cld = &cloud.Cloud{
 				Name:              dbCloud.Name,
-				Type:              m["cloud_type"].(string),
+				Type:              cloudType,
 				Endpoint:          dbCloud.Endpoint,
 				IdentityEndpoint:  dbCloud.IdentityEndpoint,
 				StorageEndpoint:   dbCloud.StorageEndpoint,
@@ -470,7 +473,9 @@ FROM   cloud
 			clouds[dbCloud.ID] = cld
 		}
 		// "cloud_auth_type" will be in the map since iter.Get succeeded but may be set to nil.
-		if cloudAuthType := m["cloud_auth_type"]; cloudAuthType != nil {
+		if cloudAuthType, ok := m["cloud_auth_type"]; !ok {
+			return nil, fmt.Errorf("error getting cloud type from database")
+		} else if cloudAuthType != nil {
 			cld.AuthTypes = append(cld.AuthTypes, cloud.AuthType(cloudAuthType.(string)))
 		}
 	}

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -423,7 +423,7 @@ FROM   cloud
 `
 
 	if name != "" {
-		q = q + "WHERE cloud.name = $M.cloud_name"
+		q += "WHERE cloud.name = $M.cloud_name"
 	}
 
 	loadCloudStmt, err := sqlair.Prepare(q, sqlair.M{}, Cloud{})

--- a/domain/cloud/state/types.go
+++ b/domain/cloud/state/types.go
@@ -123,6 +123,8 @@ type CloudRegionDefaultValue struct {
 	Value string `db:"value"`
 }
 
+type CloudUUIDs []string
+
 type CloudCACert struct {
 	// ID holds the cloud ca cert document key.
 	ID string `db:"uuid"`

--- a/domain/cloud/state/types.go
+++ b/domain/cloud/state/types.go
@@ -5,6 +5,7 @@ package state
 
 // These structs represent the persistent cloud entity schema in the database.
 
+// CloudType represents a single row from the cloud_type table.
 type CloudType struct {
 	ID   int    `db:"id"`
 	Type string `db:"type"`
@@ -12,13 +13,18 @@ type CloudType struct {
 
 type AuthTypes []AuthType
 
+// AuthTypeIds represents a list of ids from the database.
 type AuthTypeIds []int
 
+// AuthType represents a single row from the auth_type table.
 type AuthType struct {
 	ID   int    `db:"id"`
 	Type string `db:"type"`
 }
 
+// Cloud represents a row from the cloud table joined with the cloud_type and
+// auth_type tables along with a column built form various tables signalling if
+// the cloud is a controller.
 type Cloud struct {
 	// ID holds the cloud document key.
 	ID string `db:"uuid"`
@@ -62,9 +68,6 @@ type CloudDefaults struct {
 }
 
 type CloudAuthType struct {
-	// ID holds the cloud auth type document key.
-	ID string `db:"uuid"`
-
 	// CloudUUID holds the cloud reference.
 	CloudUUID string `db:"cloud_uuid"`
 
@@ -76,6 +79,7 @@ type CloudAuthType struct {
 // cloud_region table.
 type RegionNames []string
 
+// CloudRegion represents a row in the cloud_region table.
 type CloudRegion struct {
 	// ID holds the cloud region document key.
 	ID string `db:"uuid"`
@@ -123,12 +127,11 @@ type CloudRegionDefaultValue struct {
 	Value string `db:"value"`
 }
 
+// CloudUUIDs is a slice of uuids from the database.
 type CloudUUIDs []string
 
+// CloudCACert represents a single row from the cloud_ca_cert table.
 type CloudCACert struct {
-	// ID holds the cloud ca cert document key.
-	ID string `db:"uuid"`
-
 	// CloudUUID holds the cloud reference.
 	CloudUUID string `db:"cloud_uuid"`
 

--- a/domain/cloud/state/types.go
+++ b/domain/cloud/state/types.go
@@ -12,6 +12,8 @@ type CloudType struct {
 
 type AuthTypes []AuthType
 
+type AuthTypeIds []int
+
 type AuthType struct {
 	ID   int    `db:"id"`
 	Type string `db:"type"`
@@ -43,6 +45,22 @@ type Cloud struct {
 	IsControllerCloud bool `db:"is_controller_cloud"`
 }
 
+// Attrs stores a list of attributes corresponding to keys in the cloud_defaults
+// table.
+type Attrs []string
+
+// CloudDefaults represents a single row from the cloud__defaults table.
+type CloudDefaults struct {
+	// ID holds the cloud uuid.
+	ID string `db:"cloud_uuid"`
+
+	// Key is the key value.
+	Key string `db:"key"`
+
+	// Value is the value associated with key.
+	Value string `db:"value"`
+}
+
 type CloudAuthType struct {
 	// ID holds the cloud auth type document key.
 	ID string `db:"uuid"`
@@ -51,8 +69,12 @@ type CloudAuthType struct {
 	CloudUUID string `db:"cloud_uuid"`
 
 	// AuthTypeID holds the auth type reference.
-	AuthTypeID string `db:"auth_type_id"`
+	AuthTypeID int `db:"auth_type_id"`
 }
+
+// RegionNames stores a list of regions names corresponding to names the
+// cloud_region table.
+type RegionNames []string
 
 type CloudRegion struct {
 	// ID holds the cloud region document key.
@@ -72,6 +94,33 @@ type CloudRegion struct {
 
 	// StorageEndpoint is the region's storage endpoint URL.
 	StorageEndpoint string `db:"storage_endpoint"`
+}
+
+// CloudRegionDefaults represents a single row from the cloud_region_defaults
+// table.
+type CloudRegionDefaults struct {
+	// ID holds the cloud region uuid.
+	ID string `db:"region_uuid"`
+
+	// Key is the key value.
+	Key string `db:"key"`
+
+	// Value is the value associated with key.
+	Value string `db:"value"`
+}
+
+// CloudRegionDefaultValue represents a single row from cloud_region_defaults
+// when joined with cloud_region on cloud_region_uuid. It is used when
+// deserializing defaults for all regions of a cloud.
+type CloudRegionDefaultValue struct {
+	// Name is the name of the region.
+	Name string `db:"name"`
+
+	// Key is the key value.
+	Key string `db:"key"`
+
+	// Value is the value associated with key.
+	Value string `db:"value"`
 }
 
 type CloudCACert struct {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
 	github.com/canonical/pebble v1.7.0
-	github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42
+	github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSH
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
 github.com/canonical/pebble v1.7.0 h1:VG7KcgEJ0eWq6JYnGWKQlWcyxZqqNdoiD+p8Dul19b8=
 github.com/canonical/pebble v1.7.0/go.mod h1:bROzibw902Vastd13S/H48BrVAjEUKnlRXv3ZIoFcPE=
-github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42 h1:s0eal/q/KeSKTZNYbkoJ1V3SSoUuhx+GCqoNN0zooto=
-github.com/canonical/sqlair v0.0.0-20240123165109-2862a9dffb42/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40 h1:ZQhteS4l8oF3adpLPCvJpLFBV638+uLpZtPQ8YLN3jk=
+github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"context"
 	"crypto/tls"
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -580,7 +579,7 @@ func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
 	credUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
 		return cloudstate.CreateCloud(ctx, tx, cloudUUID.String(), cloud.Cloud{
 			Name:      "caascloud",
 			Type:      "kubernetes",


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Use SQLair for slice queries in domain/cloud/state. Other queries in the same transactions are updated to use SQLair however there are some that could benefit from planned SQLair features and may benefit from being updated once those are added.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```TEST_PACKAGES="./domain/cloud/state -count=1 -race" TEST_FILTER="Suite" make run-go-tests```
<!-- Describe steps to verify that the change works. -->

## Documentation changes
N/A
<!-- How it affects user workflow (CLI or API). -->
