### PR TITLE
Remove DefaultEndpointBindingSpace from legacy state

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -77,7 +77,6 @@ type ModelManagerBackend interface {
 	AddSpace(string, network.Id, []string) (*state.Space, error)
 	AllEndpointBindingsSpaceNames() (set.Strings, error)
 	ConstraintsBySpaceName(string) ([]*state.Constraints, error)
-	DefaultEndpointBindingSpace() (string, error)
 	// TODO(nvinuesa): This method is necessary only until the spaces
 	// migration to dqlite is finished:
 	Space(id string) (*state.Space, error)

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -66,7 +66,6 @@ type DeployFromRepositoryState interface {
 	services.StateBackend
 
 	network.SpaceLookup
-	DefaultEndpointBindingSpace() (string, error)
 	Space(id string) (*state.Space, error)
 }
 

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -193,21 +193,6 @@ func (mr *MockDeployFromRepositoryStateMockRecorder) ControllerConfig() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockDeployFromRepositoryState)(nil).ControllerConfig))
 }
 
-// DefaultEndpointBindingSpace mocks base method.
-func (m *MockDeployFromRepositoryState) DefaultEndpointBindingSpace() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
-func (mr *MockDeployFromRepositoryStateMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockDeployFromRepositoryState)(nil).DefaultEndpointBindingSpace))
-}
-
 // Machine mocks base method.
 func (m *MockDeployFromRepositoryState) Machine(arg0 string) (Machine, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -272,21 +272,6 @@ func (mr *MockBackendMockRecorder) ControllerTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerTag", reflect.TypeOf((*MockBackend)(nil).ControllerTag))
 }
 
-// DefaultEndpointBindingSpace mocks base method.
-func (m *MockBackend) DefaultEndpointBindingSpace() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
-func (mr *MockBackendMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockBackend)(nil).DefaultEndpointBindingSpace))
-}
-
 // InferActiveRelation mocks base method.
 func (m *MockBackend) InferActiveRelation(arg0 ...string) (application.Relation, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -1210,21 +1210,6 @@ func (mr *MockReloadSpacesStateMockRecorder) ConstraintsBySpaceName(arg0 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockReloadSpacesState)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// DefaultEndpointBindingSpace mocks base method.
-func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
-func (mr *MockReloadSpacesStateMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).DefaultEndpointBindingSpace))
-}
-
 // Remove mocks base method.
 func (m *MockReloadSpacesState) Remove(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/environs/space/spaces.go
+++ b/environs/space/spaces.go
@@ -32,9 +32,6 @@ type ReloadSpacesState interface {
 	// ConstraintsBySpaceName returns all Constraints that include a positive
 	// or negative space constraint for the input space name.
 	ConstraintsBySpaceName(string) ([]Constraints, error)
-	// DefaultEndpointBindingSpace returns the current space ID to be used for
-	// the default endpoint binding.
-	DefaultEndpointBindingSpace() (string, error)
 	// AllEndpointBindingsSpaceNames returns a set of spaces names for all the
 	// endpoint bindings.
 	AllEndpointBindingsSpaceNames() (set.Strings, error)
@@ -185,10 +182,10 @@ func (s *ProviderSpaces) DeleteSpaces() ([]string, error) {
 		return nil, nil
 	}
 
-	defaultEndpointBinding, err := s.state.DefaultEndpointBindingSpace()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	// TODO (manadart 2024-01-29): The alpha space ID here is scaffolding and
+	// should be replaced with the configured model default space upon
+	// migrating this logic to Dqlite.
+	defaultEndpointBinding := network.AlphaSpaceId
 
 	allEndpointBindings, err := s.state.AllEndpointBindingsSpaceNames()
 	if err != nil {

--- a/environs/space/spaces_mock_test.go
+++ b/environs/space/spaces_mock_test.go
@@ -100,21 +100,6 @@ func (mr *MockReloadSpacesStateMockRecorder) ConstraintsBySpaceName(arg0 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockReloadSpacesState)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// DefaultEndpointBindingSpace mocks base method.
-func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
-func (mr *MockReloadSpacesStateMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).DefaultEndpointBindingSpace))
-}
-
 // Remove mocks base method.
 func (m *MockReloadSpacesState) Remove(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/environs/space/spaces_test.go
+++ b/environs/space/spaces_test.go
@@ -205,7 +205,6 @@ func (s *providerSpacesSuite) TestDeleteSpaces(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("2", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("1").Return(nil, nil)
 	mockState.EXPECT().Remove("1").Return(nil)
@@ -229,7 +228,6 @@ func (s *providerSpacesSuite) TestDeleteSpacesMatchesAlphaSpace(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("1", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 
 	provider := NewProviderSpaces(mockState)
@@ -248,11 +246,12 @@ func (s *providerSpacesSuite) TestDeleteSpacesMatchesAlphaSpace(c *gc.C) {
 }
 
 func (s *providerSpacesSuite) TestDeleteSpacesMatchesDefaultBindingSpace(c *gc.C) {
+	c.Skip("The default space is always alpha due to scaffolding in service of Dqlite migration.")
+
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("1", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 
 	provider := NewProviderSpaces(mockState)
@@ -275,7 +274,6 @@ func (s *providerSpacesSuite) TestDeleteSpacesContainedInAllEndpointBindings(c *
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("2", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings("1"), nil)
 
 	provider := NewProviderSpaces(mockState)
@@ -298,7 +296,6 @@ func (s *providerSpacesSuite) TestDeleteSpacesContainsConstraintsSpace(c *gc.C) 
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("2", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("1").Return([]Constraints{struct{}{}}, nil)
 
@@ -358,7 +355,6 @@ func (s *providerSpacesSuite) TestProviderSpacesRun(c *gc.C) {
 		},
 	})
 
-	mockState.EXPECT().DefaultEndpointBindingSpace().Return("2", nil)
 	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("space1").Return(nil, nil)
 

--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -287,6 +287,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 }
 
 func (s *bindingsSuite) TestMergeWithModelConfigNonDefaultSpace(c *gc.C) {
+	c.Skip("The default space is always alpha due to scaffolding in service of Dqlite migration.")
 	err := s.Model.UpdateModelConfig(map[string]interface{}{"default-space": s.appsSpace.Name()}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -308,20 +309,6 @@ func (s *bindingsSuite) TestMergeWithModelConfigNonDefaultSpace(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(b.Map(), jc.DeepEquals, updated)
 	c.Check(isModified, gc.Equals, true)
-}
-
-func (s *bindingsSuite) TestDefaultEndpointBindingSpaceNotDefault(c *gc.C) {
-	err := s.Model.UpdateModelConfig(map[string]interface{}{"default-space": s.clientSpace.Name()}, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	id, err := s.State.DefaultEndpointBindingSpace()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(id, gc.Equals, s.clientSpace.Id())
-}
-
-func (s *bindingsSuite) TestDefaultEndpointBindingSpaceDefault(c *gc.C) {
-	id, err := s.State.DefaultEndpointBindingSpace()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(id, gc.Equals, network.AlphaSpaceId)
 }
 
 func (s *bindingsSuite) copyMap(input map[string]string) map[string]string {

--- a/state/mocks/endpointbinding_mock.go
+++ b/state/mocks/endpointbinding_mock.go
@@ -55,21 +55,6 @@ func (mr *MockEndpointBindingMockRecorder) AllSpaceInfos() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaceInfos", reflect.TypeOf((*MockEndpointBinding)(nil).AllSpaceInfos))
 }
 
-// DefaultEndpointBindingSpace mocks base method.
-func (m *MockEndpointBinding) DefaultEndpointBindingSpace() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
-func (mr *MockEndpointBindingMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockEndpointBinding)(nil).DefaultEndpointBindingSpace))
-}
-
 // Space mocks base method.
 func (m *MockEndpointBinding) Space(arg0 string) (*state.Space, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Functionality for endpoint bindings uses a method in state called `DefaultEndpointBindingSpace`, which takes the space name configured for `default-binding` in model configuration, and looks up its ID.

Here, we add some vice code to remove the lookup, ensuring that we always just use the `alpha` space ID.

This eases the work of migrating the space domain to Dqlite.

## QA steps

Passing tests.

## Documentation changes

No, but noted in [risk register](https://docs.google.com/spreadsheets/d/1vSd3s0asNtpENdeC3tPkEo5mDja4inS5KwjCFxhyE5I).

## Links

**Jira card:** JUJU-5367

