### PR TITLE
Rollback changes on snapcraft.yaml including minikube env files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,6 @@ apps:
       - dot-google
       - dot-kubernetes
       - dot-maas
-      - dot-minikube
       - dot-openstack
       - dot-oracle
       # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
@@ -526,11 +525,6 @@ plugs:
     read:
       - $HOME/.maasrc
 
-  dot-minikube:
-    interface: personal-files
-    read:
-      - $HOME/.minikube
-
   dot-oracle:
     interface: personal-files
     read:
@@ -540,4 +534,3 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.novarc
-


### PR DESCRIPTION
These changes need to rollbacked until we get approval for auto connect from the snap store team.

Note: These same changes were also backported to 3.1, so we will get those changes when we merge forward next time.


