### PR TITLE
Fix racy test in dbaccessor

### DIFF
--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// States which report the state of the worker.
+	// States that report the state of the worker.
 	stateStarted    = "started"
 	stateDBReplaced = "db-replaced"
 )

--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -22,6 +22,12 @@ import (
 )
 
 const (
+	// States which report the state of the worker.
+	stateStarted    = "started"
+	stateDBReplaced = "db-replaced"
+)
+
+const (
 	// PollInterval is the amount of time to wait between polling the database.
 	PollInterval = time.Second * 10
 
@@ -70,7 +76,8 @@ func WithMetricsCollector(metrics *Collector) TrackedDBWorkerOption {
 }
 
 type trackedDBWorker struct {
-	tomb tomb.Tomb
+	internalStates chan string
+	tomb           tomb.Tomb
 
 	dbApp     DBApp
 	namespace string
@@ -92,12 +99,19 @@ type trackedDBWorker struct {
 func NewTrackedDBWorker(
 	ctx context.Context, dbApp DBApp, namespace string, opts ...TrackedDBWorkerOption,
 ) (TrackedDB, error) {
+	return newTrackedDBWorker(ctx, nil, dbApp, namespace, opts...)
+}
+
+func newTrackedDBWorker(
+	ctx context.Context, internalStates chan string, dbApp DBApp, namespace string, opts ...TrackedDBWorkerOption,
+) (TrackedDB, error) {
 	w := &trackedDBWorker{
-		dbApp:      dbApp,
-		namespace:  namespace,
-		clock:      clock.WallClock,
-		pingDBFunc: defaultPingDBFunc,
-		report:     &report{},
+		internalStates: internalStates,
+		dbApp:          dbApp,
+		namespace:      namespace,
+		clock:          clock.WallClock,
+		pingDBFunc:     defaultPingDBFunc,
+		report:         &report{},
 	}
 
 	for _, opt := range opts {
@@ -243,6 +257,9 @@ func (w *trackedDBWorker) loop() error {
 		}
 	}()
 
+	// Report the initial started state.
+	w.reportInternalState(stateStarted)
+
 	timer := w.clock.NewTimer(PollInterval)
 	defer timer.Stop()
 
@@ -288,6 +305,10 @@ func (w *trackedDBWorker) loop() error {
 				})
 				w.err = nil
 				w.mutex.Unlock()
+
+				// Notify the internal state channel that the database has been
+				// replaced.
+				w.reportInternalState(stateDBReplaced)
 			}
 
 			timer.Reset(PollInterval)
@@ -370,6 +391,14 @@ func (w *trackedDBWorker) ensureDBAliveAndOpenIfRequired(db *sql.DB) (*sql.DB, e
 		}
 	}
 	return nil, errors.NotValidf("database")
+}
+
+func (w *trackedDBWorker) reportInternalState(state string) {
+	select {
+	case <-w.tomb.Dying():
+	case w.internalStates <- state:
+	default:
+	}
 }
 
 func defaultPingDBFunc(ctx context.Context, db *sql.DB) error {

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -33,7 +33,7 @@ func (s *trackedDBWorkerSuite) TestWorkerStartup(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -47,7 +47,7 @@ func (s *trackedDBWorkerSuite) TestWorkerReport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -70,7 +70,7 @@ func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -93,7 +93,7 @@ func (s *trackedDBWorkerSuite) TestWorkerTxnIsNotNil(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -123,7 +123,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(1)
+	defer s.expectTimer(1)()
 
 	s.timer.EXPECT().Reset(PollInterval).Times(1)
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
@@ -153,7 +153,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) 
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(1)
+	defer s.expectTimer(1)()
 
 	s.timer.EXPECT().Reset(PollInterval).Times(1)
 
@@ -197,7 +197,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(2)
+	defer s.expectTimer(2)()
 
 	s.timer.EXPECT().Reset(PollInterval).Times(2)
 
@@ -228,7 +228,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceedsWithDiffer
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(1)
+	defer s.expectTimer(1)()
 
 	s.timer.EXPECT().Reset(PollInterval).Times(1)
 
@@ -288,7 +288,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(1)
+	defer s.expectTimer(1)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil).Times(DefaultVerifyAttempts)
 
@@ -316,7 +316,7 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxn(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -355,7 +355,7 @@ func (s *trackedDBWorkerSuite) TestWorkerCancelsTxnNoRetry(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
-	s.expectTimer(0)
+	defer s.expectTimer(0)()
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 


### PR DESCRIPTION
New patterns have formed from when we originally wrote the dbaccessor. The dbaccessor now gains an internal state, which will then send different messages to indicate different changes have occurred. This supersedes the racy sync points we've hooked on to the mocks before.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Hit the following test as much as possible:

```sh
$ TEST_PACKAGES="./internal/worker/dbaccessor -count=20 -race" TEST_FILTER="TestWorkerAttemptsToVerifyDBButSucceedsWithDifferentDB" make run-go-tests
```

## Links

**Jira card:** JUJU-

