### PR TITLE
Turn charm URL in CharmIDs into strings

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -140,7 +140,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 	deployArgs := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName:  args.ApplicationName,
-			CharmURL:         args.CharmID.URL.String(),
+			CharmURL:         args.CharmID.URL,
 			CharmOrigin:      &origin,
 			Channel:          origin.Risk,
 			NumUnits:         args.NumUnits,
@@ -234,8 +234,7 @@ func (c *Client) GetConfig(branchName string, appNames ...string) ([]map[string]
 type CharmID struct {
 
 	// URL of the given charm, includes the reference name and a revision.
-	// Old style charm URLs are also supported i.e. charmstore.
-	URL *charm.URL
+	URL string
 
 	// Origin holds the origin of a charm. This includes the source of the
 	// charm, along with the revision and channel to identify where the charm
@@ -319,7 +318,7 @@ func (c *Client) SetCharm(branchName string, cfg SetCharmConfig) error {
 
 	args := params.ApplicationSetCharm{
 		ApplicationName:    cfg.ApplicationName,
-		CharmURL:           cfg.CharmID.URL.String(),
+		CharmURL:           cfg.CharmID.URL,
 		CharmOrigin:        &paramsCharmOrigin,
 		Channel:            origin.Risk,
 		ConfigSettings:     cfg.ConfigSettings,

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -64,7 +64,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 
 	args := application.DeployArgs{
 		CharmID: application.CharmID{
-			URL: charm.MustParseURL("ch:a-charm-1"),
+			URL: "ch:a-charm-1",
 		},
 		CharmOrigin: apicharm.Origin{
 			Source: apicharm.OriginCharmHub,
@@ -117,7 +117,7 @@ func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
 
 	args := application.DeployArgs{
 		CharmID: application.CharmID{
-			URL: charm.MustParseURL("ch:a-charm-1"),
+			URL: "ch:a-charm-1",
 		},
 		CharmOrigin: apicharm.Origin{
 			Source: apicharm.OriginCharmHub,
@@ -266,7 +266,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 	cfg := application.SetCharmConfig{
 		ApplicationName: "application",
 		CharmID: application.CharmID{
-			URL: charm.MustParseURL("ch:application-1"),
+			URL: "ch:application-1",
 			Origin: apicharm.Origin{
 				Source: "charm-hub",
 				Risk:   "edge",

--- a/api/client/charms/client.go
+++ b/api/client/charms/client.go
@@ -197,10 +197,10 @@ func (c *Client) CheckCharmPlacement(applicationName string, curl *charm.URL) er
 }
 
 // ListCharmResources returns a list of associated resources for a given charm.
-func (c *Client) ListCharmResources(curl *charm.URL, origin apicharm.Origin) ([]charmresource.Resource, error) {
+func (c *Client) ListCharmResources(curl string, origin apicharm.Origin) ([]charmresource.Resource, error) {
 	args := params.CharmURLAndOrigins{
 		Entities: []params.CharmURLAndOrigin{{
-			CharmURL: curl.String(),
+			CharmURL: curl,
 			Origin:   origin.ParamsCharmOrigin(),
 		}},
 	}

--- a/api/client/charms/client_test.go
+++ b/api/client/charms/client_test.go
@@ -335,14 +335,14 @@ func (s *charmsMockSuite) TestListCharmResources(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	curl := charm.MustParseURL("a-charm")
+	curl := "a-charm"
 	noChannelParamsOrigin := params.CharmOrigin{Source: "charm-hub"}
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 
 	facadeArgs := params.CharmURLAndOrigins{
 		Entities: []params.CharmURLAndOrigin{
-			{CharmURL: curl.String(), Origin: noChannelParamsOrigin},
+			{CharmURL: curl, Origin: noChannelParamsOrigin},
 		},
 	}
 

--- a/api/client/resources/client.go
+++ b/api/client/resources/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -128,7 +127,7 @@ type CharmID struct {
 
 	// URL of the given charm, includes the reference name and a revision.
 	// Old style charm URLs are also supported i.e. charmstore.
-	URL *charm.URL
+	URL string
 
 	// Origin holds the origin of a charm. This includes the source of the
 	// charm, along with the revision and channel to identify where the charm
@@ -195,9 +194,7 @@ func newAddPendingResourcesArgsV2(tag names.ApplicationTag, chID CharmID, resour
 	}
 	args.Tag = tag.String()
 	args.Resources = apiResources
-	if chID.URL != nil {
-		args.URL = chID.URL.String()
-	}
+	args.URL = chID.URL
 	args.CharmOrigin = params.CharmOrigin{
 		Source:       chID.Origin.Source.String(),
 		ID:           chID.Origin.ID,

--- a/api/client/resources/client_upload_test.go
+++ b/api/client/resources/client_upload_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -161,7 +160,7 @@ func (s *UploadSuite) TestAddPendingResources(c *gc.C) {
 	}
 	s.mockFacadeCaller.EXPECT().FacadeCall("AddPendingResources", &args, result).SetArg(2, results).Return(nil)
 
-	cURL := charm.MustParseURL("ch:spam")
+	cURL := "ch:spam"
 	pendingIDs, err := s.client.AddPendingResources(resources.AddPendingResourcesArgs{
 		ApplicationID: "a-application",
 		CharmID: resources.CharmID{

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -274,7 +273,7 @@ func opClientApplicationSetCharm(c *gc.C, st api.Connection, _ *state.State) (fu
 	cfg := application.SetCharmConfig{
 		ApplicationName: "nosuch",
 		CharmID: application.CharmID{
-			URL:    charm.MustParseURL("local:quantal/wordpress"),
+			URL:    "local:wordpress",
 			Origin: apicharm.Origin{Source: "local"},
 		},
 	}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -821,7 +821,7 @@ func (s *DeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 
 	dArgs := application.DeployArgs{
 		CharmID: application.CharmID{
-			URL:    &deployURL,
+			URL:    deployURL.String(),
 			Origin: origin,
 		},
 		CharmOrigin:     origin,
@@ -1542,7 +1542,7 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 	)
 	s.fakeAPI.Call("Deploy", application.DeployArgs{
 		CharmID: application.CharmID{
-			URL:    curl,
+			URL:    curl.String(),
 			Origin: originWithSeries,
 		},
 		CharmOrigin:     originWithSeries,
@@ -1785,7 +1785,7 @@ func (s *DeploySuite) TestDeployCharmWithSomeEndpointBindingsSpecifiedSuccess(c 
 	}
 
 	charmID := application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: origin,
 	}
 
@@ -2576,7 +2576,7 @@ func withCharmDeployableWithDevicesAndStorage(
 	)
 	deployArgs := application.DeployArgs{
 		CharmID: application.CharmID{
-			URL:    &deployURL,
+			URL:    deployURL.String(),
 			Origin: origin,
 		},
 		CharmOrigin:     origin,
@@ -2641,7 +2641,7 @@ func withLocalBundleCharmDeployable(
 	fakeAPI.Call("ListSpaces").Returns([]apiparams.Space{}, error(nil))
 	deployArgs := application.DeployArgs{
 		CharmID: application.CharmID{
-			URL:    url,
+			URL:    url.String(),
 			Origin: commoncharm.Origin{Source: "local"},
 		},
 		CharmOrigin:     commoncharm.Origin{Source: "local", Base: base},

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -870,7 +870,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		numUnits = p.NumUnits
 	}
 
-	if charm.Local.Matches(chID.URL.Schema) {
+	if charm.Local.Matches(curl.Schema) {
 		var (
 			base corebase.Base
 			err  error
@@ -1264,7 +1264,7 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 }
 
 func (h *bundleHandler) upgradeCharmResources(chID application.CharmID, param bundlechanges.UpgradeCharmParams) (map[string]string, error) {
-	meta, err := utils.GetMetaResources(chID.URL, h.deployAPI)
+	meta, err := utils.GetMetaResources(chID.URL.String(), h.deployAPI)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -797,7 +797,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	}
 
 	chID := application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: origin,
 	}
 
@@ -834,7 +834,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		return errors.Trace(err)
 	}
 
-	charmInfo, err := h.deployAPI.CharmInfo(chID.URL.String())
+	charmInfo, err := h.deployAPI.CharmInfo(chID.URL)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1239,7 +1239,7 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 	}
 
 	chID := application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: origin,
 	}
 
@@ -1264,7 +1264,7 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 }
 
 func (h *bundleHandler) upgradeCharmResources(chID application.CharmID, param bundlechanges.UpgradeCharmParams) (map[string]string, error) {
-	meta, err := utils.GetMetaResources(chID.URL.String(), h.deployAPI)
+	meta, err := utils.GetMetaResources(chID.URL, h.deployAPI)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -2136,7 +2136,7 @@ func (s *BundleDeployRepositorySuite) bundleDeploySpecWithConstraints(cons const
 func (s *BundleDeployRepositorySuite) assertDeployArgs(c *gc.C, curl, appName, os, channel string) {
 	arg, found := s.deployArgs[appName]
 	c.Assert(found, jc.IsTrue, gc.Commentf("Application %q not found in deploy args %s", appName))
-	c.Assert(arg.CharmID.URL.String(), gc.Equals, curl)
+	c.Assert(arg.CharmID.URL, gc.Equals, curl)
 	c.Assert(arg.CharmOrigin.Base.OS, gc.Equals, os)
 	c.Assert(arg.CharmOrigin.Base.Channel.Track, gc.Equals, channel, gc.Commentf("%s", pretty.Sprint(arg)))
 }

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -61,7 +61,7 @@ func (d *deployCharm) deploy(
 	deployAPI DeployerAPI,
 ) (rErr error) {
 	id := d.id
-	charmInfo, err := deployAPI.CharmInfo(id.URL.String())
+	charmInfo, err := deployAPI.CharmInfo(id.URL)
 	if err != nil {
 		return err
 	}
@@ -87,9 +87,10 @@ func (d *deployCharm) deploy(
 			return errors.New("cannot use --num-units or --to with subordinate application")
 		}
 	}
+	charmName := charmInfo.Meta.Name
 	applicationName := d.applicationName
 	if applicationName == "" {
-		applicationName = charmInfo.Meta.Name
+		applicationName = charmName
 	}
 
 	// Process the --config args.
@@ -102,7 +103,7 @@ func (d *deployCharm) deploy(
 		delete(appConfig, app.TrustConfigOptionName)
 	}
 
-	if id.URL != nil && id.URL.Schema != "local" && len(charmInfo.Meta.Terms) > 0 {
+	if len(charmInfo.Meta.Terms) > 0 {
 		ctx.Infof("Deployment under prior agreement to terms: %s",
 			strings.Join(charmInfo.Meta.Terms, " "))
 	}
@@ -126,7 +127,7 @@ func (d *deployCharm) deploy(
 		appConfig = nil
 	}
 
-	ctx.Infof(d.formatDeployingText())
+	ctx.Infof(d.formatDeployingText(applicationName, charmName))
 	args := applicationapi.DeployArgs{
 		CharmID:          id,
 		CharmOrigin:      id.Origin,
@@ -174,20 +175,19 @@ func (d *deployCharm) validateCharmFlags() error {
 	return nil
 }
 
-func (d *deployCharm) formatDeployingText() string {
-	curl := d.id.URL
-	name := d.applicationName
-	if name == "" {
-		name = curl.Name
-	}
+func (d *deployCharm) formatDeployingText(applicationName, charmName string) string {
 	origin := d.id.Origin
 	channel := origin.CharmChannel().String()
 	if channel != "" {
 		channel = fmt.Sprintf(" in channel %s", channel)
 	}
+	var revision int
+	if origin.Revision != nil {
+		revision = *origin.Revision
+	}
 
 	return fmt.Sprintf("Deploying %q from %s charm %q, revision %d%s on %s",
-		name, origin.Source, curl.Name, curl.Revision, channel, origin.Base.String())
+		applicationName, origin.Source, charmName, revision, channel, origin.Base.String())
 }
 
 type predeployedLocalCharm struct {
@@ -254,7 +254,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 	}
 
 	d.id = application.CharmID{
-		URL:    d.userCharmURL,
+		URL:    d.userCharmURL.String(),
 		Origin: origin,
 	}
 	return d.deploy(ctx, deployAPI)
@@ -297,7 +297,7 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 
 	ctx.Infof(formatLocatedText(curl, origin))
 	l.id = application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: origin,
 	}
 	return l.deploy(ctx, deployAPI)
@@ -550,7 +550,7 @@ func (c *repositoryCharm) compatibilityPrepareAndDeploy(ctx *cmd.Context, deploy
 	}
 
 	c.id = application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: csOrigin,
 	}
 	return c.deploy(ctx, deployAPI)

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -259,7 +259,7 @@ func (s *charmSuite) newDeployCharm() *deployCharm {
 			return s.deployResourceIDs, nil
 		},
 		id: application.CharmID{
-			URL:    s.url,
+			URL:    s.url.String(),
 			Origin: commoncharm.Origin{Base: corebase.MakeDefaultBase("ubuntu", "20.04")},
 		},
 		flagSet:  &gnuflag.FlagSet{},

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -54,7 +54,7 @@ type ModelAPI interface {
 // command needs for charms.
 type CharmDeployAPI interface {
 	CharmInfo(string) (*apicharms.CharmInfo, error)
-	ListCharmResources(curl *charm.URL, origin commoncharm.Origin) ([]charmresource.Resource, error)
+	ListCharmResources(curl string, origin commoncharm.Origin) ([]charmresource.Resource, error)
 }
 
 // OfferAPI represents the methods of the API the deploy command needs

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -453,7 +453,7 @@ func (mr *MockDeployerAPIMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // ListCharmResources mocks base method.
-func (m *MockDeployerAPI) ListCharmResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockDeployerAPI) ListCharmResources(arg0 string, arg1 charm0.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -577,7 +577,7 @@ func (c *refreshCommand) upgradeResources(
 		return nil, errors.Trace(err)
 	}
 	charmsClient := c.NewCharmClient(apiRoot)
-	meta, err := utils.GetMetaResources(chID.URL, charmsClient)
+	meta, err := utils.GetMetaResources(chID.URL.String(), charmsClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -450,7 +450,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	chID := application.CharmID{
-		URL:    curl,
+		URL:    curl.String(),
 		Origin: origin,
 	}
 	resourceIDs, err := c.upgradeResources(apiRoot, chID)
@@ -577,7 +577,7 @@ func (c *refreshCommand) upgradeResources(
 		return nil, errors.Trace(err)
 	}
 	charmsClient := c.NewCharmClient(apiRoot)
-	meta, err := utils.GetMetaResources(chID.URL.String(), charmsClient)
+	meta, err := utils.GetMetaResources(chID.URL, charmsClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -1315,7 +1315,7 @@ func (m *mockCharmClient) CharmInfo(curl string) (*apicommoncharms.CharmInfo, er
 	return m.charmInfo, nil
 }
 
-func (m *mockCharmClient) ListCharmResources(curl *charm.URL, origin commoncharm.Origin) ([]charmresource.Resource, error) {
+func (m *mockCharmClient) ListCharmResources(curl string, origin commoncharm.Origin) ([]charmresource.Resource, error) {
 	m.MethodCall(m, "ListCharmResources", curl, origin)
 	if err := m.NextErr(); err != nil {
 		return nil, err

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -263,7 +263,7 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -293,7 +293,7 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -316,7 +316,7 @@ func (s *RefreshSuite) TestConfigSettingsWithTrust(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -338,7 +338,7 @@ func (s *RefreshSuite) TestConfigSettingsWithTrustFalse(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -365,7 +365,7 @@ func (s *RefreshSuite) TestConfigSettingsWithKeyValuesAndFile(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -413,7 +413,7 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -651,7 +651,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -678,7 +678,7 @@ func (s *RefreshSuite) TestUpgradeWithChannelNoNewCharmURL(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -706,7 +706,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -747,7 +747,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				Source:       "charm-hub",
 				Architecture: arch.DefaultArchitecture,
@@ -988,7 +988,7 @@ func (s *RefreshSuite) TestUpgradeSameVersionWithResourceUpload(c *gc.C) {
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
 		CharmID: application.CharmID{
-			URL: s.resolvedCharmURL,
+			URL: s.resolvedCharmURL.String(),
 			Origin: commoncharm.Origin{
 				ID:           "testing",
 				Source:       "charm-hub",
@@ -1050,7 +1050,7 @@ func (s *RefreshCharmHubSuite) TestUpgradeResourceRevision(c *gc.C) {
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmClient.CheckCallNames(c, "CharmInfo", "ListCharmResources", "CharmInfo")
 	s.CheckCall(c, 9, "DeployResources", "foo", resources.CharmID{
-		URL: s.resolvedCharmURL,
+		URL: s.resolvedCharmURL.String(),
 		Origin: commoncharm.Origin{
 			ID:           "testing",
 			Source:       "charm-hub",
@@ -1093,7 +1093,7 @@ func (s *RefreshCharmHubSuite) TestUpgradeResourceRevisionSupplied(c *gc.C) {
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmClient.CheckCallNames(c, "CharmInfo", "ListCharmResources", "CharmInfo")
 	s.CheckCall(c, 9, "DeployResources", "foo", resources.CharmID{
-		URL: s.resolvedCharmURL,
+		URL: s.resolvedCharmURL.String(),
 		Origin: commoncharm.Origin{
 			ID:           "testing",
 			Source:       "charm-hub",

--- a/cmd/juju/application/utils/interface.go
+++ b/cmd/juju/application/utils/interface.go
@@ -4,7 +4,6 @@
 package utils
 
 import (
-	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
 
 	apicharm "github.com/juju/juju/api/common/charm"
@@ -19,7 +18,7 @@ import (
 // by the upgrade-charm command and to GetMetaResources.
 type CharmClient interface {
 	CharmInfo(string) (*charms.CharmInfo, error)
-	ListCharmResources(curl *charm.URL, origin apicharm.Origin) ([]charmresource.Resource, error)
+	ListCharmResources(curl string, origin apicharm.Origin) ([]charmresource.Resource, error)
 }
 
 // ResourceLister defines a subset of the resources facade, as required

--- a/cmd/juju/application/utils/mocks/charmresource_mock.go
+++ b/cmd/juju/application/utils/mocks/charmresource_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	charm "github.com/juju/charm/v12"
 	resource "github.com/juju/charm/v12/resource"
-	charm0 "github.com/juju/juju/api/common/charm"
+	charm "github.com/juju/juju/api/common/charm"
 	charms "github.com/juju/juju/api/common/charms"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -58,7 +57,7 @@ func (mr *MockCharmClientMockRecorder) CharmInfo(arg0 any) *gomock.Call {
 }
 
 // ListCharmResources mocks base method.
-func (m *MockCharmClient) ListCharmResources(arg0 *charm.URL, arg1 charm0.Origin) ([]resource.Resource, error) {
+func (m *MockCharmClient) ListCharmResources(arg0 string, arg1 charm.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -19,6 +18,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api/client/application"
+	apicharm "github.com/juju/juju/api/common/charm"
 	app "github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/cmd/modelcmd"
 	corecharm "github.com/juju/juju/core/charm"
@@ -97,7 +97,7 @@ func GetUpgradeResources(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return filterResourcesForUpgrade(newCharmID.URL, meta, current, available, providedResources)
+	return filterResourcesForUpgrade(newCharmID.Origin.Source, meta, current, available, providedResources)
 }
 
 // getCurrentResources gets the current resources for this charm in
@@ -120,7 +120,7 @@ func getAvailableRepositoryResources(newCharmID application.CharmID, repositoryR
 		// not required for local charms
 		return nil, nil
 	}
-	available, err := repositoryResourceLister.ListCharmResources(newCharmID.URL.String(), newCharmID.Origin)
+	available, err := repositoryResourceLister.ListCharmResources(newCharmID.URL, newCharmID.Origin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -135,7 +135,7 @@ func getAvailableRepositoryResources(newCharmID application.CharmID, repositoryR
 }
 
 func filterResourcesForUpgrade(
-	newCharmURL *charm.URL,
+	source apicharm.OriginSource,
 	meta map[string]charmresource.Meta,
 	current map[string]resources.Resource,
 	available map[string]charmresource.Resource,
@@ -145,7 +145,7 @@ func filterResourcesForUpgrade(
 	for name, res := range meta {
 		var doUpgrade bool
 		var err error
-		if newCharmURL.Schema == charm.Local.String() {
+		if source == apicharm.OriginLocal {
 			doUpgrade, err = shouldUpgradeResourceLocalCharm(res.Name, providedResources, current)
 		} else {
 			doUpgrade, err = shouldUpgradeResource(res.Name, providedResources, current, available)

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -29,9 +29,9 @@ import (
 var logger = loggo.GetLogger("juju.cmd.juju.application.utils")
 
 // GetMetaResources retrieves metadata resources for the given
-// charm.URL.
-func GetMetaResources(charmURL *charm.URL, client CharmClient) (map[string]charmresource.Meta, error) {
-	charmInfo, err := client.CharmInfo(charmURL.String())
+// charmURL.
+func GetMetaResources(charmURL string, client CharmClient) (map[string]charmresource.Meta, error) {
+	charmInfo, err := client.CharmInfo(charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -120,7 +120,7 @@ func getAvailableRepositoryResources(newCharmID application.CharmID, repositoryR
 		// not required for local charms
 		return nil, nil
 	}
-	available, err := repositoryResourceLister.ListCharmResources(newCharmID.URL, newCharmID.Origin)
+	available, err := repositoryResourceLister.ListCharmResources(newCharmID.URL.String(), newCharmID.Origin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/utils/utils_test.go
+++ b/cmd/juju/application/utils/utils_test.go
@@ -52,8 +52,8 @@ var _ = gc.Suite(&utilsResourceSuite{})
 func (s *utilsResourceSuite) TestGetMetaResources(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl := charm.MustParseURL("local:trusty/multi-series-1")
-	s.expectCharmInfo(curl.String())
+	curl := "local:trusty/multi-series-1"
+	s.expectCharmInfo(curl)
 
 	obtained, err := utils.GetMetaResources(curl, s.charmClient)
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,7 +123,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesLocalCharmNewResources(c *gc
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesCHCharmNewEmptyRes(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(&charm.URL{}), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
 
 	// switching to ch charm, new empty resources will be uploaded.
 	s.assertGetUpgradeResources(c, func(
@@ -161,7 +161,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesLocalCharmError(c *gc.C) {
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesNotOriginUpload(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(&charm.URL{}), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
 
 	// switching to ch charm, empty resource will be upgraded if the existing resource origin was not OriginUpload.
 	s.assertGetUpgradeResources(c, func(
@@ -187,7 +187,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesNotOriginUpload(c *gc.C) {
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesOriginUpload(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(&charm.URL{}), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
 
 	// switching to ch charm and empty resource will NOT be upgraded if the existing resource origin was OriginUpload.
 	s.assertGetUpgradeResources(c, func(
@@ -367,7 +367,7 @@ func (s *utilsResourceSuite) expectListCharmResources(redis, snappass, testfile 
 	availableCharmResources := []charmresource.Resource{
 		r1, r2, r3,
 	}
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(&charm.URL{}), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(availableCharmResources, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(availableCharmResources, nil)
 }
 
 func (s *utilsResourceSuite) expectListResources(redis, snappass, testfile int) {

--- a/cmd/juju/application/utils/utils_test.go
+++ b/cmd/juju/application/utils/utils_test.go
@@ -123,7 +123,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesLocalCharmNewResources(c *gc
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesCHCharmNewEmptyRes(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	// switching to ch charm, new empty resources will be uploaded.
 	s.assertGetUpgradeResources(c, func(
@@ -161,7 +161,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesLocalCharmError(c *gc.C) {
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesNotOriginUpload(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	// switching to ch charm, empty resource will be upgraded if the existing resource origin was not OriginUpload.
 	s.assertGetUpgradeResources(c, func(
@@ -187,7 +187,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesNotOriginUpload(c *gc.C) {
 
 func (s *utilsResourceSuite) TestGetUpgradeResourcesOriginUpload(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(nil, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	// switching to ch charm and empty resource will NOT be upgraded if the existing resource origin was OriginUpload.
 	s.assertGetUpgradeResources(c, func(
@@ -247,7 +247,7 @@ func (s *utilsResourceSuite) assertGetUpgradeResources(
 	expected, errString := getExpectedMeta(newCharmURL, cliResources, resourcesInController, resourcesInMetadata)
 	s.resourceFacade.EXPECT().ListResources([]string{"snappass-test"}).Return(resourcesInController, nil)
 	charmID := application.CharmID{
-		URL:    newCharmURL,
+		URL:    newCharmURL.String(),
 		Origin: apicharm.Origin{Source: schemaToOriginSource(newCharmURL.Schema)},
 	}
 	filtered, err := utils.GetUpgradeResources(
@@ -339,7 +339,7 @@ func (s *utilsResourceSuite) TestGetUpgradeResourcesRepositoryCLIRevisionAlready
 }
 
 func repoCharmID() application.CharmID {
-	newCharmURL := &charm.URL{Schema: "ch", Name: "snappass-test", Revision: 0, Series: "focal"}
+	newCharmURL := "ch:snappass-test-0"
 	return application.CharmID{
 		URL: newCharmURL,
 		Origin: apicharm.Origin{
@@ -367,7 +367,7 @@ func (s *utilsResourceSuite) expectListCharmResources(redis, snappass, testfile 
 	availableCharmResources := []charmresource.Resource{
 		r1, r2, r3,
 	}
-	s.charmClient.EXPECT().ListCharmResources(gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(apicharm.Origin{})).Return(availableCharmResources, nil)
+	s.charmClient.EXPECT().ListCharmResources(gomock.Any(), gomock.Any()).Return(availableCharmResources, nil)
 }
 
 func (s *utilsResourceSuite) expectListResources(redis, snappass, testfile int) {

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -24,7 +24,7 @@ type ResourceLister interface {
 
 // CharmResourceLister lists the resource of a charm.
 type CharmResourceLister interface {
-	ListCharmResources(curl *charm.URL, origin apicharm.Origin) ([]charmresource.Resource, error)
+	ListCharmResources(curl string, origin apicharm.Origin) ([]charmresource.Resource, error)
 }
 
 // CharmID represents the charm identifier.
@@ -262,7 +262,7 @@ func (c *CharmhubResourceLister) ListResources(ids []CharmID) ([][]charmresource
 		return nil, errors.Trace(err)
 	}
 	client := charms.NewClient(apiRoot)
-	results, err := client.ListCharmResources(id.URL, apicharm.Origin{
+	results, err := client.ListCharmResources(id.URL.String(), apicharm.Origin{
 		Source: apicharm.OriginCharmHub,
 		Track:  track,
 		Risk:   string(id.Channel.Risk),

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/juju/charm/v12"
 	charmresource "github.com/juju/charm/v12/resource"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -39,7 +38,7 @@ func (s *DeploySuite) SetUpTest(c *gc.C) {
 
 func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 	deps := uploadDeps{stub: s.stub}
-	cURL := charm.MustParseURL("spam")
+	cURL := "spam"
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
@@ -84,7 +83,7 @@ func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 
 func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 	deps := uploadDeps{stub: s.stub, data: []byte("file contents")}
-	cURL := charm.MustParseURL("spam")
+	cURL := "spam"
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
@@ -138,7 +137,7 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 
 func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
 	deps := uploadDeps{stub: s.stub}
-	cURL := charm.MustParseURL("spam")
+	cURL := "spam"
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
@@ -187,7 +186,7 @@ func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
 
 func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 	deps := uploadDeps{stub: s.stub, data: []byte("file contents")}
-	cURL := charm.MustParseURL("spam")
+	cURL := "spam"
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
@@ -399,7 +398,7 @@ password: 'hunter2',,
 			deps.data = []byte(t.fileContents)
 		}
 
-		cURL := charm.MustParseURL("mysql-k8s")
+		cURL := "mysql-k8s"
 		chID := apiresources.CharmID{
 			URL: cURL,
 		}


### PR DESCRIPTION
This is part of work that is being done to treat charm URL as an opaque
string.

In the majority of cases, the charm URL was just stringified immidiately
after access.

However, in 3 places we access attributes

1) formatDeployingText
   This was resolved by passing through applicationName and charmName
   from the caller. This also has the result of reducing code
   duplication

2) terms
   Terms were only logged for non-local charms. As discussed, instead we just
   always log when we can

3) filterResourcesForUpgrade
   filterResourcesForUpgrade branches on local/charmhub charms. Instead
   of determining this using the charm url schema, use the charm origin
   source

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## Integration tests

```
./main.sh -v -c aws -p ec2 resources
```

```
./main.sh -v -c aws -p ec2 deploy
```

## QA steps

```
$ juju add-model m
$ juju deploy ubuntu
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@22.04/stable

$ juju deploy ubuntu ubu20 --base ubuntu@20.04
Deployed "ubu20" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@20.04/stable

$ juju deploy ubuntu ubu-focal --series focal
WARNING series flag is deprecated, use --base instead
Deployed "ubu-focal" from charm-hub charm "ubuntu", revision 24 in channel stable on ubuntu@20.04/stable
```

Ensure an ubuntu charm is downloaded (and optionally unzipped) to `~/charms/ubuntu`)
```
$ juju add-model m2
$ juju deploy ~/charms/ubuntu
Located local charm "ubuntu", revision 0
Deploying "ubuntu" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ~/charms/ubuntu ubu20 --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubu20" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable

$ juju deploy ~/charms/ubuntu ubu-focal --series focal
WARNING series flag is deprecated, use --base instead
Located local charm "ubuntu", revision 1
Deploying "ubu-focal" from local charm "ubuntu", revision 1 on ubuntu@20.04/stable
```

Ensure juju-qa-test is downloaded (and optionally unzipped) to `~/charms/juju-qa-test`
```
$ juju add-model m3
$ juju deploy juju-qa-test --resource foo-file="./tests/suites/resources/foo-file.txt"
(wait until active)
$ juju config juju-qa-test foo-file=true
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m3     lxd         localhost/localhost  3.4-rc1.1  unsupported  13:12:18Z

App           Version  Status  Scale  Charm         Channel  Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  stable    25  no       resource line one: did the resource attach?

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.219.211.78          resource line one: did the resource attach?

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.78  juju-b05ac2-0  ubuntu@22.04      Running

$ juju refresh juju-qa-test --channel 2.0/edge
Added charm-hub charm "juju-qa-test", revision 23 in channel 2.0/edge, to the model
no change to endpoint in space "alpha": info
(wait until active)
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m3     lxd         localhost/localhost  3.4-rc1.1  unsupported  13:27:08Z

App           Version  Status  Scale  Charm         Channel   Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  2.0/edge   23  no       resource line one: did the resource attach?

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.219.211.244         resource line one: did the resource attach?

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.244  juju-d82daf-0  ubuntu@22.04      Running

$ juju refresh juju-qa-test --path ~/charms/juju-qa-test
(wait until active)
$ juju status 
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m3     lxd         localhost/localhost  3.4-rc1.1  unsupported  13:28:29Z

App           Version  Status  Scale  Charm         Channel  Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test             0  no       resource line one: did the resource attach?

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.219.211.244         resource line one: did the resource attach?

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.244  juju-d82daf-0  ubuntu@22.04      Running

$ juju refresh juju-qa-test --path ~/charms/juju-qa-test
(wait until active)
$ juju status 
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m3     lxd         localhost/localhost  3.4-rc1.1  unsupported  13:29:11Z

App           Version  Status  Scale  Charm         Channel  Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test             1  no       resource line one: did the resource attach?

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.219.211.244         resource line one: did the resource attach?

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.244  juju-d82daf-0  ubuntu@22.04      Running
