### PR TITLE
Move address finding out of the worker

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machinelock"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/presence"
 	coretrace "github.com/juju/juju/core/trace"
@@ -875,8 +874,9 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			PopulateControllerCharm: bootstrap.PopulateControllerCharm,
 			LoggerFactory:           bootstrap.LoggoLoggerFactory(loggo.GetLogger("juju.worker.bootstrap")),
 
-			NewEnvironFunc:         config.NewEnvironFunc,
-			BootstrapAddressesFunc: bootstrap.BootstrapAddresses,
+			NewEnviron:             config.NewEnvironFunc,
+			BootstrapAddresses:     bootstrap.BootstrapAddresses,
+			BootstrapAddressFinder: bootstrap.IAASBootstrapAddressFinder,
 
 			AgentBinaryUploader:     bootstrap.IAASAgentBinaryUploader,
 			ControllerCharmDeployer: bootstrap.IAASControllerCharmUploader,
@@ -1100,12 +1100,9 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			PopulateControllerCharm: bootstrap.PopulateControllerCharm,
 			LoggerFactory:           bootstrap.LoggoLoggerFactory(loggo.GetLogger("juju.worker.bootstrap")),
 
-			NewEnvironFunc: func(context.Context, environs.OpenParams) (environs.Environ, error) {
-				return nil, errors.NotSupportedf("environ creator function in CAAS")
-			},
-			BootstrapAddressesFunc: func(ctx context.Context, env environs.Environ, bootstrapInstanceID instance.Id) (network.ProviderAddresses, error) {
-				return nil, errors.NotSupportedf("bootstrap address function in CAAS")
-			},
+			BootstrapAddressFinder: bootstrap.CAASBootstrapAddressFinder,
+			NewEnviron:             bootstrap.CAASNewEnviron,
+			BootstrapAddresses:     bootstrap.BootstrapAddresses,
 
 			AgentBinaryUploader:     bootstrap.CAASAgentBinaryUploader,
 			ControllerCharmDeployer: bootstrap.CAASControllerCharmUploader,

--- a/internal/worker/bootstrap/addressfinder.go
+++ b/internal/worker/bootstrap/addressfinder.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/internal/bootstrap"
+)
+
+// BootstrapAddressesConfig encapsulates the configuration options for the
+// bootstrap addresses finder.
+type BootstrapAddressesConfig struct {
+	BootstrapInstanceID    instance.Id
+	SystemState            SystemState
+	CloudService           CloudService
+	CredentialService      CredentialService
+	NewEnvironFunc         NewEnvironFunc
+	BootstrapAddressesFunc BootstrapAddressesFunc
+}
+
+// CAASBootstrapAddressFinder returns the bootstrap addresses for CAAS. We know
+// that currently CAAS doesn't implement InstanceListener, so we return
+// localhost.
+func CAASBootstrapAddressFinder(ctx context.Context, config BootstrapAddressesConfig) (network.ProviderAddresses, error) {
+	return network.NewMachineAddresses([]string{"localhost"}).AsProviderAddresses(), nil
+}
+
+// CAASNewEnviron returns a new environ for CAAS. We know that currently CAAS
+// doesn't implement InstanceListener, so we return an error.
+func CAASNewEnviron(ctx context.Context, params environs.OpenParams) (environs.Environ, error) {
+	return nil, errors.NotSupportedf("new environ")
+}
+
+// CAASBootstrapAddresses returns the bootstrap addresses for CAAS. We know that
+// currently CAAS doesn't implement InstanceListener, so we return an error.
+func CAASBootstrapAddresses(ctx context.Context, env environs.Environ, bootstrapInstanceID instance.Id) (network.ProviderAddresses, error) {
+	return nil, errors.NotSupportedf("bootstrap addresses")
+}
+
+// IAASBootstrapAddressFinder returns the bootstrap addresses for IAAS.
+func IAASBootstrapAddressFinder(ctx context.Context, config BootstrapAddressesConfig) (network.ProviderAddresses, error) {
+	env, err := getEnviron(ctx, config.SystemState, config.CloudService, config.CredentialService, config.NewEnvironFunc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	addresses, err := config.BootstrapAddressesFunc(ctx, env, config.BootstrapInstanceID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return addresses, nil
+}
+
+// getEnviron creates a new environ using the provided NewEnvironFunc from the
+// worker config.
+func getEnviron(ctx context.Context, state SystemState, cloudService CloudService, credentialService CredentialService, newEnviron NewEnvironFunc) (environs.Environ, error) {
+	controllerModel, err := state.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cred, err := getEnvironCredential(ctx, controllerModel, credentialService)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cloud, err := cloudService.Get(ctx, controllerModel.CloudName())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cloudSpec, err := cloudspec.MakeCloudSpec(*cloud, controllerModel.CloudRegion(), cred)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	controllerModelConfig, err := controllerModel.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return newEnviron(ctx, environs.OpenParams{
+		ControllerUUID: state.ControllerModelUUID(),
+		Cloud:          cloudSpec,
+		Config:         controllerModelConfig,
+	})
+}
+
+func getEnvironCredential(ctx context.Context, controllerModel bootstrap.Model, credentialService CredentialService) (*cloud.Credential, error) {
+	var cred *cloud.Credential
+	if cloudCredentialTag, ok := controllerModel.CloudCredentialTag(); ok {
+		credentialValue, err := credentialService.CloudCredential(ctx, credential.IdFromTag(cloudCredentialTag))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cloudCredential := cloud.NewNamedCredential(
+			credentialValue.Label,
+			credentialValue.AuthType(),
+			credentialValue.Attributes(),
+			credentialValue.Revoked,
+		)
+		cred = &cloudCredential
+	}
+
+	return cred, nil
+}

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -72,6 +72,18 @@ func (s *manifoldSuite) TestValidateConfig(c *gc.C) {
 	cfg = s.getConfig()
 	cfg.ControllerUnitPassword = nil
 	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.NewEnviron = nil
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.BootstrapAddresses = nil
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.BootstrapAddressFinder = nil
+	c.Check(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
@@ -98,8 +110,11 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		RequiresBootstrap: func(context.Context, FlagService) (bool, error) {
 			return false, nil
 		},
-		NewEnvironFunc: func(context.Context, environs.OpenParams) (environs.Environ, error) { return nil, nil },
-		BootstrapAddressesFunc: func(context.Context, environs.Environ, instance.Id) (network.ProviderAddresses, error) {
+		NewEnviron: func(context.Context, environs.OpenParams) (environs.Environ, error) { return nil, nil },
+		BootstrapAddresses: func(context.Context, environs.Environ, instance.Id) (network.ProviderAddresses, error) {
+			return nil, nil
+		},
+		BootstrapAddressFinder: func(context.Context, BootstrapAddressesConfig) (network.ProviderAddresses, error) {
 			return nil, nil
 		},
 	}

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -17,7 +17,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	cloud "github.com/juju/juju/cloud"
 	controller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/flags"
@@ -50,7 +49,6 @@ func (s *workerSuite) TestKilled(c *gc.C) {
 	s.expectAgentConfig(c)
 	s.expectObjectStoreGetter(2)
 	s.expectBootstrapFlagSet()
-	s.expectGetEnviron()
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
@@ -116,8 +114,11 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		ControllerCharmDeployer: func(ControllerCharmDeployerConfig) (bootstrap.ControllerCharmDeployer, error) {
 			return nil, nil
 		},
-		NewEnvironFunc: func(context.Context, environs.OpenParams) (environs.Environ, error) { return nil, nil },
-		BootstrapAddressesFunc: func(context.Context, environs.Environ, instance.Id) (network.ProviderAddresses, error) {
+		NewEnviron: func(context.Context, environs.OpenParams) (environs.Environ, error) { return nil, nil },
+		BootstrapAddresses: func(context.Context, environs.Environ, instance.Id) (network.ProviderAddresses, error) {
+			return nil, nil
+		},
+		BootstrapAddressFinder: func(context.Context, BootstrapAddressesConfig) (network.ProviderAddresses, error) {
 			return nil, nil
 		},
 	}, s.states)
@@ -154,23 +155,6 @@ func (s *workerSuite) ensureState(c *gc.C, st string) {
 
 func (s *workerSuite) expectControllerConfig() {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{}, nil)
-}
-
-func (s *workerSuite) expectGetEnviron() {
-	s.state.EXPECT().Model().Return(s.stateModel, nil)
-	s.stateModel.EXPECT().CloudCredentialTag()
-	s.stateModel.EXPECT().CloudName().Return("cloud-name")
-	s.stateModel.EXPECT().CloudRegion().Return("cloud-region")
-	s.stateModel.EXPECT().Config().Return(&config.Config{}, nil)
-	cloud := cloud.Cloud{
-		Regions: []cloud.Region{
-			{
-				Name: "cloud-region",
-			},
-		},
-	}
-	s.cloudService.EXPECT().Get(gomock.Any(), "cloud-name").Return(&cloud, nil)
-	s.state.EXPECT().ControllerModelUUID()
 }
 
 func (s *workerSuite) expectObjectStoreGetter(num int) {


### PR DESCRIPTION
This PR moves everything to be consistent in the bootstrap worker. In doing so, we can see that there aren't any tests around locating the bootstrap addresses. We'll need to sweep back over them to ensure that we have at least some of them.

From a consistency point of view:

 - Have types that describe funcs
 - Drop `Func` suffix for variables
 - Remove worker knowledge about environs (we can pass that in via the config) 

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Machine (local)

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
```

### Microk8s

```sh
$ juju bootstrap microk8s test
``` 

## Links

**Jira card:** JUJU-

