### PR TITLE
Ensure we can set migration phase to DONE idempotently.

### DIFF
--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -849,10 +849,10 @@ func (st *State) LatestMigration() (ModelMigration, error) {
 	// away from a model and then migrated back.
 	if phase == migration.DONE {
 		model, err := st.Model()
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			return nil, errors.Trace(err)
 		}
-		if model.MigrationMode() == MigrationModeNone {
+		if model != nil && model.MigrationMode() == MigrationModeNone {
 			return nil, errors.NotFoundf("migration")
 		}
 	}


### PR DESCRIPTION
After a model has been migrated away, after reaping the model, the migration master sets the migration phase to DONE.
Although this should not have any consequence, as the phase is already set to DONE, we need to be idempotent here. If we are setting to DONE and the model doesn't exists and we are already DONE, we should continue without error.

## QA steps

Unit tests should still pass.

## Documentation changes

N/A

## Links

[`alt-model-migration-controller-debug.log: machine-0: 11:24:57 ERROR juju.worker.dependency "migration-master" manifold worker returned unexpected error: failed to set phase: could not get migration: model "3a971d6b-338d-47aa-8cbd-f5fc83be4b2a" not found (not found)`](https://jenkins.juju.canonical.com/job/test-model-test-model-migration-aws/1923/)