### PR TITLE
Replace a bunch more context.TODO() in api clients

### DIFF
--- a/agent/engine/apiagent.go
+++ b/agent/engine/apiagent.go
@@ -21,7 +21,7 @@ type AgentAPIManifoldConfig struct {
 }
 
 // AgentAPIStartFunc encapsulates the behaviour that varies among AgentAPIManifolds.
-type AgentAPIStartFunc func(agent.Agent, base.APICaller) (worker.Worker, error)
+type AgentAPIStartFunc func(context.Context, agent.Agent, base.APICaller) (worker.Worker, error)
 
 // AgentAPIManifold returns a dependency.Manifold that calls the supplied start
 // func with the API and agent resources defined in the config (once those
@@ -41,7 +41,7 @@ func AgentAPIManifold(config AgentAPIManifoldConfig, start AgentAPIStartFunc) de
 			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
-			return start(agent, apiCaller)
+			return start(ctx, agent, apiCaller)
 		},
 	}
 }

--- a/agent/engine/apiagent_test.go
+++ b/agent/engine/apiagent_test.go
@@ -38,7 +38,7 @@ func (s *AgentAPIManifoldSuite) SetUpTest(c *gc.C) {
 	}, s.newWorker)
 }
 
-func (s *AgentAPIManifoldSuite) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (s *AgentAPIManifoldSuite) newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	s.AddCall("newWorker", a, apiCaller)
 	if err := s.NextErr(); err != nil {
 		return nil, err

--- a/agent/errors/errors.go
+++ b/agent/errors/errors.go
@@ -4,6 +4,7 @@
 package errors
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -108,20 +109,20 @@ func MoreImportantError(err0, err1 error) error {
 
 // Breakable provides a type that exposes an IsBroken check.
 type Breakable interface {
-	IsBroken() bool
+	IsBroken(ctx context.Context) bool
 }
 
 // ConnectionIsFatal returns a function suitable for passing as the
 // isFatal argument to worker.NewRunner, that diagnoses an error as
 // fatal if the connection has failed or if the error is otherwise
 // fatal.
-func ConnectionIsFatal(logger Logger, conns ...Breakable) func(err error) bool {
+func ConnectionIsFatal(ctx context.Context, logger Logger, conns ...Breakable) func(err error) bool {
 	return func(err error) bool {
 		if IsFatal(err) {
 			return true
 		}
 		for _, conn := range conns {
-			if ConnectionIsDead(logger, conn) {
+			if ConnectionIsDead(ctx, logger, conn) {
 				return true
 			}
 		}
@@ -130,8 +131,8 @@ func ConnectionIsFatal(logger Logger, conns ...Breakable) func(err error) bool {
 }
 
 // ConnectionIsDead returns true if the given Breakable is broken.
-var ConnectionIsDead = func(logger Logger, conn Breakable) bool {
-	return conn.IsBroken()
+var ConnectionIsDead = func(ctx context.Context, logger Logger, conn Breakable) bool {
+	return conn.IsBroken(ctx)
 }
 
 // Pinger provides a type that knows how to ping.

--- a/agent/errors/errors_test.go
+++ b/agent/errors/errors_test.go
@@ -4,6 +4,7 @@
 package errors_test
 
 import (
+	"context"
 	stderrors "errors"
 	"fmt"
 
@@ -97,7 +98,7 @@ func (s *toolSuite) TestConnectionIsFatal(c *gc.C) {
 	for i, conn := range []*testConn{errConn, okConn} {
 		for j, test := range isFatalTests {
 			c.Logf("test %d.%d: %s", i, j, test.err)
-			fatal := agenterrors.ConnectionIsFatal(s.logger, conn)(test.err)
+			fatal := agenterrors.ConnectionIsFatal(context.Background(), s.logger, conn)(test.err)
 			if test.isFatal {
 				c.Check(fatal, jc.IsTrue)
 			} else {
@@ -113,15 +114,16 @@ func (s *toolSuite) TestConnectionIsFatalWithMultipleConns(c *gc.C) {
 
 	someErr := stderrors.New("foo")
 
-	c.Assert(agenterrors.ConnectionIsFatal(s.logger, okConn, okConn)(someErr),
+	ctx := context.Background()
+	c.Assert(agenterrors.ConnectionIsFatal(ctx, s.logger, okConn, okConn)(someErr),
 		jc.IsFalse)
-	c.Assert(agenterrors.ConnectionIsFatal(s.logger, okConn, okConn, okConn)(someErr),
+	c.Assert(agenterrors.ConnectionIsFatal(ctx, s.logger, okConn, okConn, okConn)(someErr),
 		jc.IsFalse)
-	c.Assert(agenterrors.ConnectionIsFatal(s.logger, okConn, errConn)(someErr),
+	c.Assert(agenterrors.ConnectionIsFatal(ctx, s.logger, okConn, errConn)(someErr),
 		jc.IsTrue)
-	c.Assert(agenterrors.ConnectionIsFatal(s.logger, okConn, okConn, errConn)(someErr),
+	c.Assert(agenterrors.ConnectionIsFatal(ctx, s.logger, okConn, okConn, errConn)(someErr),
 		jc.IsTrue)
-	c.Assert(agenterrors.ConnectionIsFatal(s.logger, errConn, okConn, okConn)(someErr),
+	c.Assert(agenterrors.ConnectionIsFatal(ctx, s.logger, errConn, okConn, okConn)(someErr),
 		jc.IsTrue)
 }
 
@@ -177,7 +179,7 @@ type testConn struct {
 	broken bool
 }
 
-func (c *testConn) IsBroken() bool {
+func (c *testConn) IsBroken(_ context.Context) bool {
 	return c.broken
 }
 

--- a/api/agent/agent/client.go
+++ b/api/agent/agent/client.go
@@ -51,12 +51,12 @@ func NewClient(caller base.APICaller, options ...Option) (*Client, error) {
 	}, nil
 }
 
-func (st *Client) getEntity(tag names.Tag) (*params.AgentGetEntitiesResult, error) {
+func (st *Client) getEntity(ctx context.Context, tag names.Tag) (*params.AgentGetEntitiesResult, error) {
 	var results params.AgentGetEntitiesResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
-	err := st.facade.FacadeCall(context.TODO(), "GetEntities", args, &results)
+	err := st.facade.FacadeCall(ctx, "GetEntities", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +69,9 @@ func (st *Client) getEntity(tag names.Tag) (*params.AgentGetEntitiesResult, erro
 	return &results.Entities[0], nil
 }
 
-func (st *Client) StateServingInfo() (controller.StateServingInfo, error) {
+func (st *Client) StateServingInfo(ctx context.Context) (controller.StateServingInfo, error) {
 	var results params.StateServingInfo
-	err := st.facade.FacadeCall(context.TODO(), "StateServingInfo", nil, &results)
+	err := st.facade.FacadeCall(ctx, "StateServingInfo", nil, &results)
 	if err != nil {
 		return controller.StateServingInfo{}, errors.Trace(err)
 	}
@@ -93,8 +93,8 @@ type Entity struct {
 	doc params.AgentGetEntitiesResult
 }
 
-func (st *Client) Entity(tag names.Tag) (*Entity, error) {
-	doc, err := st.getEntity(tag)
+func (st *Client) Entity(ctx context.Context, tag names.Tag) (*Entity, error) {
+	doc, err := st.getEntity(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (m *Entity) Jobs() []model.MachineJob {
 
 // IsController returns true of the tag is for a controller (machine or agent).
 // TODO(controlleragent) - this method is needed while IAAS controllers are still machines.
-func IsController(caller base.APICaller, tag names.Tag) (bool, error) {
+func IsController(ctx context.Context, caller base.APICaller, tag names.Tag) (bool, error) {
 	if tag.Kind() == names.ControllerAgentTagKind {
 		return true, nil
 	}
@@ -133,7 +133,7 @@ func IsController(caller base.APICaller, tag names.Tag) (bool, error) {
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	machine, err := apiSt.Entity(tag)
+	machine, err := apiSt.Entity(ctx, tag)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/api/agent/agent/client_test.go
+++ b/api/agent/agent/client_test.go
@@ -4,6 +4,7 @@
 package agent_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v5"
@@ -51,7 +52,7 @@ func (s *clientSuite) TestStateServingInfo(c *gc.C) {
 	})
 	client, err := agent.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	info, err := client.StateServingInfo()
+	info, err := client.StateServingInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, controller.StateServingInfo{
 		APIPort:           666,
@@ -66,7 +67,7 @@ func (s *clientSuite) TestStateServingInfo(c *gc.C) {
 }
 
 func (s *clientSuite) TestIsControllerShortCircuits(c *gc.C) {
-	result, err := agent.IsController(nil, names.NewControllerAgentTag("0"))
+	result, err := agent.IsController(context.Background(), nil, names.NewControllerAgentTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsTrue)
 }
@@ -92,7 +93,7 @@ func (s *clientSuite) TestMachineEntity(c *gc.C) {
 	tag := names.NewMachineTag("42")
 	client, err := agent.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Entity(tag)
+	m, err := client.Entity(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, tag.String())
 	c.Assert(m.Life(), gc.Equals, life.Alive)

--- a/api/agent/agent/facade.go
+++ b/api/agent/agent/facade.go
@@ -37,10 +37,10 @@ const (
 type ConnFacade interface {
 
 	// Life returns Alive, Dying, Dead, ErrDenied, or some other error.
-	Life(names.Tag) (Life, error)
+	Life(context.Context, names.Tag) (Life, error)
 
 	// SetPassword returns nil, ErrDenied, or some other error.
-	SetPassword(names.Tag, string) error
+	SetPassword(context.Context, names.Tag, string) error
 }
 
 // ErrDenied is returned by Life and SetPassword to indicate that the
@@ -63,12 +63,12 @@ type connFacade struct {
 }
 
 // Life is part of the ConnFacade interface.
-func (facade *connFacade) Life(entity names.Tag) (Life, error) {
+func (facade *connFacade) Life(ctx context.Context, entity names.Tag) (Life, error) {
 	var results params.AgentGetEntitiesResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: entity.String()}},
 	}
-	err := facade.caller.FacadeCall(context.TODO(), "GetEntities", args, &results)
+	err := facade.caller.FacadeCall(ctx, "GetEntities", args, &results)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -90,7 +90,7 @@ func (facade *connFacade) Life(entity names.Tag) (Life, error) {
 }
 
 // SetPassword is part of the ConnFacade interface.
-func (facade *connFacade) SetPassword(entity names.Tag, password string) error {
+func (facade *connFacade) SetPassword(ctx context.Context, entity names.Tag, password string) error {
 	var results params.ErrorResults
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{{
@@ -98,7 +98,7 @@ func (facade *connFacade) SetPassword(entity names.Tag, password string) error {
 			Password: password,
 		}},
 	}
-	err := facade.caller.FacadeCall(context.TODO(), "SetPasswords", args, &results)
+	err := facade.caller.FacadeCall(ctx, "SetPasswords", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/agent/agent/facade_test.go
+++ b/api/agent/agent/facade_test.go
@@ -4,6 +4,8 @@
 package agent_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -35,7 +37,7 @@ func (s *FacadeSuite) TestLifeCallError(c *gc.C) {
 	facade, err := agent.NewConnFacade(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 
-	life, err := facade.Life(names.NewApplicationTag("omg"))
+	life, err := facade.Life(context.Background(), names.NewApplicationTag("omg"))
 	c.Check(err, gc.ErrorMatches, "splat")
 	c.Check(life, gc.Equals, agent.Life(""))
 }
@@ -45,7 +47,7 @@ func (s *FacadeSuite) TestLifeNoResult(c *gc.C) {
 	facade, err := agent.NewConnFacade(lifeChecker(c, result))
 	c.Assert(err, jc.ErrorIsNil)
 
-	life, err := facade.Life(names.NewApplicationTag("omg"))
+	life, err := facade.Life(context.Background(), names.NewApplicationTag("omg"))
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
 	c.Check(life, gc.Equals, agent.Life(""))
 }
@@ -57,7 +59,7 @@ func (s *FacadeSuite) TestLifeOversizedResult(c *gc.C) {
 	facade, err := agent.NewConnFacade(lifeChecker(c, result))
 	c.Assert(err, jc.ErrorIsNil)
 
-	life, err := facade.Life(names.NewApplicationTag("omg"))
+	life, err := facade.Life(context.Background(), names.NewApplicationTag("omg"))
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Check(life, gc.Equals, agent.Life(""))
 }
@@ -139,7 +141,7 @@ func (s *FacadeSuite) TestSetPasswordCallError(c *gc.C) {
 	facade, err := agent.NewConnFacade(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = facade.SetPassword(names.NewApplicationTag("omg"), "seekr1t")
+	err = facade.SetPassword(context.Background(), names.NewApplicationTag("omg"), "seekr1t")
 	c.Check(err, gc.ErrorMatches, "splat")
 }
 
@@ -148,7 +150,7 @@ func (s *FacadeSuite) TestSetPasswordNoResult(c *gc.C) {
 	facade, err := agent.NewConnFacade(passwordChecker(c, result))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = facade.SetPassword(names.NewApplicationTag("omg"), "blah")
+	err = facade.SetPassword(context.Background(), names.NewApplicationTag("omg"), "blah")
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
@@ -159,7 +161,7 @@ func (s *FacadeSuite) TestSetPasswordOversizedResult(c *gc.C) {
 	facade, err := agent.NewConnFacade(passwordChecker(c, result))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = facade.SetPassword(names.NewApplicationTag("omg"), "blah")
+	err = facade.SetPassword(context.Background(), names.NewApplicationTag("omg"), "blah")
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
@@ -207,7 +209,7 @@ func testLifeAPIResult(c *gc.C, result params.AgentGetEntitiesResult) (agent.Lif
 	}))
 	c.Assert(err, jc.ErrorIsNil)
 
-	return facade.Life(names.NewApplicationTag("omg"))
+	return facade.Life(context.Background(), names.NewApplicationTag("omg"))
 }
 
 func lifeChecker(c *gc.C, result params.AgentGetEntitiesResults) base.APICaller {
@@ -225,7 +227,7 @@ func testPasswordAPIResult(c *gc.C, result params.ErrorResult) error {
 	}))
 	c.Assert(err, jc.ErrorIsNil)
 
-	return facade.SetPassword(names.NewApplicationTag("omg"), "blah")
+	return facade.SetPassword(context.Background(), names.NewApplicationTag("omg"), "blah")
 }
 
 func passwordChecker(c *gc.C, result params.ErrorResults) base.APICaller {

--- a/api/agent/caasapplication/client.go
+++ b/api/agent/caasapplication/client.go
@@ -41,13 +41,13 @@ type UnitConfig struct {
 }
 
 // UnitIntroduction introduces the unit and returns an agent config.
-func (c *Client) UnitIntroduction(podName string, podUUID string) (*UnitConfig, error) {
+func (c *Client) UnitIntroduction(ctx context.Context, podName string, podUUID string) (*UnitConfig, error) {
 	var result params.CAASUnitIntroductionResult
 	args := params.CAASUnitIntroductionArgs{
 		PodName: podName,
 		PodUUID: podUUID,
 	}
-	err := c.facade.FacadeCall(context.TODO(), "UnitIntroduction", args, &result)
+	err := c.facade.FacadeCall(ctx, "UnitIntroduction", args, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +74,12 @@ type UnitTermination struct {
 
 // UnitTerminating is to be called by the CAASUnitTerminationWorker when the uniter is
 // shutting down.
-func (c *Client) UnitTerminating(unit names.UnitTag) (UnitTermination, error) {
+func (c *Client) UnitTerminating(ctx context.Context, unit names.UnitTag) (UnitTermination, error) {
 	var result params.CAASUnitTerminationResult
 	args := params.Entity{
 		Tag: unit.String(),
 	}
-	err := c.facade.FacadeCall(context.TODO(), "UnitTerminating", args, &result)
+	err := c.facade.FacadeCall(ctx, "UnitTerminating", args, &result)
 	if err != nil {
 		return UnitTermination{}, err
 	}

--- a/api/agent/caasapplication/client_test.go
+++ b/api/agent/caasapplication/client_test.go
@@ -4,6 +4,8 @@
 package caasapplication_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -45,7 +47,7 @@ func (s *provisionerSuite) TestUnitIntroduction(c *gc.C) {
 		}
 		return nil
 	})
-	unitConfig, err := client.UnitIntroduction("pod-name", "pod-uuid")
+	unitConfig, err := client.UnitIntroduction(context.Background(), "pod-name", "pod-uuid")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(unitConfig, gc.NotNil)
@@ -70,7 +72,7 @@ func (s *provisionerSuite) TestUnitIntroductionFail(c *gc.C) {
 		}
 		return nil
 	})
-	_, err := client.UnitIntroduction("pod-name", "pod-uuid")
+	_, err := client.UnitIntroduction(context.Background(), "pod-name", "pod-uuid")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 	c.Assert(called, jc.IsTrue)
 }
@@ -92,7 +94,7 @@ func (s *provisionerSuite) TestUnitIntroductionFailAlreadyExists(c *gc.C) {
 		}
 		return nil
 	})
-	_, err := client.UnitIntroduction("pod-name", "pod-uuid")
+	_, err := client.UnitIntroduction(context.Background(), "pod-name", "pod-uuid")
 	c.Assert(err, jc.ErrorIs, errors.AlreadyExists)
 	c.Assert(called, jc.IsTrue)
 }
@@ -114,7 +116,7 @@ func (s *provisionerSuite) TestUnitIntroductionFailNotAssigned(c *gc.C) {
 		}
 		return nil
 	})
-	_, err := client.UnitIntroduction("pod-name", "pod-uuid")
+	_, err := client.UnitIntroduction(context.Background(), "pod-name", "pod-uuid")
 	c.Assert(err, jc.ErrorIs, errors.NotAssigned)
 	c.Assert(called, jc.IsTrue)
 }
@@ -149,7 +151,7 @@ func (s *provisionerSuite) TestUnitTerminating(c *gc.C) {
 			}
 			return nil
 		})
-		unitTermination, err := client.UnitTerminating(names.NewUnitTag("app/0"))
+		unitTermination, err := client.UnitTerminating(context.Background(), names.NewUnitTag("app/0"))
 		if test.err == nil {
 			c.Assert(err, jc.ErrorIsNil)
 		} else {

--- a/api/agent/credentialvalidator/credentialvalidator.go
+++ b/api/agent/credentialvalidator/credentialvalidator.go
@@ -40,10 +40,10 @@ func NewFacade(caller base.APICaller, options ...Option) *Facade {
 // Some clouds do not require a credential and support the "empty" authentication
 // type. Models on these clouds will have no credentials set, and thus, will return
 // a false as 2nd argument.
-func (c *Facade) ModelCredential() (base.StoredCredential, bool, error) {
+func (c *Facade) ModelCredential(ctx context.Context) (base.StoredCredential, bool, error) {
 	out := params.ModelCredential{}
 	emptyResult := base.StoredCredential{}
-	if err := c.facade.FacadeCall(context.TODO(), "ModelCredential", nil, &out); err != nil {
+	if err := c.facade.FacadeCall(ctx, "ModelCredential", nil, &out); err != nil {
 		return emptyResult, false, errors.Trace(err)
 	}
 
@@ -65,13 +65,13 @@ func (c *Facade) ModelCredential() (base.StoredCredential, bool, error) {
 
 // WatchCredential provides a notify watcher that is responsive to changes
 // to a given cloud credential.
-func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, error) {
+func (c *Facade) WatchCredential(ctx context.Context, credentialID string) (watcher.NotifyWatcher, error) {
 	if !names.IsValidCloudCredential(credentialID) {
 		return nil, errors.NotValidf("cloud credential ID %q", credentialID)
 	}
 	in := names.NewCloudCredentialTag(credentialID).String()
 	var result params.NotifyWatchResult
-	err := c.facade.FacadeCall(context.TODO(), "WatchCredential", params.Entity{in}, &result)
+	err := c.facade.FacadeCall(ctx, "WatchCredential", params.Entity{in}, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -84,10 +84,10 @@ func (c *Facade) WatchCredential(credentialID string) (watcher.NotifyWatcher, er
 }
 
 // InvalidateModelCredential invalidates cloud credential for the model that made a connection.
-func (c *Facade) InvalidateModelCredential(reason string) error {
+func (c *Facade) InvalidateModelCredential(ctx context.Context, reason string) error {
 	in := params.InvalidateCredentialArg{reason}
 	var result params.ErrorResult
-	err := c.facade.FacadeCall(context.TODO(), "InvalidateModelCredential", in, &result)
+	err := c.facade.FacadeCall(ctx, "InvalidateModelCredential", in, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -100,9 +100,9 @@ func (c *Facade) InvalidateModelCredential(reason string) error {
 
 // WatchModelCredential provides a notify watcher that is responsive to changes
 // to a given cloud credential.
-func (c *Facade) WatchModelCredential() (watcher.NotifyWatcher, error) {
+func (c *Facade) WatchModelCredential(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
-	err := c.facade.FacadeCall(context.TODO(), "WatchModelCredential", nil, &result)
+	err := c.facade.FacadeCall(ctx, "WatchModelCredential", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/credentialvalidator/credentialvalidator_test.go
+++ b/api/agent/credentialvalidator/credentialvalidator_test.go
@@ -4,6 +4,8 @@
 package credentialvalidator_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -39,7 +41,7 @@ func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	found, exists, err := client.ModelCredential()
+	found, exists, err := client.ModelCredential(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsTrue)
 	c.Assert(found, gc.DeepEquals, base.StoredCredential{CloudCredential: "cloud/user/credential", Valid: true})
@@ -55,7 +57,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialIsNotNeeded(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential()
+	_, exists, err := client.ModelCredential(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsFalse)
 }
@@ -71,7 +73,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialInvalidCredentialTag(c *gc
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, exists, err := client.ModelCredential()
+	_, exists, err := client.ModelCredential(context.Background())
 	c.Assert(err, gc.ErrorMatches, `"some-invalid-cloud-credential-tag-as-string" is not a valid tag`)
 	c.Assert(exists, jc.IsFalse)
 }
@@ -82,7 +84,7 @@ func (s *CredentialValidatorSuite) TestModelCredentialCallError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, _, err := client.ModelCredential()
+	_, _, err := client.ModelCredential(context.Background())
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -93,7 +95,7 @@ func (s *CredentialValidatorSuite) TestWatchCredentialError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, err := client.WatchCredential(credentialID)
+	_, err := client.WatchCredential(context.Background(), credentialID)
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -103,7 +105,7 @@ func (s *CredentialValidatorSuite) TestWatchCredentialCallError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	_, err := client.WatchCredential(credentialID)
+	_, err := client.WatchCredential(context.Background(), credentialID)
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -126,7 +128,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	err := client.InvalidateModelCredential("auth fail")
+	err := client.InvalidateModelCredential(context.Background(), "auth fail")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -137,7 +139,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialBackendFailure(c
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential(context.Background(), "")
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -147,7 +149,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apiCaller)
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential(context.Background(), "")
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -157,7 +159,7 @@ func (s *CredentialValidatorSuite) TestWatchModelCredentialError(c *gc.C) {
 		return nil
 	})
 	client := credentialvalidator.NewFacade(apitesting.BestVersionCaller{apiCaller, 2})
-	_, err := client.WatchModelCredential()
+	_, err := client.WatchModelCredential(context.Background())
 	c.Assert(err, gc.ErrorMatches, "foo")
 }
 
@@ -167,6 +169,6 @@ func (s *CredentialValidatorSuite) TestWatchModelCredentialCallError(c *gc.C) {
 	})
 
 	client := credentialvalidator.NewFacade(apitesting.BestVersionCaller{apiCaller, 2})
-	_, err := client.WatchModelCredential()
+	_, err := client.WatchModelCredential(context.Background())
 	c.Assert(err, gc.ErrorMatches, "foo")
 }

--- a/api/agent/deployer/deployer.go
+++ b/api/agent/deployer/deployer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/rpc/params"
 )
 
 // Option is a function that can be used to configure a Client.
@@ -37,13 +36,13 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 }
 
 // unitLife returns the lifecycle state of the given unit.
-func (c *Client) unitLife(tag names.UnitTag) (life.Value, error) {
-	return common.OneLife(c.facade, tag)
+func (c *Client) unitLife(ctx context.Context, tag names.UnitTag) (life.Value, error) {
+	return common.OneLife(ctx, c.facade, tag)
 }
 
 // Unit returns the unit with the given tag.
-func (c *Client) Unit(tag names.UnitTag) (*Unit, error) {
-	life, err := c.unitLife(tag)
+func (c *Client) Unit(ctx context.Context, tag names.UnitTag) (*Unit, error) {
+	life, err := c.unitLife(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -61,11 +60,4 @@ func (c *Client) Machine(tag names.MachineTag) (*Machine, error) {
 		tag:    tag,
 		client: c,
 	}, nil
-}
-
-// ConnectionInfo returns all the address information that the deployer task
-// needs in one call.
-func (c *Client) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	err = c.facade.FacadeCall(context.TODO(), "ConnectionInfo", nil, &result)
-	return result, err
 }

--- a/api/agent/deployer/deployer_test.go
+++ b/api/agent/deployer/deployer_test.go
@@ -4,6 +4,7 @@
 package deployer_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v5"
@@ -50,7 +51,7 @@ func (s *deployerSuite) TestWatchUnits(c *gc.C) {
 	machineTag := names.NewMachineTag("666")
 	machine, err := client.Machine(machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = machine.WatchUnits()
+	_, err = machine.WatchUnits(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -74,7 +75,7 @@ func (s *deployerSuite) TestUnit(c *gc.C) {
 
 	client := deployer.NewClient(apiCaller)
 	unitTag := names.NewUnitTag("mysql/666")
-	unit, err := client.Unit(unitTag)
+	unit, err := client.Unit(context.Background(), unitTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Life(), gc.Equals, life.Alive)
 }
@@ -105,9 +106,9 @@ func (s *deployerSuite) TestUnitLifeRefresh(c *gc.C) {
 
 	client := deployer.NewClient(apiCaller)
 	unitTag := names.NewUnitTag("mysql/666")
-	unit, err := client.Unit(unitTag)
+	unit, err := client.Unit(context.Background(), unitTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.Refresh()
+	err = unit.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Life(), gc.Equals, life.Dying)
 	c.Assert(calls, gc.Equals, 2)
@@ -143,9 +144,9 @@ func (s *deployerSuite) TestUnitRemove(c *gc.C) {
 
 	client := deployer.NewClient(apiCaller)
 	unitTag := names.NewUnitTag("mysql/666")
-	unit, err := client.Unit(unitTag)
+	unit, err := client.Unit(context.Background(), unitTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.Remove()
+	err = unit.Remove(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 2)
 }
@@ -185,9 +186,9 @@ func (s *deployerSuite) TestUnitSetPassword(c *gc.C) {
 
 	client := deployer.NewClient(apiCaller)
 	unitTag := names.NewUnitTag("mysql/666")
-	unit, err := client.Unit(unitTag)
+	unit, err := client.Unit(context.Background(), unitTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.SetPassword("secret")
+	err = unit.SetPassword(context.Background(), "secret")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 2)
 }
@@ -226,9 +227,9 @@ func (s *deployerSuite) TestUnitSetStatus(c *gc.C) {
 
 	client := deployer.NewClient(apiCaller)
 	unitTag := names.NewUnitTag("mysql/666")
-	unit, err := client.Unit(unitTag)
+	unit, err := client.Unit(context.Background(), unitTag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.SetStatus(status.Active, "is active", data)
+	err = unit.SetStatus(context.Background(), status.Active, "is active", data)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 2)
 }

--- a/api/agent/deployer/machine.go
+++ b/api/agent/deployer/machine.go
@@ -23,12 +23,12 @@ type Machine struct {
 // WatchUnits starts a StringsWatcher to watch all units deployed to
 // the machine, in order to track which ones should be deployed or
 // recalled.
-func (m *Machine) WatchUnits() (watcher.StringsWatcher, error) {
+func (m *Machine) WatchUnits(ctx context.Context) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "WatchUnits", args, &results)
+	err := m.client.facade.FacadeCall(ctx, "WatchUnits", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/agent/deployer/unit.go
+++ b/api/agent/deployer/unit.go
@@ -37,8 +37,8 @@ func (u *Unit) Life() life.Value {
 }
 
 // Refresh updates the cached local copy of the unit's data.
-func (u *Unit) Refresh() error {
-	life, err := common.OneLife(u.client.facade, u.tag)
+func (u *Unit) Refresh(ctx context.Context) error {
+	life, err := common.OneLife(ctx, u.client.facade, u.tag)
 	if err != nil {
 		return err
 	}
@@ -48,12 +48,12 @@ func (u *Unit) Refresh() error {
 
 // Remove removes the unit from state, calling EnsureDead first, then Remove.
 // It will fail if the unit is not present.
-func (u *Unit) Remove() error {
+func (u *Unit) Remove(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "Remove", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "Remove", args, &result)
 	if err != nil {
 		return err
 	}
@@ -61,14 +61,14 @@ func (u *Unit) Remove() error {
 }
 
 // SetPassword sets the unit's password.
-func (u *Unit) SetPassword(password string) error {
+func (u *Unit) SetPassword(ctx context.Context, password string) error {
 	var result params.ErrorResults
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{
 			{Tag: u.tag.String(), Password: password},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "SetPasswords", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "SetPasswords", args, &result)
 	if err != nil {
 		return err
 	}
@@ -76,14 +76,14 @@ func (u *Unit) SetPassword(password string) error {
 }
 
 // SetStatus sets the status of the unit.
-func (u *Unit) SetStatus(unitStatus status.Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetStatus(ctx context.Context, unitStatus status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: u.tag.String(), Status: unitStatus.String(), Info: info, Data: data},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "SetStatus", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "SetStatus", args, &result)
 	if err != nil {
 		return err
 	}

--- a/api/agent/diskmanager/diskmanager.go
+++ b/api/agent/diskmanager/diskmanager.go
@@ -38,8 +38,7 @@ func NewState(caller base.APICaller, authTag names.MachineTag, options ...Option
 
 // SetMachineBlockDevices sets the block devices attached to the machine
 // identified by the authenticated machine tag.
-// XXX
-func (st *State) SetMachineBlockDevices(devices []blockdevice.BlockDevice) error {
+func (st *State) SetMachineBlockDevices(ctx context.Context, devices []blockdevice.BlockDevice) error {
 	args := params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine:      st.tag.String(),
@@ -47,7 +46,7 @@ func (st *State) SetMachineBlockDevices(devices []blockdevice.BlockDevice) error
 		}},
 	}
 	var results params.ErrorResults
-	err := st.facade.FacadeCall(context.TODO(), "SetMachineBlockDevices", args, &results)
+	err := st.facade.FacadeCall(ctx, "SetMachineBlockDevices", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/agent/diskmanager/diskmanager_test.go
+++ b/api/agent/diskmanager/diskmanager_test.go
@@ -4,6 +4,7 @@
 package diskmanager_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -62,7 +63,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevices(c *gc.C) {
 	})
 
 	st := diskmanager.NewState(apiCaller, names.NewMachineTag("123"))
-	err := st.SetMachineBlockDevices(devices)
+	err := st.SetMachineBlockDevices(context.Background(), devices)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -85,7 +86,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesNil(c *gc.C) {
 		return nil
 	})
 	st := diskmanager.NewState(apiCaller, names.NewMachineTag("123"))
-	err := st.SetMachineBlockDevices(nil)
+	err := st.SetMachineBlockDevices(context.Background(), nil)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -95,7 +96,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesClientError(c *gc.C) {
 		return errors.New("blargh")
 	})
 	st := diskmanager.NewState(apiCaller, names.NewMachineTag("123"))
-	err := st.SetMachineBlockDevices(nil)
+	err := st.SetMachineBlockDevices(context.Background(), nil)
 	c.Check(err, gc.ErrorMatches, "blargh")
 }
 
@@ -109,7 +110,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesServerError(c *gc.C) {
 		return nil
 	})
 	st := diskmanager.NewState(apiCaller, names.NewMachineTag("123"))
-	err := st.SetMachineBlockDevices(nil)
+	err := st.SetMachineBlockDevices(context.Background(), nil)
 	c.Check(err, gc.ErrorMatches, "MSG")
 }
 
@@ -126,7 +127,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesResultCountInvalid(c *gc.C)
 			return nil
 		})
 		st := diskmanager.NewState(apiCaller, names.NewMachineTag("123"))
-		err := st.SetMachineBlockDevices(nil)
+		err := st.SetMachineBlockDevices(context.Background(), nil)
 		c.Check(err, gc.ErrorMatches, fmt.Sprintf("expected 1 result, got %d", n))
 	}
 }

--- a/api/agent/fanconfigurer/facade.go
+++ b/api/agent/fanconfigurer/facade.go
@@ -34,9 +34,9 @@ func NewFacade(caller base.APICaller, options ...Option) *Facade {
 
 // WatchForFanConfigChanges return a NotifyWatcher waiting for the
 // fan configuration to change.
-func (f *Facade) WatchForFanConfigChanges() (watcher.NotifyWatcher, error) {
+func (f *Facade) WatchForFanConfigChanges(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
-	err := f.caller.FacadeCall(context.TODO(), "WatchForFanConfigChanges", nil, &result)
+	err := f.caller.FacadeCall(ctx, "WatchForFanConfigChanges", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -44,9 +44,9 @@ func (f *Facade) WatchForFanConfigChanges() (watcher.NotifyWatcher, error) {
 }
 
 // FanConfig returns the current fan configuration.
-func (f *Facade) FanConfig() (network.FanConfig, error) {
+func (f *Facade) FanConfig(ctx context.Context) (network.FanConfig, error) {
 	var result params.FanConfigResult
-	err := f.caller.FacadeCall(context.TODO(), "FanConfig", nil, &result)
+	err := f.caller.FacadeCall(ctx, "FanConfig", nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/api/agent/hostkeyreporter/facade.go
+++ b/api/agent/hostkeyreporter/facade.go
@@ -34,13 +34,13 @@ func NewFacade(caller base.APICaller, options ...Option) *Facade {
 // ReportKeys reports the public SSH host keys for a machine to the
 // controller. The keys should be in the same format as the sshd host
 // key files, one entry per key.
-func (f *Facade) ReportKeys(machineId string, publicKeys []string) error {
+func (f *Facade) ReportKeys(ctx context.Context, machineId string, publicKeys []string) error {
 	args := params.SSHHostKeySet{EntityKeys: []params.SSHHostKeys{{
 		Tag:        names.NewMachineTag(machineId).String(),
 		PublicKeys: publicKeys,
 	}}}
 	var result params.ErrorResults
-	err := f.caller.FacadeCall(context.TODO(), "ReportKeys", args, &result)
+	err := f.caller.FacadeCall(ctx, "ReportKeys", args, &result)
 	if err != nil {
 		return err
 	}

--- a/api/agent/hostkeyreporter/facade_test.go
+++ b/api/agent/hostkeyreporter/facade_test.go
@@ -4,6 +4,7 @@
 package hostkeyreporter_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v5"
@@ -42,7 +43,7 @@ func (s *facadeSuite) TestReportKeys(c *gc.C) {
 	})
 	facade := hostkeyreporter.NewFacade(apiCaller)
 
-	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	err := facade.ReportKeys(context.Background(), "42", []string{"rsa", "dsa"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	stub.CheckCalls(c, []testing.StubCall{{
@@ -65,7 +66,7 @@ func (s *facadeSuite) TestCallError(c *gc.C) {
 	})
 	facade := hostkeyreporter.NewFacade(apiCaller)
 
-	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	err := facade.ReportKeys(context.Background(), "42", []string{"rsa", "dsa"})
 	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
@@ -84,6 +85,6 @@ func (s *facadeSuite) TestInnerError(c *gc.C) {
 	})
 	facade := hostkeyreporter.NewFacade(apiCaller)
 
-	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	err := facade.ReportKeys(context.Background(), "42", []string{"rsa", "dsa"})
 	c.Assert(err, gc.ErrorMatches, "blam")
 }

--- a/api/agent/instancemutater/instancemutater.go
+++ b/api/agent/instancemutater/instancemutater.go
@@ -45,9 +45,9 @@ func NewClientFromFacade(facadeCaller base.FacadeCaller) *Client {
 
 // WatchModelMachines returns a StringsWatcher reporting changes to machines
 // and not containers.
-func (c *Client) WatchModelMachines() (watcher.StringsWatcher, error) {
+func (c *Client) WatchModelMachines(ctx context.Context) (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := c.facade.FacadeCall(context.TODO(), "WatchModelMachines", nil, &result)
+	err := c.facade.FacadeCall(ctx, "WatchModelMachines", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -59,8 +59,8 @@ func (c *Client) WatchModelMachines() (watcher.StringsWatcher, error) {
 
 // Machine provides access to methods of a state.Machine through the
 // facade.
-func (c *Client) Machine(tag names.MachineTag) (MutaterMachine, error) {
-	life, err := common.OneLife(c.facade, tag)
+func (c *Client) Machine(ctx context.Context, tag names.MachineTag) (MutaterMachine, error) {
+	life, err := common.OneLife(ctx, c.facade, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/instancemutater/instancemutater_test.go
+++ b/api/agent/instancemutater/instancemutater_test.go
@@ -4,6 +4,7 @@
 package instancemutater_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -48,7 +49,7 @@ func (s *instanceMutaterSuite) TestMachineCallsLife(c *gc.C) {
 	}
 	apiCaller := successAPICaller(c, "Life", entitiesArgs, expectedResults)
 	api := instancemutater.NewClient(apiCaller)
-	m, err := api.Machine(names.NewMachineTag("0"))
+	m, err := api.Machine(context.Background(), names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 	c.Assert(m.Tag().String(), gc.Equals, s.tag.String())
@@ -61,7 +62,7 @@ func (s *instanceMutaterSuite) TestWatchMachines(c *gc.C) {
 		s.expectWatchModelMachines,
 		s.expectStringsWatcher,
 	)
-	ch, err := api.WatchModelMachines()
+	ch, err := api.WatchModelMachines(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes
@@ -80,7 +81,7 @@ func (s *instanceMutaterSuite) TestWatchMachinesServerError(c *gc.C) {
 	api := s.clientForScenario(c,
 		s.expectWatchModelMachinesWithError,
 	)
-	_, err := api.WatchModelMachines()
+	_, err := api.WatchModelMachines(context.Background())
 	c.Assert(err, gc.ErrorMatches, "failed")
 }
 

--- a/api/agent/instancemutater/machine_test.go
+++ b/api/agent/instancemutater/machine_test.go
@@ -4,6 +4,7 @@
 package instancemutater_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -53,7 +54,7 @@ func (s *instanceMutaterMachineSuite) TestSetCharmProfiles(c *gc.C) {
 		s.expectSetCharmProfilesFacadeCall,
 	)
 
-	err := m.SetCharmProfiles(s.profiles)
+	err := m.SetCharmProfiles(context.Background(), s.profiles)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -64,7 +65,7 @@ func (s *instanceMutaterMachineSuite) TestSetCharmProfilesError(c *gc.C) {
 		s.expectSetCharmProfilesFacadeCallReturnsError(errors.New("failed")),
 	)
 
-	err := m.SetCharmProfiles(s.profiles)
+	err := m.SetCharmProfiles(context.Background(), s.profiles)
 	c.Assert(err, gc.ErrorMatches, "failed")
 }
 
@@ -75,7 +76,7 @@ func (s *instanceMutaterMachineSuite) TestWatchLXDProfileVerificationNeeded(c *g
 		s.expectWatchLXDProfileVerificationNeeded,
 		s.expectNotifyWatcher,
 	)
-	ch, err := api.WatchLXDProfileVerificationNeeded()
+	ch, err := api.WatchLXDProfileVerificationNeeded(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes
@@ -94,7 +95,7 @@ func (s *instanceMutaterMachineSuite) TestWatchLXDProfileVerificationNeededServe
 	api := s.machineForScenario(c,
 		s.expectWatchLXDProfileVerificationNeededWithError("", "failed"),
 	)
-	_, err := api.WatchLXDProfileVerificationNeeded()
+	_, err := api.WatchLXDProfileVerificationNeeded(context.Background())
 	c.Assert(err, gc.ErrorMatches, "failed")
 }
 
@@ -104,7 +105,7 @@ func (s *instanceMutaterMachineSuite) TestWatchLXDProfileVerificationNeededNotSu
 	api := s.machineForScenario(c,
 		s.expectWatchLXDProfileVerificationNeededWithError("not supported", "failed"),
 	)
-	_, err := api.WatchLXDProfileVerificationNeeded()
+	_, err := api.WatchLXDProfileVerificationNeeded(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotSupported)
 }
 
@@ -115,7 +116,7 @@ func (s *instanceMutaterMachineSuite) TestWatchContainers(c *gc.C) {
 		s.expectWatchContainers,
 		s.expectStringsWatcher,
 	)
-	ch, err := api.WatchContainers()
+	ch, err := api.WatchContainers(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes
@@ -134,7 +135,7 @@ func (s *instanceMutaterMachineSuite) TestWatchContainersServerError(c *gc.C) {
 	api := s.machineForScenario(c,
 		s.expectWatchContainersWithErrors(errors.New("failed")),
 	)
-	_, err := api.WatchContainers()
+	_, err := api.WatchContainers(context.Background())
 	c.Assert(err, gc.ErrorMatches, "failed")
 }
 
@@ -157,7 +158,7 @@ func (s *instanceMutaterMachineSuite) TestCharmProfilingInfoSuccessChanges(c *gc
 	fExp := s.fCaller.EXPECT()
 	fExp.FacadeCall(gomock.Any(), "CharmProfilingInfo", args, gomock.Any()).SetArg(3, results).Return(nil)
 
-	info, err := s.setupMachine().CharmProfilingInfo()
+	info, err := s.setupMachine().CharmProfilingInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.InstanceId, gc.Equals, results.InstanceId)
 	c.Assert(info.ModelName, gc.Equals, results.ModelName)
@@ -182,7 +183,7 @@ func (s *instanceMutaterMachineSuite) TestCharmProfilingInfoSuccessChangesWithNo
 	fExp := s.fCaller.EXPECT()
 	fExp.FacadeCall(gomock.Any(), "CharmProfilingInfo", args, gomock.Any()).SetArg(3, results).Return(nil)
 
-	info, err := s.setupMachine().CharmProfilingInfo()
+	info, err := s.setupMachine().CharmProfilingInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.InstanceId, gc.Equals, results.InstanceId)
 	c.Assert(info.ModelName, gc.Equals, results.ModelName)
@@ -197,7 +198,7 @@ func (s *instanceMutaterMachineSuite) TestSetModificationStatus(c *gc.C) {
 		s.expectSetModificationFacadeCall(status.Applied, "applied", nil),
 	)
 
-	err := m.SetModificationStatus(status.Applied, "applied", nil)
+	err := m.SetModificationStatus(context.Background(), status.Applied, "applied", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -208,7 +209,7 @@ func (s *instanceMutaterMachineSuite) TestSetModificationStatusReturnsError(c *g
 		s.expectSetModificationFacadeCallReturnsError(errors.New("bad")),
 	)
 
-	err := m.SetModificationStatus(status.Applied, "applied", nil)
+	err := m.SetModificationStatus(context.Background(), status.Applied, "applied", nil)
 	c.Assert(err, gc.ErrorMatches, "bad")
 }
 

--- a/api/agent/instancemutater/mocks/machinemutater_mock.go
+++ b/api/agent/instancemutater/mocks/machinemutater_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancemutater "github.com/juju/juju/api/agent/instancemutater"
@@ -45,48 +46,48 @@ func (m *MockMutaterMachine) EXPECT() *MockMutaterMachineMockRecorder {
 }
 
 // CharmProfilingInfo mocks base method.
-func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileInfo, error) {
+func (m *MockMutaterMachine) CharmProfilingInfo(arg0 context.Context) (*instancemutater.UnitProfileInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmProfilingInfo")
+	ret := m.ctrl.Call(m, "CharmProfilingInfo", arg0)
 	ret0, _ := ret[0].(*instancemutater.UnitProfileInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmProfilingInfo indicates an expected call of CharmProfilingInfo.
-func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo), arg0)
 }
 
 // ContainerType mocks base method.
-func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
+func (m *MockMutaterMachine) ContainerType(arg0 context.Context) (instance.ContainerType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerType")
+	ret := m.ctrl.Call(m, "ContainerType", arg0)
 	ret0, _ := ret[0].(instance.ContainerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerType indicates an expected call of ContainerType.
-func (mr *MockMutaterMachineMockRecorder) ContainerType() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) ContainerType(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType), arg0)
 }
 
 // InstanceId mocks base method.
-func (m *MockMutaterMachine) InstanceId() (string, error) {
+func (m *MockMutaterMachine) InstanceId(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceId")
+	ret := m.ctrl.Call(m, "InstanceId", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InstanceId indicates an expected call of InstanceId.
-func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) InstanceId(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId), arg0)
 }
 
 // Life mocks base method.
@@ -104,45 +105,45 @@ func (mr *MockMutaterMachineMockRecorder) Life() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockMutaterMachine) Refresh() error {
+func (m *MockMutaterMachine) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockMutaterMachineMockRecorder) Refresh() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh), arg0)
 }
 
 // SetCharmProfiles mocks base method.
-func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
+func (m *MockMutaterMachine) SetCharmProfiles(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
+	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles.
-func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0 any) *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0, arg1)
 }
 
 // SetModificationStatus mocks base method.
-func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMutaterMachine) SetModificationStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModificationStatus indicates an expected call of SetModificationStatus.
-func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2, arg3)
 }
 
 // Tag mocks base method.
@@ -160,46 +161,46 @@ func (mr *MockMutaterMachineMockRecorder) Tag() *gomock.Call {
 }
 
 // WatchContainers mocks base method.
-func (m *MockMutaterMachine) WatchContainers() (watcher.Watcher[[]string], error) {
+func (m *MockMutaterMachine) WatchContainers(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchContainers")
+	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchContainers indicates an expected call of WatchContainers.
-func (mr *MockMutaterMachineMockRecorder) WatchContainers() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchContainers(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers), arg0)
 }
 
 // WatchLXDProfileVerificationNeeded mocks base method.
-func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded() (watcher.Watcher[struct{}], error) {
+func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationNeeded")
+	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationNeeded", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLXDProfileVerificationNeeded indicates an expected call of WatchLXDProfileVerificationNeeded.
-func (mr *MockMutaterMachineMockRecorder) WatchLXDProfileVerificationNeeded() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchLXDProfileVerificationNeeded(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationNeeded", reflect.TypeOf((*MockMutaterMachine)(nil).WatchLXDProfileVerificationNeeded))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationNeeded", reflect.TypeOf((*MockMutaterMachine)(nil).WatchLXDProfileVerificationNeeded), arg0)
 }
 
 // WatchUnits mocks base method.
-func (m *MockMutaterMachine) WatchUnits() (watcher.Watcher[[]string], error) {
+func (m *MockMutaterMachine) WatchUnits(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUnits")
+	ret := m.ctrl.Call(m, "WatchUnits", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUnits indicates an expected call of WatchUnits.
-func (mr *MockMutaterMachineMockRecorder) WatchUnits() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchUnits(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMutaterMachine)(nil).WatchUnits))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMutaterMachine)(nil).WatchUnits), arg0)
 }

--- a/api/agent/machiner/machine.go
+++ b/api/agent/machiner/machine.go
@@ -35,8 +35,8 @@ func (m *Machine) Life() life.Value {
 }
 
 // Refresh updates the cached local copy of the machine's data.
-func (m *Machine) Refresh() error {
-	l, err := m.client.machineLife(m.tag)
+func (m *Machine) Refresh(ctx context.Context) error {
+	l, err := m.client.machineLife(ctx, m.tag)
 	if err != nil {
 		return err
 	}

--- a/api/agent/machiner/machiner.go
+++ b/api/agent/machiner/machiner.go
@@ -4,6 +4,8 @@
 package machiner
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -37,13 +39,13 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 }
 
 // machineLife requests the lifecycle of the given machine from the server.
-func (c *Client) machineLife(tag names.MachineTag) (life.Value, error) {
-	return common.OneLife(c.facade, tag)
+func (c *Client) machineLife(ctx context.Context, tag names.MachineTag) (life.Value, error) {
+	return common.OneLife(ctx, c.facade, tag)
 }
 
 // Machine provides access to methods of a machine through the facade.
-func (c *Client) Machine(tag names.MachineTag) (*Machine, error) {
-	life, err := c.machineLife(tag)
+func (c *Client) Machine(ctx context.Context, tag names.MachineTag) (*Machine, error) {
+	life, err := c.machineLife(ctx, tag)
 	if err != nil {
 		return nil, errors.Annotate(err, "can't get life for machine")
 	}

--- a/api/agent/machiner/machiner_test.go
+++ b/api/agent/machiner/machiner_test.go
@@ -4,6 +4,7 @@
 package machiner_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v5"
@@ -46,7 +47,7 @@ func (s *machinerSuite) TestMachineAndMachineTag(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Life(), gc.Equals, life.Alive)
 	c.Assert(m.Tag(), jc.DeepEquals, tag)
@@ -88,7 +89,7 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetStatus(status.Error, "failed", data)
 	c.Assert(err, jc.ErrorIsNil)
@@ -122,7 +123,7 @@ func (s *machinerSuite) TestEnsureDead(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,9 +152,9 @@ func (s *machinerSuite) TestRefresh(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.Refresh()
+	err = m.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Life(), gc.Equals, life.Dead)
 	c.Assert(calls, gc.Equals, 2)
@@ -199,7 +200,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetMachineAddresses([]network.MachineAddress{{
 		Value:       "10.0.0.1",
@@ -239,7 +240,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = m.Watch()
 	c.Assert(err, gc.ErrorMatches, "FAIL")
@@ -281,7 +282,7 @@ func (s *machinerSuite) TestRecordAgentStartInformation(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := machiner.NewClient(apiCaller)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.RecordAgentStartInformation("hostname")
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/agent/provisioner/machine.go
+++ b/api/agent/provisioner/machine.go
@@ -41,7 +41,7 @@ type MachineProvisioner interface {
 	Life() life.Value
 
 	// Refresh updates the cached local copy of the machine's data.
-	Refresh() error
+	Refresh(context.Context) error
 
 	// SetInstanceStatus sets the status for the provider instance.
 	SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error
@@ -164,8 +164,8 @@ func (m *Machine) Life() life.Value {
 }
 
 // Refresh implements MachineProvisioner.Refresh.
-func (m *Machine) Refresh() error {
-	life, err := m.st.machineLife(m.tag)
+func (m *Machine) Refresh(ctx context.Context) error {
+	life, err := m.st.machineLife(ctx, m.tag)
 	if err != nil {
 		return err
 	}

--- a/api/agent/provisioner/mocks/machine_mock.go
+++ b/api/agent/provisioner/mocks/machine_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instance "github.com/juju/juju/core/instance"
@@ -207,17 +208,17 @@ func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockMachineProvisioner) Refresh() error {
+func (m *MockMachineProvisioner) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
+func (mr *MockMachineProvisionerMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh), arg0)
 }
 
 // Remove mocks base method.

--- a/api/agent/provisioner/provisioner.go
+++ b/api/agent/provisioner/provisioner.go
@@ -81,8 +81,8 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 }
 
 // machineLife requests the lifecycle of the given machine from the server.
-func (st *Client) machineLife(tag names.MachineTag) (life.Value, error) {
-	return common.OneLife(st.facade, tag)
+func (st *Client) machineLife(ctx context.Context, tag names.MachineTag) (life.Value, error) {
+	return common.OneLife(ctx, st.facade, tag)
 }
 
 // ProvisioningInfo implements MachineProvisioner.ProvisioningInfo.
@@ -97,13 +97,13 @@ func (st *Client) ProvisioningInfo(machineTags []names.MachineTag) (params.Provi
 
 // Machines provides access to methods of a state.Machine through the facade
 // for the given tags.
-func (st *Client) Machines(tags ...names.MachineTag) ([]MachineResult, error) {
+func (st *Client) Machines(ctx context.Context, tags ...names.MachineTag) ([]MachineResult, error) {
 	lenTags := len(tags)
 	genericTags := make([]names.Tag, lenTags)
 	for i, t := range tags {
 		genericTags[i] = t
 	}
-	result, err := common.Life(st.facade, genericTags)
+	result, err := common.Life(ctx, st.facade, genericTags)
 	if err != nil {
 		return []MachineResult{}, err
 	}

--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -4,6 +4,8 @@
 package provisioner_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -72,7 +74,7 @@ func (s *provisionerSuite) TestMachines(c *gc.C) {
 	s.expectCall(caller, "Life", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.Machines(names.NewMachineTag("666"), names.NewMachineTag("42"))
+	result, err := client.Machines(context.Background(), names.NewMachineTag("666"), names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 2)
 	c.Assert(result[1].Err.Message, gc.Equals, "FAIL")
@@ -295,7 +297,7 @@ func (s *provisionerSuite) setupMachines(c *gc.C, ctrl *gomock.Controller) (*moc
 	s.expectCall(caller, "Life", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.Machines(names.NewMachineTag("666"))
+	result, err := client.Machines(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	return caller, result[0].Machine
@@ -464,7 +466,7 @@ func (s *provisionerSuite) TestRefresh(c *gc.C) {
 		Results: []params.LifeResult{{Life: "dying"}},
 	}
 	s.expectCall(caller, "Life", args, results)
-	err := machine.Refresh()
+	err := machine.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Life(), gc.Equals, life.Dying)
 }

--- a/api/agent/uniter/action_test.go
+++ b/api/agent/uniter/action_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -45,7 +47,7 @@ func (s *actionSuite) TestAction(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
-	a, err := client.Action(names.NewActionTag("666"))
+	a, err := client.Action(context.Background(), names.NewActionTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(a.ID(), gc.Equals, "666")
 	c.Assert(a.Name(), gc.Equals, actionResult.Action.Name)
@@ -69,7 +71,7 @@ func (s *actionSuite) TestActionError(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
-	_, err := client.Action(names.NewActionTag("666"))
+	_, err := client.Action(context.Background(), names.NewActionTag("666"))
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -85,7 +87,7 @@ func (s *actionSuite) TestActionBegin(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	err := client.ActionBegin(names.NewActionTag("666"))
+	err := client.ActionBegin(context.Background(), names.NewActionTag("666"))
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -106,7 +108,7 @@ func (s *actionSuite) TestActionFinish(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	err := client.ActionFinish(names.NewActionTag("666"), "failed", map[string]interface{}{"foo": "bar"}, "oops")
+	err := client.ActionFinish(context.Background(), names.NewActionTag("666"), "failed", map[string]interface{}{"foo": "bar"}, "oops")
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -122,7 +124,7 @@ func (s *actionSuite) TestActionStatus(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	status, err := client.ActionStatus(names.NewActionTag("666"))
+	status, err := client.ActionStatus(context.Background(), names.NewActionTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, "failed")
 }

--- a/api/agent/uniter/application.go
+++ b/api/agent/uniter/application.go
@@ -54,8 +54,8 @@ func (s *Application) Life() life.Value {
 
 // Refresh refreshes the contents of the application from the underlying
 // state.
-func (s *Application) Refresh() error {
-	life, err := s.client.life(s.tag)
+func (s *Application) Refresh(ctx context.Context) error {
+	life, err := s.client.life(ctx, s.tag)
 	if err != nil {
 		return err
 	}

--- a/api/agent/uniter/application_test.go
+++ b/api/agent/uniter/application_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -114,7 +115,7 @@ func (s *applicationSuite) apiCallerFunc(c *gc.C) basetesting.APICallerFunc {
 func (s *applicationSuite) TestNameTagAndString(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
 	tag := names.NewApplicationTag("mysql")
-	app, err := client.Application(tag)
+	app, err := client.Application(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(app.Name(), gc.Equals, "mysql")
 	c.Assert(app.String(), gc.Equals, "mysql")
@@ -124,7 +125,7 @@ func (s *applicationSuite) TestNameTagAndString(c *gc.C) {
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := app.Watch()
@@ -143,18 +144,18 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 
 func (s *applicationSuite) TestRefresh(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.life = life.Dying
-	err = app.Refresh()
+	err = app.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(app.Life(), gc.Equals, life.Dying)
 }
 
 func (s *applicationSuite) TestCharmURL(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl, force, err := app.CharmURL()
@@ -165,7 +166,7 @@ func (s *applicationSuite) TestCharmURL(c *gc.C) {
 
 func (s *applicationSuite) TestCharmModifiedVersion(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ver, err := app.CharmModifiedVersion()
@@ -175,7 +176,7 @@ func (s *applicationSuite) TestCharmModifiedVersion(c *gc.C) {
 
 func (s *applicationSuite) TestSetApplicationStatus(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = app.SetStatus("mysql/0", status.Blocked, "app blocked", map[string]interface{}{"foo": "bar"})
@@ -185,7 +186,7 @@ func (s *applicationSuite) TestSetApplicationStatus(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationStatus(c *gc.C) {
 	client := uniter.NewClient(s.apiCallerFunc(c), names.NewUnitTag("mysql/0"))
-	app, err := client.Application(names.NewApplicationTag("mysql"))
+	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := app.Status("mysql/0")

--- a/api/agent/uniter/cloud_native_test.go
+++ b/api/agent/uniter/cloud_native_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +43,7 @@ func (s *cloudNativeUniterSuite) TestCloudSpec(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("wordpress/0"))
 
-	result, err := client.CloudSpec()
+	result, err := client.CloudSpec(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Name, gc.Equals, "dummy")
 	c.Assert(result.Credential.Attributes, gc.DeepEquals, map[string]string{

--- a/api/agent/uniter/goal-state_test.go
+++ b/api/agent/uniter/goal-state_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -101,7 +102,7 @@ func (s *goalStateSuite) testGoalState(c *gc.C, facadeResult params.GoalStateRes
 	})
 
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	goalStateResult, err := client.GoalState()
+	goalStateResult, err := client.GoalState(context.Background())
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(goalStateResult, jc.DeepEquals, apiResult)

--- a/api/agent/uniter/model_test.go
+++ b/api/agent/uniter/model_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -40,7 +42,7 @@ func (s *modelSuite) TestModel(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	m, err := client.Model()
+	m, err := client.Model(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m, jc.DeepEquals, &model.Model{
 		Name:      "mary",

--- a/api/agent/uniter/relation.go
+++ b/api/agent/uniter/relation.go
@@ -4,6 +4,8 @@
 package uniter
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -70,8 +72,8 @@ func (r *Relation) OtherApplication() string {
 // Refresh refreshes the contents of the relation from the underlying
 // state. It returns an error that satisfies errors.IsNotFound if the
 // relation has been removed.
-func (r *Relation) Refresh() error {
-	result, err := r.client.relation(r.tag, r.client.unitTag)
+func (r *Relation) Refresh(ctx context.Context) error {
+	result, err := r.client.relation(ctx, r.tag, r.client.unitTag)
 	if err != nil {
 		return err
 	}
@@ -85,8 +87,8 @@ func (r *Relation) Refresh() error {
 }
 
 // SetStatus updates the status of the relation.
-func (r *Relation) SetStatus(status relation.Status) error {
-	return r.client.setRelationStatus(r.id, status)
+func (r *Relation) SetStatus(ctx context.Context, status relation.Status) error {
+	return r.client.setRelationStatus(ctx, r.id, status)
 }
 
 func (r *Relation) toCharmRelation(cr params.CharmRelation) charm.Relation {
@@ -102,11 +104,11 @@ func (r *Relation) toCharmRelation(cr params.CharmRelation) charm.Relation {
 
 // Endpoint returns the endpoint of the relation for the application the
 // uniter's managed unit belongs to.
-func (r *Relation) Endpoint() (*Endpoint, error) {
+func (r *Relation) Endpoint(ctx context.Context) (*Endpoint, error) {
 	// NOTE: This differs from state.Relation.Endpoint(), because when
 	// talking to the API, there's already an authenticated entity - the
 	// unit, and we can find out its application name.
-	result, err := r.client.relation(r.tag, r.client.unitTag)
+	result, err := r.client.relation(ctx, r.tag, r.client.unitTag)
 	if err != nil {
 		return nil, err
 	}
@@ -114,12 +116,12 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 }
 
 // Unit returns a RelationUnit for the supplied unitTag.
-func (r *Relation) Unit(uTag names.UnitTag) (*RelationUnit, error) {
+func (r *Relation) Unit(ctx context.Context, uTag names.UnitTag) (*RelationUnit, error) {
 	appName, err := names.UnitApplication(uTag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	result, err := r.client.relation(r.tag, uTag)
+	result, err := r.client.relation(ctx, r.tag, uTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/uniter/relation_test.go
+++ b/api/agent/uniter/relation_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -56,14 +58,14 @@ func (s *relationSuite) TestRelation(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	tag := names.NewRelationTag("wordpress:db mysql:server")
-	rel, err := client.Relation(tag)
+	rel, err := client.Relation(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.Id(), gc.Equals, 666)
 	c.Assert(rel.Tag(), gc.Equals, tag)
 	c.Assert(rel.Life(), gc.Equals, life.Alive)
 	c.Assert(rel.String(), gc.Equals, tag.Id())
 	c.Assert(rel.OtherApplication(), gc.Equals, "mysql")
-	ep, err := rel.Endpoint()
+	ep, err := rel.Endpoint(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ep, jc.DeepEquals, &uniter.Endpoint{
 		charm.Relation{
@@ -99,7 +101,7 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	tag := names.NewRelationTag("wordpress:db mysql:server")
 	rel := uniter.CreateRelation(client, tag)
-	err := rel.Refresh()
+	err := rel.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rel.Life(), gc.Equals, life.Dying)
 	c.Assert(rel.Suspended(), jc.IsTrue)
@@ -139,7 +141,7 @@ func (s *relationSuite) TestSetStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	tag := names.NewRelationTag("wordpress:db mysql:server")
 	rel := uniter.CreateRelation(client, tag)
-	err := rel.SetStatus(relation.Suspended)
+	err := rel.SetStatus(context.Background(), relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusSet, jc.IsTrue)
 }
@@ -162,7 +164,7 @@ func (s *relationSuite) TestRelationById(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
-	rel, err := client.RelationById(666)
+	rel, err := client.RelationById(context.Background(), 666)
 	c.Assert(rel.Id(), gc.Equals, 666)
 	c.Assert(rel.Tag(), gc.Equals, names.NewRelationTag("wordpress:db mysql:server"))
 	c.Assert(rel.Life(), gc.Equals, life.Alive)

--- a/api/agent/uniter/relationunit_test.go
+++ b/api/agent/uniter/relationunit_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -96,7 +98,7 @@ func (s *relationUnitSuite) getRelationUnit(c *gc.C) *uniter.RelationUnit {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	tag := names.NewRelationTag("wordpress:db mysql:server")
 	rel := uniter.CreateRelation(client, tag)
-	relUnit, err := rel.Unit(names.NewUnitTag("mysql/0"))
+	relUnit, err := rel.Unit(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	return relUnit
 }
@@ -182,7 +184,7 @@ func (s *relationUnitSuite) TestWatchRelationUnits(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	tag := names.NewRelationTag("wordpress:db mysql:server")
-	w, err := client.WatchRelationUnits(tag, names.NewUnitTag("mysql/0"))
+	w, err := client.WatchRelationUnits(context.Background(), tag, names.NewUnitTag("mysql/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewRelationUnitsWatcherC(c, w)
 	defer wc.AssertStops()

--- a/api/agent/uniter/sla_test.go
+++ b/api/agent/uniter/sla_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -32,7 +34,7 @@ func (s *slaSuite) TestSLALevel(c *gc.C) {
 		return nil
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
-	level, err := client.SLALevel()
+	level, err := client.SLALevel(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(level, gc.Equals, "essential")
 }

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -63,14 +63,14 @@ func (u *Unit) Resolved() params.ResolvedMode {
 }
 
 // Refresh updates the cached local copy of the unit's data.
-func (u *Unit) Refresh() error {
+func (u *Unit) Refresh(ctx context.Context) error {
 	var results params.UnitRefreshResults
 	args := params.Entities{
 		Entities: []params.Entity{
 			{Tag: u.tag.String()},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "Refresh", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "Refresh", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -94,14 +94,14 @@ func (u *Unit) Refresh() error {
 }
 
 // SetUnitStatus sets the status of the unit.
-func (u *Unit) SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetUnitStatus(ctx context.Context, unitStatus status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: u.tag.String(), Status: unitStatus.String(), Info: info, Data: data},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "SetUnitStatus", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "SetUnitStatus", args, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -109,14 +109,14 @@ func (u *Unit) SetUnitStatus(unitStatus status.Status, info string, data map[str
 }
 
 // UnitStatus gets the status details of the unit.
-func (u *Unit) UnitStatus() (params.StatusResult, error) {
+func (u *Unit) UnitStatus(ctx context.Context) (params.StatusResult, error) {
 	var results params.StatusResults
 	args := params.Entities{
 		Entities: []params.Entity{
 			{Tag: u.tag.String()},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "UnitStatus", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "UnitStatus", args, &results)
 	if err != nil {
 		return params.StatusResult{}, errors.Trace(err)
 	}
@@ -228,14 +228,14 @@ func (u *Unit) WatchRelations() (watcher.StringsWatcher, error) {
 }
 
 // Application returns the unit's application.
-func (u *Unit) Application() (*Application, error) {
+func (u *Unit) Application(ctx context.Context) (*Application, error) {
 	application := &Application{
 		client: u.client,
 		tag:    u.ApplicationTag(),
 	}
 	// Call Refresh() immediately to get the up-to-date
 	// life and other needed locally cached fields.
-	err := application.Refresh()
+	err := application.Refresh(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/api/agent/uniter/unit_test.go
+++ b/api/agent/uniter/unit_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/charm/v12"
@@ -45,7 +46,7 @@ func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 	})
 	tag := names.NewUnitTag("mysql/0")
 	client := uniter.NewClient(apiCaller, tag)
-	unit, err := client.Unit(tag)
+	unit, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/0")
 	c.Assert(unit.Tag(), gc.Equals, tag)
@@ -94,7 +95,7 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetUnitStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
+	err := unit.SetUnitStatus(context.Background(), status.Idle, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -120,7 +121,7 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	statusInfo, err := unit.UnitStatus()
+	statusInfo, err := unit.UnitStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo, gc.DeepEquals, params.StatusResult{
 		Id:     "mysql/0",
@@ -204,7 +205,7 @@ func (s *unitSuite) TestRefresh(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.Refresh()
+	err := unit.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Life(), gc.Equals, life.Dying)
 	c.Assert(unit.Resolved(), gc.Equals, params.ResolvedRetryHooks)

--- a/api/agent/uniter/uniter_test.go
+++ b/api/agent/uniter/uniter_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -34,7 +36,7 @@ func (s *uniterSuite) TestProviderType(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
-	providerType, err := client.ProviderType()
+	providerType, err := client.ProviderType(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(providerType, gc.Equals, "somecloud")
 }
@@ -74,7 +76,7 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 	caller := testing.BestVersionCaller{apiCaller, 17}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
 
-	portRangesMap, err := client.OpenedMachinePortRangesByEndpoint(names.NewMachineTag("42"))
+	portRangesMap, err := client.OpenedMachinePortRangesByEndpoint(context.Background(), names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(portRangesMap, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
@@ -122,7 +124,7 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 	caller := testing.BestVersionCaller{apiCaller, 18}
 	client := uniter.NewClient(caller, names.NewUnitTag("gitlab/0"))
 
-	result, err := client.OpenedPortRangesByEndpoint()
+	result, err := client.OpenedPortRangesByEndpoint(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
@@ -145,7 +147,7 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpointOldAPINotSupported(c *gc.C) 
 	caller := testing.BestVersionCaller{apiCaller, 17}
 	client := uniter.NewClient(caller, names.NewUnitTag("gitlab/0"))
 
-	_, err := client.OpenedPortRangesByEndpoint()
+	_, err := client.OpenedPortRangesByEndpoint(context.Background())
 	c.Assert(err, gc.ErrorMatches, `OpenedPortRangesByEndpoint\(\) \(need V18\+\) not implemented`)
 }
 
@@ -163,7 +165,7 @@ func (s *uniterSuite) TestUnitWorkloadVersion(c *gc.C) {
 	caller := testing.BestVersionCaller{apiCaller, 17}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
 
-	workloadVersion, err := client.UnitWorkloadVersion(names.NewUnitTag("mysql/0"))
+	workloadVersion, err := client.UnitWorkloadVersion(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(workloadVersion, gc.Equals, "mysql-1.2.3")
 }
@@ -182,6 +184,6 @@ func (s *uniterSuite) TestSetUnitWorkloadVersion(c *gc.C) {
 	caller := testing.BestVersionCaller{apiCaller, 17}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
 
-	err := client.SetUnitWorkloadVersion(names.NewUnitTag("mysql/0"), "mysql-1.2.3")
+	err := client.SetUnitWorkloadVersion(context.Background(), names.NewUnitTag("mysql/0"), "mysql-1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1284,6 +1284,9 @@ func (c *conn) IsBroken(ctx context.Context) bool {
 	select {
 	case <-c.broken:
 		return true
+	case <-ctx.Done():
+		logger.Debugf("connection ping context expired")
+		return true
 	default:
 	}
 	if err := c.ping(ctx); err != nil {

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1280,13 +1280,13 @@ func (c *conn) Broken() <-chan struct{} {
 }
 
 // IsBroken implements api.Connection.
-func (c *conn) IsBroken() bool {
+func (c *conn) IsBroken(ctx context.Context) bool {
 	select {
 	case <-c.broken:
 		return true
 	default:
 	}
-	if err := c.ping(context.TODO()); err != nil {
+	if err := c.ping(ctx); err != nil {
 		logger.Debugf("connection ping failed: %v", err)
 		return true
 	}

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1187,7 +1187,7 @@ func (s *apiclientSuite) TestIsBrokenOk(c *gc.C) {
 		RPCConnection: newRPCConnection(),
 		Clock:         new(fakeClock),
 	})
-	c.Assert(conn.IsBroken(), jc.IsFalse)
+	c.Assert(conn.IsBroken(context.Background()), jc.IsFalse)
 }
 
 func (s *apiclientSuite) TestIsBrokenChannelClosed(c *gc.C) {
@@ -1198,7 +1198,7 @@ func (s *apiclientSuite) TestIsBrokenChannelClosed(c *gc.C) {
 		Clock:         new(fakeClock),
 		Broken:        broken,
 	})
-	c.Assert(conn.IsBroken(), jc.IsTrue)
+	c.Assert(conn.IsBroken(context.Background()), jc.IsTrue)
 }
 
 func (s *apiclientSuite) TestIsBrokenPingFailed(c *gc.C) {
@@ -1206,7 +1206,7 @@ func (s *apiclientSuite) TestIsBrokenPingFailed(c *gc.C) {
 		RPCConnection: newRPCConnection(errors.New("no biscuit")),
 		Clock:         new(fakeClock),
 	})
-	c.Assert(conn.IsBroken(), jc.IsTrue)
+	c.Assert(conn.IsBroken(context.Background()), jc.IsTrue)
 }
 
 func (s *apiclientSuite) TestLoginCapturesCLIArgs(c *gc.C) {

--- a/api/client/credentialmanager/client.go
+++ b/api/client/credentialmanager/client.go
@@ -32,10 +32,10 @@ func NewClient(st base.APICallCloser, options ...Option) *Client {
 }
 
 // InvalidateModelCredential invalidates cloud credential for the model that made a connection.
-func (c *Client) InvalidateModelCredential(reason string) error {
+func (c *Client) InvalidateModelCredential(ctx context.Context, reason string) error {
 	in := params.InvalidateCredentialArg{reason}
 	var result params.ErrorResult
-	err := c.facade.FacadeCall(context.TODO(), "InvalidateModelCredential", in, &result)
+	err := c.facade.FacadeCall(ctx, "InvalidateModelCredential", in, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/client/credentialmanager/client_test.go
+++ b/api/client/credentialmanager/client_test.go
@@ -4,6 +4,8 @@
 package credentialmanager_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -31,7 +33,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "InvalidateModelCredential", args, result).SetArg(3, results).Return(nil)
 	client := credentialmanager.NewClientFromCaller(mockFacadeCaller)
 
-	err := client.InvalidateModelCredential("auth fail")
+	err := client.InvalidateModelCredential(context.Background(), "auth fail")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -46,7 +48,7 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredentialBackendFailure(c *
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "InvalidateModelCredential", args, result).SetArg(3, results).Return(nil)
 	client := credentialmanager.NewClientFromCaller(mockFacadeCaller)
 
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential(context.Background(), "")
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -60,6 +62,6 @@ func (s *CredentialManagerSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "InvalidateModelCredential", args, result).Return(errors.New("foo"))
 	client := credentialmanager.NewClientFromCaller(mockFacadeCaller)
 
-	err := client.InvalidateModelCredential("")
+	err := client.InvalidateModelCredential(context.Background(), "")
 	c.Assert(err, gc.ErrorMatches, "foo")
 }

--- a/api/common/life.go
+++ b/api/common/life.go
@@ -16,7 +16,7 @@ import (
 
 // Life requests the life cycle of the given entities from the given
 // server-side API facade via the given caller.
-func Life(caller base.FacadeCaller, tags []names.Tag) ([]params.LifeResult, error) {
+func Life(ctx context.Context, caller base.FacadeCaller, tags []names.Tag) ([]params.LifeResult, error) {
 	if len(tags) == 0 {
 		return []params.LifeResult{}, nil
 	}
@@ -26,7 +26,7 @@ func Life(caller base.FacadeCaller, tags []names.Tag) ([]params.LifeResult, erro
 		entities[i] = params.Entity{t.String()}
 	}
 	args := params.Entities{Entities: entities}
-	if err := caller.FacadeCall(context.TODO(), "Life", args, &result); err != nil {
+	if err := caller.FacadeCall(ctx, "Life", args, &result); err != nil {
 		return []params.LifeResult{}, err
 	}
 	return result.Results, nil
@@ -34,8 +34,8 @@ func Life(caller base.FacadeCaller, tags []names.Tag) ([]params.LifeResult, erro
 
 // OneLife requests the life cycle of the given entity from the given
 // server-side API facade via the given caller.
-func OneLife(caller base.FacadeCaller, tag names.Tag) (life.Value, error) {
-	result, err := Life(caller, []names.Tag{tag})
+func OneLife(ctx context.Context, caller base.FacadeCaller, tag names.Tag) (life.Value, error) {
+	result, err := Life(ctx, caller, []names.Tag{tag})
 	if err != nil {
 		return "", err
 	}

--- a/api/controller/firewaller/application_test.go
+++ b/api/controller/firewaller/application_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -52,7 +54,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := u.Application()
 	c.Assert(err, jc.ErrorIsNil)
@@ -100,7 +102,7 @@ func (s *applicationSuite) TestExposeInfo(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := u.Application()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/controller/firewaller/firewaller.go
+++ b/api/controller/firewaller/firewaller.go
@@ -61,13 +61,13 @@ func (c *Client) ModelTag() (names.ModelTag, bool) {
 }
 
 // life requests the life cycle of the given entity from the server.
-func (c *Client) life(tag names.Tag) (life.Value, error) {
-	return common.OneLife(c.facade, tag)
+func (c *Client) life(ctx context.Context, tag names.Tag) (life.Value, error) {
+	return common.OneLife(ctx, c.facade, tag)
 }
 
 // Unit provides access to methods of a state.Unit through the facade.
-func (c *Client) Unit(tag names.UnitTag) (*Unit, error) {
-	life, err := c.life(tag)
+func (c *Client) Unit(ctx context.Context, tag names.UnitTag) (*Unit, error) {
+	life, err := c.life(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +80,8 @@ func (c *Client) Unit(tag names.UnitTag) (*Unit, error) {
 
 // Machine provides access to methods of a state.Machine through the
 // facade.
-func (c *Client) Machine(tag names.MachineTag) (*Machine, error) {
-	life, err := c.life(tag)
+func (c *Client) Machine(ctx context.Context, tag names.MachineTag) (*Machine, error) {
+	life, err := c.life(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (c *Client) WatchModelFirewallRules() (watcher.NotifyWatcher, error) {
 
 // Relation provides access to methods of a state.Relation through the
 // facade.
-func (c *Client) Relation(tag names.RelationTag) (*Relation, error) {
-	life, err := c.life(tag)
+func (c *Client) Relation(ctx context.Context, tag names.RelationTag) (*Relation, error) {
+	life, err := c.life(ctx, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/api/controller/firewaller/machine_test.go
+++ b/api/controller/firewaller/machine_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +43,7 @@ func (s *machineSuite) TestMachine(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Life(), gc.Equals, life.Alive)
 	c.Assert(m.Tag(), jc.DeepEquals, tag)
@@ -75,7 +77,7 @@ func (s *machineSuite) TestInstanceId(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := m.InstanceId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,7 +114,7 @@ func (s *machineSuite) TestWatchUnits(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = m.WatchUnits()
 	c.Assert(err, gc.ErrorMatches, "FAIL")
@@ -147,7 +149,7 @@ func (s *machineSuite) TestIsManual(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := m.IsManual()
 	c.Assert(err, jc.ErrorIsNil)
@@ -214,7 +216,7 @@ func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := client.Machine(tag)
+	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	byUnitAndCIDR, byUnitAndEndpoint, err := m.OpenedMachinePortRanges()

--- a/api/controller/firewaller/relation_test.go
+++ b/api/controller/firewaller/relation_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -39,7 +41,7 @@ func (s *relationSuite) TestRelation(c *gc.C) {
 	tag := names.NewRelationTag("mysql:db wordpress:db")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	r, err := client.Relation(tag)
+	r, err := client.Relation(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Life(), gc.Equals, life.Alive)
 	c.Assert(r.Tag(), jc.DeepEquals, tag)

--- a/api/controller/firewaller/unit.go
+++ b/api/controller/firewaller/unit.go
@@ -36,8 +36,8 @@ func (u *Unit) Life() life.Value {
 }
 
 // Refresh updates the cached local copy of the unit's data.
-func (u *Unit) Refresh() error {
-	life, err := u.client.life(u.tag)
+func (u *Unit) Refresh(ctx context.Context) error {
+	life, err := u.client.life(ctx, u.tag)
 	if err != nil {
 		return err
 	}

--- a/api/controller/firewaller/unit_test.go
+++ b/api/controller/firewaller/unit_test.go
@@ -4,6 +4,8 @@
 package firewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -39,7 +41,7 @@ func (s *unitSuite) TestUnit(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.Life(), gc.Equals, life.Alive)
 	c.Assert(u.Name(), jc.DeepEquals, "mysql/666")
@@ -70,9 +72,9 @@ func (s *unitSuite) TestRefresh(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.Refresh()
+	err = u.Refresh(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.Life(), gc.Equals, life.Dead)
 	c.Assert(calls, gc.Equals, 2)
@@ -106,7 +108,7 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := u.AssignedMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -132,7 +134,7 @@ func (s *unitSuite) TestApplication(c *gc.C) {
 	tag := names.NewUnitTag("mysql/666")
 	client, err := firewaller.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := client.Unit(tag)
+	u, err := client.Unit(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := u.Application()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/controller/instancepoller/instancepoller.go
+++ b/api/controller/instancepoller/instancepoller.go
@@ -46,8 +46,8 @@ func NewAPI(caller base.APICaller, options ...Option) *API {
 
 // Machine provides access to methods of a state.Machine through the
 // facade.
-func (api *API) Machine(tag names.MachineTag) (*Machine, error) {
-	life, err := common.OneLife(api.facade, tag)
+func (api *API) Machine(ctx context.Context, tag names.MachineTag) (*Machine, error) {
+	life, err := common.OneLife(ctx, api.facade, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/controller/instancepoller/instancepoller_test.go
+++ b/api/controller/instancepoller/instancepoller_test.go
@@ -34,7 +34,7 @@ func (s *InstancePollerSuite) TestNewAPI(c *gc.C) {
 	c.Check(apiCaller.CallCount, gc.Equals, 0)
 
 	// Nothing happens until we actually call something else.
-	m, err := api.Machine(names.MachineTag{})
+	m, err := api.Machine(context.Background(), names.MachineTag{})
 	c.Assert(err, gc.ErrorMatches, "client error!")
 	c.Assert(m, gc.IsNil)
 	c.Check(apiCaller.CallCount, gc.Equals, 1)
@@ -53,7 +53,7 @@ func (s *InstancePollerSuite) TestMachineCallsLife(c *gc.C) {
 	}
 	apiCaller := successAPICaller(c, "Life", entitiesArgs, expectedResults)
 	api := instancepoller.NewAPI(apiCaller)
-	m, err := api.Machine(names.NewMachineTag("42"))
+	m, err := api.Machine(context.Background(), names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 	c.Assert(m.Life(), gc.Equals, life.Value("working"))

--- a/api/controller/instancepoller/machine.go
+++ b/api/controller/instancepoller/machine.go
@@ -48,8 +48,8 @@ func (m *Machine) Life() life.Value {
 }
 
 // Refresh updates the cached local copy of the machine's data.
-func (m *Machine) Refresh() error {
-	life, err := common.OneLife(m.facade, m.tag)
+func (m *Machine) Refresh(ctx context.Context) error {
+	life, err := common.OneLife(ctx, m.facade, m.tag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/interface.go
+++ b/api/interface.go
@@ -259,7 +259,7 @@ type Connection interface {
 	// IsBroken returns whether the connection is broken. It checks
 	// the Broken channel and if that is open, attempts a connection
 	// ping.
-	IsBroken() bool
+	IsBroken(ctx context.Context) bool
 
 	// IsProxied returns weather the connection is proxied.
 	IsProxied() bool

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -90,7 +90,7 @@ func (s *watcherSuite) TestWatchMachine(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "Machiner", 666, "", "Watch", args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
 	client := machiner.NewClient(caller)
-	m, err := client.Machine(names.NewMachineTag("666"))
+	m, err := client.Machine(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := m.Watch()
@@ -125,7 +125,7 @@ func (s *watcherSuite) TestNotifyWatcherStopsWithPendingSend(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "Machiner", 666, "", "Watch", args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
 	client := machiner.NewClient(caller)
-	m, err := client.Machine(names.NewMachineTag("666"))
+	m, err := client.Machine(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := m.Watch()
@@ -158,7 +158,7 @@ func (s *watcherSuite) TestWatchUnits(c *gc.C) {
 	m, err := client.Machine(names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := m.WatchUnits()
+	w, err := m.WatchUnits(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -199,7 +199,7 @@ func (s *watcherSuite) TestStringsWatcherStopsWithPendingSend(c *gc.C) {
 	m, err := client.Machine(names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := m.WatchUnits()
+	w, err := m.WatchUnits(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -141,7 +141,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			// operations on the connection before calling Login.
 			st := s.openAPIWithoutLogin(c)
 
-			_, err := apimachiner.NewClient(st).Machine(names.NewMachineTag("0"))
+			_, err := apimachiner.NewClient(st).Machine(context.Background(), names.NewMachineTag("0"))
 			c.Assert(err, gc.NotNil)
 			c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
 			c.Check(strings.Contains(err.Error(), `unknown facade type "Machiner"`), jc.IsTrue)
@@ -151,7 +151,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			c.Assert(errors.Cause(err), gc.DeepEquals, t.err)
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
-			_, err = apimachiner.NewClient(st).Machine(names.NewMachineTag("0"))
+			_, err = apimachiner.NewClient(st).Machine(context.Background(), names.NewMachineTag("0"))
 			c.Assert(err, gc.NotNil)
 			c.Check(errors.Is(err, errors.NotImplemented), jc.IsTrue)
 			c.Check(strings.Contains(err.Error(), `unknown facade type "Machiner"`), jc.IsTrue)
@@ -919,7 +919,7 @@ func (s *migrationSuite) TestImportingModel(c *gc.C) {
 
 	// Machines should be able to use the API.
 	machineConn := s.OpenModelAPIAs(c, s.ControllerModelUUID(), m.Tag(), password, "nonce")
-	_, err = apimachiner.NewClient(machineConn).Machine(m.MachineTag())
+	_, err = apimachiner.NewClient(machineConn).Machine(context.Background(), m.MachineTag())
 	c.Check(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/domain/credential"
-	envcontext "github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/rpc/params"
 )
 

--- a/apiserver/facades/client/credentialmanager/client_integration_test.go
+++ b/apiserver/facades/client/credentialmanager/client_integration_test.go
@@ -48,7 +48,7 @@ func (s *CredentialManagerIntegrationSuite) TestInvalidateModelCredential(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cred.Invalid, jc.IsFalse)
 
-	c.Assert(s.client.InvalidateModelCredential("no reason really"), jc.ErrorIsNil)
+	c.Assert(s.client.InvalidateModelCredential(ctx.Background(), "no reason really"), jc.ErrorIsNil)
 	cred, err = credService.CloudCredential(ctx.Background(), credential.IdFromTag(tag))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cred.Invalid, jc.IsTrue)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -69,16 +69,16 @@ var _ = gc.Suite(&serverSuite{})
 func (s *serverSuite) TestStop(c *gc.C) {
 	conn, machine := s.OpenAPIAsNewMachine(c, state.JobManageModel)
 
-	_, err := apimachiner.NewClient(conn).Machine(machine.MachineTag())
+	_, err := apimachiner.NewClient(conn).Machine(context.Background(), machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = apimachiner.NewClient(conn).Machine(machine.MachineTag())
+	_, err = apimachiner.NewClient(conn).Machine(context.Background(), machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.Server.Stop()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = apimachiner.NewClient(conn).Machine(machine.MachineTag())
+	_, err = apimachiner.NewClient(conn).Machine(context.Background(), machine.MachineTag())
 	// The client has not necessarily seen the server shutdown yet, so there
 	// are multiple possible errors. All we should care about is that there is
 	// an error, not what the error actually is.
@@ -121,7 +121,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 		network.NewMachineHostPorts(port, "localhost"),
 	})
 
-	_, err = apimachiner.NewClient(ipv4Conn).Machine(machine.MachineTag())
+	_, err = apimachiner.NewClient(ipv4Conn).Machine(context.Background(), machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	info.Addrs = []string{net.JoinHostPort("::1", portString)}
@@ -133,7 +133,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 		network.NewMachineHostPorts(port, "::1"),
 	})
 
-	_, err = apimachiner.NewClient(ipv6Conn).Machine(machine.MachineTag())
+	_, err = apimachiner.NewClient(ipv6Conn).Machine(context.Background(), machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -60,7 +60,7 @@ type initCommand struct {
 
 // ApplicationAPI provides methods for unit introduction.
 type ApplicationAPI interface {
-	UnitIntroduction(podName string, podUUID string) (*caasapplication.UnitConfig, error)
+	UnitIntroduction(ctx context.Context, podName string, podUUID string) (*caasapplication.UnitConfig, error)
 	Close() error
 }
 
@@ -93,9 +93,9 @@ func (c *initCommand) Info() *cmd.Info {
 	})
 }
 
-func (c *initCommand) getApplicationAPI() (ApplicationAPI, error) {
+func (c *initCommand) getApplicationAPI(ctx context.Context) (ApplicationAPI, error) {
 	if c.applicationAPI == nil {
-		connection, err := apicaller.OnlyConnect(c, api.Open, loggo.GetLogger("juju.containeragent"))
+		connection, err := apicaller.OnlyConnect(ctx, c, api.Open, loggo.GetLogger("juju.containeragent"))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -140,7 +140,7 @@ func (c *initCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Trace(err)
 	}
 
-	applicationAPI, err := c.getApplicationAPI()
+	applicationAPI, err := c.getApplicationAPI(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -154,7 +154,7 @@ func (c *initCommand) Run(ctx *cmd.Context) (err error) {
 	var unitConfig *caasapplication.UnitConfig
 	err = retry.Call(retry.CallArgs{
 		Func: func() error {
-			unitConfig, err = applicationAPI.UnitIntroduction(identity.PodName, identity.PodUUID)
+			unitConfig, err = applicationAPI.UnitIntroduction(ctx, identity.PodName, identity.PodUUID)
 			return errors.Trace(err)
 		},
 		IsFatalError: func(err error) bool {

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -145,9 +145,9 @@ checks:
 
 	gomock.InOrder(
 		s.fileReaderWriter.EXPECT().Stat("/var/lib/juju/template-agent.conf").Return(nil, os.ErrNotExist),
-		s.applicationAPI.EXPECT().UnitIntroduction(`gitlab-0`, `gitlab-uuid`).Times(1).Return(nil, errors.NotAssignedf("yo we not needed yet")),
-		s.applicationAPI.EXPECT().UnitIntroduction(`gitlab-0`, `gitlab-uuid`).Times(1).Return(nil, errors.AlreadyExistsf("yo we dead atm")),
-		s.applicationAPI.EXPECT().UnitIntroduction(`gitlab-0`, `gitlab-uuid`).Times(1).Return(&caasapplication.UnitConfig{
+		s.applicationAPI.EXPECT().UnitIntroduction(gomock.Any(), `gitlab-0`, `gitlab-uuid`).Times(1).Return(nil, errors.NotAssignedf("yo we not needed yet")),
+		s.applicationAPI.EXPECT().UnitIntroduction(gomock.Any(), `gitlab-0`, `gitlab-uuid`).Times(1).Return(nil, errors.AlreadyExistsf("yo we dead atm")),
+		s.applicationAPI.EXPECT().UnitIntroduction(gomock.Any(), `gitlab-0`, `gitlab-uuid`).Times(1).Return(&caasapplication.UnitConfig{
 			UnitTag:   names.NewUnitTag("gitlab/0"),
 			AgentConf: data,
 		}, nil),

--- a/cmd/containeragent/initialize/mocks/application_mock.go
+++ b/cmd/containeragent/initialize/mocks/application_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	caasapplication "github.com/juju/juju/api/agent/caasapplication"
@@ -54,16 +55,16 @@ func (mr *MockApplicationAPIMockRecorder) Close() *gomock.Call {
 }
 
 // UnitIntroduction mocks base method.
-func (m *MockApplicationAPI) UnitIntroduction(arg0, arg1 string) (*caasapplication.UnitConfig, error) {
+func (m *MockApplicationAPI) UnitIntroduction(arg0 context.Context, arg1, arg2 string) (*caasapplication.UnitConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitIntroduction", arg0, arg1)
+	ret := m.ctrl.Call(m, "UnitIntroduction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*caasapplication.UnitConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitIntroduction indicates an expected call of UnitIntroduction.
-func (mr *MockApplicationAPIMockRecorder) UnitIntroduction(arg0, arg1 any) *gomock.Call {
+func (mr *MockApplicationAPIMockRecorder) UnitIntroduction(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitIntroduction", reflect.TypeOf((*MockApplicationAPI)(nil).UnitIntroduction), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitIntroduction", reflect.TypeOf((*MockApplicationAPI)(nil).UnitIntroduction), arg0, arg1, arg2)
 }

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -4,6 +4,7 @@
 package unit
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -362,7 +363,7 @@ func (c *containerUnitAgent) Run(ctx *cmd.Context) (err error) {
 
 // validateMigration is called by the migrationminion to help check
 // that the agent will be ok when connected to a new controller.
-func (c *containerUnitAgent) validateMigration(apiCaller base.APICaller) error {
+func (c *containerUnitAgent) validateMigration(ctx context.Context, apiCaller base.APICaller) error {
 	// TODO(mjs) - more extensive checks to come.
 	tag := c.CurrentConfig().Tag()
 	unitTag, ok := tag.(names.UnitTag)
@@ -370,11 +371,11 @@ func (c *containerUnitAgent) validateMigration(apiCaller base.APICaller) error {
 		return errors.NotValidf("expected a unit tag; got %q", tag)
 	}
 	facade := uniter.NewClient(apiCaller, unitTag)
-	_, err := facade.Unit(unitTag)
+	_, err := facade.Unit(ctx, unitTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	model, err := facade.Model()
+	model, err := facade.Model(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -4,6 +4,7 @@
 package unit
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -75,7 +76,7 @@ type manifoldsConfig struct {
 	// ValidateMigration is called by the migrationminion during the
 	// migration process to check that the agent will be ok when
 	// connected to the new target controller.
-	ValidateMigration func(base.APICaller) error
+	ValidateMigration func(context.Context, base.APICaller) error
 
 	// PreviousAgentVersion passes through the version the unit
 	// agent was running before the current restart.

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -81,7 +82,7 @@ func (dummyHookContext) StorageInstance(id string) (*storage.StorageInstance, er
 	return nil, errors.NotFoundf("StorageInstance")
 }
 
-func (dummyHookContext) UnitStatus() (*jujuc.StatusInfo, error) {
+func (dummyHookContext) UnitStatus(context.Context) (*jujuc.StatusInfo, error) {
 	return &jujuc.StatusInfo{}, nil
 }
 

--- a/cmd/jujud/agent/checkconnection.go
+++ b/cmd/jujud/agent/checkconnection.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -21,12 +22,12 @@ import (
 )
 
 // ConnectFunc connects to the API as the given agent.
-type ConnectFunc func(agent.Agent) (io.Closer, error)
+type ConnectFunc func(context.Context, agent.Agent) (io.Closer, error)
 
 // ConnectAsAgent really connects to the API specified in the agent
 // config. It's extracted so tests can pass something else in.
-func ConnectAsAgent(a agent.Agent) (io.Closer, error) {
-	return apicaller.ScaryConnect(a, api.Open, loggo.GetLogger("juju.agent"))
+func ConnectAsAgent(ctx context.Context, a agent.Agent) (io.Closer, error) {
+	return apicaller.ScaryConnect(ctx, a, api.Open, loggo.GetLogger("juju.agent"))
 }
 
 type checkConnectionCommand struct {
@@ -80,7 +81,7 @@ func (c *checkConnectionCommand) Init(args []string) error {
 
 // Run is part of cmd.Command.
 func (c *checkConnectionCommand) Run(ctx *cmd.Context) error {
-	conn, err := c.connect(c.config)
+	conn, err := c.connect(ctx, c.config)
 	if err != nil {
 		return errors.Annotatef(err, "checking connection for %s", c.agentName)
 	}

--- a/cmd/jujud/agent/checkconnection_test.go
+++ b/cmd/jujud/agent/checkconnection_test.go
@@ -4,6 +4,7 @@
 package agent_test
 
 import (
+	"context"
 	"io"
 
 	"github.com/juju/errors"
@@ -36,7 +37,7 @@ func (s *checkConnectionSuite) TestInitChecksTag(c *gc.C) {
 
 func (s *checkConnectionSuite) TestRunComplainsAboutConnectionErrors(c *gc.C) {
 	cmd := agentcmd.NewCheckConnectionCommand(newAgentConf(),
-		func(a agent.Agent) (io.Closer, error) {
+		func(_ context.Context, a agent.Agent) (io.Closer, error) {
 			return nil, errors.Errorf("hartz-timor swarm detected")
 		})
 	c.Assert(cmd.Init([]string{"unit-artemis-5"}), jc.ErrorIsNil)
@@ -46,7 +47,7 @@ func (s *checkConnectionSuite) TestRunComplainsAboutConnectionErrors(c *gc.C) {
 
 func (s *checkConnectionSuite) TestRunClosesConnection(c *gc.C) {
 	cmd := agentcmd.NewCheckConnectionCommand(newAgentConf(),
-		func(a agent.Agent) (io.Closer, error) {
+		func(_ context.Context, a agent.Agent) (io.Closer, error) {
 			return &mockConnection{}, nil
 		})
 	c.Assert(cmd.Init([]string{"unit-artemis-5"}), jc.ErrorIsNil)

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -169,7 +169,7 @@ type ManifoldsConfig struct {
 
 	// MachineStartup is passed to the machine manifold. It does
 	// machine setup work which relies on an API connection.
-	MachineStartup func(api.Connection, Logger) error
+	MachineStartup func(context.Context, api.Connection, Logger) error
 
 	// PreUpgradeSteps is a function that is used by the upgradesteps
 	// worker to ensure that conditions are OK for an upgrade to
@@ -194,7 +194,7 @@ type ManifoldsConfig struct {
 	// ValidateMigration is called by the migrationminion during the
 	// migration process to check that the agent will be ok when
 	// connected to the new target controller.
-	ValidateMigration func(base.APICaller) error
+	ValidateMigration func(context.Context, base.APICaller) error
 
 	// PrometheusRegisterer is a prometheus.Registerer that may be used
 	// by workers to register Prometheus metric collectors.
@@ -220,7 +220,7 @@ type ManifoldsConfig struct {
 	UpdateLoggerConfig func(string) error
 
 	// NewAgentStatusSetter provides upgradesteps.StatusSetter.
-	NewAgentStatusSetter func(base.APICaller) (upgradesteps.StatusSetter, error)
+	NewAgentStatusSetter func(context.Context, base.APICaller) (upgradesteps.StatusSetter, error)
 
 	// ControllerLeaseDuration defines for how long this agent will ask
 	// for controller administration rights.

--- a/cmd/jujud/agent/machine/startupmanifold.go
+++ b/cmd/jujud/agent/machine/startupmanifold.go
@@ -25,7 +25,7 @@ type Logger interface {
 // machinestartup manifold.
 type MachineStartupConfig struct {
 	APICallerName  string
-	MachineStartup func(api.Connection, Logger) error
+	MachineStartup func(context.Context, api.Connection, Logger) error
 	Logger         Logger
 }
 
@@ -60,7 +60,7 @@ func MachineStartupManifold(config MachineStartupConfig) dependency.Manifold {
 			if err := getter.Get(config.APICallerName, &apiConn); err != nil {
 				return nil, err
 			}
-			if err := config.MachineStartup(apiConn, config.Logger); err != nil {
+			if err := config.MachineStartup(ctx, apiConn, config.Logger); err != nil {
 				return nil, err
 			}
 			config.Logger.Debugf("Finished machine setup requiring an API connection")

--- a/cmd/jujud/agent/machine/startupmanifold_test.go
+++ b/cmd/jujud/agent/machine/startupmanifold_test.go
@@ -28,7 +28,7 @@ func (s *MachineStartupSuite) SetUpTest(c *gc.C) {
 	s.startCalled = false
 	s.manifold = machine.MachineStartupManifold(machine.MachineStartupConfig{
 		APICallerName: "api-caller",
-		MachineStartup: func(api.Connection, machine.Logger) error {
+		MachineStartup: func(context.Context, api.Connection, machine.Logger) error {
 			s.startCalled = true
 			return nil
 		},

--- a/cmd/jujud/agent/machine_legacy_test.go
+++ b/cmd/jujud/agent/machine_legacy_test.go
@@ -473,7 +473,7 @@ func (s *MachineLegacySuite) TestManageModelServesAPI(c *gc.C) {
 		st, err := api.Open(apiInfo, fastDialOpts)
 		c.Assert(err, jc.ErrorIsNil)
 		defer st.Close()
-		m, err := apimachiner.NewClient(st).Machine(conf.Tag().(names.MachineTag))
+		m, err := apimachiner.NewClient(st).Machine(context.Background(), conf.Tag().(names.MachineTag))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(m.Life(), gc.Equals, life.Alive)
 	})
@@ -492,7 +492,7 @@ func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFile(c *gc.C) {
 			st, err := api.Open(apiInfo, fastDialOpts)
 			c.Assert(err, jc.ErrorIsNil)
 			defer func() { _ = st.Close() }()
-			err = a.machineStartup(st, coretesting.NewCheckLogger(c))
+			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
 			c.Assert(err, jc.ErrorIsNil)
 		},
 	)
@@ -511,7 +511,7 @@ func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFileErrored(c *
 			st, err := api.Open(apiInfo, fastDialOpts)
 			c.Assert(err, jc.ErrorIsNil)
 			defer func() { _ = st.Close() }()
-			err = a.machineStartup(st, coretesting.NewCheckLogger(c))
+			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
 			c.Assert(err, gc.ErrorMatches, `unknown error`)
 		},
 	)
@@ -530,7 +530,7 @@ func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFileNonZeroExit
 			st, err := api.Open(apiInfo, fastDialOpts)
 			c.Assert(err, jc.ErrorIsNil)
 			defer func() { _ = st.Close() }()
-			err = a.machineStartup(st, coretesting.NewCheckLogger(c))
+			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
 			c.Assert(err, gc.ErrorMatches, `cannot patch /etc/update-manager/release-upgrades: unknown error`)
 		},
 	)

--- a/internal/upgradesteps/worker.go
+++ b/internal/upgradesteps/worker.go
@@ -122,7 +122,7 @@ func (w *BaseWorker) RunUpgradeSteps(ctx context.Context, targets []upgrades.Tar
 				if !ok {
 					return false
 				}
-				return agenterrors.ConnectionIsDead(w.Logger, breakable)
+				return agenterrors.ConnectionIsDead(ctx, w.Logger, breakable)
 			},
 			NotifyFunc: func(lastErr error, attempt int) {
 				w.reportUpgradeFailure(lastErr, attempt == DefaultRetryAttempts)

--- a/internal/upgradesteps/worker_test.go
+++ b/internal/upgradesteps/worker_test.go
@@ -6,7 +6,7 @@ package upgradesteps
 import (
 	"context"
 	"errors"
-	time "time"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -130,6 +130,6 @@ type breakableAPICaller struct {
 	broken bool
 }
 
-func (b *breakableAPICaller) IsBroken() bool {
+func (b *breakableAPICaller) IsBroken(_ context.Context) bool {
 	return b.broken
 }

--- a/internal/worker/agentconfigupdater/manifold.go
+++ b/internal/worker/agentconfigupdater/manifold.go
@@ -77,7 +77,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			// If the machine needs Client, grab the state serving info
 			// over the API and write it to the agent configuration.
-			if controller, err := apiagent.IsController(apiCaller, tag); err != nil {
+			if controller, err := apiagent.IsController(ctx, apiCaller, tag); err != nil {
 				return nil, errors.Annotate(err, "checking controller status")
 			} else if !controller {
 				// Not a controller, nothing to do.
@@ -150,7 +150,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configOpenTelemetrySampleRatio := controllerConfig.OpenTelemetrySampleRatio()
 			openTelemetrySampleRatioChanged := agentsOpenTelemetrySampleRatio != configOpenTelemetrySampleRatio
 
-			info, err := apiState.StateServingInfo()
+			info, err := apiState.StateServingInfo(ctx)
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
 			}

--- a/internal/worker/apiaddressupdater/manifold.go
+++ b/internal/worker/apiaddressupdater/manifold.go
@@ -4,6 +4,8 @@
 package apiaddressupdater
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/worker/v4"
@@ -44,7 +46,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 // newWorker trivially wraps NewAPIAddressUpdater for use in a engine.AgentAPIManifold.
 // It's not tested at the moment, because the scaffolding necessary is too
 // unwieldy/distracting to introduce at this point.
-func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (config ManifoldConfig) newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	tag := a.CurrentConfig().Tag()
 
 	// TODO(fwereade): use appropriate facade!

--- a/internal/worker/apicaller/connect_test.go
+++ b/internal/worker/apicaller/connect_test.go
@@ -4,6 +4,7 @@
 package apicaller_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/loggo"
@@ -52,7 +53,7 @@ func testEntityFine(c *gc.C, life apiagent.Life) {
 	// use an entity that doesn't correspond to an agent at all.
 	entity := names.NewApplicationTag("omg")
 	connect := func() (api.Connection, error) {
-		return apicaller.ScaryConnect(&mockAgent{
+		return apicaller.ScaryConnect(context.Background(), &mockAgent{
 			stub:   stub,
 			model:  coretesting.ModelTag,
 			entity: entity,
@@ -81,7 +82,7 @@ func (*ScaryConnectSuite) TestEntityDead(c *gc.C) {
 
 	entity := names.NewApplicationTag("omg")
 	connect := func() (api.Connection, error) {
-		return apicaller.ScaryConnect(&mockAgent{
+		return apicaller.ScaryConnect(context.Background(), &mockAgent{
 			stub:   stub,
 			model:  coretesting.ModelTag,
 			entity: entity,
@@ -110,7 +111,7 @@ func (*ScaryConnectSuite) TestEntityDenied(c *gc.C) {
 
 	entity := names.NewApplicationTag("omg")
 	connect := func() (api.Connection, error) {
-		return apicaller.ScaryConnect(&mockAgent{
+		return apicaller.ScaryConnect(context.Background(), &mockAgent{
 			stub:   stub,
 			model:  coretesting.ModelTag,
 			entity: entity,
@@ -138,7 +139,7 @@ func (*ScaryConnectSuite) TestEntityUnknownLife(c *gc.C) {
 
 	entity := names.NewApplicationTag("omg")
 	connect := func() (api.Connection, error) {
-		return apicaller.ScaryConnect(&mockAgent{
+		return apicaller.ScaryConnect(context.Background(), &mockAgent{
 			stub:   stub,
 			model:  coretesting.ModelTag,
 			entity: entity,
@@ -252,7 +253,7 @@ func checkChangePassword(c *gc.C, stub *testing.Stub) error {
 
 	entity := names.NewApplicationTag("omg")
 	connect := func() (api.Connection, error) {
-		return apicaller.ScaryConnect(&mockAgent{
+		return apicaller.ScaryConnect(context.Background(), &mockAgent{
 			stub:   stub,
 			model:  coretesting.ModelTag,
 			entity: entity,

--- a/internal/worker/apicaller/manifold.go
+++ b/internal/worker/apicaller/manifold.go
@@ -24,7 +24,7 @@ type Logger interface {
 
 // ConnectFunc is responsible for making and validating an API connection
 // on behalf of an agent.
-type ConnectFunc func(agent.Agent, api.OpenFunc, Logger) (api.Connection, error)
+type ConnectFunc func(context.Context, agent.Agent, api.OpenFunc, Logger) (api.Connection, error)
 
 // ManifoldConfig defines a Manifold's dependencies.
 type ManifoldConfig struct {
@@ -91,7 +91,7 @@ func (config ManifoldConfig) startFunc() dependency.StartFunc {
 			return nil, err
 		}
 
-		conn, err := config.NewConnection(agent, config.APIOpen, config.Logger)
+		conn, err := config.NewConnection(ctx, agent, config.APIOpen, config.Logger)
 		if errors.Cause(err) == ErrChangedPassword {
 			return nil, dependency.ErrBounce
 		} else if err != nil {

--- a/internal/worker/apicaller/manifold_test.go
+++ b/internal/worker/apicaller/manifold_test.go
@@ -45,7 +45,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		APIOpen: func(*api.Info, api.DialOpts) (api.Connection, error) {
 			panic("just a fake")
 		},
-		NewConnection: func(a agent.Agent, apiOpen api.OpenFunc, logger apicaller.Logger) (api.Connection, error) {
+		NewConnection: func(_ context.Context, a agent.Agent, apiOpen api.OpenFunc, logger apicaller.Logger) (api.Connection, error) {
 			c.Check(apiOpen, gc.NotNil) // uncomparable
 			c.Check(logger, gc.NotNil)  // uncomparable
 			s.AddCall("NewConnection", a)

--- a/internal/worker/apicaller/retry_test.go
+++ b/internal/worker/apicaller/retry_test.go
@@ -4,6 +4,7 @@
 package apicaller_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -53,7 +54,7 @@ func (s *RetryStrategySuite) TestOnlyConnectSuccess(c *gc.C) {
 		nil,               // success on second strategy attempt
 	)
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
-		return apicaller.OnlyConnect(&mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
+		return apicaller.OnlyConnect(context.Background(), &mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
 	})
 	checkOpenCalls(c, stub, "new", "new", "new")
 	c.Check(conn, gc.NotNil)
@@ -69,7 +70,7 @@ func (s *RetryStrategySuite) TestOnlyConnectOldPasswordSuccess(c *gc.C) {
 		nil,               // second strategy attempt
 	)
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
-		return apicaller.OnlyConnect(&mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
+		return apicaller.OnlyConnect(context.Background(), &mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
 	})
 	checkOpenCalls(c, stub, "new", "old", "old", "old")
 	c.Check(err, jc.ErrorIsNil)
@@ -97,7 +98,7 @@ func checkWaitProvisionedError(c *gc.C, connect apicaller.ConnectFunc) (api.Conn
 		errors.New("splat pow"), // third strategy attempt
 	)
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
-		return connect(&mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
+		return connect(context.Background(), &mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
 	})
 	checkOpenCalls(c, stub, "new", "new", "new", "new")
 	return conn, err
@@ -124,7 +125,7 @@ func checkWaitNeverProvisioned(c *gc.C, connect apicaller.ConnectFunc) (api.Conn
 		errNotProvisioned, // third strategy attempt
 	)
 	conn, err := strategyTest(stub, strategy, func(apiOpen api.OpenFunc) (api.Connection, error) {
-		return connect(&mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
+		return connect(context.Background(), &mockAgent{stub: stub, entity: testEntity}, apiOpen, loggo.GetLogger("test"))
 	})
 	checkOpenCalls(c, stub, "new", "new", "new", "new")
 	return conn, err

--- a/internal/worker/apicaller/util_test.go
+++ b/internal/worker/apicaller/util_test.go
@@ -4,6 +4,7 @@
 package apicaller_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -128,7 +129,7 @@ type mockConnFacade struct {
 	life apiagent.Life
 }
 
-func (mock *mockConnFacade) Life(entity names.Tag) (apiagent.Life, error) {
+func (mock *mockConnFacade) Life(_ context.Context, entity names.Tag) (apiagent.Life, error) {
 	mock.stub.AddCall("Life", entity)
 	if err := mock.stub.NextErr(); err != nil {
 		return "", err
@@ -136,7 +137,7 @@ func (mock *mockConnFacade) Life(entity names.Tag) (apiagent.Life, error) {
 	return mock.life, nil
 }
 
-func (mock *mockConnFacade) SetPassword(entity names.Tag, password string) error {
+func (mock *mockConnFacade) SetPassword(_ context.Context, entity names.Tag, password string) error {
 	mock.stub.AddCall("SetPassword", entity, password)
 	return mock.stub.NextErr()
 }

--- a/internal/worker/authenticationworker/manifold.go
+++ b/internal/worker/authenticationworker/manifold.go
@@ -4,6 +4,8 @@
 package authenticationworker
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
@@ -25,7 +27,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return engine.AgentAPIManifold(typedConfig, newWorker)
 }
 
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	w, err := NewWorker(keyupdater.NewClient(apiCaller), a.CurrentConfig())
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start ssh auth-keys updater worker")

--- a/internal/worker/caasunitterminationworker/worker.go
+++ b/internal/worker/caasunitterminationworker/worker.go
@@ -4,6 +4,7 @@
 package caasunitterminationworker
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
@@ -41,7 +42,7 @@ type Config struct {
 }
 
 type State interface {
-	UnitTerminating(tag names.UnitTag) (caasapplication.UnitTermination, error)
+	UnitTerminating(ctx context.Context, tag names.UnitTag) (caasapplication.UnitTermination, error)
 }
 
 type UnitTerminator interface {
@@ -80,7 +81,7 @@ func (w *terminationWorker) loop(c <-chan os.Signal) (err error) {
 	select {
 	case <-c:
 		w.logger.Infof("terminating due to SIGTERM")
-		term, err := w.state.UnitTerminating(w.agent.CurrentConfig().Tag().(names.UnitTag))
+		term, err := w.state.UnitTerminating(context.TODO(), w.agent.CurrentConfig().Tag().(names.UnitTag))
 		if err != nil {
 			w.logger.Errorf("error while terminating unit: %v", err)
 			return err

--- a/internal/worker/caasunitterminationworker/worker_test.go
+++ b/internal/worker/caasunitterminationworker/worker_test.go
@@ -4,6 +4,7 @@
 package caasunitterminationworker_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -105,7 +106,7 @@ type mockState struct {
 	termination caasapplication.UnitTermination
 }
 
-func (s *mockState) UnitTerminating(tag names.UnitTag) (caasapplication.UnitTermination, error) {
+func (s *mockState) UnitTerminating(_ context.Context, tag names.UnitTag) (caasapplication.UnitTermination, error) {
 	s.MethodCall(s, "UnitTerminating", tag)
 	return s.termination, s.NextErr()
 }

--- a/internal/worker/common/credentialinvalidator.go
+++ b/internal/worker/common/credentialinvalidator.go
@@ -13,7 +13,7 @@ import (
 
 // CredentialAPI exposes functionality of the credential validator API facade to a worker.
 type CredentialAPI interface {
-	InvalidateModelCredential(reason string) error
+	InvalidateModelCredential(ctx stdcontext.Context, reason string) error
 }
 
 // NewCredentialInvalidatorFacade creates an API facade capable of invalidating credential.
@@ -24,9 +24,9 @@ func NewCredentialInvalidatorFacade(apiCaller base.APICaller) (CredentialAPI, er
 // NewCloudCallContextFunc creates a function returning a cloud call context to be used by workers.
 func NewCloudCallContextFunc(c CredentialAPI) CloudCallContextFunc {
 	return func(ctx stdcontext.Context) envcontext.ProviderCallContext {
-		return envcontext.WithCredentialInvalidator(ctx, func(_ stdcontext.Context, reason string) error {
+		return envcontext.WithCredentialInvalidator(ctx, func(ctx stdcontext.Context, reason string) error {
 			// This is a client api facade call which doesn't take a context.
-			return c.InvalidateModelCredential(reason)
+			return c.InvalidateModelCredential(ctx, reason)
 		})
 	}
 }

--- a/internal/worker/containerbroker/broker_test.go
+++ b/internal/worker/containerbroker/broker_test.go
@@ -4,6 +4,8 @@
 package containerbroker_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	"go.uber.org/mock/gomock"
@@ -226,7 +228,7 @@ func (s *trackerSuite) withScenario(c *gc.C, expected *broker.Config, behaviours
 	for _, b := range behaviours {
 		b()
 	}
-	return containerbroker.NewTracker(containerbroker.Config{
+	return containerbroker.NewTracker(context.Background(), containerbroker.Config{
 		APICaller:   s.apiCaller,
 		AgentConfig: s.agentConfig,
 		MachineLock: s.machineLock,
@@ -250,18 +252,18 @@ func (s *trackerSuite) expectMachineTag() {
 }
 
 func (s *trackerSuite) expectMachines() {
-	s.state.EXPECT().Machines(s.machineTag).Return([]provisioner.MachineResult{{
+	s.state.EXPECT().Machines(gomock.Any(), s.machineTag).Return([]provisioner.MachineResult{{
 		Machine: s.machine,
 	}}, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 }
 
 func (s *trackerSuite) expectNoMachines() {
-	s.state.EXPECT().Machines(s.machineTag).Return([]provisioner.MachineResult{}, nil)
+	s.state.EXPECT().Machines(gomock.Any(), s.machineTag).Return([]provisioner.MachineResult{}, nil)
 }
 
 func (s *trackerSuite) expectDeadMachines() {
-	s.state.EXPECT().Machines(s.machineTag).Return([]provisioner.MachineResult{{
+	s.state.EXPECT().Machines(gomock.Any(), s.machineTag).Return([]provisioner.MachineResult{{
 		Machine: s.machine,
 	}}, nil)
 	s.machine.EXPECT().Life().Return(life.Dead)

--- a/internal/worker/containerbroker/manifold.go
+++ b/internal/worker/containerbroker/manifold.go
@@ -24,7 +24,7 @@ type ManifoldConfig struct {
 	APICallerName string
 	MachineLock   machinelock.Lock
 	NewBrokerFunc func(broker.Config) (environs.InstanceBroker, error)
-	NewTracker    func(Config) (worker.Worker, error)
+	NewTracker    func(context.Context, Config) (worker.Worker, error)
 }
 
 // Validate validates the manifold configuration.
@@ -69,7 +69,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
-			w, err := config.NewTracker(Config{
+			w, err := config.NewTracker(ctx, Config{
 				APICaller:     apiCaller,
 				AgentConfig:   agent.CurrentConfig(),
 				MachineLock:   config.MachineLock,

--- a/internal/worker/containerbroker/manifold_test.go
+++ b/internal/worker/containerbroker/manifold_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
-	worker "github.com/juju/worker/v4"
+	"github.com/juju/worker/v4"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -98,7 +98,7 @@ func (s *manifoldConfigSuite) TestValidConfigValidate(c *gc.C) {
 		NewBrokerFunc: func(broker.Config) (environs.InstanceBroker, error) {
 			return mocks.NewMockInstanceBroker(ctrl), nil
 		},
-		NewTracker: func(containerbroker.Config) (worker.Worker, error) {
+		NewTracker: func(context.Context, containerbroker.Config) (worker.Worker, error) {
 			return mocks.NewMockWorker(ctrl), nil
 		},
 	}
@@ -147,7 +147,7 @@ func (s *manifoldSuite) TestNewTrackerIsCalled(c *gc.C) {
 		NewBrokerFunc: func(broker.Config) (environs.InstanceBroker, error) {
 			return s.broker, nil
 		},
-		NewTracker: func(cfg containerbroker.Config) (worker.Worker, error) {
+		NewTracker: func(_ context.Context, cfg containerbroker.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 	}
@@ -170,7 +170,7 @@ func (s *manifoldSuite) TestNewTrackerReturnsError(c *gc.C) {
 		NewBrokerFunc: func(broker.Config) (environs.InstanceBroker, error) {
 			return s.broker, nil
 		},
-		NewTracker: func(cfg containerbroker.Config) (worker.Worker, error) {
+		NewTracker: func(_ context.Context, cfg containerbroker.Config) (worker.Worker, error) {
 			return nil, errors.New("errored")
 		},
 	}

--- a/internal/worker/containerbroker/mocks/machine_mock.go
+++ b/internal/worker/containerbroker/mocks/machine_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instance "github.com/juju/juju/core/instance"
@@ -207,17 +208,17 @@ func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockMachineProvisioner) Refresh() error {
+func (m *MockMachineProvisioner) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
+func (mr *MockMachineProvisionerMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh), arg0)
 }
 
 // Remove mocks base method.

--- a/internal/worker/containerbroker/mocks/state_mock.go
+++ b/internal/worker/containerbroker/mocks/state_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	provisioner "github.com/juju/juju/api/agent/provisioner"
@@ -105,10 +106,10 @@ func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 any) *gomock.Call 
 }
 
 // Machines mocks base method.
-func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineResult, error) {
+func (m *MockState) Machines(arg0 context.Context, arg1 ...names.MachineTag) ([]provisioner.MachineResult, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Machines", varargs...)
@@ -118,9 +119,10 @@ func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineRes
 }
 
 // Machines indicates an expected call of Machines.
-func (mr *MockStateMockRecorder) Machines(arg0 ...any) *gomock.Call {
+func (mr *MockStateMockRecorder) Machines(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockState)(nil).Machines), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockState)(nil).Machines), varargs...)
 }
 
 // PrepareContainerInterfaceInfo mocks base method.

--- a/internal/worker/credentialvalidator/manifold.go
+++ b/internal/worker/credentialvalidator/manifold.go
@@ -26,7 +26,7 @@ type ManifoldConfig struct {
 	APICallerName string
 
 	NewFacade func(base.APICaller) (Facade, error)
-	NewWorker func(Config) (worker.Worker, error)
+	NewWorker func(context.Context, Config) (worker.Worker, error)
 	Logger    Logger
 }
 
@@ -48,7 +48,7 @@ func (config ManifoldConfig) Validate() error {
 }
 
 // start is a StartFunc for a Worker manifold.
-func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -60,7 +60,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	w, err := config.NewWorker(Config{
+	w, err := config.NewWorker(ctx, Config{
 		Facade: facade,
 		Logger: config.Logger,
 	})

--- a/internal/worker/credentialvalidator/manifold_test.go
+++ b/internal/worker/credentialvalidator/manifold_test.go
@@ -124,7 +124,7 @@ func (*ManifoldSuite) TestStartNewWorkerError(c *gc.C) {
 	config.NewFacade = func(base.APICaller) (credentialvalidator.Facade, error) {
 		return expectFacade, nil
 	}
-	config.NewWorker = func(workerConfig credentialvalidator.Config) (worker.Worker, error) {
+	config.NewWorker = func(_ context.Context, workerConfig credentialvalidator.Config) (worker.Worker, error) {
 		c.Check(workerConfig.Facade, gc.Equals, expectFacade)
 		return nil, errors.New("snerk")
 	}
@@ -144,7 +144,7 @@ func (*ManifoldSuite) TestStartSuccess(c *gc.C) {
 	config.NewFacade = func(base.APICaller) (credentialvalidator.Facade, error) {
 		return &struct{ credentialvalidator.Facade }{}, nil
 	}
-	config.NewWorker = func(credentialvalidator.Config) (worker.Worker, error) {
+	config.NewWorker = func(context.Context, credentialvalidator.Config) (worker.Worker, error) {
 		return expectWorker, nil
 	}
 	manifold := credentialvalidator.Manifold(config)

--- a/internal/worker/credentialvalidator/util_test.go
+++ b/internal/worker/credentialvalidator/util_test.go
@@ -4,6 +4,8 @@
 package credentialvalidator_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -36,7 +38,7 @@ func (m *mockFacade) setupModelHasNoCredential() {
 }
 
 // ModelCredential is part of the credentialvalidator.Facade interface.
-func (m *mockFacade) ModelCredential() (base.StoredCredential, bool, error) {
+func (m *mockFacade) ModelCredential(context.Context) (base.StoredCredential, bool, error) {
 	m.AddCall("ModelCredential")
 	if err := m.NextErr(); err != nil {
 		return base.StoredCredential{}, false, err
@@ -45,7 +47,7 @@ func (m *mockFacade) ModelCredential() (base.StoredCredential, bool, error) {
 }
 
 // WatchCredential is part of the credentialvalidator.Facade interface.
-func (mock *mockFacade) WatchCredential(id string) (watcher.NotifyWatcher, error) {
+func (mock *mockFacade) WatchCredential(_ context.Context, id string) (watcher.NotifyWatcher, error) {
 	mock.AddCall("WatchCredential", id)
 	if err := mock.NextErr(); err != nil {
 		return nil, err
@@ -54,7 +56,7 @@ func (mock *mockFacade) WatchCredential(id string) (watcher.NotifyWatcher, error
 }
 
 // WatchModelCredential is part of the credentialvalidator.Facade interface.
-func (mock *mockFacade) WatchModelCredential() (watcher.NotifyWatcher, error) {
+func (mock *mockFacade) WatchModelCredential(context.Context) (watcher.NotifyWatcher, error) {
 	mock.AddCall("WatchModelCredential")
 	if err := mock.NextErr(); err != nil {
 		return nil, err
@@ -72,7 +74,7 @@ func panicFacade(base.APICaller) (credentialvalidator.Facade, error) {
 }
 
 // panicWorker is a NewWorker that should not be called.
-func panicWorker(credentialvalidator.Config) (worker.Worker, error) {
+func panicWorker(context.Context, credentialvalidator.Config) (worker.Worker, error) {
 	panic("panicWorker")
 }
 
@@ -96,7 +98,7 @@ func checkNotValid(c *gc.C, config credentialvalidator.Config, expect string) {
 	err := config.Validate()
 	check(err)
 
-	worker, err := credentialvalidator.NewWorker(config)
+	worker, err := credentialvalidator.NewWorker(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	check(err)
 }

--- a/internal/worker/credentialvalidator/worker_test.go
+++ b/internal/worker/credentialvalidator/worker_test.go
@@ -4,6 +4,7 @@
 package credentialvalidator_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -56,7 +57,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestStartStop(c *gc.C) {
-	w, err := testWorker(s.config)
+	w, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckAlive(c, w)
 	workertest.CleanKill(c, w)
@@ -72,7 +73,7 @@ func (s *WorkerSuite) TestStartStop(c *gc.C) {
 
 func (s *WorkerSuite) TestStartStopNoCredential(c *gc.C) {
 	s.facade.setupModelHasNoCredential()
-	w, err := testWorker(s.config)
+	w, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckAlive(c, w)
 	workertest.CleanKill(c, w)
@@ -88,7 +89,7 @@ func (s *WorkerSuite) TestStartStopNoCredential(c *gc.C) {
 func (s *WorkerSuite) TestModelCredentialError(c *gc.C) {
 	s.facade.SetErrors(errors.New("mc fail"))
 
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Check(err, gc.ErrorMatches, "mc fail")
 	c.Assert(worker, gc.IsNil)
 	s.facade.CheckCallNames(c, "ModelCredential")
@@ -99,7 +100,7 @@ func (s *WorkerSuite) TestModelCredentialWatcherError(c *gc.C) {
 		errors.New("mcw fail"), // WatchModelCredential call
 	)
 
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Check(err, gc.ErrorMatches, "mcw fail")
 	c.Assert(worker, gc.IsNil)
 	s.facade.CheckCallNames(c, "ModelCredential", "WatchModelCredential")
@@ -111,7 +112,7 @@ func (s *WorkerSuite) TestWatchError(c *gc.C) {
 		errors.New("watch fail"), // WatchCredential call
 	)
 
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, gc.ErrorMatches, "watch fail")
 	c.Assert(worker, gc.IsNil)
 	s.facade.CheckCallNames(c, "ModelCredential", "WatchModelCredential", "WatchCredential")
@@ -119,7 +120,7 @@ func (s *WorkerSuite) TestWatchError(c *gc.C) {
 
 func (s *WorkerSuite) TestModelCredentialNotNeeded(c *gc.C) {
 	s.facade.setupModelHasNoCredential()
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	workertest.CheckAlive(c, worker)
@@ -128,7 +129,7 @@ func (s *WorkerSuite) TestModelCredentialNotNeeded(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestCredentialChangeToInvalid(c *gc.C) {
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.facade.credential.Valid = false
@@ -141,7 +142,7 @@ func (s *WorkerSuite) TestCredentialChangeToInvalid(c *gc.C) {
 
 func (s *WorkerSuite) TestCredentialChangeFromInvalid(c *gc.C) {
 	s.facade.credential.Valid = false
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.facade.credential.Valid = true
@@ -153,7 +154,7 @@ func (s *WorkerSuite) TestCredentialChangeFromInvalid(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestNoRelevantCredentialChange(c *gc.C) {
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.sendChange(c)
@@ -165,7 +166,7 @@ func (s *WorkerSuite) TestNoRelevantCredentialChange(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestModelCredentialNoChanged(c *gc.C) {
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.sendModelChange(c)
@@ -176,7 +177,7 @@ func (s *WorkerSuite) TestModelCredentialNoChanged(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestModelCredentialChanged(c *gc.C) {
-	worker, err := testWorker(s.config)
+	worker, err := testWorker(context.Background(), s.config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.facade.credential.CloudCredential = names.NewCloudCredentialTag("cloud/anotheruser/credential").String()

--- a/internal/worker/deployer/manifold.go
+++ b/internal/worker/deployer/manifold.go
@@ -4,6 +4,8 @@
 package deployer
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -52,7 +54,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 //
 // It's not tested at the moment, because the scaffolding
 // necessary is too unwieldy/distracting to introduce at this point.
-func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (config ManifoldConfig) newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	// TODO: run config.Validate()
 	cfg := a.CurrentConfig()
 	// Grab the tag and ensure that it's for a machine.
@@ -95,8 +97,8 @@ func (s *facadeShim) Machine(tag names.MachineTag) (Machine, error) {
 	return machine, nil
 }
 
-func (s *facadeShim) Unit(tag names.UnitTag) (Unit, error) {
-	unit, err := s.st.Unit(tag)
+func (s *facadeShim) Unit(ctx context.Context, tag names.UnitTag) (Unit, error) {
+	unit, err := s.st.Unit(ctx, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/worker/deployer/mocks/deployer_mocks.go
+++ b/internal/worker/deployer/mocks/deployer_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	life "github.com/juju/juju/core/life"
@@ -59,18 +60,18 @@ func (mr *MockClientMockRecorder) Machine(arg0 any) *gomock.Call {
 }
 
 // Unit mocks base method.
-func (m *MockClient) Unit(arg0 names.UnitTag) (deployer.Unit, error) {
+func (m *MockClient) Unit(arg0 context.Context, arg1 names.UnitTag) (deployer.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
+	ret := m.ctrl.Call(m, "Unit", arg0, arg1)
 	ret0, _ := ret[0].(deployer.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockClientMockRecorder) Unit(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) Unit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockClient)(nil).Unit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockClient)(nil).Unit), arg0, arg1)
 }
 
 // MockMachine is a mock of Machine interface.
@@ -97,18 +98,18 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 }
 
 // WatchUnits mocks base method.
-func (m *MockMachine) WatchUnits() (watcher.Watcher[[]string], error) {
+func (m *MockMachine) WatchUnits(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUnits")
+	ret := m.ctrl.Call(m, "WatchUnits", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUnits indicates an expected call of WatchUnits.
-func (mr *MockMachineMockRecorder) WatchUnits() *gomock.Call {
+func (mr *MockMachineMockRecorder) WatchUnits(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMachine)(nil).WatchUnits))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMachine)(nil).WatchUnits), arg0)
 }
 
 // MockUnit is a mock of Unit interface.
@@ -163,43 +164,43 @@ func (mr *MockUnitMockRecorder) Name() *gomock.Call {
 }
 
 // Remove mocks base method.
-func (m *MockUnit) Remove() error {
+func (m *MockUnit) Remove(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Remove")
+	ret := m.ctrl.Call(m, "Remove", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockUnitMockRecorder) Remove() *gomock.Call {
+func (mr *MockUnitMockRecorder) Remove(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockUnit)(nil).Remove))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockUnit)(nil).Remove), arg0)
 }
 
 // SetPassword mocks base method.
-func (m *MockUnit) SetPassword(arg0 string) error {
+func (m *MockUnit) SetPassword(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPassword", arg0)
+	ret := m.ctrl.Call(m, "SetPassword", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPassword indicates an expected call of SetPassword.
-func (mr *MockUnitMockRecorder) SetPassword(arg0 any) *gomock.Call {
+func (mr *MockUnitMockRecorder) SetPassword(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockUnit)(nil).SetPassword), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockUnit)(nil).SetPassword), arg0, arg1)
 }
 
 // SetStatus mocks base method.
-func (m *MockUnit) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockUnit) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockUnitMockRecorder) SetStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockUnitMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUnit)(nil).SetStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUnit)(nil).SetStatus), arg0, arg1, arg2, arg3)
 }

--- a/internal/worker/deployer/unit_agent.go
+++ b/internal/worker/deployer/unit_agent.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -315,14 +316,14 @@ func (a *UnitAgent) CurrentConfig() agent.Config {
 
 // validateMigration is called by the migrationminion to help check
 // that the agent will be ok when connected to a new controller.
-func (a *UnitAgent) validateMigration(apiCaller base.APICaller) error {
+func (a *UnitAgent) validateMigration(ctx context.Context, apiCaller base.APICaller) error {
 	// TODO(mjs) - more extensive checks to come.
 	facade := uniter.NewClient(apiCaller, a.tag)
-	_, err := facade.Unit(a.tag)
+	_, err := facade.Unit(ctx, a.tag)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	model, err := facade.Model()
+	model, err := facade.Model(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -69,7 +70,7 @@ type UnitManifoldsConfig struct {
 	// ValidateMigration is called by the migrationminion during the
 	// migration process to check that the agent will be ok when
 	// connected to the new target controller.
-	ValidateMigration func(base.APICaller) error
+	ValidateMigration func(context.Context, base.APICaller) error
 
 	// UpdateLoggerConfig is a function that will save the specified
 	// config value as the logging config in the agent.conf file.

--- a/internal/worker/diskmanager/manifold.go
+++ b/internal/worker/diskmanager/manifold.go
@@ -4,6 +4,8 @@
 package diskmanager
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/worker/v4"
@@ -26,7 +28,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // newWorker trivially wraps NewWorker for use in a engine.AgentAPIManifold.
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	t := a.CurrentConfig().Tag()
 	tag, ok := t.(names.MachineTag)
 	if !ok {

--- a/internal/worker/diskmanager/manifold_test.go
+++ b/internal/worker/diskmanager/manifold_test.go
@@ -4,6 +4,8 @@
 package diskmanager_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4"
@@ -59,7 +61,7 @@ func (s *manifoldSuite) TestMachineDiskmanager(c *gc.C) {
 		},
 	}
 
-	_, err := diskmanager.NewWorkerFunc(a, apiCaller)
+	_, err := diskmanager.NewWorkerFunc(context.Background(), a, apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/internal/worker/environupgrader/worker_test.go
+++ b/internal/worker/environupgrader/worker_test.go
@@ -4,6 +4,7 @@
 package environupgrader_test
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/errors"
@@ -415,6 +416,6 @@ func (w *mockNotifyWatcher) Wait() error {
 
 type credentialAPIForTest struct{}
 
-func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+func (*credentialAPIForTest) InvalidateModelCredential(_ context.Context, reason string) error {
 	return nil
 }

--- a/internal/worker/fanconfigurer/manifold.go
+++ b/internal/worker/fanconfigurer/manifold.go
@@ -51,7 +51,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			facade := apifanconfigurer.NewFacade(apiCaller)
 
-			fanconfigurer, err := NewFanConfigurer(FanConfigurerConfig{
+			fanconfigurer, err := NewFanConfigurer(ctx, FanConfigurerConfig{
 				Facade: facade,
 			}, config.Clock)
 			return fanconfigurer, errors.Annotate(err, "creating fanconfigurer orchestrator")

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -265,7 +265,7 @@ func (s *firewallerBaseSuite) addModelMachine(ctrl *gomock.Controller, manual bo
 
 	m := mocks.NewMockMachine(ctrl)
 	tag := names.NewMachineTag(id)
-	s.firewaller.EXPECT().Machine(tag).Return(m, nil).MinTimes(1)
+	s.firewaller.EXPECT().Machine(gomock.Any(), tag).Return(m, nil).MinTimes(1)
 	m.EXPECT().Tag().Return(tag).AnyTimes()
 	m.EXPECT().Life().DoAndReturn(func() life.Value {
 		s.mu.Lock()
@@ -309,7 +309,7 @@ func (s *firewallerBaseSuite) addUnit(c *gc.C, ctrl *gomock.Controller, app *moc
 	unitTag := names.NewUnitTag(fmt.Sprintf("%s/%d", app.Name(), unitId))
 	m, unitsCh := s.addMachine(ctrl)
 	u := mocks.NewMockUnit(ctrl)
-	s.firewaller.EXPECT().Unit(unitTag).Return(u, nil).AnyTimes()
+	s.firewaller.EXPECT().Unit(gomock.Any(), unitTag).Return(u, nil).AnyTimes()
 	u.EXPECT().Life().Return(life.Alive)
 	u.EXPECT().Tag().Return(unitTag).AnyTimes()
 	u.EXPECT().Application().Return(app, nil).AnyTimes()

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -33,9 +33,9 @@ type FirewallerAPI interface {
 	WatchModelFirewallRules() (watcher.NotifyWatcher, error)
 	ModelFirewallRules() (firewall.IngressRules, error)
 	ModelConfig(stdcontext.Context) (*config.Config, error)
-	Machine(tag names.MachineTag) (Machine, error)
-	Unit(tag names.UnitTag) (Unit, error)
-	Relation(tag names.RelationTag) (*firewaller.Relation, error)
+	Machine(ctx stdcontext.Context, tag names.MachineTag) (Machine, error)
+	Unit(ctx stdcontext.Context, tag names.UnitTag) (Unit, error)
+	Relation(ctx stdcontext.Context, tag names.RelationTag) (*firewaller.Relation, error)
 	WatchEgressAddressesForRelation(tag names.RelationTag) (watcher.StringsWatcher, error)
 	WatchIngressAddressesForRelation(tag names.RelationTag) (watcher.StringsWatcher, error)
 	ControllerAPIInfoForModel(modelUUID string) (*api.Info, error)
@@ -106,7 +106,7 @@ type Unit interface {
 	Name() string
 	Tag() names.UnitTag
 	Life() life.Value
-	Refresh() error
+	Refresh(ctx stdcontext.Context) error
 	Application() (Application, error)
 	AssignedMachine() (names.MachineTag, error)
 }

--- a/internal/worker/firewaller/mocks/credential_mocks.go
+++ b/internal/worker/firewaller/mocks/credential_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -39,15 +40,15 @@ func (m *MockCredentialAPI) EXPECT() *MockCredentialAPIMockRecorder {
 }
 
 // InvalidateModelCredential mocks base method.
-func (m *MockCredentialAPI) InvalidateModelCredential(arg0 string) error {
+func (m *MockCredentialAPI) InvalidateModelCredential(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0)
+	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InvalidateModelCredential indicates an expected call of InvalidateModelCredential.
-func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0 any) *gomock.Call {
+func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0, arg1)
 }

--- a/internal/worker/firewaller/mocks/entity_mocks.go
+++ b/internal/worker/firewaller/mocks/entity_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instance "github.com/juju/juju/core/instance"
@@ -216,17 +217,17 @@ func (mr *MockUnitMockRecorder) Name() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockUnit) Refresh() error {
+func (m *MockUnit) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockUnitMockRecorder) Refresh() *gomock.Call {
+func (mr *MockUnitMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUnit)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUnit)(nil).Refresh), arg0)
 }
 
 // Tag mocks base method.

--- a/internal/worker/firewaller/mocks/facade_mocks.go
+++ b/internal/worker/firewaller/mocks/facade_mocks.go
@@ -99,18 +99,18 @@ func (mr *MockFirewallerAPIMockRecorder) MacaroonForRelation(arg0 any) *gomock.C
 }
 
 // Machine mocks base method.
-func (m *MockFirewallerAPI) Machine(arg0 names.MachineTag) (firewaller0.Machine, error) {
+func (m *MockFirewallerAPI) Machine(arg0 context.Context, arg1 names.MachineTag) (firewaller0.Machine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Machine", arg0)
+	ret := m.ctrl.Call(m, "Machine", arg0, arg1)
 	ret0, _ := ret[0].(firewaller0.Machine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Machine indicates an expected call of Machine.
-func (mr *MockFirewallerAPIMockRecorder) Machine(arg0 any) *gomock.Call {
+func (mr *MockFirewallerAPIMockRecorder) Machine(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockFirewallerAPI)(nil).Machine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockFirewallerAPI)(nil).Machine), arg0, arg1)
 }
 
 // ModelConfig mocks base method.
@@ -144,18 +144,18 @@ func (mr *MockFirewallerAPIMockRecorder) ModelFirewallRules() *gomock.Call {
 }
 
 // Relation mocks base method.
-func (m *MockFirewallerAPI) Relation(arg0 names.RelationTag) (*firewaller.Relation, error) {
+func (m *MockFirewallerAPI) Relation(arg0 context.Context, arg1 names.RelationTag) (*firewaller.Relation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Relation", arg0)
+	ret := m.ctrl.Call(m, "Relation", arg0, arg1)
 	ret0, _ := ret[0].(*firewaller.Relation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Relation indicates an expected call of Relation.
-func (mr *MockFirewallerAPIMockRecorder) Relation(arg0 any) *gomock.Call {
+func (mr *MockFirewallerAPIMockRecorder) Relation(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockFirewallerAPI)(nil).Relation), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockFirewallerAPI)(nil).Relation), arg0, arg1)
 }
 
 // SetRelationStatus mocks base method.
@@ -173,18 +173,18 @@ func (mr *MockFirewallerAPIMockRecorder) SetRelationStatus(arg0, arg1, arg2 any)
 }
 
 // Unit mocks base method.
-func (m *MockFirewallerAPI) Unit(arg0 names.UnitTag) (firewaller0.Unit, error) {
+func (m *MockFirewallerAPI) Unit(arg0 context.Context, arg1 names.UnitTag) (firewaller0.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
+	ret := m.ctrl.Call(m, "Unit", arg0, arg1)
 	ret0, _ := ret[0].(firewaller0.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockFirewallerAPIMockRecorder) Unit(arg0 any) *gomock.Call {
+func (mr *MockFirewallerAPIMockRecorder) Unit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockFirewallerAPI)(nil).Unit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockFirewallerAPI)(nil).Unit), arg0, arg1)
 }
 
 // WatchEgressAddressesForRelation mocks base method.

--- a/internal/worker/firewaller/shim.go
+++ b/internal/worker/firewaller/shim.go
@@ -36,12 +36,12 @@ type firewallerShim struct {
 	*firewaller.Client
 }
 
-func (s *firewallerShim) Machine(tag names.MachineTag) (Machine, error) {
-	return s.Client.Machine(tag)
+func (s *firewallerShim) Machine(ctx context.Context, tag names.MachineTag) (Machine, error) {
+	return s.Client.Machine(ctx, tag)
 }
 
-func (s *firewallerShim) Unit(tag names.UnitTag) (Unit, error) {
-	u, err := s.Client.Unit(tag)
+func (s *firewallerShim) Unit(ctx context.Context, tag names.UnitTag) (Unit, error) {
+	u, err := s.Client.Unit(ctx, tag)
 	return &unitShim{u}, err
 }
 

--- a/internal/worker/hostkeyreporter/worker.go
+++ b/internal/worker/hostkeyreporter/worker.go
@@ -4,6 +4,7 @@
 package hostkeyreporter
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
@@ -21,7 +22,7 @@ var logger = loggo.GetLogger("juju.worker.hostkeyreporter")
 
 // Facade exposes controller functionality to a Worker.
 type Facade interface {
-	ReportKeys(machineId string, publicKeys []string) error
+	ReportKeys(ctx context.Context, machineId string, publicKeys []string) error
 }
 
 // Config defines the parameters of the hostkeyreporter worker.
@@ -80,7 +81,7 @@ func (w *hostkeyreporter) run() error {
 	if len(keys) < 1 {
 		return errors.New("no SSH host keys found")
 	}
-	err = w.config.Facade.ReportKeys(w.config.MachineId, keys)
+	err = w.config.Facade.ReportKeys(context.TODO(), w.config.MachineId, keys)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/hostkeyreporter/worker_test.go
+++ b/internal/worker/hostkeyreporter/worker_test.go
@@ -4,6 +4,7 @@
 package hostkeyreporter_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,7 +115,7 @@ type stubFacade struct {
 	reportErr error
 }
 
-func (c *stubFacade) ReportKeys(machineId string, publicKeys []string) error {
+func (c *stubFacade) ReportKeys(_ context.Context, machineId string, publicKeys []string) error {
 	c.stub.AddCall("ReportKeys", machineId, publicKeys)
 	return c.reportErr
 }

--- a/internal/worker/identityfilewriter/manifold.go
+++ b/internal/worker/identityfilewriter/manifold.go
@@ -4,6 +4,8 @@
 package identityfilewriter
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
@@ -27,7 +29,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // newWorker trivially wraps NewWorker for use in a engine.AgentAPIManifold.
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func newWorker(ctx context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	cfg := a.CurrentConfig()
 
 	// Grab the tag and ensure that it's for a controller.
@@ -35,7 +37,7 @@ func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 		return nil, errors.New("this manifold may only be used inside a machine or controller agent")
 	}
 
-	isController, err := apiagent.IsController(apiCaller, cfg.Tag())
+	isController, err := apiagent.IsController(ctx, apiCaller, cfg.Tag())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/worker/instancemutater/export_test.go
+++ b/internal/worker/instancemutater/export_test.go
@@ -4,9 +4,11 @@
 package instancemutater
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	worker "github.com/juju/worker/v4"
+	"github.com/juju/worker/v4"
 
 	"github.com/juju/juju/api/agent/instancemutater"
 	"github.com/juju/juju/core/lxdprofile"
@@ -41,22 +43,22 @@ func NewEnvironTestWorker(config Config, ctxFn RequiredMutaterContextFunc) (work
 		return []string{"default", "juju-" + modelName}
 	}
 	config.GetRequiredContext = ctxFn
-	return newWorker(config)
+	return newWorker(context.Background(), config)
 }
 
 func NewContainerTestWorker(config Config, ctxFn RequiredMutaterContextFunc) (worker.Worker, error) {
-	m, err := config.Facade.Machine(config.Tag.(names.MachineTag))
+	m, err := config.Facade.Machine(context.Background(), config.Tag.(names.MachineTag))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	config.GetRequiredLXDProfiles = func(_ string) []string { return []string{"default"} }
 	config.GetMachineWatcher = m.WatchContainers
 	config.GetRequiredContext = ctxFn
-	return newWorker(config)
+	return newWorker(context.Background(), config)
 }
 
 func ProcessMachineProfileChanges(m *MutaterMachine, info *instancemutater.UnitProfileInfo) error {
-	return m.processMachineProfileChanges(info)
+	return m.processMachineProfileChanges(context.Background(), info)
 }
 
 func GatherProfileData(m *MutaterMachine, info *instancemutater.UnitProfileInfo) ([]lxdprofile.ProfilePost, error) {

--- a/internal/worker/instancemutater/manifold.go
+++ b/internal/worker/instancemutater/manifold.go
@@ -23,7 +23,7 @@ type ModelManifoldConfig struct {
 	AgentName     string
 
 	Logger    Logger
-	NewWorker func(Config) (worker.Worker, error)
+	NewWorker func(context.Context, Config) (worker.Worker, error)
 	NewClient func(base.APICaller) InstanceMutaterAPI
 }
 
@@ -50,7 +50,7 @@ func (config ModelManifoldConfig) Validate() error {
 	return nil
 }
 
-func (config ModelManifoldConfig) newWorker(environ environs.Environ, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
+func (config ModelManifoldConfig) newWorker(ctx context.Context, environ environs.Environ, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -73,7 +73,7 @@ func (config ModelManifoldConfig) newWorker(environ environs.Environ, apiCaller 
 		Tag:         agentConfig.Tag(),
 	}
 
-	w, err := config.NewWorker(cfg)
+	w, err := config.NewWorker(ctx, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start model instance-mutater worker")
 	}
@@ -100,7 +100,7 @@ type EnvironAPIConfig struct {
 
 // EnvironAPIStartFunc encapsulates creation of a worker based on the environ
 // and APICaller.
-type EnvironAPIStartFunc func(environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error)
+type EnvironAPIStartFunc func(context.Context, environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error)
 
 // EnvironAPIManifold returns a dependency.Manifold that calls the supplied
 // start func with the API and envrion resources defined in the config
@@ -125,7 +125,7 @@ func EnvironAPIManifold(config EnvironAPIConfig, start EnvironAPIStartFunc) depe
 			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
-			return start(environ, apiCaller, agent)
+			return start(ctx, environ, apiCaller, agent)
 		},
 	}
 }
@@ -137,7 +137,7 @@ type MachineManifoldConfig struct {
 	AgentName     string
 
 	Logger    Logger
-	NewWorker func(Config) (worker.Worker, error)
+	NewWorker func(context.Context, Config) (worker.Worker, error)
 	NewClient func(base.APICaller) InstanceMutaterAPI
 }
 
@@ -164,7 +164,7 @@ func (config MachineManifoldConfig) Validate() error {
 	return nil
 }
 
-func (config MachineManifoldConfig) newWorker(instanceBroker environs.InstanceBroker, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
+func (config MachineManifoldConfig) newWorker(ctx context.Context, instanceBroker environs.InstanceBroker, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -192,7 +192,7 @@ func (config MachineManifoldConfig) newWorker(instanceBroker environs.InstanceBr
 		Tag:         tag,
 	}
 
-	w, err := config.NewWorker(cfg)
+	w, err := config.NewWorker(ctx, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot start machine instancemutater worker")
 	}
@@ -219,7 +219,7 @@ type BrokerAPIConfig struct {
 
 // BrokerAPIStartFunc encapsulates creation of a worker based on the environ
 // and APICaller.
-type BrokerAPIStartFunc func(environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error)
+type BrokerAPIStartFunc func(context.Context, environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error)
 
 // BrokerAPIManifold returns a dependency.Manifold that calls the supplied
 // start func with the API and envrion resources defined in the config
@@ -244,7 +244,7 @@ func BrokerAPIManifold(config BrokerAPIConfig, start BrokerAPIStartFunc) depende
 			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, errors.Trace(err)
 			}
-			return start(broker, apiCaller, agent)
+			return start(ctx, broker, apiCaller, agent)
 		},
 	}
 }

--- a/internal/worker/instancemutater/manifold_test.go
+++ b/internal/worker/instancemutater/manifold_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
-	worker "github.com/juju/worker/v4"
+	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -57,7 +57,7 @@ func (s *modelManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no new client constructor",
 			config: instancemutater.ModelManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 			},
@@ -67,7 +67,7 @@ func (s *modelManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no agent name",
 			config: instancemutater.ModelManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -80,7 +80,7 @@ func (s *modelManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no environ name",
 			config: instancemutater.ModelManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -94,7 +94,7 @@ func (s *modelManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no api caller name",
 			config: instancemutater.ModelManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -119,7 +119,7 @@ func (s *modelManifoldConfigSuite) TestValidConfigValidate(c *gc.C) {
 
 	config := instancemutater.ModelManifoldConfig{
 		Logger: mocks.NewMockLogger(ctrl),
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return mocks.NewMockWorker(ctrl), nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -172,7 +172,7 @@ func (s *environAPIManifoldSuite) TestStartReturnsWorker(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.EnvironAPIManifold(config, func(environ environs.Environ, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.EnvironAPIManifold(config, func(_ context.Context, environ environs.Environ, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
 		c.Assert(environ, gc.Equals, s.environ)
 		c.Assert(apiCaller, gc.Equals, s.apiCaller)
 		c.Assert(agent, gc.Equals, s.agent)
@@ -196,7 +196,7 @@ func (s *environAPIManifoldSuite) TestMissingEnvironFromContext(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.EnvironAPIManifold(config, func(environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.EnvironAPIManifold(config, func(context.Context, environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error) {
 		c.Fail()
 		return nil, nil
 	})
@@ -217,7 +217,7 @@ func (s *environAPIManifoldSuite) TestMissingAPICallerFromContext(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.EnvironAPIManifold(config, func(environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.EnvironAPIManifold(config, func(context.Context, environs.Environ, base.APICaller, agent.Agent) (worker.Worker, error) {
 		c.Fail()
 		return nil, nil
 	})
@@ -269,7 +269,7 @@ func (s *modelManifoldSuite) TestNewWorkerIsCalled(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -293,7 +293,7 @@ func (s *modelManifoldSuite) TestNewWorkerFromK8sController(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -317,7 +317,7 @@ func (s *modelManifoldSuite) TestNewWorkerReturnsError(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return nil, errors.New("errored")
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -355,7 +355,7 @@ func (s *modelManifoldSuite) TestConfigValidatesForMissingClient(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 	}
@@ -428,7 +428,7 @@ func (s *machineManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no new client constructor",
 			config: instancemutater.MachineManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 			},
@@ -438,7 +438,7 @@ func (s *machineManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no agent name",
 			config: instancemutater.MachineManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -451,7 +451,7 @@ func (s *machineManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no environ name",
 			config: instancemutater.MachineManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -465,7 +465,7 @@ func (s *machineManifoldConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 			description: "Test no api caller name",
 			config: instancemutater.MachineManifoldConfig{
 				Logger: mocks.NewMockLogger(ctrl),
-				NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+				NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 					return mocks.NewMockWorker(ctrl), nil
 				},
 				NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -490,7 +490,7 @@ func (s *machineManifoldConfigSuite) TestValidConfigValidate(c *gc.C) {
 
 	config := instancemutater.MachineManifoldConfig{
 		Logger: mocks.NewMockLogger(ctrl),
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return mocks.NewMockWorker(ctrl), nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -543,7 +543,7 @@ func (s *brokerAPIManifoldSuite) TestStartReturnsWorker(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.BrokerAPIManifold(config, func(broker environs.InstanceBroker, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.BrokerAPIManifold(config, func(_ context.Context, broker environs.InstanceBroker, apiCaller base.APICaller, agent agent.Agent) (worker.Worker, error) {
 		c.Assert(broker, gc.Equals, s.broker)
 		c.Assert(apiCaller, gc.Equals, s.apiCaller)
 		c.Assert(agent, gc.Equals, s.agent)
@@ -567,7 +567,7 @@ func (s *brokerAPIManifoldSuite) TestMissingBrokerFromContext(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.BrokerAPIManifold(config, func(environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.BrokerAPIManifold(config, func(context.Context, environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error) {
 		c.Fail()
 		return nil, nil
 	})
@@ -588,7 +588,7 @@ func (s *brokerAPIManifoldSuite) TestMissingAPICallerFromContext(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 	}
-	manifold := instancemutater.BrokerAPIManifold(config, func(environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error) {
+	manifold := instancemutater.BrokerAPIManifold(config, func(context.Context, environs.InstanceBroker, base.APICaller, agent.Agent) (worker.Worker, error) {
 		c.Fail()
 		return nil, nil
 	})
@@ -640,7 +640,7 @@ func (s *machineManifoldSuite) TestNewWorkerIsCalled(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -664,7 +664,7 @@ func (s *machineManifoldSuite) TestNewWorkerIsRejectedForK8sController(c *gc.C) 
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -688,7 +688,7 @@ func (s *machineManifoldSuite) TestNewWorkerReturnsError(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return nil, errors.New("errored")
 		},
 		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
@@ -726,7 +726,7 @@ func (s *machineManifoldSuite) TestConfigValidatesForMissingClient(c *gc.C) {
 		APICallerName: "baz",
 		AgentName:     "moon",
 		Logger:        s.logger,
-		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, cfg instancemutater.Config) (worker.Worker, error) {
 			return s.worker, nil
 		},
 	}

--- a/internal/worker/instancemutater/mocks/instancebroker_mock.go
+++ b/internal/worker/instancemutater/mocks/instancebroker_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancemutater "github.com/juju/juju/api/agent/instancemutater"
@@ -42,31 +43,31 @@ func (m *MockInstanceMutaterAPI) EXPECT() *MockInstanceMutaterAPIMockRecorder {
 }
 
 // Machine mocks base method.
-func (m *MockInstanceMutaterAPI) Machine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
+func (m *MockInstanceMutaterAPI) Machine(arg0 context.Context, arg1 names.MachineTag) (instancemutater.MutaterMachine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Machine", arg0)
+	ret := m.ctrl.Call(m, "Machine", arg0, arg1)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Machine indicates an expected call of Machine.
-func (mr *MockInstanceMutaterAPIMockRecorder) Machine(arg0 any) *gomock.Call {
+func (mr *MockInstanceMutaterAPIMockRecorder) Machine(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).Machine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).Machine), arg0, arg1)
 }
 
 // WatchModelMachines mocks base method.
-func (m *MockInstanceMutaterAPI) WatchModelMachines() (watcher.Watcher[[]string], error) {
+func (m *MockInstanceMutaterAPI) WatchModelMachines(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchModelMachines")
+	ret := m.ctrl.Call(m, "WatchModelMachines", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchModelMachines indicates an expected call of WatchModelMachines.
-func (mr *MockInstanceMutaterAPIMockRecorder) WatchModelMachines() *gomock.Call {
+func (mr *MockInstanceMutaterAPIMockRecorder) WatchModelMachines(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchModelMachines))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchModelMachines), arg0)
 }

--- a/internal/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/internal/worker/instancemutater/mocks/machinemutater_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancemutater "github.com/juju/juju/api/agent/instancemutater"
@@ -45,48 +46,48 @@ func (m *MockMutaterMachine) EXPECT() *MockMutaterMachineMockRecorder {
 }
 
 // CharmProfilingInfo mocks base method.
-func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileInfo, error) {
+func (m *MockMutaterMachine) CharmProfilingInfo(arg0 context.Context) (*instancemutater.UnitProfileInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmProfilingInfo")
+	ret := m.ctrl.Call(m, "CharmProfilingInfo", arg0)
 	ret0, _ := ret[0].(*instancemutater.UnitProfileInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmProfilingInfo indicates an expected call of CharmProfilingInfo.
-func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo), arg0)
 }
 
 // ContainerType mocks base method.
-func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
+func (m *MockMutaterMachine) ContainerType(arg0 context.Context) (instance.ContainerType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerType")
+	ret := m.ctrl.Call(m, "ContainerType", arg0)
 	ret0, _ := ret[0].(instance.ContainerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerType indicates an expected call of ContainerType.
-func (mr *MockMutaterMachineMockRecorder) ContainerType() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) ContainerType(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType), arg0)
 }
 
 // InstanceId mocks base method.
-func (m *MockMutaterMachine) InstanceId() (string, error) {
+func (m *MockMutaterMachine) InstanceId(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceId")
+	ret := m.ctrl.Call(m, "InstanceId", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InstanceId indicates an expected call of InstanceId.
-func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) InstanceId(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId), arg0)
 }
 
 // Life mocks base method.
@@ -104,45 +105,45 @@ func (mr *MockMutaterMachineMockRecorder) Life() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockMutaterMachine) Refresh() error {
+func (m *MockMutaterMachine) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockMutaterMachineMockRecorder) Refresh() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh), arg0)
 }
 
 // SetCharmProfiles mocks base method.
-func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
+func (m *MockMutaterMachine) SetCharmProfiles(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
+	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles.
-func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0 any) *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0, arg1)
 }
 
 // SetModificationStatus mocks base method.
-func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMutaterMachine) SetModificationStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModificationStatus indicates an expected call of SetModificationStatus.
-func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2, arg3)
 }
 
 // Tag mocks base method.
@@ -160,46 +161,46 @@ func (mr *MockMutaterMachineMockRecorder) Tag() *gomock.Call {
 }
 
 // WatchContainers mocks base method.
-func (m *MockMutaterMachine) WatchContainers() (watcher.Watcher[[]string], error) {
+func (m *MockMutaterMachine) WatchContainers(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchContainers")
+	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchContainers indicates an expected call of WatchContainers.
-func (mr *MockMutaterMachineMockRecorder) WatchContainers() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchContainers(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers), arg0)
 }
 
 // WatchLXDProfileVerificationNeeded mocks base method.
-func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded() (watcher.Watcher[struct{}], error) {
+func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationNeeded")
+	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationNeeded", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLXDProfileVerificationNeeded indicates an expected call of WatchLXDProfileVerificationNeeded.
-func (mr *MockMutaterMachineMockRecorder) WatchLXDProfileVerificationNeeded() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchLXDProfileVerificationNeeded(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationNeeded", reflect.TypeOf((*MockMutaterMachine)(nil).WatchLXDProfileVerificationNeeded))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationNeeded", reflect.TypeOf((*MockMutaterMachine)(nil).WatchLXDProfileVerificationNeeded), arg0)
 }
 
 // WatchUnits mocks base method.
-func (m *MockMutaterMachine) WatchUnits() (watcher.Watcher[[]string], error) {
+func (m *MockMutaterMachine) WatchUnits(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUnits")
+	ret := m.ctrl.Call(m, "WatchUnits", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUnits indicates an expected call of WatchUnits.
-func (mr *MockMutaterMachineMockRecorder) WatchUnits() *gomock.Call {
+func (mr *MockMutaterMachineMockRecorder) WatchUnits(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMutaterMachine)(nil).WatchUnits))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMutaterMachine)(nil).WatchUnits), arg0)
 }

--- a/internal/worker/instancemutater/mocks/mutatercontext_mock.go
+++ b/internal/worker/instancemutater/mocks/mutatercontext_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instancemutater "github.com/juju/juju/api/agent/instancemutater"
@@ -112,18 +113,18 @@ func (mr *MockMutaterContextMockRecorder) getBroker() *gomock.Call {
 }
 
 // getMachine mocks base method.
-func (m *MockMutaterContext) getMachine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
+func (m *MockMutaterContext) getMachine(arg0 context.Context, arg1 names.MachineTag) (instancemutater.MutaterMachine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getMachine", arg0)
+	ret := m.ctrl.Call(m, "getMachine", arg0, arg1)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // getMachine indicates an expected call of getMachine.
-func (mr *MockMutaterContextMockRecorder) getMachine(arg0 any) *gomock.Call {
+func (mr *MockMutaterContextMockRecorder) getMachine(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getMachine", reflect.TypeOf((*MockMutaterContext)(nil).getMachine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getMachine", reflect.TypeOf((*MockMutaterContext)(nil).getMachine), arg0, arg1)
 }
 
 // getRequiredLXDProfiles mocks base method.

--- a/internal/worker/instancemutater/mutater_test.go
+++ b/internal/worker/instancemutater/mutater_test.go
@@ -235,23 +235,23 @@ func (s *mutaterSuite) expectLXDProfileNames(profiles []string, err error) {
 
 func (s *mutaterSuite) expectRefreshLifeAliveStatusIdle() {
 	mExp := s.machine.EXPECT()
-	mExp.Refresh().Return(nil)
+	mExp.Refresh(gomock.Any()).Return(nil)
 	mExp.Life().Return(life.Alive)
-	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
+	mExp.SetModificationStatus(gomock.Any(), status.Idle, "", nil).Return(nil)
 }
 
 func (s *mutaterSuite) expectRefreshLifeDead() {
 	mExp := s.machine.EXPECT()
-	mExp.Refresh().Return(nil)
+	mExp.Refresh(gomock.Any()).Return(nil)
 	mExp.Life().Return(life.Dead)
 }
 
 func (s *mutaterSuite) expectModificationStatusApplied() {
-	s.machine.EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
+	s.machine.EXPECT().SetModificationStatus(gomock.Any(), status.Applied, "", nil).Return(nil)
 }
 
 func (s *mutaterSuite) expectModificationStatusError() {
-	s.machine.EXPECT().SetModificationStatus(status.Error, gomock.Any(), gomock.Any()).Return(nil)
+	s.machine.EXPECT().SetModificationStatus(gomock.Any(), status.Error, gomock.Any(), gomock.Any()).Return(nil)
 }
 
 func (s *mutaterSuite) expectAssignLXDProfiles(profiles []string, err error) {
@@ -259,7 +259,7 @@ func (s *mutaterSuite) expectAssignLXDProfiles(profiles []string, err error) {
 }
 
 func (s *mutaterSuite) expectSetCharmProfiles(profiles []string) {
-	s.machine.EXPECT().SetCharmProfiles(profiles)
+	s.machine.EXPECT().SetCharmProfiles(gomock.Any(), profiles)
 }
 
 func (s *mutaterSuite) getRequiredLXDProfiles(modelName string) []string {

--- a/internal/worker/instancepoller/manifold.go
+++ b/internal/worker/instancepoller/manifold.go
@@ -38,7 +38,9 @@ type facadeShim struct {
 	api *instancepoller.API
 }
 
-func (s facadeShim) Machine(tag names.MachineTag) (Machine, error) { return s.api.Machine(tag) }
+func (s facadeShim) Machine(ctx context.Context, tag names.MachineTag) (Machine, error) {
+	return s.api.Machine(ctx, tag)
+}
 func (s facadeShim) WatchModelMachines() (watcher.StringsWatcher, error) {
 	return s.api.WatchModelMachines()
 }

--- a/internal/worker/instancepoller/mocks/mocks_cred_api.go
+++ b/internal/worker/instancepoller/mocks/mocks_cred_api.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -39,15 +40,15 @@ func (m *MockCredentialAPI) EXPECT() *MockCredentialAPIMockRecorder {
 }
 
 // InvalidateModelCredential mocks base method.
-func (m *MockCredentialAPI) InvalidateModelCredential(arg0 string) error {
+func (m *MockCredentialAPI) InvalidateModelCredential(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0)
+	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InvalidateModelCredential indicates an expected call of InvalidateModelCredential.
-func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0 any) *gomock.Call {
+func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0, arg1)
 }

--- a/internal/worker/instancepoller/mocks/mocks_instancepoller.go
+++ b/internal/worker/instancepoller/mocks/mocks_instancepoller.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	instance "github.com/juju/juju/core/instance"
@@ -172,17 +173,17 @@ func (mr *MockMachineMockRecorder) Life() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockMachine) Refresh() error {
+func (m *MockMachine) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockMachineMockRecorder) Refresh() *gomock.Call {
+func (mr *MockMachineMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachine)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachine)(nil).Refresh), arg0)
 }
 
 // SetInstanceStatus mocks base method.

--- a/internal/worker/machineactions/manifold.go
+++ b/internal/worker/machineactions/manifold.go
@@ -5,6 +5,8 @@
 package machineactions
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/worker/v4"
@@ -27,7 +29,7 @@ type ManifoldConfig struct {
 }
 
 // start is used by engine.AgentAPIManifold to create a StartFunc.
-func (config ManifoldConfig) start(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (config ManifoldConfig) start(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	machineTag, ok := a.CurrentConfig().Tag().(names.MachineTag)
 	if !ok {
 		return nil, errors.Errorf("this manifold can only be used inside a machine")

--- a/internal/worker/machiner/machiner.go
+++ b/internal/worker/machiner/machiner.go
@@ -78,9 +78,9 @@ var NewMachiner = func(cfg Config) (worker.Worker, error) {
 // GetObservedNetworkConfig is patched for testing.
 var GetObservedNetworkConfig = common.GetObservedNetworkConfig
 
-func (mr *Machiner) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
+func (mr *Machiner) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 	// Find which machine we're responsible for.
-	m, err := mr.config.MachineAccessor.Machine(mr.config.Tag)
+	m, err := mr.config.MachineAccessor.Machine(ctx, mr.config.Tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, jworker.ErrTerminateAgent
 	} else if err != nil {
@@ -177,8 +177,8 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 	return m.SetMachineAddresses(machineAddresses)
 }
 
-func (mr *Machiner) Handle(_ context.Context) error {
-	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
+func (mr *Machiner) Handle(ctx context.Context) error {
+	if err := mr.machine.Refresh(ctx); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
 		// so we could call NotifyMachineDead here in case the agent failed to
 		// call NotifyMachineDead directly after setting the machine Dead in

--- a/internal/worker/machiner/mock_test.go
+++ b/internal/worker/machiner/mock_test.go
@@ -4,6 +4,8 @@
 package machiner_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
 
@@ -36,7 +38,7 @@ type mockMachine struct {
 	life    life.Value
 }
 
-func (m *mockMachine) Refresh() error {
+func (m *mockMachine) Refresh(context.Context) error {
 	m.MethodCall(m, "Refresh")
 	return m.NextErr()
 }
@@ -79,7 +81,7 @@ type mockMachineAccessor struct {
 	machine mockMachine
 }
 
-func (a *mockMachineAccessor) Machine(tag names.MachineTag) (machiner.Machine, error) {
+func (a *mockMachineAccessor) Machine(_ context.Context, tag names.MachineTag) (machiner.Machine, error) {
 	a.MethodCall(a, "Machine", tag)
 	if err := a.NextErr(); err != nil {
 		return nil, err

--- a/internal/worker/machiner/state.go
+++ b/internal/worker/machiner/state.go
@@ -4,6 +4,8 @@
 package machiner
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -16,11 +18,11 @@ import (
 )
 
 type MachineAccessor interface {
-	Machine(names.MachineTag) (Machine, error)
+	Machine(context.Context, names.MachineTag) (Machine, error)
 }
 
 type Machine interface {
-	Refresh() error
+	Refresh(context.Context) error
 	Life() life.Value
 	EnsureDead() error
 	SetMachineAddresses(addresses []network.MachineAddress) error
@@ -33,8 +35,8 @@ type APIMachineAccessor struct {
 	State *machiner.Client
 }
 
-func (a APIMachineAccessor) Machine(tag names.MachineTag) (Machine, error) {
-	m, err := a.State.Machine(tag)
+func (a APIMachineAccessor) Machine(ctx context.Context, tag names.MachineTag) (Machine, error) {
+	m, err := a.State.Machine(ctx, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/machineundertaker/package_test.go
+++ b/internal/worker/machineundertaker/package_test.go
@@ -4,6 +4,7 @@
 package machineundertaker_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	gc "gopkg.in/check.v1"
@@ -15,6 +16,6 @@ func TestPackage(t *stdtesting.T) {
 
 type fakeCredentialAPI struct{}
 
-func (*fakeCredentialAPI) InvalidateModelCredential(reason string) error {
+func (*fakeCredentialAPI) InvalidateModelCredential(_ context.Context, reason string) error {
 	return nil
 }

--- a/internal/worker/meterstatus/connected.go
+++ b/internal/worker/meterstatus/connected.go
@@ -101,7 +101,7 @@ func (w *connectedStatusHandler) Handle(ctx context.Context) error {
 		w.config.Logger.Tracef("meter status (%q, %q) matches stored information (%q, %q), skipping", currentCode, currentInfo, w.st.Code, w.st.Info)
 		return nil
 	}
-	w.applyStatus(currentCode, currentInfo, ctx.Done())
+	w.applyStatus(ctx, currentCode, currentInfo, ctx.Done())
 	w.st.Code, w.st.Info = currentCode, currentInfo
 	if err = w.config.StateReadWriter.Write(w.st); err != nil {
 		return errors.Annotate(err, "failed to record meter status worker state")
@@ -109,7 +109,7 @@ func (w *connectedStatusHandler) Handle(ctx context.Context) error {
 	return nil
 }
 
-func (w *connectedStatusHandler) applyStatus(code, info string, abort <-chan struct{}) {
+func (w *connectedStatusHandler) applyStatus(ctx context.Context, code, info string, abort <-chan struct{}) {
 	w.config.Logger.Tracef("applying meter status change: %q (%q)", code, info)
-	w.config.Runner.RunHook(code, info, abort)
+	w.config.Runner.RunHook(ctx, code, info, abort)
 }

--- a/internal/worker/meterstatus/context.go
+++ b/internal/worker/meterstatus/context.go
@@ -4,6 +4,7 @@
 package meterstatus
 
 import (
+	stdcontext "context"
 	"fmt"
 	"math/rand"
 	"path"
@@ -101,7 +102,7 @@ func (ctx *limitedContext) ActionData() (*context.ActionData, error) {
 }
 
 // Flush implements runner.Context.
-func (ctx *limitedContext) Flush(_ string, err error) error {
+func (ctx *limitedContext) Flush(_ stdcontext.Context, _ string, err error) error {
 	return err
 }
 
@@ -115,6 +116,6 @@ func (ctx *limitedContext) ResetExecutionSetUnitStatus() {}
 func (ctx *limitedContext) Id() string { return ctx.id }
 
 // Prepare implements runner.Context.
-func (ctx *limitedContext) Prepare() error {
+func (ctx *limitedContext) Prepare(stdcontext.Context) error {
 	return jujuc.ErrRestrictedContext
 }

--- a/internal/worker/meterstatus/isolated.go
+++ b/internal/worker/meterstatus/isolated.go
@@ -4,6 +4,7 @@
 package meterstatus
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -118,7 +119,7 @@ func (w *isolatedStatusWorker) loop() error {
 			currentCode := "RED"
 			currentInfo := "unit agent has been disconnected"
 
-			w.applyStatus(currentCode, currentInfo)
+			w.applyStatus(context.TODO(), currentCode, currentInfo)
 			st.Code, st.Info = currentCode, currentInfo
 			st.Disconnected.State = Done
 		case <-amberSignal:
@@ -126,7 +127,7 @@ func (w *isolatedStatusWorker) loop() error {
 			currentCode := "AMBER"
 			currentInfo := "unit agent has been disconnected"
 
-			w.applyStatus(currentCode, currentInfo)
+			w.applyStatus(context.TODO(), currentCode, currentInfo)
 			st.Code, st.Info = currentCode, currentInfo
 			st.Disconnected.State = WaitingRed
 		}
@@ -136,9 +137,9 @@ func (w *isolatedStatusWorker) loop() error {
 	}
 }
 
-func (w *isolatedStatusWorker) applyStatus(code, info string) {
+func (w *isolatedStatusWorker) applyStatus(ctx context.Context, code, info string) {
 	w.config.Logger.Tracef("applying meter status change: %q (%q)", code, info)
-	w.config.Runner.RunHook(code, info, w.tomb.Dying())
+	w.config.Runner.RunHook(ctx, code, info, w.tomb.Dying())
 }
 
 // Kill is part of the worker.Worker interface.

--- a/internal/worker/meterstatus/manifold_test.go
+++ b/internal/worker/meterstatus/manifold_test.go
@@ -256,7 +256,7 @@ type stubRunner struct {
 	ran  chan struct{}
 }
 
-func (r *stubRunner) RunHook(code, info string, abort <-chan struct{}) {
+func (r *stubRunner) RunHook(_ context.Context, code, info string, abort <-chan struct{}) {
 	r.stub.MethodCall(r, "RunHook", code, info)
 	if r.ran != nil {
 		select {

--- a/internal/worker/meterstatus/runner.go
+++ b/internal/worker/meterstatus/runner.go
@@ -4,6 +4,8 @@
 package meterstatus
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -17,7 +19,7 @@ import (
 
 // HookRunner implements the functionality necessary to run a meter-status-changed hook.
 type HookRunner interface {
-	RunHook(string, string, <-chan struct{})
+	RunHook(context.Context, string, string, <-chan struct{})
 }
 
 // hookRunner implements functionality for running a hook.
@@ -63,7 +65,7 @@ func (w *hookRunner) acquireExecutionLock(action string, interrupt <-chan struct
 	return releaser, nil
 }
 
-func (w *hookRunner) RunHook(code, info string, interrupt <-chan struct{}) {
+func (w *hookRunner) RunHook(stdCtx context.Context, code, info string, interrupt <-chan struct{}) {
 	unitTag := w.tag
 	ctx := newLimitedContext(hookConfig{
 		unitName: unitTag.String(),
@@ -82,7 +84,7 @@ func (w *hookRunner) RunHook(code, info string, interrupt <-chan struct{}) {
 		return
 	}
 	defer releaser()
-	handlerType, err := r.RunHook(string(hooks.MeterStatusChanged))
+	handlerType, err := r.RunHook(stdCtx, string(hooks.MeterStatusChanged))
 	cause := errors.Cause(err)
 	switch {
 	case charmrunner.IsMissingHookError(cause):

--- a/internal/worker/metrics/collect/context.go
+++ b/internal/worker/metrics/collect/context.go
@@ -4,6 +4,7 @@
 package collect
 
 import (
+	stdcontext "context"
 	"fmt"
 	"math/rand"
 	"path"
@@ -79,7 +80,7 @@ func (ctx *hookContext) ModelType() model.ModelType {
 }
 
 // Flush implements runner.Context.
-func (ctx *hookContext) Flush(process string, ctxErr error) (err error) {
+func (ctx *hookContext) Flush(_ stdcontext.Context, process string, ctxErr error) (err error) {
 	return ctx.config.recorder.Close()
 }
 
@@ -125,6 +126,6 @@ func (ctx *hookContext) ResetExecutionSetUnitStatus() {}
 func (ctx *hookContext) Id() string { return ctx.id }
 
 // Prepare implements runner.Context.
-func (ctx *hookContext) Prepare() error {
+func (ctx *hookContext) Prepare(stdcontext.Context) error {
 	return jujuc.ErrRestrictedContext
 }

--- a/internal/worker/metrics/collect/context_test.go
+++ b/internal/worker/metrics/collect/context_test.go
@@ -4,6 +4,7 @@
 package collect_test
 
 import (
+	stdcontext "context"
 	"time"
 
 	jujucharm "github.com/juju/charm/v12"
@@ -39,7 +40,7 @@ func (s *ContextSuite) TestCtxDeclaredMetric(c *gc.C) {
 	ctx := collect.NewHookContext("u/0", s.recorder)
 	err := ctx.AddMetric("pings", "1", time.Now())
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.Flush("", nil)
+	err = ctx.Flush(stdcontext.Background(), "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.recorder.closed, jc.IsTrue)
 	c.Assert(s.recorder.batches, gc.HasLen, 1)

--- a/internal/worker/metrics/collect/manifold.go
+++ b/internal/worker/metrics/collect/manifold.go
@@ -260,7 +260,7 @@ func (w *collect) Do(stop <-chan struct{}) (err error) {
 	}
 
 	err = w.charmdir.Visit(func() error {
-		return w.runner.do(recorder)
+		return w.runner.do(stdcontext.TODO(), recorder)
 	}, stop)
 	if err == fortress.ErrAborted {
 		w.logger.Tracef("cannot execute collect-metrics: %v", err)
@@ -283,7 +283,7 @@ type hookRunner struct {
 	logger Logger
 }
 
-func (h *hookRunner) do(recorder spool.MetricRecorder) error {
+func (h *hookRunner) do(stdCtx stdcontext.Context, recorder spool.MetricRecorder) error {
 	h.m.Lock()
 	defer h.m.Unlock()
 	h.logger.Debugf("recording metrics")
@@ -300,7 +300,7 @@ func (h *hookRunner) do(recorder spool.MetricRecorder) error {
 	}
 
 	r := runner.NewRunner(ctx, h.paths, nil)
-	handlerType, err := r.RunHook(string(hooks.CollectMetrics))
+	handlerType, err := r.RunHook(stdCtx, string(hooks.CollectMetrics))
 	switch {
 	case charmrunner.IsMissingHookError(errors.Cause(err)):
 		fallthrough

--- a/internal/worker/migrationminion/manifold.go
+++ b/internal/worker/migrationminion/manifold.go
@@ -32,7 +32,7 @@ type ManifoldConfig struct {
 	FortressName      string
 	Clock             clock.Clock
 	APIOpen           func(*api.Info, api.DialOpts) (api.Connection, error)
-	ValidateMigration func(base.APICaller) error
+	ValidateMigration func(context.Context, base.APICaller) error
 
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)

--- a/internal/worker/migrationminion/manifold_test.go
+++ b/internal/worker/migrationminion/manifold_test.go
@@ -4,6 +4,8 @@
 package migrationminion_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -36,7 +38,7 @@ func (s *ManifoldSuite) validConfig() migrationminion.ManifoldConfig {
 		FortressName:      "fortress",
 		Clock:             struct{ clock.Clock }{},
 		APIOpen:           func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
-		ValidateMigration: func(base.APICaller) error { return nil },
+		ValidateMigration: func(context.Context, base.APICaller) error { return nil },
 		NewFacade:         func(base.APICaller) (migrationminion.Facade, error) { return nil, nil },
 		NewWorker:         func(migrationminion.Config) (worker.Worker, error) { return nil, nil },
 		Logger:            loggo.GetLogger("test"),

--- a/internal/worker/migrationminion/validate_test.go
+++ b/internal/worker/migrationminion/validate_test.go
@@ -4,6 +4,8 @@
 package migrationminion_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -78,7 +80,7 @@ func validConfig() migrationminion.Config {
 		Facade:            struct{ migrationminion.Facade }{},
 		Clock:             struct{ clock.Clock }{},
 		APIOpen:           func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
-		ValidateMigration: func(base.APICaller) error { return nil },
+		ValidateMigration: func(context.Context, base.APICaller) error { return nil },
 		Logger:            loggo.GetLogger("test"),
 	}
 }

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -4,6 +4,7 @@
 package migrationminion_test
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"time"
@@ -63,7 +64,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 		Agent:   s.agent,
 		Clock:   s.clock,
 		APIOpen: s.apiOpen,
-		ValidateMigration: func(base.APICaller) error {
+		ValidateMigration: func(context.Context, base.APICaller) error {
 			s.stub.AddCall("ValidateMigration")
 			return nil
 		},
@@ -279,7 +280,7 @@ func (s *Suite) TestVALIDATIONFail(c *gc.C) {
 		MigrationId: "id",
 		Phase:       migration.VALIDATION,
 	}
-	s.config.ValidateMigration = func(base.APICaller) error {
+	s.config.ValidateMigration = func(context.Context, base.APICaller) error {
 		s.stub.AddCall("ValidateMigration")
 		return errors.New("boom")
 	}
@@ -311,7 +312,7 @@ func (s *Suite) TestVALIDATIONRetrySucceed(c *gc.C) {
 	}
 	var stub jujutesting.Stub
 	stub.SetErrors(errors.New("nope"), errors.New("not yet"), nil)
-	s.config.ValidateMigration = func(base.APICaller) error {
+	s.config.ValidateMigration = func(context.Context, base.APICaller) error {
 		stub.AddCall("ValidateMigration")
 		return stub.NextErr()
 	}

--- a/internal/worker/provisioner/container_initialisation_test.go
+++ b/internal/worker/provisioner/container_initialisation_test.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -168,7 +169,7 @@ func (s *containerSetupSuite) expectContainerManagerConfig(cType instance.Contai
 
 type credentialAPIForTest struct{}
 
-func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+func (*credentialAPIForTest) InvalidateModelCredential(_ context.Context, reason string) error {
 	return nil
 }
 

--- a/internal/worker/provisioner/containermanifold_test.go
+++ b/internal/worker/provisioner/containermanifold_test.go
@@ -99,7 +99,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifold(c *gc.C) {
 	retval := []provisioner.ContainerMachineResult{
 		{Machine: s.machine},
 	}
-	s.getter.EXPECT().Machines([]names.MachineTag{tag}).Return(retval, nil)
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
 	s.machine.EXPECT().SupportedContainers().Return([]instance.ContainerType{instance.LXD}, true, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
@@ -118,7 +118,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldContainersNotK
 	retval := []provisioner.ContainerMachineResult{
 		{Machine: s.machine},
 	}
-	s.getter.EXPECT().Machines([]names.MachineTag{tag}).Return(retval, nil)
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
 	s.machine.EXPECT().SupportedContainers().Return(nil, false, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
@@ -136,7 +136,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldNoContainerSup
 	retval := []provisioner.ContainerMachineResult{
 		{Machine: s.machine},
 	}
-	s.getter.EXPECT().Machines([]names.MachineTag{tag}).Return(retval, nil)
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
 	s.machine.EXPECT().SupportedContainers().Return(nil, true, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
@@ -154,7 +154,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldMachineDead(c 
 	retval := []provisioner.ContainerMachineResult{
 		{Machine: s.machine},
 	}
-	s.getter.EXPECT().Machines([]names.MachineTag{tag}).Return(retval, nil)
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
 	s.machine.EXPECT().Life().Return(life.Dead)
 	cfg := provisioner.ContainerManifoldConfig{
 		Logger:        &noOpLogger{},

--- a/internal/worker/provisioner/containerprovisioner_test.go
+++ b/internal/worker/provisioner/containerprovisioner_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -56,7 +57,7 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C, ctrl *gomock.Controller
 
 	s.containersCh = make(chan []string)
 	m0 := &testMachine{containersCh: s.containersCh}
-	s.machinesAPI.EXPECT().Machines(mTag).Return([]apiprovisioner.MachineResult{{
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), mTag).Return([]apiprovisioner.MachineResult{{
 		Machine: m0,
 	}}, nil)
 
@@ -110,7 +111,7 @@ func (s *kvmProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 
 	c666 := &testMachine{id: "0/kvm/666"}
 	s.broker.EXPECT().AllRunningInstances(gomock.Any()).Return([]instances.Instance{&testInstance{id: "inst-666"}}, nil).Times(2)
-	s.machinesAPI.EXPECT().Machines(cTag).Return([]apiprovisioner.MachineResult{{
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), cTag).Return([]apiprovisioner.MachineResult{{
 		Machine: c666,
 	}}, nil).Times(2)
 	s.machinesAPI.EXPECT().ProvisioningInfo([]names.MachineTag{cTag}).Return(params.ProvisioningInfoResults{
@@ -164,6 +165,6 @@ func (s *kvmProvisionerSuite) TestKVMProvisionerObservesConfigChangesWorkerCount
 
 type credentialAPIForTest struct{}
 
-func (*credentialAPIForTest) InvalidateModelCredential(reason string) error {
+func (*credentialAPIForTest) InvalidateModelCredential(_ context.Context, reason string) error {
 	return nil
 }

--- a/internal/worker/provisioner/export_test.go
+++ b/internal/worker/provisioner/export_test.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	"context"
 	"sort"
 
 	"github.com/juju/names/v5"
@@ -76,5 +77,5 @@ func SetupToStartMachine(
 func MachineSupportsContainers(
 	cfg ContainerManifoldConfig, pr ContainerMachineGetter, mTag names.MachineTag,
 ) (ContainerMachine, error) {
-	return cfg.machineSupportsContainers(pr, mTag)
+	return cfg.machineSupportsContainers(context.Background(), pr, mTag)
 }

--- a/internal/worker/provisioner/mocks/provisioner.go
+++ b/internal/worker/provisioner/mocks/provisioner.go
@@ -134,10 +134,10 @@ func (m *MockContainerMachineGetter) EXPECT() *MockContainerMachineGetterMockRec
 }
 
 // Machines mocks base method.
-func (m *MockContainerMachineGetter) Machines(arg0 ...names.MachineTag) ([]provisioner0.ContainerMachineResult, error) {
+func (m *MockContainerMachineGetter) Machines(arg0 context.Context, arg1 ...names.MachineTag) ([]provisioner0.ContainerMachineResult, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Machines", varargs...)
@@ -147,9 +147,10 @@ func (m *MockContainerMachineGetter) Machines(arg0 ...names.MachineTag) ([]provi
 }
 
 // Machines indicates an expected call of Machines.
-func (mr *MockContainerMachineGetterMockRecorder) Machines(arg0 ...any) *gomock.Call {
+func (mr *MockContainerMachineGetterMockRecorder) Machines(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockContainerMachineGetter)(nil).Machines), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockContainerMachineGetter)(nil).Machines), varargs...)
 }
 
 // MockContainerProvisionerAPI is a mock of ContainerProvisionerAPI interface.
@@ -416,10 +417,10 @@ func (m *MockMachinesAPI) EXPECT() *MockMachinesAPIMockRecorder {
 }
 
 // Machines mocks base method.
-func (m *MockMachinesAPI) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineResult, error) {
+func (m *MockMachinesAPI) Machines(arg0 context.Context, arg1 ...names.MachineTag) ([]provisioner.MachineResult, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Machines", varargs...)
@@ -429,9 +430,10 @@ func (m *MockMachinesAPI) Machines(arg0 ...names.MachineTag) ([]provisioner.Mach
 }
 
 // Machines indicates an expected call of Machines.
-func (mr *MockMachinesAPIMockRecorder) Machines(arg0 ...any) *gomock.Call {
+func (mr *MockMachinesAPIMockRecorder) Machines(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockMachinesAPI)(nil).Machines), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockMachinesAPI)(nil).Machines), varargs...)
 }
 
 // MachinesWithTransientErrors mocks base method.

--- a/internal/worker/provisioner/provisioner_task.go
+++ b/internal/worker/provisioner/provisioner_task.go
@@ -63,7 +63,7 @@ type ProvisionerTask interface {
 
 // MachinesAPI describes API methods required to access machine provisioning info.
 type MachinesAPI interface {
-	Machines(...names.MachineTag) ([]apiprovisioner.MachineResult, error)
+	Machines(stdcontext.Context, ...names.MachineTag) ([]apiprovisioner.MachineResult, error)
 	MachinesWithTransientErrors() ([]apiprovisioner.MachineStatusResult, error)
 	WatchMachineErrorRetry() (watcher.NotifyWatcher, error)
 	WatchModelMachines() (watcher.StringsWatcher, error)
@@ -420,7 +420,7 @@ func (task *provisionerTask) populateMachineMaps(ctx envcontext.ProviderCallCont
 	for i, id := range ids {
 		machineTags[i] = names.NewMachineTag(id)
 	}
-	machines, err := task.machinesAPI.Machines(machineTags...)
+	machines, err := task.machinesAPI.Machines(ctx, machineTags...)
 	if err != nil {
 		return errors.Annotatef(err, "getting machines %v", ids)
 	}

--- a/internal/worker/provisioner/provisioner_task_test.go
+++ b/internal/worker/provisioner/provisioner_task_test.go
@@ -1116,7 +1116,7 @@ func (s *ProvisionerTaskSuite) TestMachineErrorsRetainInstances(c *gc.C) {
 	instUnknown := &testInstance{id: "unknown"}
 
 	s.instances = []instances.Instance{inst0, instUnknown}
-	s.machinesAPI.EXPECT().Machines(names.NewMachineTag("0")).Return([]apiprovisioner.MachineResult{{
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), names.NewMachineTag("0")).Return([]apiprovisioner.MachineResult{{
 		Err: &params.Error{Code: "some error"},
 	}}, nil).MinTimes(1)
 
@@ -1275,9 +1275,9 @@ func (s *ProvisionerTaskSuite) TestProvisioningDoesNotProvisionTheSameMachineAft
 	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).MinTimes(1)
 
 	done := make(chan bool)
-	s.machinesAPI.EXPECT().Machines(names.NewMachineTag("0")).Return([]apiprovisioner.MachineResult{{
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), names.NewMachineTag("0")).Return([]apiprovisioner.MachineResult{{
 		Machine: m0,
-	}}, nil).Do(func(_ ...names.MachineTag) {
+	}}, nil).Do(func(_ context.Context, _ ...names.MachineTag) {
 		go func() { done <- true }()
 	})
 
@@ -1508,7 +1508,7 @@ func (s *ProvisionerTaskSuite) expectMachines(machines ...*testMachine) {
 		return apiprovisioner.MachineResult{Machine: m}
 	})
 
-	s.machinesAPI.EXPECT().Machines(tags).Return(mResults, nil).MinTimes(1)
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), tags).Return(mResults, nil).MinTimes(1)
 }
 
 func (s *ProvisionerTaskSuite) expectProvisioningInfo(machines ...*testMachine) {

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -290,7 +290,7 @@ func (s *ProvisionerSuite) TestMachineStartedAndStopped(c *gc.C) {
 	m666 := &testMachine{id: "666"}
 
 	s.broker.EXPECT().AllRunningInstances(gomock.Any()).Return([]instances.Instance{&testInstance{id: "inst-666"}}, nil).Times(2)
-	s.machinesAPI.EXPECT().Machines(mTag).Return([]apiprovisioner.MachineResult{{
+	s.machinesAPI.EXPECT().Machines(gomock.Any(), mTag).Return([]apiprovisioner.MachineResult{{
 		Machine: m666,
 	}}, nil).Times(2)
 	s.machinesAPI.EXPECT().ProvisioningInfo([]names.MachineTag{mTag}).Return(params.ProvisioningInfoResults{

--- a/internal/worker/retrystrategy/manifold.go
+++ b/internal/worker/retrystrategy/manifold.go
@@ -5,6 +5,8 @@
 package retrystrategy
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
@@ -47,7 +49,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return manifold
 }
 
-func (mc ManifoldConfig) start(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (mc ManifoldConfig) start(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	agentTag := a.CurrentConfig().Tag()
 	retryStrategyFacade := mc.NewFacade(apiCaller)
 	initialRetryStrategy, err := retryStrategyFacade.RetryStrategy(agentTag)

--- a/internal/worker/stateconverter/converter.go
+++ b/internal/worker/stateconverter/converter.go
@@ -49,8 +49,8 @@ type wrapper struct {
 
 // Machine implements machiner.Machine and returns a machine from the wrapper
 // api/machiner.
-func (w wrapper) Machine(tag names.MachineTag) (Machine, error) {
-	m, err := w.m.Machine(tag)
+func (w wrapper) Machine(ctx context.Context, tag names.MachineTag) (Machine, error) {
+	m, err := w.m.Machine(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -59,9 +59,9 @@ func (w wrapper) Machine(tag names.MachineTag) (Machine, error) {
 
 // SetUp implements NotifyWatchHandler's SetUp method. It returns a watcher that
 // checks for changes to the current machine.
-func (c *converter) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
+func (c *converter) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 	c.logger.Tracef("Calling SetUp for %s", c.machineTag)
-	m, err := c.machiner.Machine(c.machineTag)
+	m, err := c.machiner.Machine(ctx, c.machineTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/stateconverter/converter_test.go
+++ b/internal/worker/stateconverter/converter_test.go
@@ -27,7 +27,7 @@ type converterSuite struct {
 
 func (s *converterSuite) TestSetUp(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(s.machine, nil)
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	s.machine.EXPECT().Watch().Return(nil, nil)
 
 	conv := s.newConverter()
@@ -38,7 +38,7 @@ func (s *converterSuite) TestSetUp(c *gc.C) {
 func (s *converterSuite) TestSetupMachinerErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	expectedError := errors.NotValidf("machine tag")
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(nil, expectedError)
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(nil, expectedError)
 
 	conv := s.newConverter()
 	w, err := conv.SetUp(context.Background())
@@ -48,7 +48,7 @@ func (s *converterSuite) TestSetupMachinerErr(c *gc.C) {
 
 func (s *converterSuite) TestSetupWatchErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(s.machine, nil)
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	expectedError := errors.NotValidf("machine tag")
 	s.machine.EXPECT().Watch().Return(nil, expectedError)
 
@@ -60,7 +60,7 @@ func (s *converterSuite) TestSetupWatchErr(c *gc.C) {
 
 func (s *converterSuite) TestHandle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(s.machine, nil)
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	s.machine.EXPECT().Watch().Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
@@ -76,7 +76,7 @@ func (s *converterSuite) TestHandle(c *gc.C) {
 
 func (s *converterSuite) TestHandleNotController(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(s.machine, nil)
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	s.machine.EXPECT().Watch().Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
@@ -90,7 +90,7 @@ func (s *converterSuite) TestHandleNotController(c *gc.C) {
 
 func (s *converterSuite) TestHandleJobsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.machiner.EXPECT().Machine(gomock.Any()).Return(s.machine, nil).AnyTimes()
+	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil).AnyTimes()
 	s.machine.EXPECT().Watch().Return(nil, nil).AnyTimes()
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)

--- a/internal/worker/stateconverter/interfaces.go
+++ b/internal/worker/stateconverter/interfaces.go
@@ -4,6 +4,8 @@
 package stateconverter
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/watcher"
@@ -20,7 +22,7 @@ type Logger interface {
 // Machiner represents necessary methods for this worker from the
 // machiner api.
 type Machiner interface {
-	Machine(tag names.MachineTag) (Machine, error)
+	Machine(ctx context.Context, tag names.MachineTag) (Machine, error)
 }
 
 // Machine represents necessary methods for this worker from the

--- a/internal/worker/stateconverter/manifold_test.go
+++ b/internal/worker/stateconverter/manifold_test.go
@@ -78,7 +78,7 @@ func (s *manifoldConfigSuite) TestManifoldStart(c *gc.C) {
 		s.getter.EXPECT().Get(cfg.AgentName, gomock.Any()).SetArg(1, s.agent).Return(nil),
 		s.agent.EXPECT().CurrentConfig().Return(s.config),
 		s.config.EXPECT().Tag().Return(names.NewMachineTag("3")),
-		s.machiner.EXPECT().Machine(names.NewMachineTag("3")).DoAndReturn(func(_ names.MachineTag) (stateconverter.Machine, error) {
+		s.machiner.EXPECT().Machine(gomock.Any(), names.NewMachineTag("3")).DoAndReturn(func(_ context.Context, _ names.MachineTag) (stateconverter.Machine, error) {
 			close(done)
 			return nil, errors.New("nope")
 		}),

--- a/internal/worker/stateconverter/mocks/machiner_mock.go
+++ b/internal/worker/stateconverter/mocks/machiner_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -43,18 +44,18 @@ func (m *MockMachiner) EXPECT() *MockMachinerMockRecorder {
 }
 
 // Machine mocks base method.
-func (m *MockMachiner) Machine(arg0 names.MachineTag) (stateconverter.Machine, error) {
+func (m *MockMachiner) Machine(arg0 context.Context, arg1 names.MachineTag) (stateconverter.Machine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Machine", arg0)
+	ret := m.ctrl.Call(m, "Machine", arg0, arg1)
 	ret0, _ := ret[0].(stateconverter.Machine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Machine indicates an expected call of Machine.
-func (mr *MockMachinerMockRecorder) Machine(arg0 any) *gomock.Call {
+func (mr *MockMachinerMockRecorder) Machine(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockMachiner)(nil).Machine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockMachiner)(nil).Machine), arg0, arg1)
 }
 
 // MockMachine is a mock of Machine interface.

--- a/internal/worker/storageprovisioner/manifold_machine.go
+++ b/internal/worker/storageprovisioner/manifold_machine.go
@@ -4,6 +4,7 @@
 package storageprovisioner
 
 import (
+	stdcontext "context"
 	"path/filepath"
 
 	"github.com/juju/clock"
@@ -29,7 +30,7 @@ type MachineManifoldConfig struct {
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
 }
 
-func (config MachineManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (config MachineManifoldConfig) newWorker(_ stdcontext.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	if config.Clock == nil {
 		return nil, errors.NotValidf("missing Clock")
 	}

--- a/internal/worker/toolsversionchecker/manifold.go
+++ b/internal/worker/toolsversionchecker/manifold.go
@@ -4,6 +4,7 @@
 package toolsversionchecker
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -28,13 +29,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return engine.AgentAPIManifold(typedConfig, newWorker)
 }
 
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func newWorker(ctx context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	tag := a.CurrentConfig().Tag()
 	if tag.Kind() != names.MachineTagKind {
 		return nil, errors.New("this manifold may only be used inside a machine agent")
 	}
 
-	isController, err := apiagent.IsController(apiCaller, tag)
+	isController, err := apiagent.IsController(ctx, apiCaller, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/undertaker/credentialapi_mock_test.go
+++ b/internal/worker/undertaker/credentialapi_mock_test.go
@@ -10,6 +10,7 @@
 package undertaker_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -39,15 +40,15 @@ func (m *MockCredentialAPI) EXPECT() *MockCredentialAPIMockRecorder {
 }
 
 // InvalidateModelCredential mocks base method.
-func (m *MockCredentialAPI) InvalidateModelCredential(arg0 string) error {
+func (m *MockCredentialAPI) InvalidateModelCredential(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0)
+	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InvalidateModelCredential indicates an expected call of InvalidateModelCredential.
-func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0 any) *gomock.Call {
+func (mr *MockCredentialAPIMockRecorder) InvalidateModelCredential(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockCredentialAPI)(nil).InvalidateModelCredential), arg0, arg1)
 }

--- a/internal/worker/undertaker/manifold_test.go
+++ b/internal/worker/undertaker/manifold_test.go
@@ -188,7 +188,7 @@ type fakeWorker struct {
 
 type fakeCredentialAPI struct{}
 
-func (*fakeCredentialAPI) InvalidateModelCredential(reason string) error {
+func (*fakeCredentialAPI) InvalidateModelCredential(_ context.Context, reason string) error {
 	return nil
 }
 

--- a/internal/worker/uniter/actions/resolver.go
+++ b/internal/worker/uniter/actions/resolver.go
@@ -96,7 +96,7 @@ func (r *actionsResolver) NextOp(
 	case operation.RunHook:
 		// We can still run actions if the unit is in a hook error state.
 		if localState.Step == operation.Pending && err == nil {
-			return opFactory.NewAction(nextAction)
+			return opFactory.NewAction(ctx, nextAction)
 		}
 	case operation.RunAction:
 		if localState.Hook != nil {
@@ -124,10 +124,10 @@ func (r *actionsResolver) NextOp(
 		// (re)preparing the running operation should move the
 		// uniter's state along safely. Thus, we return the
 		// running action.
-		return opFactory.NewAction(*localState.ActionId)
+		return opFactory.NewAction(ctx, *localState.ActionId)
 	case operation.Continue:
 		if err != resolver.ErrNoOperation {
-			return opFactory.NewAction(nextAction)
+			return opFactory.NewAction(ctx, nextAction)
 		}
 	}
 	return nil, resolver.ErrNoOperation

--- a/internal/worker/uniter/actions/resolver_test.go
+++ b/internal/worker/uniter/actions/resolver_test.go
@@ -260,7 +260,7 @@ type mockOperations struct {
 	err error
 }
 
-func (m *mockOperations) NewAction(id string) (operation.Operation, error) {
+func (m *mockOperations) NewAction(_ context.Context, id string) (operation.Operation, error) {
 	if m.err != nil {
 		return nil, errors.Annotate(m.err, "action error")
 	}

--- a/internal/worker/uniter/api/domain_mocks.go
+++ b/internal/worker/uniter/api/domain_mocks.go
@@ -10,6 +10,7 @@
 package api
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charm "github.com/juju/charm/v12"
@@ -48,18 +49,18 @@ func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 }
 
 // Application mocks base method.
-func (m *MockUnit) Application() (Application, error) {
+func (m *MockUnit) Application(arg0 context.Context) (Application, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application")
+	ret := m.ctrl.Call(m, "Application", arg0)
 	ret0, _ := ret[0].(Application)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application.
-func (mr *MockUnitMockRecorder) Application() *gomock.Call {
+func (mr *MockUnitMockRecorder) Application(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUnit)(nil).Application))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUnit)(nil).Application), arg0)
 }
 
 // ApplicationName mocks base method.
@@ -399,17 +400,17 @@ func (mr *MockUnitMockRecorder) PublicAddress() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockUnit) Refresh() error {
+func (m *MockUnit) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockUnitMockRecorder) Refresh() *gomock.Call {
+func (mr *MockUnitMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUnit)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUnit)(nil).Refresh), arg0)
 }
 
 // RelationsStatus mocks base method.
@@ -498,17 +499,17 @@ func (mr *MockUnitMockRecorder) SetState(arg0 any) *gomock.Call {
 }
 
 // SetUnitStatus mocks base method.
-func (m *MockUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockUnit) SetUnitStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitStatus indicates an expected call of SetUnitStatus.
-func (mr *MockUnitMockRecorder) SetUnitStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockUnitMockRecorder) SetUnitStatus(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockUnit)(nil).SetUnitStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockUnit)(nil).SetUnitStatus), arg0, arg1, arg2, arg3)
 }
 
 // SetUpgradeSeriesStatus mocks base method.
@@ -555,18 +556,18 @@ func (mr *MockUnitMockRecorder) Tag() *gomock.Call {
 }
 
 // UnitStatus mocks base method.
-func (m *MockUnit) UnitStatus() (params.StatusResult, error) {
+func (m *MockUnit) UnitStatus(arg0 context.Context) (params.StatusResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitStatus")
+	ret := m.ctrl.Call(m, "UnitStatus", arg0)
 	ret0, _ := ret[0].(params.StatusResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitStatus indicates an expected call of UnitStatus.
-func (mr *MockUnitMockRecorder) UnitStatus() *gomock.Call {
+func (mr *MockUnitMockRecorder) UnitStatus(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockUnit)(nil).UnitStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockUnit)(nil).UnitStatus), arg0)
 }
 
 // UpgradeSeriesStatus mocks base method.
@@ -744,18 +745,18 @@ func (m *MockRelation) EXPECT() *MockRelationMockRecorder {
 }
 
 // Endpoint mocks base method.
-func (m *MockRelation) Endpoint() (*uniter.Endpoint, error) {
+func (m *MockRelation) Endpoint(arg0 context.Context) (*uniter.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Endpoint")
+	ret := m.ctrl.Call(m, "Endpoint", arg0)
 	ret0, _ := ret[0].(*uniter.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Endpoint indicates an expected call of Endpoint.
-func (mr *MockRelationMockRecorder) Endpoint() *gomock.Call {
+func (mr *MockRelationMockRecorder) Endpoint(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoint", reflect.TypeOf((*MockRelation)(nil).Endpoint))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoint", reflect.TypeOf((*MockRelation)(nil).Endpoint), arg0)
 }
 
 // Id mocks base method.
@@ -801,31 +802,31 @@ func (mr *MockRelationMockRecorder) OtherApplication() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockRelation) Refresh() error {
+func (m *MockRelation) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockRelationMockRecorder) Refresh() *gomock.Call {
+func (mr *MockRelationMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockRelation)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockRelation)(nil).Refresh), arg0)
 }
 
 // SetStatus mocks base method.
-func (m *MockRelation) SetStatus(arg0 relation.Status) error {
+func (m *MockRelation) SetStatus(arg0 context.Context, arg1 relation.Status) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockRelationMockRecorder) SetStatus(arg0 any) *gomock.Call {
+func (mr *MockRelationMockRecorder) SetStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockRelation)(nil).SetStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockRelation)(nil).SetStatus), arg0, arg1)
 }
 
 // String mocks base method.
@@ -871,18 +872,18 @@ func (mr *MockRelationMockRecorder) Tag() *gomock.Call {
 }
 
 // Unit mocks base method.
-func (m *MockRelation) Unit(arg0 names.UnitTag) (RelationUnit, error) {
+func (m *MockRelation) Unit(arg0 context.Context, arg1 names.UnitTag) (RelationUnit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
+	ret := m.ctrl.Call(m, "Unit", arg0, arg1)
 	ret0, _ := ret[0].(RelationUnit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockRelationMockRecorder) Unit(arg0 any) *gomock.Call {
+func (mr *MockRelationMockRecorder) Unit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockRelation)(nil).Unit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockRelation)(nil).Unit), arg0, arg1)
 }
 
 // UpdateSuspended mocks base method.
@@ -1090,17 +1091,17 @@ func (mr *MockApplicationMockRecorder) Life() *gomock.Call {
 }
 
 // Refresh mocks base method.
-func (m *MockApplication) Refresh() error {
+func (m *MockApplication) Refresh(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh")
+	ret := m.ctrl.Call(m, "Refresh", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Refresh indicates an expected call of Refresh.
-func (mr *MockApplicationMockRecorder) Refresh() *gomock.Call {
+func (mr *MockApplicationMockRecorder) Refresh(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockApplication)(nil).Refresh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockApplication)(nil).Refresh), arg0)
 }
 
 // SetStatus mocks base method.

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -4,6 +4,8 @@
 package api
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/names/v5"
 
@@ -24,7 +26,7 @@ import (
 // ProviderIDGetter defines the API to get provider ID.
 type ProviderIDGetter interface {
 	ProviderID() string
-	Refresh() error
+	Refresh(ctx stdcontext.Context) error
 	Name() string
 }
 
@@ -32,7 +34,7 @@ type ProviderIDGetter interface {
 type Unit interface {
 	ProviderIDGetter
 	Life() life.Value
-	Refresh() error
+	Refresh(stdcontext.Context) error
 	ApplicationTag() names.ApplicationTag
 	EnsureDead() error
 	ClearResolved() error
@@ -51,12 +53,12 @@ type Unit interface {
 	Name() string
 	NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error)
 	RequestReboot() error
-	SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error
+	SetUnitStatus(ctx stdcontext.Context, unitStatus status.Status, info string, data map[string]interface{}) error
 	SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error
 	State() (params.UnitStateResult, error)
 	SetState(unitState params.SetUnitStateArg) error
 	Tag() names.UnitTag
-	UnitStatus() (params.StatusResult, error)
+	UnitStatus(stdcontext.Context) (params.StatusResult, error)
 	CommitHookChanges(params.CommitHookChangesArgs) error
 	PublicAddress() (string, error)
 	PrincipalName() (string, bool, error)
@@ -80,7 +82,7 @@ type Unit interface {
 
 	// Used by relationer.
 
-	Application() (Application, error)
+	Application(stdcontext.Context) (Application, error)
 	RelationsStatus() ([]uniter.RelationStatus, error)
 	Destroy() error
 
@@ -103,21 +105,21 @@ type Application interface {
 
 	WatchLeadershipSettings() (watcher.NotifyWatcher, error)
 	Watch() (watcher.NotifyWatcher, error)
-	Refresh() error
+	Refresh(stdcontext.Context) error
 }
 
 // Relation defines the methods on uniter.api.Relation.
 type Relation interface {
-	Endpoint() (*uniter.Endpoint, error)
+	Endpoint(stdcontext.Context) (*uniter.Endpoint, error)
 	Id() int
 	Life() life.Value
 	OtherApplication() string
-	Refresh() error
-	SetStatus(status2 relation.Status) error
+	Refresh(stdcontext.Context) error
+	SetStatus(ctx stdcontext.Context, status2 relation.Status) error
 	String() string
 	Suspended() bool
 	Tag() names.RelationTag
-	Unit(names.UnitTag) (RelationUnit, error)
+	Unit(stdcontext.Context, names.UnitTag) (RelationUnit, error)
 	UpdateSuspended(bool)
 }
 

--- a/internal/worker/uniter/api/interface_generics.go
+++ b/internal/worker/uniter/api/interface_generics.go
@@ -22,29 +22,29 @@ import (
 type UniterClient interface {
 	StorageAccessor
 	Charm(curl string) (Charm, error)
-	Unit(tag names.UnitTag) (Unit, error)
-	Action(tag names.ActionTag) (*uniter.Action, error)
-	Application(tag names.ApplicationTag) (Application, error)
-	ActionStatus(tag names.ActionTag) (string, error)
-	Relation(tag names.RelationTag) (Relation, error)
-	RelationById(int) (Relation, error)
-	Model() (*model.Model, error)
+	Unit(ctx context.Context, tag names.UnitTag) (Unit, error)
+	Action(ctx context.Context, tag names.ActionTag) (*uniter.Action, error)
+	Application(ctx context.Context, tag names.ApplicationTag) (Application, error)
+	ActionStatus(ctx context.Context, tag names.ActionTag) (string, error)
+	Relation(ctx context.Context, tag names.RelationTag) (Relation, error)
+	RelationById(context.Context, int) (Relation, error)
+	Model(context.Context) (*model.Model, error)
 	ModelConfig(context.Context) (*config.Config, error)
 	UnitStorageAttachments(unitTag names.UnitTag) ([]params.StorageAttachmentId, error)
 	StorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error)
-	GoalState() (application.GoalState, error)
-	CloudSpec() (*params.CloudSpec, error)
-	ActionBegin(tag names.ActionTag) error
-	ActionFinish(tag names.ActionTag, status string, results map[string]interface{}, message string) error
-	UnitWorkloadVersion(tag names.UnitTag) (string, error)
-	SetUnitWorkloadVersion(tag names.UnitTag, version string) error
-	OpenedMachinePortRangesByEndpoint(machineTag names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error)
-	OpenedPortRangesByEndpoint() (map[names.UnitTag]network.GroupedPortRanges, error)
+	GoalState(context.Context) (application.GoalState, error)
+	CloudSpec(context.Context) (*params.CloudSpec, error)
+	ActionBegin(ctx context.Context, tag names.ActionTag) error
+	ActionFinish(ctx context.Context, tag names.ActionTag, status string, results map[string]interface{}, message string) error
+	UnitWorkloadVersion(ctx context.Context, tag names.UnitTag) (string, error)
+	SetUnitWorkloadVersion(ctx context.Context, tag names.UnitTag, version string) error
+	OpenedMachinePortRangesByEndpoint(ctx context.Context, machineTag names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error)
+	OpenedPortRangesByEndpoint(ctx context.Context) (map[names.UnitTag]network.GroupedPortRanges, error)
 	LeadershipSettings() uniter.LeadershipSettingsAccessor
-	SLALevel() (string, error)
-	CloudAPIVersion() (string, error)
+	SLALevel(context.Context) (string, error)
+	CloudAPIVersion(context.Context) (string, error)
 	APIAddresses() ([]string, error)
-	WatchRelationUnits(names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
+	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)
 	UpdateStatusHookInterval() (time.Duration, error)

--- a/internal/worker/uniter/api/shim.go
+++ b/internal/worker/uniter/api/shim.go
@@ -4,6 +4,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -21,48 +23,48 @@ func (s UniterClientShim) Charm(curl string) (Charm, error) {
 	return s.Client.Charm(curl)
 }
 
-func (s UniterClientShim) Unit(tag names.UnitTag) (Unit, error) {
-	u, err := s.Client.Unit(tag)
+func (s UniterClientShim) Unit(ctx context.Context, tag names.UnitTag) (Unit, error) {
+	u, err := s.Client.Unit(ctx, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return UnitShim{u}, nil
 }
 
-func (s UniterClientShim) Relation(tag names.RelationTag) (Relation, error) {
-	r, err := s.Client.Relation(tag)
+func (s UniterClientShim) Relation(ctx context.Context, tag names.RelationTag) (Relation, error) {
+	r, err := s.Client.Relation(ctx, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return relationShim{r}, nil
 }
 
-func (s UniterClientShim) RelationById(id int) (Relation, error) {
-	r, err := s.Client.RelationById(id)
+func (s UniterClientShim) RelationById(ctx context.Context, id int) (Relation, error) {
+	r, err := s.Client.RelationById(ctx, id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return relationShim{r}, nil
 }
 
-func (s UniterClientShim) Application(tag names.ApplicationTag) (Application, error) {
-	return s.Client.Application(tag)
+func (s UniterClientShim) Application(ctx context.Context, tag names.ApplicationTag) (Application, error) {
+	return s.Client.Application(ctx, tag)
 }
 
 type UnitShim struct {
 	*uniter.Unit
 }
 
-func (s UnitShim) Application() (Application, error) {
-	return s.Unit.Application()
+func (s UnitShim) Application(ctx context.Context) (Application, error) {
+	return s.Unit.Application(ctx)
 }
 
 type relationShim struct {
 	*uniter.Relation
 }
 
-func (s relationShim) Unit(tag names.UnitTag) (RelationUnit, error) {
-	ru, err := s.Relation.Unit(tag)
+func (s relationShim) Unit(ctx context.Context, tag names.UnitTag) (RelationUnit, error) {
+	ru, err := s.Relation.Unit(ctx, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/uniter/api/uniter_mocks.go
+++ b/internal/worker/uniter/api/uniter_mocks.go
@@ -64,76 +64,76 @@ func (mr *MockUniterClientMockRecorder) APIAddresses() *gomock.Call {
 }
 
 // Action mocks base method.
-func (m *MockUniterClient) Action(tag names.ActionTag) (*uniter.Action, error) {
+func (m *MockUniterClient) Action(ctx context.Context, tag names.ActionTag) (*uniter.Action, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Action", tag)
+	ret := m.ctrl.Call(m, "Action", ctx, tag)
 	ret0, _ := ret[0].(*uniter.Action)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Action indicates an expected call of Action.
-func (mr *MockUniterClientMockRecorder) Action(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) Action(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Action", reflect.TypeOf((*MockUniterClient)(nil).Action), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Action", reflect.TypeOf((*MockUniterClient)(nil).Action), ctx, tag)
 }
 
 // ActionBegin mocks base method.
-func (m *MockUniterClient) ActionBegin(tag names.ActionTag) error {
+func (m *MockUniterClient) ActionBegin(ctx context.Context, tag names.ActionTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionBegin", tag)
+	ret := m.ctrl.Call(m, "ActionBegin", ctx, tag)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ActionBegin indicates an expected call of ActionBegin.
-func (mr *MockUniterClientMockRecorder) ActionBegin(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) ActionBegin(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionBegin", reflect.TypeOf((*MockUniterClient)(nil).ActionBegin), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionBegin", reflect.TypeOf((*MockUniterClient)(nil).ActionBegin), ctx, tag)
 }
 
 // ActionFinish mocks base method.
-func (m *MockUniterClient) ActionFinish(tag names.ActionTag, status string, results map[string]any, message string) error {
+func (m *MockUniterClient) ActionFinish(ctx context.Context, tag names.ActionTag, status string, results map[string]any, message string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionFinish", tag, status, results, message)
+	ret := m.ctrl.Call(m, "ActionFinish", ctx, tag, status, results, message)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ActionFinish indicates an expected call of ActionFinish.
-func (mr *MockUniterClientMockRecorder) ActionFinish(tag, status, results, message any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) ActionFinish(ctx, tag, status, results, message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionFinish", reflect.TypeOf((*MockUniterClient)(nil).ActionFinish), tag, status, results, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionFinish", reflect.TypeOf((*MockUniterClient)(nil).ActionFinish), ctx, tag, status, results, message)
 }
 
 // ActionStatus mocks base method.
-func (m *MockUniterClient) ActionStatus(tag names.ActionTag) (string, error) {
+func (m *MockUniterClient) ActionStatus(ctx context.Context, tag names.ActionTag) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionStatus", tag)
+	ret := m.ctrl.Call(m, "ActionStatus", ctx, tag)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ActionStatus indicates an expected call of ActionStatus.
-func (mr *MockUniterClientMockRecorder) ActionStatus(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) ActionStatus(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionStatus", reflect.TypeOf((*MockUniterClient)(nil).ActionStatus), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionStatus", reflect.TypeOf((*MockUniterClient)(nil).ActionStatus), ctx, tag)
 }
 
 // Application mocks base method.
-func (m *MockUniterClient) Application(tag names.ApplicationTag) (Application, error) {
+func (m *MockUniterClient) Application(ctx context.Context, tag names.ApplicationTag) (Application, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", tag)
+	ret := m.ctrl.Call(m, "Application", ctx, tag)
 	ret0, _ := ret[0].(Application)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application.
-func (mr *MockUniterClientMockRecorder) Application(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) Application(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUniterClient)(nil).Application), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUniterClient)(nil).Application), ctx, tag)
 }
 
 // Charm mocks base method.
@@ -152,33 +152,33 @@ func (mr *MockUniterClientMockRecorder) Charm(curl any) *gomock.Call {
 }
 
 // CloudAPIVersion mocks base method.
-func (m *MockUniterClient) CloudAPIVersion() (string, error) {
+func (m *MockUniterClient) CloudAPIVersion(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudAPIVersion")
+	ret := m.ctrl.Call(m, "CloudAPIVersion", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloudAPIVersion indicates an expected call of CloudAPIVersion.
-func (mr *MockUniterClientMockRecorder) CloudAPIVersion() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) CloudAPIVersion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudAPIVersion", reflect.TypeOf((*MockUniterClient)(nil).CloudAPIVersion))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudAPIVersion", reflect.TypeOf((*MockUniterClient)(nil).CloudAPIVersion), arg0)
 }
 
 // CloudSpec mocks base method.
-func (m *MockUniterClient) CloudSpec() (*params.CloudSpec, error) {
+func (m *MockUniterClient) CloudSpec(arg0 context.Context) (*params.CloudSpec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudSpec")
+	ret := m.ctrl.Call(m, "CloudSpec", arg0)
 	ret0, _ := ret[0].(*params.CloudSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloudSpec indicates an expected call of CloudSpec.
-func (mr *MockUniterClientMockRecorder) CloudSpec() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) CloudSpec(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockUniterClient)(nil).CloudSpec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockUniterClient)(nil).CloudSpec), arg0)
 }
 
 // DestroyUnitStorageAttachments mocks base method.
@@ -196,18 +196,18 @@ func (mr *MockUniterClientMockRecorder) DestroyUnitStorageAttachments(arg0 any) 
 }
 
 // GoalState mocks base method.
-func (m *MockUniterClient) GoalState() (application.GoalState, error) {
+func (m *MockUniterClient) GoalState(arg0 context.Context) (application.GoalState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GoalState")
+	ret := m.ctrl.Call(m, "GoalState", arg0)
 	ret0, _ := ret[0].(application.GoalState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GoalState indicates an expected call of GoalState.
-func (mr *MockUniterClientMockRecorder) GoalState() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) GoalState(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockUniterClient)(nil).GoalState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockUniterClient)(nil).GoalState), arg0)
 }
 
 // LeadershipSettings mocks base method.
@@ -225,18 +225,18 @@ func (mr *MockUniterClientMockRecorder) LeadershipSettings() *gomock.Call {
 }
 
 // Model mocks base method.
-func (m *MockUniterClient) Model() (*model.Model, error) {
+func (m *MockUniterClient) Model(arg0 context.Context) (*model.Model, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Model")
+	ret := m.ctrl.Call(m, "Model", arg0)
 	ret0, _ := ret[0].(*model.Model)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Model indicates an expected call of Model.
-func (mr *MockUniterClientMockRecorder) Model() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) Model(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockUniterClient)(nil).Model))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockUniterClient)(nil).Model), arg0)
 }
 
 // ModelConfig mocks base method.
@@ -255,63 +255,63 @@ func (mr *MockUniterClientMockRecorder) ModelConfig(arg0 any) *gomock.Call {
 }
 
 // OpenedMachinePortRangesByEndpoint mocks base method.
-func (m *MockUniterClient) OpenedMachinePortRangesByEndpoint(machineTag names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error) {
+func (m *MockUniterClient) OpenedMachinePortRangesByEndpoint(ctx context.Context, machineTag names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenedMachinePortRangesByEndpoint", machineTag)
+	ret := m.ctrl.Call(m, "OpenedMachinePortRangesByEndpoint", ctx, machineTag)
 	ret0, _ := ret[0].(map[names.UnitTag]network.GroupedPortRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // OpenedMachinePortRangesByEndpoint indicates an expected call of OpenedMachinePortRangesByEndpoint.
-func (mr *MockUniterClientMockRecorder) OpenedMachinePortRangesByEndpoint(machineTag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) OpenedMachinePortRangesByEndpoint(ctx, machineTag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedMachinePortRangesByEndpoint", reflect.TypeOf((*MockUniterClient)(nil).OpenedMachinePortRangesByEndpoint), machineTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedMachinePortRangesByEndpoint", reflect.TypeOf((*MockUniterClient)(nil).OpenedMachinePortRangesByEndpoint), ctx, machineTag)
 }
 
 // OpenedPortRangesByEndpoint mocks base method.
-func (m *MockUniterClient) OpenedPortRangesByEndpoint() (map[names.UnitTag]network.GroupedPortRanges, error) {
+func (m *MockUniterClient) OpenedPortRangesByEndpoint(ctx context.Context) (map[names.UnitTag]network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenedPortRangesByEndpoint")
+	ret := m.ctrl.Call(m, "OpenedPortRangesByEndpoint", ctx)
 	ret0, _ := ret[0].(map[names.UnitTag]network.GroupedPortRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // OpenedPortRangesByEndpoint indicates an expected call of OpenedPortRangesByEndpoint.
-func (mr *MockUniterClientMockRecorder) OpenedPortRangesByEndpoint() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) OpenedPortRangesByEndpoint(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPortRangesByEndpoint", reflect.TypeOf((*MockUniterClient)(nil).OpenedPortRangesByEndpoint))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPortRangesByEndpoint", reflect.TypeOf((*MockUniterClient)(nil).OpenedPortRangesByEndpoint), ctx)
 }
 
 // Relation mocks base method.
-func (m *MockUniterClient) Relation(tag names.RelationTag) (Relation, error) {
+func (m *MockUniterClient) Relation(ctx context.Context, tag names.RelationTag) (Relation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Relation", tag)
+	ret := m.ctrl.Call(m, "Relation", ctx, tag)
 	ret0, _ := ret[0].(Relation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Relation indicates an expected call of Relation.
-func (mr *MockUniterClientMockRecorder) Relation(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) Relation(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockUniterClient)(nil).Relation), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockUniterClient)(nil).Relation), ctx, tag)
 }
 
 // RelationById mocks base method.
-func (m *MockUniterClient) RelationById(arg0 int) (Relation, error) {
+func (m *MockUniterClient) RelationById(arg0 context.Context, arg1 int) (Relation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RelationById", arg0)
+	ret := m.ctrl.Call(m, "RelationById", arg0, arg1)
 	ret0, _ := ret[0].(Relation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RelationById indicates an expected call of RelationById.
-func (mr *MockUniterClientMockRecorder) RelationById(arg0 any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) RelationById(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationById", reflect.TypeOf((*MockUniterClient)(nil).RelationById), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationById", reflect.TypeOf((*MockUniterClient)(nil).RelationById), arg0, arg1)
 }
 
 // RemoveStorageAttachment mocks base method.
@@ -329,32 +329,32 @@ func (mr *MockUniterClientMockRecorder) RemoveStorageAttachment(arg0, arg1 any) 
 }
 
 // SLALevel mocks base method.
-func (m *MockUniterClient) SLALevel() (string, error) {
+func (m *MockUniterClient) SLALevel(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SLALevel")
+	ret := m.ctrl.Call(m, "SLALevel", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SLALevel indicates an expected call of SLALevel.
-func (mr *MockUniterClientMockRecorder) SLALevel() *gomock.Call {
+func (mr *MockUniterClientMockRecorder) SLALevel(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SLALevel", reflect.TypeOf((*MockUniterClient)(nil).SLALevel))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SLALevel", reflect.TypeOf((*MockUniterClient)(nil).SLALevel), arg0)
 }
 
 // SetUnitWorkloadVersion mocks base method.
-func (m *MockUniterClient) SetUnitWorkloadVersion(tag names.UnitTag, version string) error {
+func (m *MockUniterClient) SetUnitWorkloadVersion(ctx context.Context, tag names.UnitTag, version string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", tag, version)
+	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", ctx, tag, version)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitWorkloadVersion indicates an expected call of SetUnitWorkloadVersion.
-func (mr *MockUniterClientMockRecorder) SetUnitWorkloadVersion(tag, version any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) SetUnitWorkloadVersion(ctx, tag, version any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockUniterClient)(nil).SetUnitWorkloadVersion), tag, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockUniterClient)(nil).SetUnitWorkloadVersion), ctx, tag, version)
 }
 
 // StorageAttachment mocks base method.
@@ -388,18 +388,18 @@ func (mr *MockUniterClientMockRecorder) StorageAttachmentLife(arg0 any) *gomock.
 }
 
 // Unit mocks base method.
-func (m *MockUniterClient) Unit(tag names.UnitTag) (Unit, error) {
+func (m *MockUniterClient) Unit(ctx context.Context, tag names.UnitTag) (Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", tag)
+	ret := m.ctrl.Call(m, "Unit", ctx, tag)
 	ret0, _ := ret[0].(Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockUniterClientMockRecorder) Unit(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) Unit(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUniterClient)(nil).Unit), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUniterClient)(nil).Unit), ctx, tag)
 }
 
 // UnitStorageAttachments mocks base method.
@@ -418,18 +418,18 @@ func (mr *MockUniterClientMockRecorder) UnitStorageAttachments(arg0 any) *gomock
 }
 
 // UnitWorkloadVersion mocks base method.
-func (m *MockUniterClient) UnitWorkloadVersion(tag names.UnitTag) (string, error) {
+func (m *MockUniterClient) UnitWorkloadVersion(ctx context.Context, tag names.UnitTag) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitWorkloadVersion", tag)
+	ret := m.ctrl.Call(m, "UnitWorkloadVersion", ctx, tag)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitWorkloadVersion indicates an expected call of UnitWorkloadVersion.
-func (mr *MockUniterClientMockRecorder) UnitWorkloadVersion(tag any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) UnitWorkloadVersion(ctx, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockUniterClient)(nil).UnitWorkloadVersion), tag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockUniterClient)(nil).UnitWorkloadVersion), ctx, tag)
 }
 
 // UpdateStatusHookInterval mocks base method.
@@ -448,18 +448,18 @@ func (mr *MockUniterClientMockRecorder) UpdateStatusHookInterval() *gomock.Call 
 }
 
 // WatchRelationUnits mocks base method.
-func (m *MockUniterClient) WatchRelationUnits(arg0 names.RelationTag, arg1 names.UnitTag) (watcher.RelationUnitsWatcher, error) {
+func (m *MockUniterClient) WatchRelationUnits(arg0 context.Context, arg1 names.RelationTag, arg2 names.UnitTag) (watcher.RelationUnitsWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRelationUnits", arg0, arg1)
+	ret := m.ctrl.Call(m, "WatchRelationUnits", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.RelationUnitsWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchRelationUnits indicates an expected call of WatchRelationUnits.
-func (mr *MockUniterClientMockRecorder) WatchRelationUnits(arg0, arg1 any) *gomock.Call {
+func (mr *MockUniterClientMockRecorder) WatchRelationUnits(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelationUnits", reflect.TypeOf((*MockUniterClient)(nil).WatchRelationUnits), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelationUnits", reflect.TypeOf((*MockUniterClient)(nil).WatchRelationUnits), arg0, arg1, arg2)
 }
 
 // WatchStorageAttachment mocks base method.

--- a/internal/worker/uniter/hook/hook.go
+++ b/internal/worker/uniter/hook/hook.go
@@ -4,6 +4,8 @@
 package hook
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -141,7 +143,7 @@ func (hi Info) Validate() error {
 // Committer is an interface that may be used to convey the fact that the
 // specified hook has been successfully executed, and committed.
 type Committer interface {
-	CommitHook(Info) error
+	CommitHook(context.Context, Info) error
 }
 
 // Validator is an interface that may be used to validate a hook execution

--- a/internal/worker/uniter/mockrunner_test.go
+++ b/internal/worker/uniter/mockrunner_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sync"
 
@@ -42,7 +43,7 @@ func (r *mockRunner) ranActions() []actionData {
 }
 
 // RunCommands exists to satisfy the Runner interface.
-func (r *mockRunner) RunCommands(commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
+func (r *mockRunner) RunCommands(_ stdcontext.Context, commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
 	result := &utilexec.ExecResponse{
 		Code:   0,
 		Stdout: []byte(fmt.Sprintf("%s on %s", commands, runLocation)),
@@ -51,7 +52,7 @@ func (r *mockRunner) RunCommands(commands string, runLocation runner.RunLocation
 }
 
 // RunAction exists to satisfy the Runner interface.
-func (r *mockRunner) RunAction(actionName string) (runner.HookHandlerType, error) {
+func (r *mockRunner) RunAction(_ stdcontext.Context, actionName string) (runner.HookHandlerType, error) {
 	data, err := r.stdContext.ActionData()
 	if err != nil {
 		return runner.ExplicitHookHandler, errors.Trace(err)
@@ -69,7 +70,7 @@ func (r *mockRunner) RunAction(actionName string) (runner.HookHandlerType, error
 }
 
 // RunHook exists to satisfy the Runner interface.
-func (r *mockRunner) RunHook(hookName string) (runner.HookHandlerType, error) {
+func (r *mockRunner) RunHook(_ stdcontext.Context, hookName string) (runner.HookHandlerType, error) {
 	r.ctx.unit.mu.Lock()
 	if hookName == string(hooks.Install) {
 		r.ctx.unit.unitStatus = status.StatusInfo{

--- a/internal/worker/uniter/operation/factory.go
+++ b/internal/worker/uniter/operation/factory.go
@@ -4,6 +4,8 @@
 package operation
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -128,13 +130,13 @@ func (f *factory) NewNoOpSecretsRemoved(uris []string) (Operation, error) {
 }
 
 // NewAction is part of the Factory interface.
-func (f *factory) NewAction(actionId string) (Operation, error) {
+func (f *factory) NewAction(ctx context.Context, actionId string) (Operation, error) {
 	if !names.IsValidAction(actionId) {
 		return nil, errors.Errorf("invalid action id %q", actionId)
 	}
 
 	tag := names.NewActionTag(actionId)
-	action, err := f.config.ActionGetter.Action(tag)
+	action, err := f.config.ActionGetter.Action(ctx, tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, charmrunner.ErrActionNotAvailable
 	} else if params.IsCodeActionNotAvailable(err) {

--- a/internal/worker/uniter/operation/factory_test.go
+++ b/internal/worker/uniter/operation/factory_test.go
@@ -4,6 +4,8 @@
 package operation_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -110,13 +112,13 @@ func (s *FactorySuite) TestNewResolvedUpgradeString(c *gc.C) {
 }
 
 func (s *FactorySuite) TestNewActionError(c *gc.C) {
-	op, err := s.factory.NewAction("lol-something")
+	op, err := s.factory.NewAction(context.Background(), "lol-something")
 	c.Check(op, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, `invalid action id "lol-something"`)
 }
 
 func (s *FactorySuite) TestNewActionString(c *gc.C) {
-	op, err := s.factory.NewAction(someActionId)
+	op, err := s.factory.NewAction(context.Background(), someActionId)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, "run action "+someActionId)
 }
@@ -243,14 +245,14 @@ func (s *FactorySuite) TestNewResignLeadershipString(c *gc.C) {
 
 func (s *FactorySuite) TestNewActionNotAvailable(c *gc.C) {
 	s.actionErr = &params.Error{Code: "action no longer available"}
-	rnr, err := s.factory.NewAction("666")
+	rnr, err := s.factory.NewAction(context.Background(), "666")
 	c.Assert(rnr, gc.IsNil)
 	c.Assert(err, gc.Equals, charmrunner.ErrActionNotAvailable)
 }
 
 func (s *FactorySuite) TestNewActionUnauthorised(c *gc.C) {
 	s.actionErr = &params.Error{Code: "unauthorized access"}
-	rnr, err := s.factory.NewAction("666")
+	rnr, err := s.factory.NewAction(context.Background(), "666")
 	c.Assert(rnr, gc.IsNil)
 	c.Assert(err, gc.Equals, charmrunner.ErrActionNotAvailable)
 }

--- a/internal/worker/uniter/operation/failaction.go
+++ b/internal/worker/uniter/operation/failaction.go
@@ -33,7 +33,7 @@ func (fa *failAction) Prepare(ctx context.Context, state State) (*State, error) 
 
 // Execute is part of the Operation interface.
 func (fa *failAction) Execute(ctx context.Context, state State) (*State, error) {
-	if err := fa.callbacks.FailAction(fa.actionId, "action terminated"); err != nil {
+	if err := fa.callbacks.FailAction(ctx, fa.actionId, "action terminated"); err != nil {
 		return nil, err
 	}
 

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -145,7 +145,7 @@ type Factory interface {
 	NewSkipHook(hookInfo hook.Info) (Operation, error)
 
 	// NewAction creates an operation to execute the supplied action.
-	NewAction(actionId string) (Operation, error)
+	NewAction(ctx stdcontext.Context, actionId string) (Operation, error)
 
 	// NewFailAction creates an operation that marks an action as failed.
 	NewFailAction(actionId string) (Operation, error)
@@ -209,8 +209,8 @@ type Callbacks interface {
 	// PrepareHook and CommitHook exist so that we can defer worrying about how
 	// to untangle Uniter.relationers from everything else. They're only used by
 	// RunHook operations.
-	PrepareHook(info hook.Info) (name string, err error)
-	CommitHook(info hook.Info) error
+	PrepareHook(ctx stdcontext.Context, info hook.Info) (name string, err error)
+	CommitHook(ctx stdcontext.Context, info hook.Info) error
 
 	// SetExecutingStatus sets the agent state to "Executing" with a message.
 	SetExecutingStatus(string) error
@@ -226,11 +226,11 @@ type Callbacks interface {
 
 	// FailAction marks the supplied action failed. It's only used by
 	// RunActions operations.
-	FailAction(actionId, message string) error
+	FailAction(ctx stdcontext.Context, actionId, message string) error
 
 	// ActionStatus returns the status of the action required by the action operation for
 	// cancelation.
-	ActionStatus(actionId string) (string, error)
+	ActionStatus(ctx stdcontext.Context, actionId string) (string, error)
 
 	// GetArchiveInfo is used to find out how to download a charm archive. It's
 	// only used by Deploy operations.
@@ -269,5 +269,5 @@ type StorageUpdater interface {
 
 // ActionGetter provides a method to query a given action.
 type ActionGetter interface {
-	Action(tag names.ActionTag) (*uniter.Action, error)
+	Action(ctx stdcontext.Context, tag names.ActionTag) (*uniter.Action, error)
 }

--- a/internal/worker/uniter/operation/mocks/interface_mock.go
+++ b/internal/worker/uniter/operation/mocks/interface_mock.go
@@ -183,18 +183,18 @@ func (mr *MockFactoryMockRecorder) NewAcceptLeadership() *gomock.Call {
 }
 
 // NewAction mocks base method.
-func (m *MockFactory) NewAction(arg0 string) (operation.Operation, error) {
+func (m *MockFactory) NewAction(arg0 context.Context, arg1 string) (operation.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewAction", arg0)
+	ret := m.ctrl.Call(m, "NewAction", arg0, arg1)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewAction indicates an expected call of NewAction.
-func (mr *MockFactoryMockRecorder) NewAction(arg0 any) *gomock.Call {
+func (mr *MockFactoryMockRecorder) NewAction(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAction", reflect.TypeOf((*MockFactory)(nil).NewAction), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAction", reflect.TypeOf((*MockFactory)(nil).NewAction), arg0, arg1)
 }
 
 // NewCommands mocks base method.
@@ -416,46 +416,46 @@ func (m *MockCallbacks) EXPECT() *MockCallbacksMockRecorder {
 }
 
 // ActionStatus mocks base method.
-func (m *MockCallbacks) ActionStatus(arg0 string) (string, error) {
+func (m *MockCallbacks) ActionStatus(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionStatus", arg0)
+	ret := m.ctrl.Call(m, "ActionStatus", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ActionStatus indicates an expected call of ActionStatus.
-func (mr *MockCallbacksMockRecorder) ActionStatus(arg0 any) *gomock.Call {
+func (mr *MockCallbacksMockRecorder) ActionStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionStatus", reflect.TypeOf((*MockCallbacks)(nil).ActionStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionStatus", reflect.TypeOf((*MockCallbacks)(nil).ActionStatus), arg0, arg1)
 }
 
 // CommitHook mocks base method.
-func (m *MockCallbacks) CommitHook(arg0 hook.Info) error {
+func (m *MockCallbacks) CommitHook(arg0 context.Context, arg1 hook.Info) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitHook", arg0)
+	ret := m.ctrl.Call(m, "CommitHook", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitHook indicates an expected call of CommitHook.
-func (mr *MockCallbacksMockRecorder) CommitHook(arg0 any) *gomock.Call {
+func (mr *MockCallbacksMockRecorder) CommitHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockCallbacks)(nil).CommitHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockCallbacks)(nil).CommitHook), arg0, arg1)
 }
 
 // FailAction mocks base method.
-func (m *MockCallbacks) FailAction(arg0, arg1 string) error {
+func (m *MockCallbacks) FailAction(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FailAction", arg0, arg1)
+	ret := m.ctrl.Call(m, "FailAction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FailAction indicates an expected call of FailAction.
-func (mr *MockCallbacksMockRecorder) FailAction(arg0, arg1 any) *gomock.Call {
+func (mr *MockCallbacksMockRecorder) FailAction(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailAction", reflect.TypeOf((*MockCallbacks)(nil).FailAction), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailAction", reflect.TypeOf((*MockCallbacks)(nil).FailAction), arg0, arg1, arg2)
 }
 
 // GetArchiveInfo mocks base method.
@@ -498,18 +498,18 @@ func (mr *MockCallbacksMockRecorder) NotifyHookFailed(arg0, arg1 any) *gomock.Ca
 }
 
 // PrepareHook mocks base method.
-func (m *MockCallbacks) PrepareHook(arg0 hook.Info) (string, error) {
+func (m *MockCallbacks) PrepareHook(arg0 context.Context, arg1 hook.Info) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareHook", arg0)
+	ret := m.ctrl.Call(m, "PrepareHook", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareHook indicates an expected call of PrepareHook.
-func (mr *MockCallbacksMockRecorder) PrepareHook(arg0 any) *gomock.Call {
+func (mr *MockCallbacksMockRecorder) PrepareHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockCallbacks)(nil).PrepareHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockCallbacks)(nil).PrepareHook), arg0, arg1)
 }
 
 // RemoteInit mocks base method.

--- a/internal/worker/uniter/operation/runaction_test.go
+++ b/internal/worker/uniter/operation/runaction_test.go
@@ -64,7 +64,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailSucceeds(c *gc.C) {
 		MockFailAction: &MockFailAction{err: errors.New("squelch")},
 	}
 	factory := newOpFactory(runnerFactory, callbacks)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -85,7 +85,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailErrors(c *gc.C) {
 		MockFailAction: &MockFailAction{},
 	}
 	factory := newOpFactory(runnerFactory, callbacks)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -102,7 +102,7 @@ func (s *RunActionSuite) TestPrepareErrorActionNotAvailable(c *gc.C) {
 		MockNewActionRunner: &MockNewActionRunner{err: charmrunner.ErrActionNotAvailable},
 	}
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -117,7 +117,7 @@ func (s *RunActionSuite) TestPrepareErrorOther(c *gc.C) {
 		MockNewActionRunner: &MockNewActionRunner{err: errors.New("foop")},
 	}
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -137,7 +137,7 @@ func (s *RunActionSuite) TestPrepareCtxCalled(c *gc.C) {
 		},
 	}
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -157,7 +157,7 @@ func (s *RunActionSuite) TestPrepareCtxError(c *gc.C) {
 		},
 	}
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -169,7 +169,7 @@ func (s *RunActionSuite) TestPrepareCtxError(c *gc.C) {
 func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 	runnerFactory := NewRunActionRunnerFactory(errors.New("should not call"))
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), operation.State{})
@@ -186,7 +186,7 @@ func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 	runnerFactory := NewRunActionRunnerFactory(errors.New("should not call"))
 	factory := newOpFactory(runnerFactory, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(stdcontext.Background(), overwriteState)
@@ -231,7 +231,7 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 		runnerFactory := NewRunActionRunnerFactory(nil)
 		callbacks := &RunActionCallbacks{}
 		factory := newOpFactory(runnerFactory, callbacks)
-		op, err := factory.NewAction(someActionId)
+		op, err := factory.NewAction(stdcontext.Background(), someActionId)
 		c.Assert(err, jc.ErrorIsNil)
 		midState, err := op.Prepare(stdcontext.Background(), test.before)
 		c.Assert(midState, gc.NotNil)
@@ -254,7 +254,7 @@ func (s *RunActionSuite) TestExecuteCancel(c *gc.C) {
 		actionStatus: "running",
 	}
 	factory := newOpFactory(runnerFactory, callbacks)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 	midState, err := op.Prepare(stdcontext.Background(), operation.State{})
 	c.Assert(midState, gc.NotNil)
@@ -351,7 +351,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 	for i, test := range stateChangeTests {
 		c.Logf("test %d: %s", i, test.description)
 		factory := newOpFactory(nil, nil)
-		op, err := factory.NewAction(someActionId)
+		op, err := factory.NewAction(stdcontext.Background(), someActionId)
 		c.Assert(err, jc.ErrorIsNil)
 
 		newState, err := op.Commit(stdcontext.Background(), test.before)
@@ -362,7 +362,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 
 func (s *RunActionSuite) TestNeedsGlobalMachineLock(c *gc.C) {
 	factory := newOpFactory(nil, nil)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.NeedsGlobalMachineLock(), jc.IsTrue)
 }
@@ -373,7 +373,7 @@ func (s *RunActionSuite) TestDoesNotNeedGlobalMachineLock(c *gc.C) {
 		Action: &params.Action{Name: "backup", Parallel: &parallel},
 	}
 	factory := newOpFactoryForAction(nil, nil, actionResult)
-	op, err := factory.NewAction(someActionId)
+	op, err := factory.NewAction(stdcontext.Background(), someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
 }

--- a/internal/worker/uniter/operation/runcommands.go
+++ b/internal/worker/uniter/operation/runcommands.go
@@ -43,7 +43,7 @@ func (rc *runCommands) String() string {
 // Prepare ensures the commands can be run. It never returns a state change.
 // Prepare is part of the Operation interface.
 func (rc *runCommands) Prepare(ctx stdcontext.Context, state State) (*State, error) {
-	rnr, err := rc.runnerFactory.NewCommandRunner(context.CommandInfo{
+	rnr, err := rc.runnerFactory.NewCommandRunner(ctx, context.CommandInfo{
 		RelationId:     rc.args.RelationId,
 		RemoteUnitName: rc.args.RemoteUnitName,
 		// TODO(jam): 2019-10-24 include RemoteAppName
@@ -52,7 +52,7 @@ func (rc *runCommands) Prepare(ctx stdcontext.Context, state State) (*State, err
 	if err != nil {
 		return nil, err
 	}
-	err = rnr.Context().Prepare()
+	err = rnr.Context().Prepare(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -70,7 +70,7 @@ func (rc *runCommands) Execute(ctx stdcontext.Context, state State) (*State, err
 		return nil, errors.Trace(err)
 	}
 
-	response, err := rc.runner.RunCommands(rc.args.Commands, rc.args.RunLocation)
+	response, err := rc.runner.RunCommands(ctx, rc.args.Commands, rc.args.RunLocation)
 	switch err {
 	case context.ErrRequeueAndReboot:
 		rc.logger.Warningf("cannot requeue external commands")

--- a/internal/worker/uniter/operation/runhook_test.go
+++ b/internal/worker/uniter/operation/runhook_test.go
@@ -225,7 +225,7 @@ func (s *RunHookSuite) TestExecuteMissingHookError(c *gc.C) {
 		c.Assert(callbacks.MockNotifyHookCompleted.gotName, gc.IsNil)
 		c.Assert(callbacks.MockNotifyHookFailed.gotName, gc.IsNil)
 
-		status, err := runnerFactory.MockNewHookRunner.runner.Context().UnitStatus()
+		status, err := runnerFactory.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 		c.Assert(err, jc.ErrorIsNil)
 		testAfterHookStatus(c, kind, status, false)
 	}
@@ -310,7 +310,7 @@ func (s *RunHookSuite) TestExecuteTerminated(c *gc.C) {
 
 func (s *RunHookSuite) TestInstallHookPreservesStatus(c *gc.C) {
 	op, callbacks, f := s.getExecuteRunnerTest(c, operation.Factory.NewRunHook, hooks.Install, nil)
-	err := f.MockNewHookRunner.runner.Context().SetUnitStatus(jujuc.StatusInfo{Status: "blocked", Info: "no database"})
+	err := f.MockNewHookRunner.runner.Context().SetUnitStatus(stdcontext.Background(), jujuc.StatusInfo{Status: "blocked", Info: "no database"})
 	c.Assert(err, jc.ErrorIsNil)
 	st := operation.State{
 		StatusSet: true,
@@ -322,7 +322,7 @@ func (s *RunHookSuite) TestInstallHookPreservesStatus(c *gc.C) {
 	_, err = op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callbacks.executingMessage, gc.Equals, "running install hook")
-	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
+	status, err := f.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Status, gc.Equals, "blocked")
 	c.Assert(status.Info, gc.Equals, "no database")
@@ -340,7 +340,7 @@ func (s *RunHookSuite) TestInstallHookWHenNoStatusSet(c *gc.C) {
 	_, err = op.Execute(stdcontext.Background(), *midState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callbacks.executingMessage, gc.Equals, "running install hook")
-	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
+	status, err := f.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Status, gc.Equals, "maintenance")
 	c.Assert(status.Info, gc.Equals, "installing charm software")
@@ -401,7 +401,7 @@ func (s *RunHookSuite) testExecuteThenCharmStatus(
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(midState, gc.NotNil)
 
-	_, err = f.MockNewHookRunner.runner.Context().UnitStatus()
+	_, err = f.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Execute(stdcontext.Background(), *midState)
@@ -411,7 +411,7 @@ func (s *RunHookSuite) testExecuteThenCharmStatus(
 	c.Assert(newState.Started, gc.Equals, after.Started)
 	c.Assert(newState.StatusSet, gc.Equals, after.StatusSet)
 
-	status, err := f.MockNewHookRunner.runner.Context().UnitStatus()
+	status, err := f.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	testAfterHookStatus(c, kind, status, after.StatusSet)
 }
@@ -465,7 +465,7 @@ func (s *RunHookSuite) testBeforeHookExecute(c *gc.C, newHook newHook, kind hook
 	c.Assert(err, gc.Equals, operation.ErrHookFailed)
 	c.Assert(newState, gc.IsNil)
 
-	status, err := runnerFactory.MockNewHookRunner.runner.Context().UnitStatus()
+	status, err := runnerFactory.MockNewHookRunner.runner.Context().UnitStatus(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	testBeforeHookStatus(c, kind, status)
 }

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -4,6 +4,7 @@
 package operation_test
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/charm/v12/hooks"
@@ -128,7 +129,7 @@ type RunActionCallbacks struct {
 	mut              sync.Mutex
 }
 
-func (cb *RunActionCallbacks) FailAction(actionId, message string) error {
+func (cb *RunActionCallbacks) FailAction(_ context.Context, actionId, message string) error {
 	return cb.MockFailAction.Call(actionId, message)
 }
 
@@ -139,7 +140,7 @@ func (cb *RunActionCallbacks) SetExecutingStatus(message string) error {
 	return nil
 }
 
-func (cb *RunActionCallbacks) ActionStatus(actionId string) (string, error) {
+func (cb *RunActionCallbacks) ActionStatus(_ context.Context, actionId string) (string, error) {
 	cb.mut.Lock()
 	defer cb.mut.Unlock()
 	return cb.actionStatus, cb.actionStatusErr
@@ -179,7 +180,7 @@ type PrepareHookCallbacks struct {
 	executingMessage string
 }
 
-func (cb *PrepareHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
+func (cb *PrepareHookCallbacks) PrepareHook(_ context.Context, hookInfo hook.Info) (string, error) {
 	return cb.MockPrepareHook.Call(hookInfo)
 }
 
@@ -234,11 +235,11 @@ type CommitHookCallbacks struct {
 	rotatedOldRevision int
 }
 
-func (cb *CommitHookCallbacks) PrepareHook(hookInfo hook.Info) (string, error) {
+func (cb *CommitHookCallbacks) PrepareHook(_ context.Context, hookInfo hook.Info) (string, error) {
 	return "", nil
 }
 
-func (cb *CommitHookCallbacks) CommitHook(hookInfo hook.Info) error {
+func (cb *CommitHookCallbacks) CommitHook(_ context.Context, hookInfo hook.Info) error {
 	return cb.MockCommitHook.Call(hookInfo)
 }
 
@@ -303,15 +304,15 @@ type MockRunnerFactory struct {
 	*MockNewCommandRunner
 }
 
-func (f *MockRunnerFactory) NewActionRunner(action *uniter.Action, cancel <-chan struct{}) (runner.Runner, error) {
+func (f *MockRunnerFactory) NewActionRunner(_ context.Context, action *uniter.Action, cancel <-chan struct{}) (runner.Runner, error) {
 	return f.MockNewActionRunner.Call(action.ID(), cancel)
 }
 
-func (f *MockRunnerFactory) NewHookRunner(hookInfo hook.Info) (runner.Runner, error) {
+func (f *MockRunnerFactory) NewHookRunner(_ context.Context, hookInfo hook.Info) (runner.Runner, error) {
 	return f.MockNewHookRunner.Call(hookInfo)
 }
 
-func (f *MockRunnerFactory) NewCommandRunner(commandInfo runnercontext.CommandInfo) (runner.Runner, error) {
+func (f *MockRunnerFactory) NewCommandRunner(_ context.Context, commandInfo runnercontext.CommandInfo) (runner.Runner, error) {
 	return f.MockNewCommandRunner.Call(commandInfo)
 }
 
@@ -320,7 +321,7 @@ type MockRunnerActionWaitFactory struct {
 	*MockNewActionWaitRunner
 }
 
-func (f *MockRunnerActionWaitFactory) NewActionRunner(action *uniter.Action, cancel <-chan struct{}) (runner.Runner, error) {
+func (f *MockRunnerActionWaitFactory) NewActionRunner(_ context.Context, action *uniter.Action, cancel <-chan struct{}) (runner.Runner, error) {
 	return f.MockNewActionWaitRunner.Call(action.ID(), cancel)
 }
 
@@ -361,7 +362,7 @@ func (mock *MockContext) ResetExecutionSetUnitStatus() {
 	mock.setStatusCalled = false
 }
 
-func (mock *MockContext) SetUnitStatus(status jujuc.StatusInfo) error {
+func (mock *MockContext) SetUnitStatus(_ context.Context, status jujuc.StatusInfo) error {
 	mock.setStatusCalled = true
 	mock.status = status
 	return nil
@@ -371,11 +372,11 @@ func (mock *MockContext) UnitName() string {
 	return "unit/0"
 }
 
-func (mock *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
+func (mock *MockContext) UnitStatus(_ context.Context) (*jujuc.StatusInfo, error) {
 	return &mock.status, nil
 }
 
-func (mock *MockContext) Prepare() error {
+func (mock *MockContext) Prepare(context.Context) error {
 	mock.MethodCall(mock, "Prepare")
 	return mock.NextErr()
 }
@@ -398,7 +399,7 @@ func (mock *MockRelation) Suspended() bool {
 	return mock.suspended
 }
 
-func (mock *MockRelation) SetStatus(status relation.Status) error {
+func (mock *MockRelation) SetStatus(_ context.Context, status relation.Status) error {
 	mock.status = status
 	return nil
 }
@@ -448,15 +449,15 @@ func (r *MockRunner) Context() runnercontext.Context {
 	return r.context
 }
 
-func (r *MockRunner) RunAction(actionName string) (runner.HookHandlerType, error) {
+func (r *MockRunner) RunAction(_ context.Context, actionName string) (runner.HookHandlerType, error) {
 	return runner.ExplicitHookHandler, r.MockRunAction.Call(actionName)
 }
 
-func (r *MockRunner) RunCommands(commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
+func (r *MockRunner) RunCommands(_ context.Context, commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
 	return r.MockRunCommands.Call(commands, runLocation)
 }
 
-func (r *MockRunner) RunHook(hookName string) (runner.HookHandlerType, error) {
+func (r *MockRunner) RunHook(_ context.Context, hookName string) (runner.HookHandlerType, error) {
 	r.Context().(*MockContext).setStatusCalled = r.MockRunHook.setStatusCalled
 	return runner.ExplicitHookHandler, r.MockRunHook.Call(hookName)
 }
@@ -474,7 +475,7 @@ func (r *MockActionWaitRunner) Context() runnercontext.Context {
 	return r.context
 }
 
-func (r *MockActionWaitRunner) RunAction(actionName string) (runner.HookHandlerType, error) {
+func (r *MockActionWaitRunner) RunAction(_ context.Context, actionName string) (runner.HookHandlerType, error) {
 	r.actionName = actionName
 	return runner.ExplicitHookHandler, <-r.actionChan
 }

--- a/internal/worker/uniter/relation/export_test.go
+++ b/internal/worker/uniter/relation/export_test.go
@@ -4,6 +4,8 @@
 package relation
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/internal/worker/uniter/api"
@@ -41,7 +43,7 @@ func NewStateTrackerForTest(cfg StateTrackerForTestConfig) (RelationStateTracker
 		newRelationer:   cfg.NewRelationerFunc,
 	}
 
-	return rst, rst.loadInitialState()
+	return rst, rst.loadInitialState(stdcontext.Background())
 }
 
 func NewStateTrackerForSyncScopesTest(cfg StateTrackerForTestConfig) (RelationStateTracker, error) {

--- a/internal/worker/uniter/relation/interface.go
+++ b/internal/worker/uniter/relation/interface.go
@@ -4,6 +4,8 @@
 package relation
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/life"
@@ -22,12 +24,12 @@ type RelationStateTracker interface {
 	// CommitHook persists the state change encoded in the supplied relation
 	// hook, or returns an error if the hook is unknown or invalid given
 	// current relation state.
-	CommitHook(hook.Info) error
+	CommitHook(stdcontext.Context, hook.Info) error
 
 	// SynchronizeScopes ensures that the locally tracked relation scopes
 	// reflect the contents of the remote state snapshot by entering or
 	// exiting scopes as required.
-	SynchronizeScopes(remotestate.Snapshot) error
+	SynchronizeScopes(stdcontext.Context, remotestate.Snapshot) error
 
 	// IsKnown returns true if the relation ID is known by the tracker.
 	IsKnown(int) bool
@@ -71,7 +73,7 @@ type RelationStateTracker interface {
 
 	// LocalUnitAndApplicationLife returns the life values for the local
 	// unit and application.
-	LocalUnitAndApplicationLife() (life.Value, life.Value, error)
+	LocalUnitAndApplicationLife(stdcontext.Context) (life.Value, life.Value, error)
 
 	// Report provides information for the engine report.
 	Report() map[string]interface{}
@@ -102,13 +104,13 @@ type StateManager interface {
 
 	// RemoveRelation removes the state for the given id from the
 	// manager.
-	RemoveRelation(id int, unitGetter UnitGetter, knownUnits map[string]bool) error
+	RemoveRelation(ctx stdcontext.Context, id int, unitGetter UnitGetter, knownUnits map[string]bool) error
 }
 
 // UnitGetter encapsulates methods to get unit info.
 type UnitGetter interface {
 	// Unit returns the existing unit with the given tag.
-	Unit(tag names.UnitTag) (api.Unit, error)
+	Unit(ctx stdcontext.Context, tag names.UnitTag) (api.Unit, error)
 }
 
 // UnitStateReadWriter encapsulates the methods from a state.Unit
@@ -127,13 +129,13 @@ type UnitStateReadWriter interface {
 // required by a relationStateTracker.
 type StateTrackerClient interface {
 	// Unit returns the existing unit with the given tag.
-	Unit(tag names.UnitTag) (api.Unit, error)
+	Unit(ctx stdcontext.Context, tag names.UnitTag) (api.Unit, error)
 
 	// Relation returns the existing relation with the given tag.
-	Relation(tag names.RelationTag) (api.Relation, error)
+	Relation(ctx stdcontext.Context, tag names.RelationTag) (api.Relation, error)
 
 	// RelationById returns the existing relation with the given id.
-	RelationById(int) (api.Relation, error)
+	RelationById(stdcontext.Context, int) (api.Relation, error)
 }
 
 // Application encapsulates the methods from
@@ -145,7 +147,7 @@ type Application interface {
 // Relationer encapsulates the methods from relationer required by a stateTracker.
 type Relationer interface {
 	// CommitHook persists the fact of the supplied hook's completion.
-	CommitHook(hi hook.Info) error
+	CommitHook(ctx stdcontext.Context, hi hook.Info) error
 
 	// ContextInfo returns a representation of the relationer's current state.
 	ContextInfo() *context.RelationInfo
@@ -172,5 +174,5 @@ type Relationer interface {
 	// SetDying informs the relationer that the unit is departing the relation,
 	// and that the only hooks it should send henceforth are -departed hooks,
 	// until the relation is empty, followed by a -broken hook.
-	SetDying() error
+	SetDying(ctx stdcontext.Context) error
 }

--- a/internal/worker/uniter/relation/mocks/mock_relationer.go
+++ b/internal/worker/uniter/relation/mocks/mock_relationer.go
@@ -10,11 +10,12 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	api "github.com/juju/juju/internal/worker/uniter/api"
 	hook "github.com/juju/juju/internal/worker/uniter/hook"
-	context "github.com/juju/juju/internal/worker/uniter/runner/context"
+	context0 "github.com/juju/juju/internal/worker/uniter/runner/context"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,24 +43,24 @@ func (m *MockRelationer) EXPECT() *MockRelationerMockRecorder {
 }
 
 // CommitHook mocks base method.
-func (m *MockRelationer) CommitHook(arg0 hook.Info) error {
+func (m *MockRelationer) CommitHook(arg0 context.Context, arg1 hook.Info) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitHook", arg0)
+	ret := m.ctrl.Call(m, "CommitHook", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitHook indicates an expected call of CommitHook.
-func (mr *MockRelationerMockRecorder) CommitHook(arg0 any) *gomock.Call {
+func (mr *MockRelationerMockRecorder) CommitHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationer)(nil).CommitHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationer)(nil).CommitHook), arg0, arg1)
 }
 
 // ContextInfo mocks base method.
-func (m *MockRelationer) ContextInfo() *context.RelationInfo {
+func (m *MockRelationer) ContextInfo() *context0.RelationInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContextInfo")
-	ret0, _ := ret[0].(*context.RelationInfo)
+	ret0, _ := ret[0].(*context0.RelationInfo)
 	return ret0
 }
 
@@ -141,15 +142,15 @@ func (mr *MockRelationerMockRecorder) RelationUnit() *gomock.Call {
 }
 
 // SetDying mocks base method.
-func (m *MockRelationer) SetDying() error {
+func (m *MockRelationer) SetDying(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDying")
+	ret := m.ctrl.Call(m, "SetDying", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetDying indicates an expected call of SetDying.
-func (mr *MockRelationerMockRecorder) SetDying() *gomock.Call {
+func (mr *MockRelationerMockRecorder) SetDying(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDying", reflect.TypeOf((*MockRelationer)(nil).SetDying))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDying", reflect.TypeOf((*MockRelationer)(nil).SetDying), arg0)
 }

--- a/internal/worker/uniter/relation/mocks/mock_state_manager.go
+++ b/internal/worker/uniter/relation/mocks/mock_state_manager.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	relation "github.com/juju/juju/internal/worker/uniter/relation"
@@ -83,17 +84,17 @@ func (mr *MockStateManagerMockRecorder) RelationFound(arg0 any) *gomock.Call {
 }
 
 // RemoveRelation mocks base method.
-func (m *MockStateManager) RemoveRelation(arg0 int, arg1 relation.UnitGetter, arg2 map[string]bool) error {
+func (m *MockStateManager) RemoveRelation(arg0 context.Context, arg1 int, arg2 relation.UnitGetter, arg3 map[string]bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRelation", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RemoveRelation", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveRelation indicates an expected call of RemoveRelation.
-func (mr *MockStateManagerMockRecorder) RemoveRelation(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateManagerMockRecorder) RemoveRelation(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelation", reflect.TypeOf((*MockStateManager)(nil).RemoveRelation), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelation", reflect.TypeOf((*MockStateManager)(nil).RemoveRelation), arg0, arg1, arg2, arg3)
 }
 
 // SetRelation mocks base method.

--- a/internal/worker/uniter/relation/mocks/mock_state_tracker.go
+++ b/internal/worker/uniter/relation/mocks/mock_state_tracker.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	api "github.com/juju/juju/internal/worker/uniter/api"
@@ -41,46 +42,46 @@ func (m *MockStateTrackerClient) EXPECT() *MockStateTrackerClientMockRecorder {
 }
 
 // Relation mocks base method.
-func (m *MockStateTrackerClient) Relation(arg0 names.RelationTag) (api.Relation, error) {
+func (m *MockStateTrackerClient) Relation(arg0 context.Context, arg1 names.RelationTag) (api.Relation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Relation", arg0)
+	ret := m.ctrl.Call(m, "Relation", arg0, arg1)
 	ret0, _ := ret[0].(api.Relation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Relation indicates an expected call of Relation.
-func (mr *MockStateTrackerClientMockRecorder) Relation(arg0 any) *gomock.Call {
+func (mr *MockStateTrackerClientMockRecorder) Relation(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockStateTrackerClient)(nil).Relation), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockStateTrackerClient)(nil).Relation), arg0, arg1)
 }
 
 // RelationById mocks base method.
-func (m *MockStateTrackerClient) RelationById(arg0 int) (api.Relation, error) {
+func (m *MockStateTrackerClient) RelationById(arg0 context.Context, arg1 int) (api.Relation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RelationById", arg0)
+	ret := m.ctrl.Call(m, "RelationById", arg0, arg1)
 	ret0, _ := ret[0].(api.Relation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RelationById indicates an expected call of RelationById.
-func (mr *MockStateTrackerClientMockRecorder) RelationById(arg0 any) *gomock.Call {
+func (mr *MockStateTrackerClientMockRecorder) RelationById(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationById", reflect.TypeOf((*MockStateTrackerClient)(nil).RelationById), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationById", reflect.TypeOf((*MockStateTrackerClient)(nil).RelationById), arg0, arg1)
 }
 
 // Unit mocks base method.
-func (m *MockStateTrackerClient) Unit(arg0 names.UnitTag) (api.Unit, error) {
+func (m *MockStateTrackerClient) Unit(arg0 context.Context, arg1 names.UnitTag) (api.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
+	ret := m.ctrl.Call(m, "Unit", arg0, arg1)
 	ret0, _ := ret[0].(api.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockStateTrackerClientMockRecorder) Unit(arg0 any) *gomock.Call {
+func (mr *MockStateTrackerClientMockRecorder) Unit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockStateTrackerClient)(nil).Unit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockStateTrackerClient)(nil).Unit), arg0, arg1)
 }

--- a/internal/worker/uniter/relation/mocks/mock_statetracker.go
+++ b/internal/worker/uniter/relation/mocks/mock_statetracker.go
@@ -10,13 +10,14 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	life "github.com/juju/juju/core/life"
 	hook "github.com/juju/juju/internal/worker/uniter/hook"
 	relation "github.com/juju/juju/internal/worker/uniter/relation"
 	remotestate "github.com/juju/juju/internal/worker/uniter/remotestate"
-	context "github.com/juju/juju/internal/worker/uniter/runner/context"
+	context0 "github.com/juju/juju/internal/worker/uniter/runner/context"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -44,24 +45,24 @@ func (m *MockRelationStateTracker) EXPECT() *MockRelationStateTrackerMockRecorde
 }
 
 // CommitHook mocks base method.
-func (m *MockRelationStateTracker) CommitHook(arg0 hook.Info) error {
+func (m *MockRelationStateTracker) CommitHook(arg0 context.Context, arg1 hook.Info) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitHook", arg0)
+	ret := m.ctrl.Call(m, "CommitHook", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitHook indicates an expected call of CommitHook.
-func (mr *MockRelationStateTrackerMockRecorder) CommitHook(arg0 any) *gomock.Call {
+func (mr *MockRelationStateTrackerMockRecorder) CommitHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationStateTracker)(nil).CommitHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationStateTracker)(nil).CommitHook), arg0, arg1)
 }
 
 // GetInfo mocks base method.
-func (m *MockRelationStateTracker) GetInfo() map[int]*context.RelationInfo {
+func (m *MockRelationStateTracker) GetInfo() map[int]*context0.RelationInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfo")
-	ret0, _ := ret[0].(map[int]*context.RelationInfo)
+	ret0, _ := ret[0].(map[int]*context0.RelationInfo)
 	return ret0
 }
 
@@ -131,9 +132,9 @@ func (mr *MockRelationStateTrackerMockRecorder) IsPeerRelation(arg0 any) *gomock
 }
 
 // LocalUnitAndApplicationLife mocks base method.
-func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, life.Value, error) {
+func (m *MockRelationStateTracker) LocalUnitAndApplicationLife(arg0 context.Context) (life.Value, life.Value, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LocalUnitAndApplicationLife")
+	ret := m.ctrl.Call(m, "LocalUnitAndApplicationLife", arg0)
 	ret0, _ := ret[0].(life.Value)
 	ret1, _ := ret[1].(life.Value)
 	ret2, _ := ret[2].(error)
@@ -141,9 +142,9 @@ func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, li
 }
 
 // LocalUnitAndApplicationLife indicates an expected call of LocalUnitAndApplicationLife.
-func (mr *MockRelationStateTrackerMockRecorder) LocalUnitAndApplicationLife() *gomock.Call {
+func (mr *MockRelationStateTrackerMockRecorder) LocalUnitAndApplicationLife(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitAndApplicationLife", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitAndApplicationLife))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitAndApplicationLife", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitAndApplicationLife), arg0)
 }
 
 // LocalUnitName mocks base method.
@@ -262,15 +263,15 @@ func (mr *MockRelationStateTrackerMockRecorder) StateFound(arg0 any) *gomock.Cal
 }
 
 // SynchronizeScopes mocks base method.
-func (m *MockRelationStateTracker) SynchronizeScopes(arg0 remotestate.Snapshot) error {
+func (m *MockRelationStateTracker) SynchronizeScopes(arg0 context.Context, arg1 remotestate.Snapshot) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SynchronizeScopes", arg0)
+	ret := m.ctrl.Call(m, "SynchronizeScopes", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SynchronizeScopes indicates an expected call of SynchronizeScopes.
-func (mr *MockRelationStateTrackerMockRecorder) SynchronizeScopes(arg0 any) *gomock.Call {
+func (mr *MockRelationStateTrackerMockRecorder) SynchronizeScopes(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeScopes", reflect.TypeOf((*MockRelationStateTracker)(nil).SynchronizeScopes), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeScopes", reflect.TypeOf((*MockRelationStateTracker)(nil).SynchronizeScopes), arg0, arg1)
 }

--- a/internal/worker/uniter/relation/mocks/mock_unit_getter.go
+++ b/internal/worker/uniter/relation/mocks/mock_unit_getter.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	api "github.com/juju/juju/internal/worker/uniter/api"
@@ -41,16 +42,16 @@ func (m *MockUnitGetter) EXPECT() *MockUnitGetterMockRecorder {
 }
 
 // Unit mocks base method.
-func (m *MockUnitGetter) Unit(arg0 names.UnitTag) (api.Unit, error) {
+func (m *MockUnitGetter) Unit(arg0 context.Context, arg1 names.UnitTag) (api.Unit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
+	ret := m.ctrl.Call(m, "Unit", arg0, arg1)
 	ret0, _ := ret[0].(api.Unit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unit indicates an expected call of Unit.
-func (mr *MockUnitGetterMockRecorder) Unit(arg0 any) *gomock.Call {
+func (mr *MockUnitGetterMockRecorder) Unit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUnitGetter)(nil).Unit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUnitGetter)(nil).Unit), arg0, arg1)
 }

--- a/internal/worker/uniter/relation/relationer_test.go
+++ b/internal/worker/uniter/relation/relationer_test.go
@@ -4,6 +4,7 @@
 package relation_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/charm/v12"
@@ -51,7 +52,7 @@ func (s *relationerSuite) TestImplicitRelationerCommitHook(c *gc.C) {
 	r := s.newRelationer()
 
 	// Hooks are not allowed.
-	err := r.CommitHook(hook.Info{})
+	err := r.CommitHook(context.Background(), hook.Info{})
 	c.Assert(err, gc.ErrorMatches, `restart immediately`)
 }
 
@@ -66,7 +67,7 @@ func (s *relationerSuite) TestImplicitRelationerSetDying(c *gc.C) {
 
 	// Set it to Dying
 	c.Assert(r.IsDying(), jc.IsFalse)
-	err := r.SetDying()
+	err := r.SetDying(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.IsDying(), jc.IsTrue)
 }
@@ -80,7 +81,7 @@ func (s *relationerSuite) TestSetDying(c *gc.C) {
 
 	// Set it to Dying
 	c.Assert(r.IsDying(), jc.IsFalse)
-	err := r.SetDying()
+	err := r.SetDying(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.IsDying(), jc.IsTrue)
 }
@@ -93,7 +94,7 @@ func (s *relationerSuite) TestIfDyingFailJoin(c *gc.C) {
 	r := s.newRelationer()
 
 	// Set it to Dying
-	err := r.SetDying()
+	err := r.SetDying(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Try to Join
@@ -110,7 +111,7 @@ func (s *relationerSuite) TestCommitHookRelationBrokenDies(c *gc.C) {
 
 	r := s.newRelationer()
 
-	err := r.CommitHook(hook.Info{Kind: hooks.RelationBroken})
+	err := r.CommitHook(context.Background(), hook.Info{Kind: hooks.RelationBroken})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -123,7 +124,7 @@ func (s *relationerSuite) TestCommitHookRelationRemoved(c *gc.C) {
 
 	r := s.newRelationer()
 
-	err := r.CommitHook(hook.Info{Kind: hooks.RelationBroken})
+	err := r.CommitHook(context.Background(), hook.Info{Kind: hooks.RelationBroken})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -136,7 +137,7 @@ func (s *relationerSuite) TestCommitHook(c *gc.C) {
 
 	r := s.newRelationer()
 
-	err := r.CommitHook(hook.Info{Kind: hooks.RelationJoined, RelationId: 1})
+	err := r.CommitHook(context.Background(), hook.Info{Kind: hooks.RelationJoined, RelationId: 1})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -148,7 +149,7 @@ func (s *relationerSuite) TestCommitHookRelationFail(c *gc.C) {
 
 	r := s.newRelationer()
 
-	err := r.CommitHook(hook.Info{Kind: hooks.RelationJoined, RelationId: 1})
+	err := r.CommitHook(context.Background(), hook.Info{Kind: hooks.RelationJoined, RelationId: 1})
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -277,7 +278,7 @@ func (s *relationerSuite) expectRelationId() {
 
 // StateManager
 func (s *relationerSuite) expectRemoveRelation() {
-	s.stateManager.EXPECT().RemoveRelation(1, s.unitGetter, map[string]bool{}).Return(nil)
+	s.stateManager.EXPECT().RemoveRelation(gomock.Any(), 1, s.unitGetter, map[string]bool{}).Return(nil)
 }
 
 func (s *relationerSuite) expectRelationFound(found bool) {

--- a/internal/worker/uniter/relation/resolver.go
+++ b/internal/worker/uniter/relation/resolver.go
@@ -70,7 +70,7 @@ func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.Loca
 		return nil, resolver.ErrNoOperation
 	}
 
-	if err := r.stateTracker.SynchronizeScopes(remoteState); err != nil {
+	if err := r.stateTracker.SynchronizeScopes(ctx, remoteState); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -100,7 +100,7 @@ func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.Loca
 			//
 			relState = NewState(relationId)
 		}
-		hInfo, err := r.nextHookForRelation(relState, relationSnapshot, remoteBroken)
+		hInfo, err := r.nextHookForRelation(ctx, relState, relationSnapshot, remoteBroken)
 		if err == resolver.ErrNoOperation {
 			continue
 		}
@@ -139,7 +139,7 @@ func (r *relationsResolver) maybeDestroySubordinates(remoteState remotestate.Sna
 	return nil
 }
 
-func (r *relationsResolver) nextHookForRelation(localState *State, remote remotestate.RelationSnapshot, remoteBroken bool) (hook.Info, error) {
+func (r *relationsResolver) nextHookForRelation(ctx context.Context, localState *State, remote remotestate.RelationSnapshot, remoteBroken bool) (hook.Info, error) {
 	// If there's a guaranteed next hook, return that.
 	relationId := localState.RelationId
 	if localState.ChangedPending != "" {
@@ -201,7 +201,7 @@ func (r *relationsResolver) nextHookForRelation(localState *State, remote remote
 			// figure out if its the localState or the remote unit going
 			// away. Note that if the app is removed, the unit will
 			// still be alive but its parent app will by dying.
-			localUnitLife, localAppLife, err := r.stateTracker.LocalUnitAndApplicationLife()
+			localUnitLife, localAppLife, err := r.stateTracker.LocalUnitAndApplicationLife(ctx)
 			if err != nil {
 				return hook.Info{}, errors.Trace(err)
 			}
@@ -361,7 +361,7 @@ func (r *createdRelationsResolver) NextOp(
 		return nil, resolver.ErrNoOperation
 	}
 
-	if err := r.stateTracker.SynchronizeScopes(remoteState); err != nil {
+	if err := r.stateTracker.SynchronizeScopes(ctx, remoteState); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/relation/statemanager.go
+++ b/internal/worker/uniter/relation/statemanager.go
@@ -4,6 +4,7 @@
 package relation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -43,7 +44,7 @@ func (m *stateManager) Relation(id int) (*State, error) {
 // RemoveRelation removes the state for the given id from the
 // manager.  The change to the manager is only made when the
 // data is successfully saved.
-func (m *stateManager) RemoveRelation(id int, unitGetter UnitGetter, knownUnits map[string]bool) error {
+func (m *stateManager) RemoveRelation(ctx context.Context, id int, unitGetter UnitGetter, knownUnits map[string]bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	st, ok := m.relationState[id]
@@ -57,7 +58,7 @@ func (m *stateManager) RemoveRelation(id int, unitGetter UnitGetter, knownUnits 
 	for unitName := range st.Members {
 		unitExists, ok := knownUnits[unitName]
 		if !ok {
-			_, err := unitGetter.Unit(names.NewUnitTag(unitName))
+			_, err := unitGetter.Unit(ctx, names.NewUnitTag(unitName))
 			if err != nil && !params.IsCodeNotFoundOrCodeUnauthorized(err) {
 				return errors.Trace(err)
 			}

--- a/internal/worker/uniter/relation/statetracker_test.go
+++ b/internal/worker/uniter/relation/statetracker_test.go
@@ -4,6 +4,7 @@
 package relation_test
 
 import (
+	stdcontext "context"
 	"os"
 	"path/filepath"
 	"time"
@@ -218,7 +219,7 @@ func (s *stateTrackerSuite) TestCommitHookOnlyRelationHooks(c *gc.C) {
 		Kind:       hooks.MeterStatusChanged,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, gc.ErrorMatches, "not a relation hook.*")
 }
 
@@ -235,7 +236,7 @@ func (s *stateTrackerSuite) TestCommitHookNotFound(c *gc.C) {
 		Kind:       hooks.RelationCreated,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -253,7 +254,7 @@ func (s *stateTrackerSuite) TestCommitHookRelationCreated(c *gc.C) {
 		Kind:       hooks.RelationCreated,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rst.RelationCreated(1), jc.IsTrue)
 }
@@ -272,7 +273,7 @@ func (s *stateTrackerSuite) TestCommitHookRelationCreatedFail(c *gc.C) {
 		Kind:       hooks.RelationCreated,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, gc.NotNil)
 	c.Assert(rst.RelationCreated(1), jc.IsFalse)
 }
@@ -291,7 +292,7 @@ func (s *stateTrackerSuite) TestCommitHookRelationBroken(c *gc.C) {
 		Kind:       hooks.RelationBroken,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rst.IsKnown(1), jc.IsFalse)
 }
@@ -310,7 +311,7 @@ func (s *stateTrackerSuite) TestCommitHookRelationBrokenFail(c *gc.C) {
 		Kind:       hooks.RelationBroken,
 		RelationId: 1,
 	}
-	err = rst.CommitHook(info)
+	err = rst.CommitHook(stdcontext.Background(), info)
 	c.Assert(err, gc.NotNil)
 	c.Assert(rst.IsKnown(1), jc.IsTrue)
 }
@@ -356,7 +357,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesNoRemoteRelations(c *gc.C) {
 	r := s.newStateTracker(c)
 
 	remote := remotestate.Snapshot{}
-	err := r.SynchronizeScopes(remote)
+	err := r.SynchronizeScopes(stdcontext.Background(), remote)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -381,7 +382,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesNoRemoteRelationsDestroySubordina
 	c.Assert(err, jc.ErrorIsNil)
 
 	remote := remotestate.Snapshot{}
-	err = rst.SynchronizeScopes(remote)
+	err = rst.SynchronizeScopes(stdcontext.Background(), remote)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -424,7 +425,7 @@ func (s *syncScopesSuite) testSynchronizeScopesDying(c *gc.C, implicit bool) rel
 		},
 	}
 
-	err := rst.SynchronizeScopes(remoteState)
+	err := rst.SynchronizeScopes(stdcontext.Background(), remoteState)
 	c.Assert(err, jc.ErrorIsNil)
 	return rst
 }
@@ -462,7 +463,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesSuspendedDying(c *gc.C) {
 		},
 	}
 
-	err := rst.SynchronizeScopes(remoteState)
+	err := rst.SynchronizeScopes(stdcontext.Background(), remoteState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rst.IsKnown(1), jc.IsFalse)
 }
@@ -511,7 +512,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesJoinRelation(c *gc.C) {
 		},
 	}
 
-	err := rst.SynchronizeScopes(remoteState)
+	err := rst.SynchronizeScopes(stdcontext.Background(), remoteState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rst.RemoteApplication(1), gc.Equals, "mysql")
 }
@@ -555,7 +556,7 @@ func (s *syncScopesSuite) assertSynchronizeScopesFailImplementedBy(c *gc.C, crea
 		},
 	}
 
-	err := rst.SynchronizeScopes(remoteState)
+	err := rst.SynchronizeScopes(stdcontext.Background(), remoteState)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -595,7 +596,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesSeenNotDying(c *gc.C) {
 		},
 	}
 
-	err := rst.SynchronizeScopes(remoteState)
+	err := rst.SynchronizeScopes(stdcontext.Background(), remoteState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rst.RemoteApplication(1), gc.Equals, "mysql")
 }
@@ -606,11 +607,11 @@ func (s *baseStateTrackerSuite) expectRelationerPrepareHook() {
 }
 
 func (s *baseStateTrackerSuite) expectRelationerCommitHook() {
-	s.relationer.EXPECT().CommitHook(gomock.Any()).Return(nil)
+	s.relationer.EXPECT().CommitHook(gomock.Any(), gomock.Any()).Return(nil)
 }
 
 func (s *baseStateTrackerSuite) expectRelationerCommitHookFail() {
-	s.relationer.EXPECT().CommitHook(gomock.Any()).Return(errors.NotFoundf("testing"))
+	s.relationer.EXPECT().CommitHook(gomock.Any(), gomock.Any()).Return(errors.NotFoundf("testing"))
 }
 
 func (s *baseStateTrackerSuite) expectRelationerJoin() {
@@ -622,7 +623,7 @@ func (s *baseStateTrackerSuite) expectRelationerRelationUnit() {
 }
 
 func (s *baseStateTrackerSuite) expectRelationerSetDying() {
-	s.relationer.EXPECT().SetDying().Return(nil)
+	s.relationer.EXPECT().SetDying(gomock.Any()).Return(nil)
 }
 
 func (s *baseStateTrackerSuite) expectRelationerIsImplicit(imp bool) {
@@ -640,11 +641,11 @@ func (s *baseStateTrackerSuite) expectRelationUpdateSuspended(suspend bool) {
 }
 
 func (s *baseStateTrackerSuite) expectRelationUnit() {
-	s.relation.EXPECT().Unit(s.unitTag).Return(s.relationUnit, nil).AnyTimes()
+	s.relation.EXPECT().Unit(gomock.Any(), s.unitTag).Return(s.relationUnit, nil).AnyTimes()
 }
 
 func (s *baseStateTrackerSuite) expectRelationSetStatusJoined() {
-	s.relation.EXPECT().SetStatus(corerelation.Joined)
+	s.relation.EXPECT().SetStatus(gomock.Any(), corerelation.Joined)
 }
 
 func (s *baseStateTrackerSuite) expectRelationID(id int) {
@@ -652,7 +653,7 @@ func (s *baseStateTrackerSuite) expectRelationID(id int) {
 }
 
 func (s *baseStateTrackerSuite) expectRelationEndpoint(ep *uniter.Endpoint) {
-	s.relation.EXPECT().Endpoint().Return(ep, nil)
+	s.relation.EXPECT().Endpoint(gomock.Any()).Return(ep, nil)
 }
 
 func (s *syncScopesSuite) expectRelationOtherApplication() {
@@ -665,7 +666,7 @@ func (s *syncScopesSuite) expectString() {
 
 // StateManager
 func (s *baseStateTrackerSuite) expectStateMgrRemoveRelation(id int) {
-	s.stateMgr.EXPECT().RemoveRelation(id, s.client, map[string]bool{}).Return(nil)
+	s.stateMgr.EXPECT().RemoveRelation(gomock.Any(), id, s.client, map[string]bool{}).Return(nil)
 }
 
 func (s *baseStateTrackerSuite) expectStateMgrKnownIDs(ids []int) {
@@ -678,11 +679,11 @@ func (s *baseStateTrackerSuite) expectStateMgrRelationFound(id int) {
 
 // State
 func (s *baseStateTrackerSuite) expectRelation(relTag names.RelationTag) {
-	s.client.EXPECT().Relation(relTag).Return(s.relation, nil)
+	s.client.EXPECT().Relation(gomock.Any(), relTag).Return(s.relation, nil)
 }
 
 func (s *syncScopesSuite) expectRelationById(id int) {
-	s.client.EXPECT().RelationById(id).Return(s.relation, nil)
+	s.client.EXPECT().RelationById(gomock.Any(), id).Return(s.relation, nil)
 }
 
 // Unit

--- a/internal/worker/uniter/remotestate/interface.go
+++ b/internal/worker/uniter/remotestate/interface.go
@@ -4,6 +4,7 @@
 package remotestate
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -35,11 +36,11 @@ type UpdateStatusTimerFunc func(duration time.Duration) Waiter
 
 type UniterClient interface {
 	Charm(url string) (api.Charm, error)
-	Relation(tag names.RelationTag) (api.Relation, error)
+	Relation(ctx context.Context, tag names.RelationTag) (api.Relation, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
 	StorageAttachmentLife([]params.StorageAttachmentId) ([]params.LifeResult, error)
-	Unit(names.UnitTag) (api.Unit, error)
-	WatchRelationUnits(names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
+	Unit(context.Context, names.UnitTag) (api.Unit, error)
+	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)
 	UpdateStatusHookInterval() (time.Duration, error)

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -4,6 +4,7 @@
 package remotestate_test
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -129,7 +130,7 @@ func (c *mockCharm) LXDProfileRequired() (bool, error) {
 	return c.required, nil
 }
 
-func (m *mockUniterClient) Relation(tag names.RelationTag) (api.Relation, error) {
+func (m *mockUniterClient) Relation(_ context.Context, tag names.RelationTag) (api.Relation, error) {
 	r, ok := m.relations[tag]
 	if !ok {
 		return nil, &params.Error{Code: params.CodeNotFound}
@@ -173,7 +174,7 @@ func (m *mockUniterClient) StorageAttachmentLife(
 	return results, nil
 }
 
-func (m *mockUniterClient) Unit(tag names.UnitTag) (api.Unit, error) {
+func (m *mockUniterClient) Unit(_ context.Context, tag names.UnitTag) (api.Unit, error) {
 	if tag != m.unit.tag {
 		return nil, &params.Error{Code: params.CodeNotFound}
 	}
@@ -181,7 +182,7 @@ func (m *mockUniterClient) Unit(tag names.UnitTag) (api.Unit, error) {
 }
 
 func (m *mockUniterClient) WatchRelationUnits(
-	relationTag names.RelationTag, unitTag names.UnitTag,
+	_ context.Context, relationTag names.RelationTag, unitTag names.UnitTag,
 ) (watcher.RelationUnitsWatcher, error) {
 	if unitTag != m.unit.tag {
 		return nil, &params.Error{Code: params.CodeNotFound}
@@ -241,7 +242,7 @@ func (u *mockUnit) LXDProfileName() (string, error) {
 	return u.lxdProfileName, nil
 }
 
-func (u *mockUnit) Refresh() error {
+func (u *mockUnit) Refresh(context.Context) error {
 	return nil
 }
 
@@ -253,7 +254,7 @@ func (u *mockUnit) Resolved() params.ResolvedMode {
 	return u.resolved
 }
 
-func (u *mockUnit) Application() (api.Application, error) {
+func (u *mockUnit) Application(context.Context) (api.Application, error) {
 	return &u.application, nil
 }
 
@@ -328,7 +329,7 @@ func (s *mockApplication) Life() life.Value {
 	return s.life
 }
 
-func (s *mockApplication) Refresh() error {
+func (s *mockApplication) Refresh(context.Context) error {
 	return nil
 }
 

--- a/internal/worker/uniter/resolver/mock_test.go
+++ b/internal/worker/uniter/resolver/mock_test.go
@@ -64,7 +64,7 @@ func (f *mockOpFactory) NewSkipHook(info hook.Info) (operation.Operation, error)
 	return f.op, f.NextErr()
 }
 
-func (f *mockOpFactory) NewAction(id string) (operation.Operation, error) {
+func (f *mockOpFactory) NewAction(_ context.Context, id string) (operation.Operation, error) {
 	f.MethodCall(f, "NewAction", id)
 	return f.op, f.NextErr()
 }

--- a/internal/worker/uniter/resolver/opfactory.go
+++ b/internal/worker/uniter/resolver/opfactory.go
@@ -102,8 +102,8 @@ func (s *resolverOpFactory) NewResolvedUpgrade(charmURL string) (operation.Opera
 	return s.wrapUpgradeOp(op, charmURL), nil
 }
 
-func (s *resolverOpFactory) NewAction(id string) (operation.Operation, error) {
-	op, err := s.Factory.NewAction(id)
+func (s *resolverOpFactory) NewAction(ctx context.Context, id string) (operation.Operation, error) {
+	op, err := s.Factory.NewAction(ctx, id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/uniter/resolver/opfactory_test.go
+++ b/internal/worker/uniter/resolver/opfactory_test.go
@@ -234,7 +234,7 @@ func (s *ResolverOpFactorySuite) TestActionsCommit(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
 	f.RemoteState.ActionsPending = []string{"action 1", "action 2", "action 3"}
 	f.LocalState.CompletedActions = map[string]struct{}{}
-	op, err := f.NewAction("action 1")
+	op, err := f.NewAction(context.Background(), "action 1")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -251,7 +251,7 @@ func (s *ResolverOpFactorySuite) TestActionsTrimming(c *gc.C) {
 		"b": {},
 		"c": {},
 	}
-	op, err := f.NewAction("d")
+	op, err := f.NewAction(context.Background(), "d")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runcommands/mock_test.go
+++ b/internal/worker/uniter/runcommands/mock_test.go
@@ -4,6 +4,8 @@
 package runcommands_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	"github.com/juju/utils/v3/exec"
 
@@ -17,7 +19,7 @@ type mockRunnerFactory struct {
 	newCommandRunner func(runnercontext.CommandInfo) (runner.Runner, error)
 }
 
-func (f *mockRunnerFactory) NewCommandRunner(info runnercontext.CommandInfo) (runner.Runner, error) {
+func (f *mockRunnerFactory) NewCommandRunner(_ context.Context, info runnercontext.CommandInfo) (runner.Runner, error) {
 	return f.newCommandRunner(info)
 }
 
@@ -30,7 +32,7 @@ func (r *mockRunner) Context() runnercontext.Context {
 	return &mockRunnerContext{}
 }
 
-func (r *mockRunner) RunCommands(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+func (r *mockRunner) RunCommands(_ context.Context, commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
 	return r.runCommands(commands, runLocation)
 }
 
@@ -38,7 +40,7 @@ type mockRunnerContext struct {
 	runnercontext.Context
 }
 
-func (*mockRunnerContext) Prepare() error {
+func (*mockRunnerContext) Prepare(context.Context) error {
 	return nil
 }
 

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -4,6 +4,8 @@
 package context
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -92,12 +94,12 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	machPorts, err := hcParams.Uniter.OpenedMachinePortRangesByEndpoint(ctx.assignedMachineTag)
+	machPorts, err := hcParams.Uniter.OpenedMachinePortRangesByEndpoint(context.Background(), ctx.assignedMachineTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	appPortRanges, err := hcParams.Uniter.OpenedPortRangesByEndpoint()
+	appPortRanges, err := hcParams.Uniter.OpenedPortRangesByEndpoint(context.Background())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/context/flush_test.go
+++ b/internal/worker/uniter/runner/context/flush_test.go
@@ -4,6 +4,8 @@
 package context_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -55,7 +57,7 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingError(c *gc.C) {
 	node1.Set("bar", "2")
 
 	// Flush the context with a failure.
-	err = ctx.Flush("some badge", errors.New("blam pow"))
+	err = ctx.Flush(stdcontext.Background(), "some badge", errors.New("blam pow"))
 	c.Assert(err, gc.ErrorMatches, "blam pow")
 }
 
@@ -97,7 +99,7 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingSuccess(c *gc.C) {
 	}}).Return(nil)
 
 	// Flush the context with a success.
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -113,13 +115,13 @@ func (s *FlushContextSuite) TestRebootAfterHook(c *gc.C) {
 
 	// Flush the context with an error and check that reboot is not triggered.
 	expErr := errors.New("hook execution failed")
-	err = ctx.Flush("some badge", expErr)
+	err = ctx.Flush(stdcontext.Background(), "some badge", expErr)
 	c.Assert(err, gc.Equals, expErr)
 
 	// Flush the context without an error and check that reboot is triggered.
 	s.unit.EXPECT().SetAgentStatus(status.Rebooting, "", nil).Return(nil)
 	s.unit.EXPECT().RequestReboot().Return(nil)
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, gc.Equals, context.ErrReboot)
 }
 
@@ -143,7 +145,7 @@ func (s *FlushContextSuite) TestRebootWhenHookFails(c *gc.C) {
 
 	// Flush the context with an error and check that reboot is not triggered.
 	expErr := errors.New("hook execution failed")
-	err = ctx.Flush("some badge", expErr)
+	err = ctx.Flush(stdcontext.Background(), "some badge", expErr)
 	c.Assert(err, gc.ErrorMatches, "hook execution failed")
 }
 
@@ -170,7 +172,7 @@ func (s *FlushContextSuite) TestRebootNowWhenHookFails(c *gc.C) {
 	s.unit.EXPECT().RequestReboot().Return(nil)
 
 	expErr := errors.New("hook execution failed")
-	err = ctx.Flush("some badge", expErr)
+	err = ctx.Flush(stdcontext.Background(), "some badge", expErr)
 	c.Assert(err, gc.Equals, context.ErrRequeueAndReboot)
 }
 
@@ -196,7 +198,7 @@ func (s *FlushContextSuite) TestRebootNow(c *gc.C) {
 	s.unit.EXPECT().SetAgentStatus(status.Rebooting, "", nil).Return(nil)
 	s.unit.EXPECT().RequestReboot().Return(nil)
 
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, gc.Equals, context.ErrRequeueAndReboot)
 }
 
@@ -277,7 +279,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	}}).Return(nil)
 
 	// Flush the context with a success.
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -341,7 +343,7 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 	}}).Return(nil)
 
 	// Flush the context with a success.
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -366,7 +368,7 @@ func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
 		paths.GetMetricsSpoolDir(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.Flush("some badge", nil)
+	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/context/relation.go
+++ b/internal/worker/uniter/runner/context/relation.go
@@ -4,6 +4,7 @@
 package context
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -137,8 +138,8 @@ func (ctx *ContextRelation) Suspended() bool {
 }
 
 // SetStatus sets the relation's status.
-func (ctx *ContextRelation) SetStatus(status relation.Status) error {
-	return errors.Trace(ctx.ru.Relation().SetStatus(status))
+func (ctx *ContextRelation) SetStatus(stdCtx context.Context, status relation.Status) error {
+	return errors.Trace(ctx.ru.Relation().SetStatus(stdCtx, status))
 }
 
 // RemoteApplicationName returns the application on the other end of this

--- a/internal/worker/uniter/runner/context/relation_test.go
+++ b/internal/worker/uniter/runner/context/relation_test.go
@@ -4,6 +4,8 @@
 package context_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/charm/v12"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -83,10 +85,10 @@ func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
 func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 	defer s.setUp(c).Finish()
 
-	s.rel.EXPECT().SetStatus(relation.Suspended).Return(nil)
+	s.rel.EXPECT().SetStatus(gomock.Any(), relation.Suspended).Return(nil)
 
 	ctx := context.NewContextRelation(s.relUnit, nil)
-	err := ctx.SetStatus(relation.Suspended)
+	err := ctx.SetStatus(stdcontext.Background(), relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/worker/uniter/runner/context/storage_test.go
+++ b/internal/worker/uniter/runner/context/storage_test.go
@@ -4,6 +4,8 @@
 package context_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -67,7 +69,7 @@ func (s *StorageSuite) assertUnitStorageAdded(c *gc.C, ctrl *gomock.Controller, 
 	}}).Return(nil)
 
 	// Flush the context with a success.
-	err := ctx.Flush("success", nil)
+	err := ctx.Flush(context.Background(), "success", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -87,6 +89,6 @@ func (s *StorageSuite) TestRunHookAddStorageOnFailure(c *gc.C) {
 
 	// Flush the context with an error.
 	msg := "test fail run hook"
-	err = ctx.Flush("test fail run hook", errors.New(msg))
+	err = ctx.Flush(context.Background(), "test fail run hook", errors.New(msg))
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }

--- a/internal/worker/uniter/runner/context/util_test.go
+++ b/internal/worker/uniter/runner/context/util_test.go
@@ -4,6 +4,7 @@
 package context_test
 
 import (
+	"context"
 	"reflect"
 	"time"
 
@@ -163,10 +164,10 @@ func (s *BaseHookContextSuite) setupUnit(ctrl *gomock.Controller) names.MachineT
 func (s *BaseHookContextSuite) setupUniter(ctrl *gomock.Controller) names.MachineTag {
 	machineTag := s.setupUnit(ctrl)
 	s.uniter = uniterapi.NewMockUniterClient(ctrl)
-	s.uniter.EXPECT().OpenedMachinePortRangesByEndpoint(machineTag).DoAndReturn(func(_ names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error) {
+	s.uniter.EXPECT().OpenedMachinePortRangesByEndpoint(gomock.Any(), machineTag).DoAndReturn(func(_ context.Context, _ names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error) {
 		return s.machinePortRanges, nil
 	}).AnyTimes()
-	s.uniter.EXPECT().OpenedPortRangesByEndpoint().Return(nil, nil).AnyTimes()
+	s.uniter.EXPECT().OpenedPortRangesByEndpoint(gomock.Any()).Return(nil, nil).AnyTimes()
 	return machineTag
 }
 

--- a/internal/worker/uniter/runner/jujuc/application-version-set.go
+++ b/internal/worker/uniter/runner/jujuc/application-version-set.go
@@ -52,5 +52,5 @@ func (c *applicationVersionSetCommand) Init(args []string) error {
 
 // Run is part of the cmd.Command interface.
 func (c *applicationVersionSetCommand) Run(ctx *cmd.Context) error {
-	return c.ctx.SetUnitWorkloadVersion(c.version)
+	return c.ctx.SetUnitWorkloadVersion(ctx, c.version)
 }

--- a/internal/worker/uniter/runner/jujuc/context.go
+++ b/internal/worker/uniter/runner/jujuc/context.go
@@ -147,10 +147,10 @@ type ContextUnit interface {
 	ConfigSettings() (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.
-	GoalState() (*application.GoalState, error)
+	GoalState(context.Context) (*application.GoalState, error)
 
 	// CloudSpec returns the unit's cloud specification
-	CloudSpec() (*params.CloudSpec, error)
+	CloudSpec(context.Context) (*params.CloudSpec, error)
 }
 
 // SecretCreateArgs specifies args used to create a secret.
@@ -222,17 +222,17 @@ type ContextSecrets interface {
 // ContextStatus is the part of a hook context related to the unit's status.
 type ContextStatus interface {
 	// UnitStatus returns the executing unit's current status.
-	UnitStatus() (*StatusInfo, error)
+	UnitStatus(context.Context) (*StatusInfo, error)
 
 	// SetUnitStatus updates the unit's status.
-	SetUnitStatus(StatusInfo) error
+	SetUnitStatus(context.Context, StatusInfo) error
 
 	// ApplicationStatus returns the executing unit's application status
 	// (including all units).
-	ApplicationStatus() (ApplicationStatusInfo, error)
+	ApplicationStatus(context.Context) (ApplicationStatusInfo, error)
 
 	// SetApplicationStatus updates the status for the unit's application.
-	SetApplicationStatus(StatusInfo) error
+	SetApplicationStatus(context.Context, StatusInfo) error
 }
 
 // RebootPriority is the type used for reboot requests.
@@ -398,7 +398,7 @@ type ContextRelation interface {
 	Suspended() bool
 
 	// SetStatus sets the relation's status.
-	SetStatus(relation.Status) error
+	SetStatus(context.Context, relation.Status) error
 
 	// RemoteApplicationName returns the application on the other end of
 	// the relation from the perspective of this unit.
@@ -430,10 +430,10 @@ type ContextVersion interface {
 
 	// UnitWorkloadVersion returns the currently set workload version for
 	// the unit.
-	UnitWorkloadVersion() (string, error)
+	UnitWorkloadVersion(context.Context) (string, error)
 
 	// SetUnitWorkloadVersion updates the workload version for the unit.
-	SetUnitWorkloadVersion(string) error
+	SetUnitWorkloadVersion(context.Context, string) error
 }
 
 // Settings is implemented by types that manipulate unit settings.

--- a/internal/worker/uniter/runner/jujuc/credential-get.go
+++ b/internal/worker/uniter/runner/jujuc/credential-get.go
@@ -48,7 +48,7 @@ func (c *CredentialGetCommand) Init(args []string) error {
 
 // Run is part of the cmd.Command interface.
 func (c *CredentialGetCommand) Run(ctx *cmd.Context) error {
-	credential, err := c.ctx.CloudSpec()
+	credential, err := c.ctx.CloudSpec(ctx)
 	if err != nil {
 		return errors.Annotatef(err, "cannot access cloud credentials")
 	}

--- a/internal/worker/uniter/runner/jujuc/goal-state.go
+++ b/internal/worker/uniter/runner/jujuc/goal-state.go
@@ -45,7 +45,7 @@ func (c *GoalStateCommand) Init(args []string) error {
 }
 
 func (c *GoalStateCommand) Run(ctx *cmd.Context) error {
-	goalState, err := c.ctx.GoalState()
+	goalState, err := c.ctx.GoalState(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -4,6 +4,7 @@
 package jujuctesting
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -174,7 +175,7 @@ func (r *ContextRelation) Suspended() bool {
 }
 
 // SetStatus implements jujuc.ContextRelation.
-func (r *ContextRelation) SetStatus(status relation.Status) error {
+func (r *ContextRelation) SetStatus(_ context.Context, status relation.Status) error {
 	return nil
 }
 

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/status.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/status.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/internal/worker/uniter/runner/jujuc"
@@ -30,7 +32,7 @@ type ContextStatus struct {
 }
 
 // UnitStatus implements jujuc.ContextStatus.
-func (c *ContextStatus) UnitStatus() (*jujuc.StatusInfo, error) {
+func (c *ContextStatus) UnitStatus(context.Context) (*jujuc.StatusInfo, error) {
 	c.stub.AddCall("UnitStatus")
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -40,7 +42,7 @@ func (c *ContextStatus) UnitStatus() (*jujuc.StatusInfo, error) {
 }
 
 // SetUnitStatus implements jujuc.ContextStatus.
-func (c *ContextStatus) SetUnitStatus(status jujuc.StatusInfo) error {
+func (c *ContextStatus) SetUnitStatus(_ context.Context, status jujuc.StatusInfo) error {
 	c.stub.AddCall("SetUnitStatus", status)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)
@@ -51,7 +53,7 @@ func (c *ContextStatus) SetUnitStatus(status jujuc.StatusInfo) error {
 }
 
 // ApplicationStatus implements jujuc.ContextStatus.
-func (c *ContextStatus) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
+func (c *ContextStatus) ApplicationStatus(context.Context) (jujuc.ApplicationStatusInfo, error) {
 	c.stub.AddCall("ApplicationStatus")
 	if err := c.stub.NextErr(); err != nil {
 		return jujuc.ApplicationStatusInfo{}, errors.Trace(err)
@@ -61,7 +63,7 @@ func (c *ContextStatus) ApplicationStatus() (jujuc.ApplicationStatusInfo, error)
 }
 
 // SetApplicationStatus implements jujuc.ContextStatus.
-func (c *ContextStatus) SetApplicationStatus(status jujuc.StatusInfo) error {
+func (c *ContextStatus) SetApplicationStatus(_ context.Context, status jujuc.StatusInfo) error {
 	c.stub.AddCall("SetApplicationStatus", status)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 
@@ -46,7 +48,7 @@ func (c *ContextUnit) ConfigSettings() (charm.Settings, error) {
 }
 
 // GoalState implements jujuc.ContextUnit.
-func (c *ContextUnit) GoalState() (*application.GoalState, error) {
+func (c *ContextUnit) GoalState(context.Context) (*application.GoalState, error) {
 	c.stub.AddCall("GoalState")
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -54,7 +56,7 @@ func (c *ContextUnit) GoalState() (*application.GoalState, error) {
 	return &c.info.GoalState, nil
 }
 
-func (c *ContextUnit) CloudSpec() (*params.CloudSpec, error) {
+func (c *ContextUnit) CloudSpec(context.Context) (*params.CloudSpec, error) {
 	c.stub.AddCall("CloudSpec")
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/version.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/version.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 )
 
@@ -19,7 +21,7 @@ type ContextVersion struct {
 }
 
 // UnitWorkloadVersion implements jujuc.ContextVersion.
-func (c *ContextVersion) UnitWorkloadVersion() (string, error) {
+func (c *ContextVersion) UnitWorkloadVersion(_ context.Context) (string, error) {
 	c.stub.AddCall("UnitWorkloadVersion")
 	if err := c.stub.NextErr(); err != nil {
 		return "", errors.Trace(err)
@@ -28,7 +30,7 @@ func (c *ContextVersion) UnitWorkloadVersion() (string, error) {
 }
 
 // SetUnitWorkloadVersion implements jujuc.ContextVersion.
-func (c *ContextVersion) SetUnitWorkloadVersion(version string) error {
+func (c *ContextVersion) SetUnitWorkloadVersion(_ context.Context, version string) error {
 	c.stub.AddCall("SetUnitWorkloadVersion", version)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -107,18 +107,18 @@ func (mr *MockContextMockRecorder) AddUnitStorage(arg0 any) *gomock.Call {
 }
 
 // ApplicationStatus mocks base method.
-func (m *MockContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
+func (m *MockContext) ApplicationStatus(arg0 context.Context) (jujuc.ApplicationStatusInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationStatus")
+	ret := m.ctrl.Call(m, "ApplicationStatus", arg0)
 	ret0, _ := ret[0].(jujuc.ApplicationStatusInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationStatus indicates an expected call of ApplicationStatus.
-func (mr *MockContextMockRecorder) ApplicationStatus() *gomock.Call {
+func (mr *MockContextMockRecorder) ApplicationStatus(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationStatus", reflect.TypeOf((*MockContext)(nil).ApplicationStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationStatus", reflect.TypeOf((*MockContext)(nil).ApplicationStatus), arg0)
 }
 
 // AvailabilityZone mocks base method.
@@ -151,18 +151,18 @@ func (mr *MockContextMockRecorder) ClosePortRange(arg0, arg1 any) *gomock.Call {
 }
 
 // CloudSpec mocks base method.
-func (m *MockContext) CloudSpec() (*params.CloudSpec, error) {
+func (m *MockContext) CloudSpec(arg0 context.Context) (*params.CloudSpec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudSpec")
+	ret := m.ctrl.Call(m, "CloudSpec", arg0)
 	ret0, _ := ret[0].(*params.CloudSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloudSpec indicates an expected call of CloudSpec.
-func (mr *MockContextMockRecorder) CloudSpec() *gomock.Call {
+func (mr *MockContextMockRecorder) CloudSpec(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockContext)(nil).CloudSpec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockContext)(nil).CloudSpec), arg0)
 }
 
 // ConfigSettings mocks base method.
@@ -313,18 +313,18 @@ func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 any) *gomock
 }
 
 // GoalState mocks base method.
-func (m *MockContext) GoalState() (*application.GoalState, error) {
+func (m *MockContext) GoalState(arg0 context.Context) (*application.GoalState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GoalState")
+	ret := m.ctrl.Call(m, "GoalState", arg0)
 	ret0, _ := ret[0].(*application.GoalState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GoalState indicates an expected call of GoalState.
-func (mr *MockContextMockRecorder) GoalState() *gomock.Call {
+func (mr *MockContextMockRecorder) GoalState(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState), arg0)
 }
 
 // GrantSecret mocks base method.
@@ -649,17 +649,17 @@ func (mr *MockContextMockRecorder) SetActionMessage(arg0 any) *gomock.Call {
 }
 
 // SetApplicationStatus mocks base method.
-func (m *MockContext) SetApplicationStatus(arg0 jujuc.StatusInfo) error {
+func (m *MockContext) SetApplicationStatus(arg0 context.Context, arg1 jujuc.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetApplicationStatus", arg0)
+	ret := m.ctrl.Call(m, "SetApplicationStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetApplicationStatus indicates an expected call of SetApplicationStatus.
-func (mr *MockContextMockRecorder) SetApplicationStatus(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetApplicationStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationStatus", reflect.TypeOf((*MockContext)(nil).SetApplicationStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationStatus", reflect.TypeOf((*MockContext)(nil).SetApplicationStatus), arg0, arg1)
 }
 
 // SetCharmStateValue mocks base method.
@@ -691,31 +691,31 @@ func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2 any) *gomoc
 }
 
 // SetUnitStatus mocks base method.
-func (m *MockContext) SetUnitStatus(arg0 jujuc.StatusInfo) error {
+func (m *MockContext) SetUnitStatus(arg0 context.Context, arg1 jujuc.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitStatus", arg0)
+	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitStatus indicates an expected call of SetUnitStatus.
-func (mr *MockContextMockRecorder) SetUnitStatus(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetUnitStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockContext)(nil).SetUnitStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockContext)(nil).SetUnitStatus), arg0, arg1)
 }
 
 // SetUnitWorkloadVersion mocks base method.
-func (m *MockContext) SetUnitWorkloadVersion(arg0 string) error {
+func (m *MockContext) SetUnitWorkloadVersion(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", arg0)
+	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitWorkloadVersion indicates an expected call of SetUnitWorkloadVersion.
-func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).SetUnitWorkloadVersion), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).SetUnitWorkloadVersion), arg0, arg1)
 }
 
 // Storage mocks base method.
@@ -777,33 +777,33 @@ func (mr *MockContextMockRecorder) UnitName() *gomock.Call {
 }
 
 // UnitStatus mocks base method.
-func (m *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
+func (m *MockContext) UnitStatus(arg0 context.Context) (*jujuc.StatusInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitStatus")
+	ret := m.ctrl.Call(m, "UnitStatus", arg0)
 	ret0, _ := ret[0].(*jujuc.StatusInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitStatus indicates an expected call of UnitStatus.
-func (mr *MockContextMockRecorder) UnitStatus() *gomock.Call {
+func (mr *MockContextMockRecorder) UnitStatus(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockContext)(nil).UnitStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockContext)(nil).UnitStatus), arg0)
 }
 
 // UnitWorkloadVersion mocks base method.
-func (m *MockContext) UnitWorkloadVersion() (string, error) {
+func (m *MockContext) UnitWorkloadVersion(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitWorkloadVersion")
+	ret := m.ctrl.Call(m, "UnitWorkloadVersion", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitWorkloadVersion indicates an expected call of UnitWorkloadVersion.
-func (mr *MockContextMockRecorder) UnitWorkloadVersion() *gomock.Call {
+func (mr *MockContextMockRecorder) UnitWorkloadVersion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).UnitWorkloadVersion))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).UnitWorkloadVersion), arg0)
 }
 
 // UntrackPayload mocks base method.

--- a/internal/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	life "github.com/juju/juju/core/life"
@@ -173,17 +174,17 @@ func (mr *MockContextRelationMockRecorder) RemoteApplicationName() *gomock.Call 
 }
 
 // SetStatus mocks base method.
-func (m *MockContextRelation) SetStatus(arg0 relation.Status) error {
+func (m *MockContextRelation) SetStatus(arg0 context.Context, arg1 relation.Status) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockContextRelationMockRecorder) SetStatus(arg0 any) *gomock.Call {
+func (mr *MockContextRelationMockRecorder) SetStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockContextRelation)(nil).SetStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockContextRelation)(nil).SetStatus), arg0, arg1)
 }
 
 // Settings mocks base method.

--- a/internal/worker/uniter/runner/jujuc/restricted.go
+++ b/internal/worker/uniter/runner/jujuc/restricted.go
@@ -30,7 +30,7 @@ type RestrictedContext struct{}
 func (*RestrictedContext) ConfigSettings() (charm.Settings, error) { return nil, ErrRestrictedContext }
 
 // GoalState implements hooks.Context.
-func (*RestrictedContext) GoalState() (*application.GoalState, error) {
+func (*RestrictedContext) GoalState(context.Context) (*application.GoalState, error) {
 	return &application.GoalState{}, ErrRestrictedContext
 }
 
@@ -55,25 +55,27 @@ func (*RestrictedContext) SetCharmStateValue(string, string) error {
 }
 
 // UnitStatus implements hooks.Context.
-func (*RestrictedContext) UnitStatus() (*StatusInfo, error) {
+func (*RestrictedContext) UnitStatus(context.Context) (*StatusInfo, error) {
 	return nil, ErrRestrictedContext
 }
 
 // CloudSpec implements hooks.Context.
-func (c *RestrictedContext) CloudSpec() (*params.CloudSpec, error) {
+func (c *RestrictedContext) CloudSpec(context.Context) (*params.CloudSpec, error) {
 	return nil, ErrRestrictedContext
 }
 
 // SetUnitStatus implements hooks.Context.
-func (*RestrictedContext) SetUnitStatus(StatusInfo) error { return ErrRestrictedContext }
+func (*RestrictedContext) SetUnitStatus(context.Context, StatusInfo) error {
+	return ErrRestrictedContext
+}
 
 // ApplicationStatus implements hooks.Context.
-func (*RestrictedContext) ApplicationStatus() (ApplicationStatusInfo, error) {
+func (*RestrictedContext) ApplicationStatus(context.Context) (ApplicationStatusInfo, error) {
 	return ApplicationStatusInfo{}, ErrRestrictedContext
 }
 
 // SetApplicationStatus implements hooks.Context.
-func (*RestrictedContext) SetApplicationStatus(StatusInfo) error {
+func (*RestrictedContext) SetApplicationStatus(context.Context, StatusInfo) error {
 	return ErrRestrictedContext
 }
 
@@ -220,12 +222,12 @@ func (*RestrictedContext) SetActionMessage(string) error { return ErrRestrictedC
 func (*RestrictedContext) SetActionFailed() error { return ErrRestrictedContext }
 
 // UnitWorkloadVersion implements hooks.Context.
-func (*RestrictedContext) UnitWorkloadVersion() (string, error) {
+func (*RestrictedContext) UnitWorkloadVersion(context.Context) (string, error) {
 	return "", ErrRestrictedContext
 }
 
 // SetUnitWorkloadVersion implements hooks.Context.
-func (*RestrictedContext) SetUnitWorkloadVersion(string) error {
+func (*RestrictedContext) SetUnitWorkloadVersion(context.Context, string) error {
 	return ErrRestrictedContext
 }
 

--- a/internal/worker/uniter/runner/jujuc/server.go
+++ b/internal/worker/uniter/runner/jujuc/server.go
@@ -5,6 +5,7 @@ package jujuc
 
 import (
 	"bytes"
+	stdcontext "context"
 	"fmt"
 	"io"
 	"net"
@@ -193,11 +194,14 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 		stdin = noStdinReader{}
 	}
 	var stdout, stderr bytes.Buffer
+	// TODO(wallyworld) - We should not allow direct construction of cmd.Context
+	// since this can result in the embedded context.Context being nil.
 	ctx := &cmd.Context{
-		Dir:    req.Dir,
-		Stdin:  stdin,
-		Stdout: &stdout,
-		Stderr: &stderr,
+		Context: stdcontext.Background(),
+		Dir:     req.Dir,
+		Stdin:   stdin,
+		Stdout:  &stdout,
+		Stderr:  &stderr,
 	}
 	j.mu.Lock()
 	defer j.mu.Unlock()

--- a/internal/worker/uniter/runner/jujuc/status-get.go
+++ b/internal/worker/uniter/runner/jujuc/status-get.go
@@ -77,7 +77,7 @@ func toDetails(info StatusInfo, includeData bool) map[string]interface{} {
 }
 
 func (c *StatusGetCommand) ApplicationStatus(ctx *cmd.Context) error {
-	applicationStatus, err := c.ctx.ApplicationStatus()
+	applicationStatus, err := c.ctx.ApplicationStatus(ctx)
 	if err != nil {
 		if errors.Is(err, errors.NotImplemented) {
 			return c.out.Write(ctx, status.Unknown)
@@ -110,7 +110,7 @@ func (c *StatusGetCommand) unitOrApplicationStatus(ctx *cmd.Context) error {
 		return c.ApplicationStatus(ctx)
 	}
 
-	unitStatus, err := c.ctx.UnitStatus()
+	unitStatus, err := c.ctx.UnitStatus(ctx)
 	if err != nil {
 		if errors.Is(err, errors.NotImplemented) {
 			return c.out.Write(ctx, status.Unknown)

--- a/internal/worker/uniter/runner/jujuc/status-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/status-get_test.go
@@ -4,6 +4,7 @@
 package jujuc_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ var statusGetTests = []struct {
 }
 
 func setFakeStatus(ctx *Context) {
-	ctx.SetUnitStatus(jujuc.StatusInfo{
+	ctx.SetUnitStatus(context.Background(), jujuc.StatusInfo{
 		Status: statusAttributes["status"].(string),
 		Info:   statusAttributes["message"].(string),
 		Data:   statusAttributes["status-data"].(map[string]interface{}),

--- a/internal/worker/uniter/runner/jujuc/status-set.go
+++ b/internal/worker/uniter/runner/jujuc/status-set.go
@@ -79,8 +79,8 @@ func (c *StatusSetCommand) Run(ctx *cmd.Context) error {
 		Info:   c.message,
 	}
 	if c.application {
-		return c.ctx.SetApplicationStatus(statusInfo)
+		return c.ctx.SetApplicationStatus(ctx, statusInfo)
 	}
-	return c.ctx.SetUnitStatus(statusInfo)
+	return c.ctx.SetUnitStatus(ctx, statusInfo)
 
 }

--- a/internal/worker/uniter/runner/jujuc/status-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/status-set_test.go
@@ -4,6 +4,8 @@
 package jujuc_test
 
 import (
+	"context"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	jc "github.com/juju/testing/checkers"
@@ -84,7 +86,7 @@ func (s *statusSetSuite) TestStatus(c *gc.C) {
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-		status, err := hctx.UnitStatus()
+		status, err := hctx.UnitStatus(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(status.Status, gc.Equals, args[0])
 		c.Assert(status.Info, gc.Equals, args[1])
@@ -105,7 +107,7 @@ func (s *statusSetSuite) TestApplicationStatus(c *gc.C) {
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-		status, err := hctx.ApplicationStatus()
+		status, err := hctx.ApplicationStatus(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(status.Application.Status, gc.Equals, args[1])
 		c.Assert(status.Application.Info, gc.Equals, args[2])

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -124,18 +124,18 @@ func (mr *MockContextMockRecorder) AddUnitStorage(arg0 any) *gomock.Call {
 }
 
 // ApplicationStatus mocks base method.
-func (m *MockContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
+func (m *MockContext) ApplicationStatus(arg0 context.Context) (jujuc.ApplicationStatusInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationStatus")
+	ret := m.ctrl.Call(m, "ApplicationStatus", arg0)
 	ret0, _ := ret[0].(jujuc.ApplicationStatusInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationStatus indicates an expected call of ApplicationStatus.
-func (mr *MockContextMockRecorder) ApplicationStatus() *gomock.Call {
+func (mr *MockContextMockRecorder) ApplicationStatus(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationStatus", reflect.TypeOf((*MockContext)(nil).ApplicationStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationStatus", reflect.TypeOf((*MockContext)(nil).ApplicationStatus), arg0)
 }
 
 // AvailabilityZone mocks base method.
@@ -168,18 +168,18 @@ func (mr *MockContextMockRecorder) ClosePortRange(arg0, arg1 any) *gomock.Call {
 }
 
 // CloudSpec mocks base method.
-func (m *MockContext) CloudSpec() (*params.CloudSpec, error) {
+func (m *MockContext) CloudSpec(arg0 context.Context) (*params.CloudSpec, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudSpec")
+	ret := m.ctrl.Call(m, "CloudSpec", arg0)
 	ret0, _ := ret[0].(*params.CloudSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloudSpec indicates an expected call of CloudSpec.
-func (mr *MockContextMockRecorder) CloudSpec() *gomock.Call {
+func (mr *MockContextMockRecorder) CloudSpec(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockContext)(nil).CloudSpec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockContext)(nil).CloudSpec), arg0)
 }
 
 // ConfigSettings mocks base method.
@@ -242,17 +242,17 @@ func (mr *MockContextMockRecorder) DownloadResource(arg0, arg1 any) *gomock.Call
 }
 
 // Flush mocks base method.
-func (m *MockContext) Flush(arg0 string, arg1 error) error {
+func (m *MockContext) Flush(arg0 context.Context, arg1 string, arg2 error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Flush", arg0, arg1)
+	ret := m.ctrl.Call(m, "Flush", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Flush indicates an expected call of Flush.
-func (mr *MockContextMockRecorder) Flush(arg0, arg1 any) *gomock.Call {
+func (mr *MockContextMockRecorder) Flush(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockContext)(nil).Flush), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockContext)(nil).Flush), arg0, arg1, arg2)
 }
 
 // FlushPayloads mocks base method.
@@ -344,18 +344,18 @@ func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 any) *gomock
 }
 
 // GoalState mocks base method.
-func (m *MockContext) GoalState() (*application.GoalState, error) {
+func (m *MockContext) GoalState(arg0 context.Context) (*application.GoalState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GoalState")
+	ret := m.ctrl.Call(m, "GoalState", arg0)
 	ret0, _ := ret[0].(*application.GoalState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GoalState indicates an expected call of GoalState.
-func (mr *MockContextMockRecorder) GoalState() *gomock.Call {
+func (mr *MockContextMockRecorder) GoalState(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState), arg0)
 }
 
 // GrantSecret mocks base method.
@@ -562,17 +562,17 @@ func (mr *MockContextMockRecorder) OpenedPortRanges() *gomock.Call {
 }
 
 // Prepare mocks base method.
-func (m *MockContext) Prepare() error {
+func (m *MockContext) Prepare(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prepare")
+	ret := m.ctrl.Call(m, "Prepare", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Prepare indicates an expected call of Prepare.
-func (mr *MockContextMockRecorder) Prepare() *gomock.Call {
+func (mr *MockContextMockRecorder) Prepare(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockContext)(nil).Prepare))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockContext)(nil).Prepare), arg0)
 }
 
 // PrivateAddress mocks base method.
@@ -763,17 +763,17 @@ func (mr *MockContextMockRecorder) SetActionMessage(arg0 any) *gomock.Call {
 }
 
 // SetApplicationStatus mocks base method.
-func (m *MockContext) SetApplicationStatus(arg0 jujuc.StatusInfo) error {
+func (m *MockContext) SetApplicationStatus(arg0 context.Context, arg1 jujuc.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetApplicationStatus", arg0)
+	ret := m.ctrl.Call(m, "SetApplicationStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetApplicationStatus indicates an expected call of SetApplicationStatus.
-func (mr *MockContextMockRecorder) SetApplicationStatus(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetApplicationStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationStatus", reflect.TypeOf((*MockContext)(nil).SetApplicationStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationStatus", reflect.TypeOf((*MockContext)(nil).SetApplicationStatus), arg0, arg1)
 }
 
 // SetCharmStateValue mocks base method.
@@ -817,31 +817,31 @@ func (mr *MockContextMockRecorder) SetProcess(arg0 any) *gomock.Call {
 }
 
 // SetUnitStatus mocks base method.
-func (m *MockContext) SetUnitStatus(arg0 jujuc.StatusInfo) error {
+func (m *MockContext) SetUnitStatus(arg0 context.Context, arg1 jujuc.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitStatus", arg0)
+	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitStatus indicates an expected call of SetUnitStatus.
-func (mr *MockContextMockRecorder) SetUnitStatus(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetUnitStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockContext)(nil).SetUnitStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockContext)(nil).SetUnitStatus), arg0, arg1)
 }
 
 // SetUnitWorkloadVersion mocks base method.
-func (m *MockContext) SetUnitWorkloadVersion(arg0 string) error {
+func (m *MockContext) SetUnitWorkloadVersion(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", arg0)
+	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUnitWorkloadVersion indicates an expected call of SetUnitWorkloadVersion.
-func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0 any) *gomock.Call {
+func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).SetUnitWorkloadVersion), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).SetUnitWorkloadVersion), arg0, arg1)
 }
 
 // Storage mocks base method.
@@ -903,33 +903,33 @@ func (mr *MockContextMockRecorder) UnitName() *gomock.Call {
 }
 
 // UnitStatus mocks base method.
-func (m *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
+func (m *MockContext) UnitStatus(arg0 context.Context) (*jujuc.StatusInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitStatus")
+	ret := m.ctrl.Call(m, "UnitStatus", arg0)
 	ret0, _ := ret[0].(*jujuc.StatusInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitStatus indicates an expected call of UnitStatus.
-func (mr *MockContextMockRecorder) UnitStatus() *gomock.Call {
+func (mr *MockContextMockRecorder) UnitStatus(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockContext)(nil).UnitStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockContext)(nil).UnitStatus), arg0)
 }
 
 // UnitWorkloadVersion mocks base method.
-func (m *MockContext) UnitWorkloadVersion() (string, error) {
+func (m *MockContext) UnitWorkloadVersion(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitWorkloadVersion")
+	ret := m.ctrl.Call(m, "UnitWorkloadVersion", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitWorkloadVersion indicates an expected call of UnitWorkloadVersion.
-func (mr *MockContextMockRecorder) UnitWorkloadVersion() *gomock.Call {
+func (mr *MockContextMockRecorder) UnitWorkloadVersion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).UnitWorkloadVersion))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).UnitWorkloadVersion), arg0)
 }
 
 // UntrackPayload mocks base method.

--- a/internal/worker/uniter/runner/mocks/factory_mock.go
+++ b/internal/worker/uniter/runner/mocks/factory_mock.go
@@ -10,12 +10,13 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uniter "github.com/juju/juju/api/agent/uniter"
 	hook "github.com/juju/juju/internal/worker/uniter/hook"
 	runner "github.com/juju/juju/internal/worker/uniter/runner"
-	context "github.com/juju/juju/internal/worker/uniter/runner/context"
+	context0 "github.com/juju/juju/internal/worker/uniter/runner/context"
 	exec "github.com/juju/utils/v3/exec"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -44,48 +45,48 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // NewActionRunner mocks base method.
-func (m *MockFactory) NewActionRunner(arg0 *uniter.Action, arg1 <-chan struct{}) (runner.Runner, error) {
+func (m *MockFactory) NewActionRunner(arg0 context.Context, arg1 *uniter.Action, arg2 <-chan struct{}) (runner.Runner, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewActionRunner", arg0, arg1)
+	ret := m.ctrl.Call(m, "NewActionRunner", arg0, arg1, arg2)
 	ret0, _ := ret[0].(runner.Runner)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewActionRunner indicates an expected call of NewActionRunner.
-func (mr *MockFactoryMockRecorder) NewActionRunner(arg0, arg1 any) *gomock.Call {
+func (mr *MockFactoryMockRecorder) NewActionRunner(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewActionRunner", reflect.TypeOf((*MockFactory)(nil).NewActionRunner), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewActionRunner", reflect.TypeOf((*MockFactory)(nil).NewActionRunner), arg0, arg1, arg2)
 }
 
 // NewCommandRunner mocks base method.
-func (m *MockFactory) NewCommandRunner(arg0 context.CommandInfo) (runner.Runner, error) {
+func (m *MockFactory) NewCommandRunner(arg0 context.Context, arg1 context0.CommandInfo) (runner.Runner, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCommandRunner", arg0)
+	ret := m.ctrl.Call(m, "NewCommandRunner", arg0, arg1)
 	ret0, _ := ret[0].(runner.Runner)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewCommandRunner indicates an expected call of NewCommandRunner.
-func (mr *MockFactoryMockRecorder) NewCommandRunner(arg0 any) *gomock.Call {
+func (mr *MockFactoryMockRecorder) NewCommandRunner(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCommandRunner", reflect.TypeOf((*MockFactory)(nil).NewCommandRunner), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCommandRunner", reflect.TypeOf((*MockFactory)(nil).NewCommandRunner), arg0, arg1)
 }
 
 // NewHookRunner mocks base method.
-func (m *MockFactory) NewHookRunner(arg0 hook.Info) (runner.Runner, error) {
+func (m *MockFactory) NewHookRunner(arg0 context.Context, arg1 hook.Info) (runner.Runner, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewHookRunner", arg0)
+	ret := m.ctrl.Call(m, "NewHookRunner", arg0, arg1)
 	ret0, _ := ret[0].(runner.Runner)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewHookRunner indicates an expected call of NewHookRunner.
-func (mr *MockFactoryMockRecorder) NewHookRunner(arg0 any) *gomock.Call {
+func (mr *MockFactoryMockRecorder) NewHookRunner(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewHookRunner", reflect.TypeOf((*MockFactory)(nil).NewHookRunner), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewHookRunner", reflect.TypeOf((*MockFactory)(nil).NewHookRunner), arg0, arg1)
 }
 
 // MockRunner is a mock of Runner interface.
@@ -112,10 +113,10 @@ func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 }
 
 // Context mocks base method.
-func (m *MockRunner) Context() context.Context {
+func (m *MockRunner) Context() context0.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
-	ret0, _ := ret[0].(context.Context)
+	ret0, _ := ret[0].(context0.Context)
 	return ret0
 }
 
@@ -126,46 +127,46 @@ func (mr *MockRunnerMockRecorder) Context() *gomock.Call {
 }
 
 // RunAction mocks base method.
-func (m *MockRunner) RunAction(arg0 string) (runner.HookHandlerType, error) {
+func (m *MockRunner) RunAction(arg0 context.Context, arg1 string) (runner.HookHandlerType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunAction", arg0)
+	ret := m.ctrl.Call(m, "RunAction", arg0, arg1)
 	ret0, _ := ret[0].(runner.HookHandlerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunAction indicates an expected call of RunAction.
-func (mr *MockRunnerMockRecorder) RunAction(arg0 any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) RunAction(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAction", reflect.TypeOf((*MockRunner)(nil).RunAction), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAction", reflect.TypeOf((*MockRunner)(nil).RunAction), arg0, arg1)
 }
 
 // RunCommands mocks base method.
-func (m *MockRunner) RunCommands(arg0 string, arg1 runner.RunLocation) (*exec.ExecResponse, error) {
+func (m *MockRunner) RunCommands(arg0 context.Context, arg1 string, arg2 runner.RunLocation) (*exec.ExecResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunCommands", arg0, arg1)
+	ret := m.ctrl.Call(m, "RunCommands", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*exec.ExecResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunCommands indicates an expected call of RunCommands.
-func (mr *MockRunnerMockRecorder) RunCommands(arg0, arg1 any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) RunCommands(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommands", reflect.TypeOf((*MockRunner)(nil).RunCommands), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommands", reflect.TypeOf((*MockRunner)(nil).RunCommands), arg0, arg1, arg2)
 }
 
 // RunHook mocks base method.
-func (m *MockRunner) RunHook(arg0 string) (runner.HookHandlerType, error) {
+func (m *MockRunner) RunHook(arg0 context.Context, arg1 string) (runner.HookHandlerType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunHook", arg0)
+	ret := m.ctrl.Call(m, "RunHook", arg0, arg1)
 	ret0, _ := ret[0].(runner.HookHandlerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunHook indicates an expected call of RunHook.
-func (mr *MockRunnerMockRecorder) RunHook(arg0 any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) RunHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHook", reflect.TypeOf((*MockRunner)(nil).RunHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHook", reflect.TypeOf((*MockRunner)(nil).RunHook), arg0, arg1)
 }

--- a/internal/worker/uniter/secrets/interface.go
+++ b/internal/worker/uniter/secrets/interface.go
@@ -4,6 +4,8 @@
 package secrets
 
 import (
+	"context"
+
 	"github.com/juju/juju/internal/worker/uniter/hook"
 )
 
@@ -12,12 +14,12 @@ import (
 type SecretStateTracker interface {
 	// PrepareHook returns an error if the hook is unknown
 	// or invalid given current state.
-	PrepareHook(hook.Info) error
+	PrepareHook(context.Context, hook.Info) error
 
 	// CommitHook persists the state change encoded in the supplied secret
 	// hook, or returns an error if the hook is unknown or invalid given
 	// current secret state.
-	CommitHook(info hook.Info) error
+	CommitHook(_ context.Context, info hook.Info) error
 
 	// ConsumedSecretRevision returns the revision that
 	// is currently tracked for the given secret.

--- a/internal/worker/uniter/secrets/mocks/tracker_mock.go
+++ b/internal/worker/uniter/secrets/mocks/tracker_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	hook "github.com/juju/juju/internal/worker/uniter/hook"
@@ -40,17 +41,17 @@ func (m *MockSecretStateTracker) EXPECT() *MockSecretStateTrackerMockRecorder {
 }
 
 // CommitHook mocks base method.
-func (m *MockSecretStateTracker) CommitHook(arg0 hook.Info) error {
+func (m *MockSecretStateTracker) CommitHook(arg0 context.Context, arg1 hook.Info) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitHook", arg0)
+	ret := m.ctrl.Call(m, "CommitHook", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitHook indicates an expected call of CommitHook.
-func (mr *MockSecretStateTrackerMockRecorder) CommitHook(arg0 any) *gomock.Call {
+func (mr *MockSecretStateTrackerMockRecorder) CommitHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockSecretStateTracker)(nil).CommitHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockSecretStateTracker)(nil).CommitHook), arg0, arg1)
 }
 
 // ConsumedSecretRevision mocks base method.
@@ -68,17 +69,17 @@ func (mr *MockSecretStateTrackerMockRecorder) ConsumedSecretRevision(arg0 any) *
 }
 
 // PrepareHook mocks base method.
-func (m *MockSecretStateTracker) PrepareHook(arg0 hook.Info) error {
+func (m *MockSecretStateTracker) PrepareHook(arg0 context.Context, arg1 hook.Info) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareHook", arg0)
+	ret := m.ctrl.Call(m, "PrepareHook", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PrepareHook indicates an expected call of PrepareHook.
-func (mr *MockSecretStateTrackerMockRecorder) PrepareHook(arg0 any) *gomock.Call {
+func (mr *MockSecretStateTrackerMockRecorder) PrepareHook(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockSecretStateTracker)(nil).PrepareHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockSecretStateTracker)(nil).PrepareHook), arg0, arg1)
 }
 
 // Report mocks base method.

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -154,10 +154,10 @@ func (s *triggerSecretsSuite) TestRotateCommit(c *gc.C) {
 		Kind:      hooks.SecretRotate,
 		SecretURI: uri.String(),
 	}
-	s.mockCallbacks.EXPECT().PrepareHook(hi).Return("", nil)
-	s.mockFactory.EXPECT().NewHookRunner(hi).Return(s.mockRunner, nil)
+	s.mockCallbacks.EXPECT().PrepareHook(gomock.Any(), hi).Return("", nil)
+	s.mockFactory.EXPECT().NewHookRunner(gomock.Any(), hi).Return(s.mockRunner, nil)
 	s.mockRunner.EXPECT().Context().Return(s.mockContext).AnyTimes()
-	s.mockContext.EXPECT().Prepare().Return(nil)
+	s.mockContext.EXPECT().Prepare(context.Background()).Return(nil)
 	s.mockContext.EXPECT().SecretMetadata().Return(map[string]jujuc.SecretMetadata{
 		uri.ID: {
 			LatestRevision: 666,
@@ -166,7 +166,7 @@ func (s *triggerSecretsSuite) TestRotateCommit(c *gc.C) {
 	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.mockCallbacks.EXPECT().CommitHook(hi).Return(nil)
+	s.mockCallbacks.EXPECT().CommitHook(gomock.Any(), hi).Return(nil)
 	s.mockCallbacks.EXPECT().SetSecretRotated(uri.String(), 666).Return(nil)
 
 	_, err = op.Commit(context.Background(), operation.State{})
@@ -214,14 +214,14 @@ func (s *triggerSecretsSuite) TestExpireCommit(c *gc.C) {
 		SecretURI:      uri.String(),
 		SecretRevision: 666,
 	}
-	s.mockCallbacks.EXPECT().PrepareHook(hi).Return("", nil)
-	s.mockFactory.EXPECT().NewHookRunner(hi).Return(s.mockRunner, nil)
+	s.mockCallbacks.EXPECT().PrepareHook(gomock.Any(), hi).Return("", nil)
+	s.mockFactory.EXPECT().NewHookRunner(context.Background(), hi).Return(s.mockRunner, nil)
 	s.mockRunner.EXPECT().Context().Return(s.mockContext).AnyTimes()
-	s.mockContext.EXPECT().Prepare().Return(nil)
+	s.mockContext.EXPECT().Prepare(gomock.Any()).Return(nil)
 	_, err = op.Prepare(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.mockCallbacks.EXPECT().CommitHook(hi).Return(nil)
+	s.mockCallbacks.EXPECT().CommitHook(context.Background(), hi).Return(nil)
 
 	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/secrets/secrets.go
+++ b/internal/worker/uniter/secrets/secrets.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"context"
 	"reflect"
 	"sync"
 
@@ -124,7 +125,7 @@ func (s *Secrets) SecretObsoleteRevisions(uri string) []int {
 }
 
 // PrepareHook implements SecretStateTracker.
-func (s *Secrets) PrepareHook(hi hook.Info) error {
+func (s *Secrets) PrepareHook(_ context.Context, hi hook.Info) error {
 	if !hi.Kind.IsSecret() {
 		return errors.Errorf("not a secret hook: %#v", hi)
 	}
@@ -133,7 +134,7 @@ func (s *Secrets) PrepareHook(hi hook.Info) error {
 }
 
 // CommitHook implements SecretStateTracker.
-func (s *Secrets) CommitHook(hi hook.Info) error {
+func (s *Secrets) CommitHook(_ context.Context, hi hook.Info) error {
 	if !hi.Kind.IsSecret() {
 		return errors.Errorf("not a secret hook: %#v", hi)
 	}

--- a/internal/worker/uniter/secrets/secrets_test.go
+++ b/internal/worker/uniter/secrets/secrets_test.go
@@ -4,6 +4,8 @@
 package secrets_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -84,7 +86,7 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 		SecretURI:      "secret:9m4e2mr0ui3e8a215n4g",
 		SecretRevision: 666,
 	}
-	err = tracker.CommitHook(info)
+	err = tracker.CommitHook(context.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -126,7 +128,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 		SecretURI:      "secret:9m4e2mr0ui3e8a215n4g",
 		SecretRevision: 666,
 	}
-	err = tracker.CommitHook(info)
+	err = tracker.CommitHook(context.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/worker/units3caller/api_mocks_test.go
+++ b/internal/worker/units3caller/api_mocks_test.go
@@ -262,17 +262,17 @@ func (mr *MockConnectionMockRecorder) IPAddr() *gomock.Call {
 }
 
 // IsBroken mocks base method.
-func (m *MockConnection) IsBroken() bool {
+func (m *MockConnection) IsBroken(arg0 context.Context) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsBroken")
+	ret := m.ctrl.Call(m, "IsBroken", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsBroken indicates an expected call of IsBroken.
-func (mr *MockConnectionMockRecorder) IsBroken() *gomock.Call {
+func (mr *MockConnectionMockRecorder) IsBroken(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBroken", reflect.TypeOf((*MockConnection)(nil).IsBroken))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBroken", reflect.TypeOf((*MockConnection)(nil).IsBroken), arg0)
 }
 
 // IsProxied mocks base method.

--- a/internal/worker/upgradeseries/manifold.go
+++ b/internal/worker/upgradeseries/manifold.go
@@ -4,6 +4,8 @@
 package upgradeseries
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/worker/v4"
@@ -51,7 +53,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // newWorker wraps NewWorker for use in a engine.AgentAPIManifold.
-func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (config ManifoldConfig) newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/upgradesteps/manifold.go
+++ b/internal/worker/upgradesteps/manifold.go
@@ -61,7 +61,7 @@ type ManifoldConfig struct {
 	ServiceFactoryName   string
 	PreUpgradeSteps      upgrades.PreUpgradeStepsFunc
 	UpgradeSteps         upgrades.UpgradeStepsFunc
-	NewAgentStatusSetter func(base.APICaller) (StatusSetter, error)
+	NewAgentStatusSetter func(context.Context, base.APICaller) (StatusSetter, error)
 	NewMachineWorker     MachineWorkerFunc
 	NewControllerWorker  ControllerWorkerFunc
 	Logger               Logger
@@ -131,14 +131,14 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			agentTag := agent.CurrentConfig().Tag()
-			isController, err := apiagent.IsController(apiCaller, agentTag)
+			isController, err := apiagent.IsController(ctx, apiCaller, agentTag)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 
 			// Get a component capable of setting machine status
 			// to indicate progress to the user.
-			statusSetter, err := config.NewAgentStatusSetter(apiCaller)
+			statusSetter, err := config.NewAgentStatusSetter(ctx, apiCaller)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
A mechanical change to replace a bunch more `context.TODO()` in many api clients with a proper context.
The affected files are *mostly* either `api/*` or `worker/*`. 
The job is by no means complete, but I stopped when the thread I started to pull didn't untwirl any more.

In the workers, this PR just uses `context.TODO()` to pass to the newly context enabled api code. A follow up PR will need to go in and use scoped contexts. But this PR is already large enough without doing that here.


## QA steps

bootstrap and deploy 

## Links

**Jira card:** JUJU-5369

