### PR TITLE
Bind dbaccessor to loopback for k8s

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -111,6 +111,9 @@ func InitializeState(
 
 	// If we're running caas, we need to bind to the loopback address
 	// and eschew TLS termination.
+	// This is to prevent dqlite to become all at sea when the controller pod
+	// is rescheduled. This is only a temporary measure until we have HA
+	// dqlite for k8s.
 	isLoopbackPreferred := isCAAS
 
 	if err := database.BootstrapDqlite(

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -217,9 +217,8 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 
 	err = database.BootstrapDqlite(
 		context.Background(),
-		database.NewNodeManager(conf, logger, coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(conf, true, logger, coredatabase.NoopSlowQueryLogger{}),
 		logger,
-		true,
 		s.InitialDBOps...,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -695,19 +695,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:            peergrouper.New,
 		})),
 
-		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:            agentName,
-			QueryLoggerName:      queryLoggerName,
-			Clock:                config.Clock,
-			Hub:                  config.CentralHub,
-			Logger:               loggo.GetLogger("juju.worker.dbaccessor"),
-			LogDir:               agentConfig.LogDir(),
-			PrometheusRegisterer: config.PrometheusRegisterer,
-			NewApp:               dbaccessor.NewApp,
-			NewDBWorker:          dbaccessor.NewTrackedDBWorker,
-			NewMetricsCollector:  dbaccessor.NewMetricsCollector,
-		})),
-
 		queryLoggerName: ifController(querylogger.Manifold(querylogger.ManifoldConfig{
 			LogDir: agentConfig.LogDir(),
 			Clock:  config.Clock,
@@ -803,6 +790,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 // IAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a IAAS machine agent.
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	agentConfig := config.Agent.CurrentConfig()
+
 	manifolds := dependency.Manifolds{
 		toolsVersionCheckerName: ifNotMigrating(toolsversionchecker.Manifold(toolsversionchecker.ManifoldConfig{
 			AgentName:     agentName,
@@ -843,6 +832,22 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FanConfigurerName: fanConfigurerName,
+		})),
+
+		// DBAccessor is a manifold that provides a DBAccessor worker
+		// that can be used to access the database.
+		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
+			AgentName:            agentName,
+			QueryLoggerName:      queryLoggerName,
+			Clock:                config.Clock,
+			Hub:                  config.CentralHub,
+			Logger:               loggo.GetLogger("juju.worker.dbaccessor"),
+			LogDir:               agentConfig.LogDir(),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewApp:               dbaccessor.NewApp,
+			NewDBWorker:          dbaccessor.NewTrackedDBWorker,
+			NewMetricsCollector:  dbaccessor.NewMetricsCollector,
+			NewNodeManager:       dbaccessor.IAASNodeManager,
 		})),
 
 		// The diskmanager worker periodically lists block devices on the
@@ -989,6 +994,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 // CAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a CAAS machine agent.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
+	agentConfig := config.Agent.CurrentConfig()
+
 	return mergeManifolds(config, dependency.Manifolds{
 		// TODO(caas) - when we support HA, only want this on primary
 		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
@@ -1012,6 +1019,22 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:        loggo.GetLogger("juju.worker.caasunitsmanager"),
 			Hub:           config.LocalHub,
 		}),
+
+		// DBAccessor is a manifold that provides a DBAccessor worker
+		// that can be used to access the database.
+		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
+			AgentName:            agentName,
+			QueryLoggerName:      queryLoggerName,
+			Clock:                config.Clock,
+			Hub:                  config.CentralHub,
+			Logger:               loggo.GetLogger("juju.worker.dbaccessor"),
+			LogDir:               agentConfig.LogDir(),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewApp:               dbaccessor.NewApp,
+			NewDBWorker:          dbaccessor.NewTrackedDBWorker,
+			NewMetricsCollector:  dbaccessor.NewMetricsCollector,
+			NewNodeManager:       dbaccessor.CAASNodeManager,
+		})),
 	})
 }
 

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -52,12 +52,6 @@ type bootstrapNodeManager interface {
 //
 // It accepts an optional list of functions to perform operations on the
 // controller database.
-//
-// If preferLoopback is true, we bind Dqlite to 127.0.0.1 and eschew TLS
-// termination. This is useful primarily in unit testing.
-// If it is false, we attempt to identify a unique local-cloud address.
-// If we find one, we use it as the bind address. Otherwise, we fall back
-// to the loopback binding.
 func BootstrapDqlite(
 	ctx context.Context,
 	mgr bootstrapNodeManager,

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -20,6 +20,10 @@ type bootstrapNodeManager interface {
 	// a path determined by the agent config, then returns that path.
 	EnsureDataDir() (string, error)
 
+	// IsLoopbackPreferred returns true if the Dqlite application should
+	// be bound to the loopback address.
+	IsLoopbackPreferred() bool
+
 	// WithLoopbackAddressOption returns a Dqlite application
 	// Option that will bind Dqlite to the loopback IP.
 	WithLoopbackAddressOption() app.Option
@@ -58,7 +62,6 @@ func BootstrapDqlite(
 	ctx context.Context,
 	mgr bootstrapNodeManager,
 	logger Logger,
-	preferLoopback bool,
 	ops ...func(db *sql.DB) error,
 ) error {
 	dir, err := mgr.EnsureDataDir()
@@ -67,7 +70,7 @@ func BootstrapDqlite(
 	}
 
 	options := []app.Option{mgr.WithLogFuncOption()}
-	if preferLoopback {
+	if mgr.IsLoopbackPreferred() {
 		options = append(options, mgr.WithLoopbackAddressOption())
 	} else {
 		addrOpt, err := mgr.WithPreferredCloudLocalAddressOption(network.DefaultConfigSource())

--- a/database/bootstrap_test.go
+++ b/database/bootstrap_test.go
@@ -55,7 +55,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 		return nil
 	}
 
-	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, true, check)
+	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, check)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -70,6 +70,10 @@ func (f *testNodeManager) EnsureDataDir() (string, error) {
 		f.dataDir = f.c.MkDir()
 	}
 	return f.dataDir, nil
+}
+
+func (f *testNodeManager) IsLoopbackPreferred() bool {
+	return true
 }
 
 func (f *testNodeManager) WithPreferredCloudLocalAddressOption(network.ConfigSource) (app.Option, error) {

--- a/database/node.go
+++ b/database/node.go
@@ -53,6 +53,14 @@ type NodeManager struct {
 
 // NewNodeManager returns a new NodeManager reference
 // based on the input agent configuration.
+//
+// If isLoopbackPreferred is true, we bind Dqlite to 127.0.0.1 and eschew TLS
+// termination. This is useful primarily in unit testing and a temporary
+// workaround for CAAS, which does not yet support enable-ha.
+//
+// If it is false, we attempt to identify a unique local-cloud address.
+// If we find one, we use it as the bind address. Otherwise, we fall back
+// to the loopback binding.
 func NewNodeManager(cfg agent.Config, isLoopbackPreferred bool, logger Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
 	m := &NodeManager{
 		cfg:                 cfg,

--- a/database/node.go
+++ b/database/node.go
@@ -42,22 +42,24 @@ const (
 // and emitting configuration for starting its Dqlite `App` based on
 // operational requirements and controller agent config.
 type NodeManager struct {
-	cfg             agent.Config
-	port            int
-	logger          Logger
-	slowQueryLogger coredatabase.SlowQueryLogger
+	cfg                 agent.Config
+	port                int
+	isLoopbackPreferred bool
+	logger              Logger
+	slowQueryLogger     coredatabase.SlowQueryLogger
 
 	dataDir string
 }
 
 // NewNodeManager returns a new NodeManager reference
 // based on the input agent configuration.
-func NewNodeManager(cfg agent.Config, logger Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
+func NewNodeManager(cfg agent.Config, isLoopbackPreferred bool, logger Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
 	m := &NodeManager{
-		cfg:             cfg,
-		port:            dqlitePort,
-		logger:          logger,
-		slowQueryLogger: slowQueryLogger,
+		cfg:                 cfg,
+		port:                dqlitePort,
+		isLoopbackPreferred: isLoopbackPreferred,
+		logger:              logger,
+		slowQueryLogger:     slowQueryLogger,
 	}
 	if cfg != nil {
 		if port, ok := cfg.DqlitePort(); ok {
@@ -65,6 +67,14 @@ func NewNodeManager(cfg agent.Config, logger Logger, slowQueryLogger coredatabas
 		}
 	}
 	return m
+}
+
+// IsLoopbackPreferred returns true if we should prefer to bind Dqlite
+// to the loopback IP address.
+// This is currently true for CAAS and unit testing. Once CAAS supports
+// enable-ha we'll have to revisit this.
+func (m *NodeManager) IsLoopbackPreferred() bool {
+	return m.isLoopbackPreferred
 }
 
 // IsLoopbackBound returns true if we are a cluster of one,

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -90,9 +90,8 @@ func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
 	logger := loggo.GetLogger("juju.featuretests")
 	err = database.BootstrapDqlite(
 		context.Background(),
-		database.NewNodeManager(cfg, logger, coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(cfg, true, logger, coredatabase.NoopSlowQueryLogger{}),
 		logger,
-		true,
 		s.InitialDBOps...)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/dbaccessor/manifold_test.go
+++ b/worker/dbaccessor/manifold_test.go
@@ -10,6 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database/app"
 )
 
@@ -61,6 +63,10 @@ func (s *manifoldSuite) TestValidateConfig(c *gc.C) {
 	cfg = s.getConfig()
 	cfg.NewMetricsCollector = nil
 	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
+
+	cfg = s.getConfig()
+	cfg.NewNodeManager = nil
+	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
@@ -80,6 +86,9 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		},
 		NewMetricsCollector: func() *Collector {
 			return &Collector{}
+		},
+		NewNodeManager: func(agent.Config, Logger, coredatabase.SlowQueryLogger) NodeManager {
+			return s.nodeManager
 		},
 	}
 }

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -351,6 +351,20 @@ func (mr *MockNodeManagerMockRecorder) IsLoopbackBound(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoopbackBound", reflect.TypeOf((*MockNodeManager)(nil).IsLoopbackBound), arg0)
 }
 
+// IsLoopbackPreferred mocks base method.
+func (m *MockNodeManager) IsLoopbackPreferred() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLoopbackPreferred")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLoopbackPreferred indicates an expected call of IsLoopbackPreferred.
+func (mr *MockNodeManagerMockRecorder) IsLoopbackPreferred() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoopbackPreferred", reflect.TypeOf((*MockNodeManager)(nil).IsLoopbackPreferred))
+}
+
 // SetClusterServers mocks base method.
 func (m *MockNodeManager) SetClusterServers(arg0 context.Context, arg1 []dqlite.NodeInfo) error {
 	m.ctrl.T.Helper()

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -34,6 +34,7 @@ type baseSuite struct {
 	client               *MockClient
 	trackedDB            *MockTrackedDB
 	prometheusRegisterer *MockRegisterer
+	nodeManager          *MockNodeManager
 }
 
 func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -47,6 +48,7 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.client = NewMockClient(ctrl)
 	s.trackedDB = NewMockTrackedDB(ctrl)
 	s.prometheusRegisterer = NewMockRegisterer(ctrl)
+	s.nodeManager = NewMockNodeManager(ctrl)
 
 	return ctrl
 }

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -41,6 +41,10 @@ type NodeManager interface {
 	// Dqlite node in the past.
 	IsExistingNode() (bool, error)
 
+	// IsLoopbackPreferred returns true if the Dqlite application should
+	// be bound to the loopback address.
+	IsLoopbackPreferred() bool
+
 	// IsLoopbackBound returns true if we are a cluster of one,
 	// and bound to the loopback IP address.
 	IsLoopbackBound(context.Context) (bool, error)
@@ -370,9 +374,14 @@ func (w *dbWorker) GetDB(namespace string) (database.TrackedDB, error) {
 // startExistingDqliteNode takes care of starting Dqlite
 // when this host has run a node previously.
 func (w *dbWorker) startExistingDqliteNode() error {
-	w.cfg.Logger.Infof("host is configured as a Dqlite node")
-
 	mgr := w.cfg.NodeManager
+	if mgr.IsLoopbackPreferred() {
+		w.cfg.Logger.Infof("host is configured to use loopback address as a Dqlite node")
+
+		return errors.Trace(w.initialiseDqlite())
+	}
+
+	w.cfg.Logger.Infof("host is configured to use cloud-local address as a Dqlite node")
 
 	ctx, cancel := w.scopedContext()
 	defer cancel()
@@ -399,10 +408,7 @@ func (w *dbWorker) startExistingDqliteNode() error {
 }
 
 func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
-	ctx, cancel := w.scopedContext()
-	defer cancel()
-
-	if err := w.startDqliteNode(ctx, options...); err != nil {
+	if err := w.startDqliteNode(options...); err != nil {
 		if errors.Is(err, errNotReady) {
 			return nil
 		}
@@ -422,7 +428,7 @@ func (w *dbWorker) initialiseDqlite(options ...app.Option) error {
 	return nil
 }
 
-func (w *dbWorker) startDqliteNode(ctx context.Context, options ...app.Option) error {
+func (w *dbWorker) startDqliteNode(options ...app.Option) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -559,6 +565,30 @@ func (w *dbWorker) processAPIServerChange(apiDetails apiserver.Details) error {
 
 	ctx, cancel := w.scopedContext()
 	defer cancel()
+
+	// If we prefer the loopback address, we shouldn't need to do anything.
+	// We double-check that we are bound to the loopback address, if not,
+	// we bounce the worker and try and resolve that in the next go around.
+	if mgr.IsLoopbackPreferred() {
+		if extant {
+			isLoopbackBound, err := mgr.IsLoopbackBound(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			// Everything is find, we're bound to the loopback address and
+			// can return early.
+			if isLoopbackBound {
+				return nil
+			}
+
+			// This should never happen, but we want to be conservative.
+			w.cfg.Logger.Warningf("existing Dqlite node is not bound to loopback; but should be; restarting worker")
+		}
+
+		// We don't have a Dqlite node, but somehow we got here, we should just
+		// bounce the worker and try again.
+		return dependency.ErrBounce
+	}
 
 	if extant {
 		asBootstrapped, err := mgr.IsLoopbackBound(ctx)

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -575,7 +575,7 @@ func (w *dbWorker) processAPIServerChange(apiDetails apiserver.Details) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			// Everything is find, we're bound to the loopback address and
+			// Everything is fine, we're bound to the loopback address and
 			// can return early.
 			if isLoopbackBound {
 				return nil


### PR DESCRIPTION
The prior change bootstrapped dqlite to a cloud-local address where possible. This included k8s setup, although it was never required because CAAS allowed HA. Unfortunately, this becomes a problem, if you delete the pod and it becomes rescheduled. When comming back it can't rebind to the address, as it's not the same one.

To fix the problem, we prefer loopback address for CAAS deployments. The node manager now gains that capability to know if the nodes should perfer loopback or not. Then in the dbaccessor worker, we can the ask the node manager for the information.
As the node manager is setup in the manifold for the dbaccessor worker, we can then employ the IAAS vs CAAS manifolds to provide the different functionality. This is a leaf from the 4.0 branch, where we're trying to remove the `if isCAAS`-isms.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Microk8s

```sh
$ juju bootstrap microk8s test
```

Ensure it's up and running...

```sh
$ microk8s kubectl logs --namespace=controller-test controller-0 -c api-server -f 
```

Kill the controller pod

```sh
$ microk8s kubectl delete pod controller-0 --namespace=controller-test
```

Make sure it comes back (takes some time to kill the pod)....

```sh
$ microk8s kubectl logs --namespace=controller-test controller-0 -c api-server -f 
```

### Regression test

```sh
$ juju bootstrap lxd test --build-agent
$ juju enable-ha
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2051836

**Jira card:** JUJU-5393

