### PR TITLE
[WIP] Check instance/machine mapping exclusively for model migration in credential validation

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -63,7 +63,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -74,7 +74,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -83,21 +83,14 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstances(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return []instances.Instance{s.instance, instance2}, nil
-	}
-
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.IsNil)
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstancesWhenMigrating(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return []instances.Instance{s.instance, instance2}, nil
-	}
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -109,18 +102,8 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachines(c *gc.C) {
 		return nil, errors.New("boom")
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
-}
-
-func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return nil, errors.New("kaboom")
-	}
-
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
-	c.Assert(err, gc.ErrorMatches, "kaboom")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
@@ -131,7 +114,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -143,12 +126,12 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 
 	machine1.manualFunc = func() (bool, error) { return true, nil }
-	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -160,7 +143,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -177,7 +160,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -195,7 +178,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// There should be 3 errors here:
 	// * 2 of them because failing to get an instance id from one machine should not stop the processing the rest of the machines;
@@ -218,7 +201,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -243,14 +226,14 @@ func (s *ModelCredentialSuite) TestValidateNewModelCredentialUnknownModelType(c 
 		return unknownModel, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, `model type "unknown" not supported`)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingModel(c *gc.C) {
 	s.backend.SetErrors(errors.New("get model error"))
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -261,7 +244,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingCloud(c *gc.C) 
 		nil, // getting model
 		errors.New("get cloud error"),
 	)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false, false)
 	s.backend.CheckCallNames(c, "Model", "Cloud")
 	c.Assert(err, gc.ErrorMatches, "get cloud error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
@@ -277,7 +260,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingModelConfig(c *
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model config error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "Cloud")
@@ -293,7 +276,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorValidateCredentialForM
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, "credential not for model cloud error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "Cloud")
@@ -301,7 +284,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorValidateCredentialForM
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialErrorGettingModel(c *gc.C) {
 	s.backend.SetErrors(errors.New("get model error"))
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -317,7 +300,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialUnsetCloudCred
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -328,7 +311,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialErrorGettingCr
 		return state.Credential{}, errors.New("no nope niet")
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "no nope niet")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "CloudCredential")
@@ -342,7 +325,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialInvalidCredent
 		return cred, nil
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, `credential "cred" not valid`)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "CloudCredential")
@@ -352,21 +335,21 @@ func (s *ModelCredentialSuite) TestOpeningProviderFails(c *gc.C) {
 	s.PatchValue(credentialcommon.NewEnv, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return nil, errors.New("explosive")
 	})
-	results, err := credentialcommon.CheckIAASModelCredential(environs.OpenParams{}, s.backend, s.callContext, false)
+	results, err := credentialcommon.CheckIAASModelCredential(environs.OpenParams{}, s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "explosive")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateNewModelCredentialForIAASModel(c *gc.C) {
 	s.ensureEnvForIAASModel(c)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialForIAASModel(c *gc.C) {
 	s.ensureEnvForIAASModel(c)
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -404,14 +387,14 @@ func (s *ModelCredentialSuite) TestCAASCredentialCheckSucceeds(c *gc.C) {
 
 func (s *ModelCredentialSuite) TestValidateNewModelCredentialForCAASModel(c *gc.C) {
 	s.ensureEnvForCAASModel(c)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialForCAASSuccess(c *gc.C) {
 	s.ensureEnvForCAASModel(c)
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -63,7 +63,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -74,7 +74,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -114,7 +114,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -126,12 +126,12 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 
 	machine1.manualFunc = func() (bool, error) { return true, nil }
-	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -143,7 +143,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -178,7 +178,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	// There should be 3 errors here:
 	// * 2 of them because failing to get an instance id from one machine should not stop the processing the rest of the machines;
@@ -201,7 +201,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -683,6 +683,7 @@ func (api *CloudAPI) validateCredentialForModel(modelUUID string, tag names.Clou
 		tag,
 		credential,
 		false,
+		false,
 	)
 	if err != nil {
 		return append(result, params.ErrorResult{apiservererrors.ServerError(err)})

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -341,6 +341,7 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 		credentialcommon.NewPersistentBackend(st.State),
 		context.CallContext(st.State),
 		cloud.Type != "manual",
+		true,
 	)
 }
 


### PR DESCRIPTION
Currently there are two checks being done for credential validation. 1) can we reach all cloud instances? 2) can we cross examine all machines we know about with all the instances we can reach. The 2nd one is redundant for just checking the validity of a credential (we can already reach in the 1st check), but it absolutely needs to be done for model migrations. So this change move things around to perform that check only for migrations, because if one of the machine gets down during that process (of checking the instance mapping) we deem the credential not valid, which is incorrect.

https://bugs.launchpad.net/juju/+bug/2049917

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-5361

