### PR TITLE
Remove the need for ha-space on the peergrouper

### DIFF
--- a/internal/worker/peergrouper/controllertracker.go
+++ b/internal/worker/peergrouper/controllertracker.go
@@ -95,31 +95,6 @@ func (c *controllerTracker) Addresses() network.SpaceAddresses {
 	return out
 }
 
-// SelectMongoAddressFromSpace returns the best address on the controller node for MongoDB peer
-// use, using the input space.
-func (c *controllerTracker) SelectMongoAddressFromSpace(port int, space network.SpaceInfo) (string, error) {
-	if space.ID == "" {
-		return "", fmt.Errorf(
-			"empty space supplied as an argument for selecting Mongo address for controller node %q", c.id)
-	}
-
-	c.mu.Lock()
-	hostPorts := network.SpaceAddressesWithPort(c.addresses, port)
-	c.mu.Unlock()
-
-	addrs, ok := hostPorts.InSpaces(space)
-	if ok {
-		addr := network.DialAddress(addrs[0])
-		logger.Debugf("controller node %q selected address %q by space %q from %v", c.id, addr, space.Name, hostPorts)
-		return addr, nil
-	}
-
-	// If we end up here, then there are no addresses available in the
-	// specified space. This should not happen, because the configured
-	// space is used as a constraint when first enabling HA.
-	return "", errors.NotFoundf("addresses for controller node %q in space %q", c.id, space.Name)
-}
-
 // GetPotentialMongoHostPorts simply returns all the available addresses
 // with the Mongo port appended.
 func (c *controllerTracker) GetPotentialMongoHostPorts(port int) network.SpaceHostPorts {

--- a/internal/worker/peergrouper/controllertracker_test.go
+++ b/internal/worker/peergrouper/controllertracker_test.go
@@ -18,48 +18,6 @@ type machineTrackerSuite struct {
 
 var _ = gc.Suite(&machineTrackerSuite{})
 
-func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddress(c *gc.C) {
-	space := network.SpaceInfo{
-		ID:   "123",
-		Name: network.SpaceName("ha-space"),
-	}
-
-	m := &controllerTracker{
-		addresses: []network.SpaceAddress{
-			network.NewSpaceAddress("192.168.5.5", network.WithScope(network.ScopeCloudLocal)),
-			network.NewSpaceAddress("192.168.10.5", network.WithScope(network.ScopeCloudLocal)),
-			network.NewSpaceAddress("localhost", network.WithScope(network.ScopeMachineLocal)),
-		},
-	}
-	m.addresses[0].SpaceID = space.ID
-	m.addresses[1].SpaceID = "456"
-
-	addr, err := m.SelectMongoAddressFromSpace(666, space)
-	c.Assert(err, gc.IsNil)
-	c.Check(addr, gc.Equals, "192.168.5.5:666")
-}
-
-func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressFound(c *gc.C) {
-	m := &controllerTracker{
-		id: "3",
-		addresses: []network.SpaceAddress{
-			network.NewSpaceAddress("localhost", network.WithScope(network.ScopeMachineLocal))},
-	}
-
-	addrs, err := m.SelectMongoAddressFromSpace(666, network.SpaceInfo{ID: "whatever", Name: "bad-space"})
-	c.Check(addrs, gc.Equals, "")
-	c.Check(err, gc.ErrorMatches, `addresses for controller node "3" in space "bad-space" not found`)
-}
-
-func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorForEmptySpace(c *gc.C) {
-	m := &controllerTracker{
-		id: "3",
-	}
-
-	_, err := m.SelectMongoAddressFromSpace(666, network.SpaceInfo{})
-	c.Check(err, gc.ErrorMatches, `empty space supplied as an argument for selecting Mongo address for controller node "3"`)
-}
-
 func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(c *gc.C) {
 	m := &controllerTracker{
 		id: "3",

--- a/internal/worker/peergrouper/desired.go
+++ b/internal/worker/peergrouper/desired.go
@@ -5,6 +5,7 @@ package peergrouper
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -564,9 +565,9 @@ func (p *peerGroupChanges) updateAddressesFromInternal() error {
 			}
 		}
 
-		// If this member was not previously in the replica-set, or if its
-		// address has changed, we enforce the policy of requiring a
-		// configured HA space when there are multiple cloud-local addresses.
+		// If this member was not previously in the replica-set, or if
+		// its address has changed, we simply select the first one when
+		// there are multiple cloud-local addresses.
 		if !unchanged {
 			member.Address = selectSingleAddress(addrs)
 			p.desired.isChanged = true
@@ -577,10 +578,10 @@ func (p *peerGroupChanges) updateAddressesFromInternal() error {
 }
 
 // selectSingleAddress selects only one address from list of addresses. The
-// selection is done in a consistent fashion.
+// selection is done in a consistent fashion by simply sorting the list of
+// addresses and then selecting the first one.
 func selectSingleAddress(addrs []string) string {
-	// FIXME: this should first sort addresses (or filter them) according
-	// to some criteria (which?).
+	slices.Sort(addrs)
 	return addrs[0]
 }
 

--- a/internal/worker/peergrouper/desired_test.go
+++ b/internal/worker/peergrouper/desired_test.go
@@ -374,7 +374,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 			trackerMap[m.Id()] = m
 		}
 
-		info, err := newPeerGroupInfo(trackerMap, test.statuses, test.members, mongoPort, network.SpaceInfo{})
+		info, err := newPeerGroupInfo(trackerMap, test.statuses, test.members, mongoPort)
 		c.Assert(err, jc.ErrorIsNil)
 
 		desired, err := desiredPeerGroup(info)
@@ -420,7 +420,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 
 		// Make sure that when the members are set as required, that there
 		// is no further change if desiredPeerGroup is called again.
-		info, err = newPeerGroupInfo(trackerMap, test.statuses, members, mongoPort, network.SpaceInfo{})
+		info, err = newPeerGroupInfo(trackerMap, test.statuses, members, mongoPort)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(info, gc.NotNil)
 
@@ -465,7 +465,7 @@ func (s *desiredPeerGroupSuite) TestIsPrimary(c *gc.C) {
 	}
 	members := mkMembers("1v 2v 3v", testIPv4)
 	statuses := mkStatuses("1p 2s 3s", testIPv4)
-	info, err := newPeerGroupInfo(trackerMap, statuses, members, mongoPort, network.SpaceInfo{})
+	info, err := newPeerGroupInfo(trackerMap, statuses, members, mongoPort)
 	c.Assert(err, jc.ErrorIsNil)
 	isPrimary, err := info.isPrimary("11")
 	c.Assert(err, jc.ErrorIsNil)
@@ -476,7 +476,7 @@ func (s *desiredPeerGroupSuite) TestIsPrimary(c *gc.C) {
 }
 
 func (s *desiredPeerGroupSuite) TestNewPeerGroupInfoErrWhenNoMembers(c *gc.C) {
-	_, err := newPeerGroupInfo(nil, nil, nil, 666, network.SpaceInfo{})
+	_, err := newPeerGroupInfo(nil, nil, nil, 666)
 	c.Check(err, gc.ErrorMatches, "current member set is empty")
 }
 

--- a/internal/worker/peergrouper/mock_test.go
+++ b/internal/worker/peergrouper/mock_test.go
@@ -46,7 +46,6 @@ var (
 	_ State          = (*fakeState)(nil)
 	_ ControllerNode = (*fakeController)(nil)
 	_ MongoSession   = (*fakeMongoSession)(nil)
-	_ Space          = (*fakeSpace)(nil)
 )
 
 type errorPatterns struct {
@@ -313,22 +312,6 @@ func (st *fakeState) setHASpace(spaceName string) {
 	cfg := st.controllerConfig.Get().(controller.Config)
 	cfg[controller.JujuHASpace] = spaceName
 	st.controllerConfig.Set(cfg)
-}
-
-func (st *fakeState) Space(name string) (Space, error) {
-	// Return a representation of the default space whenever requested.
-	if name == network.AlphaSpaceName {
-		return &fakeSpace{network.SpaceInfo{}}, nil
-	}
-
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	space, ok := st.spaces[name]
-	if !ok {
-		return nil, errors.NotFoundf("space %q", name)
-	}
-	return space, nil
 }
 
 type fakeController struct {

--- a/internal/worker/peergrouper/mock_test.go
+++ b/internal/worker/peergrouper/mock_test.go
@@ -39,7 +39,6 @@ type fakeState struct {
 	session          *fakeMongoSession
 	checkMu          sync.Mutex
 	check            func(st *fakeState) error
-	spaces           map[string]*fakeSpace
 }
 
 var (
@@ -297,23 +296,6 @@ func (st *fakeState) RemoveControllerReference(c ControllerNode) error {
 	return nil
 }
 
-func (st *fakeState) setHASpace(spaceName string) {
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	// Ensure the configured space always exists in state.
-	if spaceName != network.AlphaSpaceName {
-		if st.spaces == nil {
-			st.spaces = make(map[string]*fakeSpace)
-		}
-		st.spaces[spaceName] = &fakeSpace{network.SpaceInfo{ID: spaceName, Name: network.SpaceName(spaceName)}}
-	}
-
-	cfg := st.controllerConfig.Get().(controller.Config)
-	cfg[controller.JujuHASpace] = spaceName
-	st.controllerConfig.Set(cfg)
-}
-
 type fakeController struct {
 	mu      sync.Mutex
 	errors  *errorPatterns
@@ -439,14 +421,6 @@ func (m *fakeController) advanceLifecycle(life state.Life, wantsVote bool) {
 		doc.life = life
 		doc.wantsVote = wantsVote
 	})
-}
-
-type fakeSpace struct {
-	network.SpaceInfo
-}
-
-func (s *fakeSpace) NetworkSpace() (network.SpaceInfo, error) {
-	return s.SpaceInfo, nil
 }
 
 type fakeMongoSession struct {

--- a/internal/worker/peergrouper/shim.go
+++ b/internal/worker/peergrouper/shim.go
@@ -45,10 +45,6 @@ func (s StateShim) RemoveControllerReference(c ControllerNode) error {
 	return s.State.RemoveControllerReference(c)
 }
 
-func (s StateShim) Space(name string) (Space, error) {
-	return s.State.SpaceByName(name)
-}
-
 // cloudServiceShim stubs out functionality not yet
 // supported by the k8s service abstraction.
 // We don't yet support HA on k8s.


### PR DESCRIPTION
This patch is a step forward in removing the legacy state spaces/subnets domain.
Particularly, here we get rid of the need for querying the spaces when updating the member's address in the peergrouper. The case where this has an impact is when more than one address is available for a member: in this case we don't request the user to set the ha-space config and select the address that corresponds to that space, we simply select one address from the list without failing.



## Checklist



- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

``` 
juju bootstrap localhost c
juju enable-ha
```

## Links

**Jira card:** JUJU-5389

