### PR TITLE
Fix RegisterCredentials for kubernetes provider.

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -146,7 +146,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 
 	var credentials cloud.Credential
 	if cld.Name != k8s.K8sCloudMicrok8s {
-		creds, err := p.RegisterCredentials(ctx, cld)
+		creds, err := p.RegisterCredentials(cld)
 		if err != nil {
 			return cld, err
 		}
@@ -165,7 +165,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 		}
 		cld = mk8sCloud
 
-		creds, err := p.RegisterCredentials(ctx, cld)
+		creds, err := p.RegisterCredentials(cld)
 		if err != nil {
 			return cld, err
 		}

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -22,6 +22,8 @@ type environProviderCredentials struct {
 	builtinCredentialGetter func(context.Context, CommandRunner) (cloud.Credential, error)
 }
 
+var _ environs.ProviderCredentials = (*environProviderCredentials)(nil)
+
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	schemas := make(map[cloud.AuthType]cloud.CredentialSchema)
@@ -69,12 +71,12 @@ func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredenti
 }
 
 // RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
-func (p environProviderCredentials) RegisterCredentials(ctx context.Context, cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
+func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	cloudName := cld.Name
 	if cloudName != k8s.K8sCloudMicrok8s {
-		return registerCredentialsKubeConfig(ctx, cld)
+		return registerCredentialsKubeConfig(context.TODO(), cld)
 	}
-	cred, err := p.builtinCredentialGetter(ctx, p.cmdRunner)
+	cred, err := p.builtinCredentialGetter(context.TODO(), p.cmdRunner)
 
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -4,7 +4,6 @@
 package provider_test
 
 import (
-	"context"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -96,7 +95,7 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 
 func (s *credentialsSuite) TestRegisterCredentialsNotMicrok8s(c *gc.C) {
 	p := provider.NewProviderCredentials(credentialGetterFunc(builtinCloudRet{}))
-	credentials, err := p.RegisterCredentials(context.Background(), cloud.Cloud{})
+	credentials, err := p.RegisterCredentials(cloud.Cloud{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 0)
 }
@@ -111,7 +110,7 @@ func (s *credentialsSuite) TestRegisterCredentialsMicrok8s(c *gc.C) {
 			},
 		),
 	)
-	credentials, err := p.RegisterCredentials(context.Background(), defaultK8sCloud)
+	credentials, err := p.RegisterCredentials(defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
 	c.Assert(credentials[k8s.K8sCloudMicrok8s], gc.DeepEquals, &cloud.CloudCredential{


### PR DESCRIPTION
RegisterCredentials does indeed not take a context.Context, yet. This fixes it up and adds the relevant context.TODOs.

## QA steps

Bootstrap microk8s.

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/test-coslite-test-deploy-coslite-microk8s/970/consoleText