### PR TITLE
[SQLair] Replace slice queries in domain/externalcontroller/state

### DIFF
--- a/domain/externalcontroller/state/types.go
+++ b/domain/externalcontroller/state/types.go
@@ -6,15 +6,17 @@ package state
 import (
 	"database/sql"
 
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/crossmodel"
 )
 
-// ExternalController represents a single row from the database when
+// Controller represents a single row from the database when
 // external_controller is joined with external_controller_address and
 // external_model.
-type ExternalController struct {
+type Controller struct {
 	// ID is the controller UUID.
 	ID string `db:"uuid"`
 
@@ -33,14 +35,110 @@ type ExternalController struct {
 	ModelUUID sql.NullString `db:"model"`
 }
 
-type ExternalControllers []ExternalController
+// Address represents a single row from external_controller_address.
+type Address struct {
+	// ID is the address UUID.
+	ID string `db:"uuid"`
 
-// ToControllerInfo ExternalControllers to a slice of crossmodel.ControllerInfo
+	// Addr holds a single host:port value for
+	// the external controller's API server.
+	Addr string `db:"address"`
+
+	// ControllerUUID holds the controller uuid.
+	ControllerUUID string `db:"controller_uuid"`
+}
+
+// Model represents a single row from external_model.
+type Model struct {
+	// ID is the model UUID.
+	ID string `db:"uuid"`
+
+	// ControllerUUID holds the controller uuid.
+	ControllerUUID string `db:"controller_uuid"`
+}
+
+type Controllers []Controller
+
+// uuids is a slice of controller uuids from the database.
+type uuids []string
+
+// updateStatements contains the prepared statements used by
+// updateExternalControllerTx.
+type updateStatements struct {
+	// upsertController upserts the controller alias and certificate in
+	// external_controller.
+	upsertController *sqlair.Statement
+	// deleteUnusedAddresses removes addresses not passed in the uuids slice
+	// from external_controller_addresses.
+	deleteUnusedAddresses *sqlair.Statement
+	// insertNewAddresses adds new addresses to external_controller_addresses,
+	// leaving existing ones untouched.
+	insertNewAddresses *sqlair.Statement
+	// upsertModel upserts the model uuids associated with the controller in
+	// external_model.
+	upsertModel *sqlair.Statement
+}
+
+// NewUpdateStatements prepares the SQLair statements used by
+// updateExternalControllerTx.
+func NewUpdateStatements() (*updateStatements, error) {
+	upsertControllerQuery := `
+INSERT INTO external_controller (uuid, alias, ca_cert)
+VALUES ($Controller.uuid, $Controller.alias, $Controller.ca_cert)
+  ON CONFLICT(uuid) DO UPDATE SET alias=excluded.alias, ca_cert=excluded.ca_cert
+`
+	upsertControllerStmt, err := sqlair.Prepare(upsertControllerQuery, Controller{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q:", upsertControllerQuery)
+	}
+
+	deleteUnusedAddressesQuery := `
+DELETE FROM external_controller_address
+WHERE  controller_uuid = $Controller.uuid
+AND    address NOT IN ($uuids[:])
+`
+	deleteUnusedAddressesStmt, err := sqlair.Prepare(deleteUnusedAddressesQuery, Controller{}, uuids{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q:", deleteUnusedAddressesQuery)
+	}
+
+	insertNewAddressesQuery := `
+INSERT INTO external_controller_address (uuid, controller_uuid, address)
+VALUES ($Address.uuid, $Address.controller_uuid, $Address.address)
+  ON CONFLICT(controller_uuid, address) DO NOTHING
+`
+	insertNewAddressesStmt, err := sqlair.Prepare(insertNewAddressesQuery, Address{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q:", insertNewAddressesQuery)
+	}
+
+	// TODO (manadart 2023-05-13): Check current implementation and see if
+	// we need to delete models as we do for addresses, or whether this
+	// (additive) approach is what we have now.
+	upsertModelQuery := `
+INSERT INTO external_model (uuid, controller_uuid)
+VALUES ($Model.uuid, $Model.controller_uuid)
+  ON CONFLICT(uuid) DO UPDATE SET controller_uuid=excluded.controller_uuid
+`
+	upsertModelStmt, err := sqlair.Prepare(upsertModelQuery, Model{})
+	if err != nil {
+		return nil, errors.Annotatef(err, "preparing %q:", upsertModelQuery)
+	}
+
+	return &updateStatements{
+		upsertController:      upsertControllerStmt,
+		deleteUnusedAddresses: deleteUnusedAddressesStmt,
+		insertNewAddresses:    insertNewAddressesStmt,
+		upsertModel:           upsertModelStmt,
+	}, nil
+}
+
+// ToControllerInfo Controllers to a slice of crossmodel.ControllerInfo
 // structs. This method makes sure only unique models and addresses are mapped
 // and flattens them into each controller.
 // Order of addresses, models and the resulting crossmodel.ControllerInfo
 // elements are not guaranteed, no sorting is applied.
-func (e ExternalControllers) ToControllerInfo() []crossmodel.ControllerInfo {
+func (e Controllers) ToControllerInfo() []crossmodel.ControllerInfo {
 	var resultControllers []crossmodel.ControllerInfo
 	// Prepare structs for unique models and addresses for each
 	// controller.


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Switch queries using slices to SQLair queries along with surrounding queries in the same transaction. This change does not add a huge amount of value here but once SQLair supports bulk inserts this will be a good use case. 
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
### Unit tests
```
TEST_PACKAGES="./domain/externalcontroller/... -count=1 -race" TEST_FILTER="Suite" make run-go-tests
```
### Testing cross model relations
```
#! /bin/bash

for c in "cns" "src" "dst"; do juju bootstrap lxd $c; done
juju switch src; juju add-model default; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model default; juju consume src:admin/default.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch dst; juju destroy-model default -y
juju switch src
watch -c juju status -m default --relations --storage --color
```
### Testing migrations

First, let's create two controllers (one with influxdb, other with grafana) and integrate them:
```
juju bootstrap localhost ctrl-src1
juju add-model model-src1
juju deploy influxdb
juju offer influxdb:grafana-source  
---
juju bootstrap localhost ctrl-src2
juju add-model model-src2
juju deploy grafana
juju integrate grafana ctrl-src1:admin/model-src1.influxdb
```
Now you can check the status with `--relations` to validate that the integration worked.

Also, let's check that the external controller have been stored in dqlite and not in mongodb:
(still on ctrl-src2)
connect to controller machine and run dqlite:
```
lxc exec juju-xxx bash
apt install go-dqlite
dqlite -s 127.0.0.1:17666 controller
SELECT * FROM external_controller; // Here you should see one external controller:
dqlite> SELECT * FROM external_controller;
b350dd86-cff7-4e42-8979-f8b40d5907e0|ctrl-src1|-----BEGIN CERTIFICATE-----
MIIEEzCCAnugAwIBAgIVALivOnMNMuM2SgZNOFE1dgDwKoZ3MA0GCSqGSIb3DQEB
...
-----END CERTIFICATE-----

// If the SELECT * FROM external_controller is not working, you may need to add
// the tls certificates to interact with DQLite directly. This can be done with:
- sudo snap install yq
- sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
- sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
- sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
```
And mongodb:
```
juju:PRIMARY> db.externalControllers.count()
0
```

Now let's bootstrap a new controller and migrate model-src2 (grafana integrated with influxdb) to it:
```
juju bootstrap localhost ctrl-target
juju switch ctrl-src2
juju migrate model-src2 ctrl-target
```
Let's check that everything has been migrated correctly and stored in dqlite and not in mogodb:
```
juju switch ctrl-target
juju switch model-src2

lxc exec juju-xxx bash

apt install go-dqlite
dqlite -s 127.0.0.1:17666 controller

dqlite> SELECT * FROM external_controller;
b350dd86-cff7-4e42-8979-f8b40d5907e0|ctrl-src1|-----BEGIN CERTIFICATE-----
MIIEEzCCAnugAwIBAgIVALivOnMNMuM2SgZNOFE1dgDwKoZ3MA0GCSqGSIb3DQEB
...
-----END CERTIFICATE-----
```
and mongodb:
```
juju:PRIMARY> db.externalControllers.count()
0
```



There is also some migration QA that can be tried here: https://github.com/juju/juju/pull/15940
This works except the last step, the external controller does not appear to be registered in the database.
<!-- Describe steps to verify that the change works. -->

## Documentation changes
N/A
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-5374

