### PR TITLE
Write dqlite machine rows after enable-ha adds new controller machines

### DIFF
--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -39,9 +39,10 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 	}
 
 	return &HighAvailabilityAPI{
-		st:          st,
-		nodeService: ctx.ServiceFactory().ControllerNode(),
-		authorizer:  authorizer,
-		logger:      ctx.Logger().Child("highavailability"),
+		st:           st,
+		nodeService:  ctx.ServiceFactory().ControllerNode(),
+		machineSaver: ctx.ServiceFactory().Machine(),
+		authorizer:   authorizer,
+		logger:       ctx.Logger().Child("highavailability"),
 	}, nil
 }


### PR DESCRIPTION
When machines are added to juju state (mongo), we also need to create minimal rows in the dqlite machine table. This was not being done when enable-ha is used to create new controllers. The issue is fixed in this PR. This is a very minimal fix as all the HA stuff is currently being rewritten.

## QA steps

bootstrap
juju enable-ha

check logs for errors like - there should be none
`machine-1: 11:27:57 ERROR juju.worker.dependency "storage-provisioner" manifold worker returned unexpected error: watching block devices: machine "1" not found`

Check dqlite machine table

```
dqlite> select * from machine;
8b08a571-6504-47e7-8465-b9e2d6e5f377|0|d1b7f5dc-bb95-4837-8c5c-506e03d728c3|0
64f7f39b-428e-41e7-87e2-d9f6e62ae9a6|1|8b1f2f40-cfec-4762-8a6f-77e2df3d4ada|0
ece2290d-cb9c-4ff5-80c7-c5990b8ee536|2|5a2316e5-66d9-4a92-87a7-fa98a6b4e2d7|0
dqlite> 
```