### PR TITLE
Improve TestStop on serverSuite from failing in teardown fixture.

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -87,6 +87,10 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	// Check it can be stopped twice.
 	err = s.Server.Stop()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// nil Server to prevent connection cleanup during teardown complaining due
+	// to connection close errors.
+	s.Server = nil
 }
 
 func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -536,12 +536,12 @@ func (s *ApiServerSuite) Model(c *gc.C, uuid string) (*state.Model, func() bool)
 
 func (s *ApiServerSuite) tearDownConn(c *gc.C) {
 	testServer := mgotesting.MgoServer.Addr()
-	serverAlive := testServer != ""
+	serverDead := testServer == "" || s.Server == nil
 
 	// Close any api connections we know about first.
 	for _, st := range s.apiConns {
 		err := st.Close()
-		if serverAlive {
+		if !serverDead {
 			c.Check(err, jc.ErrorIsNil)
 		}
 	}


### PR DESCRIPTION
In serverSuite.TestStop the api server is forcefully stopped before the connection cleanup logic in
the base api server suite. This fix allows tests to nil out the Server field, to mark the server as "stopped"
as far as the connection cleanup is concerned in tearDownConn.

```
----------------------------------------------------------------------
FAIL: <autogenerated>:1: serverSuite.TearDownTest

/home/jenkins/go/src/github.com/juju/juju/juju/testing/apiserver.go:545:
    c.Check(err, jc.ErrorIsNil)
... value *errors.Err = &errors.unformatter{message:"codec.ReadHeader error", cause:(*websocket.netError)(0xc0004bc7b0), previous:(*errors.Err)(0xc001ea11d0), function:"github.com/juju/juju/rpc.(*Conn).loop", line:435} ("codec.ReadHeader error: receiving message: write tcp 127.0.0.1:40462->127.0.0.1:46393: write: broken pipe")
... error stack:
	write tcp 127.0.0.1:40462->127.0.0.1:46393: write: broken pipe
	github.com/juju/juju/rpc/jsoncodec.(*Codec).ReadHeader:108: receiving message
	github.com/juju/juju/rpc.(*Conn).loop:435: codec.ReadHeader error
----------------------------------------------------------------------
```

## QA steps

- `cd apiserver`
- `go test -c`
- `./apiserver.test -check.f=serverSuite.TestStop`
- `OK: 1 passed`
- `stress ./apiserver.test -check.f=serverSuite.TestStop`
- `20s: 48 runs so far, 0 failures`

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/github-make-check-juju/11473/consoleText

