### PR TITLE
Move the tmp file location for the objectstore

### DIFF
--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -142,6 +142,7 @@ func ObjectStoreFactory(ctx context.Context, backendType objectstore.BackendType
 		return NewS3ObjectStore(ctx, S3ObjectStoreConfig{
 			RootBucket:      opts.rootBucket,
 			Namespace:       namespace,
+			RootDir:         opts.rootDir,
 			Client:          opts.s3Client,
 			MetadataService: opts.metadataService.ObjectStore(),
 			Claimer:         opts.claimer,

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -442,6 +442,7 @@ func (s *s3ObjectStoreSuite) newS3ObjectStore(c *gc.C) TrackedObjectStore {
 	store, err := NewS3ObjectStore(context.Background(), S3ObjectStoreConfig{
 		RootBucket:      defaultBucketName,
 		Namespace:       "inferi",
+		RootDir:         c.MkDir(),
 		Client:          s.client,
 		MetadataService: s.service,
 		Claimer:         s.claimer,


### PR DESCRIPTION
When putting files into the objectstore, we first need to place them into a temporary location.

This is for two reasons:

 - Checksum of the file to ensure it matches the expectation
 - Prevent reads whilst streaming the new file into location and rename (atomic on same filesystems - this part is key) to the desired location.

As each namespace is self managed, we need to have a better location to ensure clean up. Unfortunately on container based workloads (k8s), we aren't guaranteed to be on the same filesystem (different mounting strategies). Moving the tmp to the same location as the rootPath then allows us to have a clean location.

Once the worker bounces, we'll also attempt to clean up any files that might be left. The pruner worker (new PR comming) will run at a given interval to clean up any temp files left as well.

This PR is currently required before https://github.com/juju/juju/pull/16870 can be progressed further.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### S3 based

We're going to use local s3 setup, but this works just as well with AWS S3.

Install docker or podman (I'll demonstrate using docker).

```sh
docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   --user $(id -u):$(id -g) \
   --name minio1 \
   -e "MINIO_ROOT_USER=ROOTUSER" \
   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
   -v ${HOME}/.local/minio/data:/data \
   quay.io/minio/minio server /data --console-address ":9001"
```

Go to http://localhost:9001/access-keys and add an access key, keeping note of the key and secret.

Locate the IP for minio, we'll use that later.

```sh
$ juju bootstrap lxd test --build-agent --config="object-store-type=s3" --config="object-store-s3-endpoint=http://${IP_ADDRESS}:9000" --config="object-store-s3-static-key=${S3_KEY}" --config="object-store-s3-static-secret=${S3_SECRET}"
```

Once deployed you can inspect minio bucket.



### File based


```sh
$ juju bootstrap lxd test --build-agent --config="object-store-type=file"
```

### Additional tests

```sh
$ juju enable-ha
$ juju add-model default
$ juju deploy juju-qa-test --resource foo-file="./tests/suites/resources/foo-file.txt"
```

## Links


**Jira card:** JUJU-5354

