### PR TITLE
Provide controller config rules

### DIFF
--- a/.github/golangci-lint.config.yaml
+++ b/.github/golangci-lint.config.yaml
@@ -40,6 +40,7 @@ linters:
     - unconvert
     - exportloopref
     - unused
+    - sqlclosecheck
 run:
   timeout: 30m
   modules-download-mode: readonly

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -57,7 +57,7 @@ jobs:
           libdqlite-dev \
           libsqlite3-dev \
           sqlite3
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
         sudo curl -sSfL https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_$(go env GOARCH) -o /usr/bin/shfmt
         sudo chmod +x /usr/bin/shfmt
     

--- a/controller/config.go
+++ b/controller/config.go
@@ -571,6 +571,7 @@ var (
 		PublicDNSAddress,
 		QueryTracingEnabled,
 		QueryTracingThreshold,
+		ObjectStoreType,
 		ObjectStoreS3Endpoint,
 		ObjectStoreS3StaticKey,
 		ObjectStoreS3StaticSecret,

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -218,6 +218,7 @@ WHERE   cloud.name = ?
 		if err != nil {
 			return fmt.Errorf("fetching cloud %q region defaults: %w", cloudName, err)
 		}
+		defer rows.Close()
 
 		var regionName, key, value string
 		for rows.Next() {
@@ -226,7 +227,7 @@ WHERE   cloud.name = ?
 					"compiling cloud %q region %q defaults: %w",
 					cloudName,
 					regionName,
-					stderrors.Join(err, rows.Close()),
+					stderrors.Join(err, rows.Err()),
 				)
 			}
 			store, has := defaults[regionName]

--- a/domain/controllerconfig/service/package_mock_test.go
+++ b/domain/controllerconfig/service/package_mock_test.go
@@ -71,17 +71,17 @@ func (mr *MockStateMockRecorder) ControllerConfig(arg0 any) *gomock.Call {
 }
 
 // UpdateControllerConfig mocks base method.
-func (m *MockState) UpdateControllerConfig(arg0 context.Context, arg1 map[string]string, arg2 []string) error {
+func (m *MockState) UpdateControllerConfig(arg0 context.Context, arg1 map[string]string, arg2 []string, arg3 func(map[string]string) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateControllerConfig", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateControllerConfig", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateControllerConfig indicates an expected call of UpdateControllerConfig.
-func (mr *MockStateMockRecorder) UpdateControllerConfig(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateMockRecorder) UpdateControllerConfig(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateControllerConfig", reflect.TypeOf((*MockState)(nil).UpdateControllerConfig), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateControllerConfig", reflect.TypeOf((*MockState)(nil).UpdateControllerConfig), arg0, arg1, arg2, arg3)
 }
 
 // MockWatcherFactory is a mock of WatcherFactory interface.

--- a/domain/controllerconfig/service/service_test.go
+++ b/domain/controllerconfig/service/service_test.go
@@ -29,25 +29,12 @@ var _ = gc.Suite(&serviceSuite{})
 func (s *serviceSuite) TestUpdateControllerConfigSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cfg := controller.Config{
-		controller.AuditingEnabled:     true,
-		controller.AuditLogCaptureArgs: false,
-		controller.AuditLogMaxBackups:  10,
-		controller.PublicDNSAddress:    "controller.test.com:1234",
-		controller.APIPortOpenDelay:    "100ms",
-	}
-	coerced := map[string]string{
-		controller.AuditingEnabled:     "true",
-		controller.AuditLogCaptureArgs: "false",
-		controller.AuditLogMaxBackups:  "10",
-		controller.PublicDNSAddress:    "controller.test.com:1234",
-		controller.APIPortOpenDelay:    "100ms",
-	}
+	cfg, coerced := makeDefaultConfig("file")
 
 	k1 := controller.AuditingEnabled
 	k2 := controller.APIPortOpenDelay
 
-	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, []string{k1, k2}).Return(nil)
+	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, []string{k1, k2}, gomock.Any()).Return(nil)
 
 	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, []string{k1, k2})
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,25 +43,46 @@ func (s *serviceSuite) TestUpdateControllerConfigSuccess(c *gc.C) {
 func (s *serviceSuite) TestUpdateControllerError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cfg := controller.Config{
-		controller.AuditingEnabled:     true,
-		controller.AuditLogCaptureArgs: false,
-		controller.AuditLogMaxBackups:  10,
-		controller.PublicDNSAddress:    "controller.test.com:1234",
-		controller.APIPortOpenDelay:    "100ms",
-	}
-	coerced := map[string]string{
-		controller.AuditingEnabled:     "true",
-		controller.AuditLogCaptureArgs: "false",
-		controller.AuditLogMaxBackups:  "10",
-		controller.PublicDNSAddress:    "controller.test.com:1234",
-		controller.APIPortOpenDelay:    "100ms",
-	}
+	cfg, coerced := makeDefaultConfig("file")
 
-	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, nil).Return(errors.New("boom"))
+	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, nil, gomock.Any()).Return(errors.New("boom"))
 
 	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
 	c.Assert(err, gc.ErrorMatches, "updating controller config state: boom")
+}
+
+func (s *serviceSuite) TestUpdateControllerValidationNoError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Ensure that we allow changes to the object-store-type config key, from
+	// file to s3.
+
+	cfg, coerced := makeDefaultConfig("s3")
+	_, current := makeDefaultConfig("file")
+
+	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, nil, gomock.Any()).DoAndReturn(func(ctx context.Context, updateAttrs map[string]string, removeAttrs []string, validateModification ModificationValidatorFunc) error {
+		return validateModification(current)
+	})
+
+	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestUpdateControllerValidationError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Ensure that we prevent and reject changes to the object-store-type
+	// config key, from s3 to file.
+
+	cfg, coerced := makeDefaultConfig("file")
+	_, current := makeDefaultConfig("s3")
+
+	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, nil, gomock.Any()).DoAndReturn(func(ctx context.Context, updateAttrs map[string]string, removeAttrs []string, validateModification ModificationValidatorFunc) error {
+		return validateModification(current)
+	})
+
+	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
+	c.Assert(err, gc.ErrorMatches, `updating controller config state: can not change "object-store-type" from "s3" to "file"`)
 }
 
 func (s *serviceSuite) TestWatch(c *gc.C) {
@@ -97,4 +105,22 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.stringsWatcher = NewMockStringsWatcher(ctrl)
 
 	return ctrl
+}
+
+func makeDefaultConfig(objectType string) (controller.Config, map[string]string) {
+	return controller.Config{
+			controller.AuditingEnabled:     true,
+			controller.AuditLogCaptureArgs: false,
+			controller.AuditLogMaxBackups:  10,
+			controller.PublicDNSAddress:    "controller.test.com:1234",
+			controller.APIPortOpenDelay:    "100ms",
+			controller.ObjectStoreType:     objectType,
+		}, map[string]string{
+			controller.AuditingEnabled:     "true",
+			controller.AuditLogCaptureArgs: "false",
+			controller.AuditLogMaxBackups:  "10",
+			controller.PublicDNSAddress:    "controller.test.com:1234",
+			controller.APIPortOpenDelay:    "100ms",
+			controller.ObjectStoreType:     objectType,
+		}
 }

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -32,6 +32,7 @@ func (s *stateSuite) TestCurateNodes(c *gc.C) {
 
 	rows, err := db.QueryContext(context.Background(), "SELECT controller_id FROM controller_node")
 	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
 
 	ids := set.NewStrings()
 	for rows.Next() {

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -242,11 +242,11 @@ WHERE  controller_uuid = ?`
 		if err != nil {
 			return errors.Trace(err)
 		}
+		defer rows.Close()
 
 		for rows.Next() {
 			var modelUUID string
 			if err := rows.Scan(&modelUUID); err != nil {
-				_ = rows.Close()
 				return errors.Trace(err)
 			}
 			modelUUIDs = append(modelUUIDs, modelUUID)

--- a/domain/externalcontroller/state/state_test.go
+++ b/domain/externalcontroller/state/state_test.go
@@ -203,6 +203,7 @@ func (s *stateSuite) TestUpdateExternalControllerNewData(c *gc.C) {
 	// Check the addresses.
 	rows, err := db.Query("SELECT address FROM external_controller_address WHERE controller_uuid = ?", ecUUID)
 	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
 
 	addrs := set.NewStrings()
 	for rows.Next() {
@@ -261,6 +262,7 @@ func (s *stateSuite) TestUpdateExternalControllerUpsertAndReplace(c *gc.C) {
 	// Addresses should have one preserved and one replaced.
 	rows, err := db.Query("SELECT address FROM external_controller_address WHERE controller_uuid = ?", ecUUID)
 	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
 
 	addrs := set.NewStrings()
 	for rows.Next() {

--- a/domain/lease/state/state.go
+++ b/domain/lease/state/state.go
@@ -292,6 +292,7 @@ ORDER BY l.uuid;`[1:]
 		if err != nil {
 			return errors.Trace(err)
 		}
+		defer rows.Close()
 
 		seen := set.NewStrings()
 
@@ -302,7 +303,6 @@ ORDER BY l.uuid;`[1:]
 			var entity string
 
 			if err := rows.Scan(&leaseUUID, &key.Namespace, &key.ModelUUID, &key.Lease, &entity); err != nil {
-				_ = rows.Close()
 				return errors.Trace(err)
 			}
 

--- a/domain/lease/state/state_test.go
+++ b/domain/lease/state/state_test.go
@@ -264,6 +264,8 @@ VALUES (?, 1, 'some-model-uuid', ?, ?, datetime('now'), datetime('now', ?))`[1:]
 	stmt, err := s.DB().Prepare(q)
 	c.Assert(err, jc.ErrorIsNil)
 
+	defer stmt.Close()
+
 	_, err = stmt.Exec(utils.MustNewUUID().String(), "postgresql", "postgresql/0", "+2 minutes")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -239,6 +239,7 @@ SELECT type FROM model_type;
 		if err != nil {
 			return fmt.Errorf("getting supported model types: %w", err)
 		}
+		defer rows.Close()
 
 		var t model.Type
 		for rows.Next() {

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -67,6 +67,8 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	// Check the subnet ids for that space.
 	rows, err := db.Query("SELECT uuid FROM subnet WHERE space_uuid = ?", uuid.String())
 	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
 	i := 0
 	for rows.Next() {
 		var subnetID string

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -178,6 +178,8 @@ func (s *stateSuite) TestAddSubnet(c *gc.C) {
 	ON     availability_zone_uuid = availability_zone.uuid
 	WHERE  subnet_uuid = ?`, uuid.String())
 	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
 	var retrievedAZs []string
 	for rows.Next() {
 		var retrievedAZ string

--- a/scripts/dqlite-bench/ops.go
+++ b/scripts/dqlite-bench/ops.go
@@ -81,6 +81,7 @@ LIMIT ?
 		if err != nil {
 			return err
 		}
+		defer rows.Close()
 
 		agentUUIDS := make([]any, 0, agentUpdates)
 
@@ -114,6 +115,7 @@ LIMIT ?
 		if err != nil {
 			return err
 		}
+		defer rows.Close()
 
 		agentUUIDS := make([]any, 0, agents*2)
 		insertStrings := make([]string, 0, agents)
@@ -157,6 +159,7 @@ WHERE model_name = ?
 		if err != nil {
 			return err
 		}
+		defer rows.Close()
 
 		if !rows.Next() {
 			return nil
@@ -194,6 +197,7 @@ WHERE agent.model_name = ?
 		if err != nil {
 			return err
 		}
+		defer rows.Close()
 
 		if !rows.Next() {
 			return nil

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -15,8 +15,8 @@ run_api_imports() {
 
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.54" ]] && [[ ${VER} != "v1.54" ]]; then
-		(echo >&2 -e '\nError: golangci-lint version does not match 1.54. Please upgrade/downgrade to the right version.')
+	if [[ ${VER} != "1.55" ]] && [[ ${VER} != "v1.55" ]]; then
+		(echo >&2 -e '\nError: golangci-lint version does not match 1.55. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
 	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)


### PR DESCRIPTION
The following allows the defining of controller config rules to prevent certain keys from moving to other values without first being validated.

The driver for this change, is to enable a object store from moving to s3 from file backed storage. To do that gracefully, we need to check what the current value is and the new value. If both values are correct the update can proceed.

This provides a nice way of ensuring the controller config updates are atomic, that they do happen in the service layer and that we're not exposing too much information at each layer.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent --config="object-store-type=file"
$ juju controller-config object-store-type=s3
$ juju controller-config object-store-type=file
```

## Links

**Jira card:** JUJU-5235

