### PR TITLE
Have podman build append to manifest when building images.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -135,14 +135,16 @@ build_push_operator_image() {
             ${output} \
             "${BUILD_DIR}"
     elif [[ "${OCI_BUILDER}" = "podman" ]]; then
+        "$DOCKER_BIN" manifest rm "$(operator_image_path)" || true
+        "$DOCKER_BIN" manifest create "$(operator_image_path)"
         "$DOCKER_BIN" build \
             --jobs "4" \
             -f "${WORKDIR}/Dockerfile" \
-            -t "$(operator_image_path)" \
+            --manifest "$(operator_image_path)" \
             --platform="$build_multi_osarch" \
             "${BUILD_DIR}"
         if [[ "$push_image" = true ]]; then
-            "$DOCKER_BIN" push "$(operator_image_path)"
+            "$DOCKER_BIN" manifest push "$(operator_image_path)" "docker://$(operator_image_path)"
         fi
     else
         echo "unknown OCI_BUILDER=${OCI_BUILDER} expected docker or podman"


### PR DESCRIPTION
Fixes podman not automatically creating a manifest list for all the listed platforms.

## QA steps

Build operator images. Check `podman manifest inspect <jujud-operator-name>`.

## Documentation changes

N/A

## Links

N/A