### PR TITLE
Adds setting and configuring agent version.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -224,16 +224,17 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	// and a function to insert it into the database.
 	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(b.adminUser.Name(), auth.NewPassword(info.Password))
 
-	controllerUUID := modeldomain.UUID(
+	controllerModelUUID := modeldomain.UUID(
 		stateParams.ControllerModelConfig.UUID(),
 	)
 	controllerModelArgs := modeldomain.ModelCreationArgs{
-		Name:        stateParams.ControllerModelConfig.Name(),
-		Owner:       adminUserUUID,
-		Cloud:       stateParams.ControllerCloud.Name,
-		CloudRegion: stateParams.ControllerCloudRegion,
-		Credential:  credential.IdFromTag(cloudCredTag),
-		Type:        controllerModelType,
+		AgentVersion: stateParams.AgentVersion,
+		Name:         stateParams.ControllerModelConfig.Name(),
+		Owner:        adminUserUUID,
+		Cloud:        stateParams.ControllerCloud.Name,
+		CloudRegion:  stateParams.ControllerCloudRegion,
+		Credential:   credential.IdFromTag(cloudCredTag),
+		Type:         controllerModelType,
 	}
 
 	controllerModelDefaults := modeldefaultsbootstrap.ModelDefaultsProvider(
@@ -250,9 +251,9 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 			addAdminUser,
-			modelbootstrap.CreateModel(controllerUUID, controllerModelArgs),
+			modelbootstrap.CreateModel(controllerModelUUID, controllerModelArgs),
 		),
-		database.BootstrapModelConcern(controllerUUID,
+		database.BootstrapModelConcern(controllerModelUUID,
 			modelconfigbootstrap.SetModelConfig(stateParams.ControllerModelConfig, controllerModelDefaults),
 		),
 	}
@@ -260,7 +261,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	if !isCAAS {
 		// TODO(wallyworld) - this is just a placeholder for now
 		databaseBootstrapConcerns = append(databaseBootstrapConcerns,
-			database.BootstrapModelConcern(controllerUUID,
+			database.BootstrapModelConcern(controllerModelUUID,
 				machinebootstrap.InsertMachine(agent.BootstrapControllerId),
 			))
 	}

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -8,20 +8,29 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/juju/version/v2"
+
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/model"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/model/state"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // CreateModel is responsible for making a new model with all of its associated
 // metadata during the bootstrap process.
-// If the ModelCreationArgs do not have a credential name set then no cloud
+// If the ModelCreationArgs does not have a credential name set then no cloud
 // credential will be associated with the model.
+//
+// The only supported agent version during bootstrap is that of the current
+// controller. This will be the default if no agent version is supplied.
+//
 // The following error types can be expected to be returned:
 // - modelerrors.AlreadyExists: When the model uuid is already in use or a model
 // with the same name and owner already exists.
 // - errors.NotFound: When the cloud, cloud region, or credential do not exist.
 // - errors.NotValid: When the model uuid is not valid.
+// - [modelerrors.AgentVersionNotSupported]
 func CreateModel(
 	uuid model.UUID,
 	args model.ModelCreationArgs,
@@ -30,6 +39,17 @@ func CreateModel(
 		if err := args.Validate(); err != nil {
 			return fmt.Errorf("model creation args: %w", err)
 		}
+
+		agentVersion := args.AgentVersion
+		if args.AgentVersion == version.Zero {
+			agentVersion = jujuversion.Current
+		}
+
+		if agentVersion.Compare(jujuversion.Current) != 0 {
+			return fmt.Errorf("%w %q during bootstrap", modelerrors.AgentVersionNotSupported, agentVersion)
+		}
+		args.AgentVersion = agentVersion
+
 		if err := uuid.Validate(); err != nil {
 			return fmt.Errorf("invalid model uuid: %w", err)
 		}

--- a/domain/model/errors/errors.go
+++ b/domain/model/errors/errors.go
@@ -8,6 +8,11 @@ import (
 )
 
 const (
+	// AgentVersionNotSupported describes an error that occurs when then agent
+	// version chosen for model is not supported with respect to the currently
+	// running controller.
+	AgentVersionNotSupported = errors.ConstError("agent version not supported")
+
 	// AlreadyExists describes an error that occurs when a model already exists.
 	AlreadyExists = errors.ConstError("model already exists")
 

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3"
+	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
@@ -16,6 +17,9 @@ import (
 // ModelCreationArgs supplies the information required for instantiating a new
 // model.
 type ModelCreationArgs struct {
+	// AgentVersion is the target version for agents running under this model.
+	AgentVersion version.Number
+
 	// Cloud is the name of the cloud to associate with the model.
 	// Must not be empty for a valid struct.
 	Cloud string
@@ -34,6 +38,7 @@ type ModelCreationArgs struct {
 	Name string
 
 	// Owner is the uuid of the user that owns this model in the Juju controller.
+	// Must not be empty for a valid struct.
 	Owner user.UUID
 
 	// Type is the type of the model.

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type typesSuite struct {
@@ -55,10 +56,12 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 	userUUID, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	tests := []struct {
-		Args    ModelCreationArgs
-		ErrTest error
+		TestName string
+		Args     ModelCreationArgs
+		ErrTest  error
 	}{
 		{
+			TestName: "test model creation args with zero value agent version fails",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
@@ -69,16 +72,19 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: errors.NotValid,
 		},
 		{
+			TestName: "test model creation args with empty name fails",
 			Args: ModelCreationArgs{
-				Cloud:       "my-cloud",
-				CloudRegion: "my-region",
-				Name:        "my-awesome-model",
-				Owner:       "",
-				Type:        TypeCAAS,
+				AgentVersion: jujuversion.Current,
+				Cloud:        "my-cloud",
+				CloudRegion:  "my-region",
+				Name:         "",
+				Owner:        "wallyworld-ipv6",
+				Type:         TypeCAAS,
 			},
 			ErrTest: errors.NotValid,
 		},
 		{
+			TestName: "test model creation args with empty owner fails",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
@@ -89,6 +95,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: errors.NotSupported,
 		},
 		{
+			TestName: "test model creation args with empty cloud fails",
 			Args: ModelCreationArgs{
 				Cloud:       "",
 				CloudRegion: "my-region",
@@ -99,6 +106,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: errors.NotValid,
 		},
 		{
+			TestName: "test model creation args with empty cloud region doesn't fail",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "",
@@ -109,9 +117,11 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: nil,
 		},
 		{
+			TestName: "test model creation args with invalid credential fails",
 			Args: ModelCreationArgs{
-				Cloud:       "my-cloud",
-				CloudRegion: "my-region",
+				AgentVersion: jujuversion.Current,
+				Cloud:        "my-cloud",
+				CloudRegion:  "my-region",
 				Credential: credential.ID{
 					Owner: "wallyworld",
 				},
@@ -122,6 +132,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: errors.NotValid,
 		},
 		{
+			TestName: "test model creation args happy path 1",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
@@ -132,9 +143,11 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			ErrTest: nil,
 		},
 		{
+			TestName: "test model creation args happy path 2",
 			Args: ModelCreationArgs{
-				Cloud:       "my-cloud",
-				CloudRegion: "my-region",
+				AgentVersion: jujuversion.Current,
+				Cloud:        "my-cloud",
+				CloudRegion:  "my-region",
 				Credential: credential.ID{
 					Cloud: "cloud",
 					Owner: "wallyworld",
@@ -151,9 +164,9 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 	for _, test := range tests {
 		err := test.Args.Validate()
 		if test.ErrTest == nil {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(err, jc.ErrorIsNil, gc.Commentf(test.TestName))
 		} else {
-			c.Assert(err, jc.ErrorIs, test.ErrTest)
+			c.Assert(err, jc.ErrorIs, test.ErrTest, gc.Commentf(test.TestName))
 		}
 	}
 }

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -86,6 +86,7 @@ func (s *ControllerFactory) ControllerNode() *controllernodeservice.Service {
 func (s *ControllerFactory) Model() *modelservice.Service {
 	return modelservice.NewService(
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+		modelservice.DefaultAgentBinaryFinder(),
 	)
 }
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -787,6 +787,11 @@ func finalizeInstanceBootstrapConfig(
 		return errors.Annotate(err, "encoding default controller cert to pem")
 	}
 
+	agentVersion, has := cfg.AgentVersion()
+	if !has {
+		return errors.New("finalising instance bootstrap config, agent version not set on model config")
+	}
+
 	icfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		StatePort:    controllerCfg.StatePort(),
 		APIPort:      controllerCfg.APIPort(),
@@ -794,6 +799,7 @@ func finalizeInstanceBootstrapConfig(
 		PrivateKey:   string(key),
 		CAPrivateKey: args.CAPrivateKey,
 	}
+	icfg.Bootstrap.StateInitializationParams.AgentVersion = agentVersion
 	icfg.Bootstrap.ControllerModelConfig = cfg
 	icfg.Bootstrap.ControllerModelEnvironVersion = environVersion
 	icfg.Bootstrap.CustomImageMetadata = customImageMetadata

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -270,6 +270,10 @@ type SSHKeyPair struct {
 // This structure will be passed to the bootstrap agent. To do so, the
 // Marshal and Unmarshal methods must be used.
 type StateInitializationParams struct {
+	// AgentVersion is the desired agent version to run for models created as
+	// part of state initialization.
+	AgentVersion version.Number
+
 	// ControllerModelConfig holds the initial controller model configuration.
 	ControllerModelConfig *config.Config
 
@@ -347,6 +351,7 @@ type StateInitializationParams struct {
 }
 
 type stateInitializationParamsInternal struct {
+	AgentVersion                            string                            `yaml:"agent-version"`
 	ControllerConfig                        map[string]interface{}            `yaml:"controller-config"`
 	ControllerModelConfig                   map[string]interface{}            `yaml:"controller-model-config"`
 	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
@@ -379,6 +384,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		return nil, errors.Annotate(err, "marshalling cloud definition")
 	}
 	internal := stateInitializationParamsInternal{
+		AgentVersion:                            p.AgentVersion.String(),
 		ControllerConfig:                        p.ControllerConfig,
 		ControllerModelConfig:                   p.ControllerModelConfig.AllAttrs(),
 		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
@@ -421,7 +427,12 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	agentVersion, err := version.Parse(internal.AgentVersion)
+	if err != nil {
+		return fmt.Errorf("parsing agent-version in state initialisation params: %w", err)
+	}
 	*p = StateInitializationParams{
+		AgentVersion:                            agentVersion,
 		ControllerConfig:                        internal.ControllerConfig,
 		ControllerModelConfig:                   cfg,
 		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,


### PR DESCRIPTION
During model creation and bootstrap we are adding support for both setting a models agent version and for also implementing the buisness logic for determining what a model's agent version should be when it has not been supplied.

This code has been copied over from controller model config creator. For this PR we are leaving a small todo around the tools finder that will be implemented in a follow up PR when the API facade gets wired up.

- Adds logic to model state for setting the agent version record on model creation.
- Adds service layer logic for choosing and validating the model agent version chosen based on the current rules Juju implements.
- Defines a slim downed tools finder interface for model service to check for available tools.
- Updates the bootstrap model process to also calculate and validate the models agent version.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. You will need to bootstrap a new controller and confirm the process is successful with no errors. We are not using the values at the moment just setting.
2. Run unit tests for the model domain.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5337

