### PR TITLE
Update ubuntu minimal image filtering on OCI

### DIFF
--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -466,7 +466,7 @@ func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, e
 		}
 		// For the moment juju does not support minimal ubuntu
 		if img.IsMinimal {
-			logger.Debugf("ubuntu minimal images (%q), not supported", *val.DisplayName)
+			logger.Tracef("ubuntu minimal images (%q), not supported", *val.DisplayName)
 			continue
 		}
 		// Only set the instance types to the images that we correctly

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -5,7 +5,6 @@ package oci
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -111,6 +110,9 @@ type InstanceImage struct {
 	CompartmentId *string
 	// InstanceTypes holds a list of shapes compatible with this image
 	InstanceTypes []instances.InstanceType
+	// IsMinimal is true when the image is a Minimal image. Can only be
+	// true for ubuntu OS.
+	IsMinimal bool
 }
 
 func (i *InstanceImage) SetInstanceTypes(types []instances.InstanceType) {
@@ -259,9 +261,11 @@ func getImageType(img ociCore.Image) ImageType {
 // struct returned by oci's API, the image's architecture or an error.
 func NewInstanceImage(img ociCore.Image, compartmentID *string) (InstanceImage, string, error) {
 	var (
-		err  error
-		arch string
-		base corebase.Base
+		err       error
+		arch      string
+		base      corebase.Base
+		isMinimal bool
+		imgType   InstanceImage
 	)
 	switch osName := *img.OperatingSystem; osName {
 	case centOS:
@@ -269,20 +273,17 @@ func NewInstanceImage(img ociCore.Image, compartmentID *string) (InstanceImage, 
 		// For the moment, only x86 shapes are supported
 		arch = corearch.AMD64
 	case ubuntuOS:
-		base, arch, err = parseUbuntuImage(img)
-		if err != nil {
-			return InstanceImage{}, "", err
-		}
+		base, arch, isMinimal = parseUbuntuImage(img)
 	default:
 		return InstanceImage{}, "", errors.NotSupportedf("os %s", osName)
 	}
 
-	var imgType InstanceImage
 	imgType.ImageType = getImageType(img)
 	imgType.Id = *img.Id
 	imgType.Base = base
 	imgType.Raw = img
 	imgType.CompartmentId = compartmentID
+	imgType.IsMinimal = isMinimal
 
 	version, err := NewImageVersion(img)
 	if err != nil {
@@ -295,10 +296,11 @@ func NewInstanceImage(img ociCore.Image, compartmentID *string) (InstanceImage, 
 
 // parseUbuntuImage returns the base and architecture of the returned image
 // from the OCI sdk.
-func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, error) {
+func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, bool) {
 	var (
-		arch string = corearch.AMD64
-		base corebase.Base
+		arch      string = corearch.AMD64
+		base      corebase.Base
+		isMinimal bool
 	)
 	// On some cases, the retrieved OperatingSystemVersion can contain
 	// the channel plus some extra information and in some others this
@@ -325,9 +327,7 @@ func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, error) {
 	// the channel.
 	if strings.Contains(*img.DisplayName, "Minimal") ||
 		strings.Contains(postfix, "Minimal") {
-		return corebase.Base{}, "", fmt.Errorf(
-			"ubuntu minimal image %q %w", *img.DisplayName, errors.NotSupported,
-		)
+		isMinimal = true
 	}
 
 	if strings.Contains(*img.DisplayName, "aarch64") ||
@@ -335,7 +335,7 @@ func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, error) {
 		arch = corearch.ARM64
 	}
 
-	return base, arch, nil
+	return base, arch, isMinimal
 }
 
 // instanceTypes will return the list of instanceTypes with information
@@ -462,6 +462,11 @@ func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, e
 			} else {
 				logger.Debugf("error parsing image %q", err)
 			}
+			continue
+		}
+		// For the moment juju does not support minimal ubuntu
+		if img.IsMinimal {
+			logger.Debugf("ubuntu minimal images (%q), not supported", *val.DisplayName)
 			continue
 		}
 		// Only set the instance types to the images that we correctly


### PR DESCRIPTION
On the patch https://github.com/juju/juju/pull/16859 we limit the selection of ubuntu minimal images on OCI by simply returning an error when the "Minimal" keyword is either on the display name or in the Operating System Version.
This patch adds a new field to the Image struct for OCI thus identifying minimal images. For the moment we filter all images that have the boolean IsMinimal to true, but later we might update this behaviour to filter only some of the minimal images or non at all.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrapping should always work since we are sure no minimal images are being selected:
```
juju bootstrap --config compartment-id=ocid1.compartment.oc1..aaaaaaaanvu2racnlczevenu73dlcf3nokgsjpdkbdgp4xbrz3lb2y4giyjq oci-canonical c
juju add-model m
juju deploy ubuntu
```


## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2051610

**Jira card:** JUJU-5399

