### PR TITLE
Watchable services

### DIFF
--- a/domain/blockdevice/modelmigration/export.go
+++ b/domain/blockdevice/modelmigration/export.go
@@ -42,7 +42,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	e.service = service.NewService(
-		state.NewState(scope.ModelDB()), nil, logger)
+		state.NewState(scope.ModelDB()), logger)
 	return nil
 }
 

--- a/domain/blockdevice/modelmigration/import.go
+++ b/domain/blockdevice/modelmigration/import.go
@@ -43,7 +43,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	i.service = service.NewService(
-		state.NewState(scope.ModelDB()), nil, logger)
+		state.NewState(scope.ModelDB()), logger)
 	return nil
 }
 

--- a/domain/blockdevice/service/service_test.go
+++ b/domain/blockdevice/service/service_test.go
@@ -34,8 +34,8 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *serviceSuite) service() *Service {
-	return NewService(s.state, s.watcherFactory, loggo.GetLogger("test"))
+func (s *serviceSuite) service() *WatchableService {
+	return NewWatchableService(s.state, s.watcherFactory, loggo.GetLogger("test"))
 }
 
 func (s *serviceSuite) TestBlockDevices(c *gc.C) {

--- a/domain/blockdevice/watcher_test.go
+++ b/domain/blockdevice/watcher_test.go
@@ -63,7 +63,7 @@ func (s *watcherSuite) TestWatchBlockDevicesMissingMachine(c *gc.C) {
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
 		jujutesting.NewCheckLogger(c))
-	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
+	service := service.NewWatchableService(st, factory, jujutesting.NewCheckLogger(c))
 
 	_, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, gc.ErrorMatches, `machine "666" not found`)
@@ -76,7 +76,7 @@ func (s *watcherSuite) TestStops(c *gc.C) {
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
 		jujutesting.NewCheckLogger(c))
-	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
+	service := service.NewWatchableService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -97,7 +97,7 @@ func (s *watcherSuite) TestWatchBlockDevices(c *gc.C) {
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
 		jujutesting.NewCheckLogger(c))
-	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
+	service := service.NewWatchableService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -142,7 +142,7 @@ func (s *watcherSuite) TestWatchBlockDevicesIgnoresWrongMachine(c *gc.C) {
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "uuid"),
 		jujutesting.NewCheckLogger(c))
-	service := service.NewService(st, factory, jujutesting.NewCheckLogger(c))
+	service := service.NewWatchableService(st, factory, jujutesting.NewCheckLogger(c))
 
 	w, err := service.WatchBlockDevices(context.Background(), "667")
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/cloud/service/service_test.go
+++ b/domain/cloud/service/service_test.go
@@ -39,7 +39,7 @@ func (s *serviceSuite) TestUpdateSuccess(c *gc.C) {
 	}
 	s.state.EXPECT().UpsertCloud(gomock.Any(), cloud).Return(nil)
 
-	err := NewService(s.state, s.watcherFactory).Save(context.Background(), cloud)
+	err := NewWatchableService(s.state, s.watcherFactory).Save(context.Background(), cloud)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -51,7 +51,7 @@ func (s *serviceSuite) TestUpdateError(c *gc.C) {
 	}
 	s.state.EXPECT().UpsertCloud(gomock.Any(), cloud).Return(errors.New("boom"))
 
-	err := NewService(s.state, s.watcherFactory).Save(context.Background(), cloud)
+	err := NewWatchableService(s.state, s.watcherFactory).Save(context.Background(), cloud)
 	c.Assert(err, gc.ErrorMatches, `updating cloud "fluffy": boom`)
 }
 
@@ -63,7 +63,7 @@ func (s *serviceSuite) TestListAll(c *gc.C) {
 	}}
 	s.state.EXPECT().ListClouds(gomock.Any(), "").Return(clouds, nil)
 
-	result, err := NewService(s.state, s.watcherFactory).ListAll(context.Background())
+	result, err := NewWatchableService(s.state, s.watcherFactory).ListAll(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, clouds)
 }
@@ -76,7 +76,7 @@ func (s *serviceSuite) TestGet(c *gc.C) {
 	}
 	s.state.EXPECT().ListClouds(gomock.Any(), "fluffy").Return([]cloud.Cloud{one}, nil)
 
-	result, err := NewService(s.state, s.watcherFactory).Get(context.Background(), "fluffy")
+	result, err := NewWatchableService(s.state, s.watcherFactory).Get(context.Background(), "fluffy")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &one)
 }
@@ -86,7 +86,7 @@ func (s *serviceSuite) TestGetNotFound(c *gc.C) {
 
 	s.state.EXPECT().ListClouds(gomock.Any(), "fluffy").Return(nil, nil)
 
-	result, err := NewService(s.state, s.watcherFactory).Get(context.Background(), "fluffy")
+	result, err := NewWatchableService(s.state, s.watcherFactory).Get(context.Background(), "fluffy")
 	c.Assert(err, gc.ErrorMatches, `cloud "fluffy" not found`)
 	c.Assert(result, gc.IsNil)
 }
@@ -98,7 +98,7 @@ func (s *serviceSuite) TestWatchCloud(c *gc.C) {
 
 	s.state.EXPECT().WatchCloud(gomock.Any(), gomock.Any(), "cirrus").Return(nw, nil)
 
-	w, err := NewService(s.state, s.watcherFactory).WatchCloud(context.Background(), "cirrus")
+	w, err := NewWatchableService(s.state, s.watcherFactory).WatchCloud(context.Background(), "cirrus")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }

--- a/domain/controllerconfig/controllerconfig_test.go
+++ b/domain/controllerconfig/controllerconfig_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&controllerconfigSuite{})
 
 func (s *controllerconfigSuite) TestControllerConfigRoundTrips(c *gc.C) {
 	st := domainstate.NewState(s.TxnRunnerFactory())
-	srv := service.NewService(st, nil)
+	srv := service.NewService(st)
 
 	cfgMap := map[string]any{
 		controller.AuditingEnabled:        true,

--- a/domain/controllerconfig/service/service_test.go
+++ b/domain/controllerconfig/service/service_test.go
@@ -36,7 +36,7 @@ func (s *serviceSuite) TestUpdateControllerConfigSuccess(c *gc.C) {
 
 	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, []string{k1, k2}, gomock.Any()).Return(nil)
 
-	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, []string{k1, k2})
+	err := NewWatchableService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, []string{k1, k2})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -47,7 +47,7 @@ func (s *serviceSuite) TestUpdateControllerError(c *gc.C) {
 
 	s.state.EXPECT().UpdateControllerConfig(gomock.Any(), coerced, nil, gomock.Any()).Return(errors.New("boom"))
 
-	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
+	err := NewWatchableService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
 	c.Assert(err, gc.ErrorMatches, "updating controller config state: boom")
 }
 
@@ -64,7 +64,7 @@ func (s *serviceSuite) TestUpdateControllerValidationNoError(c *gc.C) {
 		return validateModification(current)
 	})
 
-	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
+	err := NewWatchableService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -81,7 +81,7 @@ func (s *serviceSuite) TestUpdateControllerValidationError(c *gc.C) {
 		return validateModification(current)
 	})
 
-	err := NewService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
+	err := NewWatchableService(s.state, s.watcherFactory).UpdateControllerConfig(context.Background(), cfg, nil)
 	c.Assert(err, gc.ErrorMatches, `updating controller config state: can not change "object-store-type" from "s3" to "file"`)
 }
 
@@ -92,7 +92,7 @@ func (s *serviceSuite) TestWatch(c *gc.C) {
 	s.state.EXPECT().AllKeysQuery().Return(q)
 	s.watcherFactory.EXPECT().NewNamespaceWatcher("controller_config", changestream.All, q).Return(s.stringsWatcher, nil)
 
-	w, err := NewService(s.state, s.watcherFactory).Watch()
+	w, err := NewWatchableService(s.state, s.watcherFactory).Watch()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -44,7 +44,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	e.service = service.NewService(
-		state.NewState(scope.ControllerDB()), nil, logger)
+		state.NewState(scope.ControllerDB()), logger)
 	return nil
 }
 

--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -46,7 +46,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	i.service = service.NewService(
-		state.NewState(scope.ControllerDB()), nil, logger)
+		state.NewState(scope.ControllerDB()), logger)
 	return nil
 }
 

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -41,8 +41,8 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *serviceSuite) service() *Service {
-	return NewService(s.state, s.watcherFactory, loggo.GetLogger("test"))
+func (s *serviceSuite) service() *WatchableService {
+	return NewWatchableService(s.state, s.watcherFactory, loggo.GetLogger("test"))
 }
 
 func (s *serviceSuite) TestUpdateCloudCredential(c *gc.C) {

--- a/domain/externalcontroller/modelmigration/export.go
+++ b/domain/externalcontroller/modelmigration/export.go
@@ -50,7 +50,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	e.service = service.NewService(
-		state.NewState(scope.ControllerDB()), nil)
+		state.NewState(scope.ControllerDB()))
 	return nil
 }
 

--- a/domain/externalcontroller/modelmigration/import.go
+++ b/domain/externalcontroller/modelmigration/import.go
@@ -40,7 +40,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.
 	i.service = service.NewService(
-		state.NewState(scope.ControllerDB()), nil)
+		state.NewState(scope.ControllerDB()))
 	return nil
 }
 

--- a/domain/externalcontroller/service/service_test.go
+++ b/domain/externalcontroller/service/service_test.go
@@ -41,7 +41,7 @@ func (s *serviceSuite) TestUpdateExternalControllerSuccess(c *gc.C) {
 
 	s.state.EXPECT().UpdateExternalController(gomock.Any(), ec).Return(nil)
 
-	err := NewService(s.state, nil).UpdateExternalController(context.Background(), ec)
+	err := NewService(s.state).UpdateExternalController(context.Background(), ec)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -57,7 +57,7 @@ func (s *serviceSuite) TestUpdateExternalControllerError(c *gc.C) {
 
 	s.state.EXPECT().UpdateExternalController(gomock.Any(), ec).Return(errors.New("boom"))
 
-	err := NewService(s.state, nil).UpdateExternalController(context.Background(), ec)
+	err := NewService(s.state).UpdateExternalController(context.Background(), ec)
 	c.Assert(err, gc.ErrorMatches, "updating external controller state: boom")
 }
 
@@ -74,7 +74,7 @@ func (s *serviceSuite) TestRetrieveExternalControllerSuccess(c *gc.C) {
 
 	s.state.EXPECT().Controller(gomock.Any(), ctrlUUID).Return(&ec, nil)
 
-	res, err := NewService(s.state, nil).Controller(context.Background(), ctrlUUID)
+	res, err := NewService(s.state).Controller(context.Background(), ctrlUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.Equals, &ec)
 }
@@ -85,7 +85,7 @@ func (s *serviceSuite) TestRetrieveExternalControllerError(c *gc.C) {
 	ctrlUUID := "ctrl1"
 	s.state.EXPECT().Controller(gomock.Any(), ctrlUUID).Return(nil, errors.New("boom"))
 
-	_, err := NewService(s.state, nil).Controller(context.Background(), ctrlUUID)
+	_, err := NewService(s.state).Controller(context.Background(), ctrlUUID)
 	c.Assert(err, gc.ErrorMatches, "retrieving external controller ctrl1: boom")
 }
 
@@ -104,7 +104,7 @@ func (s *serviceSuite) TestRetrieveExternalControllerForModelSuccess(c *gc.C) {
 
 	s.state.EXPECT().ControllersForModels(gomock.Any(), modelUUID).Return(ec, nil)
 
-	res, err := NewService(s.state, nil).ControllerForModel(context.Background(), modelUUID)
+	res, err := NewService(s.state).ControllerForModel(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.Equals, &ec[0])
 }
@@ -115,7 +115,7 @@ func (s *serviceSuite) TestRetrieveExternalControllerForModelError(c *gc.C) {
 	modelUUID := "model1"
 	s.state.EXPECT().ControllersForModels(gomock.Any(), modelUUID).Return(nil, errors.New("boom"))
 
-	_, err := NewService(s.state, nil).ControllerForModel(context.Background(), modelUUID)
+	_, err := NewService(s.state).ControllerForModel(context.Background(), modelUUID)
 	c.Assert(err, gc.ErrorMatches, "retrieving external controller for model model1: boom")
 }
 
@@ -125,7 +125,7 @@ func (s *serviceSuite) TestRetrieveExternalControllerForModelNotFound(c *gc.C) {
 	modelUUID := "model1"
 	s.state.EXPECT().ControllersForModels(gomock.Any(), modelUUID).Return(nil, nil)
 
-	_, err := NewService(s.state, nil).ControllerForModel(context.Background(), modelUUID)
+	_, err := NewService(s.state).ControllerForModel(context.Background(), modelUUID)
 	c.Assert(err, gc.ErrorMatches, "external controller for model \"model1\" not found")
 }
 

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -49,7 +49,7 @@ func (s *serviceSuite) TestSetModelConfig(c *gc.C) {
 	st := testing.NewState()
 	defer st.Close()
 
-	svc := NewService(defaults, st, st)
+	svc := NewWatchableService(defaults, st, st)
 
 	watcher, err := svc.Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/modeldefaults/service/service.go
+++ b/domain/modeldefaults/service/service.go
@@ -59,6 +59,13 @@ func (f ModelDefaultsProviderFunc) ModelDefaults(
 	return f(ctx)
 }
 
+// NewService returns a new Service for interacting with model defaults state.
+func NewService(st State) *Service {
+	return &Service{
+		st: st,
+	}
+}
+
 // ModelDefaults will return the default config values to be used for a model
 // and it's config. If no model for uuid is found then a error satisfying
 // [github.com/juju/juju/domain/model/errors.NotFound] will be returned.
@@ -136,12 +143,5 @@ func (s *Service) ModelDefaultsProvider(
 ) ModelDefaultsProviderFunc {
 	return func(ctx context.Context) (modeldefaults.Defaults, error) {
 		return s.ModelDefaults(ctx, uuid)
-	}
-}
-
-// NewService returns a new Service for interacting with model defaults state.
-func NewService(st State) *Service {
-	return &Service{
-		st: st,
 	}
 }

--- a/domain/modelmanager/service/service.go
+++ b/domain/modelmanager/service/service.go
@@ -15,8 +15,13 @@ import (
 
 // State defines a interface for interacting with the underlying state.
 type State interface {
+	// Create takes a model UUID and creates a new model.
 	Create(context.Context, model.UUID) error
+
+	// List returns a list of all model UUIDs.
 	List(context.Context) ([]model.UUID, error)
+
+	// Delete takes a model UUID and deletes the model if it exists.
 	Delete(context.Context, model.UUID) error
 }
 

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -38,15 +38,13 @@ type WatcherFactory interface {
 
 // Service provides the API for working with the coreobjectstore.
 type Service struct {
-	st             State
-	watcherFactory WatcherFactory
+	st State
 }
 
 // NewService returns a new service reference wrapping the input state.
-func NewService(st State, watcherFactory WatcherFactory) *Service {
+func NewService(st State) *Service {
 	return &Service{
-		st:             st,
-		watcherFactory: watcherFactory,
+		st: st,
 	}
 }
 
@@ -91,9 +89,26 @@ func (s *Service) RemoveMetadata(ctx context.Context, path string) error {
 	return nil
 }
 
+// WatchableService provides the API for working with the objectstore
+// and the ability to create watchers.
+type WatchableService struct {
+	Service
+	watcherFactory WatcherFactory
+}
+
+// NewWatchableService returns a new service reference wrapping the input state.
+func NewWatchableService(st State, watcherFactory WatcherFactory) *WatchableService {
+	return &WatchableService{
+		Service: Service{
+			st: st,
+		},
+		watcherFactory: watcherFactory,
+	}
+}
+
 // Watch returns a watcher that emits the path changes that either have been
 // added or removed.
-func (s *Service) Watch() (watcher.StringsWatcher, error) {
+func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
 	table, stmt := s.st.InitialWatchStatement()
 	return s.watcherFactory.NewNamespaceWatcher(
 		table,

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -45,7 +45,7 @@ func (s *serviceSuite) TestGetMetadata(c *gc.C) {
 		Hash: metadata.Hash,
 	}, nil)
 
-	p, err := NewService(s.state, nil).GetMetadata(context.Background(), path)
+	p, err := NewService(s.state).GetMetadata(context.Background(), path)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(p, gc.DeepEquals, metadata)
 }
@@ -67,7 +67,7 @@ func (s *serviceSuite) TestPutMetadata(c *gc.C) {
 		return nil
 	})
 
-	err := NewService(s.state, nil).PutMetadata(context.Background(), metadata)
+	err := NewService(s.state).PutMetadata(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -78,7 +78,7 @@ func (s *serviceSuite) TestRemoveMetadata(c *gc.C) {
 
 	s.state.EXPECT().RemoveMetadata(gomock.Any(), key).Return(nil)
 
-	err := NewService(s.state, nil).RemoveMetadata(context.Background(), key)
+	err := NewService(s.state).RemoveMetadata(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -94,7 +94,7 @@ func (s *serviceSuite) TestWatch(c *gc.C) {
 	s.state.EXPECT().InitialWatchStatement().Return(table, stmt)
 	s.watcherFactory.EXPECT().NewNamespaceWatcher(table, changestream.All, stmt).Return(watcher, nil)
 
-	w, err := NewService(s.state, s.watcherFactory).Watch()
+	w, err := NewWatchableService(s.state, s.watcherFactory).Watch()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -29,7 +29,7 @@ var _ = gc.Suite(&watcherSuite{})
 func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "objectstore")
 
-	svc := service.NewService(state.NewState(func() (database.TxnRunner, error) { return factory() }),
+	svc := service.NewWatchableService(state.NewState(func() (database.TxnRunner, error) { return factory() }),
 		domain.NewWatcherFactory(factory,
 			testing.NewCheckLogger(c),
 		),
@@ -65,7 +65,7 @@ func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
 func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "objectstore")
 
-	svc := service.NewService(state.NewState(func() (database.TxnRunner, error) { return factory() }),
+	svc := service.NewWatchableService(state.NewState(func() (database.TxnRunner, error) { return factory() }),
 		domain.NewWatcherFactory(factory,
 			testing.NewCheckLogger(c),
 		),

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -65,8 +65,8 @@ func NewControllerFactory(
 }
 
 // ControllerConfig returns the controller configuration service.
-func (s *ControllerFactory) ControllerConfig() *controllerconfigservice.Service {
-	return controllerconfigservice.NewService(
+func (s *ControllerFactory) ControllerConfig() *controllerconfigservice.WatchableService {
+	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,
@@ -105,8 +105,8 @@ func (s *ControllerFactory) ModelManager() *modelmanagerservice.Service {
 }
 
 // ExternalController returns the external controller service.
-func (s *ControllerFactory) ExternalController() *externalcontrollerservice.Service {
-	return externalcontrollerservice.NewService(
+func (s *ControllerFactory) ExternalController() *externalcontrollerservice.WatchableService {
+	return externalcontrollerservice.NewWatchableService(
 		externalcontrollerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,
@@ -116,8 +116,8 @@ func (s *ControllerFactory) ExternalController() *externalcontrollerservice.Serv
 }
 
 // Credential returns the credential service.
-func (s *ControllerFactory) Credential() *credentialservice.Service {
-	return credentialservice.NewService(
+func (s *ControllerFactory) Credential() *credentialservice.WatchableService {
+	return credentialservice.NewWatchableService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,
@@ -128,8 +128,8 @@ func (s *ControllerFactory) Credential() *credentialservice.Service {
 }
 
 // Cloud returns the cloud service.
-func (s *ControllerFactory) Cloud() *cloudservice.Service {
-	return cloudservice.NewService(
+func (s *ControllerFactory) Cloud() *cloudservice.WatchableService {
+	return cloudservice.NewWatchableService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,
@@ -147,8 +147,8 @@ func (s *ControllerFactory) AutocertCache() *autocertcacheservice.Service {
 }
 
 // Upgrade returns the upgrade service.
-func (s *ControllerFactory) Upgrade() *upgradeservice.Service {
-	return upgradeservice.NewService(
+func (s *ControllerFactory) Upgrade() *upgradeservice.WatchableService {
+	return upgradeservice.NewWatchableService(
 		upgradestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,
@@ -158,8 +158,8 @@ func (s *ControllerFactory) Upgrade() *upgradeservice.Service {
 }
 
 // AgentObjectStore returns the object store service.
-func (s *ControllerFactory) AgentObjectStore() *objectstoreservice.Service {
-	return objectstoreservice.NewService(
+func (s *ControllerFactory) AgentObjectStore() *objectstoreservice.WatchableService {
+	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		domain.NewWatcherFactory(
 			s.controllerDB,

--- a/domain/servicefactory/model.go
+++ b/domain/servicefactory/model.go
@@ -43,8 +43,8 @@ func NewModelFactory(
 // obtained from the controller service factory model defaults service.
 func (s *ModelFactory) Config(
 	defaultsProvider modelconfigservice.ModelDefaultsProvider,
-) *modelconfigservice.Service {
-	return modelconfigservice.NewService(
+) *modelconfigservice.WatchableService {
+	return modelconfigservice.NewWatchableService(
 		defaultsProvider,
 		modelconfigstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
 		domain.NewWatcherFactory(s.modelDB, s.logger.Child("modelconfig")),
@@ -52,8 +52,8 @@ func (s *ModelFactory) Config(
 }
 
 // ObjectStore returns the model's object store service.
-func (s *ModelFactory) ObjectStore() *objectstoreservice.Service {
-	return objectstoreservice.NewService(
+func (s *ModelFactory) ObjectStore() *objectstoreservice.WatchableService {
+	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
 		domain.NewWatcherFactory(
 			s.modelDB,
@@ -70,8 +70,8 @@ func (s *ModelFactory) Machine() *machineservice.Service {
 }
 
 // BlockDevice returns the model's block device service.
-func (s *ModelFactory) BlockDevice() *blockdeviceservice.Service {
-	return blockdeviceservice.NewService(
+func (s *ModelFactory) BlockDevice() *blockdeviceservice.WatchableService {
+	return blockdeviceservice.NewWatchableService(
 		blockdevicestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
 		domain.NewWatcherFactory(s.modelDB, s.logger.Child("blockdevice")),
 		s.logger.Child("blockdevice"),

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -41,12 +41,12 @@ func (s *TestingServiceFactory) AutocertCache() *autocertcacheservice.Service {
 }
 
 // Config returns the model config service.
-func (s *TestingServiceFactory) Config(_ modelconfigservice.ModelDefaultsProvider) *modelconfigservice.Service {
+func (s *TestingServiceFactory) Config(_ modelconfigservice.ModelDefaultsProvider) *modelconfigservice.WatchableService {
 	return nil
 }
 
 // ControllerConfig returns the controller configuration service.
-func (s *TestingServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s *TestingServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	return nil
 }
 
@@ -71,32 +71,32 @@ func (s *TestingServiceFactory) ModelManager() *modelmanagerservice.Service {
 }
 
 // ExternalController returns the external controller service.
-func (s *TestingServiceFactory) ExternalController() *externalcontrollerservice.Service {
+func (s *TestingServiceFactory) ExternalController() *externalcontrollerservice.WatchableService {
 	return nil
 }
 
 // Credential returns the credential service.
-func (s *TestingServiceFactory) Credential() *credentialservice.Service {
+func (s *TestingServiceFactory) Credential() *credentialservice.WatchableService {
 	return nil
 }
 
 // Cloud returns the cloud service.
-func (s *TestingServiceFactory) Cloud() *cloudservice.Service {
+func (s *TestingServiceFactory) Cloud() *cloudservice.WatchableService {
 	return nil
 }
 
 // Upgrade returns the upgrade service.
-func (s *TestingServiceFactory) Upgrade() *upgradeservice.Service {
+func (s *TestingServiceFactory) Upgrade() *upgradeservice.WatchableService {
 	return nil
 }
 
 // AgentObjectStore returns the agent object store service.
-func (s *TestingServiceFactory) AgentObjectStore() *objectstoreservice.Service {
+func (s *TestingServiceFactory) AgentObjectStore() *objectstoreservice.WatchableService {
 	return nil
 }
 
 // ObjectStore returns the object store service.
-func (s *TestingServiceFactory) ObjectStore() *objectstoreservice.Service {
+func (s *TestingServiceFactory) ObjectStore() *objectstoreservice.WatchableService {
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (s *TestingServiceFactory) WithMachineService(getter func() *machineservice
 }
 
 // BlockDevice returns the block device service.
-func (s *TestingServiceFactory) BlockDevice() *blockdeviceservice.Service {
+func (s *TestingServiceFactory) BlockDevice() *blockdeviceservice.WatchableService {
 	return nil
 }
 

--- a/domain/upgrade/service/service_test.go
+++ b/domain/upgrade/service/service_test.go
@@ -25,7 +25,7 @@ type serviceSuite struct {
 	state          *MockState
 	watcherFactory *MockWatcherFactory
 
-	srv *Service
+	service *WatchableService
 }
 
 var _ = gc.Suite(&serviceSuite{})
@@ -36,7 +36,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.state = NewMockState(ctrl)
 	s.watcherFactory = NewMockWatcherFactory(ctrl)
 
-	s.srv = NewService(s.state, s.watcherFactory)
+	s.service = NewWatchableService(s.state, s.watcherFactory)
 	return ctrl
 }
 
@@ -45,7 +45,7 @@ func (s *serviceSuite) TestCreateUpgrade(c *gc.C) {
 
 	s.state.EXPECT().CreateUpgrade(gomock.Any(), version.MustParse("3.0.0"), version.MustParse("3.0.1")).Return(s.upgradeUUID, nil)
 
-	upgradeUUID, err := s.srv.CreateUpgrade(context.Background(), version.MustParse("3.0.0"), version.MustParse("3.0.1"))
+	upgradeUUID, err := s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.0"), version.MustParse("3.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(upgradeUUID, gc.Equals, s.upgradeUUID)
 }
@@ -56,15 +56,15 @@ func (s *serviceSuite) TestCreateUpgradeAlreadyExists(c *gc.C) {
 	ucErr := sqlite3.Error{ExtendedCode: sqlite3.ErrConstraintUnique}
 	s.state.EXPECT().CreateUpgrade(gomock.Any(), version.MustParse("3.0.0"), version.MustParse("3.0.1")).Return(s.upgradeUUID, ucErr)
 
-	_, err := s.srv.CreateUpgrade(context.Background(), version.MustParse("3.0.0"), version.MustParse("3.0.1"))
+	_, err := s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.0"), version.MustParse("3.0.1"))
 	c.Assert(err, jc.ErrorIs, upgradeerrors.ErrUpgradeAlreadyStarted)
 }
 
 func (s *serviceSuite) TestCreateUpgradeInvalidVersions(c *gc.C) {
-	_, err := s.srv.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.0"))
+	_, err := s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.0"))
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 
-	_, err = s.srv.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.1"))
+	_, err = s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.1"))
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
@@ -73,7 +73,7 @@ func (s *serviceSuite) TestSetControllerReady(c *gc.C) {
 
 	s.state.EXPECT().SetControllerReady(gomock.Any(), s.upgradeUUID, s.controllerUUID).Return(nil)
 
-	err := s.srv.SetControllerReady(context.Background(), s.upgradeUUID, s.controllerUUID)
+	err := s.service.SetControllerReady(context.Background(), s.upgradeUUID, s.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -83,7 +83,7 @@ func (s *serviceSuite) TestSetControllerReadyForeignKey(c *gc.C) {
 	fkErr := sqlite3.Error{ExtendedCode: sqlite3.ErrConstraintForeignKey}
 	s.state.EXPECT().SetControllerReady(gomock.Any(), s.upgradeUUID, s.controllerUUID).Return(fkErr)
 
-	err := s.srv.SetControllerReady(context.Background(), s.upgradeUUID, s.controllerUUID)
+	err := s.service.SetControllerReady(context.Background(), s.upgradeUUID, s.controllerUUID)
 	c.Log(err)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
@@ -93,7 +93,7 @@ func (s *serviceSuite) TestStartUpgrade(c *gc.C) {
 
 	s.state.EXPECT().StartUpgrade(gomock.Any(), s.upgradeUUID).Return(nil)
 
-	err := s.srv.StartUpgrade(context.Background(), s.upgradeUUID)
+	err := s.service.StartUpgrade(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -102,7 +102,7 @@ func (s *serviceSuite) TestStartUpgradeBeforeCreated(c *gc.C) {
 
 	s.state.EXPECT().StartUpgrade(gomock.Any(), s.upgradeUUID).Return(sql.ErrNoRows)
 
-	err := s.srv.StartUpgrade(context.Background(), s.upgradeUUID)
+	err := s.service.StartUpgrade(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -111,7 +111,7 @@ func (s *serviceSuite) TestActiveUpgrade(c *gc.C) {
 
 	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 
-	activeUpgrade, err := s.srv.ActiveUpgrade(context.Background())
+	activeUpgrade, err := s.service.ActiveUpgrade(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(activeUpgrade, gc.Equals, s.upgradeUUID)
 }
@@ -121,7 +121,7 @@ func (s *serviceSuite) TestActiveUpgradeNoUpgrade(c *gc.C) {
 
 	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Trace(sql.ErrNoRows))
 
-	_, err := s.srv.ActiveUpgrade(context.Background())
+	_, err := s.service.ActiveUpgrade(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -130,7 +130,7 @@ func (s *serviceSuite) TestSetDBUpgradeCompleted(c *gc.C) {
 
 	s.state.EXPECT().SetDBUpgradeCompleted(gomock.Any(), s.upgradeUUID).Return(nil)
 
-	err := s.srv.SetDBUpgradeCompleted(context.Background(), s.upgradeUUID)
+	err := s.service.SetDBUpgradeCompleted(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -139,7 +139,7 @@ func (s *serviceSuite) TestSetDBUpgradeFailed(c *gc.C) {
 
 	s.state.EXPECT().SetDBUpgradeFailed(gomock.Any(), s.upgradeUUID).Return(nil)
 
-	err := s.srv.SetDBUpgradeFailed(context.Background(), s.upgradeUUID)
+	err := s.service.SetDBUpgradeFailed(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -148,7 +148,7 @@ func (s *serviceSuite) TestUpgradeInfo(c *gc.C) {
 
 	s.state.EXPECT().UpgradeInfo(gomock.Any(), s.upgradeUUID).Return(coreupgrade.Info{}, nil)
 
-	_, err := s.srv.UpgradeInfo(context.Background(), s.upgradeUUID)
+	_, err := s.service.UpgradeInfo(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -159,7 +159,7 @@ func (s *serviceSuite) TestWatchForUpgradeReady(c *gc.C) {
 
 	s.watcherFactory.EXPECT().NewValuePredicateWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
 
-	watcher, err := s.srv.WatchForUpgradeReady(context.Background(), s.upgradeUUID)
+	watcher, err := s.service.WatchForUpgradeReady(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watcher, gc.NotNil)
 }
@@ -171,7 +171,7 @@ func (s *serviceSuite) TestWatchForUpgradeState(c *gc.C) {
 
 	s.watcherFactory.EXPECT().NewValuePredicateWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
 
-	watcher, err := s.srv.WatchForUpgradeState(context.Background(), s.upgradeUUID, coreupgrade.Started)
+	watcher, err := s.service.WatchForUpgradeState(context.Background(), s.upgradeUUID, coreupgrade.Started)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watcher, gc.NotNil)
 }
@@ -181,7 +181,7 @@ func (s *serviceSuite) TestIsUpgrade(c *gc.C) {
 
 	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 
-	upgrading, err := s.srv.IsUpgrading(context.Background())
+	upgrading, err := s.service.IsUpgrading(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(upgrading, jc.IsTrue)
 }
@@ -191,7 +191,7 @@ func (s *serviceSuite) TestIsUpgradeNoUpgrade(c *gc.C) {
 
 	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Trace(sql.ErrNoRows))
 
-	upgrading, err := s.srv.IsUpgrading(context.Background())
+	upgrading, err := s.service.IsUpgrading(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(upgrading, jc.IsFalse)
 }
@@ -201,7 +201,7 @@ func (s *serviceSuite) TestIsUpgradeError(c *gc.C) {
 
 	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.New("boom"))
 
-	upgrading, err := s.srv.IsUpgrading(context.Background())
+	upgrading, err := s.service.IsUpgrading(context.Background())
 	c.Assert(err, gc.ErrorMatches, `boom`)
 	c.Assert(upgrading, jc.IsFalse)
 }

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -28,7 +28,7 @@ import (
 // apiserver.
 type ControllerServiceFactory interface {
 	// ControllerConfig returns the controller configuration service.
-	ControllerConfig() *controllerconfigservice.Service
+	ControllerConfig() *controllerconfigservice.WatchableService
 	// ControllerNode returns the controller node service.
 	ControllerNode() *controllernodeservice.Service
 	// Model returns the model service.
@@ -38,19 +38,19 @@ type ControllerServiceFactory interface {
 	// ModelManager returns the model manager service.
 	ModelManager() *modelmanagerservice.Service
 	// ExternalController returns the external controller service.
-	ExternalController() *externalcontrollerservice.Service
+	ExternalController() *externalcontrollerservice.WatchableService
 	// Credential returns the credential service.
-	Credential() *credentialservice.Service
+	Credential() *credentialservice.WatchableService
 	// AutocertCache returns the autocert cache service.
 	AutocertCache() *autocertcacheservice.Service
 	// Cloud returns the cloud service.
-	Cloud() *cloudservice.Service
+	Cloud() *cloudservice.WatchableService
 	// Upgrade returns the upgrade service.
-	Upgrade() *upgradeservice.Service
+	Upgrade() *upgradeservice.WatchableService
 	// AgentObjectStore returns the object store service.
 	// Primarily used for agent blob store. Although can be used for other
 	// blob related operations.
-	AgentObjectStore() *objectstoreservice.Service
+	AgentObjectStore() *objectstoreservice.WatchableService
 	// Flag returns the flag service.
 	Flag() *flagservice.Service
 	// User returns the user service.
@@ -61,13 +61,13 @@ type ControllerServiceFactory interface {
 // apiserver for a given model.
 type ModelServiceFactory interface {
 	// Config returns the modelconfig service.
-	Config(modelconfigservice.ModelDefaultsProvider) *modelconfigservice.Service
+	Config(modelconfigservice.ModelDefaultsProvider) *modelconfigservice.WatchableService
 	// ObjectStore returns the object store service.
-	ObjectStore() *objectstoreservice.Service
+	ObjectStore() *objectstoreservice.WatchableService
 	// Machine returns the machine service.
 	Machine() *machineservice.Service
 	// BlockDevice returns the block device service.
-	BlockDevice() *blockdeviceservice.Service
+	BlockDevice() *blockdeviceservice.WatchableService
 	// Application returns the machine service.
 	Application() *applicationservice.Service
 	// Unit returns the machine service.

--- a/internal/worker/certupdater/manifold_test.go
+++ b/internal/worker/certupdater/manifold_test.go
@@ -37,7 +37,7 @@ type ManifoldSuite struct {
 	stateTracker           stubStateTracker
 	addressWatcher         fakeAddressWatcher
 	serviceFactory         servicefactory.ServiceFactory
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 	logger                 certupdater.Logger
 
 	stub testing.Stub
@@ -50,7 +50,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.agent = &mockAgent{}
 	s.stateTracker = stubStateTracker{}
-	s.controllerConfigGetter = &controllerconfigservice.Service{}
+	s.controllerConfigGetter = &controllerconfigservice.WatchableService{}
 	s.serviceFactory = stubServiceFactory{
 		controllerConfigGetter: s.controllerConfigGetter,
 	}
@@ -231,9 +231,9 @@ type fakeAddressWatcher struct {
 
 type stubServiceFactory struct {
 	servicefactory.ServiceFactory
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 }
 
-func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	return s.controllerConfigGetter
 }

--- a/internal/worker/httpserver/manifold_test.go
+++ b/internal/worker/httpserver/manifold_test.go
@@ -48,7 +48,7 @@ type ManifoldSuite struct {
 	controllerConfig       controller.Config
 	serviceFactory         servicefactory.ServiceFactory
 	autocertCacheGetter    *autocertcacheservice.Service
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 
 	stub testing.Stub
 }
@@ -74,7 +74,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.autocertCacheGetter = &autocertcacheservice.Service{}
-	s.controllerConfigGetter = &controllerconfigservice.Service{}
+	s.controllerConfigGetter = &controllerconfigservice.WatchableService{}
 	s.serviceFactory = stubServiceFactory{
 		controllerConfigGetter: s.controllerConfigGetter,
 		autocertCacheGetter:    s.autocertCacheGetter,
@@ -259,7 +259,7 @@ func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
 
 type stubServiceFactory struct {
 	servicefactory.ServiceFactory
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 	autocertCacheGetter    *autocertcacheservice.Service
 }
 
@@ -267,6 +267,6 @@ func (s stubServiceFactory) AutocertCache() *autocertcacheservice.Service {
 	return s.autocertCacheGetter
 }
 
-func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	return s.controllerConfigGetter
 }

--- a/internal/worker/httpserverargs/manifold_test.go
+++ b/internal/worker/httpserverargs/manifold_test.go
@@ -225,7 +225,7 @@ type stubServiceFactory struct {
 	servicefactory.ControllerServiceFactory
 }
 
-func (s *stubServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s *stubServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	s.MethodCall(s, "ControllerConfig")
 	return nil
 }

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -39,7 +39,7 @@ type ManifoldSuite struct {
 	stateTracker           stubStateTracker
 	sysLogger              stubLogger
 	serviceFactory         servicefactory.ServiceFactory
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 	mux                    *apiserverhttp.Mux
 
 	state *state.State
@@ -60,7 +60,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.state = &state.State{}
 	s.pool = &state.StatePool{}
 	s.stateTracker = stubStateTracker{pool: s.pool, state: s.state}
-	s.controllerConfigGetter = &controllerconfigservice.Service{}
+	s.controllerConfigGetter = &controllerconfigservice.WatchableService{}
 	s.serviceFactory = stubServiceFactory{
 		controllerConfigGetter: s.controllerConfigGetter,
 	}
@@ -229,9 +229,9 @@ type stubLogger struct {
 
 type stubServiceFactory struct {
 	servicefactory.ServiceFactory
-	controllerConfigGetter *controllerconfigservice.Service
+	controllerConfigGetter *controllerconfigservice.WatchableService
 }
 
-func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s stubServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	return s.controllerConfigGetter
 }

--- a/internal/worker/objectstore/manifold_test.go
+++ b/internal/worker/objectstore/manifold_test.go
@@ -158,6 +158,6 @@ type stubServiceFactory struct {
 	servicefactory.ServiceFactory
 }
 
-func (s *stubServiceFactory) ControllerConfig() *controllerconfigservice.Service {
+func (s *stubServiceFactory) ControllerConfig() *controllerconfigservice.WatchableService {
 	return nil
 }

--- a/internal/worker/servicefactory/servicefactory_mock_test.go
+++ b/internal/worker/servicefactory/servicefactory_mock_test.go
@@ -58,10 +58,10 @@ func (m *MockControllerServiceFactory) EXPECT() *MockControllerServiceFactoryMoc
 }
 
 // AgentObjectStore mocks base method.
-func (m *MockControllerServiceFactory) AgentObjectStore() *service13.Service {
+func (m *MockControllerServiceFactory) AgentObjectStore() *service13.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AgentObjectStore")
-	ret0, _ := ret[0].(*service13.Service)
+	ret0, _ := ret[0].(*service13.WatchableService)
 	return ret0
 }
 
@@ -86,10 +86,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) AutocertCache() *gomock.Call
 }
 
 // Cloud mocks base method.
-func (m *MockControllerServiceFactory) Cloud() *service2.Service {
+func (m *MockControllerServiceFactory) Cloud() *service2.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cloud")
-	ret0, _ := ret[0].(*service2.Service)
+	ret0, _ := ret[0].(*service2.WatchableService)
 	return ret0
 }
 
@@ -100,10 +100,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // ControllerConfig mocks base method.
-func (m *MockControllerServiceFactory) ControllerConfig() *service3.Service {
+func (m *MockControllerServiceFactory) ControllerConfig() *service3.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
-	ret0, _ := ret[0].(*service3.Service)
+	ret0, _ := ret[0].(*service3.WatchableService)
 	return ret0
 }
 
@@ -128,10 +128,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) ControllerNode() *gomock.Cal
 }
 
 // Credential mocks base method.
-func (m *MockControllerServiceFactory) Credential() *service5.Service {
+func (m *MockControllerServiceFactory) Credential() *service5.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Credential")
-	ret0, _ := ret[0].(*service5.Service)
+	ret0, _ := ret[0].(*service5.WatchableService)
 	return ret0
 }
 
@@ -142,10 +142,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) Credential() *gomock.Call {
 }
 
 // ExternalController mocks base method.
-func (m *MockControllerServiceFactory) ExternalController() *service6.Service {
+func (m *MockControllerServiceFactory) ExternalController() *service6.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalController")
-	ret0, _ := ret[0].(*service6.Service)
+	ret0, _ := ret[0].(*service6.WatchableService)
 	return ret0
 }
 
@@ -212,10 +212,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) ModelManager() *gomock.Call 
 }
 
 // Upgrade mocks base method.
-func (m *MockControllerServiceFactory) Upgrade() *service15.Service {
+func (m *MockControllerServiceFactory) Upgrade() *service15.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upgrade")
-	ret0, _ := ret[0].(*service15.Service)
+	ret0, _ := ret[0].(*service15.WatchableService)
 	return ret0
 }
 
@@ -277,10 +277,10 @@ func (mr *MockModelServiceFactoryMockRecorder) Application() *gomock.Call {
 }
 
 // BlockDevice mocks base method.
-func (m *MockModelServiceFactory) BlockDevice() *service1.Service {
+func (m *MockModelServiceFactory) BlockDevice() *service1.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockDevice")
-	ret0, _ := ret[0].(*service1.Service)
+	ret0, _ := ret[0].(*service1.WatchableService)
 	return ret0
 }
 
@@ -291,10 +291,10 @@ func (mr *MockModelServiceFactoryMockRecorder) BlockDevice() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockModelServiceFactory) Config(arg0 service10.ModelDefaultsProvider) *service10.Service {
+func (m *MockModelServiceFactory) Config(arg0 service10.ModelDefaultsProvider) *service10.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config", arg0)
-	ret0, _ := ret[0].(*service10.Service)
+	ret0, _ := ret[0].(*service10.WatchableService)
 	return ret0
 }
 
@@ -319,10 +319,10 @@ func (mr *MockModelServiceFactoryMockRecorder) Machine() *gomock.Call {
 }
 
 // ObjectStore mocks base method.
-func (m *MockModelServiceFactory) ObjectStore() *service13.Service {
+func (m *MockModelServiceFactory) ObjectStore() *service13.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectStore")
-	ret0, _ := ret[0].(*service13.Service)
+	ret0, _ := ret[0].(*service13.WatchableService)
 	return ret0
 }
 
@@ -370,10 +370,10 @@ func (m *MockServiceFactory) EXPECT() *MockServiceFactoryMockRecorder {
 }
 
 // AgentObjectStore mocks base method.
-func (m *MockServiceFactory) AgentObjectStore() *service13.Service {
+func (m *MockServiceFactory) AgentObjectStore() *service13.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AgentObjectStore")
-	ret0, _ := ret[0].(*service13.Service)
+	ret0, _ := ret[0].(*service13.WatchableService)
 	return ret0
 }
 
@@ -412,10 +412,10 @@ func (mr *MockServiceFactoryMockRecorder) AutocertCache() *gomock.Call {
 }
 
 // BlockDevice mocks base method.
-func (m *MockServiceFactory) BlockDevice() *service1.Service {
+func (m *MockServiceFactory) BlockDevice() *service1.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockDevice")
-	ret0, _ := ret[0].(*service1.Service)
+	ret0, _ := ret[0].(*service1.WatchableService)
 	return ret0
 }
 
@@ -426,10 +426,10 @@ func (mr *MockServiceFactoryMockRecorder) BlockDevice() *gomock.Call {
 }
 
 // Cloud mocks base method.
-func (m *MockServiceFactory) Cloud() *service2.Service {
+func (m *MockServiceFactory) Cloud() *service2.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cloud")
-	ret0, _ := ret[0].(*service2.Service)
+	ret0, _ := ret[0].(*service2.WatchableService)
 	return ret0
 }
 
@@ -440,10 +440,10 @@ func (mr *MockServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockServiceFactory) Config(arg0 service10.ModelDefaultsProvider) *service10.Service {
+func (m *MockServiceFactory) Config(arg0 service10.ModelDefaultsProvider) *service10.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config", arg0)
-	ret0, _ := ret[0].(*service10.Service)
+	ret0, _ := ret[0].(*service10.WatchableService)
 	return ret0
 }
 
@@ -454,10 +454,10 @@ func (mr *MockServiceFactoryMockRecorder) Config(arg0 any) *gomock.Call {
 }
 
 // ControllerConfig mocks base method.
-func (m *MockServiceFactory) ControllerConfig() *service3.Service {
+func (m *MockServiceFactory) ControllerConfig() *service3.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
-	ret0, _ := ret[0].(*service3.Service)
+	ret0, _ := ret[0].(*service3.WatchableService)
 	return ret0
 }
 
@@ -482,10 +482,10 @@ func (mr *MockServiceFactoryMockRecorder) ControllerNode() *gomock.Call {
 }
 
 // Credential mocks base method.
-func (m *MockServiceFactory) Credential() *service5.Service {
+func (m *MockServiceFactory) Credential() *service5.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Credential")
-	ret0, _ := ret[0].(*service5.Service)
+	ret0, _ := ret[0].(*service5.WatchableService)
 	return ret0
 }
 
@@ -496,10 +496,10 @@ func (mr *MockServiceFactoryMockRecorder) Credential() *gomock.Call {
 }
 
 // ExternalController mocks base method.
-func (m *MockServiceFactory) ExternalController() *service6.Service {
+func (m *MockServiceFactory) ExternalController() *service6.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalController")
-	ret0, _ := ret[0].(*service6.Service)
+	ret0, _ := ret[0].(*service6.WatchableService)
 	return ret0
 }
 
@@ -580,10 +580,10 @@ func (mr *MockServiceFactoryMockRecorder) ModelManager() *gomock.Call {
 }
 
 // ObjectStore mocks base method.
-func (m *MockServiceFactory) ObjectStore() *service13.Service {
+func (m *MockServiceFactory) ObjectStore() *service13.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectStore")
-	ret0, _ := ret[0].(*service13.Service)
+	ret0, _ := ret[0].(*service13.WatchableService)
 	return ret0
 }
 
@@ -608,10 +608,10 @@ func (mr *MockServiceFactoryMockRecorder) Unit() *gomock.Call {
 }
 
 // Upgrade mocks base method.
-func (m *MockServiceFactory) Upgrade() *service15.Service {
+func (m *MockServiceFactory) Upgrade() *service15.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upgrade")
-	ret0, _ := ret[0].(*service15.Service)
+	ret0, _ := ret[0].(*service15.WatchableService)
 	return ret0
 }
 

--- a/internal/worker/upgradedatabase/manifold_test.go
+++ b/internal/worker/upgradedatabase/manifold_test.go
@@ -109,7 +109,7 @@ func (s *manifoldSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.agentConfig.EXPECT().Tag().Return(names.NewMachineTag("0")).AnyTimes()
 	s.agentConfig.EXPECT().UpgradedToVersion().Return(version.MustParse("1.0.0")).AnyTimes()
 
-	s.serviceFactory.EXPECT().Upgrade().Return(&upgradeservice.Service{}).AnyTimes()
+	s.serviceFactory.EXPECT().Upgrade().Return(&upgradeservice.WatchableService{}).AnyTimes()
 	s.serviceFactory.EXPECT().ModelManager().Return(&modelmanagerservice.Service{}).AnyTimes()
 	s.serviceFactory.EXPECT().ControllerNode().Return(&controllernodeservice.Service{}).AnyTimes()
 

--- a/internal/worker/upgradedatabase/servicefactory_mock_test.go
+++ b/internal/worker/upgradedatabase/servicefactory_mock_test.go
@@ -52,10 +52,10 @@ func (m *MockControllerServiceFactory) EXPECT() *MockControllerServiceFactoryMoc
 }
 
 // AgentObjectStore mocks base method.
-func (m *MockControllerServiceFactory) AgentObjectStore() *service9.Service {
+func (m *MockControllerServiceFactory) AgentObjectStore() *service9.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AgentObjectStore")
-	ret0, _ := ret[0].(*service9.Service)
+	ret0, _ := ret[0].(*service9.WatchableService)
 	return ret0
 }
 
@@ -80,10 +80,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) AutocertCache() *gomock.Call
 }
 
 // Cloud mocks base method.
-func (m *MockControllerServiceFactory) Cloud() *service0.Service {
+func (m *MockControllerServiceFactory) Cloud() *service0.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cloud")
-	ret0, _ := ret[0].(*service0.Service)
+	ret0, _ := ret[0].(*service0.WatchableService)
 	return ret0
 }
 
@@ -94,10 +94,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // ControllerConfig mocks base method.
-func (m *MockControllerServiceFactory) ControllerConfig() *service1.Service {
+func (m *MockControllerServiceFactory) ControllerConfig() *service1.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
-	ret0, _ := ret[0].(*service1.Service)
+	ret0, _ := ret[0].(*service1.WatchableService)
 	return ret0
 }
 
@@ -122,10 +122,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) ControllerNode() *gomock.Cal
 }
 
 // Credential mocks base method.
-func (m *MockControllerServiceFactory) Credential() *service3.Service {
+func (m *MockControllerServiceFactory) Credential() *service3.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Credential")
-	ret0, _ := ret[0].(*service3.Service)
+	ret0, _ := ret[0].(*service3.WatchableService)
 	return ret0
 }
 
@@ -136,10 +136,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) Credential() *gomock.Call {
 }
 
 // ExternalController mocks base method.
-func (m *MockControllerServiceFactory) ExternalController() *service4.Service {
+func (m *MockControllerServiceFactory) ExternalController() *service4.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalController")
-	ret0, _ := ret[0].(*service4.Service)
+	ret0, _ := ret[0].(*service4.WatchableService)
 	return ret0
 }
 
@@ -206,10 +206,10 @@ func (mr *MockControllerServiceFactoryMockRecorder) ModelManager() *gomock.Call 
 }
 
 // Upgrade mocks base method.
-func (m *MockControllerServiceFactory) Upgrade() *service10.Service {
+func (m *MockControllerServiceFactory) Upgrade() *service10.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upgrade")
-	ret0, _ := ret[0].(*service10.Service)
+	ret0, _ := ret[0].(*service10.WatchableService)
 	return ret0
 }
 


### PR DESCRIPTION
This splits the services with each domain package; services and watchable services. Service types provide just CRUD based operations and the WatchableService types provide the ability to watch for changes.

The type then can be used in the migration import and export without passing nil into the construction. Thus preventing any chances of nil panics in production.

This separation of concerns forces us to understand what is a watchable service and not. This is a convention-only implementation and it is expected not to violate that concern when implementing new domain packages. The niceness that this does afford is two-fold:

 1.  No need to handle `nil` when running import/export migrations
 2.  The service factory tells you if the service offers watchable methods just from the type signature (via convention admittedly)


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

All the domain tests pass.

## Links

**Jira card:** JUJU-

