### PR TITLE
Hides state based sql errors.

### DIFF
--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package domain
+
+import (
+	"fmt"
+
+	dqlite "github.com/canonical/go-dqlite/driver"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/mattn/go-sqlite3"
+	gc "gopkg.in/check.v1"
+)
+
+type asError struct {
+	Message string
+}
+
+type errorsSuite struct{}
+
+var _ = gc.Suite(&errorsSuite{})
+
+func (a asError) Error() string {
+	return a.Message
+}
+
+// TestCoerceForNilError checks that if you pass a nil error to CoerceError you
+// get back a nil error.
+func (e *errorsSuite) TestCoerceForNilError(c *gc.C) {
+	err := CoerceError(nil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+// TestMaskErrorIsHidesSqlErrors is testing that if we construct a maskError
+// with with an error chain that contains either sqlite or dqlite errors calls
+// to [errors.Is] will return false and mask the errors presence.
+func (e *errorsSuite) TestMaskErrorIsHidesSqlErrors(c *gc.C) {
+	tests := []struct {
+		Name  string
+		Error error
+		Rval  bool
+	}{
+		{
+			Name: "Test sqlite3 errors are hidden from Is()",
+			Error: sqlite3.Error{
+				Code:         sqlite3.ErrAbort,
+				ExtendedCode: sqlite3.ErrBusyRecovery,
+			},
+			Rval: false,
+		},
+		{
+			Name: "Test dqlite errors are hidden from Is()",
+			Error: dqlite.Error{
+				Code:    dqlite.ErrBusy,
+				Message: "something went wrong",
+			},
+			Rval: false,
+		},
+	}
+
+	for _, test := range tests {
+		err := maskError{fmt.Errorf("%q %w", test.Name, test.Error)}
+		c.Check(test.Rval, gc.Equals, errors.Is(err, test.Error), gc.Commentf(test.Name))
+	}
+}
+
+// TestMaskErrorIsNoHide is here to check that if maskError contains non sql
+// errors within its chain that it doesn't attempt to hide their existence.
+func (e *errorsSuite) TestMaskErrorIsNoHide(c *gc.C) {
+	origError := errors.New("test error")
+	err := fmt.Errorf("wrap orig error: %w", origError)
+	maskErr := maskError{err}
+	c.Check(errors.Is(maskErr, origError), jc.IsTrue)
+
+	sqlErr := sqlite3.Error{
+		Code:         sqlite3.ErrAbort,
+		ExtendedCode: sqlite3.ErrBusyRecovery,
+	}
+
+	err = fmt.Errorf("double wrap %w %w", sqlErr, origError)
+	maskErr = maskError{err}
+	c.Check(errors.Is(maskErr, origError), jc.IsTrue)
+}
+
+// TestMaskErrorAsNoHide is here to check that if maskError contains non sql
+// errors within its chain that it doesn't attempt to hide their existence.
+func (e *errorsSuite) TestMaskErrorAsNoHide(c *gc.C) {
+	origError := asError{"ipv6 rocks"}
+	err := fmt.Errorf("wrap orig error: %w", origError)
+	maskErr := maskError{err}
+
+	var rval asError
+	c.Check(errors.As(maskErr, &rval), jc.IsTrue)
+
+	sqlErr := sqlite3.Error{
+		Code:         sqlite3.ErrAbort,
+		ExtendedCode: sqlite3.ErrBusyRecovery,
+	}
+
+	err = fmt.Errorf("double wrap %w %w", sqlErr, origError)
+	maskErr = maskError{err}
+	c.Check(errors.As(maskErr, &rval), jc.IsTrue)
+}
+
+// TestMaskErrorAsHidesSqlLiteErrors is here to assert that if we try and
+// extract a sqlite error from a [maskError] that we get back false even though
+// it does exist.
+func (e *errorsSuite) TestMaskErrorAsHidesSqlLiteErrors(c *gc.C) {
+	var rval sqlite3.Error
+	err := maskError{sqlite3.Error{
+		Code:         sqlite3.ErrAbort,
+		ExtendedCode: sqlite3.ErrBusyRecovery,
+	}}
+
+	c.Check(errors.As(err, &rval), jc.IsFalse)
+}
+
+// TestMaskErrorAsHidesSqlLiteErrors is here to assert that if we try and
+// extract a dqlite error from a [maskError] that we get back false even though
+// it does exist.
+func (e *errorsSuite) TestMaskErrorAsHidesDQLiteErrors(c *gc.C) {
+	var rval dqlite.Error
+	err := maskError{dqlite.Error{
+		Code:    dqlite.ErrBusy,
+		Message: "something went wrong",
+	}}
+
+	c.Check(errors.As(err, &rval), jc.IsFalse)
+}

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -81,3 +81,23 @@ func isErrCode(err error, code sqlite3.ErrNoExtended) bool {
 	var sqliteErr sqlite3.Error
 	return errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == code
 }
+
+// IsError reports if the any type passed to it is a database driver error in
+// Juju. The purpose of this function is so that our domain error masking can
+// assert if a specific error needs to be hidden from layers above that of the
+// domain/state.
+func IsError(target any) bool {
+	if _, is := target.(*dqlite.Error); is {
+		return true
+	}
+	if _, is := target.(*sqlite3.Error); is {
+		return true
+	}
+	if _, is := target.(dqlite.Error); is {
+		return true
+	}
+	if _, is := target.(sqlite3.Error); is {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
After discussions within the Juju team we decided that we would like a mechanism to hide the sql error types that bubble up from the domain state layer.

The primary purpose of this is stop code that could potentially check for these types outside of the state layer.

With this change maskError now implements Is and As from std errors and checks to see if the caller is trying to establish an error type that is for one of our sql drivers and returns false.

maskError will not try and hide any other error types. This commit just introduces the change but does not attempt any inteogration at the moment.

If this PR goes through it is expected that integration will look something like the following:

```go
func createModelAgent(
	ctx context.Context,
	modelUUID model.UUID,
	agentVersion version.Number,
	tx *sql.Tx,
) error {
	stmt := `
INSERT INTO model_agent (model_uuid, previous_version, target_version)
    VALUES (?, ?, ?)
`

	res, err := tx.ExecContext(ctx, stmt, modelUUID, agentVersion.String(), agentVersion.String())
        // We are checking for specific sql errors here to return a stronger typed error and disregard the sql error.
        // In this case Coerce() does not need to be used.
	if jujudb.IsErrConstraintPrimaryKey(err) {
		return fmt.Errorf(
			"%w for uuid %q while setting model agent version",
			modelerrors.AlreadyExists, modelUUID,
		)
	} else if jujudb.IsErrConstraintForeignKey(err) {
		return fmt.Errorf(
			"%w for uuid %q while setting model agent version",
			modelerrors.NotFound,
			modelUUID,
		)
	} else if err != nil {
                // We need to use Coerce() here as we are wrapping up a potential sql error
		return fmt.Errorf("creating model %q agent information: %w", modelUUID, domain.CoerceError(err))
	}

	if num, err := res.RowsAffected(); err != nil {
                // We need to use Coerce() here as we are wrapping up a potential sql error
		return domain.CoerceError(err)
	} else if num != 1 {
		return fmt.Errorf("creating model agent record, expected 1 row to be inserted got %d", num)
	}

	return nil
}
```

### Planned Juju Crew Email
Dear Juju Crew,

After some discussions recently we have talked about the need to introduce a programatic way to stop users of the domain layer from potentially checking returned error types for sql specific errors that bubble up from the state layer.

To do this we have expanded the domain/errors.go file to handle wrapping of sql related errors in the state layer and stop users from hydrating these errors back to sql like errors at layers above that of state.

What this means for you is that any time you are returning or wrapping an error that you have received from the sql drivers in the state layer you should pass them through a call to `domain.CoerceError(err)`. The simplest case being `return domain.CoerceError(err)`

Please refer to this PR (https://github.com/juju/juju/pull/16888) for discussion on the topic and some examples. When reviewing future PR's onto the main branch please make sure that the implementor has coerced their state errors before returning them. This should be PR check that we enforce from now on.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Unit tests
2. Please review the contents of the planned email to Juju crew above and make sure the instructions are accurate and relevant.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5407

