### PR TITLE
Revert dot-minikube on snapcraft until auto-connect is approved

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,6 @@ apps:
       - dot-google
       - dot-kubernetes
       - dot-maas
-      - dot-minikube
       - dot-openstack
       - dot-oracle
       # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
@@ -178,11 +177,6 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.maasrc
-
-  dot-minikube:
-    interface: personal-files
-    read:
-      - $HOME/.minikube
 
   dot-oracle:
     interface: personal-files


### PR DESCRIPTION
We need to revert this until we get an approved auto-connect (or decide that it must be manually done).

Snapcraft forum request: https://forum.snapcraft.io/t/auto-connect-request-for-juju/38717
