### PR TITLE
Suppress klog log messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
 	golang.org/x/sys v0.15.0
+	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.16.0
 	google.golang.org/api v0.152.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
@@ -286,7 +287,6 @@ require (
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	google.golang.org/grpc v1.59.0 // indirect


### PR DESCRIPTION
The klog log messages are noisy and fill up the logs easily. It then becomes hard to work out what is signal and what is noise. As log messages are probably important, it's worth suppressing the message rather than blanket ignoring it. As the klog might be dumping a lot of messages for large controllers, I've ensured that we only make the request once we have a match.

The only match we have atm is the `Use tokens from the TokenRequest`. We can always add more if we need to.

Work will be required in the future to fix this message completely.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

<!-- Describe steps to verify that the change works. -->

```sh
$ juju bootstrap microk8s test
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2038495

**Jira card:** JUJU-5235

