### PR TITLE
Lint against exported and unexported docs

### DIFF
--- a/.github/golangci-lint.config.yaml
+++ b/.github/golangci-lint.config.yaml
@@ -29,6 +29,25 @@ linters-settings:
       - unreachable
       - unsafeptr
       - unusedresult
+  revive:
+    rules:
+      - name: unexported-naming
+        severity: error
+        disabled: false
+      - name: exported
+        severity: error
+        disabled: false
+        arguments:
+          - "disableStutteringCheck"
+          - "sayRepetitiveInsteadOfStutters"
+      - name: atomic
+        severity: error
+        disabled: false
+      - name: defer
+        severity: error
+        disabled: false
+        arguments:
+          - [ "return", "recover", "method-call" ]
 linters:
   disable-all: true
   enable:
@@ -41,6 +60,7 @@ linters:
     - exportloopref
     - unused
     - sqlclosecheck
+    - revive
 run:
   timeout: 30m
   modules-download-mode: readonly

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -127,7 +127,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	controllerCfg := testing.FakeControllerConfig()
 
 	initialModelUUID := utils.MustNewUUID().String()
-	InitialModelConfigAttrs := map[string]interface{}{
+	initialModelConfigAttrs := map[string]interface{}{
 		"name": "hosted",
 		"uuid": initialModelUUID,
 	}
@@ -160,7 +160,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 		ControllerModelEnvironVersion: 666,
 		ModelConstraints:              expectModelConstraints,
 		ControllerInheritedConfig:     controllerInheritedConfig,
-		InitialModelConfig:            InitialModelConfigAttrs,
+		InitialModelConfig:            initialModelConfigAttrs,
 		StoragePools: map[string]storage.Attrs{
 			"spool": {
 				"type": "loop",
@@ -424,7 +424,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	InitialModelConfigAttrs := map[string]interface{}{
+	initialModelConfigAttrs := map[string]interface{}{
 		"name": "hosted",
 		"uuid": utils.MustNewUUID().String(),
 	}
@@ -440,7 +440,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		},
 		ControllerConfig:      testing.FakeControllerConfig(),
 		ControllerModelConfig: modelCfg,
-		InitialModelConfig:    InitialModelConfigAttrs,
+		InitialModelConfig:    initialModelConfigAttrs,
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")

--- a/api/client/action/client.go
+++ b/api/client/action/client.go
@@ -67,9 +67,9 @@ func (c *Client) ListOperations(arg OperationQueryArgs) (Operations, error) {
 }
 
 // Operation fetches the operation with the specified ID.
-func (c *Client) Operation(ID string) (Operation, error) {
+func (c *Client) Operation(id string) (Operation, error) {
 	arg := params.Entities{
-		Entities: []params.Entity{{names.NewOperationTag(ID).String()}},
+		Entities: []params.Entity{{Tag: names.NewOperationTag(id).String()}},
 	}
 	var results params.OperationResults
 	err := c.facade.FacadeCall(context.TODO(), "Operations", arg, &results)

--- a/apiserver/apiserverhttp/mux_test.go
+++ b/apiserver/apiserverhttp/mux_test.go
@@ -92,19 +92,21 @@ func (s *MuxSuite) TestConcurrentAddHandler(c *gc.C) {
 	// Concurrently add and remove another handler to show that
 	// adding and removing handlers will not race with request
 	// handling.
-	const N = 1000
+
+	// bN is the number of add and remove handlers to make.
+	const bN = 1000
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < N; i++ {
+		for i := 0; i < bN; i++ {
 			s.mux.AddHandler("POST", "/", http.NotFoundHandler())
 			s.mux.RemoveHandler("POST", "/")
 		}
 	}()
 	defer wg.Wait()
 
-	for i := 0; i < N; i++ {
+	for i := 0; i < bN; i++ {
 		resp, err := s.client.Get(s.server.URL + "/")
 		c.Assert(err, jc.ErrorIsNil)
 		resp.Body.Close()
@@ -118,14 +120,16 @@ func (s *MuxSuite) TestConcurrentRemoveHandler(c *gc.C) {
 	// Concurrently add and remove another handler to show that
 	// adding and removing handlers will not race with request
 	// handling.
-	const N = 500
+
+	// bN is the number of add and remove handlers to make.
+	const bN = 500
 	var wg sync.WaitGroup
 	wg.Add(1)
 	done := make(chan struct{})
 	go func() {
 		defer wg.Done()
 		defer close(done)
-		for i := 0; i < N; i++ {
+		for i := 0; i < bN; i++ {
 			s.mux.AddHandler("GET", "/", h)
 			// Sleep to give the client a
 			// chance to hit the endpoint.
@@ -140,7 +144,7 @@ func (s *MuxSuite) TestConcurrentRemoveHandler(c *gc.C) {
 out:
 	for {
 		select {
-		case _, _ = <-done:
+		case <-done:
 			break out
 		default:
 		}

--- a/apiserver/authentication/jwt/package_test.go
+++ b/apiserver/authentication/jwt/package_test.go
@@ -4,7 +4,7 @@
 package jwt_test
 
 import (
-	. "testing"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,7 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-func TestPackage(t *T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }
 

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
-	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
@@ -26,7 +25,7 @@ type State interface {
 // ControllerState provides the subset of controller state
 // required by the CAAS application facade.
 type ControllerState interface {
-	ControllerConfig() (jujucontroller.Config, error)
+	ControllerConfig() (controller.Config, error)
 	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 }
 

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -229,8 +229,8 @@ func (s *SecretsManagerAPI) CreateSecrets(ctx context.Context, args params.Creat
 		Results: make([]params.StringResult, len(args.Args)),
 	}
 	for i, arg := range args.Args {
-		ID, err := s.createSecret(arg)
-		result.Results[i].Result = ID
+		id, err := s.createSecret(arg)
+		result.Results[i].Result = id
 		if errors.Is(err, state.LabelExists) {
 			err = errors.AlreadyExistsf("secret with label %q", *arg.Label)
 		}

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -480,18 +480,15 @@ func (n *NetworkInfoIAAS) networkInfoForSpace(spaceID string) params.NetworkInfo
 		}
 
 		// Otherwise, add a new device.
-		var MAC string
 		mac, err := addr.HWAddr()
-		if err == nil {
-			MAC = mac
-		} else if !errors.Is(err, errors.NotFound) {
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			res.Error = apiservererrors.ServerError(err)
 			return res
 		}
 
 		res.Info = append(res.Info, params.NetworkInfo{
 			InterfaceName: addr.DeviceName(),
-			MACAddress:    MAC,
+			MACAddress:    mac,
 			Addresses:     []params.InterfaceAddress{deviceAddr},
 		})
 	}

--- a/apiserver/facades/client/annotations/client_test.go
+++ b/apiserver/facades/client/annotations/client_test.go
@@ -16,7 +16,6 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/juju/testing"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -24,7 +23,7 @@ import (
 
 type annotationSuite struct {
 	// TODO(anastasiamac) mock to remove ApiServerSuite
-	jujutesting.ApiServerSuite
+	testing.ApiServerSuite
 
 	annotationsAPI *annotations.API
 	authorizer     apiservertesting.FakeAuthorizer
@@ -37,7 +36,7 @@ var _ = gc.Suite(&annotationSuite{})
 func (s *annotationSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: jujutesting.AdminUser,
+		Tag: testing.AdminUser,
 	}
 	var err error
 	s.annotationsAPI, err = annotations.NewAPI(facadetest.Context{

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -621,14 +621,14 @@ func (b *BundleAPI) bundleDataMachines(machines []description.Machine, machineId
 }
 
 func bundleDataRemoteApplications(remoteApps []description.RemoteApplication) map[string]*charm.SaasSpec {
-	Saas := make(map[string]*charm.SaasSpec, len(remoteApps))
+	saas := make(map[string]*charm.SaasSpec, len(remoteApps))
 	for _, application := range remoteApps {
 		newSaas := &charm.SaasSpec{
 			URL: application.URL(),
 		}
-		Saas[application.Name()] = newSaas
+		saas[application.Name()] = newSaas
 	}
-	return Saas
+	return saas
 }
 
 func bundleDataRelations(relations []description.Relation) [][]string {

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -239,13 +239,13 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 			"in the way the addresses are processed"))
 }
 
-func (s *statusSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
+func (s *statusSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, cidr, providerSubnetID string) {
 	st := s.ControllerModel(c).State()
 	space, err := st.AddSpace(spaceName, network.Id(spaceName), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = st.AddSubnet(network.SubnetInfo{
-		CIDR:       CIDR,
+		CIDR:       cidr,
 		SpaceID:    space.Id(),
 		ProviderId: network.Id(providerSubnetID),
 	})

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -225,14 +225,14 @@ func (a *API) addPendingResource(appName string, chRes charmresource.Resource) (
 }
 
 func parseApplicationTag(tagStr string) (names.ApplicationTag, *params.Error) { // note the concrete error type
-	ApplicationTag, err := names.ParseApplicationTag(tagStr)
+	applicationTag, err := names.ParseApplicationTag(tagStr)
 	if err != nil {
-		return ApplicationTag, &params.Error{
+		return applicationTag, &params.Error{
 			Message: err.Error(),
 			Code:    params.CodeBadRequest,
 		}
 	}
-	return ApplicationTag, nil
+	return applicationTag, nil
 }
 
 func errorResult(err error) params.ResourcesResult {

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -268,8 +268,8 @@ func (s *SecretsAPI) CreateSecrets(ctx context.Context, args params.CreateSecret
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
-		ID, err := s.createSecret(ctx, backend, arg)
-		result.Results[i].Result = ID
+		id, err := s.createSecret(ctx, backend, arg)
+		result.Results[i].Result = id
 		if errors.Is(err, state.LabelExists) {
 			err = errors.AlreadyExistsf("secret with name %q", *arg.Label)
 		}

--- a/apiserver/facades/controller/applicationscaler/facade.go
+++ b/apiserver/facades/controller/applicationscaler/facade.go
@@ -79,9 +79,9 @@ func (facade *Facade) rescaleOne(tagString string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ApplicationTag, ok := tag.(names.ApplicationTag)
+	applicationTag, ok := tag.(names.ApplicationTag)
 	if !ok {
 		return apiservererrors.ErrPerm
 	}
-	return facade.backend.RescaleService(ApplicationTag.Id())
+	return facade.backend.RescaleService(applicationTag.Id())
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -268,10 +268,10 @@ func mapNetworkConfigsToProviderAddresses(
 }
 
 func spaceInfoForAddress(
-	spaceInfos network.SpaceInfos, CIDR, providerSubnetID, addr string,
+	spaceInfos network.SpaceInfos, cidr, providerSubnetID, addr string,
 ) (*network.SpaceInfo, error) {
-	if CIDR != "" {
-		return spaceInfos.InferSpaceFromCIDRAndSubnetID(CIDR, providerSubnetID)
+	if cidr != "" {
+		return spaceInfos.InferSpaceFromCIDRAndSubnetID(cidr, providerSubnetID)
 	}
 	return spaceInfos.InferSpaceFromAddress(addr)
 }

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -246,8 +246,8 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case m, ok := <-logCh:
 				if !ok {
 					h.mu.Lock()
-					defer h.mu.Unlock()
 					h.receiverStopped = true
+					h.mu.Unlock()
 					return
 				}
 
@@ -330,8 +330,8 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 				// has already disconnected from us, this will fail, but we don't
 				// care that much.
 				h.mu.Lock()
-				defer h.mu.Unlock()
 				_ = socket.WriteMessage(gorillaws.CloseMessage, []byte{})
+				h.mu.Unlock()
 				return
 			}
 			h.metrics.LogReadCount(resolvedModelUUID, metricLogReadLabelSuccess).Inc()

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -244,10 +244,10 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 func (s *LogStreamIntSuite) newReq(c *gc.C, cfg params.LogStreamConfig) *http.Request {
 	attrs, err := query.Values(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	URL, err := url.Parse("https://a.b.c/logstream")
+	u, err := url.Parse("https://a.b.c/logstream")
 	c.Assert(err, jc.ErrorIsNil)
-	URL.RawQuery = attrs.Encode()
-	req, err := http.NewRequest("GET", URL.String(), nil)
+	u.RawQuery = attrs.Encode()
+	req, err := http.NewRequest("GET", u.String(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return req
 }

--- a/apiserver/testing/fakeapi.go
+++ b/apiserver/testing/fakeapi.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/apiserver/observer/fakeobserver"
 	apiwebsocket "github.com/juju/juju/apiserver/websocket"
 	"github.com/juju/juju/core/trace"
-	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -133,5 +132,5 @@ func (av allVersions) FindMethod(rootMethodName string, version int, objMethodNa
 }
 
 func (av allVersions) StartTrace(ctx context.Context) (context.Context, trace.Span) {
-	return ctx, coretrace.NoopSpan{}
+	return ctx, trace.NoopSpan{}
 }

--- a/caas/kubernetes/clientconfig/plugins.go
+++ b/caas/kubernetes/clientconfig/plugins.go
@@ -30,14 +30,14 @@ const (
 	rbacStackPrefix = "juju-credential"
 )
 
-func getRBACLabels(UID string) map[string]string {
+func getRBACLabels(uid string) map[string]string {
 	return map[string]string{
-		rbacStackPrefix: UID,
+		rbacStackPrefix: uid,
 	}
 }
 
-func getRBACResourceName(UID string) string {
-	return fmt.Sprintf("%s-%s", rbacStackPrefix, UID)
+func getRBACResourceName(uid string) string {
+	return fmt.Sprintf("%s-%s", rbacStackPrefix, uid)
 }
 
 type cleanUpFuncs []func()
@@ -58,13 +58,13 @@ func newK8sClientSet(config *clientcmdapi.Config, contextName string) (*kubernet
 func ensureJujuAdminServiceAccount(
 	ctx context.Context,
 	clientset kubernetes.Interface,
-	UID string,
+	uid string,
 	config *clientcmdapi.Config,
 	contextName string,
 	clock jujuclock.Clock,
 ) (_ *clientcmdapi.Config, err error) {
-	labels := getRBACLabels(UID)
-	name := getRBACResourceName(UID)
+	labels := getRBACLabels(uid)
+	name := getRBACResourceName(uid)
 
 	var cleanUps cleanUpFuncs
 	defer func() {
@@ -117,17 +117,17 @@ func ensureJujuAdminServiceAccount(
 }
 
 // RemoveCredentialRBACResources removes all RBAC resources for specific caas credential UID.
-func RemoveCredentialRBACResources(ctx context.Context, config *rest.Config, UID string) error {
+func RemoveCredentialRBACResources(ctx context.Context, config *rest.Config, uid string) error {
 	// TODO(caas): call this in destroy/kill-controller with UID == "microk8s".
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return removeJujuAdminServiceAccount(ctx, clientset, UID)
+	return removeJujuAdminServiceAccount(ctx, clientset, uid)
 }
 
-func removeJujuAdminServiceAccount(ctx context.Context, clientset kubernetes.Interface, UID string) error {
-	labels := getRBACLabels(UID)
+func removeJujuAdminServiceAccount(ctx context.Context, clientset kubernetes.Interface, uid string) error {
+	labels := getRBACLabels(uid)
 	for _, api := range []rbacDeleter{
 		// Order matters.
 		clientset.RbacV1().ClusterRoleBindings(),

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -366,7 +366,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		},
 	}
 
-	APIPort := s.controllerCfg.APIPort()
+	apiPort := s.controllerCfg.APIPort()
 	ns := &core.Namespace{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   s.namespace,
@@ -388,8 +388,8 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Ports: []core.ServicePort{
 				{
 					Name:       "api-server",
-					TargetPort: intstr.FromInt(APIPort),
-					Port:       int32(APIPort),
+					TargetPort: intstr.FromInt(apiPort),
+					Port:       int32(apiPort),
 				},
 			},
 			ExternalIPs: []string{"10.0.0.1"},
@@ -410,8 +410,8 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Ports: []core.ServicePort{
 				{
 					Name:       "api-server",
-					TargetPort: intstr.FromInt(APIPort),
-					Port:       int32(APIPort),
+					TargetPort: intstr.FromInt(apiPort),
+					Port:       int32(apiPort),
 				},
 			},
 			ClusterIP:   svcPublicIP,

--- a/caas/kubernetes/provider/exec/copy.go
+++ b/caas/kubernetes/provider/exec/copy.go
@@ -158,8 +158,8 @@ func (c client) copyToPod(ctx context.Context, params CopyParams, cancel <-chan 
 
 	go func() {
 		defer writer.Close()
-		err = makeTar(src.Path, dest.Path, writer)
-		if err != nil {
+
+		if err := makeTar(src.Path, dest.Path, writer); err != nil {
 			logger.Errorf("make tar %q failed: %v", src.Path, err)
 		}
 	}()
@@ -270,9 +270,9 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) e
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 
 			if _, err := io.Copy(tw, f); err != nil {
+				_ = f.Close()
 				return err
 			}
 			return f.Close()
@@ -329,8 +329,8 @@ func unTarAll(src FileResource, reader io.Reader, destDir, prefix string) error 
 		if err != nil {
 			return errors.Trace(err)
 		}
-		defer outFile.Close()
 		if _, err := io.Copy(outFile, tarReader); err != nil {
+			_ = outFile.Close()
 			return errors.Trace(err)
 		}
 		if err := outFile.Close(); err != nil {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
-	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
@@ -419,7 +418,7 @@ func (k *kubernetesClient) EnsureImageRepoSecret(ctx context.Context, imageRepo 
 }
 
 func (k *kubernetesClient) validateOperatorStorage(ctx context.Context) (string, error) {
-	storageClass, _ := k.Config().AllAttrs()[k8sconstants.OperatorStorageKey].(string)
+	storageClass, _ := k.Config().AllAttrs()[constants.OperatorStorageKey].(string)
 	if storageClass == "" {
 		return "", errors.NewNotValid(nil, "config without operator-storage value not valid.\nRun juju add-k8s to reimport your k8s cluster.")
 	}
@@ -490,7 +489,7 @@ please choose a different initial model name then try again.`, initialModelName)
 		}
 
 		// create configmap, secret, volume, statefulset, etc resources for controller stack.
-		controllerStack, err := newControllerStack(ctx, k8sconstants.JujuControllerStackName, storageClass, k, pcfg)
+		controllerStack, err := newControllerStack(ctx, constants.JujuControllerStackName, storageClass, k, pcfg)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -13,7 +13,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -78,7 +77,7 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 					},
 				},
 			},
-		}, v1.CreateOptions{})
+		}, meta.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(modelOperatorUpgrade(context.Background(), operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -135,9 +135,9 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 		return nil, errors.Errorf("cloud %v has no credential", cloudSpec.Name)
 	}
 
-	var CAData []byte
+	var caData []byte
 	for _, cacert := range cloudSpec.CACertificates {
-		CAData = append(CAData, cacert...)
+		caData = append(caData, cacert...)
 	}
 
 	credentialAttrs := cloudSpec.Credential.Attributes()
@@ -149,7 +149,7 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 		TLSClientConfig: rest.TLSClientConfig{
 			CertData: []byte(credentialAttrs[k8scloud.CredAttrClientCertificateData]),
 			KeyData:  []byte(credentialAttrs[k8scloud.CredAttrClientKeyData]),
-			CAData:   CAData,
+			CAData:   caData,
 			Insecure: cloudSpec.SkipTLSVerify,
 		},
 	}, nil

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -349,8 +349,8 @@ func (k *kubernetesClient) ensureRoleBinding(ctx context.Context, rb *rbacv1.Rol
 			return existing, cleanups, nil
 		}
 		name := existing.GetName()
-		UID := existing.GetUID()
-		if err := k.deleteRoleBinding(ctx, name, UID); err != nil {
+		uid := existing.GetUID()
+		if err := k.deleteRoleBinding(ctx, name, uid); err != nil {
 			return nil, cleanups, errors.Trace(err)
 		}
 

--- a/caas/kubernetes/provider/resources/rolebinding_test.go
+++ b/caas/kubernetes/provider/resources/rolebinding_test.go
@@ -23,22 +23,22 @@ type roleBindingSuite struct {
 var _ = gc.Suite(&roleBindingSuite{})
 
 func (s *roleBindingSuite) TestApply(c *gc.C) {
-	RoleBinding := &rbacv1.RoleBinding{
+	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "roleBinding1",
 			Namespace: "test",
 		},
 	}
 	// Create.
-	rbResource := resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
+	rbResource := resources.NewRoleBinding("roleBinding1", "test", roleBinding)
 	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 	result, err := s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
-	RoleBinding.SetAnnotations(map[string]string{"a": "b"})
-	rbResource = resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
+	roleBinding.SetAnnotations(map[string]string{"a": "b"})
+	rbResource = resources.NewRoleBinding("roleBinding1", "test", roleBinding)
 	c.Assert(rbResource.Apply(context.Background(), s.client), jc.ErrorIsNil)
 
 	result, err = s.client.RbacV1().RoleBindings("test").Get(context.Background(), "roleBinding1", metav1.GetOptions{})

--- a/cmd/containeragent/initialize/config_test.go
+++ b/cmd/containeragent/initialize/config_test.go
@@ -38,8 +38,8 @@ func (s *initCommandSuit) TestConfigFromEnv(c *gc.C) {
 }
 
 func (s *initCommandSuit) TestDefaultIdentityOnK8S(c *gc.C) {
-	ID, err := initialize.Identity()
+	id, err := initialize.Identity()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ID.PodName, gc.DeepEquals, `gitlab-0`)
-	c.Assert(ID.PodUUID, gc.DeepEquals, `gitlab-uuid`)
+	c.Assert(id.PodName, gc.DeepEquals, `gitlab-0`)
+	c.Assert(id.PodUUID, gc.DeepEquals, `gitlab-uuid`)
 }

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
 	"github.com/juju/juju/cmd/juju/caas/mocks"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
@@ -379,7 +378,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 				return c, nil
 			}
 		},
-		func(_ context.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+		func(_ context.Context, cloud cloud.Cloud, credential cloud.Credential) (k8s.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 		caas.FakeCluster(kubeConfigStr),
@@ -788,11 +787,11 @@ func (s *addCAASSuite) assertAddCloudResult(
 
 	if t.client {
 		s.credentialStoreAPI.EXPECT().UpdateCredential(
-			"myk8s", jujucloud.CloudCredential{
-				AuthCredentials: map[string]jujucloud.Credential{
-					"myk8s": jujucloud.NewNamedCredential(
+			"myk8s", cloud.CloudCredential{
+				AuthCredentials: map[string]cloud.Credential{
+					"myk8s": cloud.NewNamedCredential(
 						"myk8s",
-						jujucloud.AuthType("oauth2"),
+						cloud.AuthType("oauth2"),
 						map[string]string{
 							"Token":   "xfdfsdfsdsd",
 							"rbac-id": "9baa5e46",
@@ -806,7 +805,7 @@ func (s *addCAASSuite) assertAddCloudResult(
 
 	testRun()
 
-	_, region, err := jujucloud.SplitHostCloudRegion(cloudRegion)
+	_, region, err := cloud.SplitHostCloudRegion(cloudRegion)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeK8sClusterMetadataChecker.CheckCall(c, 0, "GetClusterMetadata")
 	expectedCloudToAdd := cloud.Cloud{
@@ -1125,11 +1124,11 @@ func (s *addCAASSuite) TestCorrectParseFromStdIn(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.credentialStoreAPI.EXPECT().UpdateCredential(
-		"myk8s", jujucloud.CloudCredential{
-			AuthCredentials: map[string]jujucloud.Credential{
-				"myk8s": jujucloud.NewNamedCredential(
+		"myk8s", cloud.CloudCredential{
+			AuthCredentials: map[string]cloud.Credential{
+				"myk8s": cloud.NewNamedCredential(
 					"myk8s",
-					jujucloud.AuthType("userpass"),
+					cloud.AuthType("userpass"),
 					map[string]string{
 						"password": "thepassword",
 						"rbac-id":  "9baa5e46",
@@ -1187,11 +1186,11 @@ func (s *addCAASSuite) TestAddGkeCluster(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.credentialStoreAPI.EXPECT().UpdateCredential(
-		"myk8s", jujucloud.CloudCredential{
-			AuthCredentials: map[string]jujucloud.Credential{
-				"myk8s": jujucloud.NewNamedCredential(
+		"myk8s", cloud.CloudCredential{
+			AuthCredentials: map[string]cloud.Credential{
+				"myk8s": cloud.NewNamedCredential(
 					"myk8s",
-					jujucloud.AuthType("userpass"),
+					cloud.AuthType("userpass"),
 					map[string]string{
 						"password": "thepassword",
 						"rbac-id":  "9baa5e46",

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -22,10 +22,8 @@ import (
 	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
 	"github.com/juju/juju/jujuclient"
-	// To allow a maas cloud type to be parsed in the test data.
 	_ "github.com/juju/juju/provider/maas"
 	"github.com/juju/juju/rpc/params"
 )
@@ -45,7 +43,7 @@ type fakeUpdateCloudAPI struct {
 	*jujutesting.CallMocker
 	caas.UpdateCloudAPI
 
-	cloud       jujucloud.Cloud
+	cloud       cloud.Cloud
 	modelResult []params.UpdateCredentialModelResult
 	errorResult *params.Error
 }
@@ -64,7 +62,7 @@ func (api *fakeUpdateCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
 	return api.cloud, nil
 }
 
-func (api *fakeUpdateCloudAPI) UpdateCloudsCredentials(cloudCredentials map[string]jujucloud.Credential, force bool) ([]params.UpdateCredentialResult, error) {
+func (api *fakeUpdateCloudAPI) UpdateCloudsCredentials(cloudCredentials map[string]cloud.Credential, force bool) ([]params.UpdateCredentialResult, error) {
 	api.MethodCall(api, "UpdateCloudsCredentials", cloudCredentials, force)
 	var tag string
 	for k := range cloudCredentials {
@@ -140,7 +138,7 @@ func (s *updateCAASSuite) makeCommand() cmd.Command {
 		func() (caas.UpdateCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(_ context.Context, cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
+		func(_ context.Context, cloud cloud.Cloud, credential cloud.Credential) (k8s.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 	)
@@ -182,7 +180,7 @@ func (s *updateCAASSuite) assertUpdateCloudResult(
 
 	testRun()
 
-	_, region, err := jujucloud.SplitHostCloudRegion(cloudRegion)
+	_, region, err := cloud.SplitHostCloudRegion(cloudRegion)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeK8sClusterMetadataChecker.CheckNoCalls(c)
 	expectedCloudToUpdate := cloud.Cloud{
@@ -250,7 +248,7 @@ func (s *updateCAASSuite) TestLocalOnly(c *gc.C) {
 }
 
 func (s *updateCAASSuite) TestInvalidControllerCloud(c *gc.C) {
-	s.fakeCloudAPI.cloud = jujucloud.Cloud{Type: "maas"}
+	s.fakeCloudAPI.cloud = cloud.Cloud{Type: "maas"}
 	command := s.makeCommand()
 	ctx, err := s.runCommand(c, command, "myk8s", "-c", "foo")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1435,20 +1435,20 @@ func (s *BootstrapSuite) TestMissingToolsError(c *gc.C) {
 	)
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{{
-		loggo.ERROR,
-		"failed to bootstrap model: Juju cannot bootstrap because no agent binaries are available for your model",
+		Level:   loggo.ERROR,
+		Message: "failed to bootstrap model: Juju cannot bootstrap because no agent binaries are available for your model",
 	}})
 }
 
 func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
-	BuildAgentTarballAlwaysFails := func(
+	buildAgentTarballAlwaysFails := func(
 		bool, string, func(version.Number) version.Number,
 	) (*sync.BuiltAgent, error) {
 		return nil, errors.New("an error")
 	}
 
 	s.setupAutoUploadTest(c, "1.7.3", "jammy")
-	s.PatchValue(&sync.BuildAgentTarball, BuildAgentTarballAlwaysFails)
+	s.PatchValue(&sync.BuildAgentTarball, buildAgentTarballAlwaysFails)
 
 	ctx, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
@@ -1465,8 +1465,8 @@ No packaged binary found, preparing local Juju agent binary
 `[1:])
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{{
-		loggo.ERROR,
-		"failed to bootstrap model: cannot package bootstrap agent binary: an error",
+		Level:   loggo.ERROR,
+		Message: "failed to bootstrap model: cannot package bootstrap agent binary: an error",
 	}})
 }
 
@@ -1502,10 +1502,10 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	c.Assert(opDestroy.Error, gc.ErrorMatches, "dummy.Destroy is broken")
 
 	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{
-		{loggo.ERROR, "failed to bootstrap model: dummy.Bootstrap is broken"},
-		{loggo.DEBUG, "(error details.*)"},
-		{loggo.DEBUG, "cleaning up after failed bootstrap"},
-		{loggo.ERROR, "error cleaning up: dummy.Destroy is broken"},
+		{Level: loggo.ERROR, Message: "failed to bootstrap model: dummy.Bootstrap is broken"},
+		{Level: loggo.DEBUG, Message: "(error details.*)"},
+		{Level: loggo.DEBUG, Message: "cleaning up after failed bootstrap"},
+		{Level: loggo.ERROR, Message: "error cleaning up: dummy.Destroy is broken"},
 	})
 }
 

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -177,8 +177,8 @@ func (s *UpgradeMachineSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArg
 }
 
 func (s *UpgradeMachineSuite) TestPrepareCommandShouldOnlyAcceptSupportedSeries(c *gc.C) {
-	BadSeries := "Combative Caribou"
-	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, BadSeries)
+	badSeries := "Combative Caribou"
+	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, badSeries)
 	c.Assert(err, gc.ErrorMatches, ".* is an unsupported series")
 }
 

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -82,7 +82,7 @@ type SpaceCommandBase struct {
 // like missing/invalid name or CIDRs (validated when given, but it's
 // an error for CIDRs to be empty if cidrsOptional is false).
 func ParseNameAndCIDRs(args []string, cidrsOptional bool) (
-	name string, CIDRs set.Strings, err error,
+	name string, cidrs set.Strings, err error,
 ) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
@@ -94,8 +94,8 @@ func ParseNameAndCIDRs(args []string, cidrsOptional bool) (
 		return name, nil, errors.Trace(err)
 	}
 
-	CIDRs, err = CheckCIDRs(args[1:], cidrsOptional)
-	return name, CIDRs, errors.Trace(err)
+	cidrs, err = CheckCIDRs(args[1:], cidrsOptional)
+	return name, cidrs, errors.Trace(err)
 }
 
 // CheckName checks whether name is a valid space name.
@@ -112,28 +112,28 @@ func CheckName(name string) (string, error) {
 // if no CIDRs are provided, unless cidrsOptional is true.
 func CheckCIDRs(args []string, cidrsOptional bool) (set.Strings, error) {
 	// Validate any given CIDRs.
-	CIDRs := set.NewStrings()
+	cidrs := set.NewStrings()
 	for _, arg := range args {
 		_, ipNet, err := net.ParseCIDR(arg)
 		if err != nil {
 			logger.Debugf("cannot parse %q: %v", arg, err)
-			return CIDRs, errors.Errorf("%q is not a valid CIDR", arg)
+			return cidrs, errors.Errorf("%q is not a valid CIDR", arg)
 		}
 		cidr := ipNet.String()
-		if CIDRs.Contains(cidr) {
+		if cidrs.Contains(cidr) {
 			if cidr == arg {
-				return CIDRs, errors.Errorf("duplicate subnet %q specified", cidr)
+				return cidrs, errors.Errorf("duplicate subnet %q specified", cidr)
 			}
-			return CIDRs, errors.Errorf("subnet %q overlaps with %q", arg, cidr)
+			return cidrs, errors.Errorf("subnet %q overlaps with %q", arg, cidr)
 		}
-		CIDRs.Add(cidr)
+		cidrs.Add(cidr)
 	}
 
-	if CIDRs.IsEmpty() && !cidrsOptional {
-		return CIDRs, errors.New("CIDRs required but not provided")
+	if cidrs.IsEmpty() && !cidrsOptional {
+		return cidrs, errors.New("CIDRs required but not provided")
 	}
 
-	return CIDRs, nil
+	return cidrs, nil
 }
 
 // APIShim forwards SpaceAPI methods to the real API facade for

--- a/cmd/juju/space/space_test.go
+++ b/cmd/juju/space/space_test.go
@@ -97,7 +97,7 @@ func (s *SpaceCommandSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// modelcmd.Wrap().
-		name, CIDRs, err := space.ParseNameAndCIDRs(test.args, test.cidrsOptional)
+		name, cidrs, err := space.ParseNameAndCIDRs(test.args, test.cidrsOptional)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
@@ -105,6 +105,6 @@ func (s *SpaceCommandSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 		}
 		c.Check(name, gc.Equals, test.expectName)
-		c.Check(CIDRs.SortedValues(), jc.DeepEquals, test.expectCIDRs)
+		c.Check(cidrs.SortedValues(), jc.DeepEquals, test.expectCIDRs)
 	}
 }

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -116,8 +116,8 @@ func (s *SecretURISuite) TestName(c *gc.C) {
 }
 
 func (s *SecretURISuite) TestNew(c *gc.C) {
-	URI := secrets.NewURI()
-	_, err := xid.FromString(URI.ID)
+	uri := secrets.NewURI()
+	_, err := xid.FromString(uri.ID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -129,11 +129,11 @@ func (s *SecretURISuite) TestWithSource(c *gc.C) {
 }
 
 func (s *SecretURISuite) TestIsLocal(c *gc.C) {
-	URI := secrets.NewURI()
-	c.Assert(URI.IsLocal("other-uuid"), jc.IsTrue)
-	URI2 := URI.WithSource("some-uuid")
-	c.Assert(URI2.IsLocal("some-uuid"), jc.IsTrue)
-	c.Assert(URI2.IsLocal("other-uuid"), jc.IsFalse)
+	uri := secrets.NewURI()
+	c.Assert(uri.IsLocal("other-uuid"), jc.IsTrue)
+	uri2 := uri.WithSource("some-uuid")
+	c.Assert(uri2.IsLocal("some-uuid"), jc.IsTrue)
+	c.Assert(uri2.IsLocal("other-uuid"), jc.IsFalse)
 }
 
 type SecretSuite struct{}

--- a/domain/annotation/service/service.go
+++ b/domain/annotation/service/service.go
@@ -38,15 +38,15 @@ func NewService(st State) *Service {
 
 // GetAnnotations retrieves all the annotations associated with a given ID.
 // If no annotations are found, an empty map is returned.
-func (s *Service) GetAnnotations(ctx context.Context, ID annotations.ID) (map[string]string, error) {
-	annotations, err := s.st.GetAnnotations(ctx, ID)
+func (s *Service) GetAnnotations(ctx context.Context, id annotations.ID) (map[string]string, error) {
+	annotations, err := s.st.GetAnnotations(ctx, id)
 	return annotations, errors.Trace(err)
 }
 
 // SetAnnotations associates key/value annotation pairs with a given ID.
 // If annotation already exists for the given ID, then it will be updated with
 // the given value.
-func (s *Service) SetAnnotations(ctx context.Context, ID annotations.ID, annotations map[string]string) error {
-	err := s.st.SetAnnotations(ctx, ID, annotations)
-	return errors.Annotatef(err, "updating annotations for ID: %q", ID.Name)
+func (s *Service) SetAnnotations(ctx context.Context, id annotations.ID, annotations map[string]string) error {
+	err := s.st.SetAnnotations(ctx, id, annotations)
+	return errors.Annotatef(err, "updating annotations for ID: %q", id.Name)
 }

--- a/domain/annotation/service/service_test.go
+++ b/domain/annotation/service/service_test.go
@@ -44,20 +44,19 @@ func (s *serviceSuite) TestGetAnnotations(c *gc.C) {
 	id1 := annotations.ID{Kind: annotations.KindUnit, Name: "unit1"}
 	id33 := annotations.ID{Kind: annotations.KindUnit, Name: "unit33"}
 	id44 := annotations.ID{Kind: annotations.KindUnit, Name: "unit44"}
-	IDNotExist := annotations.ID{Kind: annotations.KindUnit, Name: "unitNoAnnotations"}
+	idNotExist := annotations.ID{Kind: annotations.KindUnit, Name: "unitNoAnnotations"}
 	mockState := map[stateAnnotationKey]string{
-		{id1, "annotationKey1"}:  "annotationValue1",
-		{id1, "annotationKey2"}:  "annotationValue2",
-		{id33, "annotationKey3"}: "annotationValue3",
-		{id44, "annotationKey4"}: "annotationValue4",
+		{ID: id1, key: "annotationKey1"}:  "annotationValue1",
+		{ID: id1, key: "annotationKey2"}:  "annotationValue2",
+		{ID: id33, key: "annotationKey3"}: "annotationValue3",
+		{ID: id44, key: "annotationKey4"}: "annotationValue4",
 	}
 
 	s.state.EXPECT().GetAnnotations(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context,
-			ID annotations.ID) (map[string]string, error) {
+		func(_ context.Context, id annotations.ID) (map[string]string, error) {
 			annotations := make(map[string]string)
 			for annKey := range mockState {
-				if annKey.ID == ID {
+				if annKey.ID == id {
 					annotations[annKey.key] = mockState[annKey]
 				}
 			}
@@ -73,7 +72,7 @@ func (s *serviceSuite) TestGetAnnotations(c *gc.C) {
 
 	// Assert that an empty map (not nil) is returend if no annotations
 	// are associated with a given ID
-	noAnnotations, err := s.service().GetAnnotations(context.Background(), IDNotExist)
+	noAnnotations, err := s.service().GetAnnotations(context.Background(), idNotExist)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(noAnnotations), gc.Equals, 0)
 }
@@ -85,21 +84,19 @@ func (s *serviceSuite) TestSetAnnotations(c *gc.C) {
 	id33 := annotations.ID{Kind: annotations.KindUnit, Name: "unit33"}
 	id44 := annotations.ID{Kind: annotations.KindUnit, Name: "unit44"}
 	mockState := map[stateAnnotationKey]string{
-		{id1, "annotationKey1"}:  "annotationValue1",
-		{id1, "annotationKey2"}:  "annotationValue2",
-		{id33, "annotationKey3"}: "annotationValue3",
-		{id44, "annotationKey4"}: "annotationValue4",
+		{ID: id1, key: "annotationKey1"}:  "annotationValue1",
+		{ID: id1, key: "annotationKey2"}:  "annotationValue2",
+		{ID: id33, key: "annotationKey3"}: "annotationValue3",
+		{ID: id44, key: "annotationKey4"}: "annotationValue4",
 	}
 
 	s.state.EXPECT().SetAnnotations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context,
-			ID annotations.ID,
-			annotations map[string]string) error {
+		func(_ context.Context, id annotations.ID, annotations map[string]string) error {
 			for annKey, annVal := range annotations {
 				if annVal == "" {
-					delete(mockState, stateAnnotationKey{ID, annKey})
+					delete(mockState, stateAnnotationKey{ID: id, key: annKey})
 				} else {
-					mockState[stateAnnotationKey{ID, annKey}] = annVal
+					mockState[stateAnnotationKey{ID: id, key: annKey}] = annVal
 				}
 			}
 			return nil
@@ -114,8 +111,8 @@ func (s *serviceSuite) TestSetAnnotations(c *gc.C) {
 	err := s.service().SetAnnotations(context.Background(), id1, annotations)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(mockState), gc.Equals, 5)
-	c.Assert(mockState[stateAnnotationKey{id1, "annotationKey5"}], gc.Equals, "annotationValue5")
-	c.Assert(mockState[stateAnnotationKey{id1, "annotationKey1"}], gc.Equals, "annotationValue1Updated")
+	c.Assert(mockState[stateAnnotationKey{ID: id1, key: "annotationKey5"}], gc.Equals, "annotationValue5")
+	c.Assert(mockState[stateAnnotationKey{ID: id1, key: "annotationKey1"}], gc.Equals, "annotationValue1Updated")
 
 	// Unset a key
 	unsetAnnotations := map[string]string{"annotationKey4": ""}

--- a/environs/imagemetadata/urls_test.go
+++ b/environs/imagemetadata/urls_test.go
@@ -63,14 +63,14 @@ func (s *URLsSuite) TestImageMetadataURL(c *gc.C) {
 func (s *URLsSuite) TestImageMetadataURLOfficialSource(c *gc.C) {
 	baseURL := imagemetadata.UbuntuCloudImagesURL
 	// Released streams.
-	URL, err := imagemetadata.ImageMetadataURL(baseURL, "")
+	url, err := imagemetadata.ImageMetadataURL(baseURL, "")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(URL, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "releases"))
-	URL, err = imagemetadata.ImageMetadataURL(baseURL, imagemetadata.ReleasedStream)
+	c.Assert(url, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "releases"))
+	url, err = imagemetadata.ImageMetadataURL(baseURL, imagemetadata.ReleasedStream)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(URL, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "releases"))
+	c.Assert(url, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "releases"))
 	// Non-released streams.
-	URL, err = imagemetadata.ImageMetadataURL(baseURL, "daily")
+	url, err = imagemetadata.ImageMetadataURL(baseURL, "daily")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(URL, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "daily"))
+	c.Assert(url, gc.Equals, fmt.Sprintf("%s/%s", baseURL, "daily"))
 }

--- a/internal/container/kvm/libvirt/domainxml_test.go
+++ b/internal/container/kvm/libvirt/domainxml_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	. "github.com/juju/juju/internal/container/kvm/libvirt"
+	"github.com/juju/juju/internal/container/kvm/libvirt"
 )
 
 // gocheck boilerplate.
@@ -156,12 +156,12 @@ func (domainXMLSuite) TestNewDomain(c *gc.C) {
 	}
 	for i, test := range table {
 		c.Logf("TestNewDomain: test #%d for %s", i+1, test.arch)
-		ifaces := []InterfaceInfo{
+		ifaces := []libvirt.InterfaceInfo{
 			dummyInterface{
 				mac:    "00:00:00:00:00:00",
 				parent: "parent-dev",
 				name:   "device-name"}}
-		disks := []DiskInfo{
+		disks := []libvirt.DiskInfo{
 			dummyDisk{driver: "qcow2", source: "/some/path"},
 			dummyDisk{driver: "raw", source: "/another/path"},
 		}
@@ -171,7 +171,7 @@ func (domainXMLSuite) TestNewDomain(c *gc.C) {
 			params.loader = "/shared/readonly.fd"
 		}
 
-		d, err := NewDomain(params)
+		d, err := libvirt.NewDomain(params)
 		c.Check(err, jc.ErrorIsNil)
 		ml, err := xml.MarshalIndent(&d, "", "    ")
 		c.Check(err, jc.ErrorIsNil)
@@ -180,7 +180,7 @@ func (domainXMLSuite) TestNewDomain(c *gc.C) {
 }
 
 func (domainXMLSuite) TestNewDomainWithOvsBridge(c *gc.C) {
-	ifaces := []InterfaceInfo{
+	ifaces := []libvirt.InterfaceInfo{
 		dummyInterface{
 			mac:                   "00:00:00:00:00:00",
 			parent:                "parent-dev",
@@ -188,13 +188,13 @@ func (domainXMLSuite) TestNewDomainWithOvsBridge(c *gc.C) {
 			parentVirtualPortType: "openvswitch",
 		},
 	}
-	disks := []DiskInfo{
+	disks := []libvirt.DiskInfo{
 		dummyDisk{driver: "qcow2", source: "/some/path"},
 		dummyDisk{driver: "raw", source: "/another/path"},
 	}
 	params := dummyParams{ifaceInfo: ifaces, diskInfo: disks, memory: 1024, cpuCores: 2, hostname: "juju-someid", arch: "amd64"}
 
-	d, err := NewDomain(params)
+	d, err := libvirt.NewDomain(params)
 	c.Check(err, jc.ErrorIsNil)
 	ml, err := xml.MarshalIndent(&d, "", "    ")
 	c.Check(err, jc.ErrorIsNil)
@@ -202,8 +202,8 @@ func (domainXMLSuite) TestNewDomainWithOvsBridge(c *gc.C) {
 }
 
 func (domainXMLSuite) TestNewDomainError(c *gc.C) {
-	d, err := NewDomain(dummyParams{err: errors.Errorf("boom")})
-	c.Check(d, jc.DeepEquals, Domain{})
+	d, err := libvirt.NewDomain(dummyParams{err: errors.Errorf("boom")})
+	c.Check(d, jc.DeepEquals, libvirt.Domain{})
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 
@@ -211,23 +211,23 @@ type dummyParams struct {
 	err       error
 	arch      string
 	cpuCores  uint64
-	diskInfo  []DiskInfo
+	diskInfo  []libvirt.DiskInfo
 	hostname  string
-	ifaceInfo []InterfaceInfo
+	ifaceInfo []libvirt.InterfaceInfo
 	loader    string
 	memory    uint64
 	nvram     string
 }
 
-func (p dummyParams) Arch() string                 { return p.arch }
-func (p dummyParams) CPUs() uint64                 { return p.cpuCores }
-func (p dummyParams) DiskInfo() []DiskInfo         { return p.diskInfo }
-func (p dummyParams) Host() string                 { return p.hostname }
-func (p dummyParams) Loader() string               { return p.loader }
-func (p dummyParams) NVRAM() string                { return p.nvram }
-func (p dummyParams) NetworkInfo() []InterfaceInfo { return p.ifaceInfo }
-func (p dummyParams) RAM() uint64                  { return p.memory }
-func (p dummyParams) ValidateDomainParams() error  { return p.err }
+func (p dummyParams) Arch() string                         { return p.arch }
+func (p dummyParams) CPUs() uint64                         { return p.cpuCores }
+func (p dummyParams) DiskInfo() []libvirt.DiskInfo         { return p.diskInfo }
+func (p dummyParams) Host() string                         { return p.hostname }
+func (p dummyParams) Loader() string                       { return p.loader }
+func (p dummyParams) NVRAM() string                        { return p.nvram }
+func (p dummyParams) NetworkInfo() []libvirt.InterfaceInfo { return p.ifaceInfo }
+func (p dummyParams) RAM() uint64                          { return p.memory }
+func (p dummyParams) ValidateDomainParams() error          { return p.err }
 
 type dummyDisk struct {
 	source string

--- a/internal/container/kvm/sync_test.go
+++ b/internal/container/kvm/sync_test.go
@@ -10,7 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/imagedownloads"
-	. "github.com/juju/juju/internal/container/kvm"
+	"github.com/juju/juju/internal/container/kvm"
 )
 
 // cacheSuite is gocheck boilerplate.
@@ -24,7 +24,7 @@ var _ = gc.Suite(&cacheSuite{})
 func (cacheSuite) TestSyncOnerErrors(c *gc.C) {
 	o := fakeParams{FakeData: nil, Err: errors.New("oner failed")}
 	u := fakeFetcher{}
-	got := Sync(o, u, "", nil)
+	got := kvm.Sync(o, u, "", nil)
 	c.Assert(got, gc.ErrorMatches, "oner failed")
 }
 
@@ -33,21 +33,21 @@ func (cacheSuite) TestSyncOnerExists(c *gc.C) {
 		FakeData: nil,
 		Err:      errors.AlreadyExistsf("exists")}
 	u := fakeFetcher{}
-	got := Sync(o, u, "", nil)
+	got := kvm.Sync(o, u, "", nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 
 func (cacheSuite) TestSyncUpdaterErrors(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}, Err: nil}
 	u := fakeFetcher{Err: errors.New("updater failed")}
-	got := Sync(o, u, "", nil)
+	got := kvm.Sync(o, u, "", nil)
 	c.Assert(got, gc.ErrorMatches, "updater failed")
 }
 
 func (cacheSuite) TestSyncSucceeds(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}}
 	u := fakeFetcher{}
-	got := Sync(o, u, "", nil)
+	got := kvm.Sync(o, u, "", nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 

--- a/internal/docker/registry/internal/ecr.go
+++ b/internal/docker/registry/internal/ecr.go
@@ -74,13 +74,13 @@ func newElasticContainerRegistry(repoDetails docker.ImageRepoDetails, transport 
 
 func newElasticContainerRegistryForTest(
 	repoDetails docker.ImageRepoDetails, transport http.RoundTripper,
-	ECRClientFunc func(ctx context.Context, accessKeyID, secretAccessKey, region string) (ECRInterface, error),
+	ecrClientFunc func(ctx context.Context, accessKeyID, secretAccessKey, region string) (ECRInterface, error),
 ) (RegistryInternal, error) {
 	c, err := newBase(repoDetails, transport, normalizeRepoDetailsElasticContainerRegistry)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &elasticContainerRegistry{baseClient: c, ECRClientFunc: ECRClientFunc}, nil
+	return &elasticContainerRegistry{baseClient: c, ECRClientFunc: ecrClientFunc}, nil
 }
 
 func normalizeRepoDetailsElasticContainerRegistry(repoDetails *docker.ImageRepoDetails) error {

--- a/internal/downloader/download_test.go
+++ b/internal/downloader/download_test.go
@@ -46,9 +46,9 @@ var _ = gc.Suite(&DownloadSuite{})
 
 func (s *DownloadSuite) URL(c *gc.C, path string) *url.URL {
 	urlStr := s.HTTPSuite.URL(path)
-	URL, err := url.Parse(urlStr)
+	url, err := url.Parse(urlStr)
 	c.Assert(err, jc.ErrorIsNil)
-	return URL
+	return url
 }
 
 func (s *DownloadSuite) testDownload(c *gc.C, hostnameVerification bool) {

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -45,9 +45,9 @@ var _ = gc.Suite(&DownloaderSuite{})
 
 func (s *DownloaderSuite) URL(c *gc.C, path string) *url.URL {
 	urlStr := s.HTTPSuite.URL(path)
-	URL, err := url.Parse(urlStr)
+	url, err := url.Parse(urlStr)
 	c.Assert(err, jc.ErrorIsNil)
-	return URL
+	return url
 }
 
 func (s *DownloaderSuite) testStart(c *gc.C, hostnameVerification bool) {

--- a/internal/network/netplan/netplan_test.go
+++ b/internal/network/netplan/netplan_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
-	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/internal/network/netplan"
 	coretesting "github.com/juju/juju/testing"
@@ -35,7 +34,7 @@ func MustNetplanFromYaml(c *gc.C, input string) *netplan.Netplan {
 	if strings.HasPrefix(input, "\n") {
 		input = input[1:]
 	}
-	err := goyaml.UnmarshalStrict([]byte(input), &np)
+	err := yaml.UnmarshalStrict([]byte(input), &np)
 	c.Assert(err, jc.ErrorIsNil)
 	return &np
 }

--- a/internal/pki/assertion/x509_test.go
+++ b/internal/pki/assertion/x509_test.go
@@ -5,18 +5,18 @@ package assertion_test
 
 import (
 	"crypto/x509"
-	. "testing"
+	"testing"
 
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/internal/pki/assertion"
 )
 
-func TestAll(t *T) {
+func TestAll(t *testing.T) {
 	gc.TestingT(t)
 }
 
-func TestHasExtKeyUsage(t *T) {
+func TestHasExtKeyUsage(t *testing.T) {
 	tests := []struct {
 		Name        string
 		ExtKeyUsage []x509.ExtKeyUsage
@@ -58,7 +58,7 @@ func TestHasExtKeyUsage(t *T) {
 	}
 
 	for _, test := range tests {
-		_ = t.Run(test.Name, func(t *T) {
+		_ = t.Run(test.Name, func(t *testing.T) {
 			rval := assertion.HasExtKeyUsage(&x509.Certificate{
 				ExtKeyUsage: test.ExtKeyUsage,
 			}, test.CheckKey)

--- a/internal/storage/provider/managedfs.go
+++ b/internal/storage/provider/managedfs.go
@@ -209,7 +209,7 @@ func createFilesystem(run runCommandFunc, devicePath string) error {
 	return nil
 }
 
-func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, UUID, mountPoint string, readOnly bool) error {
+func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, uuid, mountPoint string, readOnly bool) error {
 	logger.Debugf("attempting to mount filesystem on %q at %q", devicePath, mountPoint)
 	if err := dirFuncs.mkDirAll(mountPoint, 0755); err != nil {
 		return errors.Annotate(err, "creating mount point")
@@ -241,7 +241,7 @@ func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, UUID, mo
 	if mtabEntry == "" {
 		return nil
 	}
-	return ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, mtabEntry)
+	return ensureFstabEntry(etcDir, devicePath, uuid, mountPoint, mtabEntry)
 }
 
 // extractMtabEntry returns any /etc/mtab entry for the specified
@@ -273,7 +273,7 @@ func extractMtabEntry(etcDir string, devicePath, mountPoint string) (string, err
 
 // ensureFstabEntry creates an entry in /etc/fstab for the specified
 // device path and mount point so long as there's no existing entry already.
-func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error {
+func ensureFstabEntry(etcDir, devicePath, uuid, mountPoint, entry string) error {
 	f, err := os.Open(filepath.Join(etcDir, "fstab"))
 	if err != nil && !os.IsNotExist(err) {
 		return errors.Annotate(err, "opening /etc/fstab")
@@ -310,7 +310,7 @@ func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error 
 		}
 	}
 
-	uuidField := "UUID=" + UUID
+	uuidField := "UUID=" + uuid
 	addNewEntry := true
 	// Scan all the fstab lines, searching for one
 	// which describes the entry we want to create.
@@ -331,7 +331,7 @@ func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error 
 			goto writeLine
 		}
 		// We have a match, if UUID is not yet known, retain the line.
-		if UUID == "" {
+		if uuid == "" {
 			addNewEntry = false
 			goto writeLine
 		}
@@ -347,7 +347,7 @@ func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error 
 	}
 
 	if addNewEntry {
-		if UUID != "" {
+		if uuid != "" {
 			if len(resultFields) >= 2 { // just being defensive, check should never fail.
 				_, err := newFsTab.WriteString(fmt.Sprintf("# %s was on %s during installation\n", resultFields[1], resultFields[0]))
 				if err != nil {

--- a/internal/storage/provider/managedfs_test.go
+++ b/internal/storage/provider/managedfs_test.go
@@ -177,7 +177,7 @@ func (s *managedfsSuite) TestAttachFilesystemsReattach(c *gc.C) {
 	s.testAttachFilesystems(c, true, true, "", mtabEntry, "")
 }
 
-func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool, UUID, mtab, fstab string) {
+func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool, uuid, mtab, fstab string) {
 	mountInfo := ""
 	if reattach {
 		mountInfo = mountInfoLine(666, 0, "/different/to/rootfs", testMountPoint, "/dev/sda1")
@@ -202,7 +202,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool,
 		DeviceName: "sda",
 		HardwareId: "capncrunch",
 		SizeMiB:    2,
-		UUID:       UUID,
+		UUID:       uuid,
 	}
 	s.filesystems[names.NewFilesystemTag("0/0")] = storage.Filesystem{
 		Tag:    names.NewFilesystemTag("0/0"),
@@ -222,9 +222,9 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool,
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []storage.AttachFilesystemsResult{{
 		FilesystemAttachment: &storage.FilesystemAttachment{
-			names.NewFilesystemTag("0/0"),
-			names.NewMachineTag("0"),
-			storage.FilesystemAttachmentInfo{
+			Filesystem: names.NewFilesystemTag("0/0"),
+			Machine:    names.NewMachineTag("0"),
+			FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
 				Path:     testMountPoint,
 				ReadOnly: readOnly,
 			},

--- a/internal/worker/storageprovisioner/mock_test.go
+++ b/internal/worker/storageprovisioner/mock_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
-	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -857,7 +856,7 @@ func newMockMachineAccessor(c *gc.C) *mockMachineAccessor {
 }
 
 type mockClock struct {
-	jujutesting.Stub
+	testing.Stub
 	now         time.Time
 	onNow       func() time.Time
 	onAfter     func(time.Duration) <-chan time.Time

--- a/juju/osenv/home.go
+++ b/juju/osenv/home.go
@@ -49,19 +49,19 @@ func JujuXDGDataHomePath(names ...string) string {
 
 // JujuXDGDataHomeDir returns the directory where juju should store application-specific files
 func JujuXDGDataHomeDir() string {
-	JujuXDGDataHomeDir := JujuXDGDataHome()
-	if JujuXDGDataHomeDir != "" {
-		return JujuXDGDataHomeDir
+	homeDir := JujuXDGDataHome()
+	if homeDir != "" {
+		return homeDir
 	}
-	JujuXDGDataHomeDir = os.Getenv(JujuXDGDataHomeEnvKey)
-	if JujuXDGDataHomeDir == "" {
+	homeDir = os.Getenv(JujuXDGDataHomeEnvKey)
+	if homeDir == "" {
 		if runtime.GOOS == "windows" {
-			JujuXDGDataHomeDir = jujuXDGDataHomeWin()
+			homeDir = jujuXDGDataHomeWin()
 		} else {
-			JujuXDGDataHomeDir = jujuXDGDataHomeLinux()
+			homeDir = jujuXDGDataHomeLinux()
 		}
 	}
-	return JujuXDGDataHomeDir
+	return homeDir
 }
 
 // jujuXDGDataHomeLinux returns the directory where juju should store application-specific files on Linux.

--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -779,7 +779,7 @@ func (*EquinixUtils) TestGetArchitectureFromPlan(c *gc.C) {
 }
 
 func (*EquinixUtils) TestValidPlan(c *gc.C) {
-	const UNEXPECTED = "unexpected"
+	const unexpected = "unexpected"
 
 	plan := func(f func(*packngo.Plan)) packngo.Plan {
 		p := &packngo.Plan{
@@ -812,7 +812,7 @@ func (*EquinixUtils) TestValidPlan(c *gc.C) {
 		{
 			name: "unexpected.line",
 			plan: plan(func(p *packngo.Plan) {
-				p.Line = UNEXPECTED
+				p.Line = unexpected
 			}),
 			region: "dc",
 			expect: false,
@@ -820,7 +820,7 @@ func (*EquinixUtils) TestValidPlan(c *gc.C) {
 		{
 			plan: plan(func(p *packngo.Plan) {
 				p.Slug = "unexpected.deploymenttype"
-				p.DeploymentTypes[0] = UNEXPECTED
+				p.DeploymentTypes[0] = unexpected
 			}),
 			region: "dc",
 			expect: false,
@@ -828,7 +828,7 @@ func (*EquinixUtils) TestValidPlan(c *gc.C) {
 		{
 			plan: plan(func(p *packngo.Plan) {
 				p.Slug = "unexpected.metro"
-				p.AvailableInMetros[0].Code = UNEXPECTED
+				p.AvailableInMetros[0].Code = unexpected
 			}),
 			region: "dc",
 			expect: false,

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -524,8 +524,8 @@ func (conn *StubClient) UpdateContainerProfiles(name string, profiles []string) 
 	return conn.NextErr()
 }
 
-func (conn *StubClient) VerifyNetworkDevice(profile *api.Profile, ETag string) error {
-	conn.AddCall("VerifyNetworkDevice", profile, ETag)
+func (conn *StubClient) VerifyNetworkDevice(profile *api.Profile, etag string) error {
+	conn.AddCall("VerifyNetworkDevice", profile, etag)
 	return conn.NextErr()
 }
 
@@ -534,12 +534,12 @@ func (conn *StubClient) StorageSupported() bool {
 	return conn.StorageIsSupported
 }
 
-func (conn *StubClient) EnsureDefaultStorage(profile *api.Profile, ETag string) error {
-	conn.AddCall("EnsureDefaultStorage", profile, ETag)
+func (conn *StubClient) EnsureDefaultStorage(profile *api.Profile, etag string) error {
+	conn.AddCall("EnsureDefaultStorage", profile, etag)
 	return conn.NextErr()
 }
 
-func (conn *StubClient) GetStoragePool(name string) (pool *api.StoragePool, ETag string, err error) {
+func (conn *StubClient) GetStoragePool(name string) (pool *api.StoragePool, etag string, err error) {
 	conn.AddCall("GetStoragePool", name)
 	return &api.StoragePool{
 		Name:   name,
@@ -597,9 +597,9 @@ func (conn *StubClient) GetStoragePoolVolumes(pool string) ([]api.StorageVolume,
 }
 
 func (conn *StubClient) UpdateStoragePoolVolume(
-	pool string, volType string, name string, volume api.StorageVolumePut, ETag string,
+	pool string, volType string, name string, volume api.StorageVolumePut, etag string,
 ) error {
-	conn.AddCall("UpdateStoragePoolVolume", pool, volType, name, volume, ETag)
+	conn.AddCall("UpdateStoragePoolVolume", pool, volType, name, volume, etag)
 	return conn.NextErr()
 }
 

--- a/provider/oci/common_integration_test.go
+++ b/provider/oci/common_integration_test.go
@@ -148,10 +148,10 @@ func makeGetVnicRequestResponse(vnicDetails []ociCore.GetVnicResponse) ([]ociCor
 	return requests, responses
 }
 
-func newFakeOCIInstance(Id, compartment string, state ociCore.InstanceLifecycleStateEnum) *ociCore.Instance {
+func newFakeOCIInstance(id, compartment string, state ociCore.InstanceLifecycleStateEnum) *ociCore.Instance {
 	return &ociCore.Instance{
 		AvailabilityDomain: makeStringPointer("fake-az"),
-		Id:                 &Id,
+		Id:                 &id,
 		CompartmentId:      &compartment,
 		Region:             makeStringPointer("us-phoenix-1"),
 		Shape:              makeStringPointer("VM.Standard1.1"),

--- a/provider/oci/environ_integration_test.go
+++ b/provider/oci/environ_integration_test.go
@@ -1094,10 +1094,10 @@ func (s *environSuite) setupDeleteRouteTableExpectations(vcnId, routeTableId str
 	s.netw.EXPECT().GetRouteTable(context.Background(), requestGet).Return(responseGet, nil).AnyTimes()
 }
 
-func (s *environSuite) setupDeleteInternetGatewayExpectations(vcnId, IgId string, t map[string]string) {
+func (s *environSuite) setupDeleteInternetGatewayExpectations(vcnId, igId string, t map[string]string) {
 	s.setupInternetGatewaysExpectations(vcnId, t, 1)
 	request := ociCore.DeleteInternetGatewayRequest{
-		IgId: &IgId,
+		IgId: &igId,
 	}
 
 	response := ociCore.DeleteInternetGatewayResponse{
@@ -1108,11 +1108,11 @@ func (s *environSuite) setupDeleteInternetGatewayExpectations(vcnId, IgId string
 	s.netw.EXPECT().DeleteInternetGateway(context.Background(), request).Return(response, nil)
 
 	requestGet := ociCore.GetInternetGatewayRequest{
-		IgId: &IgId,
+		IgId: &igId,
 	}
 
 	ig := ociCore.InternetGateway{
-		Id:             &IgId,
+		Id:             &igId,
 		LifecycleState: ociCore.InternetGatewayLifecycleStateTerminated,
 	}
 

--- a/state/application.go
+++ b/state/application.go
@@ -1873,8 +1873,8 @@ func (a *Application) SetDownloadedIDAndHash(id, hash string) error {
 				C:      applicationsC,
 				Id:     a.doc.DocID,
 				Assert: txn.DocExists,
-				Update: bson.D{{"$set", bson.D{
-					{"charm-origin.id", id},
+				Update: bson.D{{Name: "$set", Value: bson.D{
+					{Name: "charm-origin.id", Value: id},
 				}}},
 			})
 		}
@@ -1883,8 +1883,8 @@ func (a *Application) SetDownloadedIDAndHash(id, hash string) error {
 				C:      applicationsC,
 				Id:     a.doc.DocID,
 				Assert: txn.DocExists,
-				Update: bson.D{{"$set", bson.D{
-					{"charm-origin.hash", hash},
+				Update: bson.D{{Name: "$set", Value: bson.D{
+					{Name: "charm-origin.hash", Value: hash},
 				}}},
 			})
 		}
@@ -1903,12 +1903,12 @@ func (a *Application) SetDownloadedIDAndHash(id, hash string) error {
 }
 
 // checkBaseForSetCharm verifies that the
-func checkBaseForSetCharm(currentPlatform *Platform, ch *Charm, ForceBase bool) error {
+func checkBaseForSetCharm(currentPlatform *Platform, ch *Charm, forceBase bool) error {
 	curBase, err := corebase.ParseBase(currentPlatform.OS, currentPlatform.Channel)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !ForceBase {
+	if !forceBase {
 		return errors.Trace(corecharm.BaseIsCompatibleWithCharm(curBase, ch))
 	}
 	// Even with forceBase=true, we do not allow a charm to be used which is for

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -762,7 +762,7 @@ func (s *linkLayerDevicesStateSuite) TestAddDeviceOpsWithAddresses(c *gc.C) {
 	c.Assert(addrs[0].Value(), gc.Equals, "10.1.1.1")
 }
 
-func (s *linkLayerDevicesStateSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
+func (s *linkLayerDevicesStateSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, cidr, providerSubnetID string) {
 	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	spaceInfo, err := space.NetworkSpace()
@@ -770,7 +770,7 @@ func (s *linkLayerDevicesStateSuite) createSpaceAndSubnetWithProviderID(c *gc.C,
 	s.spaces[spaceName] = spaceInfo
 
 	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
-		CIDR:       CIDR,
+		CIDR:       cidr,
 		SpaceID:    space.Id(),
 		ProviderId: corenetwork.Id(providerSubnetID),
 	})

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -267,39 +267,39 @@ func (s *MeterStateSuite) TestMeterStatusMetricsManagerCombinations(c *gc.C) {
 
 func (s *MeterStateSuite) TestMeterStatusCombination(c *gc.C) {
 	var (
-		Red          = state.MeterStatus{state.MeterRed, ""}
-		Amber        = state.MeterStatus{state.MeterAmber, ""}
-		Green        = state.MeterStatus{state.MeterGreen, ""}
-		NotSet       = state.MeterStatus{state.MeterNotSet, ""}
-		NotAvailable = state.MeterStatus{state.MeterNotAvailable, ""}
+		red          = state.MeterStatus{state.MeterRed, ""}
+		amber        = state.MeterStatus{state.MeterAmber, ""}
+		green        = state.MeterStatus{state.MeterGreen, ""}
+		notSet       = state.MeterStatus{state.MeterNotSet, ""}
+		notAvailable = state.MeterStatus{state.MeterNotAvailable, ""}
 	)
-	c.Assert(state.CombineMeterStatus(Red, Red).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Red, Amber).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Red, Green).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Red, NotSet).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Red, NotAvailable).Code, gc.Equals, NotAvailable.Code)
+	c.Assert(state.CombineMeterStatus(red, red).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(red, amber).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(red, green).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(red, notSet).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(red, notAvailable).Code, gc.Equals, notAvailable.Code)
 
-	c.Assert(state.CombineMeterStatus(Amber, Red).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Amber, Amber).Code, gc.Equals, Amber.Code)
-	c.Assert(state.CombineMeterStatus(Amber, Green).Code, gc.Equals, Amber.Code)
-	c.Assert(state.CombineMeterStatus(Amber, NotSet).Code, gc.Equals, Amber.Code)
-	c.Assert(state.CombineMeterStatus(Amber, NotAvailable).Code, gc.Equals, NotAvailable.Code)
+	c.Assert(state.CombineMeterStatus(amber, red).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(amber, amber).Code, gc.Equals, amber.Code)
+	c.Assert(state.CombineMeterStatus(amber, green).Code, gc.Equals, amber.Code)
+	c.Assert(state.CombineMeterStatus(amber, notSet).Code, gc.Equals, amber.Code)
+	c.Assert(state.CombineMeterStatus(amber, notAvailable).Code, gc.Equals, notAvailable.Code)
 
-	c.Assert(state.CombineMeterStatus(Green, Red).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(Green, Amber).Code, gc.Equals, Amber.Code)
-	c.Assert(state.CombineMeterStatus(Green, Green).Code, gc.Equals, Green.Code)
-	c.Assert(state.CombineMeterStatus(Green, NotSet).Code, gc.Equals, NotSet.Code)
-	c.Assert(state.CombineMeterStatus(Green, NotAvailable).Code, gc.Equals, NotAvailable.Code)
+	c.Assert(state.CombineMeterStatus(green, red).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(green, amber).Code, gc.Equals, amber.Code)
+	c.Assert(state.CombineMeterStatus(green, green).Code, gc.Equals, green.Code)
+	c.Assert(state.CombineMeterStatus(green, notSet).Code, gc.Equals, notSet.Code)
+	c.Assert(state.CombineMeterStatus(green, notAvailable).Code, gc.Equals, notAvailable.Code)
 
-	c.Assert(state.CombineMeterStatus(NotSet, Red).Code, gc.Equals, Red.Code)
-	c.Assert(state.CombineMeterStatus(NotSet, Amber).Code, gc.Equals, Amber.Code)
-	c.Assert(state.CombineMeterStatus(NotSet, Green).Code, gc.Equals, NotSet.Code)
-	c.Assert(state.CombineMeterStatus(NotSet, NotSet).Code, gc.Equals, NotSet.Code)
-	c.Assert(state.CombineMeterStatus(NotSet, NotAvailable).Code, gc.Equals, NotAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notSet, red).Code, gc.Equals, red.Code)
+	c.Assert(state.CombineMeterStatus(notSet, amber).Code, gc.Equals, amber.Code)
+	c.Assert(state.CombineMeterStatus(notSet, green).Code, gc.Equals, notSet.Code)
+	c.Assert(state.CombineMeterStatus(notSet, notSet).Code, gc.Equals, notSet.Code)
+	c.Assert(state.CombineMeterStatus(notSet, notAvailable).Code, gc.Equals, notAvailable.Code)
 
-	c.Assert(state.CombineMeterStatus(NotAvailable, Red).Code, gc.Equals, NotAvailable.Code)
-	c.Assert(state.CombineMeterStatus(NotAvailable, Amber).Code, gc.Equals, NotAvailable.Code)
-	c.Assert(state.CombineMeterStatus(NotAvailable, Green).Code, gc.Equals, NotAvailable.Code)
-	c.Assert(state.CombineMeterStatus(NotAvailable, NotSet).Code, gc.Equals, NotAvailable.Code)
-	c.Assert(state.CombineMeterStatus(NotAvailable, NotAvailable).Code, gc.Equals, NotAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notAvailable, red).Code, gc.Equals, notAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notAvailable, amber).Code, gc.Equals, notAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notAvailable, green).Code, gc.Equals, notAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notAvailable, notSet).Code, gc.Equals, notAvailable.Code)
+	c.Assert(state.CombineMeterStatus(notAvailable, notAvailable).Code, gc.Equals, notAvailable.Code)
 }

--- a/state/model.go
+++ b/state/model.go
@@ -607,10 +607,10 @@ func (m *Model) Status() (status.StatusInfo, error) {
 
 // localID returns the local id value by stripping off the model uuid prefix
 // if it is there.
-func (m *Model) localID(ID string) string {
-	modelUUID, localID, ok := splitDocID(ID)
+func (m *Model) localID(id string) string {
+	modelUUID, localID, ok := splitDocID(id)
 	if !ok || modelUUID != m.doc.UUID {
-		return ID
+		return id
 	}
 	return localID
 }

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -575,11 +575,11 @@ func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
-	State3 := s.Factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { State3.Close() })
+	state3 := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { state3.Close() })
 	// Ensure that all the creation events have flowed through the system.
-	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
-	_, wc3 := s.createMigrationWatcher(c, State3)
+	s.WaitForModelWatchersIdle(c, state3.ModelUUID())
+	_, wc3 := s.createMigrationWatcher(c, state3)
 	wc3.AssertOneChange()
 
 	// Create a migration for 2.
@@ -589,7 +589,7 @@ func (s *MigrationSuite) TestWatchForMigrationMultiModel(c *gc.C) {
 	wc3.AssertNoChange()
 
 	// Create a migration for 3.
-	_, err = State3.CreateMigration(s.stdSpec)
+	_, err = state3.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertNoChange()
 	wc3.AssertOneChange()
@@ -654,12 +654,12 @@ func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
-	State3 := s.Factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { State3.Close() })
+	state3 := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { state3.Close() })
 	// Ensure that all the creation events have flowed through the system.
-	s.WaitForModelWatchersIdle(c, State3.ModelUUID())
+	s.WaitForModelWatchersIdle(c, state3.ModelUUID())
 
-	_, wc3 := s.createStatusWatcher(c, State3)
+	_, wc3 := s.createStatusWatcher(c, state3)
 	wc3.AssertOneChange() // initial event
 
 	// Create a migration for 2.
@@ -669,7 +669,7 @@ func (s *MigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	wc3.AssertNoChange()
 
 	// Create a migration for 3.
-	_, err = State3.CreateMigration(s.stdSpec)
+	_, err = state3.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	wc2.AssertNoChange()
 	wc3.AssertOneChange()
@@ -834,9 +834,9 @@ func (s *MigrationSuite) TestWatchMinionReportsMultiModel(c *gc.C) {
 	mig, wc := s.createMigAndWatchReports(c, s.State2)
 	wc.AssertOneChange() // initial event
 
-	State3 := s.Factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { State3.Close() })
-	mig3, wc3 := s.createMigAndWatchReports(c, State3)
+	state3 := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { state3.Close() })
+	mig3, wc3 := s.createMigAndWatchReports(c, state3)
 	wc3.AssertOneChange() // initial event
 
 	// Ensure the correct watchers are triggered.

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -22,16 +22,16 @@ type SpacesSuite struct {
 
 var _ = gc.Suite(&SpacesSuite{})
 
-func (s *SpacesSuite) addSubnets(c *gc.C, CIDRs []string) []string {
-	return s.addSubnetsForState(c, CIDRs, s.State)
+func (s *SpacesSuite) addSubnets(c *gc.C, cidrs []string) []string {
+	return s.addSubnetsForState(c, cidrs, s.State)
 }
 
-func (s *SpacesSuite) addSubnetsForState(c *gc.C, CIDRs []string, st *state.State) []string {
-	if len(CIDRs) == 0 {
+func (s *SpacesSuite) addSubnetsForState(c *gc.C, cidrs []string, st *state.State) []string {
+	if len(cidrs) == 0 {
 		return nil
 	}
-	subnetIDs := make([]string, len(CIDRs))
-	for i, info := range s.makeSubnetInfosForCIDRs(c, CIDRs) {
+	subnetIDs := make([]string, len(cidrs))
+	for i, info := range s.makeSubnetInfosForCIDRs(c, cidrs) {
 		subnet, err := st.AddSubnet(info)
 		c.Assert(err, jc.ErrorIsNil)
 		subnetIDs[i] = subnet.ID()
@@ -39,9 +39,9 @@ func (s *SpacesSuite) addSubnetsForState(c *gc.C, CIDRs []string, st *state.Stat
 	return subnetIDs
 }
 
-func (s *SpacesSuite) makeSubnetInfosForCIDRs(c *gc.C, CIDRs []string) []network.SubnetInfo {
-	infos := make([]network.SubnetInfo, len(CIDRs))
-	for i, cidr := range CIDRs {
+func (s *SpacesSuite) makeSubnetInfosForCIDRs(c *gc.C, cidrs []string) []network.SubnetInfo {
+	infos := make([]network.SubnetInfo, len(cidrs))
+	for i, cidr := range cidrs {
 		_, _, err := net.ParseCIDR(cidr)
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -224,26 +224,27 @@ func (s *HubWatcherSuite) TestWatchAlreadyRemoved(c *gc.C) {
 }
 
 func (s *HubWatcherSuite) TestWatchUnwatchOnQueue(c *gc.C) {
-	const N = 10
-	for i := 0; i < N; i++ {
+	// bN is the number of changes to publish.
+	const bN = 10
+	for i := 0; i < bN; i++ {
 		s.w.Watch("test", i, s.ch)
 	}
-	for i := 0; i < N; i++ {
+	for i := 0; i < bN; i++ {
 		s.publish(c, watcher.Change{"test", i, int64(i + 3)})
 	}
-	for i := 1; i < N; i += 2 {
+	for i := 1; i < bN; i += 2 {
 		s.w.Unwatch("test", i, s.ch)
 	}
 	seen := make(map[interface{}]bool)
-	for i := 0; i < N/2; i++ {
+	for i := 0; i < bN/2; i++ {
 		select {
 		case change := <-s.ch:
 			seen[change.Id] = true
 		case <-time.After(worstCase):
-			c.Fatalf("not enough changes: got %d, want %d", len(seen), N/2)
+			c.Fatalf("not enough changes: got %d, want %d", len(seen), bN/2)
 		}
 	}
-	c.Assert(len(seen), gc.Equals, N/2)
+	c.Assert(len(seen), gc.Equals, bN/2)
 	assertNoChange(c, s.ch)
 }
 

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -266,18 +266,20 @@ func (s *TxnWatcherSuite) TestTransactionWithMultiple(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestScale(c *gc.C) {
-	const N = 500
-	const T = 10
+	// bN is the number of documents to insert.
+	const bN = 500
+	// bT is the number of documents to insert per transaction.
+	const bT = 10
 
 	s.newRunner(c)
-	_, hub := s.newWatcher(c, N)
+	_, hub := s.newWatcher(c, bN)
 
-	c.Logf("Creating %d documents, %d per transaction...", N, T)
-	ops := make([]txn.Op, T)
-	for i := 0; i < (N / T); i++ {
+	c.Logf("Creating %d documents, %d per transaction...", bN, bT)
+	ops := make([]txn.Op, bT)
+	for i := 0; i < (bN / bT); i++ {
 		ops = ops[:0]
-		for j := 0; j < T && i*T+j < N; j++ {
-			ops = append(ops, txn.Op{C: "test", Id: i*T + j, Insert: M{"n": 1}})
+		for j := 0; j < bT && i*bT+j < bN; j++ {
+			ops = append(ops, txn.Op{C: "test", Id: i*bT + j, Insert: M{"n": 1}})
 		}
 		err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
 			return ops, nil
@@ -288,11 +290,11 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 	count, err := s.Session.DB("juju").C("test").Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("Got %d documents in the collection...", count)
-	c.Assert(count, gc.Equals, N)
+	c.Assert(count, gc.Equals, bN)
 
 	hub.waitForExpected()
 
-	for i := 0; i < N; i++ {
+	for i := 0; i < bN; i++ {
 		c.Assert(hub.values[i].Id, gc.Equals, i)
 	}
 }

--- a/testing/cert.go
+++ b/testing/cert.go
@@ -18,19 +18,31 @@ import (
 // ServerCert and ServerKey hold a CA-signed server cert/key.
 // Certs holds the certificates and keys required to make a secure
 // connection to a Mongo database.
+//
+//revive:disable:exported
 var (
+	// CACert and CAKey make up a CA key pair and ServerCert and ServerKey
+	// hold a CA-signed server cert/key.
 	CACert, CAKey, ServerCert, ServerKey = chooseGeneratedCA()
 
+	// CACertX509 and CAKeyRSA hold their parsed equivalents.
 	CACertX509, CAKeyRSA = mustParseCertAndKey(CACert, CAKey)
 
+	// ServerTLSCert is the parsed server certificate.
 	ServerTLSCert = mustParseServerCert(ServerCert, ServerKey)
 
+	// Certs holds the certificates and keys required to make a secure
 	Certs = serverCerts()
 
 	// Other valid test certs different from the default.
-	OtherCACert, OtherCAKey        = chooseGeneratedOtherCA()
+
+	// OtherCACert and OtherCAKey is the other CA certificate and key.
+	OtherCACert, OtherCAKey = chooseGeneratedOtherCA()
+	// OtherCACertX509 and OtherCAKeyRSA hold their parsed equivalents.
 	OtherCACertX509, OtherCAKeyRSA = mustParseCertAndKey(OtherCACert, OtherCAKey)
 )
+
+//revive:enable:exported
 
 func chooseGeneratedCA() (string, string, string, string) {
 	index := rand.Intn(len(generatedCA))

--- a/testing/certs.go
+++ b/testing/certs.go
@@ -13,7 +13,7 @@ import (
 
 // NewCA returns a random one of the pre-generated certs to speed up
 // tests. The comment on the certs are not going to match the args.
-func NewCA(commonName, UUID string, expiry time.Time) (certPEM, keyPEM string, err error) {
+func NewCA(commonName, uuid string, expiry time.Time) (certPEM, keyPEM string, err error) {
 	index := rand.Intn(len(generatedCA))
 	cert := generatedCA[index]
 	return cert.certPEM, cert.keyPEM, nil


### PR DESCRIPTION
This is the first round of linter rules added to the code base to improve the code base at large.

The following linter rules that I added:

 - unexported-naming
 - exported
 - atomic
 - defer

I really wanted to add "loop" argument to defer, but unfortunately, the fallout requires a lot more time and effort to undo some of the problems.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
```

Also, all the tests should pass.


## Links

**Jira card:** JUJU-

