### PR TITLE
Copy remaining charms handler tests to s3 charm handler

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -752,8 +752,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		dataDir:           srv.dataDir,
 		objectStoreGetter: srv.shared.objectStoreGetter,
 	}
-	modelRestServer := &RestHTTPHandler{
-		GetHandler: modelRestHandler.ServeGet,
+	modelRestServer := &restHTTPHandler{
+		getHandler: modelRestHandler.ServeGet,
 	}
 	modelCharmsHandler := &charmsHandler{
 		ctxt:              httpCtxt,
@@ -762,16 +762,16 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		objectStoreGetter: srv.shared.objectStoreGetter,
 		logger:            logger.Child("charms-handler"),
 	}
-	modelCharmsHTTPHandler := &CharmsHTTPHandler{
-		PostHandler: modelCharmsHandler.ServePost,
-		GetHandler:  modelCharmsHandler.ServeGet,
+	modelCharmsHTTPHandler := &charmsHTTPHandler{
+		postHandler: modelCharmsHandler.ServePost,
+		getHandler:  modelCharmsHandler.ServeGet,
 	}
 	modelCharmsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
 
 	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
-		ctxt:                httpCtxt,
-		objectStoreGetter:   srv.shared.objectStoreGetter,
-		LegacyCharmsHandler: modelCharmsHTTPHandler,
+		ctxt:              httpCtxt,
+		objectStoreGetter: srv.shared.objectStoreGetter,
+		LegacyPostHandler: modelCharmsHandler.ServePost,
 	}
 
 	modelToolsUploadHandler := &toolsUploadHandler{
@@ -843,14 +843,14 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		objectStoreGetter: srv.shared.objectStoreGetter,
 		logger:            logger.Child("charms-handler"),
 	}
-	migrateCharmsHTTPHandler := &CharmsHTTPHandler{
-		PostHandler: migrateCharmsHandler.ServePost,
-		GetHandler:  migrateCharmsHandler.ServeUnsupported,
+	migrateCharmsHTTPHandler := &charmsHTTPHandler{
+		postHandler: migrateCharmsHandler.ServePost,
+		getHandler:  migrateCharmsHandler.ServeUnsupported,
 	}
 	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
-		ctxt:                httpCtxt,
-		objectStoreGetter:   srv.shared.objectStoreGetter,
-		LegacyCharmsHandler: migrateCharmsHTTPHandler,
+		ctxt:              httpCtxt,
+		objectStoreGetter: srv.shared.objectStoreGetter,
+		LegacyPostHandler: migrateCharmsHandler.ServePost,
 	}
 	migrateToolsUploadHandler := &toolsUploadHandler{
 		ctxt:          httpCtxt,

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -31,9 +31,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-type FailableHandlerFunc func(http.ResponseWriter, *http.Request) error
-
-// CharmsHTTPHandler creates is a http.Handler which serves POST
+// charmsHTTPHandler creates is a http.Handler which serves POST
 // requests to a PostHandler and GET requests to a GetHandler.
 //
 // TODO(katco): This is the beginning of inverting the dependencies in
@@ -56,18 +54,18 @@ type FailableHandlerFunc func(http.ResponseWriter, *http.Request) error
 // pipeline.
 //
 // As usual big methods lead to untestable code and it causes testing pain.
-type CharmsHTTPHandler struct {
-	PostHandler FailableHandlerFunc
-	GetHandler  FailableHandlerFunc
+type charmsHTTPHandler struct {
+	postHandler endpointMethodHandlerFunc
+	getHandler  endpointMethodHandlerFunc
 }
 
-func (h *CharmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *charmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch r.Method {
 	case "POST":
-		err = errors.Annotate(h.PostHandler(w, r), "cannot upload charm")
+		err = errors.Annotate(h.postHandler(w, r), "cannot upload charm")
 	case "GET":
-		err = errors.Annotate(h.GetHandler(w, r), "cannot retrieve charm")
+		err = errors.Annotate(h.getHandler(w, r), "cannot retrieve charm")
 	default:
 		err = emitUnsupportedMethodErr(r.Method)
 	}

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -5,8 +5,7 @@ package apiserver_test
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +14,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/juju/charm/v13"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	apitesting "github.com/juju/juju/apiserver/testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/testing/factory"
 )
 
 type baseObjectsSuite struct {
@@ -57,12 +59,27 @@ func (s *baseObjectsSuite) uploadRequest(c *gc.C, url, contentType, curl string,
 	})
 }
 
-func (s *baseObjectsSuite) objectsCharmsURL(charmurl string) *url.URL {
-	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.ControllerModelUUID(), charmurl), nil)
+func (s *baseObjectsSuite) migrateObjectsCharmsURL(charmRef string) *url.URL {
+	return s.URL(fmt.Sprintf("/migrate/charms/%s", charmRef), nil)
 }
 
-func (s *baseObjectsSuite) objectsCharmsURI(charmurl string) string {
-	return s.objectsCharmsURL(charmurl).String()
+func (s *baseObjectsSuite) migrateObjectsCharmsURI(charmRef string) string {
+	return s.migrateObjectsCharmsURL(charmRef).String()
+}
+
+func (s *baseObjectsSuite) objectsCharmsURL(charmRef string) *url.URL {
+	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.ControllerModelUUID(), charmRef), nil)
+}
+
+func (s *baseObjectsSuite) objectsCharmsURI(charmRef string) string {
+	return s.objectsCharmsURL(charmRef).String()
+}
+
+func (s *baseObjectsSuite) setModelImporting(c *gc.C) {
+	model, err := s.ControllerModel(c).State().Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *baseObjectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
@@ -125,7 +142,7 @@ func (s *getCharmObjectSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *g
 	fakeSHA256 := "123456789abcde123456789abcde123456789abcde123456789abcde12345678"
 	// Add a charm in pending mode.
 	chInfo := state.CharmInfo{
-		ID:          "ch:focal/dummy-1",
+		ID:          "ch:testcharm-1",
 		Charm:       testcharms.Repo.CharmArchive(c.MkDir(), "dummy"),
 		StoragePath: "", // indicates that we don't have the data in the blobstore yet.
 		SHA256:      fakeSHA256,
@@ -134,25 +151,93 @@ func (s *getCharmObjectSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *g
 	_, err := s.ControllerModel(c).State().AddCharmMetadata(chInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("dummy-" + fakeSHA256)})
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("testcharm-" + fakeSHA256)})
 	body := apitesting.AssertResponse(c, resp, http.StatusConflict, "application/json")
-	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: ch:focal/dummy-1","error-code":"not yet available; try again later"}`)
+	c.Assert(string(body), gc.Equals, `{"error":"cannot retrieve charm: ch:testcharm-1","error-code":"not yet available; try again later"}`)
 }
 
 func (s *getCharmObjectSuite) TestGetReturnsMatchingContents(c *gc.C) {
 	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(chArchive.Path)
+	defer f.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	_ = s.uploadRequest(c, s.objectsCharmsURI("dummy-"+getCharmHash(c, f)), "application/zip", "local:quantal/dummy-1", &fileReader{path: chArchive.Path})
+	_ = s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
 
 	// get uploaded charm's SHA256 for GET request
-	ch, err := s.ControllerModel(c).State().Charm("local:quantal/dummy-1")
+	ch, err := s.ControllerModel(c).State().Charm("local:testcharm-1")
 	c.Assert(err, jc.ErrorIsNil)
 	sha256 := ch.BundleSha256()
 
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("dummy-" + sha256)})
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("testcharm-" + sha256)})
 	body := apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
 	archiveBytes, err := os.ReadFile(chArchive.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
+}
+
+func (s *getCharmObjectSuite) TestGetWorksForControllerMachines(c *gc.C) {
+	// Make a controller machine.
+	fact, release := s.NewFactory(c, s.ControllerModelUUID())
+	defer release()
+	const nonce = "noncey"
+	m, password := fact.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Jobs:  []state.MachineJob{state.JobManageModel},
+		Nonce: nonce,
+	})
+
+	// Create a hosted model and upload a charm for it.
+	newSt := fact.MakeModel(c, nil)
+	defer newSt.Close()
+
+	curl := "local:testcharm-1"
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	_, err := jujutesting.AddCharm(newSt, s.ObjectStore(c, newSt.ModelUUID()), curl, ch, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	f, err := os.Open(ch.Path)
+	defer f.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Controller machine should be able to download the charm from
+	// the hosted model. This is required for controller workers which
+	// are acting on behalf of a particular hosted model.
+
+	uri := s.URL(fmt.Sprintf("/model-%s/charms/%s", newSt.ModelUUID(), "testcharm-"+getCharmHash(c, f)), nil).String()
+	params := apitesting.HTTPRequestParams{
+		Method:   "GET",
+		URL:      uri,
+		Tag:      m.Tag().String(),
+		Password: password,
+		Nonce:    nonce,
+	}
+	resp := apitesting.SendHTTPRequest(c, params)
+
+	body := apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
+	archiveBytes, err := os.ReadFile(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
+}
+
+func (s *getCharmObjectSuite) TestGetAllowsOtherEnvironments(c *gc.C) {
+	fact, release := s.NewFactory(c, s.ControllerModelUUID())
+	defer release()
+	newSt := fact.MakeModel(c, nil)
+	defer newSt.Close()
+
+	curl := "local:testcharm-1"
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	_, err := jujutesting.AddCharm(newSt, s.ObjectStore(c, newSt.ModelUUID()), curl, ch, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	f, err := os.Open(ch.Path)
+	defer f.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	uri := s.URL(fmt.Sprintf("/model-%s/charms/%s", newSt.ModelUUID(), "testcharm-"+getCharmHash(c, f)), nil).String()
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
+
+	body := apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
+	archiveBytes, err := os.ReadFile(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bytes.Equal(body, archiveBytes), jc.IsTrue)
 }
@@ -175,6 +260,27 @@ func (s *putCharmObjectSuite) assertUploadResponse(c *gc.C, resp *http.Response,
 	c.Check(charmResponse.CharmURL, gc.Equals, expCharmURL)
 }
 
+func (s *putCharmObjectSuite) TestPUTRequiresUserAuth(c *gc.C) {
+	f, release := s.NewFactory(c, s.ControllerModelUUID())
+	defer release()
+	machine, password := f.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: "noncy",
+	})
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Tag:         machine.Tag().String(),
+		Password:    password,
+		Method:      s.method,
+		URL:         s.objectsCharmsURI("somecharm-abcd0123"),
+		Nonce:       "noncy",
+		ContentType: "foo/bar",
+	})
+	body := apitesting.AssertResponse(c, resp, http.StatusForbidden, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "authorization failed: tag kind machine not valid\n")
+
+	resp = sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: s.method, URL: s.objectsCharmsURI("somecharm-abcdef0")})
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*expected Content-Type: application/zip.+")
+}
+
 func (s *putCharmObjectSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 	empty := strings.NewReader("")
 
@@ -191,12 +297,12 @@ func (s *putCharmObjectSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 func (s *putCharmObjectSuite) TestUploadBumpsRevision(c *gc.C) {
 	// Add the dummy charm with revision 1.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision())
+	curl := fmt.Sprintf("local:%s-%d", "testcharm", ch.Revision())
 	info := state.CharmInfo{
 		Charm:       ch,
 		ID:          curl,
-		StoragePath: "dummy-storage-path",
-		SHA256:      "dummy-1-sha256",
+		StoragePath: "testcharm-storage-path",
+		SHA256:      "testcharm-1-sha256",
 	}
 	_, err := s.ControllerModel(c).State().AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
@@ -206,8 +312,8 @@ func (s *putCharmObjectSuite) TestUploadBumpsRevision(c *gc.C) {
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
 	defer f.Close()
-	resp := s.uploadRequest(c, s.objectsCharmsURI("dummy-"+getCharmHash(c, f)), "application/zip", "local:quantal/dummy", f)
-	expectedURL := "local:quantal/dummy-2"
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
+	expectedURL := "local:testcharm-2"
 	s.assertUploadResponse(c, resp, expectedURL)
 	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
@@ -219,11 +325,266 @@ func (s *putCharmObjectSuite) TestUploadBumpsRevision(c *gc.C) {
 	c.Assert(sch.BundleSha256(), gc.Not(gc.Equals), "")
 }
 
+func (s *putCharmObjectSuite) TestUploadVersion(c *gc.C) {
+	expectedVersion := "testcharm-146-g725cfd3-dirty"
+
+	// Add the dummy charm with version "juju-2.4-beta3-146-g725cfd3-dirty".
+	pathToArchive := testcharms.Repo.CharmArchivePath(c.MkDir(), "dummy")
+	err := testcharms.InjectFilesToCharmArchive(pathToArchive, map[string]string{
+		"version": expectedVersion,
+	})
+	c.Assert(err, gc.IsNil)
+	ch, err := charm.ReadCharmArchive(pathToArchive)
+	c.Assert(err, gc.IsNil)
+
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
+
+	expectedURL := "local:testcharm-1"
+	s.assertUploadResponse(c, resp, expectedURL)
+	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	version := sch.Version()
+	c.Assert(version, gc.Equals, expectedVersion)
+}
+
+func (s *putCharmObjectSuite) TestUploadRespectsLocalRevision(c *gc.C) {
+	// Make a dummy charm dir with revision 123.
+	dir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")
+	dir.SetDiskRevision(123)
+	// Now archive the dir.
+	tempFile, err := os.CreateTemp("", "charm")
+	c.Assert(err, jc.ErrorIsNil)
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+	err = dir.ArchiveTo(tempFile)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSHA256 := getCharmHash(c, tempFile)
+
+	// Now try uploading it and ensure the revision persists.
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+expectedSHA256), "application/zip", "local:testcharm", tempFile)
+	expectedURL := "local:testcharm-123"
+	s.assertUploadResponse(c, resp, expectedURL)
+	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sch.URL(), gc.Equals, expectedURL)
+	c.Assert(sch.Revision(), gc.Equals, 123)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+	c.Assert(sch.BundleSha256()[0:7], gc.Equals, expectedSHA256)
+
+	store := s.ObjectStore(c, s.ControllerModelUUID())
+	reader, _, err := store.Get(context.Background(), sch.StoragePath())
+	c.Assert(err, jc.ErrorIsNil)
+	defer reader.Close()
+	downloadedSHA256, _, err := utils.ReadSHA256(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(downloadedSHA256[0:7], gc.Equals, expectedSHA256)
+}
+
+func (s *putCharmObjectSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C) {
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+	hash := getCharmHash(c, f)
+
+	curl := fmt.Sprintf("ch:%s-%d", ch.Meta().Name, ch.Revision())
+	info := state.CharmInfo{
+		Charm:       ch,
+		ID:          curl,
+		StoragePath: "testcharm-storage-path",
+		SHA256:      hash,
+	}
+	_, err = s.ControllerModel(c).State().AddCharm(info)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+hash), "application/zip", curl, f)
+	s.assertErrorResponse(c, resp, 400, ".*charms may only be uploaded during model migration import$")
+}
+
+func (s *putCharmObjectSuite) TestNonLocalCharmUpload(c *gc.C) {
+	// Check that upload of charms with the "ch:" schema works (for
+	// model migrations).
+	s.setModelImporting(c)
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+	hash := getCharmHash(c, f)
+
+	curl := fmt.Sprintf("ch:%s-%d", ch.Meta().Name, ch.Revision())
+	info := state.CharmInfo{
+		Charm:       ch,
+		ID:          curl,
+		StoragePath: "testcharm-storage-path",
+		SHA256:      hash,
+	}
+	_, err = s.ControllerModel(c).State().AddCharm(info)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+hash), "application/zip", "ch:testcharm-1", f)
+
+	expectedURL := "ch:testcharm-1"
+	s.assertUploadResponse(c, resp, expectedURL)
+	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.Revision(), gc.Equals, 1)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+}
+
+func (s *putCharmObjectSuite) TestUnsupportedSchema(c *gc.C) {
+	s.setModelImporting(c)
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "zz:testcharm", f)
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		`cannot upload charm: "zz:testcharm" is not a valid charm url`,
+	)
+}
+
+func (s *putCharmObjectSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
+	s.setModelImporting(c)
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "ch:testcharm-99", f)
+
+	expectedURL := "ch:testcharm-99"
+	s.assertUploadResponse(c, resp, expectedURL)
+	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
+	c.Assert(sch.Revision(), gc.Equals, 99)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+}
+
+func (s *putCharmObjectSuite) TestMigrateCharm(c *gc.C) {
+	s.setModelImporting(c)
+
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	// The default user is just a normal user, not a controller admin
+	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "PUT",
+		URL:         url,
+		ContentType: "application/zip",
+		Body:        f,
+		ExtraHeaders: map[string]string{
+			params.MigrationModelHTTPHeader: s.ControllerModelUUID(),
+			"Juju-Curl":                     "ch:testcharm-10",
+		},
+	})
+	expectedURL := "ch:testcharm-10"
+	s.assertUploadResponse(c, resp, expectedURL)
+
+	// The charm was added to the migrated model.
+	_, err = s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *putCharmObjectSuite) TestMigrateCharmName(c *gc.C) {
+	s.setModelImporting(c)
+
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	// The default user is just a normal user, not a controller admin
+	url := s.migrateObjectsCharmsURI("meshuggah-" + getCharmHash(c, f))
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "PUT",
+		URL:         url,
+		ContentType: "application/zip",
+		Body:        f,
+		ExtraHeaders: map[string]string{
+			params.MigrationModelHTTPHeader: s.ControllerModelUUID(),
+			"Juju-Curl":                     "ch:meshuggah-1",
+		},
+	})
+	expectedURL := "ch:meshuggah-1"
+	s.assertUploadResponse(c, resp, expectedURL)
+
+	// The charm was added to the migrated model.
+	_, err = s.ControllerModel(c).State().Charm(expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *putCharmObjectSuite) TestMigrateCharmNotMigrating(c *gc.C) {
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	// The default user is just a normal user, not a controller admin
+	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
+	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "PUT",
+		URL:         url,
+		ContentType: "application/zip",
+		Body:        f,
+		ExtraHeaders: map[string]string{
+			params.MigrationModelHTTPHeader: s.ControllerModelUUID(),
+			"Juju-Curl":                     "ch:testcharm-1",
+		},
+	})
+
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		`model migration mode is "" instead of "importing"`,
+	)
+}
+
+func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
+	s.setModelImporting(c)
+
+	fact, release := s.NewFactory(c, s.ControllerModelUUID())
+	defer release()
+	user := fact.MakeUser(c, &factory.UserParams{Password: "hunter2"})
+
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
+
+	// The default user is just a normal user, not a controller admin
+	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:   "PUT",
+		URL:      url,
+		Tag:      user.Tag().String(),
+		Password: "hunter2",
+		Body:     f,
+		ExtraHeaders: map[string]string{
+			params.MigrationModelHTTPHeader: s.ControllerModelUUID(),
+			"Juju-Curl":                     "ch:testcharm-1",
+		},
+	})
+	body := apitesting.AssertResponse(c, resp, http.StatusForbidden, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Matches, "authorization failed: user .* not a controller admin\n")
+}
+
 func getCharmHash(c *gc.C, stream io.ReadSeeker) string {
-	hash := sha256.New()
-	_, err := io.Copy(hash, stream)
+	_, err := stream.Seek(0, os.SEEK_SET)
+	c.Assert(err, jc.ErrorIsNil)
+	hash, _, err := utils.ReadSHA256(stream)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = stream.Seek(0, os.SEEK_SET)
 	c.Assert(err, jc.ErrorIsNil)
-	return hex.EncodeToString(hash.Sum(nil))[0:7]
+	return hash[0:7]
 }

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -17,17 +17,17 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// RestHTTPHandler creates is a http.Handler which serves ReST requests.
-type RestHTTPHandler struct {
-	GetHandler FailableHandlerFunc
+// restHTTPHandler creates is a http.Handler which serves ReST requests.
+type restHTTPHandler struct {
+	getHandler endpointMethodHandlerFunc
 }
 
 // ServeHTTP is defined on handler.Handler.
-func (h *RestHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *restHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch r.Method {
 	case "GET":
-		err = errors.Annotate(h.GetHandler(w, r), "cannot retrieve model data")
+		err = errors.Annotate(h.getHandler(w, r), "cannot retrieve model data")
 	default:
 		err = emitUnsupportedMethodErr(r.Method)
 	}


### PR DESCRIPTION
Also make some minor tweaks to the handler

Make some handlers package-local when they don't need to be exported

When the s3 object handler was first implemented for charms, it was a very light weight shim around the old handler. So the test suite was made up of a small number of tests copied over from the legacy handler, converted over to the new format

Work is being done (and is in progress) to decouple the handlers, so the old one can be removed. So far, however, the tests have remained relatively unchanged.

Convert over the remaining relevant tests. NOTE: Some tests were not copied, and represent the different capabilities of the handlers. We cannot, for instance, request a specific file from a charm with the new handler

These tests can be found here:
https://github.com/juju/juju/blob/main/apiserver/charms_test.go

Make some minor cleanness tweaks + fixes to the objects handler as well, whilst we're here

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure unit tests pass

(ensure a local charm exists at `~/charms/ubuntu`)
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ~/charms/ubuntu ubu-local
Located local charm "ubuntu", revision 0
Deploying "ubu-local" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  4.0-beta3.1  unsupported  16:14:35Z

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-local/0*  active    idle   0        10.219.211.166         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.166  juju-93fd1e-0  ubuntu@22.04      Running
```