### PR TITLE
Remove unecessary uuid columns from cloud auth and cacert tables

### DIFF
--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -656,12 +656,12 @@ AND          auth_type_id NOT IN (%s)
 	}
 
 	insertQuery := `
-INSERT INTO cloud_auth_type (uuid, cloud_uuid, auth_type_id)
-VALUES (?, ?, ?)
+INSERT INTO cloud_auth_type (cloud_uuid, auth_type_id)
+VALUES (?, ?)
 ON CONFLICT(cloud_uuid, auth_type_id) DO NOTHING;
 	`
 	for _, a := range authTypeIds {
-		if _, err := tx.ExecContext(ctx, insertQuery, utils.MustNewUUID().String(), cloudUUID, a); err != nil {
+		if _, err := tx.ExecContext(ctx, insertQuery, cloudUUID, a); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -681,12 +681,12 @@ WHERE        cloud_uuid = ?
 	}
 
 	insertQuery := `
-INSERT INTO cloud_ca_cert (uuid, cloud_uuid, ca_cert)
-VALUES (?, ?, ?)
+INSERT INTO cloud_ca_cert (cloud_uuid, ca_cert)
+VALUES (?, ?)
 `
 	for _, cert := range certs {
 
-		if _, err := tx.ExecContext(ctx, insertQuery, utils.MustNewUUID().String(), cloudUUID, cert); err != nil {
+		if _, err := tx.ExecContext(ctx, insertQuery, cloudUUID, cert); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -208,7 +208,6 @@ CREATE TABLE cloud_defaults (
 );
 
 CREATE TABLE cloud_auth_type (
-    uuid              TEXT PRIMARY KEY,
     cloud_uuid        TEXT NOT NULL,
     auth_type_id      INT NOT NULL,
     CONSTRAINT        fk_cloud_auth_type_cloud
@@ -217,6 +216,7 @@ CREATE TABLE cloud_auth_type (
     CONSTRAINT        fk_cloud_auth_type_auth_type
         FOREIGN KEY       (auth_type_id)
         REFERENCES        auth_type(id)
+    PRIMARY KEY (cloud_uuid, auth_type_id)
 );
 
 CREATE UNIQUE INDEX idx_cloud_auth_type_cloud_uuid_auth_type_id
@@ -252,12 +252,12 @@ CREATE TABLE cloud_region_defaults (
 );
 
 CREATE TABLE cloud_ca_cert (
-    uuid              TEXT PRIMARY KEY,
     cloud_uuid        TEXT NOT NULL,
     ca_cert           TEXT NOT NULL,
     CONSTRAINT        fk_cloud_ca_cert_cloud
         FOREIGN KEY       (cloud_uuid)
         REFERENCES        cloud(uuid)
+    PRIMARY KEY (cloud_uuid, ca_cert)
 );
 
 CREATE UNIQUE INDEX idx_cloud_ca_cert_cloud_uuid_ca_cert

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -469,6 +469,7 @@ CREATE TABLE block_device_link_device (
     CONSTRAINT        fk_block_device_link_device
         FOREIGN KEY   (block_device_uuid)
         REFERENCES    block_device(uuid)
+    PRIMARY KEY (block_device_uuid, name)
 );
 
 CREATE UNIQUE INDEX idx_block_device_link_device


### PR DESCRIPTION
A small tweak to the cloud DDL to remove uuid columns from the cloud auth type and ca cert tables.
The region table still needs uuid as it is reference by model defaults.
Also a drive by to add the primary key to the block device table.

## QA steps

bootstrap a controller

## Links

**Jira card:** JUJU-5368

