### PR TITLE
Ask cloud state if auth type is supported.

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -41,6 +41,11 @@ func (a AuthTypes) Contains(t AuthType) bool {
 	return false
 }
 
+// String implements the Stringer interface for AuthType.
+func (a AuthType) String() string {
+	return string(a)
+}
+
 const (
 	// AccessKeyAuthType is an authentication type using a key and secret.
 	AccessKeyAuthType AuthType = "access-key"

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -859,4 +860,53 @@ func (s *stateSuite) TestSetCloudDefaultsDelete(c *gc.C) {
 	defaults, err = st.CloudDefaults(context.Background(), cld.Name)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(len(defaults), gc.Equals, 0)
+}
+
+// TestCloudSupportsAuthTypeTrue is asserting the happy path that for a valid
+// cloud and supported auth type we get back true with no errors.
+func (s *stateSuite) TestCloudSupportsAuthTypeTrue(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	s.assertInsertCloud(c, st, testCloud)
+
+	var supports bool
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		s, err := CloudSupportsAuthType(context.Background(), tx, testCloud.Name, testCloud.AuthTypes[0])
+		supports = s
+		return err
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(supports, jc.IsTrue)
+}
+
+// TestCloudSupportsAuthTypeFalse is asserting the happy path that for a valid
+// cloud and a non supported auth type we get back false with no errors.
+func (s *stateSuite) TestCloudSupportsAuthTypeFalse(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	s.assertInsertCloud(c, st, testCloud)
+
+	var supports bool
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		s, err := CloudSupportsAuthType(context.Background(), tx, testCloud.Name, cloud.AuthType("no-exist"))
+		supports = s
+		return err
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(supports, jc.IsFalse)
+}
+
+// TestCloudSupportsAuthTypeCloudNotFound is checking to that if we ask if a
+// cloud supports an auth type and the cloud doesn't exist we get back a
+// [clouderrors.NotFound] error.
+func (s *stateSuite) TestCloudSupportsAuthTypeCloudNotFound(c *gc.C) {
+	var supports bool
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		s, err := CloudSupportsAuthType(context.Background(), tx, "no-exist", cloud.AuthType("no-exist"))
+		supports = s
+		return err
+	})
+
+	c.Assert(err, jc.ErrorIs, clouderrors.NotFound)
+	c.Check(supports, jc.IsFalse)
 }


### PR DESCRIPTION
This commit adds the ability to the cloud state to ask if a given cloud supports a specific auth type. This is needed when creating new models and config where the user has not specified a cloud credential.

I am trying to lay in the changes to the model manager facade in small increments as they are large. This is the first of many.

The specific logic we are shifting here is this https://github.com/juju/juju/blob/efab27a8f98b9056c90eed74514d31060daa9324/apiserver/facades/client/modelmanager/modelmanager.go#L340

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests for the moment. Next PR will wire this in more.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5341

