### PR TITLE
Moves model types from domain to core.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
+	coremodel "github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	ccbootstrap "github.com/juju/juju/domain/controllerconfig/bootstrap"
@@ -213,9 +214,9 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		return nil, errors.Annotate(err, "getting cloud credentials from args")
 	}
 
-	controllerModelType := modeldomain.TypeIAAS
+	controllerModelType := coremodel.IAAS
 	if cloud.CloudIsCAAS(stateParams.ControllerCloud) {
-		controllerModelType = modeldomain.TypeCAAS
+		controllerModelType = coremodel.CAAS
 	}
 
 	// Add initial Admin user to the database. This will return Admin user UUID

--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/credentialcommon"
 	"github.com/juju/juju/apiserver/facade"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/model"
 )
@@ -58,7 +59,7 @@ func newFacadeV7(context facade.Context) (*CloudAPI, error) {
 			ControllerUUID: m.ControllerUUID(),
 			Config:         cfg,
 			MachineService: credentialcommon.NewMachineService(modelState.State),
-			ModelType:      model.Type(m.Type()),
+			ModelType:      coremodel.ModelType(m.Type()),
 			Cloud:          *cld,
 			Region:         m.CloudRegion(),
 		}, nil

--- a/apiserver/facades/controller/migrationtarget/register.go
+++ b/apiserver/facades/controller/migrationtarget/register.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/facades"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/environs"
@@ -85,7 +86,7 @@ func newFacade(ctx facade.Context, facadeVersions facades.FacadeVersions) (*API,
 			ControllerUUID: m.ControllerUUID(),
 			Config:         cfg,
 			MachineService: credentialcommon.NewMachineService(modelState.State),
-			ModelType:      model.Type(m.Type()),
+			ModelType:      coremodel.ModelType(m.Type()),
 			Cloud:          *cld,
 			Region:         m.CloudRegion(),
 		}, nil

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -14,11 +14,6 @@ const (
 	CAAS ModelType = "caas"
 )
 
-// String returns m as a string.
-func (m ModelType) String() string {
-	return string(m)
-}
-
 // Model represents the state of a model.
 type Model struct {
 	// Name returns the human friendly name of the model.
@@ -29,4 +24,21 @@ type Model struct {
 
 	// ModelType is the type of model.
 	ModelType ModelType
+}
+
+// IsValid returns true if the value of Type is a known valid type.
+// Currently supported values are:
+// - CAAS
+// - IAAS
+func (m ModelType) IsValid() bool {
+	switch m {
+	case CAAS, IAAS:
+		return true
+	}
+	return false
+}
+
+// String returns m as a string.
+func (m ModelType) String() string {
+	return string(m)
 }

--- a/core/model/model_test.go
+++ b/core/model/model_test.go
@@ -1,15 +1,13 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package model_test
+package model
 
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/core/model"
 )
 
 type ModelSuite struct {
@@ -24,14 +22,25 @@ func (*ModelSuite) TestValidateBranchName(c *gc.C) {
 		valid      bool
 	}{
 		{"", false},
-		{model.GenerationMaster, false},
+		{GenerationMaster, false},
 		{"something else", true},
 	} {
-		err := model.ValidateBranchName(t.branchName)
+		err := ValidateBranchName(t.branchName)
 		if t.valid {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
 			c.Check(err, jc.ErrorIs, errors.NotValid)
 		}
+	}
+}
+
+func (*ModelSuite) TestValidModelTypes(c *gc.C) {
+	validTypes := []ModelType{
+		CAAS,
+		IAAS,
+	}
+
+	for _, vt := range validTypes {
+		c.Assert(vt.IsValid(), jc.IsTrue)
 	}
 }

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -604,7 +604,7 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 			Cloud: testCloud.Name,
 			Name:  coremodel.ControllerModelName,
 			Owner: userUUID,
-			Type:  model.TypeIAAS,
+			Type:  coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/instance"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/credential"
-	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -58,7 +58,7 @@ type CredentialValidationContext struct {
 	Config         *config.Config
 	MachineService MachineService
 
-	ModelType model.Type
+	ModelType coremodel.ModelType
 	Cloud     cloud.Cloud
 	Region    string
 }
@@ -100,9 +100,9 @@ func (v defaultCredentialValidator) Validate(
 		return nil, errors.Trace(err)
 	}
 	switch validationContext.ModelType {
-	case model.TypeCAAS:
+	case coremodel.CAAS:
 		return checkCAASModelCredential(ctx, openParams)
-	case model.TypeIAAS:
+	case coremodel.IAAS:
 		return checkIAASModelCredential(ctx, validationContext.MachineService, openParams, checkCloudInstances)
 	default:
 		return nil, errors.NotSupportedf("model type %q", validationContext.ModelType)

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/version/v2"
 	. "gopkg.in/check.v1"
 
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/model"
@@ -163,7 +164,7 @@ func (s *serviceSuite) TestModelCreation(c *C) {
 		Credential:  cred,
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -183,7 +184,7 @@ func (s *serviceSuite) TestModelCreationInvalidCloud(c *C) {
 		CloudRegion: "myregion",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -200,7 +201,7 @@ func (s *serviceSuite) TestModelCreationNoCloudRegion(c *C) {
 		CloudRegion: "noexist",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -223,7 +224,7 @@ func (s *serviceSuite) TestModelCreationOwnerNotFound(c *C) {
 		CloudRegion: "myregion",
 		Owner:       notFoundUser,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
@@ -246,7 +247,7 @@ func (s *serviceSuite) TestModelCreationNoCloudCredential(c *C) {
 		},
 		Owner: s.userUUID,
 		Name:  "my-awesome-model",
-		Type:  model.TypeIAAS,
+		Type:  coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -264,7 +265,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *C) {
 		CloudRegion: "myregion",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -274,7 +275,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *C) {
 		CloudRegion: "myregion",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, modelerrors.AlreadyExists)
@@ -313,7 +314,7 @@ func (s *serviceSuite) TestUpdateModelCredential(c *C) {
 		CloudRegion: "myregion",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -349,7 +350,7 @@ func (s *serviceSuite) TestUpdateModelCredentialReplace(c *C) {
 		Credential:  cred,
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -378,7 +379,7 @@ func (s *serviceSuite) TestUpdateModelCredentialZeroValue(c *C) {
 		CloudRegion: "myregion",
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -419,7 +420,7 @@ func (s *serviceSuite) TestUpdateModelCredentialDifferentCloud(c *C) {
 		Credential:  cred,
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -454,7 +455,7 @@ func (s *serviceSuite) TestUpdateModelCredentialNotFound(c *C) {
 		Credential:  cred,
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -483,7 +484,7 @@ func (s *serviceSuite) TestDeleteModel(c *C) {
 		Credential:  cred,
 		Owner:       s.userUUID,
 		Name:        "my-awesome-model",
-		Type:        model.TypeIAAS,
+		Type:        coremodel.IAAS,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -529,7 +530,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedGreater(c *C) {
 		Credential:   cred,
 		Owner:        s.userUUID,
 		Name:         "my-awesome-model",
-		Type:         model.TypeIAAS,
+		Type:         coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, modelerrors.AgentVersionNotSupported)
@@ -566,7 +567,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *C) {
 		Credential:   cred,
 		Owner:        s.userUUID,
 		Name:         "my-awesome-model",
-		Type:         model.TypeIAAS,
+		Type:         coremodel.IAAS,
 	})
 
 	c.Assert(err, jc.ErrorIs, modelerrors.AgentVersionNotSupported)

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/database"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/model"
@@ -276,8 +277,8 @@ func (s *State) Delete(
 }
 
 // GetModelTypes returns the slice of model.Type's supported by state.
-func (s *State) GetModelTypes(ctx context.Context) ([]model.Type, error) {
-	rval := []model.Type{}
+func (s *State) GetModelTypes(ctx context.Context) ([]coremodel.ModelType, error) {
+	rval := []coremodel.ModelType{}
 
 	db, err := s.DB()
 	if err != nil {
@@ -295,7 +296,7 @@ SELECT type FROM model_type;
 		}
 		defer rows.Close()
 
-		var t model.Type
+		var t coremodel.ModelType
 		for rows.Next() {
 			if err := rows.Scan(&t); err != nil {
 				return fmt.Errorf("building model type: %w", err)

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	dbcloud "github.com/juju/juju/domain/cloud/state"
 	"github.com/juju/juju/domain/credential"
@@ -100,7 +101,7 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 			},
 			Name:  "my-test-model",
 			Owner: m.userUUID,
-			Type:  model.TypeIAAS,
+			Type:  coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -149,7 +150,7 @@ func (m *modelSuite) TestCreateModelMetadataWithNoModel(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "fantasticmodel",
 				Owner:       m.userUUID,
-				Type:        model.TypeIAAS,
+				Type:        coremodel.IAAS,
 			},
 			tx,
 		)
@@ -170,7 +171,7 @@ func (m *modelSuite) TestCreateModelMetadataWithExistingMetadata(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "fantasticmodel",
 				Owner:       m.userUUID,
-				Type:        model.TypeIAAS,
+				Type:        coremodel.IAAS,
 			},
 			tx,
 		)
@@ -189,7 +190,7 @@ func (m *modelSuite) TestCreateModelWithSameNameAndOwner(c *gc.C) {
 			CloudRegion: "my-region",
 			Name:        "my-test-model",
 			Owner:       m.userUUID,
-			Type:        model.TypeIAAS,
+			Type:        coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, modelerrors.AlreadyExists)
@@ -206,7 +207,7 @@ func (m *modelSuite) TestCreateModelWithInvalidCloudRegion(c *gc.C) {
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       m.userUUID,
-			Type:        model.TypeIAAS,
+			Type:        coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -226,7 +227,7 @@ func (m *modelSuite) TestCreateModelWithNonExistentOwner(c *gc.C) {
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       user.UUID("noexist"), // does not exist
-			Type:        model.TypeIAAS,
+			Type:        coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
@@ -250,7 +251,7 @@ func (m *modelSuite) TestCreateModelWithRemovedOwner(c *gc.C) {
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       m.userUUID,
-			Type:        model.TypeIAAS,
+			Type:        coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
@@ -267,7 +268,7 @@ func (m *modelSuite) TestCreateModelWithInvalidCloud(c *gc.C) {
 			CloudRegion: "my-region",
 			Name:        "noregion",
 			Owner:       m.userUUID,
-			Type:        model.TypeIAAS,
+			Type:        coremodel.IAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -368,7 +369,7 @@ func (m *modelSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 			},
 			Name:  "controller",
 			Owner: m.userUUID,
-			Type:  model.TypeCAAS,
+			Type:  coremodel.CAAS,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -10,9 +10,13 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
 )
+
+// UUID represents a model unique identifier.
+type UUID string
 
 // ModelCreationArgs supplies the information required for instantiating a new
 // model.
@@ -38,40 +42,11 @@ type ModelCreationArgs struct {
 	Name string
 
 	// Owner is the uuid of the user that owns this model in the Juju controller.
-	// Must not be empty for a valid struct.
 	Owner user.UUID
 
 	// Type is the type of the model.
 	// Type must satisfy IsValid() for a valid struct.
-	Type Type
-}
-
-// Type represents the type of a model.
-type Type string
-
-// UUID represents a model unique identifier.
-type UUID string
-
-const (
-	// TypeCAAS is the type used for CAAS models.
-	TypeCAAS Type = "caas"
-
-	// TypeIAAS is the type used for IAAS models.
-	TypeIAAS Type = "iaas"
-)
-
-// IsValid returns true if the value of Type is a known valid type.
-// Currently supported values are:
-// - TypeCAAS
-// - TypeIAAS
-// - TypeNone
-func (t Type) IsValid() bool {
-	switch t {
-	case TypeCAAS,
-		TypeIAAS:
-		return true
-	}
-	return false
+	Type coremodel.ModelType
 }
 
 // NewUUID is a convince function for generating new model uuid id's.
@@ -115,11 +90,6 @@ func (u UUID) Validate() error {
 		return errors.Errorf("invalid uuid %q", u)
 	}
 	return nil
-}
-
-// String implements the stringer interface for Type.
-func (t Type) String() string {
-	return string(t)
 }
 
 // String implements the stringer interface for UUID.

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -5,23 +5,21 @@ package model
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type typesSuite struct {
-	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&typesSuite{})
 
-func (s *typesSuite) TestUUIDValidate(c *gc.C) {
+func (*typesSuite) TestUUIDValidate(c *gc.C) {
 	tests := []struct {
 		uuid string
 		err  *string
@@ -52,102 +50,94 @@ func (s *typesSuite) TestUUIDValidate(c *gc.C) {
 	}
 }
 
-func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 	userUUID, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	tests := []struct {
-		TestName string
-		Args     ModelCreationArgs
-		ErrTest  error
+		Args    ModelCreationArgs
+		ErrTest error
 	}{
 		{
-			TestName: "test model creation args with zero value agent version fails",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "",
 				Owner:       userUUID,
-				Type:        TypeCAAS,
+				Type:        coremodel.CAAS,
 			},
 			ErrTest: errors.NotValid,
 		},
 		{
-			TestName: "test model creation args with empty name fails",
 			Args: ModelCreationArgs{
-				AgentVersion: jujuversion.Current,
-				Cloud:        "my-cloud",
-				CloudRegion:  "my-region",
-				Name:         "",
-				Owner:        "wallyworld-ipv6",
-				Type:         TypeCAAS,
+				Cloud:       "my-cloud",
+				CloudRegion: "my-region",
+				Name:        "my-awesome-model",
+				Owner:       "",
+				Type:        coremodel.CAAS,
 			},
 			ErrTest: errors.NotValid,
 		},
 		{
-			TestName: "test model creation args with empty owner fails",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
-				Type:        Type("ipv6-only"),
+				Type:        coremodel.ModelType("ipv6-only"),
 			},
 			ErrTest: errors.NotSupported,
 		},
 		{
-			TestName: "test model creation args with empty cloud fails",
 			Args: ModelCreationArgs{
 				Cloud:       "",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
-				Type:        TypeIAAS,
+				Type:        coremodel.IAAS,
 			},
 			ErrTest: errors.NotValid,
 		},
 		{
-			TestName: "test model creation args with empty cloud region doesn't fail",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
-				Type:        TypeIAAS,
+				Type:        coremodel.IAAS,
 			},
 			ErrTest: nil,
 		},
 		{
-			TestName: "test model creation args with invalid credential fails",
 			Args: ModelCreationArgs{
-				AgentVersion: jujuversion.Current,
-				Cloud:        "my-cloud",
-				CloudRegion:  "my-region",
+				Cloud:       "my-cloud",
+				CloudRegion: "my-region",
 				Credential: credential.ID{
 					Owner: "wallyworld",
 				},
 				Name:  "my-awesome-model",
 				Owner: userUUID,
-				Type:  TypeIAAS,
+				Type:  coremodel.IAAS,
 			},
 			ErrTest: errors.NotValid,
 		},
 		{
-			TestName: "test model creation args happy path 1",
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
-				Type:        TypeIAAS,
+				Type:        coremodel.IAAS,
 			},
 			ErrTest: nil,
 		},
 		{
-			TestName: "test model creation args happy path 2",
 			Args: ModelCreationArgs{
-				AgentVersion: jujuversion.Current,
-				Cloud:        "my-cloud",
-				CloudRegion:  "my-region",
+				Cloud:       "my-cloud",
+				CloudRegion: "my-region",
 				Credential: credential.ID{
 					Cloud: "cloud",
 					Owner: "wallyworld",
@@ -155,7 +145,7 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				},
 				Name:  "my-awesome-model",
 				Owner: userUUID,
-				Type:  TypeIAAS,
+				Type:  coremodel.IAAS,
 			},
 			ErrTest: nil,
 		},
@@ -164,24 +154,9 @@ func (s *typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 	for _, test := range tests {
 		err := test.Args.Validate()
 		if test.ErrTest == nil {
-			c.Assert(err, jc.ErrorIsNil, gc.Commentf(test.TestName))
+			c.Assert(err, jc.ErrorIsNil)
 		} else {
-			c.Assert(err, jc.ErrorIs, test.ErrTest, gc.Commentf(test.TestName))
+			c.Assert(err, jc.ErrorIs, test.ErrTest)
 		}
 	}
-}
-
-func (s *typesSuite) TestValidModelTypes(c *gc.C) {
-	validTypes := []Type{
-		TypeCAAS,
-		TypeIAAS,
-	}
-
-	for _, vt := range validTypes {
-		c.Assert(vt.IsValid(), jc.IsTrue)
-	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }


### PR DESCRIPTION
With this change we are moving the model creation args from the domain layer to the core layer. The reason for this is to break dependencies at the facade layer onto domain specifically.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is just moving deck chairs. Unit tests will assert that nothing has broken.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5341

