### PR TITLE
Add jujud-controller binary name.

### DIFF
--- a/cmd/jujud-controller/main.go
+++ b/cmd/jujud-controller/main.go
@@ -288,6 +288,75 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	return code, nil
 }
 
+// Main registers subcommands for the jujud-controller executable, and hands over control
+// to the cmd package.
+func jujuControllerMain(args []string, ctx *cmd.Context) (code int, err error) {
+	// Assuming an average of 200 bytes per log message, use up to
+	// 200MB for the log buffer.
+	defer logger.Debugf("jujud-controller complete, code %d, err %v", code, err)
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 1048576)
+	if err != nil {
+		return 1, errors.Trace(err)
+	}
+
+	// Set the default transport to use the in-process proxy
+	// configuration.
+	if err := proxy.DefaultConfig.Set(proxyutils.DetectProxies()); err != nil {
+		return 1, errors.Trace(err)
+	}
+	if err := proxy.DefaultConfig.InstallInDefaultTransport(); err != nil {
+		return 1, errors.Trace(err)
+	}
+
+	current := version.Binary{
+		Number:  jujuversion.Current,
+		Arch:    arch.HostArch(),
+		Release: coreos.HostOSTypeName(),
+	}
+	detail := versionDetail{
+		Version:      current.String(),
+		GitCommit:    jujuversion.GitCommit,
+		GitTreeState: jujuversion.GitTreeState,
+		Compiler:     jujuversion.Compiler,
+		GoBuildTags:  jujuversion.GoBuildTags,
+	}
+
+	jujud := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name: "jujud-controller",
+		Doc:  jujudDoc,
+		Log:  jujucmd.DefaultLog,
+		// p.Version should be a version.Binary, but juju/cmd does not
+		// import juju/juju/version so this cannot happen. We have
+		// tests to assert that this string value is correct.
+		Version:       detail.Version,
+		VersionDetail: detail,
+	})
+
+	jujud.Log.NewWriter = func(target io.Writer) loggo.Writer {
+		return &jujudWriter{target: target}
+	}
+
+	jujud.Register(agentcmd.NewBootstrapCommand())
+
+	// TODO(katco-): AgentConf type is doing too much. The
+	// MachineAgent type has called out the separate concerns; the
+	// AgentConf should be split up to follow suit.
+	agentConf := agentconf.NewAgentConf("")
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
+		agentConf,
+		bufferedLogger,
+		addons.DefaultIntrospectionSocketName,
+		upgrades.PreUpgradeSteps,
+		"",
+	)
+	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
+
+	jujud.Register(jujudagentcmd.NewCheckConnectionCommand(agentConf, jujudagentcmd.ConnectAsAgent))
+
+	code = cmd.Main(jujud, ctx, args[1:])
+	return code, nil
+}
+
 // MainWrapper exists to preserve test functionality.
 func MainWrapper(args []string) {
 	os.Exit(Main(args))
@@ -320,6 +389,8 @@ func Main(args []string) int {
 	switch commandName {
 	case jujunames.Jujud:
 		code, err = jujuDMain(args, ctx)
+	case jujunames.JujudController:
+		code, err = jujuControllerMain(args, ctx)
 	case jujunames.JujuExec:
 		lock, err := machinelock.New(machinelock.Config{
 			AgentName:   "juju-exec",

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -5,11 +5,12 @@
 package names
 
 const (
-	Jujuc          = "jujuc"
-	Jujud          = "jujud"
-	ContainerAgent = "containeragent"
-	JujudVersions  = "jujud-versions.yaml"
-	JujuExec       = "juju-exec"
-	JujuDumpLogs   = "juju-dumplogs"
-	JujuIntrospect = "juju-introspect"
+	Jujuc           = "jujuc"
+	Jujud           = "jujud"
+	JujudController = "jujud-controller"
+	ContainerAgent  = "containeragent"
+	JujudVersions   = "jujud-versions.yaml"
+	JujuExec        = "juju-exec"
+	JujuDumpLogs    = "juju-dumplogs"
+	JujuIntrospect  = "juju-introspect"
 )


### PR DESCRIPTION
#16902 missed creating the jujud-controller binary name. Since we want `jujud-controller` binary to support both `jujud` and `jujud-controller` until the move to `jujud-controller` as the actual name is complete.

## QA steps

- `make install`
- `install -T $(which jujud) $(which jujud)-controller`
- `jujud --help`
- `jujud-controller --help`

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5437

