### PR TITLE
Add jujud-controller-snap-source controller config.

### DIFF
--- a/.github/microk8s-launch-config-aws.yaml
+++ b/.github/microk8s-launch-config-aws.yaml
@@ -7,9 +7,8 @@ addons:
   - name: dns
 containerdRegistryConfigs:
   docker.io: |
-    [host."http://10.0.1.123:80"]
+    [host."https://docker-cache.us-west-2.aws.jujuqa.com:443"]
       capabilities = ["pull", "resolve"]
-      skip_verify = true
   10.152.183.69: |
     [host."https://10.152.183.69:443"]
       capabilities = ["pull", "resolve", "push"]

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Setup Docker Mirror
       shell: bash
       run: |
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,8 +46,7 @@ jobs:
     - name: Setup Docker Mirror
       shell: bash
       run: |
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -110,8 +110,7 @@ jobs:
         if: matrix.cloud == 'microk8s'
         shell: bash
         run: |
-          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json ".insecure-registries += [\"10.0.1.123\",\"${DOCKER_REGISTRY}\"]" | sudo tee /etc/docker/daemon.json
+          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker system info
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -266,6 +266,11 @@ const (
 	// is enabled). The lower the threshold, the more queries will be output. A
 	// value of 0 means all queries will be output.
 	QueryTracingThreshold = "query-tracing-threshold"
+
+	// JujudControllerSnapSource returns the source for the controller snap.
+	// Can be set to "legacy", "snapstore", "local" or "local-dangerous".
+	// Cannot be changed.
+	JujudControllerSnapSource = "jujud-controller-snap-source"
 )
 
 // Attribute Defaults
@@ -390,6 +395,11 @@ const (
 	// for query tracing. If a query takes longer than this to complete
 	// it will be logged if query tracing is enabled.
 	DefaultQueryTracingThreshold = time.Second
+
+	// JujudControllerSnapSource is the default value for the jujud controller
+	// snap source, which is the snapstore.
+	// TODO(jujud-controller-snap): change this to "snapstore" once it is implemented.
+	DefaultJujudControllerSnapSource = "legacy"
 )
 
 var (
@@ -444,6 +454,7 @@ var (
 		ControllerResourceDownloadLimit,
 		QueryTracingEnabled,
 		QueryTracingThreshold,
+		JujudControllerSnapSource,
 	}
 
 	// For backwards compatibility, we must include "anything", "juju-apiserver"
@@ -848,6 +859,14 @@ func (c Config) JujuDBSnapChannel() string {
 	return c.asString(JujuDBSnapChannel)
 }
 
+// JujudControllerSnapSource returns the source of the jujud-controller snap.
+func (c Config) JujudControllerSnapSource() string {
+	if src, ok := c[JujudControllerSnapSource]; ok {
+		return src.(string)
+	}
+	return DefaultJujudControllerSnapSource
+}
+
 // NUMACtlPreference returns if numactl is preferred.
 func (c Config) NUMACtlPreference() bool {
 	if numa, ok := c[SetNUMAControlPolicyKey]; ok {
@@ -1231,6 +1250,15 @@ func Validate(c Config) error {
 	if d, ok := c[QueryTracingThreshold].(time.Duration); ok {
 		if d < 0 {
 			return errors.Errorf("%s value %q must be a positive duration", QueryTracingThreshold, d)
+		}
+	}
+
+	if v, ok := c[JujudControllerSnapSource].(string); ok {
+		switch v {
+		case "legacy": // TODO(jujud-controller-snap): remove once jujud-controller snap is fully implemented.
+		case "snapstore", "local", "local-dangerous":
+		default:
+			return errors.Errorf("%s value %q must be one of legacy, snapstore, local or local-dangerous.", JujudControllerSnapSource, v)
 		}
 	}
 

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -373,6 +373,12 @@ var newConfigTests = []struct {
 		controller.QueryTracingThreshold: "-1s",
 	},
 	expectError: `query-tracing-threshold value "-1s" must be a positive duration`,
+}, {
+	about: "invalid jujud-controller-snap-source value",
+	config: controller.Config{
+		controller.JujudControllerSnapSource: "latest/stable",
+	},
+	expectError: `jujud-controller-snap-source value "latest/stable" must be one of legacy, snapstore, local or local-dangerous.`,
 }}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -58,6 +58,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
 	QueryTracingEnabled:              schema.Bool(),
 	QueryTracingThreshold:            schema.TimeDuration(),
+	JujudControllerSnapSource:        schema.String(),
 }, schema.Defaults{
 	AgentRateLimitMax:                schema.Omit,
 	AgentRateLimitRate:               schema.Omit,
@@ -105,6 +106,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ControllerResourceDownloadLimit:  schema.Omit,
 	QueryTracingEnabled:              DefaultQueryTracingEnabled,
 	QueryTracingThreshold:            DefaultQueryTracingThreshold,
+	JujudControllerSnapSource:        DefaultJujudControllerSnapSource,
 })
 
 // ConfigSchema holds information on all the fields defined by
@@ -301,5 +303,9 @@ Use "caas-image-repo" instead.`,
 		Description: `The minimum duration of a query for it to be traced. The lower the 
 threshold, the more queries will be output. A value of 0 means all queries 
 will be output if tracing is enabled.`,
+	},
+	JujudControllerSnapSource: {
+		Type:        environschema.Tstring,
+		Description: `The source for the jujud-controller snap.`,
 	},
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -70,6 +70,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.ApplicationResourceDownloadLimit,
 		controller.QueryTracingEnabled,
 		controller.QueryTracingThreshold,
+		controller.JujudControllerSnapSource,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
When a new juju controller is bootstrapped and upgraded, to determine how the snap should be acquired, we require a controller config value.

It can be in four possible states:
- legacy: the current default, use the old behaviour (until the jujud-controller snap work is complete)
- snapstore: the future default, only install from <version>/stable channel from the snap store. (risk likely to be handled separately)
- local: uses downloaded snaps with assertions.
- local-dangerous: uses downloaded snaps with no assertions.

## QA steps

Unit tests.

## Documentation changes

N/A yet.

## Links

**Jira card:** JUJU-5436

