### PR TITLE
Bifurcate upgrade-controller and upgrade-model commands.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -399,7 +399,7 @@ func registerCommands(r commandRegistry) {
 	r.Register(model.NewModelGetConstraintsCommand())
 	r.Register(model.NewModelSetConstraintsCommand())
 	r.Register(newSyncAgentBinaryCommand())
-	r.Register(newUpgradeJujuCommand())
+	r.Register(newUpgradeModelCommand())
 	r.Register(newUpgradeControllerCommand())
 	r.Register(application.NewRefreshCommand())
 	r.Register(application.NewSetApplicationBaseCommand())

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -4,17 +4,38 @@
 package commands
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/api/client/modelconfig"
+	"github.com/juju/juju/api/client/modelupgrader"
+	apicontroller "github.com/juju/juju/api/controller/controller"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/sync"
+	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/rpc/params"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var usageUpgradeControllerSummary = `
@@ -43,15 +64,42 @@ const usageUpgradeControllerExamples = `
     juju upgrade-controller --agent-version 2.0.1
 `
 
+const upgradeControllerMessage = "upgrade to this version by running\n    juju upgrade-controller"
+
 func newUpgradeControllerCommand(options ...modelcmd.WrapControllerOption) cmd.Command {
 	command := &upgradeControllerCommand{}
 	return modelcmd.WrapController(command, options...)
 }
 
-// upgradeControllerCommand upgrades the controller agents in a juju installation.
+// upgradeControllerCommand upgrades the agents in a juju installation.
 type upgradeControllerCommand struct {
 	modelcmd.ControllerCommandBase
-	baseUpgradeCommand
+
+	vers          string
+	Version       version.Number
+	BuildAgent    bool
+	DryRun        bool
+	ResetPrevious bool
+	AssumeYes     bool
+	AgentStream   string
+	timeout       time.Duration
+	// IgnoreAgentVersions is used to allow an admin to request an agent
+	// version without waiting for all agents to be at the right version.
+	IgnoreAgentVersions bool
+
+	modelConfigAPI   ModelConfigAPI
+	modelUpgraderAPI ModelUpgraderAPI
+	controllerAPI    ControllerAPI
+
+	controllerModelDetails *jujuclient.ModelDetails
+}
+
+// ControllerAPI defines the controller API methods.
+type ControllerAPI interface {
+	CloudSpec(modelTag names.ModelTag) (environscloudspec.CloudSpec, error)
+	ControllerConfig() (controller.Config, error)
+	ModelConfig() (map[string]interface{}, error)
+	Close() error
 }
 
 func (c *upgradeControllerCommand) Info() *cmd.Info {
@@ -68,15 +116,96 @@ func (c *upgradeControllerCommand) Info() *cmd.Info {
 
 func (c *upgradeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	c.baseUpgradeCommand.SetFlags(f)
+
+	f.StringVar(&c.vers, "agent-version", "", "Upgrade to specific version")
+	f.StringVar(&c.AgentStream, "agent-stream", "", "Check this agent stream for upgrades")
+	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build a local version of the agent binary; for development use only")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Don't change anything, just report what would be changed")
+	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
+	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
+	f.BoolVar(&c.AssumeYes, "yes", false, "")
+	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
+		"Don't check if all agents have already reached the current version")
+	f.DurationVar(&c.timeout, "timeout", 10*time.Minute, "Timeout before upgrade is aborted")
 }
 
+func (c *upgradeControllerCommand) Init(args []string) error {
+	if c.vers != "" {
+		vers, err := version.Parse(c.vers)
+		if err != nil {
+			return err
+		}
+		if c.BuildAgent && vers.Build != 0 {
+			// TODO(fwereade): when we start taking versions from actual built
+			// code, we should disable --agent-version when used with --build-agent.
+			// For now, it's the only way to experiment with version upgrade
+			// behaviour live, so the only restriction is that Build cannot
+			// be used (because its value needs to be chosen internally so as
+			// not to collide with existing tools).
+			return errors.New("cannot specify build number when building an agent")
+		}
+		c.Version = vers
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *upgradeControllerCommand) getModelUpgraderAPI() (ModelUpgraderAPI, error) {
+	if c.modelUpgraderAPI != nil {
+		return c.modelUpgraderAPI, nil
+	}
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelupgrader.NewClient(root), nil
+}
+
+func (c *upgradeControllerCommand) getModelConfigAPI() (ModelConfigAPI, error) {
+	if c.modelConfigAPI != nil {
+		return c.modelConfigAPI, nil
+	}
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelconfig.NewClient(api), nil
+}
+
+func (c *upgradeControllerCommand) getControllerAPI() (ControllerAPI, error) {
+	if c.controllerAPI != nil {
+		return c.controllerAPI, nil
+	}
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apicontroller.NewClient(api), nil
+}
+
+// TODO(jujud-controller-snap): remove if not needed in final upgrade command.
+// type ClientAPI interface {
+// 	Status(args *apiclient.StatusArgs) (*params.FullStatus, error)
+// }
+// func (c *upgradeControllerCommand) getAPIClient() (ClientAPI, error) {
+// 	if c.clientAPI != nil {
+// 		return c.clientAPI, nil
+// 	}
+// 	api, err := c.NewModelAPIRoot(bootstrap.ControllerModelName)
+// 	if err != nil {
+// 		return nil, errors.Trace(err)
+// 	}
+// 	return apiclient.NewClient(api, logger), nil
+// }
+
+// Run changes the version proposed for the juju envtools.
 func (c *upgradeControllerCommand) Run(ctx *cmd.Context) (err error) {
 	controllerName, err := c.ControllerName()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	accDetails, err := c.ClientStore().AccountDetails(controllerName)
+
+	store := c.ClientStore()
+	accDetails, err := store.AccountDetails(controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -87,50 +216,323 @@ func (c *upgradeControllerCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	controllerModel := jujuclient.JoinOwnerModelName(
 		names.NewUserTag(environs.AdminUser), bootstrap.ControllerModelName)
-	_, err = c.ModelUUIDs([]string{controllerModel})
+	c.controllerModelDetails, err = store.ModelByName(controllerName, controllerModel)
 	if err != nil {
-		return errors.Annotatef(err, "cannot get controller model uuid")
+		return errors.Annotatef(err, "cannot get controller model")
 	}
-	fullControllerModelName := modelcmd.JoinModelName(controllerName, controllerModel)
+	//c.fullControllerModelName = modelcmd.JoinModelName(controllerName, controllerModel)
+
+	if c.controllerModelDetails.ModelType == model.CAAS {
+		if c.BuildAgent {
+			return errors.NotSupportedf("--build-agent for k8s model upgrades")
+		}
+	}
+	return c.upgradeController(ctx, c.timeout, c.controllerModelDetails.ModelType)
+}
+
+func (c *upgradeControllerCommand) uploadTools(
+	modelUpgrader ModelUpgraderAPI, buildAgent bool, agentVersion version.Number, dryRun bool,
+) (targetVersion version.Number, err error) {
+	builtTools, err := sync.BuildAgentTarball(
+		buildAgent, "upgrade",
+		func(builtVersion version.Number) version.Number {
+			builtVersion.Build++
+			if agentVersion.Build >= builtVersion.Build {
+				builtVersion.Build = agentVersion.Build + 1
+			}
+			targetVersion = builtVersion
+			return builtVersion
+		},
+	)
+	if err != nil {
+		return targetVersion, errors.Trace(err)
+	}
+	defer os.RemoveAll(builtTools.Dir)
+
+	if dryRun {
+		logger.Debugf("dryrun, skipping upload agent binary")
+		return targetVersion, nil
+	}
+
+	uploadToolsVersion := builtTools.Version
+	uploadToolsVersion.Number = targetVersion
+
+	toolsPath := path.Join(builtTools.Dir, builtTools.StorageName)
+	logger.Infof("uploading agent binary %v (%dkB) to Juju controller", targetVersion, (builtTools.Size+512)/1024)
+	f, err := os.Open(toolsPath)
+	if err != nil {
+		return targetVersion, errors.Trace(err)
+	}
+	defer f.Close()
+
+	_, err = modelUpgrader.UploadTools(f, uploadToolsVersion)
+	if err != nil {
+		return targetVersion, errors.Trace(err)
+	}
+	return targetVersion, nil
+}
+
+func (c *upgradeControllerCommand) upgradeWithTargetVersion(
+	ctx *cmd.Context, modelUpgrader ModelUpgraderAPI, dryRun bool,
+	modelType model.ModelType, targetVersion, agentVersion version.Number,
+) (chosenVersion version.Number, err error) {
+	chosenVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, dryRun)
+	if err == nil {
+		// All good!
+		// Upgraded to the provided target version.
+		logger.Debugf("upgraded to the provided target version %q", targetVersion)
+		return chosenVersion, nil
+	}
+	if !errors.Is(err, errors.NotFound) {
+		return chosenVersion, err
+	}
+
+	// If target version is the current local binary version, then try to upload.
+	canImplicitUpload := CheckCanImplicitUpload(
+		modelType, isOfficialClient(), jujuversion.Current, agentVersion,
+	)
+	if !canImplicitUpload {
+		// expecting to upload a local binary but we are not allowed to upload, so pretend there
+		// is no more recent version available.
+		logger.Debugf("no available binary found, and we are not allowed to upload, err %v", err)
+		return chosenVersion, errUpToDate
+	}
+
+	if targetVersion.Compare(jujuversion.Current.ToPatch()) != 0 {
+		logger.Warningf(
+			"try again with --agent-version=%s if you want to upgrade using the local packaged jujud from the snap",
+			jujuversion.Current.ToPatch(),
+		)
+		return chosenVersion, errUpToDate
+	}
+
+	// found a best target version but a local binary is required to be uploaded.
+	if chosenVersion, err = c.uploadTools(modelUpgrader, false, agentVersion, dryRun); err != nil {
+		return chosenVersion, block.ProcessBlockedError(err, block.BlockChange)
+	}
+	fmt.Fprintf(ctx.Stdout,
+		"no prepackaged agent binaries available, using the local snap jujud %v%s\n",
+		chosenVersion, "",
+	)
+
+	chosenVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, chosenVersion, dryRun)
+	if err != nil {
+		return chosenVersion, err
+	}
+	return chosenVersion, nil
+}
+
+func (c *upgradeControllerCommand) upgradeController(
+	ctx *cmd.Context, fetchTimeout time.Duration,
+	modelType model.ModelType,
+) (err error) {
+	targetVersion := c.Version
+	defer func() {
+		if err == nil {
+			fmt.Fprintf(ctx.Stderr, "best version:\n    %v\n", targetVersion)
+			if c.DryRun {
+				if c.BuildAgent {
+					fmt.Fprintf(ctx.Stderr, "%s --build-agent\n", upgradeControllerMessage)
+				} else {
+					fmt.Fprintf(ctx.Stderr, "%s\n", upgradeControllerMessage)
+				}
+			} else {
+				fmt.Fprintf(ctx.Stdout, "started upgrade to %s\n", targetVersion)
+			}
+		}
+
+		if errors.Is(err, errUpToDate) {
+			ctx.Infof(err.Error())
+			err = nil
+		}
+		if err != nil {
+			logger.Debugf("upgradeController failed %v", err)
+		}
+	}()
+
+	modelUpgrader, err := c.getModelUpgraderAPI()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.upgradeController(ctx, fullControllerModelName)
-}
+	defer modelUpgrader.Close()
 
-func (c *upgradeControllerCommand) upgradeController(ctx *cmd.Context, controllerModel string) error {
-	jcmd := &upgradeJujuCommand{
-		baseUpgradeCommand: c.baseUpgradeCommand,
+	controllerClient, err := c.getControllerAPI()
+	if err != nil {
+		return err
 	}
-	jcmd.upgradeMessage = "upgrade to this version by running\n    juju upgrade-controller"
-	jcmd.SetClientStore(c.ClientStore())
-	wrapped := modelcmd.Wrap(jcmd)
-	args := append(c.rawArgs, "-m", controllerModel)
-	if c.vers != "" {
-		args = append(args, "--agent-version", c.vers)
+	defer controllerClient.Close()
+
+	modelConfigClient, err := c.getModelConfigAPI()
+	if err != nil {
+		return errors.Trace(err)
 	}
-	if c.AgentStream != "" {
-		args = append(args, "--agent-stream", c.AgentStream)
+	defer modelConfigClient.Close()
+
+	attrs, err := modelConfigClient.ModelGet()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	agentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		// Can't happen. In theory.
+		return errors.New("incomplete model configuration")
+	}
+
+	if c.Version == agentVersion {
+		return errUpToDate
+	}
+
+	if c.BuildAgent {
+		if targetVersion != version.Zero {
+			return errors.Errorf("--build-agent cannot be used with --agent-version together")
+		}
+	}
+
+	// Decide the target version to upgrade.
+	if targetVersion != version.Zero {
+		targetVersion, err = c.upgradeWithTargetVersion(
+			ctx, modelUpgrader, c.DryRun,
+			modelType, targetVersion, agentVersion,
+		)
+		return err
 	}
 	if c.BuildAgent {
-		args = append(args, "--build-agent")
+		if targetVersion, err = c.uploadTools(modelUpgrader, c.BuildAgent, agentVersion, c.DryRun); err != nil {
+			return block.ProcessBlockedError(err, block.BlockChange)
+		}
+		builtMsg := " (built from source)"
+		fmt.Fprintf(ctx.Stdout,
+			"no prepackaged agent binaries available, using local agent binary %v%s\n",
+			targetVersion, builtMsg,
+		)
+		targetVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, c.DryRun)
+		return err
 	}
-	if c.DryRun {
-		args = append(args, "--dry-run")
-	}
-	if c.IgnoreAgentVersions {
-		args = append(args, "--ignore-agent-versions")
-	}
-	if c.ResetPrevious {
-		args = append(args, "--reset-previous-upgrade")
-	}
-	if c.AssumeYes {
-		args = append(args, "--yes")
-	}
-	args = append(args, "--timeout", c.timeout.String())
-	code := cmd.Main(wrapped, ctx, args)
-	if code == 0 {
+	// juju upgrade-controller without --build-agent or --agent-version
+	// or juju upgrade-model without --agent-version
+	targetVersion, err = c.notifyControllerUpgrade(
+		ctx, modelUpgrader,
+		version.Zero, // no target version provided, we figure it out on the server side.
+		c.DryRun,
+	)
+	if err == nil {
+		// All good!
+		// Upgraded to a next stable version or the newest stable version.
+		logger.Debugf("upgraded to a next version or latest stable version")
 		return nil
 	}
-	return cmd.ErrSilent
+	if errors.Is(err, errors.NotFound) {
+		return errUpToDate
+	}
+	return err
+}
+
+func (c *upgradeControllerCommand) notifyControllerUpgrade(
+	ctx *cmd.Context, modelUpgrader ModelUpgraderAPI, targetVersion version.Number, dryRun bool,
+) (chosenVersion version.Number, err error) {
+	modelTag := names.NewModelTag(c.controllerModelDetails.ModelUUID)
+
+	if c.ResetPrevious {
+		if ok, err := c.confirmResetPreviousUpgrade(ctx); !ok || err != nil {
+			const message = "previous upgrade not reset and no new upgrade triggered"
+			if err != nil {
+				return chosenVersion, errors.Annotate(err, message)
+			}
+			return chosenVersion, errors.New(message)
+		}
+		if err := modelUpgrader.AbortModelUpgrade(modelTag.Id()); err != nil {
+			return chosenVersion, block.ProcessBlockedError(err, block.BlockChange)
+		}
+	}
+	if chosenVersion, err = modelUpgrader.UpgradeModel(
+		modelTag.Id(), targetVersion, c.AgentStream, c.IgnoreAgentVersions, dryRun,
+	); err != nil {
+		if params.IsCodeUpgradeInProgress(err) {
+			return chosenVersion, errors.Errorf("%s\n\n"+
+				"Please wait for the upgrade to complete or if there was a problem with\n"+
+				"the last upgrade that has been resolved, consider running the\n"+
+				"upgrade-model command with the --reset-previous-upgrade option.", err,
+			)
+		}
+		if errors.Is(err, errors.AlreadyExists) {
+			err = errUpToDate
+		}
+		return chosenVersion, block.ProcessBlockedError(err, block.BlockChange)
+	}
+	return chosenVersion, nil
+}
+
+const resetPreviousUpgradeMessage = `
+WARNING! using --reset-previous-upgrade when an upgrade is in progress
+will cause the upgrade to fail. Only use this option to clear an
+incomplete upgrade where the root cause has been resolved.
+
+Continue [y/N]? `
+
+func (c *upgradeControllerCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool, error) {
+	if c.AssumeYes {
+		return true, nil
+	}
+	fmt.Fprint(ctx.Stdout, resetPreviousUpgradeMessage)
+	scanner := bufio.NewScanner(ctx.Stdin)
+	scanner.Scan()
+	err := scanner.Err()
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(scanner.Text())
+	return answer == "y" || answer == "yes", nil
+}
+
+// For test.
+var CheckCanImplicitUpload = checkCanImplicitUpload
+
+func checkCanImplicitUpload(
+	modelType model.ModelType, isOfficialClient bool,
+	clientVersion, agentVersion version.Number,
+) bool {
+	if modelType != model.IAAS {
+		logger.Tracef("the model is not IAAS model")
+		return false
+	}
+
+	if !isOfficialClient {
+		logger.Tracef("the client is not an official client")
+		// For non official (under $GOPATH) client, always use --build-agent explicitly.
+		return false
+	}
+	newerClient := clientVersion.Compare(agentVersion.ToPatch()) >= 0
+	if !newerClient {
+		logger.Tracef(
+			"the client version(%s) is not newer than agent version(%s)",
+			clientVersion, agentVersion.ToPatch(),
+		)
+		return false
+	}
+
+	if agentVersion.Build > 0 || clientVersion.Build > 0 {
+		return true
+	}
+	return false
+}
+
+func isOfficialClient() bool {
+	// If there's an error getting jujud version, play it safe.
+	// We pretend it's not official and don't do an implicit upload.
+	jujudPath, err := tools.ExistingJujuLocation()
+	if err != nil {
+		return false
+	}
+	_, official, err := tools.JujudVersion(jujudPath)
+	if err != nil {
+		return false
+	}
+	// For non official (under $GOPATH) client, always use --build-agent explicitly.
+	// For official (under /snap/juju/bin) client, upload only if the client is not a published version.
+	return official
 }

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -4,12 +4,16 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -18,13 +22,17 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cmd/juju/commands/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs/sync"
+	toolstesting "github.com/juju/juju/environs/tools/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
-type UpgradeControllerSuite struct {
+type OldUpgradeControllerSuite struct {
 	jujutesting.JujuConnSuite
 
 	resources  *common.Resources
@@ -33,9 +41,9 @@ type UpgradeControllerSuite struct {
 	modelUpgrader *mocks.MockModelUpgraderAPI
 }
 
-var _ = gc.Suite(&UpgradeControllerSuite{})
+var _ = gc.Suite(&OldUpgradeControllerSuite{})
 
-func (s *UpgradeControllerSuite) SetUpTest(c *gc.C) {
+func (s *OldUpgradeControllerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	client.SkipReplicaCheck(s)
 
@@ -49,19 +57,17 @@ func (s *UpgradeControllerSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
 }
 
-func (s *UpgradeControllerSuite) upgradeControllerCommand(c *gc.C) (*gomock.Controller, cmd.Command) {
+func (s *OldUpgradeControllerSuite) upgradeControllerCommand(c *gc.C) (*gomock.Controller, cmd.Command) {
 	ctrl := gomock.NewController(c)
 	s.modelUpgrader = mocks.NewMockModelUpgraderAPI(ctrl)
 	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{
-			modelUpgraderAPI: s.modelUpgrader,
-		},
+		modelUpgraderAPI: s.modelUpgrader,
 	}
 	cmd.SetClientStore(s.ControllerStore)
 	return ctrl, modelcmd.WrapController(cmd)
 }
 
-func (s *UpgradeControllerSuite) TestUpgradeWrongPermissions(c *gc.C) {
+func (s *OldUpgradeControllerSuite) TestUpgradeWrongPermissions(c *gc.C) {
 	details, err := s.ControllerStore.AccountDetails("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	details.LastKnownAccess = string(permission.ReadAccess)
@@ -77,7 +83,7 @@ func (s *UpgradeControllerSuite) TestUpgradeWrongPermissions(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, expectedErrMsg)
 }
 
-func (s *UpgradeControllerSuite) TestUpgradeDifferentUser(c *gc.C) {
+func (s *OldUpgradeControllerSuite) TestUpgradeDifferentUser(c *gc.C) {
 	user, err := s.BackingState.AddUser("rick", "rick", "dummy-secret", "admin")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -96,11 +102,633 @@ func (s *UpgradeControllerSuite) TestUpgradeDifferentUser(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{},
-	}
+	cmd := &upgradeControllerCommand{}
 	cmd.SetClientStore(s.ControllerStore)
 	cmdrun := modelcmd.WrapController(cmd)
 	_, err = cmdtesting.RunCommand(c, cmdrun)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func newUpgradeControllerCommandForTest(
+	store jujuclient.ClientStore,
+	modelConfigAPI ModelConfigAPI,
+	modelUpgrader ModelUpgraderAPI,
+	controllerAPI ControllerAPI,
+	options ...modelcmd.WrapControllerOption,
+) cmd.Command {
+	command := &upgradeControllerCommand{
+		modelConfigAPI:   modelConfigAPI,
+		modelUpgraderAPI: modelUpgrader,
+		controllerAPI:    controllerAPI,
+	}
+	command.SetClientStore(store)
+	return modelcmd.WrapController(command, options...)
+}
+
+type upgradeControllerSuite struct {
+	testing.IsolationSuite
+
+	modelConfigAPI *mocks.MockModelConfigAPI
+	modelUpgrader  *mocks.MockModelUpgraderAPI
+	controllerAPI  *mocks.MockControllerAPI
+	store          *mocks.MockClientStore
+}
+
+var _ = gc.Suite(&upgradeControllerSuite{})
+
+func (s *upgradeControllerSuite) upgradeControllerCommand(c *gc.C, isCAAS bool) (*gomock.Controller, cmd.Command) {
+	ctrl := gomock.NewController(c)
+	s.modelConfigAPI = mocks.NewMockModelConfigAPI(ctrl)
+	s.modelUpgrader = mocks.NewMockModelUpgraderAPI(ctrl)
+	s.controllerAPI = mocks.NewMockControllerAPI(ctrl)
+	s.store = mocks.NewMockClientStore(ctrl)
+
+	s.modelConfigAPI.EXPECT().Close().AnyTimes()
+	s.modelUpgrader.EXPECT().Close().AnyTimes()
+	s.controllerAPI.EXPECT().Close().AnyTimes()
+
+	s.store.EXPECT().CurrentController().AnyTimes().Return("c-1", nil)
+	s.store.EXPECT().ControllerByName("c-1").AnyTimes().Return(&jujuclient.ControllerDetails{
+		APIEndpoints: []string{"0.1.2.3:1234"},
+	}, nil)
+	s.store.EXPECT().CurrentModel("c-1").AnyTimes().Return("m-1", nil)
+	s.store.EXPECT().AccountDetails("c-1").AnyTimes().Return(&jujuclient.AccountDetails{User: "foo", LastKnownAccess: "superuser"}, nil)
+	cookieJar := mocks.NewMockCookieJar(ctrl)
+	cookieJar.EXPECT().Save().AnyTimes().Return(nil)
+	s.store.EXPECT().CookieJar("c-1").AnyTimes().Return(cookieJar, nil)
+
+	modelType := model.IAAS
+	if isCAAS {
+		modelType = model.CAAS
+	}
+
+	s.store.EXPECT().ModelByName("c-1", "admin/controller").AnyTimes().Return(&jujuclient.ModelDetails{
+		ModelUUID: coretesting.ModelTag.Id(),
+		ModelType: modelType,
+	}, nil)
+
+	return ctrl, newUpgradeControllerCommandForTest(s.store,
+		s.modelConfigAPI, s.modelUpgrader, s.controllerAPI,
+	)
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelFailedCAASWithBuildAgent(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, true)
+	defer ctrl.Finish()
+
+	_, err := cmdtesting.RunCommand(c, cmd, `--build-agent`)
+	c.Assert(err, gc.ErrorMatches, `--build-agent for k8s model upgrades not supported`)
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelProvidedAgentVersionUpToDate(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": coretesting.FakeVersionNumber.String(),
+	})
+
+	s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--agent-version", coretesting.FakeVersionNumber.String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelFailedWithBuildAgentAndAgentVersion(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": coretesting.FakeVersionNumber.String(),
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+	)
+
+	_, err := cmdtesting.RunCommand(c, cmd,
+		"--build-agent",
+		"--agent-version", version.MustParse("3.9.99").String(),
+	)
+	c.Assert(err, gc.ErrorMatches, `--build-agent cannot be used with --agent-version together`)
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersion(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		// TODO (hml) 19-oct-2022
+		// Once upgrade from 2.9 to 3.0 is supported, go back to
+		// using coretesting.FakeVersionNumber.String() in this
+		// test.
+		//"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": "3.0.1",
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.MustParse("3.9.99"),
+			"", false, false,
+		).Return(version.MustParse("3.9.99"), nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", version.MustParse("3.9.99").String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+best version:
+    3.9.99
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+started upgrade to 3.9.99
+`[1:])
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c *gc.C) {
+	s.reset(c)
+
+	s.PatchValue(&jujuversion.Current, func() version.Number {
+		v := jujuversion.Current
+		v.Build = 0
+		return v
+	}())
+
+	s.PatchValue(&CheckCanImplicitUpload,
+		func(model.ModelType, bool, version.Number, version.Number) bool { return true },
+	)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	c.Assert(agentVersion.Build, gc.Equals, 0)
+	builtVersion := coretesting.CurrentVersion()
+	targetVersion := builtVersion.Number
+	builtVersion.Build++
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion,
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.NotFoundf("available agent tool, upload required"),
+		),
+		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), builtVersion).Return(nil, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), builtVersion.Number,
+			"", false, false,
+		).Return(builtVersion.Number, nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+best version:
+    %s
+`, builtVersion.Number)[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, fmt.Sprintf(`
+no prepackaged agent binaries available, using the local snap jujud %s
+started upgrade to %s
+`, builtVersion.Number, builtVersion.Number)[1:])
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.C) {
+	s.reset(c)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	c.Assert(agentVersion.Build, gc.Equals, 0)
+	targetVersion := coretesting.CurrentVersion()
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion.ToPatch(),
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.AlreadyExistsf("up to date"),
+		),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.ToPatch().String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionFailedExpectUploadButWrongTargetVersion(c *gc.C) {
+	s.reset(c)
+
+	s.PatchValue(&CheckCanImplicitUpload,
+		func(model.ModelType, bool, version.Number, version.Number) bool { return true },
+	)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	current := agentVersion
+	current.Minor++ // local snap is newer.
+	s.PatchValue(&jujuversion.Current, current)
+
+	targetVersion := current
+	targetVersion.Patch++ // wrong target version (It has to be equal to local snap version).
+	c.Assert(targetVersion.Compare(current) == 0, jc.IsFalse)
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion,
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.NotFoundf("available agent tool, upload required"),
+		),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueToNotAllowed(c *gc.C) {
+	s.reset(c)
+
+	s.PatchValue(&CheckCanImplicitUpload,
+		func(model.ModelType, bool, version.Number, version.Number) bool { return false },
+	)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	targetVersion := coretesting.CurrentVersion().Number
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion,
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.NotFoundf("available agent tool, upload required"),
+		),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionDryRun(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		// TODO (hml) 19-oct-2022
+		// Once upgrade from 2.9 to 3.0 is supported, go back to
+		// using coretesting.FakeVersionNumber.String() in this
+		// test.
+		//"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": "3.0.1",
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.MustParse("3.9.99"),
+			"", false, true,
+		).Return(version.MustParse("3.9.99"), nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", version.MustParse("3.9.99").String(), "--dry-run",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+best version:
+    3.9.99
+upgrade to this version by running
+    juju upgrade-controller
+`[1:])
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionGotBlockers(c *gc.C) {
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		// TODO (hml) 19-oct-2022
+		// Once upgrade from 2.9 to 3.0 is supported, go back to
+		// using coretesting.FakeVersionNumber.String() in this
+		// test.
+		//"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": "3.0.1",
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.MustParse("3.9.99"),
+			"", false, false,
+		).Return(version.Zero, errors.New(`
+cannot upgrade to "3.9.99" due to issues with these models:
+"admin/default":
+- the model hosts deprecated ubuntu machine(s): bionic(3) (not supported)
+`[1:])),
+	)
+
+	_, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", version.MustParse("3.9.99").String(),
+	)
+	c.Assert(err.Error(), gc.Equals, `
+cannot upgrade to "3.9.99" due to issues with these models:
+"admin/default":
+- the model hosts deprecated ubuntu machine(s): bionic(3) (not supported)
+`[1:])
+}
+
+func (s *upgradeControllerSuite) reset(c *gc.C) {
+	s.PatchValue(&sync.BuildAgentTarball, toolstesting.GetMockBuildTools(c))
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithBuildAgent(c *gc.C) {
+	s.reset(c)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+	c.Assert(agentVersion.Build, gc.Equals, 0)
+	builtVersion := coretesting.CurrentVersion()
+	builtVersion.Build++
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UploadTools(gomock.Any(), builtVersion).Return(nil, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), builtVersion.Number,
+			"", false, false,
+		).Return(builtVersion.Number, nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+best version:
+    %s
+`, builtVersion.Number)[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, fmt.Sprintf(`
+no prepackaged agent binaries available, using local agent binary %s (built from source)
+started upgrade to %s
+`, builtVersion.Number, builtVersion.Number)[1:])
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelUpToDate(c *gc.C) {
+	s.reset(c)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.Zero,
+			"", false, false,
+		).Return(version.Zero, errors.AlreadyExistsf("up to date")),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelUpgradeToPublishedVersion(c *gc.C) {
+	s.reset(c)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.Zero,
+			"", false, false,
+		).Return(version.MustParse("3.9.99"), nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+best version:
+    3.9.99
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+started upgrade to 3.9.99
+`[1:])
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithStream(c *gc.C) {
+	s.reset(c)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), version.Zero,
+			"proposed", false, false,
+		).Return(version.MustParse("3.9.99"), nil),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--agent-stream", "proposed")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+best version:
+    3.9.99
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+started upgrade to 3.9.99
+`[1:])
+}
+
+func (s *upgradeControllerSuite) assertResetPreviousUpgrade(c *gc.C, answer string, expectUpgrade bool, args ...string) {
+	s.reset(c)
+
+	c.Logf("answer %q, expectUpgrade %v, args %s", answer, expectUpgrade, args)
+
+	ctx := cmdtesting.Context(c)
+	var stdin bytes.Buffer
+	ctx.Stdin = &stdin
+
+	if answer != "" {
+		stdin.WriteString(answer)
+	}
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	assertions := []any{
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+	}
+	if expectUpgrade {
+		assertions = append(assertions,
+			s.modelUpgrader.EXPECT().AbortModelUpgrade(coretesting.ModelTag.Id()).Return(nil),
+			s.modelUpgrader.EXPECT().UpgradeModel(
+				coretesting.ModelTag.Id(), version.Zero, "", false, false,
+			).Return(version.MustParse("3.9.99"), nil),
+		)
+	}
+
+	gomock.InOrder(assertions...)
+
+	err := cmdtesting.InitCommand(cmd,
+		append([]string{"--reset-previous-upgrade"}, args...))
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmd.Run(ctx)
+	if expectUpgrade {
+		// ctx, err := cmdtesting.RunCommand(c, cmd)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+best version:
+    3.9.99
+`[1:])
+		if answer != "" {
+			c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+WARNING! using --reset-previous-upgrade when an upgrade is in progress
+will cause the upgrade to fail. Only use this option to clear an
+incomplete upgrade where the root cause has been resolved.
+
+Continue [y/N]? started upgrade to 3.9.99
+`)
+		} else {
+			c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+started upgrade to 3.9.99
+`[1:])
+		}
+
+	} else {
+		c.Assert(err, gc.ErrorMatches, "previous upgrade not reset and no new upgrade triggered")
+	}
+}
+
+func (s *upgradeControllerSuite) TestResetPreviousUpgrade(c *gc.C) {
+	s.assertResetPreviousUpgrade(c, "", false)
+
+	s.assertResetPreviousUpgrade(c, "", true, "-y")
+	s.assertResetPreviousUpgrade(c, "", true, "--yes")
+	s.assertResetPreviousUpgrade(c, "y", true)
+	s.assertResetPreviousUpgrade(c, "Y", true)
+	s.assertResetPreviousUpgrade(c, "yes", true)
+	s.assertResetPreviousUpgrade(c, "YES", true)
+
+	s.assertResetPreviousUpgrade(c, "n", false)
+	s.assertResetPreviousUpgrade(c, "N", false)
+	s.assertResetPreviousUpgrade(c, "no", false)
+	s.assertResetPreviousUpgrade(c, "foo", false)
+}
+
+func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// Not IAAS model.
+	canImplicitUpload := checkCanImplicitUpload(
+		model.CAAS, true,
+		version.MustParse("3.0.0"),
+		version.MustParse("3.9.99.1"),
+	)
+	c.Check(canImplicitUpload, jc.IsFalse)
+
+	// not official client.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, false,
+		version.MustParse("3.9.99"),
+		version.MustParse("3.0.0"),
+	)
+	c.Check(canImplicitUpload, jc.IsFalse)
+
+	// non newer client.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("2.9.99"),
+		version.MustParse("3.0.0"),
+	)
+	c.Check(canImplicitUpload, jc.IsFalse)
+
+	// client version with build number.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("3.0.0.1"),
+		version.MustParse("3.0.0"),
+	)
+	c.Check(canImplicitUpload, jc.IsTrue)
+
+	// agent version with build number.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("3.0.0"),
+		version.MustParse("3.0.0.1"),
+	)
+	c.Check(canImplicitUpload, jc.IsTrue)
+
+	// both client and agent version with build number == 0.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("3.0.0"),
+		version.MustParse("3.0.0"),
+	)
+	c.Check(canImplicitUpload, jc.IsFalse)
 }

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -5,11 +5,8 @@ package commands
 
 import (
 	"bufio"
-	stderrors "errors"
 	"fmt"
 	"io"
-	"os"
-	"path"
 	"strings"
 	"time"
 
@@ -24,15 +21,9 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/model"
-	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/sync"
-	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/rpc/params"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 var usageUpgradeJujuSummary = `
@@ -54,7 +45,7 @@ The command will abort if an upgrade is in progress. It will also abort if
 a previous upgrade was not fully completed (e.g.: if one of the
 controllers in a high availability model failed to upgrade).
 
-When looking for an agent to upgrade to Juju will check the currently
+When looking for an agent to upgrade to, Juju will check the currently
 configured agent stream for that model. It's possible to overwrite this for
 the lifetime of this upgrade using --agent-stream
 
@@ -70,18 +61,19 @@ const usageUpgradeJujuExamples = `
     juju upgrade-model --agent-stream proposed
 `
 
-func newUpgradeJujuCommand() cmd.Command {
-	command := &upgradeJujuCommand{}
+const upgradeModelMessage = "upgrade to this version by running\n    juju upgrade-model"
+
+func newUpgradeModelCommand() cmd.Command {
+	command := &upgradeModelCommand{}
 	return modelcmd.Wrap(command)
 }
 
-// baseUpgradeCommand is used by both the
-// upgradeJujuCommand and upgradeControllerCommand
-// to hold flags common to both.
-type baseUpgradeCommand struct {
+// upgradeModelCommand upgrades the agents in a juju installation.
+type upgradeModelCommand struct {
+	modelcmd.ModelCommandBase
+
 	vers          string
 	Version       version.Number
-	BuildAgent    bool
 	DryRun        bool
 	ResetPrevious bool
 	AssumeYes     bool
@@ -91,58 +83,12 @@ type baseUpgradeCommand struct {
 	// version without waiting for all agents to be at the right version.
 	IgnoreAgentVersions bool
 
-	rawArgs        []string
-	upgradeMessage string
-
 	modelConfigAPI   ModelConfigAPI
 	modelUpgraderAPI ModelUpgraderAPI
 	controllerAPI    ControllerAPI
 }
 
-func (c *baseUpgradeCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.vers, "agent-version", "", "Upgrade to specific version")
-	f.StringVar(&c.AgentStream, "agent-stream", "", "Check this agent stream for upgrades")
-	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build a local version of the agent binary; for development use only")
-	f.BoolVar(&c.DryRun, "dry-run", false, "Don't change anything, just report what would be changed")
-	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
-	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
-	f.BoolVar(&c.AssumeYes, "yes", false, "")
-	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
-		"Don't check if all agents have already reached the current version")
-	f.DurationVar(&c.timeout, "timeout", 10*time.Minute, "Timeout before upgrade is aborted")
-}
-
-func (c *baseUpgradeCommand) Init(args []string) error {
-	c.rawArgs = args
-	if c.upgradeMessage == "" {
-		c.upgradeMessage = "upgrade to this version by running\n    juju upgrade-model"
-	}
-	if c.vers != "" {
-		vers, err := version.Parse(c.vers)
-		if err != nil {
-			return err
-		}
-		if c.BuildAgent && vers.Build != 0 {
-			// TODO(fwereade): when we start taking versions from actual built
-			// code, we should disable --agent-version when used with --build-agent.
-			// For now, it's the only way to experiment with version upgrade
-			// behaviour live, so the only restriction is that Build cannot
-			// be used (because its value needs to be chosen internally so as
-			// not to collide with existing tools).
-			return errors.New("cannot specify build number when building an agent")
-		}
-		c.Version = vers
-	}
-	return cmd.CheckEmpty(args)
-}
-
-// upgradeJujuCommand upgrades the agents in a juju installation.
-type upgradeJujuCommand struct {
-	modelcmd.ModelCommandBase
-	baseUpgradeCommand
-}
-
-func (c *upgradeJujuCommand) Info() *cmd.Info {
+func (c *upgradeModelCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "upgrade-model",
 		Purpose:  usageUpgradeJujuSummary,
@@ -154,13 +100,33 @@ func (c *upgradeJujuCommand) Info() *cmd.Info {
 	})
 }
 
-func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *upgradeModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	c.baseUpgradeCommand.SetFlags(f)
+
+	f.StringVar(&c.vers, "agent-version", "", "Upgrade to specific version")
+	f.StringVar(&c.AgentStream, "agent-stream", "", "Check this agent stream for upgrades")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Don't change anything, just report what would be changed")
+	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "Clear the previous (incomplete) upgrade status (use with care)")
+	f.BoolVar(&c.AssumeYes, "y", false, "Answer 'yes' to confirmation prompts")
+	f.BoolVar(&c.AssumeYes, "yes", false, "")
+	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
+		"Don't check if all agents have already reached the current version")
+	f.DurationVar(&c.timeout, "timeout", 10*time.Minute, "Timeout before upgrade is aborted")
 }
 
-var (
-	errUpToDate = stderrors.New("no upgrades available")
+func (c *upgradeModelCommand) Init(args []string) error {
+	if c.vers != "" {
+		vers, err := version.Parse(c.vers)
+		if err != nil {
+			return err
+		}
+		c.Version = vers
+	}
+	return cmd.CheckEmpty(args)
+}
+
+const (
+	errUpToDate errors.ConstError = "no upgrades available"
 )
 
 // ModelConfigAPI defines the model config API methods.
@@ -180,15 +146,7 @@ type ModelUpgraderAPI interface {
 	Close() error
 }
 
-// ControllerAPI defines the controller API methods.
-type ControllerAPI interface {
-	CloudSpec(modelTag names.ModelTag) (environscloudspec.CloudSpec, error)
-	ControllerConfig() (controller.Config, error)
-	ModelConfig() (map[string]interface{}, error)
-	Close() error
-}
-
-func (c *upgradeJujuCommand) getModelUpgraderAPI() (ModelUpgraderAPI, error) {
+func (c *upgradeModelCommand) getModelUpgraderAPI() (ModelUpgraderAPI, error) {
 	if c.modelUpgraderAPI != nil {
 		return c.modelUpgraderAPI, nil
 	}
@@ -196,7 +154,7 @@ func (c *upgradeJujuCommand) getModelUpgraderAPI() (ModelUpgraderAPI, error) {
 	return c.NewModelUpgraderAPIClient()
 }
 
-func (c *upgradeJujuCommand) getModelConfigAPI() (ModelConfigAPI, error) {
+func (c *upgradeModelCommand) getModelConfigAPI() (ModelConfigAPI, error) {
 	if c.modelConfigAPI != nil {
 		return c.modelConfigAPI, nil
 	}
@@ -208,7 +166,7 @@ func (c *upgradeJujuCommand) getModelConfigAPI() (ModelConfigAPI, error) {
 	return modelconfig.NewClient(api), nil
 }
 
-func (c *upgradeJujuCommand) getControllerAPI() (ControllerAPI, error) {
+func (c *upgradeModelCommand) getControllerAPI() (ControllerAPI, error) {
 	if c.controllerAPI != nil {
 		return c.controllerAPI, nil
 	}
@@ -221,134 +179,23 @@ func (c *upgradeJujuCommand) getControllerAPI() (ControllerAPI, error) {
 }
 
 // Run changes the version proposed for the juju envtools.
-func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
-	modelType, err := c.ModelType()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if modelType == model.CAAS {
-		if c.BuildAgent {
-			return errors.NotSupportedf("--build-agent for k8s model upgrades")
-		}
-	}
-	return c.upgradeModel(ctx, c.timeout, modelType)
+func (c *upgradeModelCommand) Run(ctx *cmd.Context) (err error) {
+	return c.upgradeModel(ctx, c.timeout)
 }
 
-func uploadTools(
-	modelUpgrader ModelUpgraderAPI, buildAgent bool, agentVersion version.Number, dryRun bool,
-) (targetVersion version.Number, err error) {
-	builtTools, err := sync.BuildAgentTarball(
-		buildAgent, "upgrade",
-		func(builtVersion version.Number) version.Number {
-			builtVersion.Build++
-			if agentVersion.Build >= builtVersion.Build {
-				builtVersion.Build = agentVersion.Build + 1
-			}
-			targetVersion = builtVersion
-			return builtVersion
-		},
-	)
-	if err != nil {
-		return targetVersion, errors.Trace(err)
-	}
-	defer os.RemoveAll(builtTools.Dir)
-
-	if dryRun {
-		logger.Debugf("dryrun, skipping upload agent binary")
-		return targetVersion, nil
-	}
-
-	uploadToolsVersion := builtTools.Version
-	uploadToolsVersion.Number = targetVersion
-
-	toolsPath := path.Join(builtTools.Dir, builtTools.StorageName)
-	logger.Infof("uploading agent binary %v (%dkB) to Juju controller", targetVersion, (builtTools.Size+512)/1024)
-	f, err := os.Open(toolsPath)
-	if err != nil {
-		return targetVersion, errors.Trace(err)
-	}
-	defer f.Close()
-
-	_, err = modelUpgrader.UploadTools(f, uploadToolsVersion)
-	if err != nil {
-		return targetVersion, errors.Trace(err)
-	}
-	return targetVersion, nil
-}
-
-func (c *upgradeJujuCommand) upgradeWithTargetVersion(
-	ctx *cmd.Context, modelUpgrader ModelUpgraderAPI, isControllerModel, dryRun bool,
-	modelType model.ModelType, targetVersion, agentVersion version.Number,
-) (chosenVersion version.Number, err error) {
-	// juju upgrade-controller --agent-version 3.x.x
-	chosenVersion = targetVersion
-
-	_, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, dryRun)
-	if err == nil {
-		// All good!
-		// Upgraded to the provided target version.
-		logger.Debugf("upgraded to the provided target version %q", targetVersion)
-		return chosenVersion, nil
-	}
-	if !errors.Is(err, errors.NotFound) {
-		return chosenVersion, err
-	}
-
-	// If target version is the current local binary version, then try to upload.
-	canImplicitUpload := CheckCanImplicitUpload(
-		modelType, isOfficialClient(), jujuversion.Current, agentVersion,
-	)
-	if !canImplicitUpload || !isControllerModel {
-		// expecting to upload a local binary but we are not allowed to upload, so pretend there
-		// is no more recent version available.
-		logger.Debugf("no available binary found, and we are not allowed to upload, err %v", err)
-		return chosenVersion, errUpToDate
-	}
-
-	if targetVersion.Compare(jujuversion.Current.ToPatch()) != 0 {
-		logger.Warningf(
-			"try again with --agent-version=%s if you want to upgrade using the local packaged jujud from the snap",
-			jujuversion.Current.ToPatch(),
-		)
-		return chosenVersion, errUpToDate
-	}
-
-	// found a best target version but a local binary is required to be uploaded.
-	if chosenVersion, err = uploadTools(modelUpgrader, false, agentVersion, dryRun); err != nil {
-		return chosenVersion, block.ProcessBlockedError(err, block.BlockChange)
-	}
-	fmt.Fprintf(ctx.Stdout,
-		"no prepackaged agent binaries available, using the local snap jujud %v%s\n",
-		chosenVersion, "",
-	)
-
-	chosenVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, chosenVersion, dryRun)
-	if err != nil {
-		return chosenVersion, err
-	}
-	return chosenVersion, nil
-}
-
-func (c *upgradeJujuCommand) upgradeModel(
-	ctx *cmd.Context, fetchTimeout time.Duration,
-	modelType model.ModelType,
-) (err error) {
+func (c *upgradeModelCommand) upgradeModel(ctx *cmd.Context, fetchTimeout time.Duration) (err error) {
 	targetVersion := c.Version
 	defer func() {
 		if err == nil {
 			fmt.Fprintf(ctx.Stderr, "best version:\n    %v\n", targetVersion)
 			if c.DryRun {
-				if c.BuildAgent {
-					fmt.Fprintf(ctx.Stderr, "%s --build-agent\n", c.upgradeMessage)
-				} else {
-					fmt.Fprintf(ctx.Stderr, "%s\n", c.upgradeMessage)
-				}
+				fmt.Fprintf(ctx.Stderr, "%s\n", upgradeModelMessage)
 			} else {
 				fmt.Fprintf(ctx.Stdout, "started upgrade to %s\n", targetVersion)
 			}
 		}
 
-		if err == errUpToDate {
+		if errors.Is(err, errUpToDate) {
 			ctx.Infof(err.Error())
 			err = nil
 		}
@@ -400,52 +247,13 @@ func (c *upgradeJujuCommand) upgradeModel(
 	}
 	haveControllerModelPermission := err == nil
 	isControllerModel := haveControllerModelPermission && cfg.UUID() == controllerModelConfig[config.UUIDKey]
-
-	if c.BuildAgent {
-		// For UploadTools, model must be the "controller" model,
-		// that is, modelUUID == controllerUUID
-		if !haveControllerModelPermission {
-			return errors.New("--build-agent can only be used with the controller model but you don't have permission to access that model")
-		}
-		if !isControllerModel {
-			return errors.Errorf("--build-agent can only be used with the controller model")
-		}
-		if targetVersion != version.Zero {
-			return errors.Errorf("--build-agent cannot be used with --agent-version together")
-		}
+	if isControllerModel {
+		return errors.Errorf("use upgrade-controller to upgrade the controller model")
 	}
 
-	// Decide the target version to upgrade.
-	if targetVersion != version.Zero {
-		targetVersion, err = c.upgradeWithTargetVersion(
-			ctx, modelUpgrader, isControllerModel, c.DryRun,
-			modelType, targetVersion, agentVersion,
-		)
-		return err
-	}
-	if c.BuildAgent {
-		if targetVersion, err = uploadTools(modelUpgrader, c.BuildAgent, agentVersion, c.DryRun); err != nil {
-			return block.ProcessBlockedError(err, block.BlockChange)
-		}
-		builtMsg := " (built from source)"
-		fmt.Fprintf(ctx.Stdout,
-			"no prepackaged agent binaries available, using local agent binary %v%s\n",
-			targetVersion, builtMsg,
-		)
-		targetVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, c.DryRun)
-		return err
-	}
-	// juju upgrade-controller without --build-agent or --agent-version
-	// or juju upgrade-model without --agent-version
-	targetVersion, err = c.notifyControllerUpgrade(
-		ctx, modelUpgrader,
-		version.Zero, // no target version provided, we figure it out on the server side.
-		c.DryRun,
-	)
+	targetVersion, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, c.DryRun)
 	if err == nil {
-		// All good!
-		// Upgraded to a next stable version or the newest stable version.
-		logger.Debugf("upgraded to a next version or latest stable version")
+		logger.Debugf("upgraded to %s", targetVersion)
 		return nil
 	}
 	if errors.Is(err, errors.NotFound) {
@@ -454,55 +262,7 @@ func (c *upgradeJujuCommand) upgradeModel(
 	return err
 }
 
-// For test.
-var CheckCanImplicitUpload = checkCanImplicitUpload
-
-func checkCanImplicitUpload(
-	modelType model.ModelType, isOfficialClient bool,
-	clientVersion, agentVersion version.Number,
-) bool {
-	if modelType != model.IAAS {
-		logger.Tracef("the model is not IAAS model")
-		return false
-	}
-
-	if !isOfficialClient {
-		logger.Tracef("the client is not an official client")
-		// For non official (under $GOPATH) client, always use --build-agent explicitly.
-		return false
-	}
-	newerClient := clientVersion.Compare(agentVersion.ToPatch()) >= 0
-	if !newerClient {
-		logger.Tracef(
-			"the client version(%s) is not newer than agent version(%s)",
-			clientVersion, agentVersion.ToPatch(),
-		)
-		return false
-	}
-
-	if agentVersion.Build > 0 || clientVersion.Build > 0 {
-		return true
-	}
-	return false
-}
-
-func isOfficialClient() bool {
-	// If there's an error getting jujud version, play it safe.
-	// We pretend it's not official and don't do an implicit upload.
-	jujudPath, err := tools.ExistingJujuLocation()
-	if err != nil {
-		return false
-	}
-	_, official, err := tools.JujudVersion(jujudPath)
-	if err != nil {
-		return false
-	}
-	// For non official (under $GOPATH) client, always use --build-agent explicitly.
-	// For official (under /snap/juju/bin) client, upload only if the client is not a published version.
-	return official
-}
-
-func (c *upgradeJujuCommand) notifyControllerUpgrade(
+func (c *upgradeModelCommand) notifyControllerUpgrade(
 	ctx *cmd.Context, modelUpgrader ModelUpgraderAPI, targetVersion version.Number, dryRun bool,
 ) (chosenVersion version.Number, err error) {
 	_, details, err := c.ModelCommandBase.ModelDetails()
@@ -541,18 +301,18 @@ func (c *upgradeJujuCommand) notifyControllerUpgrade(
 	return chosenVersion, nil
 }
 
-const resetPreviousUpgradeMessage = `
+const modelResetPreviousUpgradeMessage = `
 WARNING! using --reset-previous-upgrade when an upgrade is in progress
 will cause the upgrade to fail. Only use this option to clear an
 incomplete upgrade where the root cause has been resolved.
 
 Continue [y/N]? `
 
-func (c *baseUpgradeCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool, error) {
+func (c *upgradeModelCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool, error) {
 	if c.AssumeYes {
 		return true, nil
 	}
-	fmt.Fprint(ctx.Stdout, resetPreviousUpgradeMessage)
+	fmt.Fprint(ctx.Stdout, modelResetPreviousUpgradeMessage)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -60,8 +60,8 @@ var allowedCalls = map[string]set.Strings{
 	"juju/commands/main.go": set.NewStrings("os.Stat"),
 	// plugins are not enabled for embedded CLI commands.
 	"juju/commands/plugin.go": set.NewStrings("exec.Command"),
-	// upgrade-model is not a whitelisted embedded CLI command.
-	"juju/commands/upgrademodel.go": set.NewStrings("os.Open", "os.RemoveAll"),
+	// upgrade-controller is not a whitelisted embedded CLI command.
+	"juju/commands/upgradecontroller.go": set.NewStrings("os.Open", "os.RemoveAll"),
 	// ssh is not a whitelisted embedded CLI command.
 	"juju/ssh/ssh_machine.go": set.NewStrings("os.Remove"),
 	// agree is not exposed to shell scripts because it uses PAGER to present terms

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -289,7 +289,7 @@ func buildJujus(dir string) error {
 
 	// Build binaries.
 	cmds := [][]string{
-		{"make", "jujud"},
+		{"make", "jujud-controller"},
 	}
 	for _, args := range cmds {
 		cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
With moving to the jujud-controller snap and a new process for development build/upgrade process, it makes sense to bifurcate the upgrade-model and upgrade-controller commands because they will fundamentally serve two different purposes into the future.

Since `--build-agent` was only supported on controller models, this change simplifies the upgrade model command greatly.

Since `upgrade-controller` command used to invoke the `upgrade-model` command in a funky way, by bifurcating, we actually simplify both commands.

## QA steps

- Bootstrap controller
- Upgrade controller
- Upgrade model
- Use `--build-agent` on the `upgrade-controller` command too.

## Documentation changes

- Can no longer upgrade a controller via upgrade-model.

## Links

**Jira card:** JUJU-5439

