### PR TITLE
Record granted permission access types instead of the access type/object type pair

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -675,21 +675,23 @@ INSERT INTO permission_object_access VALUES
     (8, 2, 3), -- consume, offer
     (9, 3, 3); -- admin, offer
 
-
-CREATE TABLE user_permission (
+-- Column grant_to may extend to entities beyond users.
+-- The name of the column is general, but for now we retain the FK constraint.
+-- We will need to remove/replace it in the event of change
+CREATE TABLE permission (
     uuid               TEXT PRIMARY KEY,
-    object_identifier  TEXT NOT NULL, -- name or uuid of the object
-    object_access_id   INT NOT NULL,
-    user_uuid          TEXT NOT NULL,
+    permission_type_id INT NOT NULL,
+    grant_on  		   TEXT NOT NULL, -- name or uuid of the object
+    grant_to           TEXT NOT NULL,
     CONSTRAINT         fk_permission_user_uuid
-        FOREIGN KEY    (user_uuid)
+        FOREIGN KEY    (grant_on)
         REFERENCES     user(uuid),
-    CONSTRAINT         fk_permission_object_access
-        FOREIGN KEY    (object_access_id)
-        REFERENCES     permission_object_access(id)
+    CONSTRAINT         fk_permission_access_type
+        FOREIGN KEY    (permission_type_id)
+        REFERENCES     permission_access_type(id)
 );
 
-CREATE UNIQUE INDEX idx_user_permission
-ON user_permission (user_uuid, object_identifier);
+CREATE UNIQUE INDEX idx_permission_type_to
+ON permission (permission_type_id, grant_on, grant_to);
 `)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -107,7 +107,7 @@ func (s *schemaSuite) TestControllerDDLApply(c *gc.C) {
 		"permission_access_type",
 		"permission_object_access",
 		"permission_object_type",
-		"user_permission",
+		"permission",
 	)
 	c.Assert(readTableNames(c, s.DB()), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }


### PR DESCRIPTION
Creating permissions using IDs from `permission_object_access` would require us to input a target entity's ID _and type_ during authorisation. Instead, we just use the permission access type directly, reserving `permission_object_access` for validation of permission creations.

In addition we accommodate possible future changes that may require us to  grant permissions to entities other than users, using the general `grant_to` instead of `user_uuid` (the user FK remains for now). The target identifier becomes `grant_on` for congruence with the grantee.

## QA steps

This state layer is not yet recruited. Passing tests are sufficient verification.

