### PR TITLE
Migrate utils.Password to password.Password

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/mgo/v3"
 	"github.com/juju/names/v5"
 	utilseries "github.com/juju/os/v2/series"
-	"github.com/juju/utils/v4"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/caas"
@@ -47,6 +46,7 @@ import (
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/internal/network"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/state"
 )
@@ -396,7 +396,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	// via the API connection).
 	b.logger.Debugf("create new random password for controller %v", controllerNode.Id())
 
-	newPassword, err := utils.RandomPassword()
+	newPassword, err := password.RandomPassword()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -34,6 +33,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/uuid"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
@@ -231,7 +231,7 @@ func (s *loginSuite) setupManagementSpace(c *gc.C) *state.Space {
 func (s *loginSuite) addController(c *gc.C) (state.ControllerNode, string) {
 	node, err := s.ControllerModel(c).State().AddControllerNode()
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = node.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -44,11 +44,11 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	nonce, err := utils.RandomPassword()
+	nonce, err := internalpassword.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("foo", "", nonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := internalpassword.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
@@ -64,7 +64,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unit = unit
-	password, err = utils.RandomPassword()
+	password, err = internalpassword.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -17,12 +17,12 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/authentication"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/internal/password"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -38,11 +38,11 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 	// add machine for testing machine agent authentication
 	machine, err := s.ControllerModel(c).State().AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	nonce, err := utils.RandomPassword()
+	nonce, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("foo", "", nonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,7 +69,7 @@ func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 	})
 	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 
 	"github.com/juju/juju/agent"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/paths"
 	applicationservice "github.com/juju/juju/domain/application/service"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -167,11 +167,11 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 		upsert.ObservedAttachedVolumeIDs = append(upsert.ObservedAttachedVolumeIDs, fs.Volume.VolumeId)
 	}
 
-	password, err := utils.RandomPassword()
+	pass, err := password.RandomPassword()
 	if err != nil {
 		return errResp(err)
 	}
-	passwordHash := utils.AgentPasswordHash(password)
+	passwordHash := password.AgentPasswordHash(pass)
 	upsert.PasswordHash = &passwordHash
 
 	unit, err := application.UpsertCAASUnit(upsert)
@@ -215,7 +215,7 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 			Model:             f.model.Tag().(names.ModelTag),
 			APIAddresses:      addrs,
 			CACert:            caCert,
-			Password:          password,
+			Password:          pass,
 			UpgradedToVersion: version,
 		},
 	)

--- a/apiserver/facades/agent/meterstatus/meterstatus_integration_test.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus_integration_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/agent/meterstatus"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/internal/password"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 )
@@ -32,7 +32,7 @@ func (s *MeterStatusIntegrationSuite) SetUpTest(c *gc.C) {
 	defer release()
 	s.unit = f.MakeUnit(c, nil)
 
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/package_test.go
+++ b/apiserver/facades/agent/uniter/package_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	apiuniter "github.com/juju/juju/api/agent/uniter"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/feature"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -202,7 +202,7 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.Client, *state.CAA
 		Tag: unit.Tag(),
 	}
 
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/worker/v4/workertest"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
@@ -33,6 +32,7 @@ import (
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/password"
 	_ "github.com/juju/juju/internal/secrets/provider/all"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/juju/testing"
@@ -3032,7 +3032,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/machinemanager/instanceconfig.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/utils/v4"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
@@ -18,6 +17,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/state/binarystorage"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -111,7 +111,7 @@ func InstanceConfig(
 		}
 	}
 
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	if err != nil {
 		return nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)
 	}

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
@@ -32,6 +31,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	"github.com/juju/juju/internal/password"
 	coretools "github.com/juju/juju/internal/tools"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
@@ -194,7 +194,7 @@ func (s *toolsSuite) TestAuthRequiresUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -91,6 +91,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"internal/network/netplan",
 		"internal/packaging",
 		"internal/packaging/dependency",
+		"internal/password",
 		"internal/pki",
 		"internal/proxy",
 		"internal/proxy/config",

--- a/doc/bootstrapping.txt
+++ b/doc/bootstrapping.txt
@@ -56,7 +56,7 @@ The common finalizer function does the following:
    * populates the machine config with information from the config object
    * checks for CA Cert
    * checks for admin-secret
-   * creates a password hash using the utils.CompatSalt
+   * creates a password hash using the password.CompatSalt
    * uses this password hash for both the APIInfo and MongoInfo passwords.
    * creates the controller cert and key
    * strips the admin-secret and server ca-private-key from the config

--- a/internal/cloudconfig/podcfg/podcfg.go
+++ b/internal/cloudconfig/podcfg/podcfg.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v5"
 	"github.com/juju/proxy"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/agent"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	"github.com/juju/juju/internal/mongo"
+	"github.com/juju/juju/internal/password"
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig.podcfg")
@@ -123,7 +123,7 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 // UnitAgentConfig returns the agent config file for the controller unit charm.
 // This is created a bootstrap time.
 func (cfg *ControllerPodConfig) UnitAgentConfig() (agent.ConfigSetterWriter, error) {
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/password/package_test.go
+++ b/internal/password/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package password
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/password/password.go
+++ b/internal/password/password.go
@@ -1,0 +1,92 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package password
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// CompatSalt is because Juju 1.16 and older used a hard-coded salt to compute
+// the password hash for all users and agents
+var CompatSalt = string([]byte{0x75, 0x82, 0x81, 0xca})
+
+const randomPasswordBytes = 18
+
+// MinAgentPasswordLength describes how long agent passwords should be. We
+// require this length because we assume enough entropy in the Agent password
+// that it is safe to not do extra rounds of iterated hashing.
+var MinAgentPasswordLength = base64.StdEncoding.EncodedLen(randomPasswordBytes)
+
+// RandomBytes returns n random bytes.
+func RandomBytes(n int) ([]byte, error) {
+	buf := make([]byte, n)
+	_, err := io.ReadFull(rand.Reader, buf)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read random bytes: %v", err)
+	}
+	return buf, nil
+}
+
+// RandomPassword generates a random base64-encoded password.
+func RandomPassword() (string, error) {
+	b, err := RandomBytes(randomPasswordBytes)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// RandomSalt generates a random base64 data suitable for using as a password
+// salt The pbkdf2 guideline is to use 8 bytes of salt, so we do 12 raw bytes
+// into 16 base64 bytes. (The alternative is 6 raw into 8 base64).
+func RandomSalt() (string, error) {
+	b, err := RandomBytes(12)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// FastInsecureHash specifies whether a fast, insecure version of the hash
+// algorithm will be used.  Changing this will cause PasswordHash to
+// produce incompatible passwords.  It should only be changed for
+// testing purposes - to make tests run faster.
+var FastInsecureHash = false
+
+// UserPasswordHash returns base64-encoded one-way hash password that is
+// computationally hard to crack by iterating through possible passwords.
+func UserPasswordHash(password string, salt string) string {
+	if salt == "" {
+		panic("salt is not allowed to be empty")
+	}
+	iter := 8192
+	if FastInsecureHash {
+		iter = 1
+	}
+	// Generate 18 byte passwords because we know that MongoDB
+	// uses the MD5 sum of the password anyway, so there's
+	// no point in using more bytes. (18 so we don't get base 64
+	// padding characters).
+	h := pbkdf2.Key([]byte(password), []byte(salt), iter, 18, sha512.New)
+	return base64.StdEncoding.EncodeToString(h)
+}
+
+// AgentPasswordHash returns base64-encoded one-way hash of password. This is
+// not suitable for User passwords because those will have limited entropy (see
+// UserPasswordHash). However, since we generate long random passwords for
+// agents, we can trust that there is sufficient entropy to prevent brute force
+// search. And using a faster hash allows us to restart the state machines and
+// have 1000s of agents log in in a reasonable amount of time.
+func AgentPasswordHash(password string) string {
+	sum := sha512.New()
+	sum.Write([]byte(password))
+	h := sum.Sum(nil)
+	return base64.StdEncoding.EncodeToString(h[:18])
+}

--- a/internal/password/password_test.go
+++ b/internal/password/password_test.go
@@ -1,0 +1,92 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package password
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type passwordSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&passwordSuite{})
+
+// Base64 *can* include a tail of '=' characters, but all the tests here
+// explicitly *don't* want those because it is wasteful.
+var base64Chars = "^[A-Za-z0-9+/]+$"
+
+func (*passwordSuite) TestRandomBytes(c *gc.C) {
+	b, err := RandomBytes(16)
+	c.Assert(err, gc.IsNil)
+	c.Assert(b, gc.HasLen, 16)
+	x0 := b[0]
+	for _, x := range b {
+		if x != x0 {
+			return
+		}
+	}
+	c.Errorf("all same bytes in result of RandomBytes")
+}
+
+func (*passwordSuite) TestRandomPassword(c *gc.C) {
+	p, err := RandomPassword()
+	c.Assert(err, gc.IsNil)
+	if len(p) < 18 {
+		c.Errorf("password too short: %q", p)
+	}
+	c.Assert(p, gc.Matches, base64Chars)
+}
+
+func (*passwordSuite) TestRandomSalt(c *gc.C) {
+	salt, err := RandomSalt()
+	c.Assert(err, gc.IsNil)
+	if len(salt) < 12 {
+		c.Errorf("salt too short: %q", salt)
+	}
+	// check we're not adding base64 padding.
+	c.Assert(salt, gc.Matches, base64Chars)
+}
+
+var testPasswords = []string{"", "a", "a longer password than i would usually bother with"}
+
+var testSalts = []string{"abcd", "abcdefgh", "abcdefghijklmnop", CompatSalt}
+
+func (*passwordSuite) TestUserPasswordHash(c *gc.C) {
+	seenHashes := make(map[string]bool)
+	for i, password := range testPasswords {
+		for j, salt := range testSalts {
+			c.Logf("test %d, %d %s %s", i, j, password, salt)
+			hashed := UserPasswordHash(password, salt)
+			c.Logf("hash %q", hashed)
+			c.Assert(len(hashed), gc.Equals, 24)
+			c.Assert(seenHashes[hashed], gc.Equals, false)
+			// check we're not adding base64 padding.
+			c.Assert(hashed, gc.Matches, base64Chars)
+			seenHashes[hashed] = true
+			// check it's deterministic
+			altHashed := UserPasswordHash(password, salt)
+			c.Assert(altHashed, gc.Equals, hashed)
+		}
+	}
+}
+
+func (*passwordSuite) TestAgentPasswordHash(c *gc.C) {
+	seenValues := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		password, err := RandomPassword()
+		c.Assert(err, gc.IsNil)
+		c.Assert(seenValues[password], jc.IsFalse)
+		seenValues[password] = true
+		hashed := AgentPasswordHash(password)
+		c.Assert(hashed, gc.Not(gc.Equals), password)
+		c.Assert(seenValues[hashed], jc.IsFalse)
+		seenValues[hashed] = true
+		c.Assert(len(hashed), gc.Equals, 24)
+		// check we're not adding base64 padding.
+		c.Assert(hashed, gc.Matches, base64Chars)
+	}
+}

--- a/internal/worker/apicaller/connect.go
+++ b/internal/worker/apicaller/connect.go
@@ -11,12 +11,12 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/retry"
-	"github.com/juju/utils/v4"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent/agent"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -282,7 +282,7 @@ func ScaryConnect(ctx context.Context, a agent.Agent, apiOpen api.OpenFunc, logg
 // oldPassword -- which must be the current valid password -- is set as a
 // fallback in local config, in case we fail to update the remote password.
 func changePassword(ctx context.Context, oldPassword string, a agent.Agent, facade apiagent.ConnFacade) error {
-	newPassword, err := utils.RandomPassword()
+	newPassword, err := password.RandomPassword()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -139,7 +139,7 @@ func (a *appWorker) loop() error {
 
 	if !a.statusOnly {
 		// Update the password once per worker start to avoid it changing too frequently.
-		a.password, err = utils.RandomPassword()
+		a.password, err = password.RandomPassword()
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/worker/caasmodeloperator/modeloperator.go
+++ b/internal/worker/caasmodeloperator/modeloperator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v4/catacomb"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/juju/api/controller/caasmodeloperator"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/password"
 )
 
 type ModelOperatorAPI interface {
@@ -95,7 +95,7 @@ func (m *ModelOperatorManager) update(ctx context.Context) error {
 	}
 
 	setPassword := true
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/deployer/deployer.go
+++ b/internal/worker/deployer/deployer.go
@@ -10,13 +10,13 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 	"github.com/juju/worker/v4"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -203,7 +203,7 @@ func (d *Deployer) deploy(ctx context.Context, unit Unit) error {
 		return errors.Trace(err)
 	}
 	d.logger.Infof("deploying unit %q", unitName)
-	initialPassword, err := utils.RandomPassword()
+	initialPassword, err := password.RandomPassword()
 	if err != nil {
 		return err
 	}

--- a/internal/worker/provisioner/provisioner_task.go
+++ b/internal/worker/provisioner/provisioner_task.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
@@ -41,6 +40,7 @@ import (
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	"github.com/juju/juju/internal/container"
 	"github.com/juju/juju/internal/container/broker"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	coretools "github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/internal/uuid"
@@ -802,7 +802,7 @@ func (task *provisionerTask) constructInstanceConfig(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	if err != nil {
 		return nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)
 	}

--- a/internal/worker/uniter/runner/runner.go
+++ b/internal/worker/uniter/runner/runner.go
@@ -23,12 +23,12 @@ import (
 	"github.com/juju/cmd/v4"
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
-	"github.com/juju/utils/v4"
 	utilexec "github.com/juju/utils/v4/exec"
 	"github.com/kballard/go-shellquote"
 
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/worker/common/charmrunner"
 	"github.com/juju/juju/internal/worker/uniter/runner/context"
 	"github.com/juju/juju/internal/worker/uniter/runner/debug"
@@ -210,7 +210,7 @@ func (runner *runner) runCommandsWithTimeout(ctx stdcontext.Context, commands st
 	var err error
 	token := ""
 	if rMode == runOnRemote {
-		token, err = utils.RandomPassword()
+		token, err = password.RandomPassword()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -406,7 +406,7 @@ func (runner *runner) RunHook(ctx stdcontext.Context, hookName string) (HookHand
 func (runner *runner) runCharmHookWithLocation(ctx stdcontext.Context, hookName, charmLocation string, rMode runMode) (hookHandlerType HookHandlerType, err error) {
 	token := ""
 	if rMode == runOnRemote {
-		token, err = utils.RandomPassword()
+		token, err = password.RandomPassword()
 		if err != nil {
 			return InvalidHookHandler, errors.Trace(err)
 		}

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -24,7 +24,6 @@ import (
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
 
@@ -61,6 +60,7 @@ import (
 	"github.com/juju/juju/internal/mongo/mongotest"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	objectstoretesting "github.com/juju/juju/internal/objectstore/testing"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/pubsub/centralhub"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/uuid"
@@ -501,7 +501,7 @@ func (s *ApiServerSuite) OpenAPIAsNewMachine(c *gc.C, jobs ...state.MachineJob) 
 	st := s.ControllerModel(c).State()
 	machine, err := st.AddMachine(state.UbuntuBase("12.10"), jobs...)
 	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/v4"
+
+	"github.com/juju/juju/internal/password"
 )
 
 func main() {
@@ -36,18 +37,18 @@ func main() {
 			passwd = args[2]
 		} else {
 			var err error
-			passwd, err = utils.RandomPassword()
+			passwd, err = password.RandomPassword()
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
 	}
 	if *user != "" {
-		salt, err := utils.RandomSalt()
+		salt, err := password.RandomSalt()
 		if err != nil {
 			log.Fatal(err)
 		}
-		hash := utils.UserPasswordHash(passwd, salt)
+		hash := password.UserPasswordHash(passwd, salt)
 		fmt.Printf("Password line for ~/.local/share/juju/accounts.yaml\n")
 		fmt.Printf("  password: %s\n", passwd)
 		fmt.Printf(`db.users.update({"_id": "%s"}, {"$set": {"passwordsalt": "%s", "passwordhash": "%s"}})`+"\n",
@@ -64,7 +65,7 @@ func main() {
 		} else {
 			collection = "units"
 		}
-		hash := utils.AgentPasswordHash(passwd)
+		hash := password.AgentPasswordHash(passwd)
 		fmt.Printf("oldpassword: %s\n", passwd)
 		fmt.Printf(`db.%s.update({"_id": "%s:%s"}, {$set: {"passwordhash": "%s"}})`+"\n",
 			collection, modelUUID, agent, hash)

--- a/state/application.go
+++ b/state/application.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/schema"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	"gopkg.in/juju/environschema.v1"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
 	mgoutils "github.com/juju/juju/internal/mongo/utils"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/tools"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -3721,10 +3721,10 @@ func addApplicationOps(mb modelBackend, app *Application, args addApplicationOps
 // SetPassword sets the password for the application's agent.
 // TODO(caas) - consider a separate CAAS application entity
 func (a *Application) SetPassword(password string) error {
-	if len(password) < utils.MinAgentPasswordLength {
+	if len(password) < internalpassword.MinAgentPasswordLength {
 		return fmt.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
 	}
-	passwordHash := utils.AgentPasswordHash(password)
+	passwordHash := internalpassword.AgentPasswordHash(password)
 	ops := []txn.Op{{
 		C:      applicationsC,
 		Id:     a.doc.DocID,
@@ -3742,7 +3742,7 @@ func (a *Application) SetPassword(password string) error {
 // PasswordValid returns whether the given password is valid
 // for the given application.
 func (a *Application) PasswordValid(password string) bool {
-	agentHash := utils.AgentPasswordHash(password)
+	agentHash := internalpassword.AgentPasswordHash(password)
 	return agentHash == a.doc.PasswordHash
 }
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5772,7 +5772,7 @@ func (s *CAASApplicationSuite) TestUpsertCAASUnit(c *gc.C) {
 	address := "1.2.3.4"
 	ports := []string{"80", "443"}
 
-	// output of utils.AgentPasswordHash("juju")
+	// output of internalpassword.AgentPasswordHash("juju")
 	passwordHash := "v+jK3ht5NEdKeoQBfyxmlYe0"
 
 	p := state.UpsertCAASUnitParams{

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/replicaset/v3"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/constraints"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/mongo"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/tools"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -587,10 +587,10 @@ func (c *controllerNode) SetMongoPassword(password string) error {
 
 // SetPassword implements Authenticator.
 func (c *controllerNode) SetPassword(password string) error {
-	if len(password) < utils.MinAgentPasswordLength {
+	if len(password) < internalpassword.MinAgentPasswordLength {
 		return errors.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
 	}
-	passwordHash := utils.AgentPasswordHash(password)
+	passwordHash := internalpassword.AgentPasswordHash(password)
 	ops := []txn.Op{{
 		C:      controllerNodesC,
 		Id:     c.doc.DocID,
@@ -606,7 +606,7 @@ func (c *controllerNode) SetPassword(password string) error {
 
 // PasswordValid implements Authenticator.
 func (c *controllerNode) PasswordValid(password string) bool {
-	agentHash := utils.AgentPasswordHash(password)
+	agentHash := internalpassword.AgentPasswordHash(password)
 	return agentHash == c.doc.PasswordHash
 }
 

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v4"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/core/status"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
 )
@@ -173,7 +173,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	salt, err := utils.RandomSalt()
+	salt, err := password.RandomSalt()
 	if err != nil {
 		return nil, err
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v5"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	"github.com/kr/pretty"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/mongo"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/tools"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -584,10 +584,10 @@ func (m *Machine) SetMongoPassword(password string) error {
 
 // SetPassword sets the password for the machine's agent.
 func (m *Machine) SetPassword(password string) error {
-	if len(password) < utils.MinAgentPasswordLength {
+	if len(password) < internalpassword.MinAgentPasswordLength {
 		return errors.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
 	}
-	passwordHash := utils.AgentPasswordHash(password)
+	passwordHash := internalpassword.AgentPasswordHash(password)
 	op := m.UpdateOperation()
 	op.PasswordHash = &passwordHash
 	if err := m.st.ApplyOperation(op); err != nil {
@@ -613,7 +613,7 @@ func (m *Machine) setPasswordHashOps(passwordHash string) ([]txn.Op, error) {
 // PasswordValid returns whether the given password is valid
 // for the given machine.
 func (m *Machine) PasswordValid(password string) bool {
-	agentHash := utils.AgentPasswordHash(password)
+	agentHash := internalpassword.AgentPasswordHash(password)
 	return agentHash == m.doc.PasswordHash
 }
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
@@ -37,6 +36,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/feature"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
 	"github.com/juju/juju/internal/storage/provider"
@@ -179,7 +179,7 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	model, err := s.State.Export(map[string]string{}, state.NewObjectStore(c, s.State.ModelUUID()))
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(model.PasswordHash(), gc.Equals, utils.AgentPasswordHash("supppperrrrsecret1235556667777"))
+	c.Assert(model.PasswordHash(), gc.Equals, internalpassword.AgentPasswordHash("supppperrrrsecret1235556667777"))
 	c.Assert(model.Type(), gc.Equals, string(s.Model.Type()))
 	c.Assert(model.Tag(), gc.Equals, s.Model.ModelTag())
 	c.Assert(model.Owner(), gc.Equals, s.Model.Owner())

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	"github.com/kr/pretty"
 	"go.uber.org/mock/gomock"
@@ -37,6 +36,7 @@ import (
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/poolmanager"
 	"github.com/juju/juju/internal/storage/provider"
@@ -167,7 +167,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
 
-	c.Assert(newModel.PasswordHash(), gc.Equals, utils.AgentPasswordHash("supersecret1111111111111"))
+	c.Assert(newModel.PasswordHash(), gc.Equals, internalpassword.AgentPasswordHash("supersecret1111111111111"))
 	c.Assert(newModel.Type(), gc.Equals, original.Type())
 	c.Assert(newModel.Owner(), gc.Equals, original.Owner())
 	c.Assert(newModel.LatestToolsVersion(), gc.Equals, latestTools)

--- a/state/model.go
+++ b/state/model.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v5"
 	jujutxn "github.com/juju/txn/v3"
-	jujuutils "github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/controller"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -452,10 +452,10 @@ func (m *Model) ModelTag() names.ModelTag {
 
 // SetPassword sets the password for the model's agent.
 func (m *Model) SetPassword(password string) error {
-	if len(password) < jujuutils.MinAgentPasswordLength {
+	if len(password) < internalpassword.MinAgentPasswordLength {
 		return fmt.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
 	}
-	passwordHash := jujuutils.AgentPasswordHash(password)
+	passwordHash := internalpassword.AgentPasswordHash(password)
 	ops := []txn.Op{{
 		C:      modelsC,
 		Id:     m.doc.UUID,
@@ -483,7 +483,7 @@ func (m *Model) String() string {
 // PasswordValid returns whether the given password is valid
 // for the given application.
 func (m *Model) PasswordValid(password string) bool {
-	agentHash := jujuutils.AgentPasswordHash(password)
+	agentHash := internalpassword.AgentPasswordHash(password)
 	if agentHash == m.doc.PasswordHash {
 		return true
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v5"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/actions"
@@ -29,6 +28,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
 	mgoutils "github.com/juju/juju/internal/mongo/utils"
+	internalpassword "github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/tools"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -306,10 +306,10 @@ func (u *Unit) SetAgentVersion(v version.Binary) (err error) {
 
 // SetPassword sets the password for the machine's agent.
 func (u *Unit) SetPassword(password string) error {
-	if len(password) < utils.MinAgentPasswordLength {
+	if len(password) < internalpassword.MinAgentPasswordLength {
 		return fmt.Errorf("password is only %d bytes long, and is not a valid Agent password", len(password))
 	}
-	return u.setPasswordHash(utils.AgentPasswordHash(password))
+	return u.setPasswordHash(internalpassword.AgentPasswordHash(password))
 }
 
 // setPasswordHash sets the underlying password hash in the database directly
@@ -337,7 +337,7 @@ func (u *Unit) setPasswordHashOps(passwordHash string) []txn.Op {
 // PasswordValid returns whether the given password is valid
 // for the given unit.
 func (u *Unit) PasswordValid(password string) bool {
-	agentHash := utils.AgentPasswordHash(password)
+	agentHash := internalpassword.AgentPasswordHash(password)
 	if agentHash == u.doc.PasswordHash {
 		return true
 	}

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -120,7 +120,7 @@ func (s *UserSuite) TestAddUserSetsSalt(c *gc.C) {
 	salt, hash := state.GetUserPasswordSaltAndHash(user)
 	c.Assert(hash, gc.Not(gc.Equals), "")
 	c.Assert(salt, gc.Not(gc.Equals), "")
-	c.Assert(utils.UserPasswordHash("a-password", salt), gc.Equals, hash)
+	c.Assert(password.UserPasswordHash("a-password", salt), gc.Equals, hash)
 	c.Assert(user.PasswordValid("a-password"), jc.IsTrue)
 }
 
@@ -426,16 +426,16 @@ func (s *UserSuite) activeUsers(c *gc.C) []string {
 func (s *UserSuite) TestSetPasswordHash(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 
-	salt, err := utils.RandomSalt()
+	salt, err := password.RandomSalt()
 	c.Assert(err, jc.ErrorIsNil)
-	err = user.SetPasswordHash(utils.UserPasswordHash("foo", salt), salt)
+	err = user.SetPasswordHash(password.UserPasswordHash("foo", salt), salt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(user.PasswordValid("foo"), jc.IsTrue)
 	c.Assert(user.PasswordValid("bar"), jc.IsFalse)
 
 	// User passwords should *not* use the fast PasswordHash function
-	hash := utils.AgentPasswordHash("foo-12345678901234567890")
+	hash := password.AgentPasswordHash("foo-12345678901234567890")
 	c.Assert(err, jc.ErrorIsNil)
 	err = user.SetPasswordHash(hash, "")
 	c.Assert(err, jc.ErrorIsNil)
@@ -447,16 +447,16 @@ func (s *UserSuite) TestSetPasswordHashUppercaseName(c *gc.C) {
 	name := "NameWithUppercase"
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: name})
 
-	salt, err := utils.RandomSalt()
+	salt, err := password.RandomSalt()
 	c.Assert(err, jc.ErrorIsNil)
-	err = user.SetPasswordHash(utils.UserPasswordHash("foo", salt), salt)
+	err = user.SetPasswordHash(password.UserPasswordHash("foo", salt), salt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(user.PasswordValid("foo"), jc.IsTrue)
 	c.Assert(user.PasswordValid("bar"), jc.IsFalse)
 
 	// User passwords should *not* use the fast PasswordHash function
-	hash := utils.AgentPasswordHash("foo-12345678901234567890")
+	hash := password.AgentPasswordHash("foo-12345678901234567890")
 	c.Assert(err, jc.ErrorIsNil)
 	err = user.SetPasswordHash(hash, "")
 	c.Assert(err, jc.ErrorIsNil)
@@ -467,7 +467,7 @@ func (s *UserSuite) TestSetPasswordHashUppercaseName(c *gc.C) {
 func (s *UserSuite) TestSetPasswordHashWithSalt(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 
-	err := user.SetPasswordHash(utils.UserPasswordHash("foo", "salted"), "salted")
+	err := user.SetPasswordHash(password.UserPasswordHash("foo", "salted"), "salted")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(user.PasswordValid("foo"), jc.IsTrue)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -15,7 +15,6 @@ import (
 	charmresource "github.com/juju/charm/v13/resource"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
@@ -33,6 +32,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	objectstoretesting "github.com/juju/juju/internal/objectstore/testing"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
 	"github.com/juju/juju/internal/uuid"
@@ -285,7 +285,7 @@ func (factory *Factory) paramsFillDefaults(c *gc.C, params *MachineParams) *Mach
 	}
 	if params.Password == "" {
 		var err error
-		params.Password, err = utils.RandomPassword()
+		params.Password, err = password.RandomPassword()
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	if params.Characteristics == nil {
@@ -503,7 +503,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 	}
 	if params.Password == "" {
 		var err error
-		params.Password, err = utils.RandomPassword()
+		params.Password, err = password.RandomPassword()
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	if params.CharmOrigin == nil {
@@ -653,7 +653,7 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 	}
 	if params.Password == "" {
 		var err error
-		params.Password, err = utils.RandomPassword()
+		params.Password, err = password.RandomPassword()
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	unit, err := params.Application.AddUnit(state.AddUnitParams{})

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/internal/password"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
 	"github.com/juju/juju/state"
@@ -233,7 +233,7 @@ func (s *factorySuite) TestMakeMachineNil(c *gc.C) {
 func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	base := state.UbuntuBase("12.10")
 	jobs := []state.MachineJob{state.JobManageModel}
-	password, err := utils.RandomPassword()
+	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	nonce := "some-nonce"
 	id := instance.Id("some-id")


### PR DESCRIPTION
Following on from #16913 this brings in the password functionality to the internal package. This is an ongoing effort to centralize our dependencies. Having dependencies that are scattered into different repos, ones that aren't updated causes them to rot away. The uuid package from #16913 isn't 100% spec uuid v4, so we will need to refactor that to bring it up to spec. Nobody noticed that, and we should also audit the password package as well, to ensure that it is conformant.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-

