### PR TITLE
Fail actions which are interrupted due to an agent restart in the middle

### DIFF
--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -112,8 +112,8 @@ func (s *actionsSuite) TestNextActionNotAvailable(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{err: charmrunner.ErrActionNotAvailable})
-	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
-	c.Assert(op, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockFailAction("actionB"))
 }
 
 func (s *actionsSuite) TestNextActionBlockedRemoteInit(c *gc.C) {

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -67,6 +67,11 @@ func (f *mockOpFactory) NewAction(id string) (operation.Operation, error) {
 	return f.op, f.NextErr()
 }
 
+func (f *mockOpFactory) NewFailAction(id string) (operation.Operation, error) {
+	f.MethodCall(f, "NewFailAction", id)
+	return f.op, f.NextErr()
+}
+
 func (f *mockOpFactory) NewRemoteInit(runningStatus remotestate.ContainerRunningStatus) (operation.Operation, error) {
 	f.MethodCall(f, "NewRemoteInit", runningStatus)
 	return f.op, f.NextErr()

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -259,3 +259,34 @@ func (s *ResolverOpFactorySuite) TestActionsTrimming(c *gc.C) {
 		"d": {},
 	})
 }
+
+func (s *ResolverOpFactorySuite) TestFailActionsCommit(c *gc.C) {
+	f := resolver.NewResolverOpFactory(s.opFactory)
+	f.RemoteState.ActionsPending = []string{"action 1", "action 2", "action 3"}
+	f.LocalState.CompletedActions = map[string]struct{}{}
+	op, err := f.NewFailAction("action 1")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Commit(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
+		"action 1": {},
+	})
+}
+
+func (s *ResolverOpFactorySuite) TestFailActionsTrimming(c *gc.C) {
+	f := resolver.NewResolverOpFactory(s.opFactory)
+	f.RemoteState.ActionsPending = []string{"c", "d"}
+	f.LocalState.CompletedActions = map[string]struct{}{
+		"a": {},
+		"b": {},
+		"c": {},
+	}
+	op, err := f.NewFailAction("d")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Commit(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
+		"c": {},
+		"d": {},
+	})
+}


### PR DESCRIPTION
If a unit agent is killed and restarted in the middle of running an action, the action stays forever in the running state. This is because the unit agent was not running the FailAction operation to mark the action as failed and hence terminate it. In addition, the commit operation at the end of the fail action was not wired up to correctly update local state to remove the action from the "todo" list.

## QA steps

run an action like so

`juju exec -u someunit/0 -- "echo hello; reboot"`

After a few seconds for the machine to reboot, the CLI will exit back to a shell prompt (it blocks in the meantime).
The action is failed, and `juju show-task <n> --format yaml` shows the action was terminated and marked as failed.

Previously the CLI would block forever and the action would stay in the running state.

## Links

https://bugs.launchpad.net/juju/+bug/2012861

**Jira card:** JUJU-5438

