### PR TITLE
Insist users provide a base for pre-deployed charms

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -209,6 +209,7 @@ func (d *deployCharm) formatDeployingText() string {
 type predeployedLocalCharm struct {
 	deployCharm
 	userCharmURL *charm.URL
+	base         corebase.Base
 }
 
 // String returns a string description of the deployer.
@@ -234,20 +235,6 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		ctx.Infof("ignoring dry-run flag for local charms")
 	}
 
-	modelCfg, err := getModelConfig(deployAPI)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Avoid deploying charm if it's not valid for the model.
-	base, err := corebase.GetBaseFromSeries(d.userCharmURL.Series)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := d.validateCharmBaseWithName(base, userCharmURL.Name, modelCfg.ImageStream()); err != nil {
-		return errors.Trace(err)
-	}
-
 	if err := d.validateCharmFlags(); err != nil {
 		return errors.Trace(err)
 	}
@@ -265,7 +252,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 
-	platform := utils.MakePlatform(d.constraints, base, d.modelConstraints)
+	platform := utils.MakePlatform(d.constraints, d.base, d.modelConstraints)
 	origin, err := utils.MakeOrigin(charm.Local, userCharmURL.Revision, charm.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -54,6 +54,7 @@ func (s *deployerSuite) SetUpTest(_ *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerPredeployedLocalCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
+	s.expectModelGet(c)
 	s.expectModelType()
 
 	cfg := s.basicDeployerConfig()

--- a/core/base/supportedbases.go
+++ b/core/base/supportedbases.go
@@ -37,7 +37,7 @@ func seriesToBase(requestedBase Base, fn func(string) (set.Strings, error)) ([]B
 		var err error
 		requestedSeries, err = GetSeriesFromBase(requestedBase)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "%q is not a valid base", requestedBase.DisplayString())
 		}
 	}
 

--- a/core/base/supportedbases_test.go
+++ b/core/base/supportedbases_test.go
@@ -52,7 +52,7 @@ func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
 		name:          "invalid base",
 		requestedBase: MustParseBaseFromString("foo@bar"),
 		imageStream:   Daily,
-		err:           `os "foo" version "bar" not found`,
+		err:           `"foo@bar" is not a valid base: os "foo" version "bar" not found`,
 	}}
 	for _, test := range tests {
 		c.Logf("test %q", test.name)


### PR DESCRIPTION
Insist users provide a base for pre-deployed charms

This means we no longer need to parse a base from the series of
the charm url, which we can no longer guarentee will be present

Deploying pre-deployed charms is a very niche use case, which requires
the user to query the yaml or json output of "juju status" to find the
charm url. So a new breaking requirement like this is not a concern

A question was raised around how this would interact with bundles.
Particularly export bundle. However, this can be dismissed because
bundles and local charms are really compatible. It's not really possible
to deploy a bundle that makes reference to local charms

When, however, local charms are included in a model when export-bundle
is run, the "charm" field is filled in with the local charm url, and
bases/default-base is always included

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Ensure a local `ubuntu` charm exists at `~/charms/ubuntu`
```
$ juju add-model m
$ juju deploy ~/charm/ubuntu
$ juju status --format json | jq -r .applications.ubuntu.charm
local:jammy/ubuntu-0
$ juju deploy local:jammy/ubuntu-0 ubu2
ERROR must provide a base with the `--base` flag when deploying pre-deployed local charms

$ juju deploy local:jammy/ubuntu-0 ubu2 --base ubuntu@22.04
Located local charm "ubuntu", revision 0
Deploying "ubu2" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy local:jammy/ubuntu-0 ubu3 --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubu3" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  4.0-beta3.1  unsupported  14:30:37Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu2    22.04    active      1  ubuntu             0  no       
ubu3    20.04    active      1  ubuntu             0  no       
ubuntu  22.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubu2/0*    active    idle   1        10.219.211.228         
ubu3/0*    active    idle   2        10.219.211.82          
ubuntu/0*  active    idle   0        10.219.211.39          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.39   juju-425773-0  ubuntu@22.04      Running
1        started  10.219.211.228  juju-425773-1  ubuntu@22.04      Running
2        started  10.219.211.82   juju-425773-2  ubuntu@20.04      Running
```