### PR TITLE
Wires up credential owner to user table.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -243,13 +243,13 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 
 	databaseBootstrapConcerns := []database.BootstrapConcern{
 		database.BootstrapControllerConcern(
-			ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 			// The admin user needs to be added before everything else that
 			// requires being owned by a Juju user.
+			addAdminUser,
+			ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 			cloudbootstrap.InsertCloud(stateParams.ControllerCloud),
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
-			addAdminUser,
 			modelbootstrap.CreateModel(controllerModelUUID, controllerModelArgs),
 		),
 		database.BootstrapModelConcern(controllerModelUUID,

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/watcher/registry"
 	servicefactorytesting "github.com/juju/juju/domain/servicefactory/testing"
-	domaintesting "github.com/juju/juju/domain/testing"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -85,11 +84,10 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		controllerCfg[key] = value
 	}
 
-	s.ServiceFactorySuite.SetUpTest(c)
-	domaintesting.SeedControllerConfig(c, controllerCfg, s)
-
 	s.StateSuite.ControllerConfig = controllerCfg
 	s.StateSuite.SetUpTest(c)
+	s.ServiceFactorySuite.SetUpTest(c)
+	jujujujutesting.SeedDatabase(c, s.ControllerSuite.TxnRunner(), controllerCfg)
 
 	allWatcherBacking, err := state.NewAllWatcherBacking(s.StatePool)
 	c.Assert(err, jc.ErrorIsNil)
@@ -116,10 +114,6 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 		Tag:      s.Owner,
 		AdminTag: s.Owner,
 	}
-
-	err = jujujujutesting.InsertDummyCloudType(context.Background(), s.ControllerSuite.TxnRunner())
-	c.Assert(err, jc.ErrorIsNil)
-	jujujujutesting.SeedCloudCredentials(c, s.ControllerSuite.TxnRunner())
 
 	s.context = facadetest.Context{
 		State_:               s.State,

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -910,10 +910,14 @@ DELETE FROM cloud_auth_type
 }
 
 // AllowCloudType is responsible for applying the cloud type to
-// the given database.
+// the given database. If the unique constraint applies the error is masked and
+// returned as NIL.
 func AllowCloudType(ctx context.Context, db coredatabase.TxnRunner, version int, name string) error {
 	return errors.Trace(db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.Exec(`INSERT INTO cloud_type VALUES (?, ?)`, version, name)
+		if database.IsErrConstraintUnique(err) {
+			return nil
+		}
 		return err
 	}))
 }

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -10,9 +10,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	"github.com/juju/juju/domain/credential"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	userstate "github.com/juju/juju/domain/user/state"
 )
 
 type bootstrapSuite struct {
@@ -25,6 +27,18 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	ctx := context.Background()
 	cld := cloud.Cloud{Name: "cirrus", Type: "ec2", AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType}}
 	err := cloudbootstrap.InsertCloud(cld)(ctx, s.TxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+
+	userUUID, err := user.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	userState := userstate.NewState(s.TxnRunnerFactory())
+	err = userState.AddUser(
+		context.Background(), userUUID,
+		"fred",
+		"test user",
+		userUUID,
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
 
@@ -43,6 +57,6 @@ SELECT owner_uuid, cloud.name FROM cloud_credential
 JOIN cloud ON cloud.uuid = cloud_credential.cloud_uuid
 WHERE cloud_credential.name = ?`, "foo")
 	c.Assert(row.Scan(&owner, &cloudName), jc.ErrorIsNil)
-	c.Assert(owner, gc.Equals, "fred")
+	c.Assert(owner, gc.Equals, userUUID.String())
 	c.Assert(cloudName, gc.Equals, "cirrus")
 }

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -413,8 +413,11 @@ SELECT cloud_credential.uuid,
 FROM cloud_credential
 INNER JOIN cloud
 ON cloud.uuid = cloud_credential.cloud_uuid
+INNER JOIN user
+ON cloud_credential.owner_uuid = user.uuid
 WHERE cloud.name = ?
-AND cloud_credential.owner_uuid = ?
+AND user.name = ?
+AND user.removed = false
 AND cloud_credential.name = ?
 `
 

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -80,7 +80,7 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 	_, err = credSt.UpsertCloudCredential(
 		context.Background(), credential.ID{
 			Cloud: "my-cloud",
-			Owner: string(m.userUUID),
+			Owner: "test-user",
 			Name:  "foobar",
 		},
 		cred,
@@ -98,7 +98,7 @@ func (m *modelSuite) SetUpTest(c *gc.C) {
 			CloudRegion:  "my-region",
 			Credential: credential.ID{
 				Cloud: "my-cloud",
-				Owner: string(m.userUUID),
+				Owner: "test-user",
 				Name:  "foobar",
 			},
 			Name:  "my-test-model",
@@ -303,8 +303,8 @@ func (m *modelSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 	_, err = credSt.UpsertCloudCredential(
 		context.Background(), credential.ID{
 			Cloud: "my-cloud2",
-			Owner: string(m.userUUID),
-			Name:  "foobar",
+			Owner: "test-user",
+			Name:  "foobar1",
 		},
 		cred,
 	)
@@ -316,8 +316,8 @@ func (m *modelSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 		m.uuid,
 		credential.ID{
 			Cloud: "my-cloud2",
-			Owner: string(m.userUUID),
-			Name:  "foobar",
+			Owner: "test-user",
+			Name:  "foobar1",
 		},
 	)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
@@ -350,7 +350,7 @@ func (m *modelSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 	_, err = credSt.UpsertCloudCredential(
 		context.Background(), credential.ID{
 			Cloud: "minikube",
-			Owner: string(m.userUUID),
+			Owner: "test-user",
 			Name:  "foobar",
 		},
 		cred,
@@ -366,7 +366,7 @@ func (m *modelSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 			Cloud: "minikube",
 			Credential: credential.ID{
 				Cloud: "minikube",
-				Owner: string(m.userUUID),
+				Owner: "test-user",
 				Name:  "foobar",
 			},
 			Name:  "controller",

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -279,9 +279,9 @@ CREATE TABLE cloud_credential (
         CONSTRAINT          fk_cloud_credential_auth_type
             FOREIGN KEY         (auth_type_id)
             REFERENCES          auth_type(id)
---        CONSTRAINT          fk_cloud_credential_XXXX
---            FOREIGN KEY         (owner_uuid)
---            REFERENCES          XXXX(uuid)
+        CONSTRAINT          fk_cloud_credential_user
+            FOREIGN KEY         (owner_uuid)
+            REFERENCES          user(uuid)
 );
 
 CREATE UNIQUE INDEX idx_cloud_credential_cloud_uuid_owner_uuid

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -602,18 +602,25 @@ func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
 // SeedDatabase the database with a supplied controller config, and dummy
 // cloud and dummy credentials.
 func SeedDatabase(c *gc.C, runner database.TxnRunner, controllerConfig controller.Config) {
-	_, userAdd := userbootstrap.AddUser(coreuser.AdminUserName)
-	err := userAdd(context.Background(), runner)
-	c.Assert(err, jc.ErrorIsNil)
+	SeedAdminUser(c, runner)
 
-	err = controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), runner)
+	err := controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 
 	SeedCloudCredentials(c, runner)
 }
 
+func SeedAdminUser(c *gc.C, runner database.TxnRunner) {
+	_, userAdd := userbootstrap.AddUser(coreuser.AdminUserName)
+	err := userAdd(context.Background(), runner)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func SeedCloudCredentials(c *gc.C, runner database.TxnRunner) {
-	err := cloudbootstrap.InsertCloud(DefaultCloud)(context.Background(), runner)
+	err := InsertDummyCloudType(context.Background(), runner)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cloudbootstrap.InsertCloud(DefaultCloud)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 
 	id := credential.ID{


### PR DESCRIPTION
When we introduced the cloud credential DDL  we did not have a user table yet to wire up cloud credential owners.

This adds the missing link and updates all of our code to maintain the referential integrity.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Run unit tests
2. Bootstrap a controller and confirm all goes smoothly with no errors.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5341

