### PR TITLE
Clean up unnecessary log in the bootstrap worker

### DIFF
--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -271,8 +271,6 @@ func (w *bootstrapWorker) filterHostPortsForManagementSpace(
 ) []network.SpaceHostPorts {
 	var hostPortsForAgents []network.SpaceHostPorts
 
-	w.logger.Errorf("************************")
-
 	if mgmtSpace == "" {
 		hostPortsForAgents = apiHostPorts
 	} else {


### PR DESCRIPTION
Small patch to clean up a debug log left by error in a previous patch on the bootstrap worker in the filterHostPortsForManagementSpace() method.



