### PR TITLE
Fix the HasModelAdmin API to handle non admins properly

### DIFF
--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -113,5 +113,8 @@ func HasModelAdmin(
 	}
 
 	err = authorizer.HasPermission(permission.AdminAccess, modelTag)
-	return err == nil, err
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return false, err
+	}
+	return err == nil, nil
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -59,8 +59,14 @@ func (s *SecretsAPI) checkCanWrite() error {
 }
 
 func (s *SecretsAPI) checkCanAdmin() error {
-	_, err := common.HasModelAdmin(s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
-	return err
+	isAdmin, err := common.HasModelAdmin(s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if isAdmin {
+		return nil
+	}
+	return apiservererrors.ErrPerm
 }
 
 // ListSecrets lists available secrets.


### PR DESCRIPTION
The HasModelAdmin permission check was returning an error if the user was not a model admin. The expected semantics of the method are to match what HasPermission does: return either (false, nil) or (true, nil) if the check was done successfully, and only return an error if doing the check failed.

Once the fix was done, one of the 3 call sites - getting a secret - needed to be updated to match.

## QA steps

bootstrap and create a secret
juju secret --reveal

create a new user and juju give them read access
juju secret --reveal -> permission error
give them admin access
juju secret --reveal

## Links


**Jira card:** JUJU-5485