### PR TITLE
Adds bootstrapping of user with no auth.

### DIFF
--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -5,43 +5,94 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/user"
+	domainuser "github.com/juju/juju/domain/user"
 	"github.com/juju/juju/domain/user/state"
 	"github.com/juju/juju/internal/auth"
 )
 
-// AddUserWithPassword inserts the admin user into database.
-// It is used to bootstrap the database.
+// AddUser is responsible for registering a new user in the system at bootstrap
+// time. Sometimes it is required that we are need to register the existence of a
+// user for ownership purposes but may not necessarily want to have local
+// controller authentication for the user. The user created by this function is
+// owned by itself.
 //
-// Admin user is created with the following characteristics:
-// 1. This is first user created in the system.
-// 2. This user is used to owner of the first model created in the system.
-// 3. This user is created with no password authorization by default.
+// If the username passed to this function is invalid an error satisfying
+// [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
+func AddUser(name string) (user.UUID, func(context.Context, database.TxnRunner) error) {
+	if err := domainuser.ValidateUsername(name); err != nil {
+		return user.UUID(""), func(context.Context, database.TxnRunner) error {
+			return fmt.Errorf("validating bootstrap add user %q: %w", name, err)
+		}
+	}
+
+	uuid, err := user.NewUUID()
+	if err != nil {
+		return user.UUID(""), func(_ context.Context, _ database.TxnRunner) error {
+			return fmt.Errorf("generating bootstrap user %q uuid: %w", name, err)
+		}
+	}
+
+	return uuid, func(ctx context.Context, db database.TxnRunner) error {
+		err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			return state.AddUser(ctx, tx, uuid, name, "", uuid)
+		})
+
+		if err != nil {
+			return fmt.Errorf("adding bootstrap user %q: %w", name, err)
+		}
+		return nil
+	}
+}
+
+// AddUserWithPassword is responsible for adding a new user in the system at
+// bootstrap time with an associated authentication password. The user created
+// by this function is owned by itself.
+//
+// If the username passed to this function is invalid an error satisfying
+// [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
 func AddUserWithPassword(name string, password auth.Password) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	defer password.Destroy()
+
+	if err := domainuser.ValidateUsername(name); err != nil {
+		return user.UUID(""), func(context.Context, database.TxnRunner) error {
+			return fmt.Errorf("validating bootstrap add user %q with password: %w", name, err)
+		}
+	}
+
 	uuid, err := user.NewUUID()
 	if err != nil {
 		return "", func(context.Context, database.TxnRunner) error {
-			return errors.Annotate(err, "generating uuid for bootstrap admin user")
+			return fmt.Errorf(
+				"generating uuid for bootstrap add user %q with password: %w",
+				name, err,
+			)
 		}
 	}
 
 	salt, err := auth.NewSalt()
 	if err != nil {
 		return "", func(context.Context, database.TxnRunner) error {
-			return errors.Annotate(err, "generating salt for bootstrap admin user")
+			return fmt.Errorf(
+				"generating salt for bootstrap add user %q with password: %w",
+				name, err,
+			)
 		}
 	}
 
 	pwHash, err := auth.HashPassword(password, salt)
 	if err != nil {
 		return "", func(context.Context, database.TxnRunner) error {
-			return errors.Annotate(err, "generating password hash for bootstrap admin user")
+			return fmt.Errorf(
+				"generating password hash for bootstrap add user %q with password: %w",
+				name, err,
+			)
 		}
 	}
 
@@ -57,7 +108,9 @@ func AddUserWithPassword(name string, password auth.Password) (user.UUID, func(c
 				pwHash,
 				salt,
 			); err != nil {
-				return errors.Annotate(err, "creating bootstrap admin user")
+				return fmt.Errorf("adding bootstrap user %q with password: %w",
+					name, err,
+				)
 			}
 			return nil
 		}))

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -19,6 +19,21 @@ type bootstrapSuite struct {
 
 var _ = gc.Suite(&bootstrapSuite{})
 
+func (s *bootstrapSuite) TestAddUser(c *gc.C) {
+	ctx := context.Background()
+	uuid, addAdminUser := AddUser("admin")
+	err := addAdminUser(ctx, s.TxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uuid.Validate(), jc.ErrorIsNil)
+
+	// Check that the user was created.
+	var name string
+	row := s.DB().QueryRow(`
+SELECT name FROM user WHERE name = ?`, "admin")
+	c.Assert(row.Scan(&name), jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "admin")
+}
+
 func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 	ctx := context.Background()
 	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"))

--- a/domain/user/package_test.go
+++ b/domain/user/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -48,7 +48,7 @@ func (st *State) AddUser(
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(addUser(ctx, tx, uuid, name, displayName, creatorUUID))
+		return errors.Trace(AddUser(ctx, tx, uuid, name, displayName, creatorUUID))
 	})
 }
 
@@ -94,7 +94,7 @@ func (st *State) AddUserWithActivationKey(
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = addUser(ctx, tx, uuid, name, displayName, creatorUUID)
+		err = AddUser(ctx, tx, uuid, name, displayName, creatorUUID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -489,7 +489,7 @@ func AddUserWithPassword(
 	passwordHash string,
 	salt []byte,
 ) error {
-	err := addUser(ctx, tx, uuid, name, displayName, creatorUUID)
+	err := AddUser(ctx, tx, uuid, name, displayName, creatorUUID)
 	if err != nil {
 		return errors.Annotatef(err, "adding user with uuid %q", uuid)
 	}
@@ -536,11 +536,11 @@ WHERE user_uuid = $M.uuid
 	})
 }
 
-// addUser adds a new user to the database. If the user already exists an error
+// AddUser adds a new user to the database. If the user already exists an error
 // that satisfies usererrors.AlreadyExists will be returned. If the creator does
 // not exist an error that satisfies usererrors.UserCreatorUUIDNotFound will be
 // returned.
-func addUser(ctx context.Context, tx *sqlair.TX, uuid user.UUID, name string, displayName string, creatorUuid user.UUID) error {
+func AddUser(ctx context.Context, tx *sqlair.TX, uuid user.UUID, name string, displayName string, creatorUuid user.UUID) error {
 	addUserQuery := `
 INSERT INTO user (uuid, name, display_name, created_by_uuid, created_at) 
 VALUES ($M.uuid, $M.name, $M.display_name, $M.created_by_uuid, $M.created_at)

--- a/domain/user/testing/testing.go
+++ b/domain/user/testing/testing.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+var (
+	InvalidUsernames = []string{
+		"😱",  // We don't support emoji's
+		"+蓮", // Cannot start with a +
+		"-蓮", // Cannot start with a -
+		".蓮", // Cannot start with a .
+		"蓮+", // Cannot end with a +
+		"蓮-", // Cannot end with a -
+		"蓮.", // Cannot end with a .
+
+		// long username that is valid for the regex but too long.
+		"A1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRa",
+	}
+
+	ValidUsernames = []string{
+		"蓮", // Ren in Japanese
+		"wallyworld",
+		"r", // username for Rob Pike, fixes lp1620444
+		"Jürgen.test",
+		"Günter+++test",
+		"王",      // Wang in Chinese
+		"杨-test", // Yang in Chinese
+		"اقتدار",
+		"f00-Bar.ram77",
+		// long username that is pushing the boundaries of 255 chars.
+		"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.+-1234567890",
+
+		// Some Romanian usernames. Thanks Dora!!!
+		"Alinuța",
+		"Bulișor",
+		"Gheorghiță",
+		"Mărioara",
+		"Vasilică",
+
+		// Some Turkish usernames, Thanks Caner!!!
+		"rüştü",
+		"özlem",
+		"yağız",
+	}
+)

--- a/domain/user/validation.go
+++ b/domain/user/validation.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"regexp"
+
+	"github.com/juju/errors"
+
+	usererrors "github.com/juju/juju/domain/user/errors"
+)
+
+const (
+	// usernameValidationRegex is the regex used to validate that user names are
+	// valid for consumption by Juju. User names must be 1 or more runes long,
+	// can contain any unicode rune from the letter/number class and may contain
+	// zero or more of .,+ or - runes as long as they don't appear at the
+	// start or end of the user name. User names can be a maximum of 255
+	// characters long.
+	usernameValidationRegex = "^([\\pL\\pN]|[\\pL\\pN][\\pL\\pN.+-]{0,253}[\\pL\\pN])$"
+)
+
+var (
+	// validUserName is a compiled regex that is used to validate that a user
+	validUserName = regexp.MustCompile(usernameValidationRegex)
+)
+
+// ValidateUsername takes a user name and validates that the user name is
+// conformant to our regex rules defined in usernameValidationRegex. If a
+// user name is not valid, an error is returned that satisfies
+// usererrors.UsernameNotValid.
+//
+// User names must be one or more runes long, can contain any unicode rune from
+// the letter or number class and may contain zero or more of .,+ or - runes as
+// long as they don't appear at the start or end of the user name. User names can
+// be a maximum length of 255 characters.
+func ValidateUsername(name string) error {
+	if !validUserName.MatchString(name) {
+		return errors.Annotatef(usererrors.UsernameNotValid, "%q", name)
+	}
+	return nil
+}

--- a/domain/user/validation_test.go
+++ b/domain/user/validation_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	usererrors "github.com/juju/juju/domain/user/errors"
+	usertesting "github.com/juju/juju/domain/user/testing"
+)
+
+type validationSuite struct{}
+
+var _ = gc.Suite(&validationSuite{})
+
+// TestUsernameValidation exists to assert the regex that is in use by
+// ValidateUsername. We want to pass it a wide range of unicode names with weird
+func (s *validationSuite) TestUsernameValidation(c *gc.C) {
+	tests := []struct {
+		Username   string
+		ShouldPass bool
+	}{}
+
+	for _, valid := range usertesting.ValidUsernames {
+		tests = append(tests, struct {
+			Username   string
+			ShouldPass bool
+		}{valid, true})
+	}
+
+	for _, invalid := range usertesting.InvalidUsernames {
+		tests = append(tests, struct {
+			Username   string
+			ShouldPass bool
+		}{invalid, false})
+	}
+
+	for _, test := range tests {
+		err := ValidateUsername(test.Username)
+		if test.ShouldPass {
+			c.Assert(err, jc.ErrorIsNil, gc.Commentf("test username %q", test.Username))
+		} else {
+			c.Assert(
+				err, jc.ErrorIs, usererrors.UsernameNotValid,
+				gc.Commentf("test username %q", test.Username),
+			)
+		}
+	}
+}

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -49,6 +49,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/trace"
+	coreuser "github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	cloudstate "github.com/juju/juju/domain/cloud/state"
 	controllerconfigbootstrap "github.com/juju/juju/domain/controllerconfig/bootstrap"
@@ -57,6 +58,7 @@ import (
 	credentialstate "github.com/juju/juju/domain/credential/state"
 	"github.com/juju/juju/domain/model"
 	servicefactorytesting "github.com/juju/juju/domain/servicefactory/testing"
+	userbootstrap "github.com/juju/juju/domain/user/bootstrap"
 	databasetesting "github.com/juju/juju/internal/database/testing"
 	internallease "github.com/juju/juju/internal/lease"
 	"github.com/juju/juju/internal/mongo"
@@ -587,7 +589,11 @@ func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
 // SeedDatabase the database with a supplied controller config, and dummy
 // cloud and dummy credentials.
 func SeedDatabase(c *gc.C, runner database.TxnRunner, controllerConfig controller.Config) {
-	err := controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), runner)
+	_, userAdd := userbootstrap.AddUser(coreuser.AdminUserName)
+	err := userAdd(context.Background(), runner)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), runner)
 	c.Assert(err, jc.ErrorIsNil)
 
 	SeedCloudCredentials(c, runner)


### PR DESCRIPTION
It is sometimes needed that we must register a user in the Juju database with no authentication information. This could be in cases where the Juju user comes from another system or cases where we just need the user for testing to create ownership links.

This change adds a new function to bootstrap for adding a user with no auth. It also updates the bootstrap functions to validate usernames that are being passed in as they are created outside of the bootstrap process and may violate the buisness logic we have.

Change also creates the admin user in the apiserver suite for testing.

This is work is needed as part of #16925 to fix failing unit tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

- Unit tests are sufficient for this change.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5341

