### PR TITLE
Fix behaviour of relation-get hook tool when no --app flag passed

### DIFF
--- a/worker/uniter/runner/jujuc/relation-get.go
+++ b/worker/uniter/runner/jujuc/relation-get.go
@@ -104,13 +104,19 @@ func (c *RelationGetCommand) determineUnitOrAppName(args *[]string) error {
 				c.UnitOrAppName = appName
 			}
 		} else {
+			if !names.IsValidUnit(userSupplied) {
+				if names.IsValidApplication(userSupplied) {
+					return fmt.Errorf("expected unit name, got application name %q", userSupplied)
+				}
+				return fmt.Errorf("invalid unit name %q", userSupplied)
+			}
 			c.UnitOrAppName = userSupplied
 		}
 		return nil
 	}
 	if c.Application {
 		name, err := c.ctx.RemoteApplicationName()
-		if errors.IsNotFound(err) {
+		if errors.Is(err, errors.NotFound) {
 			return fmt.Errorf("no unit or application specified")
 		} else if err != nil {
 			return errors.Trace(err)

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -444,26 +444,38 @@ var relationGetInitTests = []relationGetInitTest{
 		unit:        "u",
 		application: true,
 	}, {
-		summary:     "app name but overridden by args",
+		summary:     "app name in context but overridden by args",
 		ctxunit:     "",
 		ctxapp:      "u",
 		unit:        "mysql/0",
 		args:        []string{"-", "mysql/0"},
 		application: false,
 	}, {
-		summary: "app name but overridden by unit args",
-		ctxunit: "",
-		ctxapp:  "u",
-		unit:    "mysql",
-		args:    []string{"-", "mysql"},
-		// This doesn't get auto set if we didn't pull it from the context
-		application: false,
-	}, {
 		summary: "extra arguments",
 		ctxunit: "u/0",
 		ctxapp:  "u",
-		args:    []string{"-", "mysql", "args"},
+		args:    []string{"-", "--app", "mysql", "args"},
 		err:     `unrecognized args: \["args"\]`,
+	}, {
+		summary: "app name in context but overridden by app args",
+		ctxunit: "",
+		ctxapp:  "u",
+		unit:    "mysql",
+		args:    []string{"-", "--app", "mysql"},
+		// This doesn't get auto set if we didn't pull it from the context
+		application: true,
+	}, {
+		summary: "application name with no --app",
+		ctxunit: "u/0",
+		ctxapp:  "u",
+		args:    []string{"-", "mysql"},
+		err:     `expected unit name, got application name "mysql"`,
+	}, {
+		summary: "invalid unit name",
+		ctxunit: "u/0",
+		ctxapp:  "u",
+		args:    []string{"-", "unit//0"},
+		err:     `invalid unit name "unit//0"`,
 	},
 }
 


### PR DESCRIPTION
The relation-get hook tool defaults to getting info about the unit relation. It has an `--app` flag to get information about the application relation instead. 

The documentation for the function that determins which relation to get (`determineUnitOrAppName`) states that if no `--app` flag is provided and an app name is passed then an error should be thrown. This is not what happens.

I have added in an error that is returned in this case, and an extra check to see if it is a valid unit name or not (i.e. it could be an invalid unit name and application name). I have updated the unit tests to reflect this and removed a test confirming the erroneous behavior.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Unit tests
```
go test ./worker/uniter/runner/jujuc
```
Black box test
```
# Setup
juju bootstrap lxd lxd-dev
juju add-model default
juju deploy ./testcharms/charms/dummy-sink
juju deploy ./testcharms/charms/dummy-source
# Wait for machines
juju integrate dummy-sink dummy-source

# Test app name with no --app flag
juju exec --unit dummy-sink/0 "relation-get -r 0 - dummy-sink"   
# ERROR expected unit name, got applicaiton name dummy-sink

# Test invalid unit name
juju exec --unit dummy-sink/0 "relation-get -r 0 - dummy-sink//0"
# ERROR invalid unit name dummy-sink//0
```

<!-- Describe steps to verify that the change works. -->


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2053282

