### PR TITLE
Merge 3.3 to 3.4

### DIFF
--- a/.github/microk8s-launch-config-aws.yaml
+++ b/.github/microk8s-launch-config-aws.yaml
@@ -7,9 +7,8 @@ addons:
   - name: dns
 containerdRegistryConfigs:
   docker.io: |
-    [host."http://10.0.1.123:80"]
+    [host."https://docker-cache.us-west-2.aws.jujuqa.com:443"]
       capabilities = ["pull", "resolve"]
-      skip_verify = true
   10.152.183.69: |
     [host."https://10.152.183.69:443"]
       capabilities = ["pull", "resolve", "push"]

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Setup Docker Mirror
       shell: bash
       run: |
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,8 +46,7 @@ jobs:
     - name: Setup Docker Mirror
       shell: bash
       run: |
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.insecure-registries += ["10.0.1.123"]' | sudo tee /etc/docker/daemon.json
+        (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
         docker system info
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -110,8 +110,7 @@ jobs:
         if: matrix.cloud == 'microk8s'
         shell: bash
         run: |
-          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["http://10.0.1.123:80"]' | sudo tee /etc/docker/daemon.json
-          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json ".insecure-registries += [\"10.0.1.123\",\"${DOCKER_REGISTRY}\"]" | sudo tee /etc/docker/daemon.json
+          (cat /etc/docker/daemon.json 2> /dev/null || echo "{}") | yq -o json '.registry-mirrors += ["https://docker-cache.us-west-2.aws.jujuqa.com:443"]' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker system info
 

--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -113,5 +113,8 @@ func HasModelAdmin(
 	}
 
 	err = authorizer.HasPermission(permission.AdminAccess, modelTag)
-	return err == nil, err
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return false, err
+	}
+	return err == nil, nil
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/crossmodel.go
@@ -111,6 +111,20 @@ func (m *MockCrossModelSecretsClient) EXPECT() *MockCrossModelSecretsClientMockR
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockCrossModelSecretsClient) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockCrossModelSecretsClientMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCrossModelSecretsClient)(nil).Close))
+}
+
 // GetRemoteSecretContentInfo mocks base method.
 func (m *MockCrossModelSecretsClient) GetRemoteSecretContentInfo(arg0 *secrets.URI, arg1 int, arg2, arg3 bool, arg4, arg5 string, arg6 int, arg7 macaroon.Slice) (*secrets0.ContentParams, *provider.ModelBackendConfig, int, bool, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1293,6 +1293,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	mac := apitesting.MustNewMacaroon("id")
 
 	s.remoteClient = mocks.NewMockCrossModelSecretsClient(ctrl)
+	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumer).Return(&coresecrets.SecretConsumerMetadata{
@@ -1359,6 +1360,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	mac := apitesting.MustNewMacaroon("id")
 
 	s.remoteClient = mocks.NewMockCrossModelSecretsClient(ctrl)
+	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumer).Return(&coresecrets.SecretConsumerMetadata{
@@ -1430,6 +1432,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 	mac := apitesting.MustNewMacaroon("id")
 
 	s.remoteClient = mocks.NewMockCrossModelSecretsClient(ctrl)
+	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumer).Return(&coresecrets.SecretConsumerMetadata{
@@ -1501,6 +1504,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 	mac := apitesting.MustNewMacaroon("id")
 
 	s.remoteClient = mocks.NewMockCrossModelSecretsClient(ctrl)
+	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumer).Return(nil, errors.NotFoundf(""))

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -59,8 +59,14 @@ func (s *SecretsAPI) checkCanWrite() error {
 }
 
 func (s *SecretsAPI) checkCanAdmin() error {
-	_, err := common.HasModelAdmin(s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
-	return err
+	isAdmin, err := common.HasModelAdmin(s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if isAdmin {
+		return nil
+	}
+	return apiservererrors.ErrPerm
 }
 
 // ListSecrets lists available secrets.

--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
 	golang.org/x/sys v0.15.0
+	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.16.1
 	google.golang.org/api v0.154.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
@@ -292,7 +293,6 @@ require (
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect
 	google.golang.org/grpc v1.59.0 // indirect

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -11,6 +11,7 @@ import (
 
 	lxdapi "github.com/canonical/lxd/shared/api"
 	"github.com/juju/collections/set"
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -39,13 +40,10 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 		}
 	}
 
-	// Query the lxd server name; we will use that as the AZ name for any
-	// subnets that we report.
-	serverInfo, _, err := srv.GetServer()
+	availabilityZones, err := e.AvailabilityZones(ctx)
 	if err != nil {
-		return nil, errors.Annotate(err, "looking up lxd server details")
+		return nil, errors.Annotate(err, "retrieving lxd availability zones")
 	}
-	azName := serverInfo.Environment.ServerName
 
 	networks, err := srv.GetNetworks()
 	if err != nil {
@@ -80,7 +78,7 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 			// so this call will fail. If that's the case then
 			// use a fallback method for detecting subnets.
 			if isErrMissingAPIExtension(err, "network_state") {
-				return e.subnetDetectionFallback(srv, inst, keepList, azName)
+				return e.subnetDetectionFallback(srv, inst, keepList, availabilityZones)
 			}
 			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
 		}
@@ -108,7 +106,7 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 			}
 
 			uniqueSubnetIDs.Add(subnetID)
-			subnets = append(subnets, makeSubnetInfo(network.Id(subnetID), makeNetworkID(networkName), cidr, azName))
+			subnets = append(subnets, makeSubnetInfo(network.Id(subnetID), makeNetworkID(networkName), cidr, availabilityZones))
 		}
 	}
 
@@ -127,7 +125,7 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 // Caveat: this method offers lower data fidelity compared to Subnets() as it
 // cannot accurately detect the CIDRs for any host devices that are not bridged
 // into the container.
-func (e *environ) subnetDetectionFallback(srv Server, inst instance.Id, keepSubnetIDs set.Strings, azName string) ([]network.SubnetInfo, error) {
+func (e *environ) subnetDetectionFallback(srv Server, inst instance.Id, keepSubnetIDs set.Strings, availabilityZones network.AvailabilityZones) ([]network.SubnetInfo, error) {
 	logger.Warningf("falling back to subnet discovery via introspection of devices bridged to the controller container; consider upgrading to a newer LXD version and running 'juju reload-spaces' to get full subnet discovery for the LXD host")
 
 	// If no instance ID is specified, list the alive containers, query the
@@ -184,7 +182,7 @@ func (e *environ) subnetDetectionFallback(srv Server, inst instance.Id, keepSubn
 			}
 
 			uniqueSubnetIDs.Add(subnetID)
-			subnets = append(subnets, makeSubnetInfo(network.Id(subnetID), makeNetworkID(hostNetworkName), cidr, azName))
+			subnets = append(subnets, makeSubnetInfo(network.Id(subnetID), makeNetworkID(hostNetworkName), cidr, availabilityZones))
 		}
 	}
 
@@ -206,13 +204,14 @@ func makeSubnetIDForNetwork(networkName, address, mask string) (string, string, 
 	return subnetID, cidr, nil
 }
 
-func makeSubnetInfo(subnetID network.Id, networkID network.Id, cidr, azName string) network.SubnetInfo {
+func makeSubnetInfo(subnetID network.Id, networkID network.Id, cidr string, availabilityZones network.AvailabilityZones) network.SubnetInfo {
+	azNames := transform.Slice(availabilityZones, func(az network.AvailabilityZone) string { return az.Name() })
 	return network.SubnetInfo{
 		ProviderId:        subnetID,
 		ProviderNetworkId: networkID,
 		CIDR:              cidr,
 		VLANTag:           0,
-		AvailabilityZones: []string{azName},
+		AvailabilityZones: azNames,
 	}
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -534,3 +534,4 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.novarc
+

--- a/worker/lease/doc.go
+++ b/worker/lease/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package lease, also known as the manager, manages the leases used by
+// individual Juju workers.
+//
+// Workers will claim a lease, and they are either attributed (i.e., the workers
+// gets the lease ) or blocked (i.e., the worker is waiting for a lease to
+// become available).
+// In the latter case, the manager will keep track of all the blocked claims.
+// When a worker's lease expires or gets revoked, then the manager will
+// re-attribute it to one of other workers, thus unblocking them and satisfying
+// their claim.
+// In the special case where a worker is upgrading an application, it will ask
+// the manager to "pin" the lease. This means that the lease will not expire or
+// be revoked during the upgrade, and the validity of the lease will get
+// refreshed once the upgrade has completed. The overall effect is that the
+// application unit does not lose leadership during an upgrade.
+package lease

--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -112,8 +112,8 @@ func (s *actionsSuite) TestNextActionNotAvailable(c *gc.C) {
 		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{err: charmrunner.ErrActionNotAvailable})
-	c.Assert(err, gc.DeepEquals, resolver.ErrNoOperation)
-	c.Assert(op, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockFailAction("actionB"))
 }
 
 func (s *actionsSuite) TestNextActionBlockedRemoteInit(c *gc.C) {

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -67,6 +67,11 @@ func (f *mockOpFactory) NewAction(id string) (operation.Operation, error) {
 	return f.op, f.NextErr()
 }
 
+func (f *mockOpFactory) NewFailAction(id string) (operation.Operation, error) {
+	f.MethodCall(f, "NewFailAction", id)
+	return f.op, f.NextErr()
+}
+
 func (f *mockOpFactory) NewRemoteInit(runningStatus remotestate.ContainerRunningStatus) (operation.Operation, error) {
 	f.MethodCall(f, "NewRemoteInit", runningStatus)
 	return f.op, f.NextErr()

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -259,3 +259,34 @@ func (s *ResolverOpFactorySuite) TestActionsTrimming(c *gc.C) {
 		"d": {},
 	})
 }
+
+func (s *ResolverOpFactorySuite) TestFailActionsCommit(c *gc.C) {
+	f := resolver.NewResolverOpFactory(s.opFactory)
+	f.RemoteState.ActionsPending = []string{"action 1", "action 2", "action 3"}
+	f.LocalState.CompletedActions = map[string]struct{}{}
+	op, err := f.NewFailAction("action 1")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Commit(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
+		"action 1": {},
+	})
+}
+
+func (s *ResolverOpFactorySuite) TestFailActionsTrimming(c *gc.C) {
+	f := resolver.NewResolverOpFactory(s.opFactory)
+	f.RemoteState.ActionsPending = []string{"c", "d"}
+	f.LocalState.CompletedActions = map[string]struct{}{
+		"a": {},
+		"b": {},
+		"c": {},
+	}
+	op, err := f.NewFailAction("d")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Commit(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.LocalState.CompletedActions, gc.DeepEquals, map[string]struct{}{
+		"c": {},
+		"d": {},
+	})
+}

--- a/worker/uniter/runner/jujuc/relation-get.go
+++ b/worker/uniter/runner/jujuc/relation-get.go
@@ -104,13 +104,19 @@ func (c *RelationGetCommand) determineUnitOrAppName(args *[]string) error {
 				c.UnitOrAppName = appName
 			}
 		} else {
+			if !names.IsValidUnit(userSupplied) {
+				if names.IsValidApplication(userSupplied) {
+					return fmt.Errorf("expected unit name, got application name %q", userSupplied)
+				}
+				return fmt.Errorf("invalid unit name %q", userSupplied)
+			}
 			c.UnitOrAppName = userSupplied
 		}
 		return nil
 	}
 	if c.Application {
 		name, err := c.ctx.RemoteApplicationName()
-		if errors.IsNotFound(err) {
+		if errors.Is(err, errors.NotFound) {
 			return fmt.Errorf("no unit or application specified")
 		} else if err != nil {
 			return errors.Trace(err)

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -444,26 +444,38 @@ var relationGetInitTests = []relationGetInitTest{
 		unit:        "u",
 		application: true,
 	}, {
-		summary:     "app name but overridden by args",
+		summary:     "app name in context but overridden by args",
 		ctxunit:     "",
 		ctxapp:      "u",
 		unit:        "mysql/0",
 		args:        []string{"-", "mysql/0"},
 		application: false,
 	}, {
-		summary: "app name but overridden by unit args",
-		ctxunit: "",
-		ctxapp:  "u",
-		unit:    "mysql",
-		args:    []string{"-", "mysql"},
-		// This doesn't get auto set if we didn't pull it from the context
-		application: false,
-	}, {
 		summary: "extra arguments",
 		ctxunit: "u/0",
 		ctxapp:  "u",
-		args:    []string{"-", "mysql", "args"},
+		args:    []string{"-", "--app", "mysql", "args"},
 		err:     `unrecognized args: \["args"\]`,
+	}, {
+		summary: "app name in context but overridden by app args",
+		ctxunit: "",
+		ctxapp:  "u",
+		unit:    "mysql",
+		args:    []string{"-", "--app", "mysql"},
+		// This doesn't get auto set if we didn't pull it from the context
+		application: true,
+	}, {
+		summary: "application name with no --app",
+		ctxunit: "u/0",
+		ctxapp:  "u",
+		args:    []string{"-", "mysql"},
+		err:     `expected unit name, got application name "mysql"`,
+	}, {
+		summary: "invalid unit name",
+		ctxunit: "u/0",
+		ctxapp:  "u",
+		args:    []string{"-", "unit//0"},
+		err:     `invalid unit name "unit//0"`,
 	},
 }
 


### PR DESCRIPTION
There were no merge conflicts from this, the commits added are:

#16844 Support minikube env folder on juju snap.
#16876 Pass all the availability zones when discovering subnets in clustered lxd.
#16890 Revert dot-minikube on snapcraft until auto-connect is approved.
#16567 Add lease manager worker documentation.
#16898 Suppress klog log messages. 
#16905 Ensure we close client.
#16915 Merge branch '3.1' of https://github.com/juju/juju into 3.1-into-3.3.
#16917 Fix docker cache for github actions.
#16922 Fail actions which are interrupted due to an agent restart in the middle.
#16930 Fix the HasModelAdmin API to handle non admins properly.
#16936 Merge branch '2.9' into merge-2.9-3.1. 
#16937 Merge branch '3.1' into merge-3.1-3.3.
#16938 Add check for relation-get with app arguemnt but no --app flag.

