### PR TITLE
Increase the allowed size of a single secret attribute

### DIFF
--- a/core/secrets/createsecret.go
+++ b/core/secrets/createsecret.go
@@ -23,7 +23,7 @@ type SecretData map[string]string
 
 const (
 	fileSuffix          = "#file"
-	maxValueSizeBytes   = 5 * 1024
+	maxValueSizeBytes   = 8 * 1024
 	maxContentSizeBytes = 64 * 1024
 )
 

--- a/core/secrets/createsecret_test.go
+++ b/core/secrets/createsecret_test.go
@@ -35,9 +35,9 @@ func (s *CreateSecretSuite) TestKeyValues(c *gc.C) {
 }
 
 func (s *CreateSecretSuite) TestKeyContentTooLarge(c *gc.C) {
-	content := strings.Repeat("a", 8*1024)
+	content := strings.Repeat("a", 9*1024)
 	_, err := secrets.CreateSecretData([]string{"foo=" + content})
-	c.Assert(err, gc.ErrorMatches, `secret content for key "foo" too large: 8192 bytes`)
+	c.Assert(err, gc.ErrorMatches, `secret content for key "foo" too large: 9216 bytes`)
 }
 
 func (s *CreateSecretSuite) TestTotalContentTooLarge(c *gc.C) {


### PR DESCRIPTION
A user reported not being able to create a secret with a "certs" attribute because the size of 5207 bytes was too large. We limit the size of attribute values and also the overall secret size. This PR increases the allowed attribute size to 8kiB (it was 5kiB).

## QA steps

unit tests

## Links

**Jira card:** JUJU-5502

