### PR TITLE
Login changes

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -30,8 +30,6 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/parallel"
-	"github.com/juju/version/v2"
-	"gopkg.in/macaroon.v2"
 	"gopkg.in/retry.v1"
 
 	"github.com/juju/juju/api/base"
@@ -63,102 +61,6 @@ type rpcConnection interface {
 	Call(req rpc.Request, params, response interface{}) error
 	Dead() <-chan struct{}
 	Close() error
-}
-
-// state is the internal implementation of the Connection interface.
-type state struct {
-	ctx    context.Context
-	client rpcConnection
-	conn   jsoncodec.JSONConn
-	clock  clock.Clock
-
-	// addr is the address used to connect to the API server.
-	addr string
-
-	// ipAddr is the IP address used to connect to the API server.
-	ipAddr string
-
-	// cookieURL is the URL that HTTP cookies for the API
-	// will be associated with (specifically macaroon auth cookies).
-	cookieURL *url.URL
-
-	// modelTag holds the model tag.
-	// It is empty if there is no model tag associated with the connection.
-	modelTag names.ModelTag
-
-	// controllerTag holds the controller's tag once we're connected.
-	controllerTag names.ControllerTag
-
-	// serverVersion holds the version of the API server that we are
-	// connected to.  It is possible that this version is 0 if the
-	// server does not report this during login.
-	serverVersion version.Number
-
-	// hostPorts is the API server addresses returned from Login,
-	// which the client may cache and use for fail-over.
-	hostPorts []network.MachineHostPorts
-
-	// publicDNSName is the public host name returned from Login
-	// which the client can use to make a connection verified
-	// by an officially signed certificate.
-	publicDNSName string
-
-	// facadeVersions holds the versions of all facades as reported by
-	// Login
-	facadeVersions map[string][]int
-
-	// pingFacadeVersion is the version to use for the pinger. This is lazily
-	// set at initialization to avoid a race in our tests. See
-	// http://pad.lv/1614732 for more details regarding the race.
-	pingerFacadeVersion int
-
-	// authTag holds the authenticated entity's tag after login.
-	authTag names.Tag
-
-	// mpdelAccess holds the access level of the user to the connected model.
-	modelAccess string
-
-	// controllerAccess holds the access level of the user to the connected controller.
-	controllerAccess string
-
-	// broken is a channel that gets closed when the connection is
-	// broken.
-	broken chan struct{}
-
-	// closed is a channel that gets closed when State.Close is called.
-	closed chan struct{}
-
-	// loggedIn holds whether the client has successfully logged
-	// in. It's a int32 so that the atomic package can be used to
-	// access it safely.
-	loggedIn int32
-
-	// tag, password, macaroons and nonce hold the cached login
-	// credentials. These are only valid if loggedIn is 1.
-	tag       string
-	password  string
-	macaroons []macaroon.Slice
-	nonce     string
-
-	// serverRootAddress holds the cached API server address and port used
-	// to login.
-	serverRootAddress string
-
-	// serverScheme is the URI scheme of the API Server
-	serverScheme string
-
-	// tlsConfig holds the TLS config appropriate for making SSL
-	// connections to the API endpoints.
-	tlsConfig *tls.Config
-
-	// bakeryClient holds the client that will be used to
-	// authorize macaroon based login requests.
-	bakeryClient *httpbakery.Client
-
-	// proxier is the proxier used for this connection when not nil. If's expected
-	// the proxy has already been started when placing in this var. This struct
-	// will take the responsibility of closing the proxy.
-	proxier jujuproxy.Proxier
 }
 
 // RedirectError is returned from Open when the controller
@@ -253,6 +155,16 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		return nil, errors.Errorf("pinger facade version is required")
 	}
 
+	loginProvider := opts.LoginProvider
+	// TODO (alesstimec, wallyworld): login provider should be constructed outside
+	// of this function and always passed in as part of dial opts. Also Info
+	// does not need to hold the authentication related data anymore. Until that
+	// is refactored we fall back to using the user-pass login provider
+	// with information from Info.
+	if loginProvider == nil {
+		loginProvider = NewUserpassLoginProvider(info.Tag, info.Password, info.Nonce, info.Macaroons, bakeryClient, CookieURLFromHost(host))
+	}
+
 	st := &state{
 		ctx:                 context.Background(),
 		client:              client,
@@ -278,7 +190,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		proxier:      dialResult.proxier,
 	}
 	if !info.SkipLogin {
-		if err := loginWithContext(dialCtx, st, info); err != nil {
+		if err := loginWithContext(dialCtx, st, loginProvider); err != nil {
 			dialResult.conn.Close()
 			return nil, errors.Trace(err)
 		}
@@ -326,10 +238,20 @@ func PerferredHost(info *Info) string {
 // if the context is cancelled.
 // TODO(rogpeppe) pass Context into Login (and all API calls) so
 // that this becomes unnecessary.
-func loginWithContext(ctx context.Context, st *state, info *Info) error {
+func loginWithContext(ctx context.Context, st *state, loginProvider LoginProvider) error {
+	if loginProvider == nil {
+		return errors.New("login provider not specified")
+	}
+
 	result := make(chan error, 1)
 	go func() {
-		result <- st.Login(info.Tag, info.Password, info.Nonce, info.Macaroons)
+		loginResult, err := loginProvider.Login(ctx, st)
+		if err != nil {
+			result <- err
+			return
+		}
+
+		result <- st.setLoginResult(loginResult)
 	}()
 	select {
 	case err := <-result:

--- a/api/client_credentials_login_provider.go
+++ b/api/client_credentials_login_provider.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/rpc/params"
+)
+
+var (
+	loginWithClientCredentialsAPICall = func(caller base.APICaller, request interface{}, response interface{}) error {
+		return caller.APICall("Admin", 4, "", "LoginWithClientCredentials", request, response)
+	}
+)
+
+// NewClientCredentialsLoginProvider returns a LoginProvider implementation that
+// authenticates the entity with the given client credentials.
+func NewClientCredentialsLoginProvider(clientID, clientSecret string) *clientCredentialsLoginProvider {
+	return &clientCredentialsLoginProvider{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+type clientCredentialsLoginProvider struct {
+	clientID     string
+	clientSecret string
+}
+
+// Login implements the LoginProvider.Login method.
+//
+// It authenticates as the entity using client credentials.
+// Subsequent requests on the state will act as that entity.
+func (p *clientCredentialsLoginProvider) Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
+	var result params.LoginResult
+	request := struct {
+		ClientID     string `json:"client-id"`
+		ClientSecret string `json:"client-secret"`
+	}{
+		ClientID:     p.clientID,
+		ClientSecret: p.clientSecret,
+	}
+
+	err := loginWithClientCredentialsAPICall(caller, request, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var controllerAccess string
+	var modelAccess string
+	var tag names.Tag
+	if result.UserInfo != nil {
+		tag, err = names.ParseTag(result.UserInfo.Identity)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		controllerAccess = result.UserInfo.ControllerAccess
+		modelAccess = result.UserInfo.ModelAccess
+	}
+	servers := params.ToMachineHostsPorts(result.Servers)
+	serverVersion, err := version.Parse(result.ServerVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &LoginResultParams{
+		tag:              tag,
+		modelTag:         result.ModelTag,
+		controllerTag:    result.ControllerTag,
+		servers:          servers,
+		publicDNSName:    result.PublicDNSName,
+		facades:          result.Facades,
+		modelAccess:      modelAccess,
+		controllerAccess: controllerAccess,
+		serverVersion:    serverVersion,
+	}, nil
+}

--- a/api/client_credentials_login_provider_test.go
+++ b/api/client_credentials_login_provider_test.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"encoding/json"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc/params"
+)
+
+type clientCredentialsLoginProviderProviderSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+var _ = gc.Suite(&clientCredentialsLoginProviderProviderSuite{})
+
+func (s *clientCredentialsLoginProviderProviderSuite) Test(c *gc.C) {
+	info := s.APIInfo(c)
+
+	clientID := "test-client-id"
+	clientSecret := "test-client-secret"
+
+	s.PatchValue(api.LoginWithClientCredentialsAPICall, func(_ base.APICaller, request interface{}, response interface{}) error {
+		data, err := json.Marshal(request)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		var lr struct {
+			ClientID     string `json:"client-id"`
+			ClientSecret string `json:"client-secret"`
+		}
+
+		err = json.Unmarshal(data, &lr)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if lr.ClientID != clientID {
+			return errors.Unauthorized
+		}
+		if lr.ClientSecret != clientSecret {
+			return errors.Unauthorized
+		}
+
+		loginResult, ok := response.(*params.LoginResult)
+		if !ok {
+			return errors.Errorf("expected %T, received %T for response type", loginResult, response)
+		}
+		loginResult.ControllerTag = names.NewControllerTag(info.ControllerUUID).String()
+		loginResult.ServerVersion = "3.4.0"
+		loginResult.UserInfo = &params.AuthUserInfo{
+			DisplayName:      "alice@external",
+			Identity:         names.NewUserTag("alice@external").String(),
+			ControllerAccess: "superuser",
+		}
+		return nil
+	})
+
+	apiState, err := api.Open(&api.Info{
+		Addrs:          info.Addrs,
+		ControllerUUID: info.ControllerUUID,
+		CACert:         info.CACert,
+	}, api.DialOpts{
+		LoginProvider: api.NewClientCredentialsLoginProvider(clientID, clientSecret),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer func() { _ = apiState.Close() }()
+}

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -27,6 +27,12 @@ type SimpleConfig struct {
 	Username  string
 	Password  string
 	Macaroons []macaroon.Slice
+
+	// ClientID holds the client id part of client credentials used for authentication.
+	ClientID string
+	// ClientSecret holds the client secret part of client
+	// credentials used for authentication.
+	ClientSecret string
 }
 
 // A SimpleConnector can provide connections from a simple set of options.
@@ -53,10 +59,20 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 	if err := info.Validate(); err != nil {
 		return nil, err
 	}
+
+	dialOpts := api.DefaultDialOpts()
+	if opts.ClientID != "" && opts.ClientSecret != "" {
+		dialOpts.LoginProvider = api.NewClientCredentialsLoginProvider(
+			opts.ClientID,
+			opts.ClientSecret,
+		)
+	}
+
 	conn := &SimpleConnector{
 		info:            info,
-		defaultDialOpts: api.DefaultDialOpts(),
+		defaultDialOpts: dialOpts,
 	}
+
 	for _, f := range dialOptions {
 		f(&conn.defaultDialOpts)
 	}

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -22,6 +22,11 @@ var (
 	CertDir             = &certDir
 	SlideAddressToFront = slideAddressToFront
 	FacadeVersions      = &facadeVersions
+
+	LoginDeviceAPICall                = &loginDeviceAPICall
+	GetDeviceSessionTokenAPICall      = &getDeviceSessionTokenAPICall
+	LoginWithSessionTokenAPICall      = &loginWithSessionTokenAPICall
+	LoginWithClientCredentialsAPICall = &loginWithClientCredentialsAPICall
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
+	"github.com/juju/juju/rpc/params"
 )
 
 // AnonymousUsername is the special username to use for anonymous logins.
@@ -126,9 +127,31 @@ func (info *Info) Validate() error {
 	return nil
 }
 
+// LoginResultParams holds the login result parameters.
+type LoginResultParams struct {
+	tag              names.Tag
+	modelTag         string
+	controllerTag    string
+	modelAccess      string
+	controllerAccess string
+	servers          []network.MachineHostPorts
+	facades          []params.FacadeVersions
+	publicDNSName    string
+	serverVersion    version.Number
+}
+
+// LoginProvider implements a way to log in when connecting to a controller.
+type LoginProvider interface {
+	// Login performs log in when connecting to the controller.
+	Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error)
+}
+
 // DialOpts holds configuration parameters that control the
 // Dialing behavior when connecting to a controller.
 type DialOpts struct {
+	// LoginProvider performs the log in on the open connection.
+	LoginProvider LoginProvider
+
 	// DialAddressInterval is the amount of time to wait
 	// before starting to dial another address.
 	DialAddressInterval time.Duration
@@ -224,6 +247,14 @@ type DialOption func(*DialOpts)
 func WithDialOpts(newOpts DialOpts) DialOption {
 	return func(opts *DialOpts) {
 		*opts = newOpts
+	}
+}
+
+// WithLoginProvider returns a DialOption that sets the
+// login provider to the one specified.
+func WithLoginProvider(lp LoginProvider) DialOption {
+	return func(opts *DialOpts) {
+		opts.LoginProvider = lp
 	}
 }
 

--- a/api/session_token_login_provider.go
+++ b/api/session_token_login_provider.go
@@ -1,0 +1,158 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/rpc/params"
+)
+
+var (
+	loginDeviceAPICall = func(caller base.APICaller, request interface{}, response interface{}) error {
+		return caller.APICall("Admin", 4, "", "LoginDevice", request, response)
+	}
+	getDeviceSessionTokenAPICall = func(caller base.APICaller, request interface{}, response interface{}) error {
+		return caller.APICall("Admin", 4, "", "GetDeviceSessionToken", request, response)
+	}
+	loginWithSessionTokenAPICall = func(caller base.APICaller, request interface{}, response interface{}) error {
+		return caller.APICall("Admin", 4, "", "LoginWithSessionToken", request, response)
+	}
+)
+
+// NewSessionTokenLoginProvider returns a LoginProvider implementation that
+// authenticates the entity with the session token.
+func NewSessionTokenLoginProvider(
+	token string,
+	printOutputFunc func(string, ...any) error,
+	updateAccountDetailsFunc func(string) error,
+) *sessionTokenLoginProvider {
+	return &sessionTokenLoginProvider{
+		sessionToken:             token,
+		printOutputFunc:          printOutputFunc,
+		updateAccountDetailsFunc: updateAccountDetailsFunc,
+	}
+}
+
+type sessionTokenLoginProvider struct {
+	sessionToken string
+	// printOutpuFunc is used by the login provider to print the user code
+	// and verification URL.
+	printOutputFunc func(string, ...any) error
+	// updateAccountDetailsFunc function is used to update the session
+	// token for the account details.
+	updateAccountDetailsFunc func(string) error
+}
+
+// Login implements the LoginProvider.Login method.
+//
+// It authenticates as the entity using the specified session token.
+// Subsequent requests on the state will act as that entity.
+func (p *sessionTokenLoginProvider) Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
+	// First we try to log in using the session token we have.
+	result, err := p.login(ctx, caller)
+	if err == nil {
+		return result, nil
+	}
+
+	if params.ErrCode(err) == params.CodeUnauthorized {
+		// if we fail with an "unauthorized" error, we initiate a
+		// new device login.
+		if err := p.initiateDeviceLogin(ctx, caller); err != nil {
+			return nil, errors.Trace(err)
+		}
+		// and retry the login using the obtained session token.
+		return p.login(ctx, caller)
+	}
+	return nil, errors.Trace(err)
+}
+
+func (p *sessionTokenLoginProvider) initiateDeviceLogin(ctx context.Context, caller base.APICaller) error {
+	if p.printOutputFunc == nil {
+		return errors.New("cannot present login details")
+	}
+
+	type loginRequest struct{}
+
+	var deviceResult struct {
+		UserCode        string `json:"user-code"`
+		VerificationURI string `json:"verification-uri"`
+	}
+
+	// The first call we make is to initiate the device login oauth2 flow. This will
+	// return a user code and the verification URL - verification URL will point to the
+	// configured IdP. These two will be presented to the user. User will have to
+	// open a browser, visit the verification URL, enter the user code and log in.
+	err := loginDeviceAPICall(caller, &loginRequest{}, &deviceResult)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// We print the verification URL and the user code.
+	err = p.printOutputFunc("Please visit %s and enter code %s to log in.", deviceResult.VerificationURI, deviceResult.UserCode)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	type loginResponse struct {
+		SessionToken string `json:"session-token"`
+	}
+	var sessionTokenResult loginResponse
+	// Then we make a blocking call to get the session token.
+	err = getDeviceSessionTokenAPICall(caller, &loginRequest{}, &sessionTokenResult)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	p.sessionToken = sessionTokenResult.SessionToken
+
+	return p.updateAccountDetailsFunc(sessionTokenResult.SessionToken)
+}
+
+func (p *sessionTokenLoginProvider) login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
+	var result params.LoginResult
+	request := struct {
+		SessionToken string `json:"session-token"`
+	}{
+		SessionToken: p.sessionToken,
+	}
+
+	err := loginWithSessionTokenAPICall(caller, request, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var controllerAccess string
+	var modelAccess string
+	var tag names.Tag
+	if result.UserInfo != nil {
+		tag, err = names.ParseTag(result.UserInfo.Identity)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		controllerAccess = result.UserInfo.ControllerAccess
+		modelAccess = result.UserInfo.ModelAccess
+	}
+	servers := params.ToMachineHostsPorts(result.Servers)
+	serverVersion, err := version.Parse(result.ServerVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &LoginResultParams{
+		tag:              tag,
+		modelTag:         result.ModelTag,
+		controllerTag:    result.ControllerTag,
+		servers:          servers,
+		publicDNSName:    result.PublicDNSName,
+		facades:          result.Facades,
+		modelAccess:      modelAccess,
+		controllerAccess: controllerAccess,
+		serverVersion:    serverVersion,
+	}, nil
+}

--- a/api/session_token_login_provider_test.go
+++ b/api/session_token_login_provider_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc/params"
+)
+
+type sessionTokenLoginProviderProviderSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+var _ = gc.Suite(&sessionTokenLoginProviderProviderSuite{})
+
+func (s *sessionTokenLoginProviderProviderSuite) Test(c *gc.C) {
+	info := s.APIInfo(c)
+
+	sessionToken := "test-session-token"
+	userCode := "1234567"
+	verificationURI := "http://localhost:8080/test-verification"
+
+	var loginDetails string
+	var obtainedSessionToken string
+
+	s.PatchValue(api.LoginDeviceAPICall, func(_ base.APICaller, request interface{}, response interface{}) error {
+		lr := struct {
+			UserCode        string `json:"user-code"`
+			VerificationURI string `json:"verification-uri"`
+		}{
+			UserCode:        userCode,
+			VerificationURI: verificationURI,
+		}
+
+		data, err := json.Marshal(lr)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		return json.Unmarshal(data, response)
+	})
+
+	s.PatchValue(api.GetDeviceSessionTokenAPICall, func(_ base.APICaller, request interface{}, response interface{}) error {
+		lr := struct {
+			SessionToken string `json:"session-token"`
+		}{
+			SessionToken: sessionToken,
+		}
+
+		data, err := json.Marshal(lr)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		return json.Unmarshal(data, response)
+	})
+
+	s.PatchValue(api.LoginWithSessionTokenAPICall, func(_ base.APICaller, request interface{}, response interface{}) error {
+		data, err := json.Marshal(request)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		var lr struct {
+			SessionToken string `json:"session-token"`
+		}
+
+		err = json.Unmarshal(data, &lr)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if lr.SessionToken != sessionToken {
+			return &params.Error{
+				Message: "unauthorized",
+				Code:    params.CodeUnauthorized,
+			}
+		}
+
+		loginResult, ok := response.(*params.LoginResult)
+		if !ok {
+			return errors.Errorf("expected %T, received %T for response type", loginResult, response)
+		}
+		loginResult.ControllerTag = names.NewControllerTag(info.ControllerUUID).String()
+		loginResult.ServerVersion = "3.4.0"
+		loginResult.UserInfo = &params.AuthUserInfo{
+			DisplayName:      "alice@external",
+			Identity:         names.NewUserTag("alice@external").String(),
+			ControllerAccess: "superuser",
+		}
+		return nil
+	})
+
+	apiState, err := api.Open(&api.Info{
+		Addrs:          info.Addrs,
+		ControllerUUID: info.ControllerUUID,
+		CACert:         info.CACert,
+	}, api.DialOpts{
+		LoginProvider: api.NewSessionTokenLoginProvider(
+			"expired-token",
+			func(s string, a ...any) error {
+				loginDetails = fmt.Sprintf(s, a...)
+				return nil
+			},
+			func(sessionToken string) error {
+				obtainedSessionToken = sessionToken
+				return nil
+			},
+		),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(loginDetails, gc.Equals, "Please visit http://localhost:8080/test-verification and enter code 1234567 to log in.")
+	c.Assert(obtainedSessionToken, gc.Equals, sessionToken)
+	defer func() { _ = apiState.Close() }()
+}

--- a/api/try_in_order_login_provider.go
+++ b/api/try_in_order_login_provider.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+)
+
+// NewTryInOrderLoginProvider returns a login provider that will attempt to
+// log in using all the specified login providers in sequence - results
+// of the first on that succeeds will be returned.
+// This login provider should only be used when connecting to a controller
+// for the first time when we still don't know which login method.
+func NewTryInOrderLoginProvider(providers ...LoginProvider) LoginProvider {
+	return &tryInOrderLoginProviders{
+		providers: providers,
+	}
+}
+
+type tryInOrderLoginProviders struct {
+	providers []LoginProvider
+}
+
+// Login implements the LoginProvider.Login method.
+func (p *tryInOrderLoginProviders) Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
+	var lastError error
+	for _, provider := range p.providers {
+		result, err := provider.Login(ctx, caller)
+		if err == nil {
+			return result, nil
+		}
+		lastError = err
+	}
+	return nil, errors.Trace(lastError)
+}

--- a/api/try_in_order_login_provider_test.go
+++ b/api/try_in_order_login_provider_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+)
+
+type tryInOrderLoginProviderSuite struct{}
+
+var _ = gc.Suite(&tryInOrderLoginProviderSuite{})
+
+func (s *tryInOrderLoginProviderSuite) Test(c *gc.C) {
+	p1 := &mockLoginProvider{err: errors.New("provider 1 error")}
+	p2 := &mockLoginProvider{err: errors.New("provider 2 error")}
+	p3 := &mockLoginProvider{}
+
+	lp := api.NewTryInOrderLoginProvider(p1, p2)
+	_, err := lp.Login(context.Background(), nil)
+	c.Assert(err, gc.ErrorMatches, "provider 2 error")
+
+	lp = api.NewTryInOrderLoginProvider(p1, p2, p3)
+	_, err = lp.Login(context.Background(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type mockLoginProvider struct {
+	err error
+}
+
+func (p *mockLoginProvider) Login(ctx context.Context, caller base.APICaller) (*api.LoginResultParams, error) {
+	return &api.LoginResultParams{}, p.err
+}

--- a/api/userpass_login_provider.go
+++ b/api/userpass_login_provider.go
@@ -1,0 +1,203 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"runtime/debug"
+
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/juju/errors"
+	"github.com/juju/featureflag"
+	"github.com/juju/names/v5"
+	"github.com/juju/utils/v3"
+	"github.com/juju/version/v2"
+	"gopkg.in/macaroon.v2"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/params"
+	jujuversion "github.com/juju/juju/version"
+)
+
+// NewUserpassLoginProvider returns a LoginProvider implementation that
+// authenticates the entity with the given name and password or macaroons. The nonce
+// should be empty unless logging in as a machine agent.
+func NewUserpassLoginProvider(
+	tag names.Tag,
+	password string,
+	nonce string,
+	macaroons []macaroon.Slice,
+	bakeryClient *httpbakery.Client,
+	cookieURL *url.URL,
+) *userpassLoginProvider {
+	return &userpassLoginProvider{
+		tag:          tag,
+		password:     password,
+		nonce:        nonce,
+		macaroons:    macaroons,
+		bakeryClient: bakeryClient,
+		cookieURL:    cookieURL,
+	}
+}
+
+// userpassLoginProvider provides the default juju login provider that
+// authenticates the entity with the given name and password or macaroons. The
+// nonce should be empty unless logging in as a machine agent.
+type userpassLoginProvider struct {
+	tag          names.Tag
+	password     string
+	nonce        string
+	macaroons    []macaroon.Slice
+	bakeryClient *httpbakery.Client
+	cookieURL    *url.URL
+}
+
+// Login implements the LoginProvider.Login method.
+//
+// It authenticates as the entity with the given name and password
+// or macaroons. Subsequent requests on the state will act as that entity.
+func (p *userpassLoginProvider) Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
+	var result params.LoginResult
+	request := &params.LoginRequest{
+		AuthTag:       tagToString(p.tag),
+		Credentials:   p.password,
+		Nonce:         p.nonce,
+		Macaroons:     p.macaroons,
+		BakeryVersion: bakery.LatestVersion,
+		CLIArgs:       utils.CommandString(os.Args...),
+		ClientVersion: jujuversion.Current.String(),
+	}
+	// If we are in developer mode, add the stack location as user data to the
+	// login request. This will allow the apiserver to connect connection ids
+	// to the particular place that initiated the connection.
+	if featureflag.Enabled(feature.DeveloperMode) {
+		request.UserData = string(debug.Stack())
+	}
+
+	if p.password == "" {
+		// Add any macaroons from the cookie jar that might work for
+		// authenticating the login request.
+		request.Macaroons = append(request.Macaroons,
+			httpbakery.MacaroonsForURL(p.bakeryClient.Jar, p.cookieURL)...,
+		)
+	}
+	err := caller.APICall("Admin", 3, "", "Login", request, &result)
+	if err != nil {
+		if !params.IsRedirect(err) {
+			return nil, errors.Trace(err)
+		}
+
+		if rpcErr, ok := errors.Cause(err).(*rpc.RequestError); ok {
+			var redirInfo params.RedirectErrorInfo
+			err := rpcErr.UnmarshalInfo(&redirInfo)
+			if err == nil && redirInfo.CACert != "" && len(redirInfo.Servers) != 0 {
+				var controllerTag names.ControllerTag
+				if redirInfo.ControllerTag != "" {
+					if controllerTag, err = names.ParseControllerTag(redirInfo.ControllerTag); err != nil {
+						return nil, errors.Trace(err)
+					}
+				}
+
+				return nil, &RedirectError{
+					Servers:         params.ToMachineHostsPorts(redirInfo.Servers),
+					CACert:          redirInfo.CACert,
+					ControllerTag:   controllerTag,
+					ControllerAlias: redirInfo.ControllerAlias,
+					FollowRedirect:  false, // user-action required
+				}
+			}
+		}
+
+		// We've been asked to redirect. Find out the redirection info.
+		// If the rpc packet allowed us to return arbitrary information in
+		// an error, we'd probably put this information in the Login response,
+		// but we can't do that currently.
+		var resp params.RedirectInfoResult
+		if err := caller.APICall("Admin", 3, "", "RedirectInfo", nil, &resp); err != nil {
+			return nil, errors.Annotatef(err, "cannot get redirect addresses")
+		}
+		return nil, &RedirectError{
+			Servers:        params.ToMachineHostsPorts(resp.Servers),
+			CACert:         resp.CACert,
+			FollowRedirect: true, // JAAS-type redirect
+		}
+	}
+	if result.DischargeRequired != nil || result.BakeryDischargeRequired != nil {
+		// The result contains a discharge-required
+		// macaroon. We discharge it and retry
+		// the login request with the original macaroon
+		// and its discharges.
+		if result.DischargeRequiredReason == "" {
+			result.DischargeRequiredReason = "no reason given for discharge requirement"
+		}
+		// Prefer the newer bakery.v2 macaroon.
+		dcMac := result.BakeryDischargeRequired
+		if dcMac == nil {
+			dcMac, err = bakery.NewLegacyMacaroon(result.DischargeRequired)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		if err := p.bakeryClient.HandleError(ctx, p.cookieURL, &httpbakery.Error{
+			Message: result.DischargeRequiredReason,
+			Code:    httpbakery.ErrDischargeRequired,
+			Info: &httpbakery.ErrorInfo{
+				Macaroon:     dcMac,
+				MacaroonPath: "/",
+			},
+		}); err != nil {
+			cause := errors.Cause(err)
+			if httpbakery.IsInteractionError(cause) {
+				// Just inform the user of the reason for the
+				// failure, e.g. because the username/password
+				// they presented was invalid.
+				err = cause.(*httpbakery.InteractionError).Reason
+			}
+			return nil, errors.Trace(err)
+		}
+		// Add the macaroons that have been saved by HandleError to our login request.
+		request.Macaroons = httpbakery.MacaroonsForURL(p.bakeryClient.Jar, p.cookieURL)
+		result = params.LoginResult{} // zero result
+		err = caller.APICall("Admin", 3, "", "Login", request, &result)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if result.DischargeRequired != nil {
+			return nil, errors.Errorf("login with discharged macaroons failed: %s", result.DischargeRequiredReason)
+		}
+	}
+
+	var controllerAccess string
+	var modelAccess string
+	tag := p.tag
+	if result.UserInfo != nil {
+		tag, err = names.ParseTag(result.UserInfo.Identity)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		controllerAccess = result.UserInfo.ControllerAccess
+		modelAccess = result.UserInfo.ModelAccess
+	}
+	servers := params.ToMachineHostsPorts(result.Servers)
+	serverVersion, err := version.Parse(result.ServerVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &LoginResultParams{
+		tag:              tag,
+		modelTag:         result.ModelTag,
+		controllerTag:    result.ControllerTag,
+		servers:          servers,
+		publicDNSName:    result.PublicDNSName,
+		facades:          result.Facades,
+		modelAccess:      modelAccess,
+		controllerAccess: controllerAccess,
+		serverVersion:    serverVersion,
+	}, nil
+}

--- a/juju/api.go
+++ b/juju/api.go
@@ -156,10 +156,15 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 				accountDetails.LastKnownAccess = st.ControllerAccess()
 			}
 		}
-		if ok && !user.IsLocal() && apiInfo.Tag == nil {
+		accountType := jujuclient.UserPassAccountDetailsType
+		if accountDetails != nil {
+			accountType = accountDetails.Type
+		}
+		if ok && !user.IsLocal() && apiInfo.Tag == nil && accountType != jujuclient.OAuth2DeviceFlowAccountDetailsType {
 			// We used macaroon auth to login; save the username
 			// that we've logged in as.
 			accountDetails = &jujuclient.AccountDetails{
+				Type:            jujuclient.UserPassAccountDetailsType,
 				User:            user.Id(),
 				LastKnownAccess: st.ControllerAccess(),
 			}

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -725,7 +725,7 @@ func (s *store) UpdateAccount(controllerName string, details AccountDetails) err
 	return errors.Trace(WriteAccountsFile(accounts))
 }
 
-// AccountByName implements AccountGetter.
+// AccountDetails implements AccountGetter.
 func (s *store) AccountDetails(controllerName string) (*AccountDetails, error) {
 	if err := ValidateControllerName(controllerName); err != nil {
 		return nil, errors.Trace(err)

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -86,8 +86,24 @@ type ModelDetails struct {
 	ActiveBranch string `yaml:"branch"`
 }
 
+// AccountDetailsType defines the authentication method to be used for the account.
+type AccountDetailsType string
+
+const (
+	// UserPassAccountDetailsType means that username and password (or macaroons) are used
+	// to authenticate with the controller
+	UserPassAccountDetailsType AccountDetailsType = "userpass"
+
+	// OAuth2DeviceFlowAccountDetailsType means that the stored session token is to be used
+	// to authenticate with the controller or, if expired, initiate oauth2 device flow to
+	// obtain a valid session token.
+	OAuth2DeviceFlowAccountDetailsType AccountDetailsType = "oauth2-device"
+)
+
 // AccountDetails holds details of an account.
 type AccountDetails struct {
+	Type AccountDetailsType `yaml:"type,omitempty"`
+
 	// User is the username for the account.
 	User string `yaml:"user"`
 
@@ -101,6 +117,9 @@ type AccountDetails struct {
 	// They are only set when using the MemStore implementation,
 	// and are used by embedded commands. The are not written to disk.
 	Macaroons []macaroon.Slice `yaml:"-"`
+
+	// SessionToken, if set, is used for login.
+	SessionToken string `yaml:"access-token,omitempty"`
 }
 
 // BootstrapConfig holds the configuration used to bootstrap a controller.

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -15,6 +15,8 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
+var _ ClientStore = (*MemStore)(nil)
+
 // MemStore is an in-memory implementation of ClientStore.
 type MemStore struct {
 	mu sync.Mutex


### PR DESCRIPTION
Login changes

Since JAAS is moving away from candid to OIDC, juju clients need to be able to log in to JIMM using Admin facade version 4 that implements new methods to allow log in using either an access token or client credentials. Additional methods are used to initiate the device oauth2 flow to obtain a valid access token.

1. Introduces a LoginProvider that logs in with the juju controller once the websock connection is established:
  - implemented a login provider for the current login that uses username, password or macaroons
  - implemented a login provider that uses provided client credentials
  - implemented a login provider that uses an access token
2. Adds an additional field to AccountDetails (an access token). Changing the way we parse accounts.yaml to something other than AccountDetails (to be more in-line with credentials.yaml) would be a massive undertaking because of the many places that use the AccountDetails - one possibly done in a followup.



## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x  ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

