### PR TITLE
Introduce jaas-plugin plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,8 @@ apps:
       - network-bind
       - ssh-keys
       - lxd
+      # Needed to read the JAAS plugin binary
+      - jaas-plugin
       # Needed so that juju can still use the real ~/.local/share/juju.
       - dot-local-share-juju
       # Needed to read lxd config.
@@ -489,6 +491,11 @@ plugs:
     interface: content
     content: microk8s
     target: $SNAP_DATA/microk8s
+  
+  jaas-plugin:
+    interface: content
+    content: jaas-plugin
+    target: $SNAP/usr/bin
 
   dot-local-share-juju:
     interface: personal-files


### PR DESCRIPTION
Recreates PR #16884

This PR introduces a plug into Juju CLI's Snap, allowing it to be connected to a JAAS snap that will be used to extend the Juju CLI with functionality for JAAS. This PR follows from a similar [PR in JAAS](https://github.com/canonical/jimm/pull/1149) where we introduce the new Snap. The below is copied from that PR.
>The mechanism by which it  does this (extending the Juju CLI's functionality) is [Juju Plugins](https://juju.is/docs/juju/plugins) and Snapcraft's [content-interface](https://snapcraft.io/docs/content-interface). The juju-jaas snap shares a binary of the same name to a directory within the Juju Snap that is readable by the CLI. Because the name of the binary is juju-* the binary can be invoked via `juju jaas <command>`. It is still TBD whether it is okay to namespace the JAAS commands to `juju jaas` or whether all the JAAS commands should be surfaced as top-level commands under the Juju CLI. Regardless, the specifics for how JAAS commands are invoked can be easily changed after this by introducing symlinks/bash scripts into the JAAS Snap's `$SNAP/bin` directory of the form juju-<command> e.g. `juju-add-service-account`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the following commands to build the Juju snap, install the JAAS snap and test the integration.

- `snapcraft`
- `sudo snap install --dangerous --devmode ./<juju-snap-file>`
- `sudo snap install jaas --channel=latest/candidate`
- `sudo snap connect juju:jaas-plugin jaas`
- `juju add-service-account --help`

**Verifying that the new plug will not impede snap uploads:**
After building the snap one can run `review-tools.snap-review` against it locally. The output is as follows:
```
$ review-tools.snap-review ./juju_3.4-rc2_amd64.snap
Errors
------
 - declaration-snap-v2:plugs_installation:config-lxd:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-aws:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-azure:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-google:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-kubernetes:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-local-share-juju:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-maas:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-openstack:personal-files
	human review required due to 'allow-installation' constraint (bool)
 - declaration-snap-v2:plugs_installation:dot-oracle:personal-files
	human review required due to 'allow-installation' constraint (bool)
```

One can see that the new plug is not listed and should not require human review - cc @wallyworld on the hesitation raised in the previous PR.