### PR TITLE
Fix generate-password for --users.

### DIFF
--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	gnuflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username> [password]\n", os.Args[0])
 		gnuflag.PrintDefaults()
 	}
 	user := gnuflag.String("user", "", "supply a username to generate a password instead of modeluuid and agent")
@@ -40,6 +40,16 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
+		}
+	} else {
+		if len(args) < 1 {
+			var err error
+			passwd, err = utils.RandomPassword()
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			passwd = args[0]
 		}
 	}
 	if *user != "" {


### PR DESCRIPTION
The logic in `generate-password` always set a user's password to the empty string. It didn't read the arg, nor generate a random password.

Now you can give an arg to pass your own password, or have it generate one for you.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ make install
$ generate-password --user foo
$ generate-password --user foo MyPassWord
```

Without this patch, the output would be:
```
Password line for ~/.local/share/juju/accounts.yaml
  password:
db.users.update({"_id": "foo"}, {"$set": {"passwordsalt": "M98/0Xc2JZKrFdY4", "passwordhash": "1RDCj44MSza2szed+isUcxsy"}})
```

Where it is non-obvious that the password *is* being set, but is being set to the empty string.

With the patch, it now sets a randomly generate password if not supplied, or a supplied password. Eg:
```
Password line for ~/.local/share/juju/accounts.yaml
  password: DtgEHJQCbiywIxGdnNE4weXr
db.users.update({"_id": "foo"}, {"$set": {"passwordsalt": "a4Tn77Ttgmqcv00i", "passwordhash": "WWCG8VbOFxK+7E7+jeqbpWGd"}})
```
and
```
Password line for ~/.local/share/juju/accounts.yaml
  password: MyPassWord
db.users.update({"_id": "foo"}, {"$set": {"passwordsalt": "kGF00w6km9LaaW4/", "passwordhash": "HnkGRSxLMiQWJGdMt+vZayyk"}})
```

## Documentation changes

The help text has been updated. It doesn't include other unit tests, integration tests, or docs because scripts is intentionally casual things that we put together. I'd be ok adding some sort of basic testing, because this was a silly bug to have.