### PR TITLE
Add support for controller selection in debug-log

### DIFF
--- a/api/client/highavailability/client.go
+++ b/api/client/highavailability/client.go
@@ -58,3 +58,32 @@ func (c *Client) EnableHA(
 	}
 	return result.Result, nil
 }
+
+// ControllerDetails holds details of a controller.
+type ControllerDetails struct {
+	ControllerID string
+	APIEndpoints []string
+}
+
+func (c *Client) ControllerDetails() (map[string]ControllerDetails, error) {
+	if c.BestAPIVersion() < 3 {
+		return nil, errors.NotImplemented
+	}
+	var details params.ControllerDetailsResults
+	err := c.facade.FacadeCall(context.TODO(), "ControllerDetails", nil, &details)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]ControllerDetails)
+	for _, r := range details.Results {
+		if r.Error != nil {
+			return nil, r.Error
+		}
+		result[r.ControllerId] = ControllerDetails{
+			ControllerID: r.ControllerId,
+			APIEndpoints: r.APIAddresses,
+		}
+	}
+	return result, nil
+}

--- a/api/client/highavailability/package_test.go
+++ b/api/client/highavailability/package_test.go
@@ -15,8 +15,9 @@ func TestAll(t *testing.T) {
 	gc.TestingT(t)
 }
 
-func NewClientFromCaller(caller base.FacadeCaller) *Client {
+func NewClientFromCaller(caller base.FacadeCaller, facade base.ClientFacade) *Client {
 	return &Client{
-		facade: caller,
+		ClientFacade: facade,
+		facade:       caller,
 	}
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -64,7 +64,7 @@ var facadeVersions = facades.FacadeVersions{
 	"FanConfigurer":                {1},
 	"FilesystemAttachmentsWatcher": {2},
 	"Firewaller":                   {7},
-	"HighAvailability":             {2},
+	"HighAvailability":             {2, 3},
 	"HostKeyReporter":              {1},
 	"ImageMetadata":                {3},
 	"ImageMetadataManager":         {1},

--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -17,8 +17,20 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("HighAvailability", 2, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
+		return newHighAvailabilityAPIV2(ctx)
+	}, reflect.TypeOf((*HighAvailabilityAPIV2)(nil)))
+	registry.MustRegister("HighAvailability", 3, func(stdCtx context.Context, ctx facade.Context) (facade.Facade, error) {
 		return newHighAvailabilityAPI(ctx)
 	}, reflect.TypeOf((*HighAvailabilityAPI)(nil)))
+}
+
+// newHighAvailabilityAPI creates a new server-side highavailability API end point.
+func newHighAvailabilityAPIV2(ctx facade.Context) (*HighAvailabilityAPIV2, error) {
+	v3, err := newHighAvailabilityAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &HighAvailabilityAPIV2{*v3}, nil
 }
 
 // newHighAvailabilityAPI creates a new server-side highavailability API end point.
@@ -43,6 +55,7 @@ func newHighAvailabilityAPI(ctx facade.Context) (*HighAvailabilityAPI, error) {
 		nodeService:          ctx.ServiceFactory().ControllerNode(),
 		machineSaver:         ctx.ServiceFactory().Machine(),
 		applicationSaveSaver: ctx.ServiceFactory().Application(),
+		controllerConfig:     ctx.ServiceFactory().ControllerConfig(),
 		authorizer:           authorizer,
 		logger:               ctx.Logger().Child("highavailability"),
 	}, nil

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19810,7 +19810,7 @@
     {
         "Name": "HighAvailability",
         "Description": "HighAvailabilityAPI implements the HighAvailability interface and is the concrete\nimplementation of the api end point.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-user",
             "model-user"
@@ -19818,6 +19818,15 @@
         "Schema": {
             "type": "object",
             "properties": {
+                "ControllerDetails": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerDetailsResults"
+                        }
+                    },
+                    "description": "ControllerDetails returns details about each controller node."
+                },
                 "EnableHA": {
                     "type": "object",
                     "properties": {
@@ -19832,6 +19841,43 @@
                 }
             },
             "definitions": {
+                "ControllerDetails": {
+                    "type": "object",
+                    "properties": {
+                        "api-addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "controller-id": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-id",
+                        "api-addresses"
+                    ]
+                },
+                "ControllerDetailsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
                 "ControllersChangeResult": {
                     "type": "object",
                     "properties": {

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -4,10 +4,12 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/ansiterm"
@@ -22,6 +24,8 @@ import (
 	"github.com/juju/retry"
 	"github.com/mattn/go-isatty"
 
+	apiclient "github.com/juju/juju/api/client/client"
+	"github.com/juju/juju/api/client/highavailability"
 	"github.com/juju/juju/api/common"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -107,6 +111,16 @@ To see all WARNING and ERROR messages and then continue showing any
 new WARNING and ERROR messages as they are logged:
 
     juju debug-log --replay --level WARNING
+
+In the HA case, debug-log can be configured to stream messages from a selected controller.
+Use juju show-controller to see the available controller numbers.
+
+    juju debug-log --controller 2
+
+You can also stream messages from all controllers - a best effort will be made to correctly
+interleave them so they are ordered by timestamp.
+
+    juju debug-log --all
 `
 
 func (c *debugLogCommand) Info() *cmd.Info {
@@ -158,6 +172,9 @@ type debugLogCommand struct {
 
 	includeLabels []string
 	excludeLabels []string
+
+	controllerID   string
+	allControllers bool
 }
 
 func (c *debugLogCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -170,6 +187,9 @@ func (c *debugLogCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewAppendStringsValue(&c.params.ExcludeModule), "exclude-module", "Do not show log messages for these logging modules")
 	f.Var(cmd.NewAppendStringsValue(&c.includeLabels), "include-labels", "Only show log messages for these logging label key values")
 	f.Var(cmd.NewAppendStringsValue(&c.excludeLabels), "exclude-labels", "Do not show log messages for these logging label key values")
+
+	f.StringVar(&c.controllerID, "controller", "", "A specific controller from which to display logs.")
+	f.BoolVar(&c.allControllers, "all", false, "Display logs form all controllers.")
 
 	f.StringVar(&c.level, "l", "", "Log level to show, one of [TRACE, DEBUG, INFO, WARNING, ERROR]")
 	f.StringVar(&c.level, "level", "", "")
@@ -274,13 +294,32 @@ func (c *debugLogCommand) parseEntity(entity string) string {
 	}
 }
 
+// DebugLogAPI provides access to the client facade.
 type DebugLogAPI interface {
 	WatchDebugLog(params common.DebugLogParams) (<-chan common.LogMessage, error)
 	Close() error
 }
 
-var getDebugLogAPI = func(c *debugLogCommand) (DebugLogAPI, error) {
-	return c.NewAPIClient()
+// ControllerDetailsAPI provides access to the high availability facade.
+type ControllerDetailsAPI interface {
+	ControllerDetails() (map[string]highavailability.ControllerDetails, error)
+	BestAPIVersion() int
+}
+
+var getDebugLogAPI = func(c *debugLogCommand, addr []string) (DebugLogAPI, error) {
+	root, err := c.NewAPIRootWithAddressOverride(addr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apiclient.NewClient(root, logger), nil
+}
+
+var getControllerDetailsClient = func(c *debugLogCommand) (ControllerDetailsAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return highavailability.NewClient(root), nil
 }
 
 func isTerminal(f interface{}) bool {
@@ -289,6 +328,43 @@ func isTerminal(f interface{}) bool {
 		return false
 	}
 	return isatty.IsTerminal(f_.Fd())
+}
+
+type logFunc func([]corelogger.LogRecord) error
+
+func (f logFunc) Log(r []corelogger.LogRecord) error {
+	return f(r)
+}
+
+func (c *debugLogCommand) getControllerAddresses() ([][]string, error) {
+	var controllerDetails map[string]highavailability.ControllerDetails
+	if c.controllerID != "" || c.allControllers {
+		api, err := getControllerDetailsClient(c)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting controller HA client")
+		}
+		if api.BestAPIVersion() < 3 {
+			return nil, fmt.Errorf("debug log controller selection not supported with this version of Juju")
+		}
+		controllerDetails, err = api.ControllerDetails()
+		if err != nil {
+			return nil, errors.Annotate(err, "getting controller details")
+		}
+	}
+
+	var controllerAddr [][]string
+	if c.controllerID != "" {
+		ctrl, ok := controllerDetails[c.controllerID]
+		if !ok {
+			return nil, fmt.Errorf("controller %q %w", c.controllerID, errors.NotFound)
+		}
+		controllerAddr = append(controllerAddr, ctrl.APIEndpoints)
+	} else if c.allControllers {
+		for _, ctrl := range controllerDetails {
+			controllerAddr = append(controllerAddr, ctrl.APIEndpoints)
+		}
+	}
+	return controllerAddr, nil
 }
 
 // Run retrieves the debug log via the API.
@@ -303,9 +379,89 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 		c.params.NoTail = !isTerminal(ctx.Stdout)
 	}
 
+	// Get the controller addresses to connect to.
+	controllerAddr, err := c.getControllerAddresses()
+	if err != nil {
+		return err
+	}
+
+	// The default log buffer size is 1 for a single controller
+	// (stream log entries as they arrive).
+	bufferSize := 1
+	// If we are connecting to multiple controllers, adjust the buffer size so that
+	// we have a chance of ordering incoming records by timestamp.
+	// Replaying the logs will likely stream many initially so use a larger buffer size
+	// to account for controllers having potentially divergent log entry timestamps.
+	// This is best effort so it's ok if some log entries are printed out of order.
+	// Ideally we'd have a variable flush timeout depending on the rate of incoming messages
+	// but the buffered logger doesn't support that.
+	if len(controllerAddr) > 1 {
+		if c.params.Replay || c.params.NoTail {
+			bufferSize = 500
+		} else {
+			bufferSize = 5
+		}
+	}
+
+	buf := corelogger.NewBufferedLogger(logFunc(func(recs []corelogger.LogRecord) error {
+		for _, r := range recs {
+			_ = c.out.Write(ctx, &r)
+		}
+		return nil
+	}), bufferSize, time.Second, clock.WallClock)
+
+	// Start one log streamer per controller.
+	numStreams := 1
+	if n := len(controllerAddr); n > 0 {
+		numStreams = n
+	}
+	// Size of errors channel and wait group needs to match the number of debug log streams.
+	var (
+		errs = make(chan error, numStreams)
+		wg   sync.WaitGroup
+	)
+	wg.Add(numStreams)
+
+	pollCtx, cancel := context.WithCancel(ctx)
+	if len(controllerAddr) == 0 {
+		go func() {
+			c.streamLogs(pollCtx, nil, buf, errs)
+			wg.Done()
+		}()
+	} else {
+		for _, addr := range controllerAddr {
+			go func(addr []string) {
+				c.streamLogs(pollCtx, addr, buf, errs)
+				wg.Done()
+			}(addr)
+		}
+	}
+
+	// Wait for the streams to exit.
+	var pollErr error
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case pollErr = <-errs:
+			// Exit on the first error.
+			break loop
+		}
+	}
+	// Cancel the message polling before flushing the buffer.
+	cancel()
+	wg.Wait()
+	_ = buf.Flush()
+	return pollErr
+}
+
+// streamLogs watches debug logs from the specified controller and logs any results
+// into the supplied buffered logger. Any error is reported to the errors channel.
+func (c *debugLogCommand) streamLogs(ctx context.Context, controllerAddr []string, buf *corelogger.BufferedLogger, errs chan error) {
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
-			client, err := getDebugLogAPI(c)
+			client, err := getDebugLogAPI(c, controllerAddr)
 			if err != nil {
 				return err
 			}
@@ -322,7 +478,7 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 					return ErrConnectionClosed
 				}
 				level, _ := loggo.ParseLevel(msg.Severity)
-				logRecord := &corelogger.LogRecord{
+				logRecord := corelogger.LogRecord{
 					Time:     msg.Timestamp,
 					Entity:   msg.Entity,
 					Level:    level,
@@ -331,7 +487,9 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 					Message:  msg.Message,
 					Labels:   msg.Labels,
 				}
-				_ = c.out.Write(ctx, logRecord)
+				if err := buf.Log([]corelogger.LogRecord{logRecord}); err != nil {
+					return err
+				}
 			}
 		},
 		IsFatalError: func(err error) bool {
@@ -356,12 +514,11 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 	// user. As this is a synthetic error that is used to signal that the
 	// connection is retried, we don't want to show this to the user.
 	if errors.Is(err, ErrConnectionClosed) {
-		return nil
+		err = nil
 	}
-
 	// Unwrap the retry call error trace for all errors. We don't want to show
 	// that to the user as part of the error message.
-	return errors.Cause(err)
+	errs <- errors.Cause(err)
 }
 
 // ErrConnectionClosed is a sentinel error used to signal that the connection

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -297,7 +297,7 @@ func (s *DebugLogSuite) TestAllControllers(c *gc.C) {
 		}
 	}
 	checkOutput(
-		"--all",
+		"--controller", "all",
 		"machine-1: 14:15:20 INFO test.module this is the log output for 1\nmachine-0: 14:15:23 INFO test.module this is the log output for 0\n")
 }
 

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/v4/cmdtesting"
@@ -11,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/client/highavailability"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -139,7 +141,7 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 
 func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 	fake := &fakeDebugLogAPI{}
-	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, _ []string) (DebugLogAPI, error) {
 		return fake, nil
 	})
 	_, err := cmdtesting.RunCommand(c, newDebugLogCommand(jujuclienttesting.MinimalStore()),
@@ -163,7 +165,7 @@ func (s *DebugLogSuite) TestParamsPassed(c *gc.C) {
 func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	// test timezone is 6 hours east of UTC
 	tz := time.FixedZone("test", 6*60*60)
-	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, _ []string) (DebugLogAPI, error) {
 		return &fakeDebugLogAPI{log: []common.LogMessage{
 			{
 				Entity:    "machine-0",
@@ -205,10 +207,104 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 		`{"timestamp":"2016-10-09T08:15:23.345Z","entity":"machine-0","level":"INFO","module":"test.module","location":"somefile.go:123","message":"this is the log output"}`+"\n")
 }
 
+func (s *DebugLogSuite) TestSpecifiedController(c *gc.C) {
+	// test timezone is 6 hours east of UTC
+	tz := time.FixedZone("test", 6*60*60)
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, addr []string) (DebugLogAPI, error) {
+		c.Assert(addr, jc.SameContents, []string{"address-666"})
+		return &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-0",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "somefile.go:123",
+				Message:   "this is the log output",
+			},
+		}}, nil
+	})
+	s.PatchValue(&getControllerDetailsClient, func(_ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{}, nil
+	})
+	checkOutput := func(args ...string) {
+		count := len(args)
+		args, expected := args[:count-1], args[count-1]
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(jujuclienttesting.MinimalStore(), tz), args...)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+
+	}
+	checkOutput(
+		"--controller", "666",
+		"machine-0: 14:15:23 INFO test.module this is the log output\n")
+}
+
+func (s *DebugLogSuite) TestSpecifiedControllerNotFound(c *gc.C) {
+	s.PatchValue(&getControllerDetailsClient, func(_ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{}, nil
+	})
+	_, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(jujuclienttesting.MinimalStore(), time.UTC), "--controller", "999")
+	c.Check(err, gc.ErrorMatches, `controller "999" not found`)
+}
+
+func (s *DebugLogSuite) TestAllControllers(c *gc.C) {
+	// test timezone is 6 hours east of UTC
+	tz := time.FixedZone("test", 6*60*60)
+	debugStreams := map[string]DebugLogAPI{
+		"address-666": &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-0",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "somefile.go:123",
+				Message:   "this is the log output for 0",
+			},
+		}},
+		"address-668": &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-1",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 20, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "anotherfile.go:123",
+				Message:   "this is the log output for 1",
+			},
+		}},
+	}
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, addr []string) (DebugLogAPI, error) {
+		c.Assert(addr, gc.HasLen, 1)
+		api, ok := debugStreams[addr[0]]
+		c.Assert(ok, jc.IsTrue)
+		return api, nil
+	})
+	s.PatchValue(&getControllerDetailsClient, func(_ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{}, nil
+	})
+	checkOutput := func(args ...string) {
+		count := len(args)
+		args, expected := args[:count-1], args[count-1]
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(jujuclienttesting.MinimalStore(), tz), args...)
+		c.Check(err, jc.ErrorIsNil)
+		out := cmdtesting.Stdout(ctx)
+		lines := strings.Split(out, "\n")
+		c.Assert(lines, gc.Not(gc.HasLen), 0)
+		expectedLines := strings.Split(expected, "\n")
+		c.Check(lines[0], gc.Equals, expectedLines[0])
+		// Depending on the exact moment the log stream was stopped, we may miss the last line.
+		if len(lines) > 1 && lines[1] != "" {
+			c.Check(lines[1], gc.Equals, expectedLines[1])
+		}
+	}
+	checkOutput(
+		"--all",
+		"machine-1: 14:15:20 INFO test.module this is the log output for 1\nmachine-0: 14:15:23 INFO test.module this is the log output for 0\n")
+}
+
 func (s *DebugLogSuite) TestLogOutputWithLogs(c *gc.C) {
 	// test timezone is 6 hours east of UTC
 	tz := time.FixedZone("test", 6*60*60)
-	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, _ []string) (DebugLogAPI, error) {
 		return &fakeDebugLogAPI{log: []common.LogMessage{
 			{
 				Entity:    "machine-0",
@@ -270,5 +366,28 @@ func (fake *fakeDebugLogAPI) WatchDebugLog(params common.DebugLogParams) (<-chan
 }
 
 func (fake *fakeDebugLogAPI) Close() error {
+	return nil
+}
+
+type fakeControllerDetailsAPI struct{}
+
+func (*fakeControllerDetailsAPI) BestAPIVersion() int {
+	return 3
+}
+
+func (fake *fakeControllerDetailsAPI) ControllerDetails() (map[string]highavailability.ControllerDetails, error) {
+	return map[string]highavailability.ControllerDetails{
+		"666": {
+			ControllerID: "666",
+			APIEndpoints: []string{"address-666"},
+		},
+		"668": {
+			ControllerID: "668",
+			APIEndpoints: []string{"address-668"},
+		},
+	}, nil
+}
+
+func (fake *fakeControllerDetailsAPI) Close() error {
 	return nil
 }

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -211,7 +211,7 @@ func (c *CommandBase) NewAPIRoot(
 	store jujuclient.ClientStore,
 	controllerName, modelName string,
 ) (api.Connection, error) {
-	return c.NewAPIRootWithDialOpts(store, controllerName, modelName, nil)
+	return c.NewAPIRootWithDialOpts(store, controllerName, modelName, nil, nil)
 }
 
 // NewAPIRootWithDialOpts returns a new connection to the API server for the
@@ -220,6 +220,7 @@ func (c *CommandBase) NewAPIRoot(
 func (c *CommandBase) NewAPIRootWithDialOpts(
 	store jujuclient.ClientStore,
 	controllerName, modelName string,
+	addressOverride []string,
 	dialOpts *api.DialOpts,
 ) (api.Connection, error) {
 	c.assertRunStarted()
@@ -255,6 +256,7 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	param.APIEndpoints = addressOverride
 	if dialOpts != nil {
 		param.DialOpts = *dialOpts
 	}

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -396,13 +396,19 @@ func (c *ModelCommandBase) modelFromStore(controllerName, modelIdentifier string
 // NewAPIRoot returns a new connection to the API server for the environment
 // directed to the model specified on the command line.
 func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
+	return c.NewAPIRootWithAddressOverride(nil)
+}
+
+// NewAPIRootWithAddressOverride returns a new connection to the API server for the environment
+// directed to the model specified on the command line, using any address overrides.
+func (c *ModelCommandBase) NewAPIRootWithAddressOverride(addresses []string) (api.Connection, error) {
 	// We need to call ModelDetails() here and not just ModelName() to force
 	// a refresh of the internal model details if those are not yet stored locally.
 	modelName, _, err := c.ModelDetails()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.newAPIRoot(modelName, nil)
+	conn, err := c.newAPIRoot(modelName, nil, addresses)
 	return conn, errors.Trace(err)
 }
 
@@ -416,7 +422,7 @@ func (c *ModelCommandBase) NewAPIRootWithDialOpts(dialOpts *api.DialOpts) (api.C
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.newAPIRoot(modelName, dialOpts)
+	conn, err := c.newAPIRoot(modelName, dialOpts, nil)
 	return conn, errors.Trace(err)
 }
 
@@ -425,17 +431,17 @@ func (c *ModelCommandBase) NewAPIRootWithDialOpts(dialOpts *api.DialOpts) (api.C
 // This is for the use of model-centered commands that still want
 // to talk to controller-only APIs.
 func (c *ModelCommandBase) NewControllerAPIRoot() (api.Connection, error) {
-	return c.newAPIRoot("", nil)
+	return c.newAPIRoot("", nil, nil)
 }
 
 // newAPIRoot is the internal implementation of NewAPIRoot and NewControllerAPIRoot;
 // if modelName is empty, it makes a controller-only connection.
-func (c *ModelCommandBase) newAPIRoot(modelName string, dialOpts *api.DialOpts) (api.Connection, error) {
+func (c *ModelCommandBase) newAPIRoot(modelName string, dialOpts *api.DialOpts, addressOverride []string) (api.Connection, error) {
 	controllerName, err := c.ControllerName()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.CommandBase.NewAPIRootWithDialOpts(c.store, controllerName, modelName, dialOpts)
+	conn, err := c.CommandBase.NewAPIRootWithDialOpts(c.store, controllerName, modelName, addressOverride, dialOpts)
 	return conn, errors.Trace(err)
 }
 

--- a/juju/api.go
+++ b/juju/api.go
@@ -46,6 +46,9 @@ type NewAPIConnectionParams struct {
 	// will be scoped to the model with that UUID; otherwise it will be
 	// scoped to the controller.
 	ModelUUID string
+
+	// APIEndpoints, if set, override any other api endpoints.
+	APIEndpoints []string
 }
 
 var errNoAddresses = errors.ConstError("no API addresses")
@@ -189,6 +192,9 @@ func connectionInfo(args NewAPIConnectionParams) (*api.Info, *jujuclient.Control
 		Addrs:          controller.APIEndpoints,
 		CACert:         controller.CACert,
 		ControllerUUID: controller.ControllerUUID,
+	}
+	if len(args.APIEndpoints) > 0 {
+		apiInfo.Addrs = args.APIEndpoints
 	}
 	if controller.Proxy != nil {
 		apiInfo.Proxier = controller.Proxy.Proxier

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -181,6 +181,21 @@ func (s *NewAPIClientSuite) TestWithMacaroons(c *gc.C) {
 	c.Assert(info.Macaroons, gc.DeepEquals, []macaroon.Slice{{mac}})
 }
 
+func (s *NewAPIClientSuite) TestWithAddressOverride(c *gc.C) {
+	store := newClientStore(c, "controllername")
+	ad, err := store.AccountDetails("controllername")
+	c.Assert(err, jc.ErrorIsNil)
+
+	info, _, err := juju.ConnectionInfo(juju.NewAPIConnectionParams{
+		ControllerName: "controllername",
+		Store:          store,
+		AccountDetails: ad,
+		APIEndpoints:   []string{"address-override"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.Addrs, gc.DeepEquals, []string{"address-override"})
+}
+
 func (s *NewAPIClientSuite) TestWithRedirect(c *gc.C) {
 	store := newClientStore(c, "ctl")
 	err := store.UpdateController("ctl", jujuclient.ControllerDetails{

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -971,6 +971,19 @@ type ControllersChangeResults struct {
 	Results []ControllersChangeResult `json:"results"`
 }
 
+// ControllerDetailsResults contains the results
+// of a call to fetch controller config details.
+type ControllerDetailsResults struct {
+	Results []ControllerDetails `json:"results"`
+}
+
+// ControllerDetails contains the details about a controller.
+type ControllerDetails struct {
+	ControllerId string   `json:"controller-id"`
+	APIAddresses []string `json:"api-addresses"`
+	Error        *Error   `json:"error,omitempty"`
+}
+
 // ControllersChanges lists the servers
 // that have been added, removed or maintained in the
 // pool as a result of an enable-ha operation.


### PR DESCRIPTION
We now stream debug logs from files on the controller. For the HA case where there's no log stash integration yet, we want to allow the user to select which controller to stream from, or stream from all controllers and interleave on the client.

A new ControllerDetails api on the highavailability facade is added to allow the cli to query controller (address) details by controller number. The base command infrastructure is modified to be able to override addresses selected from `controllers.yaml` to that the specified addresses for the desired controller can be used, with all other connection details the same.

The buffered logger is tweaked to ensure the internal buffer is sorted on timestamp whenever new records are added. Thus, with the flush timer and max buffer size regulating output of records, we expect records will (mostly) be emitted in the desired chronological order so long as records arrive in a timely fashion.

The client side interleaving of records is best effort. If a particular controller is slow to serve up it records and the client side log buffer is already flushed, there's not much that can be done. And there currently limited tweaking to the buffer behaviour that is available to fine tune things.

## QA steps

bootstrap
switch controller

juju debug-log --replay

enable-ha

juju debug-log --controller all
juju debug-log --replay --controller all

juju debug-log --controller 0
juju debug-log --replay --controller 0

juju debug-log --controller 2
juju debug-log --replay --controller 2

## Documentation changes

We'll need to document the new options `--controller N` and `--controller all`.

## Links

**Jira card:** JUJU-5527

