### PR TITLE
Aligns start up probe failure with that of api.

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -68,7 +68,9 @@ const (
 	mongoDBContainerName   = "mongodb"
 	apiServerContainerName = "api-server"
 
-	startupGraceTime = 300
+	// startupGraceTime is the number of seconds afforded to startup probes to
+	// become successful before considering them a failure.
+	startupGraceTime = 600
 
 	apiServerStartupProbeInitialDelay = 3
 	apiServerStartupProbeTimeout      = 3
@@ -81,6 +83,12 @@ const (
 	apiServerLivenessProbePeriod       = 5
 	apiServerLivenessProbeSuccess      = 1
 	apiServerLivenessProbeFailure      = 2
+
+	mongoDBStartupProbeInitialDelay = 1
+	mongoDBStartupProbeTimeout      = 1
+	mongoDBStartupProbePeriod       = 5
+	mongoDBStartupProbeSuccess      = 1
+	mongoDBStartupProbeFailure      = startupGraceTime / mongoDBStartupProbePeriod
 )
 
 type controllerServiceSpec struct {
@@ -1312,11 +1320,11 @@ func (c *controllerStack) controllerContainers(setupCmd, machineCmd, controllerI
 			ProbeHandler: core.ProbeHandler{
 				Exec: probeCmds,
 			},
-			FailureThreshold:    startupGraceTime / 5,
-			InitialDelaySeconds: 1,
-			PeriodSeconds:       5,
-			SuccessThreshold:    1,
-			TimeoutSeconds:      1,
+			FailureThreshold:    mongoDBStartupProbeFailure,
+			InitialDelaySeconds: mongoDBStartupProbeInitialDelay,
+			PeriodSeconds:       mongoDBStartupProbePeriod,
+			SuccessThreshold:    mongoDBStartupProbeSuccess,
+			TimeoutSeconds:      mongoDBStartupProbeTimeout,
 		},
 		VolumeMounts: []core.VolumeMount{
 			{


### PR DESCRIPTION
We introduced start up probes to the Juju controller pod to force the readiness and liveness checks to not run until we have confirmed that the Kubernetes startup probes have succeeded.

However due to the fact that their exists a chicken and egg situation in which the mongo container requires the controller container to initialise some data it was possible for the mongo container to enter a failure state waiting for the controller.

What this fix is doing is aligning their startup probes for the moment so they at least are given equal startup time.

However the correct fix long term is move this bootstrapping activity to an init container and decouple the two containers from each other so they can startup independently.

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

@wallyworld, @ycliuhw and @tlm have been trying to reproduce this bug reported by solutions QA. The only way we have successfully be able to do this is to add an artificial 5 minute delay into the bootstrap container so that  the mongo container startup probes fail after 2 minutes.

This change is currently aligning the apiserver and mongo server so they have the same startup probe duration. This is needed until we can uncouple them in the future.

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2054930

**Jira card:** JUJU-5560

