### PR TITLE
Fix dead link in controller-service-type description

### DIFF
--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -128,8 +128,8 @@ var BootstrapConfigSchema = environschema.Fields{
 	},
 	ControllerServiceType: {
 		Description: "Controls the kubernetes service type for Juju " +
-			"controllers, see " +
-			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core " +
+			"controllers, see\n" +
+			"https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec\n" +
 			"valid values are one of cluster, loadbalancer, external",
 		Type: environschema.Tstring,
 	},


### PR DESCRIPTION
Fix dead link in controller-service-type description

Also make some minor formatting changes

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap -h
...
    controller-service-type:
      type: string
      description: |-
        Controls the kubernetes service type for Juju controllers, see
        https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
        valid values are one of cluster, loadbalancer, external
```

Verify that https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec is a valid link

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2052811