### PR TITLE
Remove check for charm config being set to same value. Bug #2043613.

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -253,23 +253,6 @@ func (c *configCommand) setConfig(client ApplicationAPI, ctx *cmd.Context) error
 		return errors.Trace(err)
 	}
 
-	result, err := client.Get(c.branchName, c.applicationName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	for k, v := range settings {
-		configValue := result.CharmConfig[k]
-
-		configValueMap, ok := configValue.(map[string]interface{})
-		if ok {
-			// convert the value to string and compare
-			if fmt.Sprintf("%v", configValueMap["value"]) == v {
-				logger.Warningf("the configuration setting %q already has the value %q", k, v)
-			}
-		}
-	}
-
 	err = client.SetConfig(c.branchName, c.applicationName, "", settings)
 	return errors.Trace(block.ProcessBlockedError(err, block.BlockChange))
 }

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -360,12 +360,8 @@ func (s *configCommandSuite) TestSetSameValue(c *gc.C) {
 		"username": "hello",
 		"outlook":  "hello@world.tld",
 	})
-	s.assertSetWarning(c, s.dir, []string{
-		"username=hello",
-	}, "the configuration setting \"username\" already has the value \"hello\"")
-	s.assertSetWarning(c, s.dir, []string{
-		"outlook=hello@world.tld",
-	}, "the configuration setting \"outlook\" already has the value \"hello@world.tld\"")
+	s.assertNoWarning(c, s.dir, []string{"username=hello"})
+	s.assertNoWarning(c, s.dir, []string{"outlook=hello@world.tld"})
 
 }
 
@@ -546,12 +542,12 @@ func (s *configCommandSuite) assertSetFail(c *gc.C, dir string, args []string, e
 	c.Assert(err, gc.ErrorMatches, expectErr)
 }
 
-func (s *configCommandSuite) assertSetWarning(c *gc.C, dir string, args []string, w string) {
+func (s *configCommandSuite) assertNoWarning(c *gc.C, dir string, args []string) {
 	cmd := application.NewConfigCommandForTest(s.fake, s.store)
 	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	_, err := cmdtesting.RunCommandInDir(c, cmd, append([]string{"dummy-application"}, args...), dir)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(strings.Replace(c.GetTestLog(), "\n", " ", -1), gc.Matches, ".*WARNING.*"+w+".*")
+	c.Assert(strings.Replace(c.GetTestLog(), "\n", " ", -1), gc.Not(gc.Matches), ".*WARNING.*")
 }
 
 // setupValueFile creates a file containing one value for testing


### PR DESCRIPTION
A warning is issued when setting a charm config value to its existing value. This warning suggests that it is a no-op. This is not the case.

If a parameter is set to its default value and the default values change with a charm update, then the value will stay the same, if it has never been set, it will change to the new default.

This behavior was added in https://github.com/juju/juju/pull/958 to fix this [bug report](https://bugs.launchpad.net/juju-core/+bug/1384622). The behavior of juju back then was different and this really was a no-op. Therefore, it makes sense to now remove this warning.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
Run unit tests in `cmd/juju/application/config_test.go`, and test config set:
```
juju bootstrap lxd lxd-dev
juju add-model default
juju deploy ./testcharms/charms/space-defender
# Set "boolean-option" to its default value
juju config space-defender boolean-option=false
```
Check in `juju debug-log` that no warning is emitted.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2043613

**Jira card:** JUJU-5493