### PR TITLE
Pin nginx-ingress-integrator charm in k8s test to avoid charm issue

### DIFF
--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,7 +7,8 @@ run_secrets() {
 	juju --show-log add-model "$model_name" --config secret-backend=auto
 
 	juju --show-log deploy hello-kubecon hello
-	juju --show-log deploy nginx-ingress-integrator nginx
+	# TODO(wallyworld) - sadly we need to pin or else the latest charm breaks with hello-kubecon
+	juju --show-log deploy --channel latest/edge --revision 83 nginx-ingress-integrator nginx
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster
 


### PR DESCRIPTION
The nginx-ingress-integrator charm updated to rev 84, and this broke our ci because it would no longer integrate with the hello-kubecon charm. This PR pins the revision to 83 as a short term ci fix.

## QA steps

run secrets_k8s ci test