### PR TITLE
Remove DQLite files when removing juju from a previously used machine

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -83,6 +83,9 @@ rm -rf /var/lib/juju/tools/*
 echo "removing /var/lib/juju/db/*"
 rm -rf /var/lib/juju/db/*
 
+echo "removing /var/lib/juju/dqlite/*"
+rm -rf /var/lib/juju/dqlite/*
+
 echo "removing /var/lib/juju/raft/*"
 rm -rf /var/lib/juju/raft/*
 

--- a/scripts/removejujuservices.bash
+++ b/scripts/removejujuservices.bash
@@ -19,6 +19,9 @@ rm -rf /var/lib/juju/tools/*
 echo "removing /var/lib/juju/db/*"
 rm -rf /var/lib/juju/db/*
 
+echo "removing /var/lib/juju/dqlite/*"
+rm -rf /var/lib/juju/dqlite/*
+
 echo "removing /var/lib/juju/raft/*"
 rm -rf /var/lib/juju/raft/*
 


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Juju allows for reusing of machines that have previously had juju on them but since been removed with `juju destroy-controller` or similar. When a machine is destroyed in this way, juju does not remove any of its files from the machine, instead, for safety, it leaves them there. They can be removed with a script juju installs:
```
/sbin/remove-juju-services
```
This script removes all juju files from the machine so that it can be bootstrapped from again. The problem is, it does not remove the dqlite files stored on disk.

This PR adds commands to remove the DQLite files too.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
#### Add manual cloud
```
lxc launch ubuntu:22.04
```
Note down lxd container name and ip:
```
lxc list
```
Copy your ssh public key to the lxd container:
```
cat ~/.ssh/id_ed25519.pub | lxc exec <lxd-container-name> -- sh -c "cat >> /home/ubuntu/.ssh/authorized_keys"
```
Check you can ssh to it:
```
ssh ubuntu@<lxd-container-ip>
```
Exit ssh session and  bootstrap on it:
```
juju bootstrap manual/ubuntu@<lxd-container-ip>
```

#### Remove controller and clean up
Destroy controller
```
juju destroy-controller manual --no-prompt
```
Run juju provided cleanup script:
```
lxc exec <lxd-container-name> sudo /sbin/remove-juju-services
```
#### Retry bootstrap
Retry bootstrap, it should work as expected.
```
juju bootstrap manual/ubuntu@<lxd-container-ip>
```
<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2046186

**Jira card:** JUJU-5494

