### PR TITLE
Bug 2053216 num provision workers

### DIFF
--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -347,15 +347,31 @@ var configTests = []configTest{
 		}),
 		err: `provisioner-harvest-mode: expected one of \[all none unknown destroyed], got "yes please"`,
 	}, {
-		about: fmt.Sprintf(
-			"%s: %d",
-			"num-provision-workers",
-			42,
-		),
+		about:       fmt.Sprintf("num-provision-workers: 42"),
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"num-provision-workers": "42",
+			"num-provision-workers": 42,
 		}),
+	}, {
+		about:       fmt.Sprintf("num-provision-workers: over max"),
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"num-provision-workers": 101,
+		}),
+		err: `num-provision-workers: must be less than 100`,
+	}, {
+		about:       fmt.Sprintf("num-container-provision-workers: 17"),
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"num-container-provision-workers": 17,
+		}),
+	}, {
+		about:       fmt.Sprintf("num-container-provision-workers: over max"),
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"num-container-provision-workers": 26,
+		}),
+		err: `num-container-provision-workers: must be less than 25`,
 	}, {
 		about:       "default image stream",
 		useDefaults: config.UseDefaults,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -657,10 +657,14 @@ func (test configTest) check(c *gc.C) {
 	cfg, err := config.New(test.useDefaults, test.attrs)
 	if test.err != "" {
 		c.Check(cfg, gc.IsNil)
-		c.Assert(err, gc.ErrorMatches, test.err)
+		c.Check(err, gc.ErrorMatches, test.err)
 		return
 	}
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil, gc.Commentf("config.New failed"))
+	if err != nil {
+		// As we have a Check not an Assert so the test
+		return
+	}
 
 	typ, _ := test.attrs["type"].(string)
 	// "null" has been deprecated in favour of "manual",
@@ -669,104 +673,104 @@ func (test configTest) check(c *gc.C) {
 		typ = "manual"
 	}
 	name, _ := test.attrs["name"].(string)
-	c.Assert(cfg.Type(), gc.Equals, typ)
-	c.Assert(cfg.Name(), gc.Equals, name)
+	c.Check(cfg.Type(), gc.Equals, typ)
+	c.Check(cfg.Name(), gc.Equals, name)
 	agentVersion, ok := cfg.AgentVersion()
 	if s := test.attrs["agent-version"]; s != nil {
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(agentVersion, gc.Equals, version.MustParse(s.(string)))
+		c.Check(ok, jc.IsTrue)
+		c.Check(agentVersion, gc.Equals, version.MustParse(s.(string)))
 	} else {
-		c.Assert(ok, jc.IsFalse)
-		c.Assert(agentVersion, gc.Equals, version.Zero)
+		c.Check(ok, jc.IsFalse)
+		c.Check(agentVersion, gc.Equals, version.Zero)
 	}
 
 	if expected, ok := test.attrs["uuid"]; ok {
-		c.Assert(cfg.UUID(), gc.Equals, expected)
+		c.Check(cfg.UUID(), gc.Equals, expected)
 	}
 
 	dev, _ := test.attrs["development"].(bool)
-	c.Assert(cfg.Development(), gc.Equals, dev)
+	c.Check(cfg.Development(), gc.Equals, dev)
 
 	seriesAttr, _ := test.attrs["default-series"].(string)
 	defaultSeries, ok := cfg.DefaultSeries()
 	if seriesAttr != "" {
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(defaultSeries, gc.Equals, seriesAttr)
+		c.Check(ok, jc.IsTrue)
+		c.Check(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(ok, jc.IsFalse)
-		c.Assert(defaultSeries, gc.Equals, "")
+		c.Check(ok, jc.IsFalse)
+		c.Check(defaultSeries, gc.Equals, "")
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
-		c.Assert(cfg.FirewallMode(), gc.Equals, m)
+		c.Check(cfg.FirewallMode(), gc.Equals, m)
 	}
 
 	if m, _ := test.attrs["default-space"].(string); m != "" {
-		c.Assert(cfg.DefaultSpace(), gc.Equals, m)
+		c.Check(cfg.DefaultSpace(), gc.Equals, m)
 	}
 
 	keys, _ := test.attrs["authorized-keys"].(string)
-	c.Assert(cfg.AuthorizedKeys(), gc.Equals, keys)
+	c.Check(cfg.AuthorizedKeys(), gc.Equals, keys)
 
 	lfCfg, hasLogCfg := cfg.LogFwdSyslog()
 	if v, ok := test.attrs["logforward-enabled"].(bool); ok {
-		c.Assert(hasLogCfg, jc.IsTrue)
-		c.Assert(lfCfg.Enabled, gc.Equals, v)
+		c.Check(hasLogCfg, jc.IsTrue)
+		c.Check(lfCfg.Enabled, gc.Equals, v)
 	}
 	if v, ok := test.attrs["syslog-ca-cert"].(string); v != "" {
-		c.Assert(hasLogCfg, jc.IsTrue)
-		c.Assert(lfCfg.CACert, gc.Equals, v)
+		c.Check(hasLogCfg, jc.IsTrue)
+		c.Check(lfCfg.CACert, gc.Equals, v)
 	} else if ok {
-		c.Assert(hasLogCfg, jc.IsTrue)
+		c.Check(hasLogCfg, jc.IsTrue)
 		c.Check(lfCfg.CACert, gc.Equals, "")
 	}
 	if v, ok := test.attrs["syslog-client-cert"].(string); v != "" {
-		c.Assert(hasLogCfg, jc.IsTrue)
-		c.Assert(lfCfg.ClientCert, gc.Equals, v)
+		c.Check(hasLogCfg, jc.IsTrue)
+		c.Check(lfCfg.ClientCert, gc.Equals, v)
 	} else if ok {
-		c.Assert(hasLogCfg, jc.IsTrue)
+		c.Check(hasLogCfg, jc.IsTrue)
 		c.Check(lfCfg.ClientCert, gc.Equals, "")
 	}
 	if v, ok := test.attrs["syslog-client-key"].(string); v != "" {
-		c.Assert(hasLogCfg, jc.IsTrue)
-		c.Assert(lfCfg.ClientKey, gc.Equals, v)
+		c.Check(hasLogCfg, jc.IsTrue)
+		c.Check(lfCfg.ClientKey, gc.Equals, v)
 	} else if ok {
-		c.Assert(hasLogCfg, jc.IsTrue)
+		c.Check(hasLogCfg, jc.IsTrue)
 		c.Check(lfCfg.ClientKey, gc.Equals, "")
 	}
 
 	if v, ok := test.attrs["ssl-hostname-verification"]; ok {
-		c.Assert(cfg.SSLHostnameVerification(), gc.Equals, v)
+		c.Check(cfg.SSLHostnameVerification(), gc.Equals, v)
 	}
 
 	if v, ok := test.attrs["provisioner-harvest-mode"]; ok {
 		harvestMeth, err := config.ParseHarvestMode(v.(string))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, harvestMeth)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(cfg.ProvisionerHarvestMode(), gc.Equals, harvestMeth)
 	} else {
-		c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, config.HarvestDestroyed)
+		c.Check(cfg.ProvisionerHarvestMode(), gc.Equals, config.HarvestDestroyed)
 	}
 
 	if v, ok := test.attrs["image-stream"]; ok {
-		c.Assert(cfg.ImageStream(), gc.Equals, v)
+		c.Check(cfg.ImageStream(), gc.Equals, v)
 	} else {
-		c.Assert(cfg.ImageStream(), gc.Equals, "released")
+		c.Check(cfg.ImageStream(), gc.Equals, "released")
 	}
 
 	url, urlPresent := cfg.ImageMetadataURL()
 	if v, _ := test.attrs["image-metadata-url"].(string); v != "" {
-		c.Assert(url, gc.Equals, v)
-		c.Assert(urlPresent, jc.IsTrue)
+		c.Check(url, gc.Equals, v)
+		c.Check(urlPresent, jc.IsTrue)
 	} else {
-		c.Assert(urlPresent, jc.IsFalse)
+		c.Check(urlPresent, jc.IsFalse)
 	}
 
 	agentURL, urlPresent := cfg.AgentMetadataURL()
 	expectedToolsURLValue := test.attrs["agent-metadata-url"]
 	if urlPresent {
-		c.Assert(agentURL, gc.Equals, expectedToolsURLValue)
+		c.Check(agentURL, gc.Equals, expectedToolsURLValue)
 	} else {
-		c.Assert(agentURL, gc.Equals, "")
+		c.Check(agentURL, gc.Equals, "")
 	}
 
 	// assertions for deprecated tools-stream attribute used with new agent-stream
@@ -787,33 +791,33 @@ func (test configTest) check(c *gc.C) {
 
 	containerURL, urlPresent := cfg.ContainerImageMetadataURL()
 	if v, _ := test.attrs["container-image-metadata-url"].(string); v != "" {
-		c.Assert(containerURL, gc.Equals, v)
-		c.Assert(urlPresent, jc.IsTrue)
+		c.Check(containerURL, gc.Equals, v)
+		c.Check(urlPresent, jc.IsTrue)
 	} else {
-		c.Assert(urlPresent, jc.IsFalse)
+		c.Check(urlPresent, jc.IsFalse)
 	}
 
 	if v, ok := test.attrs["container-image-stream"]; ok {
-		c.Assert(cfg.ContainerImageStream(), gc.Equals, v)
+		c.Check(cfg.ContainerImageStream(), gc.Equals, v)
 	} else {
-		c.Assert(cfg.ContainerImageStream(), gc.Equals, "released")
+		c.Check(cfg.ContainerImageStream(), gc.Equals, "released")
 	}
 
 	resourceTags, cfgHasResourceTags := cfg.ResourceTags()
-	c.Assert(cfgHasResourceTags, jc.IsTrue)
+	c.Check(cfgHasResourceTags, jc.IsTrue)
 	if tags, ok := test.attrs["resource-tags"]; ok {
 		switch tags := tags.(type) {
 		case []string:
 			if len(tags) > 0 {
-				c.Assert(resourceTags, jc.DeepEquals, testResourceTagsMap)
+				c.Check(resourceTags, jc.DeepEquals, testResourceTagsMap)
 			}
 		case string:
 			if tags != "" {
-				c.Assert(resourceTags, jc.DeepEquals, testResourceTagsMap)
+				c.Check(resourceTags, jc.DeepEquals, testResourceTagsMap)
 			}
 		}
 	} else {
-		c.Assert(resourceTags, gc.HasLen, 0)
+		c.Check(resourceTags, gc.HasLen, 0)
 	}
 
 	xmit := cfg.TransmitVendorMetrics()

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -676,9 +676,9 @@ func (test configTest) check(c *gc.C) {
 		c.Check(err, gc.ErrorMatches, test.err)
 		return
 	}
-	c.Check(err, jc.ErrorIsNil, gc.Commentf("config.New failed"))
-	if err != nil {
-		// As we have a Check not an Assert so the test
+	if !c.Check(err, jc.ErrorIsNil, gc.Commentf("config.New failed")) {
+		// As we have a Check not an Assert so the test should not
+		// continue from here as it will result in a nil pointer panic.
 		return
 	}
 
@@ -730,8 +730,9 @@ func (test configTest) check(c *gc.C) {
 
 	lfCfg, hasLogCfg := cfg.LogFwdSyslog()
 	if v, ok := test.attrs["logforward-enabled"].(bool); ok {
-		c.Check(hasLogCfg, jc.IsTrue)
-		c.Check(lfCfg.Enabled, gc.Equals, v)
+		if c.Check(hasLogCfg, jc.IsTrue) {
+			c.Check(lfCfg.Enabled, gc.Equals, v)
+		}
 	}
 	if v, ok := test.attrs["syslog-ca-cert"].(string); v != "" {
 		c.Check(hasLogCfg, jc.IsTrue)

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -458,7 +458,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 
 	attrs = map[string]interface{}{
 		"apt-mirror":            "http://different-mirror",
-		"num-provision-workers": 666,
+		"num-provision-workers": 66,
 	}
 	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -487,7 +487,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 			Value: "dummy-proxy",
 		}}}
 	expectedValues["num-provision-workers"] = config.AttributeDefaultValues{
-		Controller: 666,
+		Controller: 66,
 		Default:    16,
 	}
 	c.Assert(cfg, jc.DeepEquals, expectedValues)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -136,7 +136,7 @@ func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChangesWorkerCou
 		select {
 		case newCfg := <-cfgObserver:
 			if container {
-				if newCfg.NumContainerProvisionWorkers() == 42 {
+				if newCfg.NumContainerProvisionWorkers() == 10 {
 					return
 				}
 				received = append(received, newCfg.NumContainerProvisionWorkers())

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -118,7 +118,7 @@ func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChangesWorkerCou
 	// Switch to reaping on All machines.
 	attrs := map[string]interface{}{}
 	if container {
-		attrs[config.NumContainerProvisionWorkersKey] = 42
+		attrs[config.NumContainerProvisionWorkersKey] = 10
 	} else {
 		attrs[config.NumProvisionWorkersKey] = 42
 	}


### PR DESCRIPTION
Theoretically any user with model access could bring the controller to a standstill by setting the number of provisioner workers to an extremely large value. Set a sane value as a cap.

The values are larger than the default but not back by solid data today. We do know that 16 workers for containers will cause issues with LXD on some machines.

In the future we should allow the controller config to define what the max values should be. Today controller config has no linkage with model config to enable this. A question would be whether existing model config should be changed if the max is changed.

A side commit to update one of the tests so that all results are surfaced, rather than simply checking and continuing.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

$ juju model-config num-provision-workers=1024
ERROR num-provision-workers: must be less than 100
$ juju model-config num-container-provision-workers=42
ERROR num-container-provision-workers: must be less than 25

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2053216

**Jira card:** JUJU-5543

