### PR TITLE
Disallow offering non-global scoped endpoints.

### DIFF
--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -534,10 +534,17 @@ func (s *applicationOffers) validateOfferArgs(offer crossmodel.AddApplicationOff
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = getApplicationEndpoints(app, offer.Endpoints)
+
+	eps, err := getApplicationEndpoints(app, offer.Endpoints)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	for _, ep := range eps {
+		if ep.Scope != charm.ScopeGlobal {
+			return fmt.Errorf("can only offer endpoints with global scope, provided scope %q", ep.Scope)
+		}
+	}
+
 	return nil
 }
 

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -167,6 +167,22 @@ func (s *applicationOffersSuite) TestAddApplicationOfferBadEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *applicationOffersSuite) TestFaillAddApplicationOfferNonGlobalEndpoint(c *gc.C) {
+	s.AddTestingApplication(c, "local-wordpress", s.AddTestingCharm(c, "wordpress"))
+	// logging-dir is a container scoped relation.
+	eps := map[string]string{"logging-dir": "logging-dir"}
+	sd := state.NewApplicationOffers(s.State)
+	owner := s.Factory.MakeUser(c, nil)
+	args := crossmodel.AddApplicationOfferArgs{
+		OfferName:       "offer-name",
+		ApplicationName: "local-wordpress",
+		Endpoints:       eps,
+		Owner:           owner.Name(),
+	}
+	_, err := sd.AddOffer(args)
+	c.Assert(err, gc.ErrorMatches, `.*can only offer endpoints with global scope, provided scope "container".*`)
+}
+
 func (s *applicationOffersSuite) TestListOffersNone(c *gc.C) {
 	sd := state.NewApplicationOffers(s.State)
 	offers, err := sd.ListOffers()


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Juju allows users to offer container scoped endpoints. It fails when the offer is integrated in a different model after being consumed. There is no reason to wait this long to fail, it can just fail straight away.

This change stops non-global relations from being offered.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing


## QA steps
#### Unit tests
Run tests in `./state/applicationoffers_test.go`

#### Manual verification
```
juju bootstrap lxd lxd-dev
juju add-model default
juju deploy ntp
juju offer ntp:juju-info
```
The new error should occur here.

<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2032716

**Jira card:** JUJU-5492

