### PR TITLE
Fix --to placement directive

### DIFF
--- a/apiserver/facades/client/machinemanager/upgradebase.go
+++ b/apiserver/facades/client/machinemanager/upgradebase.go
@@ -524,11 +524,11 @@ func (s charmhubSeriesValidator) ValidateApplications(applications []Application
 	for _, resp := range refreshResp {
 		var found bool
 		for _, base := range resp.Entity.Bases {
-			track, err := corecharm.ChannelTrack(base.Channel)
+			channel, err := corebase.ParseChannel(base.Channel)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if channelToValidate == track || force {
+			if channelToValidate == channel.Track || force {
 				found = true
 				break
 			}

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -466,6 +466,39 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 	})
 }
 
+func (s *RefreshConfigSuite) TestRefreshOneWithBaseChannelRiskBuild(c *gc.C) {
+	id := "foo"
+	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04/stable",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	req, err := config.Build()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{{
+			InstanceKey: "instance-key",
+			ID:          "foo",
+			Revision:    1,
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
+			TrackingChannel: "latest/stable",
+		}},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "refresh",
+			InstanceKey: "instance-key",
+			ID:          &id,
+		}},
+		Fields: expRefreshFields,
+	})
+
+}
+
 func (s *RefreshConfigSuite) TestRefreshOneBuildInstanceKeyCompatibility(c *gc.C) {
 	id := "foo"
 	config, err := RefreshOne("", id, 1, "latest/stable", RefreshBase{

--- a/core/base/channel_test.go
+++ b/core/base/channel_test.go
@@ -22,6 +22,9 @@ func (s *ChannelSuite) TestParse(c *gc.C) {
 	ch, err = ParseChannel("22.04/edge")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch, jc.DeepEquals, Channel{Track: "22.04", Risk: "edge"})
+	ch, err = ParseChannel("all")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch, jc.DeepEquals, Channel{Track: "all"})
 }
 
 func (s *ChannelSuite) TestParseError(c *gc.C) {

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -192,17 +192,3 @@ func (p Platform) String() string {
 
 	return path
 }
-
-func ChannelTrack(channel string) (string, error) {
-	// Base channel can be found as either just the version `20.04` (focal)
-	// or as `20.04/latest` (focal latest). We should future proof ourself
-	// for now and just drop the risk on the floor.
-	ch, err := charm.ParseChannel(channel)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if ch.Track == "" {
-		return "", errors.NotValidf("channel track")
-	}
-	return ch.Track, nil
-}

--- a/core/charm/origin_test.go
+++ b/core/charm/origin_test.go
@@ -139,35 +139,3 @@ func (s platformSuite) TestString(c *gc.C) {
 		c.Assert(platform.String(), gc.DeepEquals, test.Expected)
 	}
 }
-
-type channelTrackSuite struct {
-	testing.IsolationSuite
-}
-
-var _ = gc.Suite(&channelTrackSuite{})
-
-func (*channelTrackSuite) TestChannelTrack(c *gc.C) {
-	tests := []struct {
-		channel string
-		result  string
-	}{{
-		channel: "20.10",
-		result:  "20.10",
-	}, {
-		channel: "focal",
-		result:  "focal",
-	}, {
-		channel: "20.10/stable",
-		result:  "20.10",
-	}, {
-		channel: "focal/stable",
-		result:  "focal",
-	}}
-
-	for i, test := range tests {
-		c.Logf("test %d - %s", i, test.channel)
-		got, err := charm.ChannelTrack(test.channel)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(got, gc.Equals, test.result)
-	}
-}

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -1006,12 +1006,13 @@ func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, or
 			base corebase.Base
 			err  error
 		)
-		track, err := corecharm.ChannelTrack(release.Base.Channel)
+
+		channel, err := corebase.ParseChannel(release.Base.Channel)
 		if err != nil {
 			c.logger.Errorf("invalid base channel %v: %s", release.Base.Channel, err)
 			continue
 		}
-		if track == "all" || release.Base.Name == "all" {
+		if channel.Track == "all" || release.Base.Name == "all" {
 			base, err = corebase.ParseBase(origin.Platform.OS, origin.Platform.Channel)
 		} else {
 			base, err = corebase.ParseBase(release.Base.Name, release.Base.Channel)

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -1005,7 +1005,8 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 
 func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 	name := "wordpress"
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/latest")
+	// 'mistakenly' include a risk in the platform
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/stable")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
 		Platform: platform,
@@ -1028,7 +1029,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 			Channel:     &ch,
 			Base: &transport.Base{
 				Name:         "ubuntu",
-				Channel:      "20.10/latest",
+				Channel:      "20.10",
 				Architecture: "amd64",
 			},
 		}},

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -14,6 +14,21 @@ run_deploy_charm() {
 	destroy_model "test-deploy-charm"
 }
 
+run_deploy_charm_placement_directive() {
+	echo
+
+	file="${TEST_DIR}/test-deploy-charm-placement-directive.log"
+
+	ensure "test-deploy-charm-placement-directive" "${file}"
+
+	juju add-machine --base ubuntu@20.04
+	juju deploy jameinel-ubuntu-lite --to 0
+	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+	destroy_model "test-deploy-charm-placement-directive"
+
+}
+
 run_deploy_charm_unsupported_series() {
 	# Test trying to deploy a charmhub charm to an operating system
 	# never supported in the specified channel. It should fail.
@@ -318,6 +333,7 @@ test_deploy_charms() {
 		cd .. || exit
 
 		run "run_deploy_charm"
+		run "run_deploy_charm_placement_directive"
 		run "run_deploy_specific_series"
 		run "run_resolve_charm"
 		run "run_deploy_charm_unsupported_series"


### PR DESCRIPTION
The charmhub api does not expect a risk to be present in OS base channels. However, under some circumstances (importantly, using the --to placement directive), a risk is included. Filter these out

Add an integration test to cover this case

Also, as a flyby, remove the ChannelTrack function from core charm. This function is confusing and encourages misuse. It was only used twice, on both occasions to filter the risk out of an OS base. However, the function lived in the charm package, and it's name/description imply it's to be used for charm channels.

A few options were considered for what to do instead. In the end, I made the decision to just remove it, and in the places it was used to parse a base channel and just read the Track.

This turns out to be exactly what a 'BaseChannelTrack' function would do, and not actually add any complexity to the code. In my opinion, a function/method to do this for us is not a helpful abstraction, since dropping it actually increases readability.

Confusion around OS channels and charm channels is avoided because call a concrete base.ParseChannel function, and deal with the concrete base.Channel struct. This would be hidden if we use a 'BaseChannelTrack' function.

This isn't perfect, however. There is still a bit of overlap between Juju-base-channel and charmhub-base-channel, which aren't quite always the same. We would now need to support channels with track "all" for instance. This was the case beforehand charm channels, so this is an improvement.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

#### Upgrade-machine

```
$ juju deploy ubuntu --base ubuntu@20.04 # NOTE: ubuntu supports both 20.04 & 22.04
$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete

$ juju deploy influxdb # NOTE: influxdb only supports uubuntu@20.04
$ juju upgrade-machine 1 prepare ubuntu@22.04
WARNING: This command will mark machine "1" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - influxdb/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - influxdb

Continue [y/N]? y
ERROR charm "influxdb" does not support ubuntu@22.04/stable, force not used

$ juju upgrade-machine 1 prepare ubuntu@22.04 --force
WARNING: This command will mark machine "1" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - influxdb/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - influxdb

Continue [y/N]? y
machine-1 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-1 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
influxdb/0 pre-series-upgrade hook running
influxdb/0 pre-series-upgrade completed
machine-1 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 1 complete
```

### composeSuggestions

```
$ juju deploy mysql --channel latest/stable
ERROR selecting releases: charm or bundle not found for channel "latest/stable", base "amd64"
available releases are:
  channel "8.0/candidate": available bases are: ubuntu@22.04
  channel "8.0/beta": available bases are: ubuntu@22.04
  channel "8.0/edge": available bases are: ubuntu@22.04
  channel "8.0/stable": available bases are: ubuntu@22.04

$ juju deploy ubuntu --channel track/stable
ERROR selecting releases: charm or bundle not found for channel "track/stable", base "amd64"
available releases are:
  channel "latest/candidate": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/beta": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/edge": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/stable": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
```

### --to

```
$ ./main.sh -v -c aws -p ec2 deploy test_deploy_charms
```

```
juju add-machine
juju deploy ubuntu --to 0
```
```
juju add-machine
juju deploy juju-dashboard --to 1
```

```
juju deploy ubuntu ubu
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2054375