### PR TITLE
Adds a view to the ddl for credentials.

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -294,6 +294,27 @@ CREATE TABLE cloud_credential (
 CREATE UNIQUE INDEX idx_cloud_credential_cloud_uuid_owner_uuid
 ON cloud_credential (cloud_uuid, owner_uuid, name);
 
+-- view_cloud_credential provides a convenience view for accessing a
+-- credentials uuid baseD on the natural key used to display the credential to
+-- users.
+CREATE VIEW v_cloud_credential
+AS
+SELECT cc.uuid,
+       cc.cloud_uuid,
+       cc.auth_type_id,
+       cc.owner_uuid,
+       cc.name,
+       cc.revoked,
+       cc.invalid,
+       cc.invalid_reason,
+       c.name AS cloud_name,
+       u.name AS owner_name
+FROM cloud_credential AS cc
+INNER JOIN cloud c
+ON c.uuid = cc.cloud_uuid
+INNER JOIN user u
+ON u.uuid = cc.owner_uuid;
+
 CREATE TABLE cloud_credential_attributes (
     cloud_credential_uuid TEXT NOT NULL,
     key TEXT NOT NULL,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -181,6 +181,9 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 	expected := set.NewStrings(
 		// Users
 		"v_user_auth",
+
+		// Credentials
+		"v_cloud_credential",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }


### PR DESCRIPTION
@manadart provided some PR feedback in #16925 around inner selects and that the way we are transferring from the natural credential key to the uuid could be cleaned up.

This PR adds a new sql view to build a mapping table from credential natural key to uuid allowing for quick and easy access.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are sufficient for this change as we have not changed the contracts of any functions. This is an internal implementation change offering the same functionality. No unit tests have broken as a result.

## Documentation changes

SQL has been documented explaining the purpose of the view.

