### PR TITLE
GOCOVERDIR causes tests to fail

### DIFF
--- a/cmd/jujuc/main_test.go
+++ b/cmd/jujuc/main_test.go
@@ -106,6 +106,8 @@ func run(c *gc.C, sockPath sockets.Socket, contextId string, exit int, stdin []b
 		fmt.Sprintf("JUJU_AGENT_SOCKET_ADDRESS=%s", sockPath.Address),
 		fmt.Sprintf("JUJU_AGENT_SOCKET_NETWORK=%s", sockPath.Network),
 		fmt.Sprintf("JUJU_CONTEXT_ID=%s", contextId),
+		// See: https://go.dev/doc/build-cover
+		fmt.Sprintf("GOCOVERDIR=%s", ps.Dir),
 		// Code that imports github.com/juju/juju/testing needs to
 		// be able to find that module at runtime (via build.Import),
 		// so we have to preserve that env variable.
@@ -225,5 +227,5 @@ func (s *HookToolMainSuite) TestStdin(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := run(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
-	c.Assert(output, gc.Equals, "some standard input")
+	c.Assert(output, jc.Contains, "some standard input")
 }

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -158,6 +158,8 @@ func runForTest(c *gc.C, sockPath sockets.Socket, contextId string, exit int, st
 		fmt.Sprintf("JUJU_AGENT_SOCKET_ADDRESS=%s", sockPath.Address),
 		fmt.Sprintf("JUJU_AGENT_SOCKET_NETWORK=%s", sockPath.Network),
 		fmt.Sprintf("JUJU_CONTEXT_ID=%s", contextId),
+		// See: https://go.dev/doc/build-cover
+		fmt.Sprintf("GOCOVERDIR=%s", ps.Dir),
 		// Code that imports github.com/juju/juju/testing needs to
 		// be able to find that module at runtime (via build.Import),
 		// so we have to preserve that env variable.
@@ -277,5 +279,5 @@ func (s *HookToolMainSuite) TestStdin(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := runForTest(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
-	c.Assert(output, gc.Equals, "some standard input")
+	c.Assert(output, jc.Contains, "some standard input")
 }


### PR DESCRIPTION
Some tests invoke the go tooling to run a test, which causes a failure as we now set juju to run with go coverage. We want to run code coverage to push that information to tiobe.

Unfortunately, GOCOVERDIR outputs a warning if the environment variable is not set. This warning is then caught by the strict equality output we're looking for on stdout/stderr. See: https://go.dev/doc/build-cover

Note: these tests should be deprecated going forward.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ go test -v ./cmd/jujuc -cover=1 -check.f=TestStdin
```

