### PR TITLE
backport to 2.9: Have podman build append to manifest when building images.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -135,14 +135,16 @@ build_push_operator_image() {
             ${output} \
             "${BUILD_DIR}"
     elif [[ "${OCI_BUILDER}" = "podman" ]]; then
+        "$DOCKER_BIN" manifest rm "$(operator_image_path)" || true
+        "$DOCKER_BIN" manifest create "$(operator_image_path)"
         "$DOCKER_BIN" build \
             --jobs "4" \
             -f "${WORKDIR}/Dockerfile" \
-            -t "$(operator_image_path)" \
+            --manifest "$(operator_image_path)" \
             --platform="$build_multi_osarch" \
             "${BUILD_DIR}"
         if [[ "$push_image" = true ]]; then
-            "$DOCKER_BIN" push "$(operator_image_path)"
+            "$DOCKER_BIN" manifest push "$(operator_image_path)" "docker://$(operator_image_path)"
         fi
     else
         echo "unknown OCI_BUILDER=${OCI_BUILDER} expected docker or podman"


### PR DESCRIPTION
We landed a fix in #16880 to fix publishing of oci architectures. We however only landed this in 3.4, and 3.3 but not 2.9. Building the latest 2.9 release is only publishing images for ppc. This PR cherry-pick the commit out to back port into 2.9.
It will then be merged into 3.1

## Links

**Launchpad bug:**  https://bugs.launchpad.net/juju/+bug/2054930


