### PR TITLE
Make sure subnets are updated when a NIC gets an address on manual cloud

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -436,6 +436,63 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpNewSubnetsAdded(c *gc.C
 	c.Check(ops, gc.HasLen, 8)
 }
 
+func (s *networkConfigSuite) TestUpdateMachineLinkLayerAddressOpNewSubnetsAdded(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	// A machine with one link-layer dev.
+	s.expectMachine()
+	mExp := s.machine.EXPECT()
+
+	// Device eth0 exists with no addresses and will have one added to it.
+	ethMAC := "aa:bb:cc:dd:ee:ff"
+	ethDev := mocks.NewMockLinkLayerDevice(ctrl)
+	ethExp := ethDev.EXPECT()
+	ethExp.Name().Return("eth0").MinTimes(1)
+	ethExp.UpdateOps(state.LinkLayerDeviceArgs{
+		Name:        "eth0",
+		Type:        "ethernet",
+		MACAddress:  ethMAC,
+		IsAutoStart: true,
+		IsUp:        true,
+	}).Return(nil)
+	ethExp.AddAddressOps(state.LinkLayerDeviceAddress{
+		DeviceName:       "eth0",
+		ConfigMethod:     "static",
+		CIDRAddress:      "0.10.0.2/24",
+		GatewayAddress:   "0.10.0.1",
+		IsDefaultGateway: true,
+	}).Return([]txn.Op{{}}, nil)
+
+	mExp.AllLinkLayerDevices().Return([]networkingcommon.LinkLayerDevice{ethDev}, nil)
+	mExp.AllDeviceAddresses().Return(nil, nil)
+
+	// Since there is a new address, then we process (and therefore add)
+	// subnets.
+	s.state.EXPECT().AddSubnetOps(network.SubnetInfo{CIDR: "0.10.0.0/24"}).Return([]txn.Op{{}}, nil)
+
+	op := s.NewUpdateMachineLinkLayerOp(s.machine, network.InterfaceInfos{
+		{
+			InterfaceName: "eth0",
+			InterfaceType: "ethernet",
+			MACAddress:    ethMAC,
+			Addresses: network.ProviderAddresses{
+				network.NewMachineAddress("0.10.0.2", network.WithCIDR("0.10.0.0/24")).AsProviderAddress(),
+			},
+			GatewayAddress:   network.NewMachineAddress("0.10.0.1").AsProviderAddress(),
+			IsDefaultGateway: true,
+		},
+	}, true, s.state)
+
+	ops, err := op.Build(0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Expected ops are:
+	// - One for the new device address.
+	// - One for the new subnet.
+	c.Check(ops, gc.HasLen, 2)
+}
+
 func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpBridgedDeviceMovesAddress(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
On manual clouds, when a new link layer device is added, the subnets are processed so that they include the new device's address. This works fine except for the case when a NIC doesn't have an address assigned at the time of provision but gets one later.

This patch therefore makes sure that the subnets are updated both when a new NIC is detected and also when a new address for an existing NIC is detected.



## Checklist



- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This scenario runs on a manual cloud, for this we'll need 2 lxd manually provided machines (one for the controller other for the juju machine provision). Also, we'll need to make sure there are two NICs available for the lxd machines, because we will assign an address on one of the NICs after the machine has been provisioned and make sure this address has been added as a subnet. 

To do this, first create a new lxd bridge, and then create and edit a lxd profile with 2 NICs such that:
```
lxc network create lxdbr1 --type=bridge
lxc profile create juju-manual
lxc profile show juju-manual
config:
  user.user-data: |+
    #cloud-config
    ssh_authorized_keys:
      - ssh-ed25519 XXX nicolas@home
      - ssh-rsa XXX juju-client-key

description: ""
devices:
  eth0:
    name: eth0
    network: lxdbr0
    type: nic
  eth1:
    name: eth1
    network: lxdbr1
    type: nic
  root:
    path: /
    pool: default
    type: disk
name: juju-manual
used_by:
```
(replace your ssh pub keys above)

Now you can manually start the two lxd machines needed for juju:
```
lxc launch ubuntu:22.04 manual-c0 --profile juju-manual
lxc launch ubuntu:22.04 manual-m0 --profile juju-manual 
```

Now you will need to update your ~/.ssh/config file to include the following lines:
```
Host <TARGET_IP_ADDRESS>     
    IdentityFile ~/.ssh/id_ed25519
     ControlMaster no
```
for both machine's IPs. As stated in our docs https://juju.is/docs/juju/manual.

Now you can bootstrap:
```
juju bootstrap manual/ubuntu@{ip-controller-machine} c 
juju add-model m
```
at the same time you can ssh into the `manual-m0` machine and make sure your device eth1 doesn't have any assigned address, if there is then delete it:
```
ip a
# sudo ip addr del {ip/24} dev eth1
```
Once bootstrap is finished provision the juju machine and you should only see one subnet afterwards:
```
juju add-machine ssh:ubuntu@{ip-manual-m0}
juju subnets
subnets:
  10.170.236.0/24:
    type: ipv4
    status: in-use
    space: alpha
    zones: []
```
Then you can ssh again into the `manual-m0` machine and this time assign an address (that's in the `lxdbr1` address space) to the device `eth1` and restart jujud:
```
sudo ip addr add 10.68.58.2/24 dev eth1
sudo systemctl restart jujud-machine-0.service
```
After this, you should see the new subnet:
```
juju subnets
subnets:
  10.68.58.0/24:
    type: ipv4
    status: in-use
    space: alpha
    zones: []
  10.170.236.0/24:
    type: ipv4
    status: in-use
    space: alpha
    zones: []
```    
## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links



**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2052598

**Jira card:** JUJU-5588

