### PR TITLE
Allow non leaders to consume app owned secrets using a label

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -466,7 +466,7 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(args params.GetSecretContentArg
 	return result, nil
 }
 
-func (s *SecretsManagerAPI) getRemoteSecretContent(uri *coresecrets.URI, refresh, peek bool, label string, updateLabel bool) (
+func (s *SecretsManagerAPI) getRemoteSecretContent(uri *coresecrets.URI, refresh, peek bool, labelToUpdate *string) (
 	*secrets.ContentParams, *secretsprovider.ModelBackendConfig, bool, error,
 ) {
 	extClient, err := s.remoteClientGetter(uri)
@@ -526,13 +526,13 @@ func (s *SecretsManagerAPI) getRemoteSecretContent(uri *coresecrets.URI, refresh
 	if err != nil {
 		return nil, nil, false, errors.Trace(err)
 	}
-	if refresh || updateLabel {
+	if refresh || labelToUpdate != nil {
 		if refresh {
 			consumerInfo.LatestRevision = latestRevision
 			consumerInfo.CurrentRevision = latestRevision
 		}
-		if label != "" {
-			consumerInfo.Label = label
+		if labelToUpdate != nil {
+			consumerInfo.Label = *labelToUpdate
 		}
 		if err := s.secretsConsumer.SaveSecretConsumer(uri, s.authTag, consumerInfo); err != nil {
 			return nil, nil, false, errors.Trace(err)
@@ -590,26 +590,29 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(arg params.SecretRevisi
 	return result, nil
 }
 
-func (s *SecretsManagerAPI) updateLabelForAppOwnedOrUnitOwnedSecret(uri *coresecrets.URI, label string, owner string) error {
+func (s *SecretsManagerAPI) canUpdateAppOwnedOrUnitOwnedSecretLabel(owner string) (bool, error) {
+	if owner != s.authTag.String() {
+		isLeaderUnit, err := commonsecrets.IsLeaderUnit(s.authTag, s.leadershipChecker)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		// Only unit leaders can update app owned secret labels.
+		if !isLeaderUnit {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (s *SecretsManagerAPI) updateAppOwnedOrUnitOwnedSecretLabel(uri *coresecrets.URI, label, owner string) error {
 	if uri == nil || label == "" {
 		// We have done this check before, but it doesn't hurt to do it again.
-		return nil
+		return errors.New("uri and label cannot be nil")
 	}
-
 	ownerTag, err := names.ParseTag(owner)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ownerTag != s.authTag {
-		isLeaderUnit, err := commonsecrets.IsLeaderUnit(s.authTag, s.leadershipChecker)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !isLeaderUnit {
-			return errors.New("only unit leaders can update an application owned secret label")
-		}
-	}
-
 	token, err := commonsecrets.OwnerToken(s.authTag, ownerTag, s.leadershipChecker)
 	if err != nil {
 		return errors.Trace(err)
@@ -674,8 +677,10 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 	}
 
 	// arg.Label could be the consumer label for consumers or the owner label for owners.
-	possibleUpdateLabel := arg.Label != "" && uri != nil
-	labelToUpdate := arg.Label
+	var labelToUpdate *string
+	if arg.Label != "" && uri != nil {
+		labelToUpdate = &arg.Label
+	}
 
 	// For local secrets, check those which may be owned by the caller.
 	if uri == nil || uri.IsLocal(s.modelUUID) {
@@ -686,10 +691,17 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 		if md != nil {
 			// If the label has is to be changed by the secret owner, update the secret metadata.
 			// TODO(wallyworld) - the label staying the same should be asserted in a txn.
-			possibleUpdateLabel = possibleUpdateLabel && labelToUpdate != md.Label
-			if possibleUpdateLabel {
-				if err = s.updateLabelForAppOwnedOrUnitOwnedSecret(uri, labelToUpdate, md.OwnerTag); err != nil {
+			isOwner := true
+			if labelToUpdate != nil && *labelToUpdate != md.Label {
+				var err error
+				if isOwner, err = s.canUpdateAppOwnedOrUnitOwnedSecretLabel(md.OwnerTag); err != nil {
 					return nil, nil, false, errors.Trace(err)
+				}
+				if isOwner {
+					err = s.updateAppOwnedOrUnitOwnedSecretLabel(uri, *labelToUpdate, md.OwnerTag)
+					if err != nil {
+						return nil, nil, false, errors.Trace(err)
+					}
 				}
 			}
 			// 1. secrets can be accessed by the owner;
@@ -697,7 +709,9 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 			uri = md.URI
 			// We don't update the consumer label in this case since the label comes
 			// from the owner metadata and we don't want to violate uniqueness checks.
-			labelToUpdate = ""
+			if isOwner {
+				labelToUpdate = nil
+			}
 		}
 	}
 
@@ -714,7 +728,7 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 	logger.Debugf("getting secret content for: %s", uri)
 
 	if !uri.IsLocal(s.modelUUID) {
-		return s.getRemoteSecretContent(uri, arg.Refresh, arg.Peek, arg.Label, possibleUpdateLabel)
+		return s.getRemoteSecretContent(uri, arg.Refresh, arg.Peek, labelToUpdate)
 	}
 
 	canRead, err := s.canRead(uri, s.authTag)
@@ -726,7 +740,7 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (
 	}
 
 	// labelToUpdate is the consumer label for consumers.
-	consumedRevision, err := s.getConsumedRevision(uri, arg.Refresh, arg.Peek, labelToUpdate, possibleUpdateLabel)
+	consumedRevision, err := s.getConsumedRevision(uri, arg.Refresh, arg.Peek, labelToUpdate)
 	if err != nil {
 		return nil, nil, false, errors.Annotate(err, "getting latest secret revision")
 	}
@@ -752,13 +766,13 @@ func (s *SecretsManagerAPI) UpdateTrackedRevisions(uris []string) (params.ErrorR
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		_, err = s.getConsumedRevision(uri, true, false, "", false)
+		_, err = s.getConsumedRevision(uri, true, false, nil)
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
 }
 
-func (s *SecretsManagerAPI) getConsumedRevision(uri *coresecrets.URI, refresh, peek bool, label string, possibleUpdateLabel bool) (int, error) {
+func (s *SecretsManagerAPI) getConsumedRevision(uri *coresecrets.URI, refresh, peek bool, labelToUpdate *string) (int, error) {
 	consumerInfo, err := s.secretsConsumer.GetSecretConsumer(uri, s.authTag)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return 0, errors.Trace(err)
@@ -787,9 +801,9 @@ func (s *SecretsManagerAPI) getConsumedRevision(uri *coresecrets.URI, refresh, p
 		wantRevision = md.LatestRevision
 	}
 	// Save the latest consumer info if required.
-	if refresh || possibleUpdateLabel {
-		if label != "" {
-			consumerInfo.Label = label
+	if refresh || labelToUpdate != nil {
+		if labelToUpdate != nil {
+			consumerInfo.Label = *labelToUpdate
 		}
 		if err := s.secretsConsumer.SaveSecretConsumer(uri, s.authTag, consumerInfo); err != nil {
 			return 0, errors.Trace(err)

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,8 +7,7 @@ run_secrets() {
 	juju --show-log add-model "$model_name" --config secret-backend=auto
 
 	juju --show-log deploy hello-kubecon hello
-	# TODO(wallyworld) - sadly we need to pin or else the latest charm breaks with hello-kubecon
-	juju --show-log deploy --channel latest/edge --revision 83 nginx-ingress-integrator nginx
+	juju --show-log deploy nginx-ingress-integrator nginx
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster
 


### PR DESCRIPTION
If a non leader unit wants to consume a secret and specify a label, it gets an error about not being leader.
This PR fixes the logic so that a non leader consuming an app owned secret is treated like any other consumer.

Also, instead of using 2 parameters to update a secret label (bool and string), just use a string pointer.

It also does a drive by fix to unpin a test charm now that upstream has been fixed.

## QA steps

bootstrap and deploy 2 units

```
$ juju deploy ubuntu -n 2
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 24 in channel latest/stable on ubuntu@22.04/stable
$ juju exec -u ubuntu/1 -- secret-add foo=bar --label ownerfoo
secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020
$ juju exec -u ubuntu/0 -- secret-get secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020 --label consumerfoo
foo: bar
$ juju exec -u ubuntu/0 -- secret-get --label consumerfoo
foo: bar

$ juju exec -u ubuntu/1 -- secret-set secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020 --label ownerfoo foo=bar2
$ juju exec -u ubuntu/0 -- secret-get --label consumerfoo --peek
foo: bar2
$ juju exec -u ubuntu/0 -- secret-get secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020 --label consumerfoo2 --peek
foo: bar2
$ juju exec -u ubuntu/1 -- secret-set secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020 --label ownerfoo3 foo=bar3
$ juju exec -u ubuntu/1 -- secret-get --label ownerfoo3
foo: bar3
$ juju exec -u ubuntu/0 -- secret-get secret://92c066cc-14fc-4f61-897a-c6d28f8c0d94/cngj3jre7ls3su1ln020 --label consumerfoo3 --refresh
foo: bar3
$ juju exec -u ubuntu/0 -- secret-get --label consumerfoo3
foo: bar3
```

## Links

https://bugs.launchpad.net/juju/+bug/2055244

**Jira card:** JUJU-593

