### PR TITLE
Refactor policy config schema source

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -190,6 +190,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 			InstancePrecheckerGetter: func(s *state.State) (environs.InstancePrechecker, error) {
 				return state.NoopInstancePrechecker{}, nil
 			},
+			ConfigSchemaSourceGetter: state.NoopConfigSchemaSource,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -392,6 +393,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 			InstancePrecheckerGetter: func(s *state.State) (environs.InstancePrechecker, error) {
 				return state.NoopInstancePrechecker{}, nil
 			},
+			ConfigSchemaSourceGetter: state.NoopConfigSchemaSource,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -470,6 +472,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 			InstancePrecheckerGetter: func(s *state.State) (environs.InstancePrechecker, error) {
 				return state.NoopInstancePrechecker{}, nil
 			},
+			ConfigSchemaSourceGetter: state.NoopConfigSchemaSource,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -492,6 +495,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 			InstancePrecheckerGetter: func(s *state.State) (environs.InstancePrechecker, error) {
 				return state.NoopInstancePrechecker{}, nil
 			},
+			ConfigSchemaSourceGetter: state.NoopConfigSchemaSource,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/storage"
@@ -61,7 +60,7 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.modelStatusAPI = common.NewModelStatusAPI(
-		common.NewModelManagerBackend(s.Model, s.StatePool),
+		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		s.authorizer,
 		s.authorizer.GetAuthTag().(names.UserTag),
 	)
@@ -77,7 +76,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 	}
 
 	api := common.NewModelStatusAPI(
-		common.NewModelManagerBackend(s.Model, s.StatePool),
+		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
 	)
@@ -100,7 +99,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{Owner: owner.Tag()})
 	defer st.Close()
 	api := common.NewModelStatusAPI(
-		common.NewModelManagerBackend(s.Model, s.StatePool),
+		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
 	)
@@ -305,10 +304,6 @@ func (s *modelStatusSuite) TestModelStatusRunsForAllModels(c *gc.C) {
 
 type statePolicy struct{}
 
-func (statePolicy) Prechecker() (environs.InstancePrechecker, error) {
-	return nil, errors.NotImplementedf("Prechecker")
-}
-
 func (statePolicy) ConfigValidator() (config.Validator, error) {
 	return nil, errors.NotImplementedf("ConfigValidator")
 }
@@ -322,8 +317,4 @@ func (statePolicy) StorageProviderRegistry() (storage.ProviderRegistry, error) {
 		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	}, nil
-}
-
-func (statePolicy) ProviderConfigSchemaSource(cloudName string) (config.ConfigSchemaSource, error) {
-	return nil, errors.NotImplementedf("ConfigSchemaSource")
 }

--- a/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
@@ -89,7 +89,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeysNothing(c *gc.C) {
 }
 
 func (s *authorisedKeysSuite) setAuthorizedKeys(c *gc.C, keys string) {
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"authorized-keys": keys}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{"authorized-keys": keys}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	modelConfig, err := s.ControllerModel(c).ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/logger/logger_integration_test.go
+++ b/apiserver/facades/agent/logger/logger_integration_test.go
@@ -42,6 +42,7 @@ func (s *LoggerIntegrationSuite) TestWatchLoggingConfig(c *gc.C) {
 
 	model := s.ControllerModel(c)
 	err = model.UpdateModelConfig(
+		s.ConfigSchemaSourceGetter(c),
 		map[string]interface{}{
 			"logging-config": "juju=INFO;test=TRACE",
 		}, nil)

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -97,7 +97,7 @@ func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
 	attr := map[string]interface{}{
 		"logging-config": loggingConfig,
 	}
-	err := s.Model.UpdateModelConfig(attr, nil)
+	err := s.Model.UpdateModelConfig(s.ConfigSchemaSourceGetter(c), attr, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1286,7 +1286,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	})
 	_, err := pm.Create("static-pool", "static", map[string]any{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]any{
+	err = s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]any{
 		"storage-default-block-source": "static-pool",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1566,7 +1566,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 		"cloudinit-userdata":           validCloudInitUserData,
 		"container-inherit-properties": "ca-certs,apt-primary",
 	}
-	err := s.ControllerModel(c).UpdateModelConfig(attrs, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAPTProxy := proxy.Settings{
 		Http:    "http://proxy.example.com:9000",
@@ -1619,7 +1619,7 @@ func (s *withoutControllerSuite) TestContainerConfigLegacy(c *gc.C) {
 		"cloudinit-userdata":           validCloudInitUserData,
 		"container-inherit-properties": "ca-certs,apt-primary",
 	}
-	err := s.ControllerModel(c).UpdateModelConfig(attrs, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedAPTProxy := proxy.Settings{
 		Http:    "http://proxy.example.com:9000",

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -650,7 +650,7 @@ func (s *withoutControllerSuite) TestStorageProviderVolumes(c *gc.C) {
 
 func (s *withoutControllerSuite) TestProviderInfoCloudInitUserData(c *gc.C) {
 	attrs := map[string]interface{}{"cloudinit-userdata": validCloudInitUserData}
-	err := s.ControllerModel(c).UpdateModelConfig(attrs, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	template := state.MachineTemplate{
 		Base: state.UbuntuBase("12.10"),

--- a/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
@@ -153,7 +153,7 @@ func (s *retryStrategySuite) assertRetryStrategy(c *gc.C, tag string) {
 }
 
 func (s *retryStrategySuite) setRetryStrategy(c *gc.C, automaticallyRetryHooks bool) {
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"automatically-retry-hooks": automaticallyRetryHooks}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{"automatically-retry-hooks": automaticallyRetryHooks}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	modelConfig, err := s.ControllerModel(c).ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -468,7 +468,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForJujuInfoDefaultSpace(c *gc.C)
 
 	m, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.UpdateModelConfig(map[string]interface{}{"default-space": "database"}, nil)
+	err = m.UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{"default-space": "database"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.NetworkInfoParams{
@@ -518,7 +518,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 	s.assertInScope(c, mysqlRelUnit, true)
 
 	// Relation specific egress subnets override model config.
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
+	err = s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	relEgress := state.NewRelationEgressNetworks(s.st)
 	_, err = relEgress.Save(rel.Tag().Id(), false, []string{"192.168.1.0/24"})
@@ -587,7 +587,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 	s.assertInScope(c, mysqlRelUnit, true)
 
 	// Relation specific egress subnets override model config.
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
+	err = s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	relEgress := state.NewRelationEgressNetworks(s.st)
 	_, err = relEgress.Save(rel.Tag().Id(), false, []string{"192.168.1.0/24"})

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -457,7 +457,7 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
+	err = s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{config.EgressSubnets: "10.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.NetworkInfoParams{
@@ -3248,7 +3248,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	relTag, relUnit := s.setupRemoteRelationScenario(c)
 
 	// Check model attributes are overridden by setting up a value.
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	egress := state.NewRelationEgressNetworks(s.ControllerModel(c).State())
@@ -3280,7 +3280,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 func (s *uniterSuite) TestModelEgressSubnets(c *gc.C) {
 	relTag, relUnit := s.setupRemoteRelationScenario(c)
 
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(s.ConfigSchemaSourceGetter(c), map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	thisUniter := s.makeMysqlUniter(c)

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -409,8 +409,11 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	c.Assert(err, jc.ErrorIsNil)
 	add(taggedUser{tag: testing.AdminUser})
 
-	err = s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{
-		config.AgentVersionKey: "2.0.0"}, nil)
+	err = s.ControllerModel(c).UpdateModelConfig(
+		s.ConfigSchemaSourceGetter(c),
+		map[string]interface{}{
+			config.AgentVersionKey: "2.0.0",
+		}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add another user.

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -103,12 +103,13 @@ type Unit interface {
 // removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
-	model   *state.Model
-	session MongoSession
+	configSchemaSourceGetter config.ConfigSchemaSourceGetter
+	model                    *state.Model
+	session                  MongoSession
 }
 
 func (s stateShim) UpdateModelConfig(u map[string]interface{}, r []string, a ...state.ValidateConfigFunc) error {
-	return s.model.UpdateModelConfig(u, r, a...)
+	return s.model.UpdateModelConfig(s.configSchemaSourceGetter, u, r, a...)
 }
 
 func (s *stateShim) Application(name string) (Application, error) {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -156,7 +156,12 @@ func NewFacade(ctx facade.ModelContext) (*Client, error) {
 	}
 
 	return NewClient(
-		&stateShim{State: st, model: model, session: nil},
+		&stateShim{
+			State:                    st,
+			model:                    model,
+			session:                  nil,
+			configSchemaSourceGetter: stateenvirons.ProviderConfigSchemaSource(serviceFactory.Cloud()),
+		},
 		&poolShim{pool: ctx.StatePool()},
 		storageAccessor,
 		ctx.ServiceFactory().BlockDevice(),

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/multiwatcher"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
 	"github.com/juju/juju/internal/docker"
@@ -160,7 +161,7 @@ func NewFacade(ctx facade.ModelContext) (*Client, error) {
 			State:                    st,
 			model:                    model,
 			session:                  nil,
-			configSchemaSourceGetter: stateenvirons.ProviderConfigSchemaSource(serviceFactory.Cloud()),
+			configSchemaSourceGetter: environs.ProviderConfigSchemaSource(serviceFactory.Cloud()),
 		},
 		&poolShim{pool: ctx.StatePool()},
 		storageAccessor,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -120,7 +120,7 @@ func NewControllerAPI(
 			externalControllerService,
 		),
 		ModelStatusAPI: common.NewModelStatusAPI(
-			common.NewModelManagerBackend(model, pool),
+			common.NewModelManagerBackend(stateenvirons.ProviderConfigSchemaSource(cloudService), model, pool),
 			authorizer,
 			apiUser,
 		),

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/migration"
@@ -120,7 +121,7 @@ func NewControllerAPI(
 			externalControllerService,
 		),
 		ModelStatusAPI: common.NewModelStatusAPI(
-			common.NewModelManagerBackend(stateenvirons.ProviderConfigSchemaSource(cloudService), model, pool),
+			common.NewModelManagerBackend(environs.ProviderConfigSchemaSource(cloudService), model, pool),
 			authorizer,
 			apiUser,
 		),

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -13,6 +13,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -55,7 +56,7 @@ func destroyController(
 	// models but set the controller to dying to prevent new
 	// models sneaking in. If we are not destroying hosted models,
 	// this will fail if any hosted models are found.
-	backend := common.NewModelManagerBackend(stateenvirons.ProviderConfigSchemaSource(cloudService), model, pool)
+	backend := common.NewModelManagerBackend(environs.ProviderConfigSchemaSource(cloudService), model, pool)
 	return errors.Trace(common.DestroyController(
 		ctx,
 		backend, args.DestroyModels, args.DestroyStorage,

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -146,7 +146,7 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedModels(c *gc.C) {
-	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.otherModel, s.StatePool()), nil, nil, nil, nil)
+	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.otherModel, s.StatePool()), nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.otherModel.Refresh(), jc.ErrorIsNil)
 	c.Assert(s.otherModel.Life(), gc.Equals, state.Dying)
@@ -160,7 +160,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedModels(c *gc.C) {
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBlock(c *gc.C) {
-	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.otherModel, s.StatePool()), nil, nil, nil, nil)
+	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.otherModel, s.StatePool()), nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -172,7 +172,7 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBl
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedModelsWithBlockFail(c *gc.C) {
-	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.otherModel, s.StatePool()), nil, nil, nil, nil)
+	err := common.DestroyModel(context.Background(), common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.otherModel, s.StatePool()), nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")

--- a/apiserver/facades/client/keymanager/mocks/keymanager_mock.go
+++ b/apiserver/facades/client/keymanager/mocks/keymanager_mock.go
@@ -72,10 +72,10 @@ func (mr *MockModelMockRecorder) ModelTag() *gomock.Call {
 }
 
 // UpdateModelConfig mocks base method.
-func (m *MockModel) UpdateModelConfig(arg0 map[string]any, arg1 []string, arg2 ...state.ValidateConfigFunc) error {
+func (m *MockModel) UpdateModelConfig(arg0 config.ConfigSchemaSourceGetter, arg1 map[string]any, arg2 []string, arg3 ...state.ValidateConfigFunc) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpdateModelConfig", varargs...)
@@ -84,9 +84,9 @@ func (m *MockModel) UpdateModelConfig(arg0 map[string]any, arg1 []string, arg2 .
 }
 
 // UpdateModelConfig indicates an expected call of UpdateModelConfig.
-func (mr *MockModelMockRecorder) UpdateModelConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockModelMockRecorder) UpdateModelConfig(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateModelConfig", reflect.TypeOf((*MockModel)(nil).UpdateModelConfig), varargs...)
 }
 

--- a/apiserver/facades/client/keymanager/register.go
+++ b/apiserver/facades/client/keymanager/register.go
@@ -13,9 +13,9 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -42,7 +42,7 @@ func newFacadeV1(ctx facade.ModelContext) (*KeyManagerAPI, error) {
 		authorizer,
 		common.NewBlockChecker(st),
 		st.ControllerTag(),
-		stateenvirons.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud()),
+		environs.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud()),
 		ctx.Logger().Child("keymanager"),
 	), nil
 }

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -30,15 +30,16 @@ type Backend interface {
 
 type stateShim struct {
 	*state.State
-	model *state.Model
+	model                    *state.Model
+	configSchemaSourceGetter config.ConfigSchemaSourceGetter
 }
 
 func (st stateShim) UpdateModelConfig(u map[string]interface{}, r []string, a ...state.ValidateConfigFunc) error {
-	return st.model.UpdateModelConfig(u, r, a...)
+	return st.model.UpdateModelConfig(st.configSchemaSourceGetter, u, r, a...)
 }
 
 func (st stateShim) ModelConfigValues() (config.ConfigValues, error) {
-	return st.model.ModelConfigValues()
+	return st.model.ModelConfigValues(st.configSchemaSourceGetter)
 }
 
 func (st stateShim) ModelTag() names.ModelTag {
@@ -61,6 +62,10 @@ func (st stateShim) GetSecretBackend(name string) (*coresecrets.SecretBackend, e
 }
 
 // NewStateBackend creates a backend for the facade to use.
-func NewStateBackend(m *state.Model) Backend {
-	return stateShim{m.State(), m}
+func NewStateBackend(m *state.Model, configSchemaSourceGetter config.ConfigSchemaSourceGetter) Backend {
+	return stateShim{
+		State:                    m.State(),
+		model:                    m,
+		configSchemaSourceGetter: configSchemaSourceGetter,
+	}
 }

--- a/apiserver/facades/client/modelconfig/register.go
+++ b/apiserver/facades/client/modelconfig/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -27,5 +28,8 @@ func newFacadeV3(ctx facade.ModelContext) (*ModelConfigAPIV3, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewModelConfigAPI(NewStateBackend(model), auth)
+
+	configSchemaSourceGetter := stateenvirons.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud())
+
+	return NewModelConfigAPI(NewStateBackend(model, configSchemaSourceGetter), auth)
 }

--- a/apiserver/facades/client/modelconfig/register.go
+++ b/apiserver/facades/client/modelconfig/register.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/environs"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -29,7 +29,7 @@ func newFacadeV3(ctx facade.ModelContext) (*ModelConfigAPIV3, error) {
 		return nil, errors.Trace(err)
 	}
 
-	configSchemaSourceGetter := stateenvirons.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud())
+	configSchemaSourceGetter := environs.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud())
 
 	return NewModelConfigAPI(NewStateBackend(model, configSchemaSourceGetter), auth)
 }

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -71,6 +71,7 @@ func (s *ListModelsWithInfoSuite) SetUpTest(c *gc.C) {
 		&mockModelManagerService{},
 		&mockModelService{},
 		&mockObjectStore{},
+		state.NoopConfigSchemaSource,
 		nil, nil,
 		common.NewBlockChecker(s.st), s.authoriser, s.st.model,
 	)
@@ -101,6 +102,7 @@ func (s *ListModelsWithInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		&mockModelManagerService{},
 		&mockModelService{},
 		&mockObjectStore{},
+		state.NoopConfigSchemaSource,
 		nil, nil,
 		common.NewBlockChecker(s.st), s.authoriser, s.st.model,
 	)

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -181,6 +181,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		&mockModelManagerService{},
 		&mockModelService{},
 		&mockObjectStore{},
+		state.NoopConfigSchemaSource,
 		nil, nil, common.NewBlockChecker(s.st),
 		&s.authorizer, s.st.model,
 	)
@@ -208,6 +209,7 @@ func (s *modelInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		&mockModelManagerService{},
 		&mockModelService{},
 		&mockObjectStore{},
+		state.NoopConfigSchemaSource,
 		nil, nil,
 		common.NewBlockChecker(s.st), s.authorizer, s.st.model,
 	)
@@ -773,7 +775,7 @@ func (st *mockState) ControllerTag() names.ControllerTag {
 	return names.NewControllerTag(st.controllerUUID)
 }
 
-func (st *mockState) ComposeNewModelConfig(modelAttr map[string]interface{}, regionSpec *environscloudspec.CloudRegionSpec) (map[string]interface{}, error) {
+func (st *mockState) ComposeNewModelConfig(_ config.ConfigSchemaSourceGetter, modelAttr map[string]interface{}, regionSpec *environscloudspec.CloudRegionSpec) (map[string]interface{}, error) {
 	st.MethodCall(st, "ComposeNewModelConfig")
 	attr := make(map[string]interface{})
 	for attrName, val := range modelAttr {
@@ -1241,7 +1243,7 @@ func (m *mockModel) LastModelConnection(user names.UserTag) (time.Time, error) {
 	return time.Time{}, m.NextErr()
 }
 
-func (m *mockModel) AutoConfigureContainerNetworking(environ environs.BootstrapEnviron) error {
+func (m *mockModel) AutoConfigureContainerNetworking(environ environs.BootstrapEnviron, _ config.ConfigSchemaSourceGetter) error {
 	m.MethodCall(m, "AutoConfigureContainerNetworking", environ)
 	return m.NextErr()
 }

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -14,6 +14,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -65,7 +66,7 @@ func newFacadeV10(ctx facade.ModelContext) (*ModelManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	configSchemaSource := stateenvirons.ProviderConfigSchemaSource(serviceFactory.Cloud())
+	configSchemaSource := environs.ProviderConfigSchemaSource(serviceFactory.Cloud())
 
 	controllerConfigGetter := serviceFactory.ControllerConfig()
 

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -65,23 +65,26 @@ func newFacadeV10(ctx facade.ModelContext) (*ModelManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
+	configSchemaSource := stateenvirons.ProviderConfigSchemaSource(serviceFactory.Cloud())
+
 	controllerConfigGetter := serviceFactory.ControllerConfig()
 
 	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
 	toolsFinder := common.NewToolsFinder(controllerConfigGetter, configGetter, st, urlGetter, newEnviron, ctx.ControllerObjectStore())
 
 	apiUser, _ := auth.GetAuthTag().(names.UserTag)
-	backend := common.NewUserAwareModelManagerBackend(model, pool, apiUser)
+	backend := common.NewUserAwareModelManagerBackend(configSchemaSource, model, pool, apiUser)
 
 	return NewModelManagerAPI(
 		backend.(StateBackend),
 		ctx.ModelExporter(backend),
-		common.NewModelManagerBackend(ctrlModel, pool),
+		common.NewModelManagerBackend(configSchemaSource, ctrlModel, pool),
 		serviceFactory.Cloud(),
 		serviceFactory.Credential(),
 		serviceFactory.ModelManager(),
 		serviceFactory.Model(),
 		ctx.ObjectStore(),
+		configSchemaSource,
 		toolsFinder,
 		caas.New,
 		common.NewBlockChecker(backend),

--- a/apiserver/facades/client/modelupgrader/register.go
+++ b/apiserver/facades/client/modelupgrader/register.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/common/credentialcommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/docker/registry"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -66,7 +67,7 @@ func newFacadeV1(ctx facade.ModelContext) (*ModelUpgraderAPI, error) {
 	toolsFinder := common.NewToolsFinder(controllerConfigGetter, configGetter, st, urlGetter, newEnviron, ctx.ControllerObjectStore())
 	environscloudspecGetter := cloudspec.MakeCloudSpecGetter(pool, cloudService, credentialService)
 
-	configSchemaSource := stateenvirons.ProviderConfigSchemaSource(cloudService)
+	configSchemaSource := environs.ProviderConfigSchemaSource(cloudService)
 
 	apiUser, _ := auth.GetAuthTag().(names.UserTag)
 	backend := common.NewUserAwareModelManagerBackend(configSchemaSource, model, pool, apiUser)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/domain/credential/service"
 	servicefactorytesting "github.com/juju/juju/domain/servicefactory/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/internal/migration"
@@ -732,8 +733,12 @@ func (s *Suite) expectImportModel(c *gc.C) {
 	s.modelImporter.EXPECT().ImportModel(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, bytes []byte) (*state.Model, *state.State, error) {
 		scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
 		controller := state.NewController(s.StatePool)
-		return migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter).ImportModel(ctx, bytes)
+		return migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter, cloudSchemaSource).ImportModel(ctx, bytes)
 	})
+}
+
+func cloudSchemaSource(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+	return state.NoopConfigSchemaSource
 }
 
 type mockEnv struct {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -737,7 +737,7 @@ func (s *Suite) expectImportModel(c *gc.C) {
 	})
 }
 
-func cloudSchemaSource(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+func cloudSchemaSource(environs.CloudService) config.ConfigSchemaSourceGetter {
 	return state.NoopConfigSchemaSource
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -27813,9 +27813,6 @@
         "Description": "ModelUpgraderAPI implements the model upgrader interface and is\nthe concrete implementation of the api end point.",
         "Version": 1,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "controller-user"
         ],
         "Schema": {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 type objectKey struct {
@@ -885,6 +886,7 @@ func (ctx *facadeContext) ModelImporter() facade.ModelImporter {
 		ctx.migrationScope,
 		ctx.ServiceFactory().ControllerConfig(),
 		ctx.r.serviceFactoryGetter,
+		stateenvirons.ProviderConfigSchemaSource,
 	)
 }
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -30,13 +30,13 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher/registry"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/rpcreflect"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 )
 
 type objectKey struct {
@@ -886,7 +886,7 @@ func (ctx *facadeContext) ModelImporter() facade.ModelImporter {
 		ctx.migrationScope,
 		ctx.ServiceFactory().ControllerConfig(),
 		ctx.r.serviceFactoryGetter,
-		stateenvirons.ProviderConfigSchemaSource,
+		environs.ProviderConfigSchemaSource,
 	)
 }
 

--- a/cmd/jujud-controller/agent/bootstrap.go
+++ b/cmd/jujud-controller/agent/bootstrap.go
@@ -356,6 +356,8 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	}
 	args.ControllerModelConfig = controllerModelCfg
 
+	configSchemaSource := stateenvirons.ProviderConfigSchemaSource(cloudGetter{cloud: &args.ControllerCloud})
+
 	// Initialise state, and store any agent config (e.g. password) changes.
 	var controller *state.Controller
 	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
@@ -397,6 +399,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 					credentialGetter{cred: args.ControllerCloudCredential},
 				)
 			},
+			ConfigSchemaSourceGetter: configSchemaSource,
 		})
 		if err != nil {
 			return errors.Trace(err)
@@ -418,7 +421,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	if err = model.AutoConfigureContainerNetworking(env); err != nil {
+	if err = model.AutoConfigureContainerNetworking(env, configSchemaSource); err != nil {
 		if errors.Is(err, errors.NotSupported) {
 			logger.Debugf("Not performing container networking auto-configuration on a non-networking environment")
 		} else {

--- a/cmd/jujud-controller/agent/bootstrap.go
+++ b/cmd/jujud-controller/agent/bootstrap.go
@@ -356,7 +356,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	}
 	args.ControllerModelConfig = controllerModelCfg
 
-	configSchemaSource := stateenvirons.ProviderConfigSchemaSource(cloudGetter{cloud: &args.ControllerCloud})
+	configSchemaSource := environs.ProviderConfigSchemaSource(cloudGetter{cloud: &args.ControllerCloud})
 
 	// Initialise state, and store any agent config (e.g. password) changes.
 	var controller *state.Controller

--- a/cmd/jujud-controller/agent/machine_test.go
+++ b/cmd/jujud-controller/agent/machine_test.go
@@ -316,7 +316,7 @@ func (s *MachineSuite) TestMachineAgentRunsAuthorisedKeysWorker(c *gc.C) {
 
 	// Update the keys in the environment.
 	sshKey := sshtesting.ValidKeyOne.Key + " user@host"
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"authorized-keys": sshKey}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"authorized-keys": sshKey}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for ssh keys file to be updated.
@@ -504,7 +504,7 @@ func (s *MachineSuite) setupIgnoreAddresses(c *gc.C, expectedIgnoreValue bool) c
 	})
 
 	attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}
-	err := s.ControllerModel(c).UpdateModelConfig(attrs, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(state.NoopConfigSchemaSource, attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return ignoreAddressCh
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -297,7 +297,7 @@ func (s *MachineSuite) TestMachineAgentRunsAuthorisedKeysWorker(c *gc.C) {
 
 	// Update the keys in the environment.
 	sshKey := sshtesting.ValidKeyOne.Key + " user@host"
-	err := s.ControllerModel(c).UpdateModelConfig(map[string]interface{}{"authorized-keys": sshKey}, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"authorized-keys": sshKey}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for ssh keys file to be updated.
@@ -432,7 +432,7 @@ func (s *MachineSuite) setupIgnoreAddresses(c *gc.C, expectedIgnoreValue bool) c
 	})
 
 	attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}
-	err := s.ControllerModel(c).UpdateModelConfig(attrs, nil)
+	err := s.ControllerModel(c).UpdateModelConfig(state.NoopConfigSchemaSource, attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return ignoreAddressCh
 }

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"context"
+
 	"github.com/juju/schema"
 )
 
@@ -51,6 +53,9 @@ func (c ConfigValues) AllAttrs() map[string]interface{} {
 	}
 	return result
 }
+
+// ConfigSchemaSourceGetter is a type for getting a ConfigSchemaSource.
+type ConfigSchemaSourceGetter func(context.Context, string) (ConfigSchemaSource, error)
 
 // ConfigSchemaSource instances provide information on config attributes
 // and the default attribute values.

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -26,9 +26,11 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resources"
 	migrations "github.com/juju/juju/domain/modelmigration"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 var logger = loggo.GetLoggerWithTags("juju.migration", corelogger.MIGRATION)
@@ -98,16 +100,21 @@ func (e *ModelExporter) Export(ctx context.Context, model description.Model) (de
 // legacyStateImporter describes the method needed to import a model
 // into the database.
 type legacyStateImporter interface {
-	Import(description.Model, controller.Config) (*state.Model, *state.State, error)
+	Import(description.Model, controller.Config, config.ConfigSchemaSourceGetter) (*state.Model, *state.State, error)
 }
+
+// ConfigSchemaSourceProvider returns a config.ConfigSchemaSourceGetter based
+// on the given cloud service.
+type ConfigSchemaSourceProvider = func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter
 
 // ModelImporter represents a model migration that implements Import.
 type ModelImporter struct {
 	// TODO(nvinuesa): This is being deprecated, only needed until the
 	// migration to dqlite is complete.
-	legacyStateImporter     legacyStateImporter
-	controllerConfigService ControllerConfigService
-	serviceFactoryGetter    servicefactory.ServiceFactoryGetter
+	legacyStateImporter        legacyStateImporter
+	controllerConfigService    ControllerConfigService
+	serviceFactoryGetter       servicefactory.ServiceFactoryGetter
+	configSchemaSourceProvider ConfigSchemaSourceProvider
 
 	scope modelmigration.ScopeForModel
 }
@@ -120,12 +127,14 @@ func NewModelImporter(
 	scope modelmigration.ScopeForModel,
 	controllerConfigService ControllerConfigService,
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter,
+	configSchemaSourceProvider ConfigSchemaSourceProvider,
 ) *ModelImporter {
 	return &ModelImporter{
-		legacyStateImporter:     stateImporter,
-		scope:                   scope,
-		controllerConfigService: controllerConfigService,
-		serviceFactoryGetter:    serviceFactoryGetter,
+		legacyStateImporter:        stateImporter,
+		scope:                      scope,
+		controllerConfigService:    controllerConfigService,
+		serviceFactoryGetter:       serviceFactoryGetter,
+		configSchemaSourceProvider: configSchemaSourceProvider,
 	}
 }
 
@@ -143,7 +152,11 @@ func (i *ModelImporter) ImportModel(ctx context.Context, bytes []byte) (*state.M
 		return nil, nil, errors.Annotatef(err, "unable to get controller config")
 	}
 
-	dbModel, dbState, err := i.legacyStateImporter.Import(model, ctrlConfig)
+	// TODO (stickupkid): We don't need to get a whole service factory here, we
+	// only need the cloud type to get the config schema source.
+	serviceFactory := i.serviceFactoryGetter.FactoryForModel(model.Tag().Id())
+	configSchemaSource := i.configSchemaSourceProvider(serviceFactory.Cloud())
+	dbModel, dbState, err := i.legacyStateImporter.Import(model, ctrlConfig, configSchemaSource)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -26,11 +26,11 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resources"
 	migrations "github.com/juju/juju/domain/modelmigration"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 )
 
 var logger = loggo.GetLoggerWithTags("juju.migration", corelogger.MIGRATION)
@@ -105,7 +105,7 @@ type legacyStateImporter interface {
 
 // ConfigSchemaSourceProvider returns a config.ConfigSchemaSourceGetter based
 // on the given cloud service.
-type ConfigSchemaSourceProvider = func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter
+type ConfigSchemaSourceProvider = func(environs.CloudService) config.ConfigSchemaSourceGetter
 
 // ModelImporter represents a model migration that implements Import.
 type ModelImporter struct {

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/resources"
 	resourcetesting "github.com/juju/juju/core/resources/testing"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -65,7 +65,7 @@ func (s *ImportSuite) TestBadBytes(c *gc.C) {
 	bytes := []byte("not a model")
 	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
 	controller := &fakeImporter{}
-	configSchemaSource := func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+	configSchemaSource := func(environs.CloudService) config.ConfigSchemaSourceGetter {
 		return state.NoopConfigSchemaSource
 	}
 	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter, configSchemaSource)
@@ -138,7 +138,7 @@ func (s *ImportSuite) exportImport(c *gc.C, leaders map[string]string) {
 	m := &state.Model{}
 	controller := &fakeImporter{st: st, m: m}
 	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
-	configSchemaSource := func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+	configSchemaSource := func(environs.CloudService) config.ConfigSchemaSourceGetter {
 		return state.NoopConfigSchemaSource
 	}
 	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter, configSchemaSource)

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/resources"
 	resourcetesting "github.com/juju/juju/core/resources/testing"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -63,7 +65,10 @@ func (s *ImportSuite) TestBadBytes(c *gc.C) {
 	bytes := []byte("not a model")
 	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
 	controller := &fakeImporter{}
-	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter)
+	configSchemaSource := func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+		return state.NoopConfigSchemaSource
+	}
+	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter, configSchemaSource)
 	model, st, err := importer.ImportModel(context.Background(), bytes)
 	c.Check(st, gc.IsNil)
 	c.Check(model, gc.IsNil)
@@ -133,7 +138,10 @@ func (s *ImportSuite) exportImport(c *gc.C, leaders map[string]string) {
 	m := &state.Model{}
 	controller := &fakeImporter{st: st, m: m}
 	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
-	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter)
+	configSchemaSource := func(stateenvirons.CloudService) config.ConfigSchemaSourceGetter {
+		return state.NoopConfigSchemaSource
+	}
+	importer := migration.NewModelImporter(controller, scope, s.controllerConfigService, s.serviceFactoryGetter, configSchemaSource)
 	gotM, gotSt, err := importer.ImportModel(context.Background(), bytes)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller.model.Tag().Id(), gc.Equals, "bd3fae18-5ea1-4bc5-8837-45400cf1f8f6")
@@ -277,6 +285,7 @@ func (s *ImportSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(jujutesting.FakeControllerConfig(), nil).AnyTimes()
 
 	s.serviceFactory = NewMockServiceFactory(ctrl)
+	s.serviceFactory.EXPECT().Cloud().Return(nil)
 	s.serviceFactory.EXPECT().Machine().Return(nil)
 	s.serviceFactory.EXPECT().Application().Return(nil)
 	s.serviceFactoryGetter = NewMockServiceFactoryGetter(ctrl)
@@ -292,7 +301,7 @@ type fakeImporter struct {
 	controllerConfig controller.Config
 }
 
-func (i *fakeImporter) Import(model description.Model, controllerConfig controller.Config) (*state.Model, *state.State, error) {
+func (i *fakeImporter) Import(model description.Model, controllerConfig controller.Config, _ config.ConfigSchemaSourceGetter) (*state.Model, *state.State, error) {
 	i.model = model
 	i.controllerConfig = controllerConfig
 	return i.m, i.st, nil

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -290,7 +290,7 @@ func (s *ApiServerSuite) setupControllerModel(c *gc.C, controllerCfg controller.
 		MongoSession:  session,
 		AdminPassword: AdminSecret,
 		NewPolicy:     stateenvirons.GetNewPolicyFunc(serviceFactory.Cloud(), serviceFactory.Credential()),
-	}, stateenvirons.ProviderConfigSchemaSource(serviceFactory.Cloud()))
+	}, environs.ProviderConfigSchemaSource(serviceFactory.Cloud()))
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = ctrl
 

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"sort"
@@ -31,6 +32,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
+	environsconfig "github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/state/watcher"
@@ -65,6 +67,10 @@ type testInstancePrechecker struct{}
 
 func (testInstancePrechecker) PrecheckInstance(envcontext.ProviderCallContext, environs.PrecheckInstanceParams) error {
 	return errors.NotSupportedf("prechecking instances")
+}
+
+func testConfigSchemaSource(ctx context.Context, cloudName string) (environsconfig.ConfigSchemaSource, error) {
+	return nil, errors.NotImplementedf("config schema source")
 }
 
 type allWatcherBaseSuite struct {
@@ -585,7 +591,7 @@ func setModelConfigAttr(c *gc.C, st *State, attr string, val interface{}) {
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.UpdateModelConfig(map[string]interface{}{attr: val}, nil)
+	err = m.UpdateModelConfig(testConfigSchemaSource, map[string]interface{}{attr: val}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -83,7 +83,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 		"uuid": s.modelUUID,
 	})
 	var err error
-	_, s.st, err = s.Controller.NewModel(state.ModelArgs{
+	_, s.st, err = s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -181,7 +181,7 @@ func (s *blockSuite) createTestModel(c *gc.C) (*state.Model, *state.State) {
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -62,7 +62,7 @@ func (s *CAASModelSuite) TestNewModel(c *gc.C) {
 	modelTag := names.NewModelTag(uuid)
 	credTag := names.NewCloudCredentialTag(
 		fmt.Sprintf("caas-cloud/%s/dummy-credential", owner.Name()))
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "caas-cloud",
 		Config:                  cfg,

--- a/state/configvalidator_test.go
+++ b/state/configvalidator_test.go
@@ -65,7 +65,7 @@ func (s *ConfigValidatorSuite) updateModelConfig(c *gc.C) error {
 		"authorized-keys": "different-keys",
 		"arbitrary-key":   "shazam!",
 	}
-	return s.Model.UpdateModelConfig(updateAttrs, nil)
+	return s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, updateAttrs, nil)
 }
 
 func (s *ConfigValidatorSuite) TestConfigValidate(c *gc.C) {

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -149,7 +149,7 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 		"uuid": uuid.MustNewUUID().String(),
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.Controller.NewModel(state.ModelArgs{
+	_, otherState, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -121,7 +121,7 @@ func (s *ConnWithWallClockSuite) NewStateForModelNamed(c *gc.C, modelName string
 		"uuid": uuid.MustNewUUID().String(),
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.Controller.NewModel(state.ModelArgs{
+	_, otherState, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/containernetworking.go
+++ b/state/containernetworking.go
@@ -18,7 +18,7 @@ import (
 
 // AutoConfigureContainerNetworking tries to set up best container networking available
 // for the specific model if user hasn't set anything.
-func (m *Model) AutoConfigureContainerNetworking(environ environs.BootstrapEnviron) error {
+func (m *Model) AutoConfigureContainerNetworking(environ environs.BootstrapEnviron, providerConfigSchemaGetter config.ConfigSchemaSourceGetter) error {
 	updateAttrs := make(map[string]interface{})
 	modelConfig, err := m.ModelConfig(stdcontext.Background())
 	if err != nil {
@@ -38,7 +38,7 @@ func (m *Model) AutoConfigureContainerNetworking(environ environs.BootstrapEnvir
 	} else {
 		updateAttrs["container-networking-method"] = "local"
 	}
-	err = m.UpdateModelConfig(updateAttrs, nil)
+	err = m.UpdateModelConfig(providerConfigSchemaGetter, updateAttrs, nil)
 	return err
 }
 

--- a/state/containernetworking_test.go
+++ b/state/containernetworking_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/state"
 )
 
 type containerTestNetworkLessEnviron struct {
@@ -45,7 +46,7 @@ func (e *containerTestNetworkedEnviron) SupportsContainerAddresses(ctx envcontex
 var _ environs.NetworkingEnviron = (*containerTestNetworkedEnviron)(nil)
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingNetworkless(c *gc.C) {
-	err := s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
+	err := s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -55,11 +56,11 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingNetworkle
 }
 
 func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingDoesntChangeDefault(c *gc.C) {
-	err := s.Model.UpdateModelConfig(map[string]interface{}{
+	err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"container-networking-method": "provider",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{})
+	err = s.Model.AutoConfigureContainerNetworking(containerTestNetworkLessEnviron{}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -73,12 +74,12 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingAlreadyCo
 		stub:         &testing.Stub{},
 		superSubnets: []string{"172.31.0.0/16", "192.168.1.0/24", "10.0.0.0/8"},
 	}
-	err := s.Model.UpdateModelConfig(map[string]interface{}{
+	err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"container-networking-method": "local",
 		"fan-config":                  "1.2.3.4/24=5.6.7.8/16",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.Model.AutoConfigureContainerNetworking(&environ)
+	err = s.Model.AutoConfigureContainerNetworking(&environ, state.NoopConfigSchemaSource)
 	c.Check(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +92,7 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingNoSuperSu
 	environ := containerTestNetworkedEnviron{
 		stub: &testing.Stub{},
 	}
-	err := s.Model.AutoConfigureContainerNetworking(&environ)
+	err := s.Model.AutoConfigureContainerNetworking(&environ, state.NoopConfigSchemaSource)
 	c.Check(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,7 +107,7 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingSupportsC
 		supportsContainerAddresses: true,
 		superSubnets:               []string{"172.31.0.0/16", "192.168.1.0/24", "10.0.0.0/8"},
 	}
-	err := s.Model.AutoConfigureContainerNetworking(&environ)
+	err := s.Model.AutoConfigureContainerNetworking(&environ, state.NoopConfigSchemaSource)
 	c.Check(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -121,7 +122,7 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingDefault(c
 		supportsContainerAddresses: false,
 		superSubnets:               []string{"172.31.0.0/16", "192.168.1.0/24", "10.0.0.0/8"},
 	}
-	err := s.Model.AutoConfigureContainerNetworking(&environ)
+	err := s.Model.AutoConfigureContainerNetworking(&environ, state.NoopConfigSchemaSource)
 	c.Check(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -136,7 +137,7 @@ func (s *ContainerNetworkingSuite) TestAutoConfigureContainerNetworkingIgnoresIP
 		supportsContainerAddresses: true,
 		superSubnets:               []string{"172.31.0.0/16", "2000::dead:beef:1/64"},
 	}
-	err := s.Model.AutoConfigureContainerNetworking(&environ)
+	err := s.Model.AutoConfigureContainerNetworking(&environ, state.NoopConfigSchemaSource)
 	c.Check(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/credentialmodels_test.go
+++ b/state/credentialmodels_test.go
@@ -50,7 +50,7 @@ func (s *CredentialModelsSuite) addModel(c *gc.C, modelName string, tag names.Cl
 		"name": modelName,
 		"uuid": uuid.String(),
 	})
-	_, st, err := s.Controller.NewModel(state.ModelArgs{
+	_, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -288,7 +288,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 
 func (s *bindingsSuite) TestMergeWithModelConfigNonDefaultSpace(c *gc.C) {
 	c.Skip("The default space is always alpha due to scaffolding in service of Dqlite migration.")
-	err := s.Model.UpdateModelConfig(map[string]interface{}{"default-space": s.appsSpace.Name()}, nil)
+	err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"default-space": s.appsSpace.Name()}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	currentMap := map[string]string{

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -80,7 +80,7 @@ func (s *FilesystemIAASModelSuite) TestAddApplicationNoPoolDefaultFilesystem(c *
 	// filesystem.
 	m, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.UpdateModelConfig(map[string]interface{}{
+	err = m.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"storage-default-filesystem-source": "machinescoped",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -92,7 +92,7 @@ func (s *FilesystemIAASModelSuite) TestAddApplicationNoPoolDefaultBlock(c *gc.C)
 	// block with managed fs on top.
 	m, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.UpdateModelConfig(map[string]interface{}{
+	err = m.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"storage-default-block-source": "modelscoped-block",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -107,7 +107,7 @@ type InitDatabaseFunc func(*mgo.Session, string, *controller.Config) error
 // It also creates the initial model for the controller.
 // This needs to be performed only once for the initial controller model.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(args InitializeParams) (_ *Controller, err error) {
+func Initialize(args InitializeParams, providerConfigSchemaGetter config.ConfigSchemaSourceGetter) (_ *Controller, err error) {
 	if err := args.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating initialization args")
 	}
@@ -161,6 +161,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 
 	modelOps, modelStatusDoc, err := st.modelSetupOps(
 		args.ControllerConfig.ControllerUUID(),
+		providerConfigSchemaGetter,
 		args.ControllerModelArgs,
 		&lineage{
 			ControllerConfig: args.ControllerInheritedConfig,
@@ -265,7 +266,7 @@ type lineage struct {
 }
 
 // modelSetupOps returns the transactions necessary to set up a model.
-func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited *lineage) ([]txn.Op, statusDoc, error) {
+func (st *State) modelSetupOps(controllerUUID string, providerConfigSchemaGetter config.ConfigSchemaSourceGetter, args ModelArgs, inherited *lineage) ([]txn.Op, statusDoc, error) {
 	var modelStatusDoc statusDoc
 	if inherited != nil {
 		if err := checkControllerInheritedConfig(inherited.ControllerConfig); err != nil {
@@ -331,7 +332,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 		}
 	} else {
 		rspec := &environscloudspec.CloudRegionSpec{Cloud: args.CloudName, Region: args.CloudRegion}
-		configSources = modelConfigSources(st, rspec)
+		configSources = modelConfigSources(providerConfigSchemaGetter, st, rspec)
 	}
 	modelCfg, err := composeModelConfigAttributes(args.Config.AllAttrs(), configSources...)
 	if err != nil {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -102,7 +102,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 		CloudName:     "dummy",
 		MongoSession:  s.Session,
 		AdminPassword: "dummy-secret",
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctlr, gc.NotNil)
 	st, err := ctlr.SystemState()
@@ -210,7 +210,7 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 		ControllerInheritedConfig: controllerInheritedConfigIn,
 		MongoSession:              s.Session,
 		AdminPassword:             "dummy-secret",
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctlr, gc.NotNil)
 	st, err := ctlr.SystemState()
@@ -262,12 +262,12 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 		MongoSession:  s.Session,
 		AdminPassword: "dummy-secret",
 	}
-	ctlr, err := state.Initialize(args)
+	ctlr, err := state.Initialize(args, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctlr.Close()
 	c.Check(err, jc.ErrorIsNil)
 
-	ctlr, err = state.Initialize(args)
+	ctlr, err = state.Initialize(args, state.NoopConfigSchemaSource)
 	c.Check(err, gc.ErrorMatches, "already initialized")
 	c.Check(ctlr, gc.IsNil)
 }
@@ -315,11 +315,11 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 		MongoSession:  s.Session,
 		AdminPassword: "dummy-secret",
 	}
-	_, err = state.Initialize(args)
+	_, err = state.Initialize(args, state.NoopConfigSchemaSource)
 	c.Assert(err, gc.ErrorMatches, expect)
 
 	args.ControllerModelArgs.Config = good
-	ctlr, err := state.Initialize(args)
+	ctlr, err := state.Initialize(args, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	sysState, err := ctlr.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
@@ -330,7 +330,7 @@ func (s *InitializeSuite) testBadModelConfig(c *gc.C, update map[string]interfac
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m.UpdateModelConfig(update, remove)
+	err = m.UpdateModelConfig(state.NoopConfigSchemaSource, update, remove)
 	c.Assert(err, gc.ErrorMatches, expect)
 
 	// ModelConfig remains inviolate.
@@ -371,7 +371,7 @@ func (s *InitializeSuite) TestCloudConfigWithForbiddenValues(c *gc.C) {
 	for _, badAttrName := range badAttrNames {
 		badAttrs := map[string]interface{}{badAttrName: "foo"}
 		args.ControllerInheritedConfig = badAttrs
-		_, err := state.Initialize(args)
+		_, err := state.Initialize(args, state.NoopConfigSchemaSource)
 		c.Assert(err, gc.ErrorMatches, "local cloud config cannot contain .*")
 	}
 }
@@ -414,7 +414,7 @@ func (s *InitializeSuite) TestInitializeWithStoragePool(c *gc.C) {
 				"foo":  "bar",
 			},
 		},
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctlr, gc.NotNil)
 	sysState, err := ctlr.SystemState()

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -78,7 +78,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 		NewPolicy: func(*State) Policy {
 			return internalStatePolicy{}
 		},
-	})
+	}, NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	s.controller = ctlr
 	s.pool = ctlr.StatePool()
@@ -101,7 +101,7 @@ func (s *internalStateSuite) newState(c *gc.C) *State {
 		"name": fmt.Sprintf("testmodel%d", s.modelCount),
 		"uuid": uuid.MustNewUUID().String(),
 	})
-	_, st, err := s.controller.NewModel(ModelArgs{
+	_, st, err := s.controller.NewModel(NoopConfigSchemaSource, ModelArgs{
 		Type:        ModelTypeIAAS,
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",
@@ -123,7 +123,7 @@ func (s *internalStateSuite) newCAASState(c *gc.C) *State {
 		"name": fmt.Sprintf("testmodel%d", s.modelCount),
 		"uuid": uuid.MustNewUUID().String(),
 	})
-	_, st, err := s.controller.NewModel(ModelArgs{
+	_, st, err := s.controller.NewModel(NoopConfigSchemaSource, ModelArgs{
 		Type:        ModelTypeCAAS,
 		CloudName:   "dummy",
 		CloudRegion: "dummy-region",

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -268,7 +268,7 @@ func (s *MachineSuite) TestMachineIsManualBootstrap(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(manual, jc.IsFalse)
 	attrs := map[string]interface{}{"type": "null"}
-	err = s.Model.UpdateModelConfig(attrs, nil)
+	err = s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	manual, err = s.machine0.IsManual()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2542,7 +2542,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.Model.UpdateModelConfig(map[string]interface{}{config.SecretBackendKey: "myvault"}, nil)
+	err = s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{config.SecretBackendKey: "myvault"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	mCfg, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_import_input_mock_test.go
+++ b/state/migration_import_input_mock_test.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	description "github.com/juju/description/v5"
+	config "github.com/juju/juju/environs/config"
 	txn "github.com/juju/mgo/v3/txn"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -413,6 +414,20 @@ func (m *MockFirewallRulesInput) EXPECT() *MockFirewallRulesInputMockRecorder {
 	return m.recorder
 }
 
+// ConfigSchemaSourceGetter mocks base method.
+func (m *MockFirewallRulesInput) ConfigSchemaSourceGetter() config.ConfigSchemaSourceGetter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConfigSchemaSourceGetter")
+	ret0, _ := ret[0].(config.ConfigSchemaSourceGetter)
+	return ret0
+}
+
+// ConfigSchemaSourceGetter indicates an expected call of ConfigSchemaSourceGetter.
+func (mr *MockFirewallRulesInputMockRecorder) ConfigSchemaSourceGetter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSchemaSourceGetter", reflect.TypeOf((*MockFirewallRulesInput)(nil).ConfigSchemaSourceGetter))
+}
+
 // FirewallRules mocks base method.
 func (m *MockFirewallRulesInput) FirewallRules() []description.FirewallRule {
 	m.ctrl.T.Helper()
@@ -451,10 +466,10 @@ func (m *MockFirewallRulesOutput) EXPECT() *MockFirewallRulesOutputMockRecorder 
 }
 
 // UpdateModelConfig mocks base method.
-func (m *MockFirewallRulesOutput) UpdateModelConfig(arg0 map[string]any, arg1 []string, arg2 ...ValidateConfigFunc) error {
+func (m *MockFirewallRulesOutput) UpdateModelConfig(arg0 config.ConfigSchemaSourceGetter, arg1 map[string]any, arg2 []string, arg3 ...ValidateConfigFunc) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpdateModelConfig", varargs...)
@@ -463,8 +478,8 @@ func (m *MockFirewallRulesOutput) UpdateModelConfig(arg0 map[string]any, arg1 []
 }
 
 // UpdateModelConfig indicates an expected call of UpdateModelConfig.
-func (mr *MockFirewallRulesOutputMockRecorder) UpdateModelConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockFirewallRulesOutputMockRecorder) UpdateModelConfig(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateModelConfig", reflect.TypeOf((*MockFirewallRulesOutput)(nil).UpdateModelConfig), varargs...)
 }

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -73,7 +73,7 @@ func (s *MigrationImportSuite) TestExisting(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	_, _, err = s.Controller.Import(out, ctrlCfg)
+	_, _, err = s.Controller.Import(out, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIs, errors.AlreadyExists)
 }
 
@@ -117,7 +117,7 @@ func (s *MigrationImportSuite) importModelDescription(
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
+	newModel, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.AddCleanup(func(c *gc.C) {
@@ -153,7 +153,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	newModel, newSt, err := s.Controller.Import(in, ctrlCfg)
+	newModel, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
 
@@ -931,7 +931,7 @@ func (s *MigrationImportSuite) TestCharmRevSequencesNotImported(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	_, newSt, err := s.Controller.Import(in, ctrlCfg)
+	_, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
 
@@ -1003,7 +1003,7 @@ func (s *MigrationImportSuite) TestApplicationsSubordinatesAfter(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	_, newSt, err := s.Controller.Import(in, ctrlCfg)
+	_, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	// add the cleanup here to close the model.
 	s.AddCleanup(func(c *gc.C) {
@@ -2516,7 +2516,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	_, newSt, err := s.Controller.Import(in, ctrlCfg)
+	_, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	if err == nil {
 		defer newSt.Close()
 	}
@@ -2588,7 +2588,7 @@ func (s *MigrationImportSuite) TestRemoteApplicationsConsumerProxy(c *gc.C) {
 
 	ctrlCfg := coretesting.FakeControllerConfig()
 
-	_, newSt, err := s.Controller.Import(in, ctrlCfg)
+	_, newSt, err := s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	if err == nil {
 		defer newSt.Close()
 	}
@@ -2800,7 +2800,7 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 		Cloud:              testModel.Cloud(),
 		CloudRegion:        testModel.CloudRegion(),
 	})
-	imported, newSt, err := s.Controller.Import(noTypeModel, ctrlCfg)
+	imported, newSt, err := s.Controller.Import(noTypeModel, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = newSt.Close() }()
 
@@ -2838,7 +2838,7 @@ func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, tool
 		Cloud:          testModel.Cloud(),
 		CloudRegion:    testModel.CloudRegion(),
 	})
-	imported, newSt, err := s.Controller.Import(importModel, ctrlCfg)
+	imported, newSt, err := s.Controller.Import(importModel, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = newSt.Close() }()
 
@@ -3064,7 +3064,7 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(backendRefCount, gc.Equals, 1)
 
-	err = s.Model.UpdateModelConfig(map[string]interface{}{config.SecretBackendKey: "myvault"}, nil)
+	err = s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{config.SecretBackendKey: "myvault"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	mCfg, err := s.Model.ModelConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -3214,7 +3214,7 @@ func (s *MigrationImportSuite) TestSecretsMissingBackend(c *gc.C) {
 
 	uuid := uuid.MustNewUUID().String()
 	in := newModel(out, uuid, "new")
-	_, _, err = s.Controller.Import(in, ctrlCfg)
+	_, _, err = s.Controller.Import(in, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, gc.ErrorMatches, "secrets: target controller does not have all required secret backends set up")
 }
 
@@ -3237,7 +3237,7 @@ func (s *MigrationImportSuite) TestDefaultSecretBackend(c *gc.C) {
 		Cloud:          testModel.Cloud(),
 		CloudRegion:    testModel.CloudRegion(),
 	})
-	imported, newSt, err := s.Controller.Import(importModel, ctrlCfg)
+	imported, newSt, err := s.Controller.Import(importModel, ctrlCfg, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = newSt.Close() }()
 

--- a/state/model.go
+++ b/state/model.go
@@ -277,7 +277,7 @@ func (m ModelArgs) Validate() error {
 // model document means that we have a way to represent external
 // models, perhaps for future use around cross model
 // relations.
-func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error) {
+func (ctlr *Controller) NewModel(configSchemaGetter config.ConfigSchemaSourceGetter, args ModelArgs) (_ *Model, _ *State, err error) {
 	st, err := ctlr.pool.SystemState()
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -323,7 +323,7 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 	}()
 	newSt.controllerModelTag = st.controllerModelTag
 
-	modelOps, modelStatusDoc, err := newSt.modelSetupOps(st.controllerTag.Id(), args, nil)
+	modelOps, modelStatusDoc, err := newSt.modelSetupOps(st.controllerTag.Id(), configSchemaGetter, args, nil)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to create new model")
 	}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -89,7 +89,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil).UserTag()
 
 	// Create the first model.
-	model, st1, err := s.Controller.NewModel(state.ModelArgs{
+	model, st1, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -109,7 +109,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 		"name": cfg.Name(),
 		"uuid": newUUID.String(),
 	})
-	_, _, err = s.Controller.NewModel(state.ModelArgs{
+	_, _, err = s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -135,7 +135,7 @@ func (s *ModelSuite) TestNewModelSameUserSameNameFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should now be able to create the other model.
-	model2, st2, err := s.Controller.NewModel(state.ModelArgs{
+	model2, st2, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -155,7 +155,7 @@ func (s *ModelSuite) TestNewCAASModelDifferentUser(c *gc.C) {
 	owner2 := s.Factory.MakeUser(c, nil).UserTag()
 
 	// Create the first model.
-	model, st1, err := s.Controller.NewModel(state.ModelArgs{
+	model, st1, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -177,7 +177,7 @@ func (s *ModelSuite) TestNewCAASModelDifferentUser(c *gc.C) {
 	})
 
 	// We should now be able to create the other model.
-	model2, st2, err := s.Controller.NewModel(state.ModelArgs{
+	model2, st2, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -195,7 +195,7 @@ func (s *ModelSuite) TestNewCAASModelSameUserFails(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil).UserTag()
 
 	// Create the first model.
-	model, st1, err := s.Controller.NewModel(state.ModelArgs{
+	model, st1, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -215,7 +215,7 @@ func (s *ModelSuite) TestNewCAASModelSameUserFails(c *gc.C) {
 		"name": cfg.Name(),
 		"uuid": newUUID.String(),
 	})
-	_, _, err = s.Controller.NewModel(state.ModelArgs{
+	_, _, err = s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -241,7 +241,7 @@ func (s *ModelSuite) TestNewCAASModelSameUserFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should now be able to create the other model.
-	model2, st2, err := s.Controller.NewModel(state.ModelArgs{
+	model2, st2, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -258,7 +258,7 @@ func (s *ModelSuite) TestNewCAASModelSameUserFails(c *gc.C) {
 func (s *ModelSuite) TestNewModelMissingType(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
-	_, _, err := s.Controller.NewModel(state.ModelArgs{
+	_, _, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		// No type
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -274,7 +274,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	cfg, uuid := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -328,7 +328,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 
 func (s *ModelSuite) TestNewModelRegionNameEscaped(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dotty.region",
@@ -345,7 +345,7 @@ func (s *ModelSuite) TestNewModelImportingMode(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -364,7 +364,7 @@ func (s *ModelSuite) TestSetMigrationMode(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
 	owner := names.NewUserTag("test@remote")
 
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",
@@ -1650,7 +1650,7 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err = cfg.Apply(map[string]interface{}{"name": "whatever"})
 	c.Assert(err, jc.ErrorIsNil)
-	m, newSt, err := controller.NewModel(state.ModelArgs{
+	m, newSt, err := controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "another",
 		Config:                  cfg,
@@ -1678,7 +1678,7 @@ func (s *ModelCloudValidationSuite) TestNewModelMissingCloudCredentialSupportsEm
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err = cfg.Apply(map[string]interface{}{"name": "whatever"})
 	c.Assert(err, jc.ErrorIsNil)
-	_, newSt, err := controller.NewModel(state.ModelArgs{
+	_, newSt, err := controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:      state.ModelTypeIAAS,
 		CloudName: "dummy", CloudRegion: "dummy-region", Config: cfg, Owner: owner,
 		StorageProviderRegistry: storage.StaticProviderRegistry{},
@@ -1721,7 +1721,7 @@ func (s *ModelCloudValidationSuite) initializeState(
 		CloudName:     "dummy",
 		MongoSession:  s.Session,
 		AdminPassword: "dummy-secret",
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	return controller, owner
 }

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -71,12 +71,12 @@ func checkModelConfig(cfg *config.Config) error {
 
 // inheritedConfigAttributes returns the merged collection of inherited config
 // values used as model defaults when adding models or unsetting values.
-func (st *State) inheritedConfigAttributes() (map[string]interface{}, error) {
+func (st *State) inheritedConfigAttributes(configSchemaGetter config.ConfigSchemaSourceGetter) (map[string]interface{}, error) {
 	rspec, err := st.regionSpec()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configSources := modelConfigSources(st, rspec)
+	configSources := modelConfigSources(configSchemaGetter, st, rspec)
 	values := make(attrValues)
 	for _, src := range configSources {
 		cfg, err := src.sourceFunc()
@@ -95,7 +95,7 @@ func (st *State) inheritedConfigAttributes() (map[string]interface{}, error) {
 
 // modelConfigValues returns the values and source for the supplied model config
 // when combined with controller and Juju defaults.
-func (model *Model) modelConfigValues(modelCfg attrValues) (config.ConfigValues, error) {
+func (model *Model) modelConfigValues(configSchemaGetter config.ConfigSchemaSourceGetter, modelCfg attrValues) (config.ConfigValues, error) {
 	resultValues := make(attrValues)
 	for k, v := range modelCfg {
 		resultValues[k] = v
@@ -107,7 +107,7 @@ func (model *Model) modelConfigValues(modelCfg attrValues) (config.ConfigValues,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configSources := modelConfigSources(model.st, rspec)
+	configSources := modelConfigSources(configSchemaGetter, model.st, rspec)
 	sourceNames := make([]string, 0, len(configSources))
 	sourceAttrs := make([]attrValues, 0, len(configSources))
 	for _, src := range configSources {
@@ -235,20 +235,20 @@ func (st *State) UpdateModelConfigDefaultValues(updateAttrs map[string]interface
 
 // ModelConfigValues returns the config values for the model represented
 // by this state.
-func (model *Model) ModelConfigValues() (config.ConfigValues, error) {
+func (model *Model) ModelConfigValues(configSchemaGetter config.ConfigSchemaSourceGetter) (config.ConfigValues, error) {
 	cfg, err := model.ModelConfig(context.Background())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return model.modelConfigValues(cfg.AllAttrs())
+	return model.modelConfigValues(configSchemaGetter, cfg.AllAttrs())
 }
 
 // ModelConfigDefaultValues returns the default config values to be used
 // when creating a new model, and the origin of those values.
-func (st *State) ModelConfigDefaultValues(cloudName string) (config.ModelDefaultAttributes, error) {
+func (st *State) ModelConfigDefaultValues(configSchemaGetter config.ConfigSchemaSourceGetter, cloudName string) (config.ModelDefaultAttributes, error) {
 	result := make(config.ModelDefaultAttributes)
 	// Juju defaults
-	defaultAttrs, err := st.defaultInheritedConfig(cloudName)()
+	defaultAttrs, err := st.defaultInheritedConfig(configSchemaGetter, cloudName)()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -310,7 +310,7 @@ type ValidateConfigFunc func(updateAttrs map[string]interface{}, removeAttrs []s
 // UpdateModelConfig adds, updates or removes attributes in the current
 // configuration of the model with the provided updateAttrs and
 // removeAttrs.
-func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttrs []string, additionalValidation ...ValidateConfigFunc) error {
+func (m *Model) UpdateModelConfig(configSchemaGetter config.ConfigSchemaSourceGetter, updateAttrs map[string]interface{}, removeAttrs []string, additionalValidation ...ValidateConfigFunc) error {
 	if len(updateAttrs)+len(removeAttrs) == 0 {
 		return nil
 	}
@@ -323,7 +323,7 @@ func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttr
 		}
 		// For each removed attribute, pick up any inherited value
 		// and if there's one, use that.
-		inherited, err := st.inheritedConfigAttributes()
+		inherited, err := st.inheritedConfigAttributes(configSchemaGetter)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -395,22 +395,22 @@ type modelConfigSource struct {
 // sources, in hierarchical order. Starting from the first source,
 // config is retrieved and each subsequent source adds to the
 // overall config values, later values override earlier ones.
-func modelConfigSources(st *State, regionSpec *environscloudspec.CloudRegionSpec) []modelConfigSource {
+func modelConfigSources(configSchemaGetter config.ConfigSchemaSourceGetter, st *State, regionSpec *environscloudspec.CloudRegionSpec) []modelConfigSource {
 	return []modelConfigSource{
-		{config.JujuDefaultSource, st.defaultInheritedConfig(regionSpec.Cloud)},
+		{config.JujuDefaultSource, st.defaultInheritedConfig(configSchemaGetter, regionSpec.Cloud)},
 		{config.JujuControllerSource, st.controllerInheritedConfig(regionSpec.Cloud)},
 	}
 }
 
 // defaultInheritedConfig returns config values which are defined
 // as defaults in either Juju or the cloud's environ provider.
-func (st *State) defaultInheritedConfig(cloudName string) func() (attrValues, error) {
+func (st *State) defaultInheritedConfig(configSchemaGetter config.ConfigSchemaSourceGetter, cloudName string) func() (attrValues, error) {
 	return func() (attrValues, error) {
 		var defaults = make(map[string]interface{})
 		for k, v := range config.ConfigDefaults() {
 			defaults[k] = v
 		}
-		providerDefaults, err := st.environsProviderConfigSchemaSource(cloudName)
+		providerDefaults, err := configSchemaGetter(context.TODO(), cloudName)
 		if errors.Is(err, errors.NotImplemented) {
 			return defaults, nil
 		} else if err != nil {
@@ -485,7 +485,7 @@ func composeModelConfigAttributes(
 
 // ComposeNewModelConfig returns a complete map of config attributes suitable for
 // creating a new model, by combining user specified values with system defaults.
-func (st *State) ComposeNewModelConfig(modelAttr map[string]interface{}, regionSpec *environscloudspec.CloudRegionSpec) (map[string]interface{}, error) {
-	configSources := modelConfigSources(st, regionSpec)
+func (st *State) ComposeNewModelConfig(configSchemaGetter config.ConfigSchemaSourceGetter, modelAttr map[string]interface{}, regionSpec *environscloudspec.CloudRegionSpec) (map[string]interface{}, error) {
+	configSources := modelConfigSources(configSchemaGetter, st, regionSpec)
 	return composeModelConfigAttributes(modelAttr, configSources...)
 }

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -161,7 +161,7 @@ func (s *ModelCredentialSuite) addModel(c *gc.C, modelName string, tag names.Clo
 		"name": modelName,
 		"uuid": uuid.String(),
 	})
-	_, st, err := s.Controller.NewModel(state.ModelArgs{
+	_, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -199,7 +199,7 @@ func (s *ModelSummariesSuite) TestModelsForIgnoresImportingModels(c *gc.C) {
 		"uuid": uuid.MustNewUUID().String(),
 		"type": state.ModelTypeIAAS,
 	})
-	_, stImporting, err := s.Controller.NewModel(state.ModelArgs{
+	_, stImporting, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -511,7 +511,7 @@ func (s *ModelUserSuite) newModelWithOwner(c *gc.C, owner names.UserTag) *state.
 		"name": uuidStr[:8],
 		"uuid": uuidStr,
 	})
-	model, st, err := s.Controller.NewModel(state.ModelArgs{
+	model, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/policy.go
+++ b/state/policy.go
@@ -30,10 +30,6 @@ type NewPolicyFunc func(*State) Policy
 // be ignored. Any other error will cause an error
 // in the use of the policy.
 type Policy interface {
-	// ProviderConfigSchemaSource returns a config.ConfigSchemaSource
-	// for the cloud, or an error.
-	ProviderConfigSchemaSource(cloudName string) (config.ConfigSchemaSource, error)
-
 	// ConfigValidator returns a config.Validator or an error.
 	ConfigValidator() (config.Validator, error)
 
@@ -146,11 +142,4 @@ func (st *State) storageProviderRegistry() (storage.ProviderRegistry, error) {
 		return storage.StaticProviderRegistry{}, nil
 	}
 	return st.policy.StorageProviderRegistry()
-}
-
-func (st *State) environsProviderConfigSchemaSource(cloudName string) (config.ConfigSchemaSource, error) {
-	if st.policy == nil {
-		return nil, errors.NotImplementedf("config.ProviderConfigSchemaSource")
-	}
-	return st.policy.ProviderConfigSchemaSource(cloudName)
 }

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -662,7 +662,7 @@ func (s *SecretsSuite) newCAASState(c *gc.C) *state.State {
 			},
 		},
 	}
-	_, st, err := s.Controller.NewModel(state.ModelArgs{
+	_, st, err := s.Controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -823,7 +823,7 @@ func (s *SpacesDiscoverySuite) TestSaveProviderSubnetsOnlyIdempotent(c *gc.C) {
 }
 
 func (s *SpacesDiscoverySuite) TestSaveProviderSubnetsWithFAN(c *gc.C) {
-	err := s.Model.UpdateModelConfig(map[string]interface{}{"fan-config": "10.100.0.0/16=253.0.0.0/8"}, nil)
+	err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"fan-config": "10.100.0.0/16=253.0.0.0/8"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.SaveProviderSubnets(twoSubnets, "")
@@ -840,6 +840,7 @@ func (s *SpacesDiscoverySuite) TestSaveProviderSubnetsIgnoredWithFAN(c *gc.C) {
 	// considered invalid in the future. Here we show that this
 	// configuration is ignored.
 	err := s.Model.UpdateModelConfig(
+		state.NoopConfigSchemaSource,
 		map[string]interface{}{"fan-config": "fe80:dead:beef::/48=fe80:dead:beef::/24"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/state.go
+++ b/state/state.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/upgrade"
 	"github.com/juju/juju/environs"
+	environsconfig "github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/internal/storage"
@@ -2624,4 +2625,8 @@ type NoopInstancePrechecker struct{}
 
 func (NoopInstancePrechecker) PrecheckInstance(envcontext.ProviderCallContext, environs.PrecheckInstanceParams) error {
 	return errors.NotSupportedf("prechecking instances")
+}
+
+func NoopConfigSchemaSource(ctx context.Context, cloudName string) (environsconfig.ConfigSchemaSource, error) {
+	return nil, errors.NotImplementedf("config schema source")
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4138,7 +4138,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 func (s *StateSuite) changeEnviron(c *gc.C, modelConfig *config.Config, name string, value interface{}) {
 	attrs := modelConfig.AllAttrs()
 	attrs[name] = value
-	c.Assert(s.Model.UpdateModelConfig(attrs, nil), gc.IsNil)
+	c.Assert(s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, attrs, nil), gc.IsNil)
 }
 
 func assertAgentVersion(c *gc.C, st *state.State, vers, stream string) {
@@ -4783,7 +4783,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		CloudName:     "dummy",
 		MongoSession:  session,
 		AdminPassword: password,
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	st, err := ctlr.SystemState()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -4,7 +4,6 @@
 package stateenvirons
 
 import (
-	"context"
 	stdcontext "context"
 	"sync"
 
@@ -51,25 +50,6 @@ func NewInstancePrechecker(st *state.State, cloudService CloudService, credentia
 		getBroker:         GetNewCAASBrokerFunc(caas.New),
 	}
 	return policy.Prechecker()
-}
-
-// ProviderConfigSchemaSource returns a function that can be used to
-// get a config.ConfigSchemaSource for the specified cloud.
-func ProviderConfigSchemaSource(cloudService CloudService) config.ConfigSchemaSourceGetter {
-	return func(ctx context.Context, cloudName string) (config.ConfigSchemaSource, error) {
-		cloud, err := cloudService.Get(ctx, cloudName)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		provider, err := environs.Provider(cloud.Type)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if cs, ok := provider.(config.ConfigSchemaSource); ok {
-			return cs, nil
-		}
-		return nil, errors.NotImplementedf("config.ConfigSource")
-	}
 }
 
 // GetNewPolicyFunc returns a state.NewPolicyFunc that will return

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -565,7 +565,7 @@ func (s *StorageStateSuite) TestAddApplicationStorageConstraintsValidation(c *gc
 
 func (s *StorageStateSuite) assertAddApplicationStorageConstraintsDefaults(c *gc.C, pool string, cons, expect map[string]state.StorageConstraints) {
 	if pool != "" {
-		err := s.Model.UpdateModelConfig(map[string]interface{}{
+		err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 			"storage-default-block-source": pool,
 		}, nil)
 		c.Assert(err, jc.ErrorIsNil)
@@ -688,7 +688,7 @@ func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
-	err := s.Model.UpdateModelConfig(map[string]interface{}{
+	err := s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"storage-default-block-source": "loop-pool",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1553,7 +1553,7 @@ func (s *StorageStateSuiteCaas) TestRemoveStoragePool(c *gc.C) {
 func (s *StorageStateSuiteCaas) TestRemoveStoragePoolInUse(c *gc.C) {
 	model, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	err = model.UpdateModelConfig(map[string]interface{}{"operator-storage": "k8s-operator-storage"}, nil)
+	err = model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"operator-storage": "k8s-operator-storage"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	poolName := "k8s-operator-storage"
 	_, err = s.pm.Get(poolName)

--- a/state/testing/agent.go
+++ b/state/testing/agent.go
@@ -18,5 +18,5 @@ func SetAgentVersion(st *state.State, vers version.Number) error {
 	if err != nil {
 		return err
 	}
-	return model.UpdateModelConfig(map[string]interface{}{"agent-version": vers.String()}, nil)
+	return model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{"agent-version": vers.String()}, nil)
 }

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -95,7 +95,7 @@ func InitializeWithArgs(c *gc.C, args InitializeArgs) *state.Controller {
 		WatcherPollInterval:       10 * time.Millisecond,
 		NewPolicy:                 args.NewPolicy,
 		AdminPassword:             args.AdminPassword,
-	})
+	}, state.NoopConfigSchemaSource)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctlr
 }

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -19,10 +19,9 @@ import (
 )
 
 type MockPolicy struct {
-	GetConfigValidator            func() (config.Validator, error)
-	GetProviderConfigSchemaSource func(cloudName string) (config.ConfigSchemaSource, error)
-	GetConstraintsValidator       func() (constraints.Validator, error)
-	GetStorageProviderRegistry    func() (storage.ProviderRegistry, error)
+	GetConfigValidator         func() (config.Validator, error)
+	GetConstraintsValidator    func() (constraints.Validator, error)
+	GetStorageProviderRegistry func() (storage.ProviderRegistry, error)
 }
 
 func (p *MockPolicy) ConfigValidator() (config.Validator, error) {
@@ -44,13 +43,6 @@ func (p *MockPolicy) StorageProviderRegistry() (storage.ProviderRegistry, error)
 		return p.GetStorageProviderRegistry()
 	}
 	return nil, errors.NotImplementedf("StorageProviderRegistry")
-}
-
-func (p *MockPolicy) ProviderConfigSchemaSource(cloudName string) (config.ConfigSchemaSource, error) {
-	if p.GetProviderConfigSchemaSource != nil {
-		return p.GetProviderConfigSchemaSource(cloudName)
-	}
-	return nil, errors.NotImplementedf("ProviderConfigSchemaSource")
 }
 
 type MockConfigSchemaSource struct {

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -48,6 +48,7 @@ type StateSuite struct {
 	modelWatcherIdle          chan string
 	modelWatcherMutex         *sync.Mutex
 	InstancePrechecker        func(*gc.C, *state.State) environs.InstancePrechecker
+	ConfigSchemaSourceGetter  func(*gc.C) config.ConfigSchemaSourceGetter
 }
 
 func (s *StateSuite) SetUpSuite(c *gc.C) {
@@ -101,6 +102,9 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 
 	s.InstancePrechecker = func(c *gc.C, st *state.State) environs.InstancePrechecker {
 		return state.NoopInstancePrechecker{}
+	}
+	s.ConfigSchemaSourceGetter = func(c *gc.C) config.ConfigSchemaSourceGetter {
+		return state.NoopConfigSchemaSource
 	}
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -70,7 +70,7 @@ func (s *upgradesSuite) makeModel(c *gc.C, name string, attr coretesting.Attrs) 
 	}.Merge(attr))
 	m, err := s.state.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	_, st, err := s.controller.NewModel(ModelArgs{
+	_, st, err := s.controller.NewModel(NoopConfigSchemaSource, ModelArgs{
 		Type:                    ModelTypeIAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "dummy-region",

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -137,7 +137,7 @@ func (s *VolumeStateSuite) TestAddApplicationDefaultPool(c *gc.C) {
 	})
 	_, err := pm.Create("default-block", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.Model.UpdateModelConfig(map[string]interface{}{
+	err = s.Model.UpdateModelConfig(state.NoopConfigSchemaSource, map[string]interface{}{
 		"storage-default-block-source": "default-block",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -790,7 +790,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		"type": cfgType,
 	}.Merge(params.ConfigAttrs))
 	controller := state.NewController(factory.pool)
-	_, st, err := controller.NewModel(state.ModelArgs{
+	_, st, err := controller.NewModel(state.NoopConfigSchemaSource, state.ModelArgs{
 		Type:                    params.Type,
 		CloudName:               params.CloudName,
 		CloudRegion:             params.CloudRegion,


### PR DESCRIPTION
Removes the ProviderConfigSchemaSource from state policy. Interestingly this didn't require state and so could have been lifted out when the cloud service was added.
The ongoing effort is to remove the concept of policy from state and free us from the cyclic dependency within the engine. Only a few locations require the config schema source and it was clear the abstraction for this didn't hold it's weight.

The interface now becomes:

```
type Policy interface {
	// ConfigValidator returns a config.Validator or an error.
	ConfigValidator() (config.Validator, error)

	// ConstraintsValidator returns a constraints.Validator or an error.
	ConstraintsValidator(envcontext.ProviderCallContext) (constraints.Validator, error)

	// StorageProviderRegistry returns a storage.ProviderRegistry or an error.
	StorageProviderRegistry() (storage.ProviderRegistry, error)
}
```

The next set of changes will attempt to remove the config and constraints validator from the policy at once. A lot of tests will be broken, so it'll be a case of working through those to be able to land this.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

<!-- Describe steps to verify that the change works. -->

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
```


## Links


**Jira card:** JUJU-5576

