### PR TITLE
Add Prepare method to StateBase to allow for SQLair statement reuse.

### DIFF
--- a/domain/annotation/state/state.go
+++ b/domain/annotation/state/state.go
@@ -37,7 +37,7 @@ func (st *State) GetAnnotations(ctx context.Context, id annotations.ID) (map[str
 		return nil, errors.Trace(err)
 	}
 
-	getAnnotationsStmt, err := sqlair.Prepare(getAnnotationsQuery, Annotation{}, sqlair.M{})
+	getAnnotationsStmt, err := st.Prepare(getAnnotationsQuery, Annotation{}, sqlair.M{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing get annotations query for ID: %q", id.Name)
 	}
@@ -63,7 +63,6 @@ func (st *State) getAnnotationsForModel(ctx context.Context, id annotations.ID, 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return tx.Query(ctx, getAnnotationsStmt).GetAll(&annotationsResults)
 	})
-
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// No errors, we return empty map if no annotation is found
@@ -95,7 +94,7 @@ func (st *State) getAnnotationsForID(ctx context.Context, id annotations.ID, get
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing get annotations query for ID: %q", id.Name)
 	}
-	kindQueryStmt, err := sqlair.Prepare(kindQuery, sqlair.M{})
+	kindQueryStmt, err := st.Prepare(kindQuery, sqlair.M{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing get annotations query for ID: %q", id.Name)
 	}
@@ -123,7 +122,6 @@ func (st *State) getAnnotationsForID(ctx context.Context, id annotations.ID, get
 			"uuid": uuid,
 		}).GetAll(&annotationsResults)
 	})
-
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// No errors, we return empty map if no annotation is found
@@ -170,11 +168,11 @@ func (st *State) SetAnnotations(ctx context.Context, id annotations.ID,
 	}
 
 	// Prepare sqlair statements
-	setAnnotationsStmt, err := sqlair.Prepare(setAnnotationsQuery, Annotation{}, sqlair.M{})
+	setAnnotationsStmt, err := st.Prepare(setAnnotationsQuery, Annotation{}, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing set annotations query for ID: %q", id.Name)
 	}
-	deleteAnnotationsStmt, err := sqlair.Prepare(deleteAnnotationsQuery, Annotation{}, sqlair.M{})
+	deleteAnnotationsStmt, err := st.Prepare(deleteAnnotationsQuery, Annotation{}, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing set annotations query for ID: %q", id.Name)
 	}
@@ -204,7 +202,7 @@ func (st *State) setAnnotationsForID(ctx context.Context, id annotations.ID,
 	if err != nil {
 		return errors.Annotatef(err, "preparing uuid retrieval query for ID: %q", id.Name)
 	}
-	kindQueryStmt, err := sqlair.Prepare(kindQuery, sqlair.M{})
+	kindQueryStmt, err := st.Prepare(kindQuery, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing uuid retrieval query for ID: %q", id.Name)
 	}

--- a/domain/autocert/state/state.go
+++ b/domain/autocert/state/state.go
@@ -73,7 +73,7 @@ func (st *State) Get(ctx context.Context, name string) ([]byte, error) {
 SELECT (name, data) AS (&Autocert.*)
 FROM   autocert_cache 
 WHERE  name = $M.name`
-	s, err := sqlair.Prepare(q, Autocert{}, sqlair.M{})
+	s, err := st.Prepare(q, Autocert{}, sqlair.M{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing %q", q)
 	}

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -37,15 +37,15 @@ func NewState(factory coredb.TxnRunnerFactory, logger Logger) *State {
 
 // UpsertMachine creates or updates the specified machine.
 // TODO - this just creates a minimal row for now.
-func (s *State) UpsertMachine(ctx context.Context, machineId string) error {
-	db, err := s.DB()
+func (st *State) UpsertMachine(ctx context.Context, machineId string) error {
+	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	machineIDParam := sqlair.M{"machine_id": machineId}
 	query := `SELECT &M.uuid FROM machine WHERE machine_id = $M.machine_id`
-	queryStmt, err := sqlair.Prepare(query, sqlair.M{})
+	queryStmt, err := st.Prepare(query, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -54,13 +54,13 @@ func (s *State) UpsertMachine(ctx context.Context, machineId string) error {
 INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
 VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 `
-	createMachineStmt, err := sqlair.Prepare(createMachine, sqlair.M{})
+	createMachineStmt, err := st.Prepare(createMachine, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	createNode := `INSERT INTO net_node (uuid) VALUES ($M.net_node_uuid)`
-	createNodeStmt, err := sqlair.Prepare(createNode, sqlair.M{})
+	createNodeStmt, err := st.Prepare(createNode, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -104,8 +104,8 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 
 // DeleteMachine deletes the specified machine and any dependent child records.
 // TODO - this just deals with child block devices for now.
-func (s *State) DeleteMachine(ctx context.Context, machineId string) error {
-	db, err := s.DB()
+func (st *State) DeleteMachine(ctx context.Context, machineId string) error {
+	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -113,13 +113,13 @@ func (s *State) DeleteMachine(ctx context.Context, machineId string) error {
 	machineIDParam := sqlair.M{"machine_id": machineId}
 
 	queryMachine := `SELECT &M.uuid FROM machine WHERE machine_id = $M.machine_id`
-	queryMachineStmt, err := sqlair.Prepare(queryMachine, sqlair.M{})
+	queryMachineStmt, err := st.Prepare(queryMachine, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	deleteMachine := `DELETE FROM machine WHERE machine_id = $M.machine_id`
-	deleteMachineStmt, err := sqlair.Prepare(deleteMachine, sqlair.M{})
+	deleteMachineStmt, err := st.Prepare(deleteMachine, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -128,7 +128,7 @@ func (s *State) DeleteMachine(ctx context.Context, machineId string) error {
 DELETE FROM net_node WHERE uuid IN
 (SELECT net_node_uuid FROM machine WHERE machine_id = $M.machine_id) 
 `
-	deleteNodeStmt, err := sqlair.Prepare(deleteNode, sqlair.M{})
+	deleteNodeStmt, err := st.Prepare(deleteNode, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -59,7 +59,7 @@ func (st *State) ModelConfigHasAttributes(
 	}
 
 	attrsSlice := sqlair.S(transform.Slice(attrs, func(s string) any { return any(s) }))
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT &key.key FROM model_config WHERE key IN ($S[:])
 `, sqlair.S{}, key{})
 	if err != nil {
@@ -176,7 +176,7 @@ func (st *State) UpdateModelConfig(
 	}
 
 	removeAttrsSlice := sqlair.S(transform.Slice(removeAttrs, func(s string) any { return any(s) }))
-	deleteStmt, err := sqlair.Prepare(`
+	deleteStmt, err := st.Prepare(`
 DELETE FROM model_config
 WHERE key IN ($S[:])
 `[1:], sqlair.S{})
@@ -184,7 +184,7 @@ WHERE key IN ($S[:])
 		return errors.Trace(err)
 	}
 
-	upsertStmt, err := sqlair.Prepare(`
+	upsertStmt, err := st.Prepare(`
 INSERT INTO model_config (key, value) VALUES ($M.key, $M.value)
 ON CONFLICT(key) DO UPDATE
 SET value = excluded.value

--- a/domain/state.go
+++ b/domain/state.go
@@ -6,6 +6,7 @@ package domain
 import (
 	"sync"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
@@ -17,12 +18,17 @@ type StateBase struct {
 	mu    sync.Mutex
 	getDB database.TxnRunnerFactory
 	db    database.TxnRunner
+
+	// stmts is a cache of sqlair statements keyed by the query string.
+	stmts     map[string]*sqlair.Statement
+	stmtMutex sync.RWMutex
 }
 
 // NewStateBase returns a new StateBase.
 func NewStateBase(getDB database.TxnRunnerFactory) *StateBase {
 	return &StateBase{
 		getDB: getDB,
+		stmts: make(map[string]*sqlair.Statement),
 	}
 }
 
@@ -43,4 +49,35 @@ func (st *StateBase) DB() (database.TxnRunner, error) {
 	}
 
 	return st.db, nil
+}
+
+// Prepare prepares a SQLair query. If the query has been prepared previously it
+// is retrieved from the statement cache.
+//
+// Note that because the type samples are not considered when retrieving a query
+// from the cache, it is possible that two queries may have identical text, but
+// use different types. Retrieving the wrong query would result in an error when
+// the query was passed the wrong type at execution.
+//
+// The likelihood of this happening is low since the statement cache is scoped
+// to individual domains meaning that the two identically worded statements
+// would have to be in the same state package. This issue should be relatively
+// rare and caught by QA if present.
+func (st *StateBase) Prepare(query string, typeSamples ...any) (*sqlair.Statement, error) {
+	// Take a read lock to check if the statement is already prepared.
+	st.stmtMutex.RLock()
+	if stmt, ok := st.stmts[query]; ok && stmt != nil {
+		st.stmtMutex.RUnlock()
+		return stmt, nil
+	}
+	st.stmtMutex.RUnlock()
+	// Grab the write lock to prepare the statement.
+	st.stmtMutex.Lock()
+	defer st.stmtMutex.Unlock()
+	stmt, err := sqlair.Prepare(query, typeSamples...)
+	if err != nil {
+		return nil, errors.Annotate(err, "preparing:")
+	}
+	st.stmts[query] = stmt
+	return stmt, nil
 }

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -4,6 +4,9 @@
 package domain
 
 import (
+	"context"
+
+	"github.com/canonical/sqlair"
 	gc "gopkg.in/check.v1"
 
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -27,4 +30,69 @@ func (s *stateSuite) TestStateBaseGetDBNilFactory(c *gc.C) {
 	base := NewStateBase(nil)
 	_, err := base.DB()
 	c.Assert(err, gc.ErrorMatches, `nil getDB`)
+}
+
+func (s *stateSuite) TestStateBasePrepare(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	// Prepare new query.
+	stmt1, err := base.Prepare("SELECT name AS &M.* FROM sqlite_schema", sqlair.M{})
+	c.Assert(err, gc.IsNil)
+	// Validate prepared statement works as expected.
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		results := sqlair.M{}
+		err := tx.Query(ctx, stmt1).Get(results)
+		if err != nil {
+			return err
+		}
+		c.Assert(results["name"], gc.Equals, "schema")
+		return nil
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Retrieve previous statement.
+	stmt2, err := base.Prepare("SELECT name AS &M.* FROM sqlite_schema", sqlair.M{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(stmt1, gc.Equals, stmt2)
+}
+
+func (s *stateSuite) TestStateBasePrepareKeyClash(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	// Prepare statement with TestType.
+	{
+		type TestType struct {
+			WrongName string `db:"type"`
+		}
+		_, err := base.Prepare("SELECT &TestType.* FROM sqlite_schema", TestType{})
+		c.Assert(err, gc.IsNil)
+	}
+
+	// Prepare statement with a different type of the same name, this will
+	// retrieve the previously prepared statement which used the shadowed type.
+	type TestType struct {
+		Name string `db:"name"`
+	}
+	stmt, err := base.Prepare("SELECT &TestType.* FROM sqlite_schema", TestType{})
+
+	// Try and run a query.
+	c.Assert(err, gc.IsNil)
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		results := TestType{}
+		err := tx.Query(ctx, stmt).Get(&results)
+		if err != nil {
+			return err
+		}
+		c.Assert(results.Name, gc.Equals, "schema")
+		return nil
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot get result: parameter with type "domain.TestType" missing, have type with same name: "domain.TestType"`)
 }

--- a/domain/storage/state/storagepool.go
+++ b/domain/storage/state/storagepool.go
@@ -194,11 +194,11 @@ DELETE FROM storage_pool
 WHERE  storage_pool.uuid = (select uuid FROM storage_pool WHERE name = $M.name)
 `
 
-	poolAttributeDeleteStmt, err := sqlair.Prepare(poolAttributeDeleteQ, sqlair.M{})
+	poolAttributeDeleteStmt, err := st.Prepare(poolAttributeDeleteQ, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
-	poolDeleteStmt, err := sqlair.Prepare(poolDeleteQ, sqlair.M{})
+	poolDeleteStmt, err := st.Prepare(poolDeleteQ, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -233,7 +233,7 @@ func (st StoragePoolState) ReplaceStoragePool(ctx context.Context, pool domainst
 		return errors.Trace(err)
 	}
 
-	selectUUIDStmt, err := sqlair.Prepare("SELECT &StoragePool.uuid FROM storage_pool WHERE name = $StoragePool.name", StoragePool{})
+	selectUUIDStmt, err := st.Prepare("SELECT &StoragePool.uuid FROM storage_pool WHERE name = $StoragePool.name", StoragePool{})
 	if err != nil {
 		return errors.Trace(domain.CoerceError(err))
 	}
@@ -304,7 +304,7 @@ FROM   storage_pool sp
 			keyValues []poolAttribute
 		)
 		err = tx.Query(ctx, queryStmt, queryArgs...).GetAll(&dbRows, &keyValues)
-		if err != nil {
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return nil, errors.Annotate(err, "loading storage pool")
 		}
 		return dbRows.toStoragePools(keyValues)

--- a/domain/unit/state/state.go
+++ b/domain/unit/state/state.go
@@ -33,8 +33,8 @@ func NewState(factory coredb.TxnRunnerFactory, logger Logger) *State {
 }
 
 // DeleteUnit deletes the specified unit.
-func (s *State) DeleteUnit(ctx context.Context, unitName string) error {
-	db, err := s.DB()
+func (st *State) DeleteUnit(ctx context.Context, unitName string) error {
+	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -42,13 +42,13 @@ func (s *State) DeleteUnit(ctx context.Context, unitName string) error {
 	unitIDParam := sqlair.M{"unit_id": unitName}
 
 	queryUnit := `SELECT uuid as &M.uuid FROM unit WHERE unit_id = $M.unit_id`
-	queryUnitStmt, err := sqlair.Prepare(queryUnit, sqlair.M{})
+	queryUnitStmt, err := st.Prepare(queryUnit, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	deleteUnit := `DELETE FROM unit WHERE unit_id = $M.unit_id`
-	deleteUnitStmt, err := sqlair.Prepare(deleteUnit, sqlair.M{})
+	deleteUnitStmt, err := st.Prepare(deleteUnit, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -57,7 +57,7 @@ func (s *State) DeleteUnit(ctx context.Context, unitName string) error {
 DELETE FROM net_node WHERE uuid IN
 (SELECT net_node_uuid FROM unit WHERE unit_id = $M.unit_id) 
 `
-	deleteNodeStmt, err := sqlair.Prepare(deleteNode, sqlair.M{})
+	deleteNodeStmt, err := st.Prepare(deleteNode, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -84,7 +84,7 @@ FROM    upgrade_info_controller_node
 WHERE   upgrade_info_uuid = $M.info_uuid
 AND     controller_node_id = $M.controller_id;
 `
-	lookForReadyNodeStmt, err := sqlair.Prepare(lookForReadyNodeQuery, infoControllerNode{}, sqlair.M{})
+	lookForReadyNodeStmt, err := st.Prepare(lookForReadyNodeQuery, infoControllerNode{}, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing %q", lookForReadyNodeQuery)
 	}
@@ -93,7 +93,7 @@ AND     controller_node_id = $M.controller_id;
 INSERT INTO upgrade_info_controller_node (uuid, controller_node_id, upgrade_info_uuid)
 VALUES ($M.uuid, $M.controller_id, $M.info_uuid);
 `
-	insertUpgradeNodeStmt, err := sqlair.Prepare(insertUpgradeNodeQuery, sqlair.M{})
+	insertUpgradeNodeStmt, err := st.Prepare(insertUpgradeNodeQuery, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing %q", insertUpgradeNodeQuery)
 	}
@@ -225,7 +225,7 @@ UPDATE upgrade_info
 SET state_type_id = $M.to_state 
 WHERE uuid = $M.info_uuid
 AND state_type_id = $M.from_state;`
-	completedDBUpgradeStmt, err := sqlair.Prepare(q, sqlair.M{})
+	completedDBUpgradeStmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing %q", q)
 	}
@@ -260,7 +260,7 @@ UPDATE upgrade_info
 SET state_type_id = $M.to_state 
 WHERE uuid = $M.info_uuid
 AND state_type_id = $M.from_state;`
-	completedDBUpgradeStmt, err := sqlair.Prepare(q, sqlair.M{})
+	completedDBUpgradeStmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing %q", q)
 	}
@@ -300,7 +300,7 @@ SELECT (controller_node_id, node_upgrade_completed_at) AS (&infoControllerNode.*
 FROM   upgrade_info_controller_node
 WHERE  upgrade_info_uuid = $M.info_uuid
 AND    controller_node_id = $M.controller_id;`
-	lookForDoneNodesStmt, err := sqlair.Prepare(lookForDoneNodesQuery, infoControllerNode{}, sqlair.M{})
+	lookForDoneNodesStmt, err := st.Prepare(lookForDoneNodesQuery, infoControllerNode{}, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing select done query")
 	}
@@ -312,7 +312,7 @@ WHERE   upgrade_info_uuid = $M.info_uuid
 AND     controller_node_id = $M.controller_id
 AND     node_upgrade_completed_at IS NULL;
 `
-	setNodeToDoneStmt, err := sqlair.Prepare(setNodeToDoneQuery, sqlair.M{})
+	setNodeToDoneStmt, err := st.Prepare(setNodeToDoneQuery, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing update node query")
 	}
@@ -332,7 +332,7 @@ AND (
     WHERE  upgrade_info_uuid = $M.info_uuid
 );
 `
-	completeUpgradeStmt, err := sqlair.Prepare(completeUpgradeQuery, sqlair.M{})
+	completeUpgradeStmt, err := st.Prepare(completeUpgradeQuery, sqlair.M{})
 	if err != nil {
 		return errors.Annotatef(err, "preparing complete upgrade query")
 	}

--- a/domain/upgrade/state/state_test.go
+++ b/domain/upgrade/state/state_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/canonical/sqlair"
 	jc "github.com/juju/testing/checkers"
@@ -452,6 +453,9 @@ WHERE upgrade_info_uuid = $M.info_uuid`
 	)
 	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, nodeInfosS, sqlair.M{"info_uuid": upgradeUUID}).GetAll(&nodeInfos)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
 		c.Assert(err, jc.ErrorIsNil)
 		return nil
 	})

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
 	github.com/canonical/pebble v1.9.0
-	github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40
+	github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSH
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
 github.com/canonical/pebble v1.9.0 h1:FWVEh1fg3aaW2HNue2Z2eYMwkJEQT8mgMFW3R5Iocn4=
 github.com/canonical/pebble v1.9.0/go.mod h1:9Qkjmq298g0+9SvM2E5eekkEN4pjHDWhgg9eB2I0tjk=
-github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40 h1:ZQhteS4l8oF3adpLPCvJpLFBV638+uLpZtPQ8YLN3jk=
-github.com/canonical/sqlair v0.0.0-20240206143658-d8b84b389a40/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa h1:eRRgzybbMhVtJXwIyrTCTuS66n46Mq0Li/tQF3ZtHtU=
+github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
When using SQLair statements in domain, there is often little to no reuse of the prepared statements. The statements are created just before they are used then dropped when the method finishes. SQLair statements are designed to be prepared once then reused.

This PR adds a `Prepare` function to state base that can be used instead of `sqlair.Prepare`. This function saves the prepared statements in a map keyed by the query itself.

`StateBase.Prepare` can be used right next to where the query is run since it is relatively cheap. This allows readers of the code to quickly grok what is going on.

This code also updates to the latest version of SQLair which returns `ErrNoRows` when `GetAll` returns no rows (previously it just left the list it was passed empty)  [SQLair PR here](https://github.com/canonical/sqlair/pull/138).

Because of this checks are added to calls of `GetAll`.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

