### PR TITLE
Check instance/machine mapping exclusively for model migration in credential validation

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -130,8 +130,14 @@ func checkIAASModelCredential(
 	// to get the instances is proof enough that the credential is valid
 	// (authenticated, authorization is a different concern), no need to check
 	// the mapping between instances and machines.
-	if !modelMigrationCheck || err != nil {
-		return params.ErrorResults{}, errors.Trace(err)
+	if err != nil {
+		return params.ErrorResults{Results: []params.ErrorResult{{
+			Error: apiservererrors.ServerError(errors.Annotate(err, "receiving instances from provider"))}},
+		}, errors.Trace(err)
+	}
+
+	if !modelMigrationCheck {
+		return params.ErrorResults{}, nil
 	}
 
 	// We only check persisted machines vs known cloud instances. In the future,

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -83,10 +83,12 @@ func checkIAASModelCredential(openParams environs.OpenParams, backend Persistent
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
-	// Check that we can see all machines' instances regardless of their state as perceived by the cloud, i.e.
-	// this call will return all non-terminated instances.
+	// Check that we can see all machines' instances regardless of their state as perceived by the
+	// cloud, i.e. this call will return all non-terminated instances.
 	instances, err := env.AllInstances(callCtx)
-	// If we're not performing this check for model migrations, then being able to get the instances is proof enough that the credential is valid, no need to check mapping between instances and machines.
+	// If we're not performing this check for model migrations; then being able to get the instances
+	// is proof enough that the credential is valid (authenticated, authorization is a different
+	// concern), no need to check the mapping between instances and machines.
 	if !modelMigrationCheck || err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -142,14 +144,9 @@ func checkMachineInstances(backend PersistentBackend, provider CloudProvider, ca
 		machinesByInstance[string(instanceId)] = machine.Id()
 	}
 
-	// From here, there 2 ways of checking whether the credential is valid:
-	// 1. Can we reach all cloud instances that machines know about?
-	// 2. Can we cross examine all machines we know about with all the instances we can reach
-	// and ensure that they correspond 1:1.
-	// Second check (2) is more useful for model migration, for example, since we want to know if
-	// we have moved the known universe correctly. However, it is a but redundant if we just care about
-	// credential validity since the first check (1) addresses all our concerns.
-
+	// From here, we cross examine all machines we know about with all the instances we can reach
+	// and ensure that they correspond 1:1. This is useful for model migration, for example, since
+	// we want to know if we have moved the known universe correctly.
 	instanceIds := set.NewStrings()
 	for _, instance := range instances {
 		id := string(instance.Id())

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -16,12 +16,13 @@ import (
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
 
 // ValidateExistingModelCredential checks if the cloud credential that a given model uses is valid for it.
-func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, checkCloudInstances bool) (params.ErrorResults, error) {
+func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, checkCloudInstances bool, modelMigrationCheck bool) (params.ErrorResults, error) {
 	model, err := backend.Model()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -41,11 +42,11 @@ func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.
 		return params.ErrorResults{}, errors.NotValidf("credential %q", storedCredential.Name)
 	}
 	credential := cloud.NewCredential(cloud.AuthType(storedCredential.AuthType), storedCredential.Attributes)
-	return ValidateNewModelCredential(backend, callCtx, credentialTag, &credential, checkCloudInstances)
+	return ValidateNewModelCredential(backend, callCtx, credentialTag, &credential, checkCloudInstances, modelMigrationCheck)
 }
 
 // ValidateNewModelCredential checks if a new cloud credential could be valid for a given model.
-func ValidateNewModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, checkCloudInstances bool) (params.ErrorResults, error) {
+func ValidateNewModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, checkCloudInstances bool, modelMigrationCheck bool) (params.ErrorResults, error) {
 	openParams, err := buildOpenParams(backend, credentialTag, credential)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -58,7 +59,7 @@ func ValidateNewModelCredential(backend PersistentBackend, callCtx context.Provi
 	case state.ModelTypeCAAS:
 		return checkCAASModelCredential(openParams)
 	case state.ModelTypeIAAS:
-		return checkIAASModelCredential(openParams, backend, callCtx, checkCloudInstances)
+		return checkIAASModelCredential(openParams, backend, callCtx, checkCloudInstances, modelMigrationCheck)
 	default:
 		return params.ErrorResults{}, errors.NotSupportedf("model type %q", model.Type())
 	}
@@ -76,22 +77,31 @@ func checkCAASModelCredential(brokerParams environs.OpenParams) (params.ErrorRes
 	return params.ErrorResults{}, nil
 }
 
-func checkIAASModelCredential(openParams environs.OpenParams, backend PersistentBackend, callCtx context.ProviderCallContext, checkCloudInstances bool) (params.ErrorResults, error) {
+func checkIAASModelCredential(openParams environs.OpenParams, backend PersistentBackend, callCtx context.ProviderCallContext, checkCloudInstances bool, modelMigrationCheck bool) (params.ErrorResults, error) {
 	env, err := newEnv(callCtx, openParams)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
+
+	// Check that we can see all machines' instances regardless of their state as perceived by the cloud, i.e.
+	// this call will return all non-terminated instances.
+	instances, err := env.AllInstances(callCtx)
+	// If we're not performing this check for model migrations, then being able to get the instances is proof enough that the credential is valid, no need to check mapping between instances and machines.
+	if !modelMigrationCheck || err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+
 	// We only check persisted machines vs known cloud instances.
 	// In the future, this check may be extended to other cloud resources,
 	// entities and operation-level authorisations such as interfaces,
 	// ability to CRUD storage, etc.
-	return checkMachineInstances(backend, env, callCtx, checkCloudInstances)
+	return checkMachineInstances(backend, env, callCtx, checkCloudInstances, instances)
 }
 
 // checkMachineInstances compares model machines from state with
 // the ones reported by the provider using supplied credential.
 // This only makes sense for non-k8s providers.
-func checkMachineInstances(backend PersistentBackend, provider CloudProvider, callCtx context.ProviderCallContext, checkCloudInstances bool) (params.ErrorResults, error) {
+func checkMachineInstances(backend PersistentBackend, provider CloudProvider, callCtx context.ProviderCallContext, checkCloudInstances bool, instances []instances.Instance) (params.ErrorResults, error) {
 	fail := func(original error) (params.ErrorResults, error) {
 		return params.ErrorResults{}, original
 	}
@@ -130,13 +140,6 @@ func checkMachineInstances(backend PersistentBackend, provider CloudProvider, ca
 			continue
 		}
 		machinesByInstance[string(instanceId)] = machine.Id()
-	}
-
-	// Check that we can see all machines' instances regardless of their state as perceived by the cloud, i.e.
-	// this call will return all non-terminated instances.
-	instances, err := provider.AllInstances(callCtx)
-	if err != nil {
-		return fail(errors.Trace(err))
 	}
 
 	// From here, there 2 ways of checking whether the credential is valid:

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -63,7 +63,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -74,7 +74,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -83,21 +83,14 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstances(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return []instances.Instance{s.instance, instance2}, nil
-	}
-
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.IsNil)
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstancesWhenMigrating(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return []instances.Instance{s.instance, instance2}, nil
-	}
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -109,18 +102,8 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachines(c *gc.C) {
 		return nil, errors.New("boom")
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
-}
-
-func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
-	s.provider.allInstancesFunc = func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-		return nil, errors.New("kaboom")
-	}
-
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
-	c.Assert(err, gc.ErrorMatches, "kaboom")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
@@ -131,7 +114,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -143,12 +126,12 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 
 	machine1.manualFunc = func() (bool, error) { return true, nil }
-	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -160,7 +143,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -177,7 +160,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -195,7 +178,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// There should be 3 errors here:
 	// * 2 of them because failing to get an instance id from one machine should not stop the processing the rest of the machines;
@@ -218,7 +201,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -243,14 +226,14 @@ func (s *ModelCredentialSuite) TestValidateNewModelCredentialUnknownModelType(c 
 		return unknownModel, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, `model type "unknown" not supported`)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingModel(c *gc.C) {
 	s.backend.SetErrors(errors.New("get model error"))
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -261,7 +244,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingCloud(c *gc.C) 
 		nil, // getting model
 		errors.New("get cloud error"),
 	)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, nil, false, false)
 	s.backend.CheckCallNames(c, "Model", "Cloud")
 	c.Assert(err, gc.ErrorMatches, "get cloud error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
@@ -277,7 +260,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorGettingModelConfig(c *
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model config error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "Cloud")
@@ -293,7 +276,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorValidateCredentialForM
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, gc.ErrorMatches, "credential not for model cloud error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "Cloud")
@@ -301,7 +284,7 @@ func (s *ModelCredentialSuite) TestBuildingOpenParamsErrorValidateCredentialForM
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialErrorGettingModel(c *gc.C) {
 	s.backend.SetErrors(errors.New("get model error"))
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "get model error")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -317,7 +300,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialUnsetCloudCred
 		return model, nil
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model")
@@ -328,7 +311,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialErrorGettingCr
 		return state.Credential{}, errors.New("no nope niet")
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "no nope niet")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "CloudCredential")
@@ -342,7 +325,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialInvalidCredent
 		return cred, nil
 	}
 
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, `credential "cred" not valid`)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 	s.backend.CheckCallNames(c, "Model", "CloudCredential")
@@ -352,21 +335,21 @@ func (s *ModelCredentialSuite) TestOpeningProviderFails(c *gc.C) {
 	s.PatchValue(credentialcommon.NewEnv, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return nil, errors.New("explosive")
 	})
-	results, err := credentialcommon.CheckIAASModelCredential(environs.OpenParams{}, s.backend, s.callContext, false)
+	results, err := credentialcommon.CheckIAASModelCredential(environs.OpenParams{}, s.backend, s.callContext, false, false)
 	c.Assert(err, gc.ErrorMatches, "explosive")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateNewModelCredentialForIAASModel(c *gc.C) {
 	s.ensureEnvForIAASModel(c)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialForIAASModel(c *gc.C) {
 	s.ensureEnvForIAASModel(c)
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -404,14 +387,14 @@ func (s *ModelCredentialSuite) TestCAASCredentialCheckSucceeds(c *gc.C) {
 
 func (s *ModelCredentialSuite) TestValidateNewModelCredentialForCAASModel(c *gc.C) {
 	s.ensureEnvForCAASModel(c)
-	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false)
+	results, err := credentialcommon.ValidateNewModelCredential(s.backend, s.callContext, names.CloudCredentialTag{}, &testCredential, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
 
 func (s *ModelCredentialSuite) TestValidateExistingModelCredentialForCAASSuccess(c *gc.C) {
 	s.ensureEnvForCAASModel(c)
-	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false)
+	results, err := credentialcommon.ValidateExistingModelCredential(s.backend, s.callContext, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -63,7 +63,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -74,7 +74,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -114,7 +114,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -126,12 +126,12 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 
 	machine1.manualFunc = func() (bool, error) { return true, nil }
-	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -143,7 +143,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -178,7 +178,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	// There should be 3 errors here:
 	// * 2 of them because failing to get an instance id from one machine should not stop the processing the rest of the machines;
@@ -201,7 +201,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -63,7 +63,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -74,7 +74,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -83,14 +83,14 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstances(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance, instance2})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.IsNil)
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesExtraInstancesWhenMigrating(c *gc.C) {
 	instance2 := &mockInstance{id: "analyse"}
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance, instance2})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, true, []instances.Instance{s.instance, instance2})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -102,7 +102,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachines(c *gc.C) {
 		return nil, errors.New("boom")
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -114,7 +114,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -126,12 +126,12 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 
 	machine1.manualFunc = func() (bool, error) { return true, nil }
-	results, err = credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err = credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }
@@ -143,7 +143,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -160,7 +160,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, nil)
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -178,7 +178,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 		return []credentialcommon.Machine{s.machine, machine1}, nil
 	}
 
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, true, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, true, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	// There should be 3 errors here:
 	// * 2 of them because failing to get an instance id from one machine should not stop the processing the rest of the machines;
@@ -201,7 +201,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.
-	results, err := credentialcommon.CheckMachineInstances(s.backend, s.provider, s.callContext, false, []instances.Instance{s.instance})
+	results, err := credentialcommon.CheckMachineInstances(s.backend, false, []instances.Instance{s.instance})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{})
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -515,6 +515,7 @@ func (api *CloudAPI) validateCredentialForModel(modelUUID string, tag names.Clou
 		tag,
 		credential,
 		false,
+		false,
 	)
 	if err != nil {
 		return append(result, params.ErrorResult{Error: apiservererrors.ServerError(err)})

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -810,7 +810,7 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *gc.C) {
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(
 			_ credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool, _ bool,
 		) (params.ErrorResults, error) {
 			return params.ErrorResults{}, nil
 		})
@@ -964,7 +964,7 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) {
 
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(backend credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool, _ bool,
 		) (params.ErrorResults, error) {
 			return params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}}}, nil
 		})
@@ -1027,7 +1027,7 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
 
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(backend credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool, _ bool,
 		) (params.ErrorResults, error) {
 			if backend.(*mockModelBackend).uuid == "deadbeef-0bad-400d-8000-4b1d0d06f00d" {
 				return params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}}}, nil
@@ -1092,7 +1092,7 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *gc.
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(
 			backend credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool, _ bool,
 		) (params.ErrorResults, error) {
 			if backend.(*mockModelBackend).uuid == "deadbeef-0bad-400d-8000-4b1d0d06f00d" {
 				return params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}}}, nil
@@ -1147,7 +1147,7 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
 
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(_ credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, _ bool, _ bool,
 		) (params.ErrorResults, error) {
 			return params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}}}, nil
 		})
@@ -1204,7 +1204,7 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidationForce(c *gc.C
 
 	s.PatchValue(cloud.ValidateNewCredentialForModelFunc,
 		func(_ credentialcommon.PersistentBackend, _ context.ProviderCallContext,
-			_ names.CloudCredentialTag, _ *jujucloud.Credential, migrating bool) (params.ErrorResults,
+			_ names.CloudCredentialTag, _ *jujucloud.Credential, migrating bool, _ bool) (params.ErrorResults,
 			error) {
 			return params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "not valid for model"}}}}, nil
 		})

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -379,6 +379,7 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 		credentialcommon.NewPersistentBackend(st.State),
 		context.CallContext(st.State),
 		cloud.Type != "manual",
+		true,
 	)
 }
 


### PR DESCRIPTION
Currently there are two checks being done for credential validation. 1) can we reach all cloud instances? 2) can we cross examine all machines we know about with all the instances we can reach. The 2nd one is redundant for just checking the validity of a credential (we can already reach in the 1st check), but it absolutely needs to be done for model migrations. So this change move things around to perform the instance/machine mapping check only for migrations, because if the credentials are invalidated external to juju and there's a problem with the instance machine checking (see the bug down below), calling `update-credentials` (even with a new valid credential) becomes a chicken-and-egg problem.

https://bugs.launchpad.net/juju/+bug/2049917

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2049917

**Jira card:** JUJU-5361

