### PR TITLE
Expose logging for errors

### DIFF
--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -45,7 +45,7 @@ func (s *stateSuite) TestGetMetadataFound(c *gc.C) {
 
 	received, err := st.GetMetadata(context.Background(), metadata.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(received, gc.DeepEquals, metadata)
+	c.Check(received, gc.DeepEquals, metadata)
 }
 
 func (s *stateSuite) TestListMetadataFound(c *gc.C) {
@@ -63,7 +63,7 @@ func (s *stateSuite) TestListMetadataFound(c *gc.C) {
 
 	received, err := st.ListMetadata(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(received, gc.DeepEquals, []objectstore.Metadata{metadata})
+	c.Check(received, gc.DeepEquals, []objectstore.Metadata{metadata})
 }
 
 func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
@@ -81,7 +81,7 @@ func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
 
 	err = st.PutMetadata(context.Background(), metadata)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
-	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrHashAlreadyExists)
+	c.Check(err, jc.ErrorIs, objectstoreerrors.ErrHashAlreadyExists)
 }
 
 func (s *stateSuite) TestPutMetadataWithSameHashAndSize(c *gc.C) {
@@ -155,7 +155,7 @@ func (s *stateSuite) TestPutMetadataMultipleTimes(c *gc.C) {
 	for i := 0; i < 10; i++ {
 		metadata, err := st.GetMetadata(context.Background(), fmt.Sprintf("blah-foo-%d", i))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(metadata, jc.DeepEquals, metadatas[i])
+		c.Check(metadata, jc.DeepEquals, metadatas[i])
 	}
 }
 
@@ -193,7 +193,7 @@ func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *gc.C
 
 	received, err := st.GetMetadata(context.Background(), metadata1.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(received, gc.DeepEquals, metadata1)
+	c.Check(received, gc.DeepEquals, metadata1)
 }
 
 func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
@@ -245,7 +245,7 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 	// removed.
 	received, err := st.GetMetadata(context.Background(), metadata3.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(received, gc.DeepEquals, metadata3)
+	c.Check(received, gc.DeepEquals, metadata3)
 }
 
 func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *gc.C) {
 
 	received, err := st.GetMetadata(context.Background(), metadata.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(received, gc.DeepEquals, metadata)
+	c.Check(received, gc.DeepEquals, metadata)
 }
 
 func (s *stateSuite) TestListMetadata(c *gc.C) {
@@ -289,5 +289,5 @@ func (s *stateSuite) TestListMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadatas, gc.HasLen, 1)
 
-	c.Assert(metadatas[0], gc.DeepEquals, metadata)
+	c.Check(metadatas[0], gc.DeepEquals, metadata)
 }

--- a/domain/schema/objectstore.go
+++ b/domain/schema/objectstore.go
@@ -19,7 +19,7 @@ ON object_store_metadata_hash_type (hash_type);
 
 INSERT INTO object_store_metadata_hash_type VALUES
     (0, 'none'),
-    (1, 'sha-256');
+    (1, 'sha512-384');
 
 CREATE TABLE object_store_metadata (
     uuid            TEXT PRIMARY KEY,


### PR DESCRIPTION
Unfortunately, there exists a bug from the dqlite driver that returns an error code that doesn't match the expected error code, even though the error message is correct.

I'm unable to reproduce this locally, so I'm adding additional logging with the hope that if someone spots it in the wild they'll pass the information on. I've set it to critical just to catch it.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd src
$ juju add-model default
$ juju deploy ubuntu
```

```sh
$ juju bootstrap lxd dst
$ juju migrate src:default dst
```

## Links


**Jira card:** JUJU-

