### PR TITLE
EthernetDeviceForBridge: try all available ips

### DIFF
--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -597,13 +597,14 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(
 	// Include a single address without an IP, but with a CIDR
 	// to indicate that we know the subnet for this bridge.
 	if len(addrs) > 0 {
-		// Find the first IP which we know the subnet for
-		// this used to check only the first one
-		for addrIdx, addr := range addrs {
-			if askProviderForAddress {
+		if askProviderForAddress {
+			// Find the first IP which we know the subnet for
+			// this used to check only the first one
+			for addrIdx, addr := range addrs {
 				sub, err := addr.Subnet()
 				if err != nil {
-					logger.Warningf("failed retrieving subnet %q used by address %q of host machine device %q (%d addresses left to evaluate)",
+					logger.Warningf("failed retrieving subnet %q used by address %q "+
+						"of host machine device %q (%d addresses left to evaluate)",
 						addr.SubnetCIDR(), addr.Value(), dev.Name(), len(addrs)-addrIdx-1)
 					// Return an error if we have no addresses left to check
 					if addrIdx == len(addrs)-1 {
@@ -620,10 +621,11 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(
 				newDev.IsDefaultGateway = addr.IsDefaultGateway()
 				newDev.Addresses = network.ProviderAddresses{
 					network.NewMachineAddress("", network.WithCIDR(sub.CIDR())).AsProviderAddress()}
-			} else {
-				newDev.Addresses = network.ProviderAddresses{
-					network.NewMachineAddress("", network.WithCIDR(addr.SubnetCIDR())).AsProviderAddress()}
+				break
 			}
+		} else {
+			newDev.Addresses = network.ProviderAddresses{
+				network.NewMachineAddress("", network.WithCIDR(addrs[0].SubnetCIDR())).AsProviderAddress()}
 		}
 	}
 


### PR DESCRIPTION
EthernetDeviceForBridge tried only the first adddress in a bridge. It now loops all the available ones and returns a device with the first valid subnet it finds.
Launchpad bug: https://bugs.launchpad.net/juju/+bug/2056365

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
- Make a bridge with two ips: one in the juju subnets and one not. 
- Ensure the first ip is the one juju does not managed or better yet a DHCPv6 ip
- Spin up some containers on that host and ensure they all get an ip on the first subnet
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2056365
