### PR TITLE
Permissions State  implementation for CreatePermission DeletePermission

### DIFF
--- a/core/permission/useraccess.go
+++ b/core/permission/useraccess.go
@@ -23,6 +23,8 @@ import (
 type UserAccess struct {
 	// UserID is the stored ID of the user.
 	UserID string
+	// PermissionID is the stored ID of the permission.
+	PermissionID string
 	// UserTag is the tag for the user.
 	UserTag names.UserTag
 	// Object is the tag for the object of this access grant.

--- a/domain/permission/errors/errors.go
+++ b/domain/permission/errors/errors.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import "github.com/juju/errors"
+
+const (
+	// AlreadyExists describes an error that occurs when the user being
+	// created already exists.
+	AlreadyExists = errors.ConstError("permission already exists")
+)

--- a/domain/permission/service/service.go
+++ b/domain/permission/service/service.go
@@ -10,6 +10,7 @@ import (
 
 	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/permission"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // State describes retrieval and persistence methods for user permission on
@@ -18,7 +19,7 @@ type State interface {
 	// CreatePermission gives the user access per the provided spec.
 	// It requires the user/target combination has not already been
 	// created.
-	CreatePermission(ctx context.Context, spec permission.UserAccessSpec) (corepermission.UserAccess, error)
+	CreatePermission(ctx context.Context, uuid uuid.UUID, spec permission.UserAccessSpec) (corepermission.UserAccess, error)
 
 	// DeletePermission removes the given subject's (user) access to the
 	// given target.
@@ -71,7 +72,11 @@ func (s *Service) CreatePermission(ctx context.Context, spec permission.UserAcce
 	if err := spec.Validate(); err != nil {
 		return corepermission.UserAccess{}, errors.Trace(err)
 	}
-	userAccess, err := s.st.CreatePermission(ctx, spec)
+	newUUID, err := uuid.NewUUID()
+	if err != nil {
+		return corepermission.UserAccess{}, errors.Trace(err)
+	}
+	userAccess, err := s.st.CreatePermission(ctx, newUUID, spec)
 	return userAccess, errors.Trace(err)
 }
 

--- a/domain/permission/service/service_test.go
+++ b/domain/permission/service/service_test.go
@@ -14,6 +14,7 @@ import (
 
 	corepermission "github.com/juju/juju/core/permission"
 	permission "github.com/juju/juju/domain/permission"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type serviceSuite struct {
@@ -32,7 +33,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *serviceSuite) TestCreatePermission(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.state.EXPECT().CreatePermission(gomock.Any(), gomock.AssignableToTypeOf(permission.UserAccessSpec{})).Return(corepermission.UserAccess{}, nil)
+	s.state.EXPECT().CreatePermission(gomock.Any(), gomock.AssignableToTypeOf(uuid.UUID{}), gomock.AssignableToTypeOf(permission.UserAccessSpec{})).Return(corepermission.UserAccess{}, nil)
 
 	spec := permission.UserAccessSpec{
 		User: "testme",

--- a/domain/permission/service/state_mock_test.go
+++ b/domain/permission/service/state_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	permission "github.com/juju/juju/core/permission"
 	permission0 "github.com/juju/juju/domain/permission"
+	uuid "github.com/juju/juju/internal/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,18 +43,18 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // CreatePermission mocks base method.
-func (m *MockState) CreatePermission(arg0 context.Context, arg1 permission0.UserAccessSpec) (permission.UserAccess, error) {
+func (m *MockState) CreatePermission(arg0 context.Context, arg1 uuid.UUID, arg2 permission0.UserAccessSpec) (permission.UserAccess, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreatePermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(permission.UserAccess)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePermission indicates an expected call of CreatePermission.
-func (mr *MockStateMockRecorder) CreatePermission(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateMockRecorder) CreatePermission(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePermission", reflect.TypeOf((*MockState)(nil).CreatePermission), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePermission", reflect.TypeOf((*MockState)(nil).CreatePermission), arg0, arg1, arg2)
 }
 
 // DeletePermission mocks base method.

--- a/domain/permission/state/package_test.go
+++ b/domain/permission/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/permission/state/state.go
+++ b/domain/permission/state/state.go
@@ -1,0 +1,358 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+
+	coredatabase "github.com/juju/juju/core/database"
+	corepermission "github.com/juju/juju/core/permission"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/permission"
+	permissionerrors "github.com/juju/juju/domain/permission/errors"
+	usererrors "github.com/juju/juju/domain/user/errors"
+	databaseutils "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// Logger is the interface used by the state to log messages.
+type Logger interface {
+	Debugf(string, ...interface{})
+}
+
+// State describes retrieval and persistence methods for storage.
+type State struct {
+	*domain.StateBase
+	logger Logger
+}
+
+// NewState returns a new state reference.
+func NewState(factory coredatabase.TxnRunnerFactory, logger Logger) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+		logger:    logger,
+	}
+}
+
+// CreatePermission gives the user access per the provided spec.
+// It requires the user/target combination has not already been
+// created. UserAccess is returned on success.
+// If the user provided does not exist or is marked removed,
+// usererrors.NotFound is returned.
+// If the user provided exists but is marked disabled,
+// usererrors.AuthenticationDisabled is returned.
+// If a permission for the user and target key already exists,
+// permissionerrors.AlreadyExists is returned.
+func (s *State) CreatePermission(ctx context.Context, newPermissionUUID uuid.UUID, spec permission.UserAccessSpec) (corepermission.UserAccess, error) {
+	var userAccess corepermission.UserAccess
+
+	db, err := s.DB()
+	if err != nil {
+		return userAccess, errors.Trace(err)
+	}
+
+	// Insert a permission doc with
+	// * permissionObjectAccess as permission_type_id
+	// * uuid of the user (spec.User) as grant_to
+	// * spec.Target.Key as grant_on
+	newPermission := `
+INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
+VALUES ($M.uuid, $M.access_type_id, $M.grant_on, $M.grant_to)
+`
+	insertPermissionStmt, err := sqlair.Prepare(newPermission, sqlair.M{})
+	if err != nil {
+		return userAccess, errors.Trace(err)
+	}
+
+	m := make(sqlair.M, 2)
+	m["grant_on"] = spec.Target.Key
+	m["uuid"] = newPermissionUUID.String()
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		user, err := findUser(ctx, tx, spec.User)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		userAccess = user.toCoreUserAccess()
+		m["grant_to"] = user.UUID
+
+		accessTypeID, err := s.objectAccessID(ctx, tx, spec.Access, spec.Target.ObjectType)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		m["access_type_id"] = accessTypeID
+
+		if err = s.validateTargetExists(ctx, tx, spec.Target.Key); err != nil {
+			return errors.Trace(err)
+		}
+
+		// No IsErrConstraintForeignKey should be seen as both foreign keys
+		// have been checked.
+		err = tx.Query(ctx, insertPermissionStmt, m).Run()
+		if databaseutils.IsErrConstraintUnique(err) {
+			return errors.Annotatef(permissionerrors.AlreadyExists, "%q on %q", spec.User, spec.Target.Key)
+		} else if err != nil {
+			return errors.Annotatef(err, "adding permission %q for %q on %q", spec.Access, spec.User, spec.Target.Key)
+		}
+		return nil
+	})
+	if err != nil {
+		return corepermission.UserAccess{}, errors.Trace(domain.CoerceError(err))
+	}
+
+	userAccess.Access = spec.Access
+	userAccess.PermissionID = newPermissionUUID.String()
+	userAccess.Object = objectTag(spec.Target)
+	return userAccess, nil
+}
+
+// findUser finds the user provided exists, hasn't been removed and is not
+// disabled. Return data needed to fill in corePermission.UserAccess.
+func findUser(
+	ctx context.Context,
+	tx *sqlair.TX,
+	userName string,
+) (User, error) {
+	var result User
+
+	getUserQuery := `
+SELECT (u.uuid, u.name, u.display_name, u.created_at, u.disabled) AS (&User.*),
+       creator.name AS &User.created_by_name
+FROM   v_user_auth u
+    LEFT JOIN user AS creator
+    ON        u.created_by_uuid = creator.uuid
+WHERE  u.removed = false AND u.name = $M.name`
+
+	selectUserStmt, err := sqlair.Prepare(getUserQuery, User{}, sqlair.M{})
+	if err != nil {
+		return result, errors.Annotate(err, "preparing select getUser query")
+	}
+
+	err = tx.Query(ctx, selectUserStmt, sqlair.M{"name": userName}).Get(&result)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return result, errors.Annotatef(usererrors.NotFound, "%q", userName)
+	} else if err != nil {
+		return result, errors.Annotatef(err, "getting user with name %q", userName)
+	}
+	if result.Disabled {
+		return result, errors.Annotatef(usererrors.AuthenticationDisabled, "%q", userName)
+	}
+	return result, nil
+}
+
+// validateTargetExists validates that the target of the permission
+// exists. An error is returned if not. Unless we have a controller
+// target, search for grant_on as a cloud.name and a model_list.uuid.
+// It must be one of those.
+func (s *State) validateTargetExists(
+	ctx context.Context,
+	tx *sqlair.TX,
+	targetKey string,
+) error {
+	if targetKey == coredatabase.ControllerNS {
+		return nil
+	}
+
+	// TODO: (hml) 6-Mar-24
+	// Add application offers check here when added to DDL.
+	targetExists := `
+SELECT &M.found_it FROM (
+    SELECT 1 AS found_it FROM cloud WHERE cloud.name = $M.grant_on
+    UNION
+    SELECT 1 AS found_it FROM model_list WHERE model_list.uuid = $M.grant_on
+)
+`
+	// Validate the grant_on target exists.
+	targetExistsStmt, err := sqlair.Prepare(targetExists, sqlair.M{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check that 1 row exists if the grant_on value is not ControllerNS.
+	// The behavior for this check is changing in sqlair, trying to
+	// account for either behavior. Old behavior: return no error and
+	// a slice length of zero. New behavior: if the length is 0, return
+	// ErrNoRows.
+	var foundIt = []sqlair.M{}
+	err = tx.Query(ctx, targetExistsStmt, sqlair.M{"grant_on": targetKey}).GetAll(&foundIt)
+	if err != nil {
+		return errors.Annotatef(err, "verifying %q target exists", targetKey)
+	}
+
+	if len(foundIt) == 1 {
+		return nil
+	}
+
+	// Any answer other than 1 is an error. The targetKey should exist
+	// as a unique identifier across the controller namespace.
+	if len(foundIt) == 0 {
+		return errors.Annotatef(err, "permission target %q does not exist", targetKey)
+	}
+	return errors.Annotatef(err, "permission target %q is not unique", targetKey)
+}
+
+func objectTag(id corepermission.ID) (result names.Tag) {
+	// The id has been validated already.
+	switch id.ObjectType {
+	case corepermission.Cloud:
+		result = names.NewCloudTag(id.Key)
+	case corepermission.Controller:
+		result = names.NewControllerTag(id.Key)
+	case corepermission.Model:
+		result = names.NewModelTag(id.Key)
+	case corepermission.Offer:
+		result = names.NewApplicationOfferTag(id.Key)
+	}
+	return
+}
+
+func (s *State) objectAccessID(
+	ctx context.Context,
+	tx *sqlair.TX,
+	access corepermission.Access,
+	objectType corepermission.ObjectType,
+) (int64, error) {
+	// id of spec.Access from permission_access_type as access_type_id
+	// id of spec.Target.ObjectType from permission_object_type as object_type_id
+	// Use access_type_id and object_type_id to validate row from permission_object_access
+	objectAccessIDExists := `
+SELECT permission_access_type.id AS &M.access_type_id
+FROM permission_object_access
+LEFT JOIN permission_object_type
+	ON permission_object_type.type = $M.object_type
+LEFT JOIN permission_access_type
+	ON permission_access_type.type = $M.access_type
+WHERE permission_object_access.access_type_id = permission_access_type.id
+	AND permission_object_access.object_type_id = permission_object_type.id
+`
+
+	// Validate the access type is allowed for the target type.
+	objectAccessIDStmt, err := sqlair.Prepare(objectAccessIDExists, sqlair.M{})
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	var resultM = sqlair.M{}
+	err = tx.Query(ctx, objectAccessIDStmt, sqlair.M{"access_type": access, "object_type": objectType}).Get(&resultM)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return -1, errors.Annotatef(err, "mismatch in %q, %q", access, objectType)
+	} else if err != nil {
+		return -1, errors.Annotatef(err, "getting id for pair %q, %q", access, objectType)
+	}
+	return resultM["access_type_id"].(int64), nil
+}
+
+// DeletePermission removes the given subject's (user) access to the
+// given target.
+// If the specified subject does not exist, a usererrors.NotFound is
+// returned.
+// If the permission does not exist, no error is returned.
+func (s *State) DeletePermission(ctx context.Context, subject string, target corepermission.ID) error {
+	// TODO: is target.Key sufficient to Delete a permission?
+	db, err := s.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	m := make(sqlair.M, 1)
+	m["grant_on"] = target.Key
+
+	// The combination of grant_to and grant_on are guaranteed to be
+	// unique, thus it is all that is deleted to select the row to be
+	// deleted.
+	deletePermission := `
+DELETE 
+FROM permission 
+WHERE grant_to = $M.grant_to AND grant_on = $M.grant_on
+`
+	deletePermissionStmt, err := sqlair.Prepare(deletePermission, m)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		userUUID, err := s.userUUIDForName(ctx, tx, subject)
+		if err != nil {
+			return errors.Annotatef(usererrors.NotFound, "looking up UUID for user %q", subject)
+		}
+		m["grant_to"] = userUUID
+
+		err = tx.Query(ctx, deletePermissionStmt, m).Run()
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Annotatef(err, "deleting permission of %q on %q", subject, target.Key)
+		}
+		return nil
+	})
+	return errors.Trace(domain.CoerceError(err))
+}
+
+// userUUIDForName returns the user UUID for the associated name
+// if the user is active.
+// Method borrowed from the user domain state.
+func (s *State) userUUIDForName(
+	ctx context.Context, tx *sqlair.TX, name string,
+) (string, error) {
+	stmt, err := sqlair.Prepare(
+		`SELECT &M.uuid FROM user WHERE name = $M.name`, sqlair.M{})
+
+	if err != nil {
+		return "", errors.Annotate(err, "preparing user UUID statement")
+	}
+
+	var inOut = sqlair.M{"name": name}
+	err = tx.Query(ctx, stmt, inOut).Get(&inOut)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", errors.Annotatef(usererrors.NotFound, "active user %q", name)
+		}
+		return "", errors.Annotatef(err, "getting user %q", name)
+	}
+
+	uuid, _ := inOut["uuid"].(string)
+	return uuid, nil
+}
+
+// UpsertPermission updates the permission on the target for the given
+// subject (user). The api user must have Admin permission on the target. If a
+// subject does not exist, it is created using the subject and api user. Access
+// can be granted or revoked.
+func (s *State) UpsertPermission(ctx context.Context, args permission.UpsertPermissionArgs) error {
+	return errors.NotImplementedf("UpsertPermission")
+}
+
+// ReadUserAccessForTarget returns the subject's (user) access for the
+// given user on the given target.
+func (s *State) ReadUserAccessForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.UserAccess, error) {
+	return corepermission.UserAccess{}, errors.NotImplementedf("ReadUserAccessForTarget")
+}
+
+// ReadUserAccessLevelForTarget returns the subject's (user) access level
+// for the given user on the given target.
+func (s *State) ReadUserAccessLevelForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.Access, error) {
+	return corepermission.NoAccess, errors.NotImplementedf("ReadUserAccessLevelForTarget")
+}
+
+// ReadAllUserAccessForUser returns a slice of the user access the given
+// subject's (user) has for any access type.
+func (s *State) ReadAllUserAccessForUser(ctx context.Context, subject string) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllUserAccessForUser")
+}
+
+// ReadAllUserAccessForTarget return a slice of user access for all users
+// with access to the given target.
+func (s *State) ReadAllUserAccessForTarget(ctx context.Context, target corepermission.ID) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllUserAccessForTarget")
+}
+
+// ReadAllAccessTypeForUser return a slice of user access for the subject
+// (user) specified and of the given access type.
+// E.G. All clouds the user has access to.
+func (s *State) ReadAllAccessTypeForUser(ctx context.Context, subject string, access_type corepermission.ObjectType) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllAccessTypeForUser")
+}

--- a/domain/permission/state/state_test.go
+++ b/domain/permission/state/state_test.go
@@ -1,0 +1,305 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/juju/names/v5"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	corepermission "github.com/juju/juju/core/permission"
+	"github.com/juju/juju/domain/permission"
+	permissionerrors "github.com/juju/juju/domain/permission/errors"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	usererrors "github.com/juju/juju/domain/user/errors"
+	"github.com/juju/juju/internal/uuid"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type stateSuite struct {
+	schematesting.ControllerSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func (s *stateSuite) TestCreatePermissionModel(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureModel(c, "model-uuid")
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+	s.ensureCloud(c, "test-cloud")
+
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+		User: "bob",
+		Target: corepermission.ID{
+			Key:        "model-uuid",
+			ObjectType: corepermission.Model,
+		},
+		Access: corepermission.WriteAccess,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(userAccess.UserID, gc.Equals, "123")
+	c.Check(userAccess.UserTag, gc.Equals, names.NewUserTag("bob"))
+	c.Check(userAccess.Object.Id(), gc.Equals, "model-uuid")
+	c.Check(userAccess.Access, gc.Equals, corepermission.WriteAccess)
+	c.Check(userAccess.DisplayName, gc.Equals, "Bob")
+	c.Check(userAccess.UserName, gc.Equals, "bob")
+	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
+
+	s.checkPermissionRow(c, corepermission.WriteAccess, "123", "model-uuid")
+}
+
+func (s *stateSuite) TestCreatePermissionCloud(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureModel(c, "model-uuid")
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+	s.ensureCloud(c, "test-cloud")
+
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+		User: "bob",
+		Target: corepermission.ID{
+			Key:        "test-cloud",
+			ObjectType: corepermission.Cloud,
+		},
+		Access: corepermission.AddModelAccess,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(userAccess.UserID, gc.Equals, "123")
+	c.Check(userAccess.UserTag, gc.Equals, names.NewUserTag("bob"))
+	c.Check(userAccess.Object.Id(), gc.Equals, "test-cloud")
+	c.Check(userAccess.Access, gc.Equals, corepermission.AddModelAccess)
+	c.Check(userAccess.DisplayName, gc.Equals, "Bob")
+	c.Check(userAccess.UserName, gc.Equals, "bob")
+	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
+
+	s.checkPermissionRow(c, corepermission.AddModelAccess, "123", "test-cloud")
+}
+
+func (s *stateSuite) TestCreatePermissionController(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+		User: "bob",
+		Target: corepermission.ID{
+			Key:        "controller",
+			ObjectType: corepermission.Controller,
+		},
+		Access: corepermission.SuperuserAccess,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(userAccess.UserID, gc.Equals, "123")
+	c.Check(userAccess.UserTag, gc.Equals, names.NewUserTag("bob"))
+	c.Check(userAccess.Object.Id(), gc.Equals, "controller")
+	c.Check(userAccess.Access, gc.Equals, corepermission.SuperuserAccess)
+	c.Check(userAccess.DisplayName, gc.Equals, "Bob")
+	c.Check(userAccess.UserName, gc.Equals, "bob")
+	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
+
+	s.checkPermissionRow(c, corepermission.SuperuserAccess, "123", "controller")
+}
+
+func (s *stateSuite) checkPermissionRow(c *gc.C, access corepermission.Access, expectedGrantTo, expectedGrantON string) {
+	db := s.DB()
+	// Find the id for access
+	accessRow := db.QueryRow(`
+SELECT id
+FROM permission_access_type
+WHERE type = ?
+`, access)
+	c.Assert(accessRow.Err(), jc.ErrorIsNil)
+	var accessTypeID int
+	err := accessRow.Scan(&accessTypeID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Find the permission
+	row := db.QueryRow(`
+SELECT uuid, permission_type_id, grant_to, grant_on 
+FROM permission
+`)
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	var (
+		userUuid, grantTo, grantOn string
+		permissionTypeId           int
+	)
+	err = row.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Verify the permission as expected.
+	c.Check(userUuid, gc.Not(gc.Equals), "")
+	c.Check(permissionTypeId, gc.Equals, accessTypeID)
+	c.Check(grantTo, gc.Equals, expectedGrantTo)
+	c.Check(grantOn, gc.Equals, expectedGrantON)
+}
+
+func (s *stateSuite) TestCreatePermissionErrorNoUser(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+		User: "bob",
+		Target: corepermission.ID{
+			Key:        "model-uuid",
+			ObjectType: corepermission.Model,
+		},
+		Access: corepermission.WriteAccess,
+	})
+	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
+}
+
+func (s *stateSuite) TestCreatePermissionErrorDuplicate(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureModel(c, "model-uuid")
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+
+	spec := permission.UserAccessSpec{
+		User: "bob",
+		Target: corepermission.ID{
+			Key:        "model-uuid",
+			ObjectType: corepermission.Model,
+		},
+		Access: corepermission.ReadAccess,
+	}
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Find the permission
+	row := s.DB().QueryRow(`
+SELECT uuid, permission_type_id, grant_to, grant_on 
+FROM permission
+WHERE permission_type_id = 0
+`)
+	c.Assert(row.Err(), jc.ErrorIsNil)
+
+	var (
+		userUuid, grantTo, grantOn string
+		permissionTypeId           int
+	)
+	err = row.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure each combination of grant_on and grant_two
+	// is unique
+	spec.Access = corepermission.WriteAccess
+	ua2, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
+	c.Assert(err, jc.ErrorIs, permissionerrors.AlreadyExists)
+	c.Logf("B +%v", ua2)
+	row2 := s.DB().QueryRow(`
+SELECT uuid, permission_type_id, grant_to, grant_on 
+FROM permission
+WHERE permission_type_id = 1
+`)
+	c.Assert(row2.Err(), jc.ErrorIsNil)
+	err = row2.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
+}
+
+func (s *stateSuite) TestDeletePermission(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureModel(c, "model-uuid")
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+
+	target := corepermission.ID{
+		Key:        "model-uuid",
+		ObjectType: corepermission.Model,
+	}
+	spec := permission.UserAccessSpec{
+		User:   "bob",
+		Target: target,
+		Access: corepermission.ReadAccess,
+	}
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.DeletePermission(context.Background(), "bob", target)
+	c.Assert(err, jc.ErrorIsNil)
+
+	db := s.DB()
+
+	var num int
+	err = db.QueryRowContext(context.Background(), "SELECT count(*) FROM permission").Scan(&num)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(num, gc.Equals, 0)
+}
+
+func (s *stateSuite) TestDeletePermissionFailUserNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	target := corepermission.ID{
+		Key:        "model-uuid",
+		ObjectType: corepermission.Model,
+	}
+	err := st.DeletePermission(context.Background(), "bob", target)
+	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
+}
+
+func (s *stateSuite) TestDeletePermissionDoesNotExist(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	// Setup to add permissions for user Bob on the model
+	s.ensureModel(c, "model-uuid")
+	s.ensureUser(c, "42", "admin", "42") // model owner
+	s.ensureUser(c, "123", "bob", "42")
+
+	target := corepermission.ID{
+		Key:        "model-uuid",
+		ObjectType: corepermission.Model,
+	}
+
+	// Don't fail if the permission does not exist.
+	err := st.DeletePermission(context.Background(), "bob", target)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) ensureUser(c *gc.C, uuid, name, createdByUUID string) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO user (uuid, name, display_name, removed, created_by_uuid, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, uuid, name, "Bob", false, createdByUUID, time.Now())
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) ensureModel(c *gc.C, uuid string) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO model_list (uuid)
+			VALUES (?)
+		`, uuid)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) ensureCloud(c *gc.C, name string) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO cloud (uuid, name, cloud_type_id, endpoint, skip_tls_verify)
+			VALUES (?, ?, 1, "test-endpoint", true)
+		`, "cloud-uuid", name)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/domain/permission/state/types.go
+++ b/domain/permission/state/types.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/names/v5"
+
+	"github.com/juju/juju/core/permission"
+)
+
+// User represents a user in the system where the values overlap with
+// corepermission.UserAccess.
+type User struct {
+	// UUID is the unique identifier for the user.
+	UUID string `db:"uuid"`
+
+	// Name is the username of the user.
+	Name string `db:"name"`
+
+	// DisplayName is a user-friendly name represent the user as.
+	DisplayName string `db:"display_name"`
+
+	// CreatorName is the name of the user that created this user.
+	CreatorName string `db:"created_by_name"`
+
+	// CreatedAt is the time that the user was created at.
+	CreatedAt time.Time `db:"created_at"`
+
+	// Disabled is true if the user is disabled.
+	Disabled bool `db:"disabled"`
+}
+
+// toCoreUserAccess converts the state user to a core permission UserAccess.
+func (u User) toCoreUserAccess() permission.UserAccess {
+	return permission.UserAccess{
+		UserID:      u.UUID,
+		UserTag:     names.NewUserTag(u.Name),
+		DisplayName: u.DisplayName,
+		UserName:    u.Name,
+		CreatedBy:   names.NewUserTag(u.CreatorName),
+		DateCreated: u.CreatedAt,
+	}
+}

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -670,7 +670,7 @@ INSERT INTO permission_access_type VALUES
     (2, 'consume'),
     (3, 'admin'),
     (4, 'login'),
-    (5, 'addmodel'),
+    (5, 'add-model'),
     (6, 'superuser');
 
 CREATE TABLE permission_object_type (
@@ -705,7 +705,7 @@ ON permission_object_access (access_type_id, object_type_id);
 
 INSERT INTO permission_object_access VALUES
     (0, 3, 0), -- admin, cloud
-    (1, 5, 0), -- addmodel, cloud
+    (1, 5, 0), -- add-model, cloud
     (2, 4, 1), -- login, controller
     (3, 6, 1), -- superuser, controller
     (4, 0, 2), -- read, model
@@ -724,14 +724,16 @@ CREATE TABLE permission (
     grant_on  		   TEXT NOT NULL, -- name or uuid of the object
     grant_to           TEXT NOT NULL,
     CONSTRAINT         fk_permission_user_uuid
-        FOREIGN KEY    (grant_on)
+        FOREIGN KEY    (grant_to)
         REFERENCES     user(uuid),
     CONSTRAINT         fk_permission_access_type
         FOREIGN KEY    (permission_type_id)
         REFERENCES     permission_access_type(id)
 );
 
+-- Allow only 1 combination of grant_on and grant_to
+-- Otherwise we will get conflicting permissions.
 CREATE UNIQUE INDEX idx_permission_type_to
-ON permission (permission_type_id, grant_on, grant_to);
+ON permission (grant_on, grant_to);
 `)
 }


### PR DESCRIPTION
This continues the DDL work for Permissions by starting on the state layer.  Most required methods currently return NotImplemented except for CreatePermission and DeletePermission which have been fully implemented.

In general CreatePermission and DeletePermission are handled as they have been prior with the following exception.

Controller UUID is handled differently in the new DDL as apposed to the prior Mongo implementation. This implementation is testing out the idea we can use the ControllerNS const rather than an actual UUID to represent controller level permissions such as SuperUser. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This code has unit tests but is not wired up to be used yet. 

## Links

**Jira card:** JUJU-5098

