### PR TITLE
Updates model bootstrap to take uuid in args.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -240,7 +240,9 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		CloudRegion:  stateParams.ControllerCloudRegion,
 		Credential:   credential.IdFromTag(cloudCredTag),
 		Type:         controllerModelType,
+		UUID:         controllerModelUUID,
 	}
+	_, controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
 
 	controllerModelDefaults := modeldefaultsbootstrap.ModelDefaultsProvider(
 		nil,
@@ -256,7 +258,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 			cloudbootstrap.InsertCloud(stateParams.ControllerCloud),
 			credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
 			cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
-			modelbootstrap.CreateModel(controllerModelUUID, controllerModelArgs),
+			controllerModelCreateFunc,
 		),
 		database.BootstrapModelConcern(controllerModelUUID,
 			modelconfigbootstrap.SetModelConfig(stateParams.ControllerModelConfig, controllerModelDefaults),

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	coremodel "github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
+	coreuser "github.com/juju/juju/core/user"
+	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
+	"github.com/juju/juju/domain/credential"
+	credentialbootstrap "github.com/juju/juju/domain/credential/bootstrap"
+	"github.com/juju/juju/domain/model"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	userbootstrap "github.com/juju/juju/domain/user/bootstrap"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type bootstrapSuite struct {
+	schematesting.ControllerSuite
+
+	adminUserUUID  coreuser.UUID
+	cloudName      string
+	credentialName string
+}
+
+var _ = gc.Suite(&bootstrapSuite{})
+
+func (s *bootstrapSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
+
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName)
+	err := fn(context.Background(), s.ControllerTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+	s.adminUserUUID = uuid
+
+	s.cloudName = "test"
+	fn = cloudbootstrap.InsertCloud(cloud.Cloud{
+		Name:      s.cloudName,
+		Type:      "ec2",
+		AuthTypes: cloud.AuthTypes{cloud.EmptyAuthType},
+	})
+
+	err = fn(context.Background(), s.ControllerTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.credentialName = "test"
+	fn = credentialbootstrap.InsertCredential(credential.ID{
+		Cloud: s.cloudName,
+		Name:  s.credentialName,
+		Owner: coreuser.AdminUserName,
+	},
+		cloud.NewCredential(cloud.EmptyAuthType, nil),
+	)
+
+	err = fn(context.Background(), s.ControllerTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *bootstrapSuite) TestUUIDIsCreated(c *gc.C) {
+	uuid, fn := CreateModel(model.ModelCreationArgs{
+		AgentVersion: jujuversion.Current,
+		Cloud:        s.cloudName,
+		Credential: credential.ID{
+			Cloud: s.cloudName,
+			Name:  s.credentialName,
+			Owner: coreuser.AdminUserName,
+		},
+		Name:  "test",
+		Owner: s.adminUserUUID,
+		Type:  coremodel.IAAS,
+	})
+
+	err := fn(context.Background(), s.ControllerTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(uuid.String() == "", jc.IsFalse)
+}
+
+func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
+	modelUUID := modeltesting.GenModelUUID(c)
+
+	uuid, fn := CreateModel(model.ModelCreationArgs{
+		AgentVersion: jujuversion.Current,
+		Cloud:        s.cloudName,
+		Credential: credential.ID{
+			Cloud: s.cloudName,
+			Name:  s.credentialName,
+			Owner: coreuser.AdminUserName,
+		},
+		Name:  "test",
+		Owner: s.adminUserUUID,
+		Type:  coremodel.IAAS,
+		UUID:  modelUUID,
+	})
+
+	err := fn(context.Background(), s.ControllerTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(uuid, gc.Equals, modelUUID)
+}

--- a/domain/model/bootstrap/package_test.go
+++ b/domain/model/bootstrap/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
In a recent commit we changed it so that args can take a uuid for the model being created to support model migration. This updates the bootstrap functions to fall in line.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run a bootstrap and confirm there are no errors.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-

