### PR TITLE
Idempotent bootstrap worker

### DIFF
--- a/internal/bootstrap/agentbinary.go
+++ b/internal/bootstrap/agentbinary.go
@@ -17,6 +17,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/core/arch"
 	coreos "github.com/juju/juju/core/os"
+	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/state/binarystorage"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -67,7 +68,9 @@ func PopulateAgentBinary(ctx context.Context, dataDir string, storage AgentBinar
 	}
 
 	logger.Debugf("Adding agent binary: %v", agentTools.Version)
-	if err := storage.Add(ctx, bytes.NewReader(data), metadata); err != nil {
+
+	// If the hash already exists, we don't need to add it again.
+	if err := storage.Add(ctx, bytes.NewReader(data), metadata); err != nil && !errors.Is(err, objectstoreerrors.ErrHashAlreadyExists) {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/charm/services/storage_test.go
+++ b/internal/charm/services/storage_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/charm/downloader"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/state"
@@ -77,6 +78,40 @@ func (s *storageTestSuite) TestStoreBlobFails(c *gc.C) {
 
 func (s *storageTestSuite) TestStoreBlobAlreadyStored(c *gc.C) {
 	defer s.setupMocks(c).Finish()
+
+	// Uploading the same blob to the _objectstore_ twice should still
+	// succeed.
+
+	curl := "ch:ubuntu-lite"
+	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl, s.uuid)
+	dlCharm := downloader.DownloadedCharm{
+		CharmData:    strings.NewReader("the-blob"),
+		Size:         7337,
+		SHA256:       "d357",
+		CharmVersion: "the-version",
+	}
+
+	s.storageBackend.EXPECT().Put(gomock.Any(), expStoreCharmPath, gomock.AssignableToTypeOf(dlCharm.CharmData), int64(7337)).Return(objectstoreerrors.ErrHashAlreadyExists)
+	s.stateBackend.EXPECT().UpdateUploadedCharm(state.CharmInfo{
+		StoragePath: expStoreCharmPath,
+		ID:          curl,
+		SHA256:      "d357",
+		Version:     "the-version",
+	}).Return(nil, stateerrors.NewErrCharmAlreadyUploaded(curl))
+
+	// As the blob is already uploaded (to another path), we need to remove
+	// the duplicate we just uploaded from the store.
+	s.storageBackend.EXPECT().Remove(gomock.Any(), expStoreCharmPath).Return(nil)
+
+	err := s.storage.Store(context.Background(), curl, dlCharm)
+	c.Assert(err, jc.ErrorIsNil) // charm already uploaded by someone; no error
+}
+
+func (s *storageTestSuite) TestStoreCharmAlreadyStored(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Uploading the same charm to the state layer twice should still
+	// succeed.
 
 	curl := "ch:ubuntu-lite"
 	expStoreCharmPath := fmt.Sprintf("charms/%s-%s", curl, s.uuid)


### PR DESCRIPTION
The bootstrap worker can retry if there is a failure. When switching over the objectstore, we didn't update the errors that the bootstrap worker can handle. If the hash already exists, we can ignore that error and continue the flow as if the objectstore was idempotent.

We still want the error because in other scenarios we want to identify that error.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
```

## Links

**Jira card:** JUJU-

