### PR TITLE
Update to new juju/description v5.0.2; tweak liveness probe failure count

### DIFF
--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -537,7 +537,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -619,7 +619,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -682,7 +682,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.14
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v5 v5.0.0
+	github.com/juju/description/v5 v5.0.2
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v5 v5.0.0 h1:koySpaGHVTvoHlr+siRLxVKS/Jzilud5iGzjE7tldks=
-github.com/juju/description/v5 v5.0.0/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
+github.com/juju/description/v5 v5.0.2 h1:gpObMHm3QAI/0mg8YG86L8z5rFXYgHFe3ukwPoNLSaE=
+github.com/juju/description/v5 v5.0.2/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=


### PR DESCRIPTION
There's a couple of small fixes.

Firstly, bring in a new juju/description update to handle empty provider id values in the cloud service record on import.

Secondly, add 3 separate constants for probe failure counts and set the charm container liveness failure count to 3, not 1. The startup and readiness failure counts are kept the same.

## QA steps

bootstrap 2 k8s controllers
deploy kubeflow
migrate kubeflow model to the other controller

## Links

https://bugs.launchpad.net/juju/+bug/2057695

**Jira card:** JUJU-5671

