### PR TITLE
Remove integration unit tests

### DIFF
--- a/cmd/jujud-controller/agent/machine_legacy_test.go
+++ b/cmd/jujud-controller/agent/machine_legacy_test.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"context"
 	"database/sql"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -15,12 +14,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v5"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	"github.com/juju/utils/v4/exec"
-	"github.com/juju/utils/v4/symlink"
-	"github.com/juju/version/v2"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
 	"github.com/juju/worker/v4/workertest"
@@ -29,7 +24,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/engine"
 	"github.com/juju/juju/api"
-	apimachiner "github.com/juju/juju/api/agent/machiner"
 	"github.com/juju/juju/api/base"
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/client/machinemanager"
@@ -37,31 +31,23 @@ import (
 	"github.com/juju/juju/cmd/jujud-controller/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud-controller/agent/model"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/arch"
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/filestorage"
 	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/internal/provider/dummy"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/internal/worker/charmrevision"
-	"github.com/juju/juju/internal/worker/instancepoller"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
-	jujuversion "github.com/juju/juju/version"
 )
 
 // MachineLegacySuite is an integration test suite that requires access to
@@ -73,6 +59,12 @@ import (
 //
 // Do not edit them to make the sync point work better. They're legacy and
 // should be treated as such, until we cut them over.
+
+const (
+	// Use a longer wait in tests that are dependent on leases - sometimes
+	// the raft workers can take a bit longer to spin up.
+	longerWait = 2 * coretesting.LongWait
+)
 
 type MachineLegacySuite struct {
 	// The duplication of the MachineSuite is important. We don't want to break
@@ -425,120 +417,6 @@ func (s *MachineLegacySuite) TestDyingModelCleanedUp(c *gc.C) {
 		})
 }
 
-func (s *MachineLegacySuite) TestMachineAgentSymlinks(c *gc.C) {
-	stm, _, _ := s.primeAgent(c, state.JobManageModel)
-	ctrl, a := s.newAgent(c, stm)
-	defer ctrl.Finish()
-	defer a.Stop()
-	done := s.waitForOpenState(c, a)
-
-	// Symlinks should have been created
-	for _, link := range jujudSymlinks {
-		_, err := os.Stat(utils.EnsureBaseDir(a.rootDir, link))
-		c.Assert(err, jc.ErrorIsNil, gc.Commentf(link))
-	}
-
-	s.waitStopped(c, state.JobManageModel, a, done)
-}
-
-func (s *MachineLegacySuite) TestMachineAgentSymlinkJujuExecExists(c *gc.C) {
-	stm, _, _ := s.primeAgent(c, state.JobManageModel)
-	ctrl, a := s.newAgent(c, stm)
-	defer ctrl.Finish()
-	defer a.Stop()
-
-	// Pre-create the symlinks, but pointing to the incorrect location.
-	a.rootDir = c.MkDir()
-	for _, link := range jujudSymlinks {
-		fullLink := utils.EnsureBaseDir(a.rootDir, link)
-		c.Assert(os.MkdirAll(filepath.Dir(fullLink), os.FileMode(0755)), jc.ErrorIsNil)
-		c.Assert(symlink.New("/nowhere/special", fullLink), jc.ErrorIsNil, gc.Commentf(link))
-	}
-
-	// Start the agent and wait for it be running.
-	done := s.waitForOpenState(c, a)
-
-	// juju-exec symlink should have been recreated.
-	for _, link := range jujudSymlinks {
-		fullLink := utils.EnsureBaseDir(a.rootDir, link)
-		linkTarget, err := symlink.Read(fullLink)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(linkTarget, gc.Not(gc.Equals), "/nowhere/special", gc.Commentf(link))
-	}
-
-	s.waitStopped(c, state.JobManageModel, a, done)
-}
-
-func (s *MachineLegacySuite) TestManageModelServesAPI(c *gc.C) {
-	s.assertJob(c, state.JobManageModel, nil, func(conf agent.Config, a *MachineAgent) {
-		apiInfo, ok := conf.APIInfo()
-		c.Assert(ok, jc.IsTrue)
-		st, err := api.Open(apiInfo, fastDialOpts)
-		c.Assert(err, jc.ErrorIsNil)
-		defer st.Close()
-		m, err := apimachiner.NewClient(st).Machine(context.Background(), conf.Tag().(names.MachineTag))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(m.Life(), gc.Equals, life.Alive)
-	})
-}
-
-func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFile(c *gc.C) {
-	s.assertJob(c, state.JobManageModel,
-		func() {
-			s.cmdRunner.EXPECT().RunCommands(exec.RunParams{
-				Commands: "[ ! -f /etc/update-manager/release-upgrades ] || sed -i '/Prompt=/ s/=.*/=never/' /etc/update-manager/release-upgrades",
-			}).Return(&exec.ExecResponse{Code: 0}, nil).AnyTimes()
-		},
-		func(conf agent.Config, a *MachineAgent) {
-			apiInfo, ok := conf.APIInfo()
-			c.Assert(ok, jc.IsTrue)
-			st, err := api.Open(apiInfo, fastDialOpts)
-			c.Assert(err, jc.ErrorIsNil)
-			defer func() { _ = st.Close() }()
-			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
-			c.Assert(err, jc.ErrorIsNil)
-		},
-	)
-}
-
-func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFileErrored(c *gc.C) {
-	s.assertJob(c, state.JobManageModel,
-		func() {
-			s.cmdRunner.EXPECT().RunCommands(exec.RunParams{
-				Commands: "[ ! -f /etc/update-manager/release-upgrades ] || sed -i '/Prompt=/ s/=.*/=never/' /etc/update-manager/release-upgrades",
-			}).Return(nil, errors.New("unknown error")).MinTimes(1)
-		},
-		func(conf agent.Config, a *MachineAgent) {
-			apiInfo, ok := conf.APIInfo()
-			c.Assert(ok, jc.IsTrue)
-			st, err := api.Open(apiInfo, fastDialOpts)
-			c.Assert(err, jc.ErrorIsNil)
-			defer func() { _ = st.Close() }()
-			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
-			c.Assert(err, gc.ErrorMatches, `unknown error`)
-		},
-	)
-}
-
-func (s *MachineLegacySuite) TestIAASControllerPatchUpdateManagerFileNonZeroExitCode(c *gc.C) {
-	s.assertJob(c, state.JobManageModel,
-		func() {
-			s.cmdRunner.EXPECT().RunCommands(exec.RunParams{
-				Commands: "[ ! -f /etc/update-manager/release-upgrades ] || sed -i '/Prompt=/ s/=.*/=never/' /etc/update-manager/release-upgrades",
-			}).Return(&exec.ExecResponse{Code: 1, Stderr: []byte(`unknown error`)}, nil).MinTimes(1)
-		},
-		func(conf agent.Config, a *MachineAgent) {
-			apiInfo, ok := conf.APIInfo()
-			c.Assert(ok, jc.IsTrue)
-			st, err := api.Open(apiInfo, fastDialOpts)
-			c.Assert(err, jc.ErrorIsNil)
-			defer func() { _ = st.Close() }()
-			err = a.machineStartup(context.Background(), st, coretesting.NewCheckLogger(c))
-			c.Assert(err, gc.ErrorMatches, `cannot patch /etc/update-manager/release-upgrades: unknown error`)
-		},
-	)
-}
-
 func (s *MachineLegacySuite) TestManageModelRunsCleaner(c *gc.C) {
 	s.assertJob(c, state.JobManageModel, nil, func(conf agent.Config, a *MachineAgent) {
 		// Create an application and unit, and destroy the app.
@@ -645,122 +523,6 @@ func (s *MachineLegacySuite) TestModelWorkersRespectSingularResponsibilityFlag(c
 	s.assertJob(c, state.JobManageModel, nil, func(agent.Config, *MachineAgent) {
 		agenttest.WaitMatch(c, matcher.Check, longerWait)
 	})
-}
-
-func (s *MachineLegacySuite) TestManageModelRunsInstancePoller(c *gc.C) {
-	jujutesting.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
-	s.AgentSuite.PatchValue(&instancepoller.ShortPoll, 500*time.Millisecond)
-	s.AgentSuite.PatchValue(&instancepoller.ShortPollCap, 500*time.Millisecond)
-
-	stream := s.Environ.Config().AgentStream()
-	usefulVersion := version.Binary{
-		Number:  jujuversion.Current,
-		Arch:    arch.HostArch(),
-		Release: "ubuntu",
-	}
-	envtesting.AssertUploadFakeToolsVersions(c, s.agentStorage, stream, stream, usefulVersion)
-
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
-	ctrl, a := s.newAgent(c, m)
-	defer ctrl.Finish()
-
-	s.cmdRunner.EXPECT().RunCommands(exec.RunParams{
-		Commands: "[ ! -f /etc/update-manager/release-upgrades ] || sed -i '/Prompt=/ s/=.*/=never/' /etc/update-manager/release-upgrades",
-	}).AnyTimes().Return(&exec.ExecResponse{Code: 0}, nil)
-
-	defer func() { _ = a.Stop() }()
-	go func() {
-		c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil)
-	}()
-
-	// Wait for the workers to start. This ensures that the central
-	// hub referred to in startAddressPublisher has been assigned,
-	// and we will not fail race tests with concurrent access.
-	select {
-	case <-a.WorkersStarted():
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for agent workers to start")
-	}
-
-	startAddressPublisher(s, c, a)
-
-	// Add one unit to an application;
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	arch := arch.HostArch()
-	app := f.MakeApplication(c, &factory.ApplicationParams{
-		Name:  "test-application",
-		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
-		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-hub",
-			Platform: &state.Platform{
-				Architecture: arch,
-				OS:           "ubuntu",
-				Channel:      "22.04",
-			}},
-		Constraints: constraints.MustParse("arch=" + arch),
-	})
-	unit, err := app.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.ControllerModel(c).State().AssignUnit(state.NoopInstancePrechecker{}, unit, state.AssignNew)
-	c.Assert(err, jc.ErrorIsNil)
-
-	m, instId := s.waitProvisioned(c, unit)
-	insts, err := s.Environ.Instances(envcontext.WithoutCredentialInvalidator(context.Background()), []instance.Id{instId})
-	c.Assert(err, jc.ErrorIsNil)
-
-	dummy.SetInstanceStatus(insts[0], "running")
-
-	strategy := &utils.AttemptStrategy{
-		Total: 60 * time.Second,
-		Delay: coretesting.ShortWait,
-	}
-	for attempt := strategy.Start(); attempt.Next(); {
-		if !attempt.HasNext() {
-			c.Logf("final machine addresses: %#v", m.Addresses())
-			c.Fatalf("timed out waiting for machine to get address")
-		}
-		err := m.Refresh()
-		c.Assert(err, jc.ErrorIsNil)
-		instStatus, err := m.InstanceStatus()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("found status is %q %q", instStatus.Status, instStatus.Message)
-
-		// The dummy provider always returns 3 devices with one address each.
-		// We don't care what they are, just that the instance-poller retrieved
-		// them and set them against the machine in state.
-		if len(m.Addresses()) == 3 && instStatus.Message == "running" {
-			break
-		}
-		c.Logf("waiting for machine %q address to be updated", m.Id())
-	}
-}
-
-func (s *MachineLegacySuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machine, instance.Id) {
-	c.Logf("waiting for unit %q to be provisioned", unit)
-	machineId, err := unit.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	m, err := s.ControllerModel(c).State().Machine(machineId)
-	c.Assert(err, jc.ErrorIsNil)
-	w := m.Watch()
-	defer worker.Stop(w)
-	timeout := time.After(longerWait)
-	for {
-		select {
-		case <-timeout:
-			c.Fatalf("timed out waiting for provisioning")
-		case _, ok := <-w.Changes():
-			c.Assert(ok, jc.IsTrue)
-			err := m.Refresh()
-			c.Assert(err, jc.ErrorIsNil)
-			if instId, err := m.InstanceId(); err == nil {
-				c.Logf("unit provisioned with instance %s", instId)
-				return m, instId
-			} else {
-				c.Check(err, jc.ErrorIs, errors.NotProvisioned)
-			}
-		}
-	}
 }
 
 func (s *MachineLegacySuite) assertJob(

--- a/cmd/jujud-controller/agent/package_test.go
+++ b/cmd/jujud-controller/agent/package_test.go
@@ -22,6 +22,11 @@ import (
 
 //go:generate go run go.uber.org/mock/mockgen -package mocks -destination mocks/machine_mock.go github.com/juju/juju/cmd/jujud-controller/agent CommandRunner
 
+const (
+	// This is the address that the raft workers will use for the server.
+	serverAddress = "localhost:17070"
+)
+
 func TestPackage(t *stdtesting.T) {
 	// TODO(waigani) 2014-03-19 bug 1294458
 	// Refactor to use base suites


### PR DESCRIPTION
The machine legacy tests start up the jujud-controller and test various parts are working. The downside is, that we require so much faked or stubbed infrastructure that we don't actually know if something is broken. Normally it's the alternative, whereby the normal workflow works correctly, but we're missing stub or faked code.

I've left in what I think are the important required tests. Other tests are already covered via integration tests or via unit tests further down the stack.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This is removing tests that are hard to determine the failure points for. Tests covering what we have here, is also present in other locations.

## Links

**Jira card:** JUJU-

