### PR TITLE
Log status updates via logging interface along with the DB write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/juju/idmclient/v2 v2.0.0
 	github.com/juju/jsonschema v1.0.0
 	github.com/juju/loggo v1.0.0
-	github.com/juju/loggo/v2 v2.0.0
+	github.com/juju/loggo/v2 v2.0.1
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mgo/v3 v3.0.4
 	github.com/juju/mutex/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,8 @@ github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVE
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/juju/loggo v1.0.0 h1:Y6ZMQOGR9Aj3BGkiWx7HBbIx6zNwNkxhVNOHU2i1bl0=
 github.com/juju/loggo v1.0.0/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
-github.com/juju/loggo/v2 v2.0.0 h1:PzyVIn+NgoZ22QUtPgKF/lh+6SnaCOEXhcP+sE4FhOk=
-github.com/juju/loggo/v2 v2.0.0/go.mod h1:647d6WvXBLj5lvka2qBvccr7vMIvF2KFkEH+0ZuFOUM=
+github.com/juju/loggo/v2 v2.0.1 h1:l7EDSQuOpW0SghK5M5cTl6/iAaTLRgjLN5n3y4wzn6A=
+github.com/juju/loggo/v2 v2.0.1/go.mod h1:647d6WvXBLj5lvka2qBvccr7vMIvF2KFkEH+0ZuFOUM=
 github.com/juju/lru v1.0.0 h1:FP8mBNF3jBnKwGO5PtsR+8iIegx8DREfhRhpcGpYcn4=
 github.com/juju/lru v1.0.0/go.mod h1:YauKGp6PAhOQyGuTOkiFdXVP1jR3vLkp/FI71GcpYcQ=
 github.com/juju/lumberjack/v2 v2.0.2 h1:FlxrR62Vb7FfN7jwpSBqqereyq5bBQUF0LqOhZ2VGeI=

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -577,13 +577,14 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	}
 	prereqOps = append(prereqOps, storageOps...)
 
+	m := newMachine(st, mdoc)
 	// At the last moment we still have statusDoc in scope, set the initial
 	// history entry. This is risky, and may lead to extra entries, but that's
 	// an intrinsic problem with mixing txn and non-txn ops -- we can't sync
 	// them cleanly.
-	_, _ = probablyUpdateStatusHistory(st.db(), machineKindPrefix, mdoc.Id, machineGlobalKey(mdoc.Id), machineStatusDoc)
-	_, _ = probablyUpdateStatusHistory(st.db(), machineInstanceKindPrefix, mdoc.Id, machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
-	_, _ = probablyUpdateStatusHistory(st.db(), machineModificationKindPrefix, mdoc.Id, machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), m.Kind(), mdoc.Id, machineGlobalKey(mdoc.Id), machineStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), m.InstanceKind(), mdoc.Id, machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), m.ModificationKind(), mdoc.Id, machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
 	return prereqOps, machineOp, nil
 }
 

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -581,9 +581,9 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	// history entry. This is risky, and may lead to extra entries, but that's
 	// an intrinsic problem with mixing txn and non-txn ops -- we can't sync
 	// them cleanly.
-	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalKey(mdoc.Id), machineStatusDoc)
-	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
-	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineKindPrefix, mdoc.Id, machineGlobalKey(mdoc.Id), machineStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineInstanceKindPrefix, mdoc.Id, machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineModificationKindPrefix, mdoc.Id, machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
 	return prereqOps, machineOp, nil
 }
 

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -80,9 +80,6 @@ func globalCloudContainerKey(name string) string {
 	return unitGlobalKey(name) + "#container"
 }
 
-// cloudContainerKindPrefix is the string we use to denote cloud container kind.
-const cloudContainerKindPrefix = unitKindPrefix + "#container"
-
 func (u *Unit) cloudContainer() (*cloudContainerDoc, error) {
 	coll, closer := u.st.db().GetCollection(cloudContainersC)
 	defer closer()

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -80,6 +80,9 @@ func globalCloudContainerKey(name string) string {
 	return unitGlobalKey(name) + "#container"
 }
 
+// cloudContainerKindPrefix is the string we use to denote cloud container kind.
+const cloudContainerKindPrefix = unitKindPrefix + "#container"
+
 func (u *Unit) cloudContainer() (*cloudContainerDoc, error) {
 	coll, closer := u.st.db().GetCollection(cloudContainersC)
 	defer closer()

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -283,12 +283,14 @@ func (f *filesystem) SetStatus(fsStatus status.StatusInfo) error {
 		return errors.Errorf("cannot set invalid status %q", fsStatus.Status)
 	}
 	return setStatus(f.mb.db(), setStatusParams{
-		badge:     "filesystem",
-		globalKey: filesystemGlobalKey(f.FilesystemTag().Id()),
-		status:    fsStatus.Status,
-		message:   fsStatus.Message,
-		rawData:   fsStatus.Data,
-		updated:   timeOrNow(fsStatus.Since, f.mb.clock()),
+		badge:      "filesystem",
+		statusKind: filesystemKindPrefix,
+		statusId:   f.FilesystemTag().Id(),
+		globalKey:  filesystemGlobalKey(f.FilesystemTag().Id()),
+		status:     fsStatus.Status,
+		message:    fsStatus.Message,
+		rawData:    fsStatus.Data,
+		updated:    timeOrNow(fsStatus.Since, f.mb.clock()),
 	})
 }
 
@@ -1531,6 +1533,10 @@ func filesystemsToInterfaces(sb []*filesystem) []Filesystem {
 	return result
 }
 
+// filesystemKindPrefix is the kind string we use to denote filesystem kind.
+const filesystemKindPrefix = "f#"
+
+// filesystemGlobalKey returns the global database key for the filesystem.
 func filesystemGlobalKey(name string) string {
-	return "f#" + name
+	return filesystemKindPrefix + name
 }

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -205,6 +205,11 @@ func (f *filesystem) Tag() names.Tag {
 	return f.FilesystemTag()
 }
 
+// Kind returns a human readable name identifying the filesystem kind.
+func (f *filesystem) Kind() string {
+	return f.Tag().Kind()
+}
+
 // FilesystemTag is required to implement Filesystem.
 func (f *filesystem) FilesystemTag() names.FilesystemTag {
 	return names.NewFilesystemTag(f.doc.FilesystemId)
@@ -284,7 +289,7 @@ func (f *filesystem) SetStatus(fsStatus status.StatusInfo) error {
 	}
 	return setStatus(f.mb.db(), setStatusParams{
 		badge:      "filesystem",
-		statusKind: filesystemKindPrefix,
+		statusKind: f.Kind(),
 		statusId:   f.FilesystemTag().Id(),
 		globalKey:  filesystemGlobalKey(f.FilesystemTag().Id()),
 		status:     fsStatus.Status,
@@ -1533,10 +1538,11 @@ func filesystemsToInterfaces(sb []*filesystem) []Filesystem {
 	return result
 }
 
-// filesystemKindPrefix is the kind string we use to denote filesystem kind.
-const filesystemKindPrefix = "f#"
+// filesystemGlobalKeyPrefix is the kind string we use to denote filesystem
+// kind.
+const filesystemGlobalKeyPrefix = "f#"
 
 // filesystemGlobalKey returns the global database key for the filesystem.
 func filesystemGlobalKey(name string) string {
-	return filesystemKindPrefix + name
+	return filesystemGlobalKeyPrefix + name
 }

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -239,7 +239,7 @@ func Initialize(args InitializeParams, providerConfigSchemaGetter config.ConfigS
 	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, _ = probablyUpdateStatusHistory(st.db(), modelGlobalKey, modelStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), modelKindPrefix, modelGlobalKey, modelGlobalKey, modelStatusDoc)
 	return ctlr, nil
 }
 

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -239,7 +239,7 @@ func Initialize(args InitializeParams, providerConfigSchemaGetter config.ConfigS
 	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, _ = probablyUpdateStatusHistory(st.db(), modelKindPrefix, modelGlobalKey, modelGlobalKey, modelStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), modelTag.Kind(), modelGlobalKey, modelGlobalKey, modelStatusDoc)
 	return ctlr, nil
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -220,14 +220,20 @@ func (m *Machine) forceDestroyedOps() []txn.Op {
 
 // machineGlobalKey returns the global database key for the identified machine.
 func machineGlobalKey(id string) string {
-	return "m#" + id
+	return machineKindPrefix + id
 }
+
+// machineKindPrefix is the kind string we use to denote machine kind.
+const machineKindPrefix = "m#"
 
 // machineGlobalInstanceKey returns the global database key for the identified
 // machine's instance.
 func machineGlobalInstanceKey(id string) string {
 	return machineGlobalKey(id) + "#instance"
 }
+
+// machineInstaanceKind is the kind string we use for machine instances.
+const machineInstanceKindPrefix = "m#instance"
 
 // globalInstanceKey returns the global database key for the machine's instance.
 func (m *Machine) globalInstanceKey() string {
@@ -239,6 +245,9 @@ func (m *Machine) globalInstanceKey() string {
 func machineGlobalModificationKey(id string) string {
 	return machineGlobalKey(id) + "#modification"
 }
+
+// machineModificationKind is the kind string we use for machine modifications.
+const machineModificationKindPrefix = "m#modification"
 
 // globalModificationKey returns the global database key for the machine's
 // modification changes.
@@ -1310,12 +1319,14 @@ func (m *Machine) InstanceStatus() (status.StatusInfo, error) {
 // SetInstanceStatus sets the provider specific instance status for a machine.
 func (m *Machine) SetInstanceStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{
-		badge:     "instance",
-		globalKey: m.globalInstanceKey(),
-		status:    sInfo.Status,
-		message:   sInfo.Message,
-		rawData:   sInfo.Data,
-		updated:   timeOrNow(sInfo.Since, m.st.clock()),
+		badge:      "instance",
+		statusKind: machineInstanceKindPrefix,
+		statusId:   m.doc.Id,
+		globalKey:  m.globalInstanceKey(),
+		status:     sInfo.Status,
+		message:    sInfo.Message,
+		rawData:    sInfo.Data,
+		updated:    timeOrNow(sInfo.Since, m.st.clock()),
 	})
 }
 
@@ -1350,12 +1361,14 @@ func (m *Machine) ModificationStatus() (status.StatusInfo, error) {
 // operator.
 func (m *Machine) SetModificationStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{
-		badge:     "modification",
-		globalKey: m.globalModificationKey(),
-		status:    sInfo.Status,
-		message:   sInfo.Message,
-		rawData:   sInfo.Data,
-		updated:   timeOrNow(sInfo.Since, m.st.clock()),
+		badge:      "modification",
+		statusKind: machineModificationKindPrefix,
+		statusId:   m.doc.Id,
+		globalKey:  m.globalModificationKey(),
+		status:     sInfo.Status,
+		message:    sInfo.Message,
+		rawData:    sInfo.Data,
+		updated:    timeOrNow(sInfo.Since, m.st.clock()),
 	})
 }
 
@@ -1965,12 +1978,14 @@ func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
 		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
 	}
 	return setStatus(m.st.db(), setStatusParams{
-		badge:     "machine",
-		globalKey: m.globalKey(),
-		status:    statusInfo.Status,
-		message:   statusInfo.Message,
-		rawData:   statusInfo.Data,
-		updated:   timeOrNow(statusInfo.Since, m.st.clock()),
+		badge:      "machine",
+		statusKind: machineKindPrefix,
+		statusId:   m.doc.Id,
+		globalKey:  m.globalKey(),
+		status:     statusInfo.Status,
+		message:    statusInfo.Message,
+		rawData:    statusInfo.Data,
+		updated:    timeOrNow(statusInfo.Since, m.st.clock()),
 	})
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -220,11 +220,11 @@ func (m *Machine) forceDestroyedOps() []txn.Op {
 
 // machineGlobalKey returns the global database key for the identified machine.
 func machineGlobalKey(id string) string {
-	return machineKindPrefix + id
+	return machineGlobalKeyPrefix + id
 }
 
-// machineKindPrefix is the kind string we use to denote machine kind.
-const machineKindPrefix = "m#"
+// machineGlobalKeyPrefix is the kind string we use to denote machine kind.
+const machineGlobalKeyPrefix = "m#"
 
 // machineGlobalInstanceKey returns the global database key for the identified
 // machine's instance.
@@ -232,8 +232,11 @@ func machineGlobalInstanceKey(id string) string {
 	return machineGlobalKey(id) + "#instance"
 }
 
-// machineInstaanceKind is the kind string we use for machine instances.
-const machineInstanceKindPrefix = "m#instance"
+// InstanceKind returns a human readable name identifying the machine instance
+// kind.
+func (m *Machine) InstanceKind() string {
+	return m.Tag().Kind() + "-instance"
+}
 
 // globalInstanceKey returns the global database key for the machine's instance.
 func (m *Machine) globalInstanceKey() string {
@@ -246,8 +249,11 @@ func machineGlobalModificationKey(id string) string {
 	return machineGlobalKey(id) + "#modification"
 }
 
-// machineModificationKind is the kind string we use for machine modifications.
-const machineModificationKindPrefix = "m#modification"
+// ModificationKind returns the human readable kind string we use for when an
+// lxd profile is applied on a machine..
+func (m *Machine) ModificationKind() string {
+	return m.Tag().Kind() + "-lxd-profile"
+}
 
 // globalModificationKey returns the global database key for the machine's
 // modification changes.
@@ -397,6 +403,11 @@ func (d *ModelInstanceData) InstanceNames(machineID string) (instance.Id, string
 // from the same state.
 func (m *Machine) Tag() names.Tag {
 	return m.MachineTag()
+}
+
+// Kind returns a human readable name identifying the machine kind.
+func (m *Machine) Kind() string {
+	return m.Tag().Kind()
 }
 
 // MachineTag returns the more specific MachineTag type as opposed
@@ -1320,7 +1331,7 @@ func (m *Machine) InstanceStatus() (status.StatusInfo, error) {
 func (m *Machine) SetInstanceStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{
 		badge:      "instance",
-		statusKind: machineInstanceKindPrefix,
+		statusKind: m.InstanceKind(),
 		statusId:   m.doc.Id,
 		globalKey:  m.globalInstanceKey(),
 		status:     sInfo.Status,
@@ -1362,7 +1373,7 @@ func (m *Machine) ModificationStatus() (status.StatusInfo, error) {
 func (m *Machine) SetModificationStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st.db(), setStatusParams{
 		badge:      "modification",
-		statusKind: machineModificationKindPrefix,
+		statusKind: m.ModificationKind(),
 		statusId:   m.doc.Id,
 		globalKey:  m.globalModificationKey(),
 		status:     sInfo.Status,
@@ -1979,7 +1990,7 @@ func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
 	}
 	return setStatus(m.st.db(), setStatusParams{
 		badge:      "machine",
-		statusKind: machineKindPrefix,
+		statusKind: m.Kind(),
 		statusId:   m.doc.Id,
 		globalKey:  m.globalKey(),
 		status:     statusInfo.Status,

--- a/state/model.go
+++ b/state/model.go
@@ -32,6 +32,9 @@ import (
 // settings and constraints.
 const modelGlobalKey = "e"
 
+// modelKindPrefix is the string we use to denote model kind.
+const modelKindPrefix = modelGlobalKey + "#"
+
 // modelKey will create the key for a given model using the modelGlobalKey.
 func modelKey(modelUUID string) string {
 	return fmt.Sprintf("%s#%s", modelGlobalKey, modelUUID)
@@ -368,7 +371,7 @@ func (ctlr *Controller) NewModel(configSchemaGetter config.ConfigSchemaSourceGet
 		return nil, nil, errors.Trace(err)
 	}
 	if args.MigrationMode != MigrationModeImporting {
-		_, _ = probablyUpdateStatusHistory(newSt.db(), modelGlobalKey, modelStatusDoc)
+		_, _ = probablyUpdateStatusHistory(newSt.db(), modelKindPrefix, modelGlobalKey, modelGlobalKey, modelStatusDoc)
 	}
 
 	_, err = newSt.SetUserAccess(newModel.Owner(), newModel.ModelTag(), permission.AdminAccess)
@@ -579,12 +582,14 @@ func (m *Model) SetStatus(sInfo status.StatusInfo) error {
 		return errors.Errorf("cannot set invalid status %q", sInfo.Status)
 	}
 	return setStatus(m.st.db(), setStatusParams{
-		badge:     "model",
-		globalKey: m.globalKey(),
-		status:    sInfo.Status,
-		message:   sInfo.Message,
-		rawData:   sInfo.Data,
-		updated:   timeOrNow(sInfo.Since, m.st.clock()),
+		badge:      "model",
+		statusKind: modelKindPrefix,
+		statusId:   modelGlobalKey,
+		globalKey:  m.globalKey(),
+		status:     sInfo.Status,
+		message:    sInfo.Message,
+		rawData:    sInfo.Data,
+		updated:    timeOrNow(sInfo.Since, m.st.clock()),
 	})
 }
 

--- a/state/model.go
+++ b/state/model.go
@@ -32,9 +32,6 @@ import (
 // settings and constraints.
 const modelGlobalKey = "e"
 
-// modelKindPrefix is the string we use to denote model kind.
-const modelKindPrefix = modelGlobalKey + "#"
-
 // modelKey will create the key for a given model using the modelGlobalKey.
 func modelKey(modelUUID string) string {
 	return fmt.Sprintf("%s#%s", modelGlobalKey, modelUUID)
@@ -371,7 +368,7 @@ func (ctlr *Controller) NewModel(configSchemaGetter config.ConfigSchemaSourceGet
 		return nil, nil, errors.Trace(err)
 	}
 	if args.MigrationMode != MigrationModeImporting {
-		_, _ = probablyUpdateStatusHistory(newSt.db(), modelKindPrefix, modelGlobalKey, modelGlobalKey, modelStatusDoc)
+		_, _ = probablyUpdateStatusHistory(newSt.db(), newModel.Kind(), modelGlobalKey, modelGlobalKey, modelStatusDoc)
 	}
 
 	_, err = newSt.SetUserAccess(newModel.Owner(), newModel.ModelTag(), permission.AdminAccess)
@@ -404,6 +401,11 @@ func (ctlr *Controller) NewModel(configSchemaGetter config.ConfigSchemaSourceGet
 // by any other entities from the same state.
 func (m *Model) Tag() names.Tag {
 	return m.ModelTag()
+}
+
+// Kind returns a human readable name identifying the model kind.
+func (m *Model) Kind() string {
+	return m.Tag().Kind()
 }
 
 // ModelTag is the concrete model tag for this model.
@@ -583,7 +585,7 @@ func (m *Model) SetStatus(sInfo status.StatusInfo) error {
 	}
 	return setStatus(m.st.db(), setStatusParams{
 		badge:      "model",
-		statusKind: modelKindPrefix,
+		statusKind: m.Kind(),
 		statusId:   modelGlobalKey,
 		globalKey:  m.globalKey(),
 		status:     sInfo.Status,

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -190,7 +190,7 @@ func (st *State) maybeSetModelStatusHistoryDoc(modelUUID string, doc statusDoc) 
 		return
 	}
 
-	if _, err = probablyUpdateStatusHistory(one.st.db(), modelKindPrefix, one.globalKey(), one.globalKey(), doc); err != nil {
+	if _, err = probablyUpdateStatusHistory(one.st.db(), one.Kind(), one.globalKey(), one.globalKey(), doc); err != nil {
 		logger.Warningf("%v", err)
 	}
 }
@@ -212,7 +212,7 @@ func (m *Model) maybeRevertModelStatus() error {
 			Updated:    timeOrNow(nil, m.st.clock()).UnixNano(),
 		}
 
-		if _, err = probablyUpdateStatusHistory(m.st.db(), modelKindPrefix, m.globalKey(), m.globalKey(), doc); err != nil {
+		if _, err = probablyUpdateStatusHistory(m.st.db(), m.Kind(), m.globalKey(), m.globalKey(), doc); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -190,7 +190,7 @@ func (st *State) maybeSetModelStatusHistoryDoc(modelUUID string, doc statusDoc) 
 		return
 	}
 
-	if _, err = probablyUpdateStatusHistory(one.st.db(), one.globalKey(), doc); err != nil {
+	if _, err = probablyUpdateStatusHistory(one.st.db(), modelKindPrefix, one.globalKey(), one.globalKey(), doc); err != nil {
 		logger.Warningf("%v", err)
 	}
 }
@@ -212,7 +212,7 @@ func (m *Model) maybeRevertModelStatus() error {
 			Updated:    timeOrNow(nil, m.st.clock()).UnixNano(),
 		}
 
-		if _, err = probablyUpdateStatusHistory(m.st.db(), m.globalKey(), doc); err != nil {
+		if _, err = probablyUpdateStatusHistory(m.st.db(), modelKindPrefix, m.globalKey(), m.globalKey(), doc); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -398,7 +398,7 @@ func migStatusHistoryAndOps(st *State, phase migration.Phase, now int64, msg str
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, _ = probablyUpdateStatusHistory(st.db(), modelKindPrefix, globalKey, globalKey, doc)
+	_, _ = probablyUpdateStatusHistory(st.db(), model.Kind(), globalKey, globalKey, doc)
 	return ops, nil
 }
 

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -398,7 +398,7 @@ func migStatusHistoryAndOps(st *State, phase migration.Phase, now int64, msg str
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, _ = probablyUpdateStatusHistory(st.db(), globalKey, doc)
+	_, _ = probablyUpdateStatusHistory(st.db(), modelKindPrefix, globalKey, globalKey, doc)
 	return ops, nil
 }
 

--- a/state/relation.go
+++ b/state/relation.go
@@ -74,6 +74,11 @@ func (r *Relation) Tag() names.Tag {
 	return names.NewRelationTag(r.doc.Key)
 }
 
+// Kind returns a human readable name identifying the relation kind.
+func (r *Relation) Kind() string {
+	return r.Tag().Kind()
+}
+
 // UnitCount is the number of units still in relation scope.
 func (r *Relation) UnitCount() int {
 	return r.doc.UnitCount
@@ -159,7 +164,7 @@ func (r *Relation) SetStatus(statusInfo status.StatusInfo) error {
 	}
 	return setStatus(r.st.db(), setStatusParams{
 		badge:      "relation",
-		statusKind: relationKindPrefix,
+		statusKind: r.Kind(),
 		statusId:   fmt.Sprint(r.Id()),
 		globalKey:  r.globalScope(),
 		status:     statusInfo.Status,
@@ -770,9 +775,6 @@ func (r *Relation) unit(
 		scope:       scope,
 	}, nil
 }
-
-// relationKindPrefix is the string we use to denote relation kind.
-const relationKindPrefix = "r#"
 
 // globalScope returns the scope prefix for relation scope document keys
 // in the global scope.

--- a/state/relation.go
+++ b/state/relation.go
@@ -158,12 +158,14 @@ func (r *Relation) SetStatus(statusInfo status.StatusInfo) error {
 		}
 	}
 	return setStatus(r.st.db(), setStatusParams{
-		badge:     "relation",
-		globalKey: r.globalScope(),
-		status:    statusInfo.Status,
-		message:   statusInfo.Message,
-		rawData:   statusInfo.Data,
-		updated:   timeOrNow(statusInfo.Since, r.st.clock()),
+		badge:      "relation",
+		statusKind: relationKindPrefix,
+		statusId:   fmt.Sprint(r.Id()),
+		globalKey:  r.globalScope(),
+		status:     statusInfo.Status,
+		message:    statusInfo.Message,
+		rawData:    statusInfo.Data,
+		updated:    timeOrNow(statusInfo.Since, r.st.clock()),
 	})
 }
 
@@ -768,6 +770,9 @@ func (r *Relation) unit(
 		scope:       scope,
 	}, nil
 }
+
+// relationKindPrefix is the string we use to denote relation kind.
+const relationKindPrefix = "r#"
 
 // globalScope returns the scope prefix for relation scope document keys
 // in the global scope.

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -108,8 +108,9 @@ func newRemoteApplication(st *State, doc *remoteApplicationDoc) *RemoteApplicati
 	return app
 }
 
-// remoteApplicationkind is the string we use to denote remoteApplication kind.
-const remoteApplicationKindPrefix = "c#"
+// remoteAppGlobalKeyPrefix is the string we use to denote
+// remoteApplication kind.
+const remoteAppGlobalKeyPrefix = "c#"
 
 // remoteApplicationGlobalKey returns the global database key for the
 // remote application with the given name.
@@ -119,7 +120,7 @@ const remoteApplicationKindPrefix = "c#"
 // and r and a were taken.
 // TODO(babbageclunk): check whether this is still the case.
 func remoteApplicationGlobalKey(appName string) string {
-	return remoteApplicationKindPrefix + appName
+	return remoteAppGlobalKeyPrefix + appName
 }
 
 // globalKey returns the global database key for the remote application.
@@ -181,6 +182,11 @@ func (a *RemoteApplication) Token() (string, error) {
 // Tag returns a name identifying the application.
 func (a *RemoteApplication) Tag() names.Tag {
 	return names.NewApplicationTag(a.Name())
+}
+
+// Kind returns a human readable name identifying the remote application kind.
+func (a *RemoteApplication) Kind() string {
+	return "remote-application"
 }
 
 // Life returns whether the application is Alive, Dying or Dead.
@@ -545,7 +551,7 @@ func (a *RemoteApplication) SetStatus(info status.StatusInfo) error {
 
 	return setStatus(a.st.db(), setStatusParams{
 		badge:      fmt.Sprintf("saas application %q", a.doc.Name),
-		statusKind: remoteApplicationKindPrefix,
+		statusKind: a.Kind(),
 		statusId:   a.Name(),
 		globalKey:  a.globalKey(),
 		status:     info.Status,
@@ -621,7 +627,7 @@ func (op *terminateRemoteApplicationOperation) Done(err error) error {
 		return errors.Annotatef(err, "terminating saas application %q", op.app.Name())
 	}
 	_, _ = probablyUpdateStatusHistory(op.app.st.db(),
-		remoteApplicationKindPrefix, op.app.Name(), op.app.globalKey(), op.doc)
+		op.app.Kind(), op.app.Name(), op.app.globalKey(), op.doc)
 	// Set the life to Dead so that the lifecycle watcher will trigger to inform the
 	// relevant workers that this application is gone.
 	ops := []txn.Op{{

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -108,6 +108,9 @@ func newRemoteApplication(st *State, doc *remoteApplicationDoc) *RemoteApplicati
 	return app
 }
 
+// remoteApplicationkind is the string we use to denote remoteApplication kind.
+const remoteApplicationKindPrefix = "c#"
+
 // remoteApplicationGlobalKey returns the global database key for the
 // remote application with the given name.
 //
@@ -116,7 +119,7 @@ func newRemoteApplication(st *State, doc *remoteApplicationDoc) *RemoteApplicati
 // and r and a were taken.
 // TODO(babbageclunk): check whether this is still the case.
 func remoteApplicationGlobalKey(appName string) string {
-	return "c#" + appName
+	return remoteApplicationKindPrefix + appName
 }
 
 // globalKey returns the global database key for the remote application.
@@ -541,12 +544,14 @@ func (a *RemoteApplication) SetStatus(info status.StatusInfo) error {
 	}
 
 	return setStatus(a.st.db(), setStatusParams{
-		badge:     fmt.Sprintf("saas application %q", a.doc.Name),
-		globalKey: a.globalKey(),
-		status:    info.Status,
-		message:   info.Message,
-		rawData:   info.Data,
-		updated:   timeOrNow(info.Since, a.st.clock()),
+		badge:      fmt.Sprintf("saas application %q", a.doc.Name),
+		statusKind: remoteApplicationKindPrefix,
+		statusId:   a.Name(),
+		globalKey:  a.globalKey(),
+		status:     info.Status,
+		message:    info.Message,
+		rawData:    info.Data,
+		updated:    timeOrNow(info.Since, a.st.clock()),
 	})
 }
 
@@ -615,7 +620,8 @@ func (op *terminateRemoteApplicationOperation) Done(err error) error {
 	if err != nil {
 		return errors.Annotatef(err, "terminating saas application %q", op.app.Name())
 	}
-	_, _ = probablyUpdateStatusHistory(op.app.st.db(), op.app.globalKey(), op.doc)
+	_, _ = probablyUpdateStatusHistory(op.app.st.db(),
+		remoteApplicationKindPrefix, op.app.Name(), op.app.globalKey(), op.doc)
 	// Set the life to Dead so that the lifecycle watcher will trigger to inform the
 	// relevant workers that this application is gone.
 	ops := []txn.Op{{

--- a/state/state.go
+++ b/state/state.go
@@ -1452,7 +1452,7 @@ func (st *State) AddApplication(prechecker environs.InstancePrechecker, args Add
 		return ops, nil
 	}
 	// At the last moment before inserting the application, prime status history.
-	_, _ = probablyUpdateStatusHistory(st.db(), app.globalKey(), statusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), applicationKindPrefix, app.Name(), app.globalKey(), statusDoc)
 
 	if err = st.db().Run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.

--- a/state/state.go
+++ b/state/state.go
@@ -1452,7 +1452,7 @@ func (st *State) AddApplication(prechecker environs.InstancePrechecker, args Add
 		return ops, nil
 	}
 	// At the last moment before inserting the application, prime status history.
-	_, _ = probablyUpdateStatusHistory(st.db(), applicationKindPrefix, app.Name(), app.globalKey(), statusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), app.Kind(), app.Name(), app.globalKey(), statusDoc)
 
 	if err = st.db().Run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.

--- a/state/status.go
+++ b/state/status.go
@@ -22,6 +22,8 @@ import (
 	"github.com/juju/juju/internal/mongo/utils"
 )
 
+var status_logger = loggo.GetLogger("juju.status")
+
 type displayStatusFunc func(unitStatus status.StatusInfo, containerStatus status.StatusInfo) status.StatusInfo
 
 // ModelStatus holds all the current status values for a given model
@@ -264,6 +266,13 @@ type setStatusParams struct {
 	// badge is used to specialize any NotFound error emitted.
 	badge string
 
+	// statusKind is the kind of the entity for which the status is being set.
+	statusKind string
+
+	// statusId is the id of the entity for which the status is being set. It's
+	// not necessarily the same as the entity's Id().
+	statusId string
+
 	// globalKey uniquely identifies the entity to which the
 	globalKey string
 
@@ -319,7 +328,8 @@ func setStatus(db Database, params setStatusParams) (err error) {
 		historyDoc = params.historyOverwrite
 	}
 
-	newStatus, historyErr := probablyUpdateStatusHistory(db, params.globalKey, *historyDoc)
+	newStatus, historyErr := probablyUpdateStatusHistory(db,
+		params.statusKind, params.statusId, params.globalKey, *historyDoc)
 	if params.historyOverwrite == nil && (!newStatus && historyErr == nil) {
 		// If this status is not new (i.e. it is exactly the same as
 		// our last status), there is no need to update the record.
@@ -407,7 +417,8 @@ type recordedHistoricalStatusDoc struct {
 // we update that record to have a new timestamp.
 // Status messages are considered to be the same if they only differ in their timestamps.
 // The call returns true if a new status history record has been created.
-func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (bool, error) {
+func probablyUpdateStatusHistory(db Database,
+	statusKind string, statusId string, globalKey string, doc statusDoc) (bool, error) {
 	historyDoc := &historicalStatusDoc{
 		Status:     doc.Status,
 		StatusInfo: doc.StatusInfo,
@@ -415,6 +426,14 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 		Updated:    doc.Updated,
 		GlobalKey:  globalKey,
 	}
+
+	status_logger.InfoWithLabelsf("status update", map[string]string{
+		"domain": "status",
+		"kind":   statusKind,
+		"id":     statusId,
+		"value":  doc.Status.String(),
+	})
+
 	history, closer := db.GetCollection(statusesHistoryC)
 	defer closer()
 

--- a/state/status.go
+++ b/state/status.go
@@ -414,9 +414,13 @@ type recordedHistoricalStatusDoc struct {
 //
 // The "idle" status for the machine-lxd-profile is omitted from the status log,
 // since only the applied or error statuses are useful in that case.
+//
+// TODO (cderici): Once the statusesHistoryC collection goes away we'll lose
+// access to the doc parameter, so we'll replace it with a couple more
+// parameters for the status info and the status value.
 func logStatusUpdate(statusKind string, statusId string, doc statusDoc) {
 	if statusKind != "machine-lxd-profile" || doc.Status != status.Idle {
-		status_logger.InfoWithLabelsf("status update", map[string]string{
+		status_logger.InfoWithLabelsf(doc.StatusInfo, map[string]string{
 			"domain": "status",
 			"kind":   statusKind,
 			"id":     statusId,

--- a/state/unit.go
+++ b/state/unit.go
@@ -190,9 +190,6 @@ func unitGlobalKey(name string) string {
 	return "u#" + name + "#charm"
 }
 
-// unitGlobalKeyPrefix is the string we use to denote unit kind.
-const unitGlobalKeyPrefix = "u#charm"
-
 // unitWorkloadVersionKind returns the unit workload version kind.
 func (u *Unit) unitWorkloadVersionKind() string {
 	return u.Kind() + "-version"

--- a/state/unit.go
+++ b/state/unit.go
@@ -190,6 +190,12 @@ func unitGlobalKey(name string) string {
 	return "u#" + name + "#charm"
 }
 
+// unitKindPrefix is the string we use to denote unit kind.
+const unitKindPrefix = "u#charm"
+
+// unitWorkloadVersionKindPrefix is the string we use to denote unit workload version kind.
+const unitWorkloadVersionKindPrefix = unitKindPrefix + "#sat#workload-version"
+
 // globalWorkloadVersionKey returns the global database key for the
 // workload version status key for this unit.
 func globalWorkloadVersionKey(name string) string {
@@ -244,11 +250,13 @@ func (u *Unit) SetWorkloadVersion(version string) error {
 	// stop a swarm of watchers being notified for irrelevant changes.
 	now := u.st.clock().Now()
 	return setStatus(u.st.db(), setStatusParams{
-		badge:     "workload",
-		globalKey: u.globalWorkloadVersionKey(),
-		status:    status.Active,
-		message:   version,
-		updated:   &now,
+		badge:      "workload",
+		statusKind: unitWorkloadVersionKindPrefix,
+		statusId:   u.Name(),
+		globalKey:  u.globalWorkloadVersionKey(),
+		status:     status.Active,
+		message:    version,
+		updated:    &now,
 	})
 }
 
@@ -490,7 +498,8 @@ func (op *UpdateUnitOperation) Done(err error) error {
 	// We can't include in the ops slice the necessary status history updates,
 	// so as with existing practice, do a best effort update of status history.
 	for key, doc := range op.setStatusDocs {
-		_, _ = probablyUpdateStatusHistory(op.unit.st.db(), key, doc)
+		_, _ = probablyUpdateStatusHistory(op.unit.st.db(),
+			unitKindPrefix, op.unit.Name(), key, doc)
 	}
 	return nil
 }
@@ -1481,6 +1490,8 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 
 	return setStatus(u.st.db(), setStatusParams{
 		badge:            "unit",
+		statusKind:       unitKindPrefix,
+		statusId:         u.Name(),
 		globalKey:        u.globalKey(),
 		status:           unitStatus.Status,
 		message:          unitStatus.Message,

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -94,7 +94,7 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 	}
 	return setStatus(u.st.db(), setStatusParams{
 		badge:      "agent",
-		statusKind: unitAgentKindPrefix,
+		statusKind: u.Kind(),
 		statusId:   u.name,
 		globalKey:  u.globalKey(),
 		status:     unitAgentStatus.Status,
@@ -119,11 +119,11 @@ func (u *UnitAgent) StatusHistory(filter status.StatusHistoryFilter) ([]status.S
 
 // unitAgentGlobalKey returns the global database key for the named unit.
 func unitAgentGlobalKey(name string) string {
-	return unitAgentKindPrefix + name
+	return unitAgentGlobalKeyPrefix + name
 }
 
-// unitAgentKindPrefix is the string we use to denote unit agent kind.
-const unitAgentKindPrefix = "u#"
+// unitAgentGlobalKeyPrefix is the string we use to denote unit agent kind.
+const unitAgentGlobalKeyPrefix = "u#"
 
 // globalKey returns the global database key for the unit.
 func (u *UnitAgent) globalKey() string {
@@ -133,4 +133,9 @@ func (u *UnitAgent) globalKey() string {
 // Tag returns a names.Tag identifying this agent's unit.
 func (u *UnitAgent) Tag() names.Tag {
 	return u.tag
+}
+
+// Kind returns a human readable name identifying the unit agent kind.
+func (u *UnitAgent) Kind() string {
+	return u.Tag().Kind() + "-agent"
 }

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -93,12 +93,14 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
 		return errors.Errorf("cannot set invalid status %q", unitAgentStatus.Status)
 	}
 	return setStatus(u.st.db(), setStatusParams{
-		badge:     "agent",
-		globalKey: u.globalKey(),
-		status:    unitAgentStatus.Status,
-		message:   unitAgentStatus.Message,
-		rawData:   unitAgentStatus.Data,
-		updated:   timeOrNow(unitAgentStatus.Since, u.st.clock()),
+		badge:      "agent",
+		statusKind: unitAgentKindPrefix,
+		statusId:   u.name,
+		globalKey:  u.globalKey(),
+		status:     unitAgentStatus.Status,
+		message:    unitAgentStatus.Message,
+		rawData:    unitAgentStatus.Data,
+		updated:    timeOrNow(unitAgentStatus.Since, u.st.clock()),
 	})
 }
 
@@ -117,8 +119,11 @@ func (u *UnitAgent) StatusHistory(filter status.StatusHistoryFilter) ([]status.S
 
 // unitAgentGlobalKey returns the global database key for the named unit.
 func unitAgentGlobalKey(name string) string {
-	return "u#" + name
+	return unitAgentKindPrefix + name
 }
+
+// unitAgentKindPrefix is the string we use to denote unit agent kind.
+const unitAgentKindPrefix = "u#"
 
 // globalKey returns the global database key for the unit.
 func (u *UnitAgent) globalKey() string {

--- a/state/volume.go
+++ b/state/volume.go
@@ -255,6 +255,11 @@ func (v *volume) Tag() names.Tag {
 	return v.VolumeTag()
 }
 
+// Kind returns a human readable name identifying the volume kind.
+func (v *volume) Kind() string {
+	return v.Tag().Kind()
+}
+
 // VolumeTag is required to implement Volume.
 func (v *volume) VolumeTag() names.VolumeTag {
 	return names.NewVolumeTag(v.doc.Name)
@@ -326,7 +331,7 @@ func (v *volume) SetStatus(volumeStatus status.StatusInfo) error {
 	}
 	return setStatus(v.mb.db(), setStatusParams{
 		badge:      "volume",
-		statusKind: volumeKindPrefix,
+		statusKind: v.Kind(),
 		statusId:   v.VolumeTag().Id(),
 		globalKey:  volumeGlobalKey(v.VolumeTag().Id()),
 		status:     volumeStatus.Status,

--- a/state/volume.go
+++ b/state/volume.go
@@ -325,12 +325,14 @@ func (v *volume) SetStatus(volumeStatus status.StatusInfo) error {
 		return errors.Errorf("cannot set invalid status %q", volumeStatus.Status)
 	}
 	return setStatus(v.mb.db(), setStatusParams{
-		badge:     "volume",
-		globalKey: volumeGlobalKey(v.VolumeTag().Id()),
-		status:    volumeStatus.Status,
-		message:   volumeStatus.Message,
-		rawData:   volumeStatus.Data,
-		updated:   timeOrNow(volumeStatus.Since, v.mb.clock()),
+		badge:      "volume",
+		statusKind: volumeKindPrefix,
+		statusId:   v.VolumeTag().Id(),
+		globalKey:  volumeGlobalKey(v.VolumeTag().Id()),
+		status:     volumeStatus.Status,
+		message:    volumeStatus.Message,
+		rawData:    volumeStatus.Data,
+		updated:    timeOrNow(volumeStatus.Since, v.mb.clock()),
 	})
 }
 
@@ -1546,6 +1548,10 @@ func (sb *storageBackend) AllVolumes() ([]Volume, error) {
 	return volumesToInterfaces(volumes), nil
 }
 
+// volumeGlobalKey returns the global database key for the named volume.
 func volumeGlobalKey(name string) string {
-	return "v#" + name
+	return volumeKindPrefix + name
 }
+
+// volumeKindPrefix is the string we use to denote a volume kind.
+const volumeKindPrefix = "v#"


### PR DESCRIPTION
This has the initial changes to ultimately move the status history in state package out of the mongo and into the logs on disk via whatever logging interface is used (e.g., debug-log, loki). It uses the new `InfoWithLabelsf` (added in https://github.com/juju/loggo/pull/48) in the `probablyUpdateStatusHistory`, along with the DB write (we're keeping it for now).

Couple of notes:

- There's a better way to do this, instead of passing individual parameters, we could create an interface like:
```go
type StatusEntity interface {
 Entity
 StatusKind() string
 StatusId() string
}
```

and have the entities implement it and just call these in `probablyUpdateStatusHistory`. But I didn't bother too much, since the entire `state` package, including `probablyUpdateStatusHistory` and everything's going away eventually.
- Kept the `globalKey` argument because the document for the DB write uses it, and again, we don't have a good way of generating it uniformly across entities.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Bootstrap with this change:
```
juju bootstrap localhost deleteme
```

Add a model and a charm:
```
juju add-model tst && juju deploy ubuntu -n 3
```
Then while it's going up take a look at the debug-logs to see status updates:

```
juju debug-log -m controller --include-module juju.status
```

You should see something like:

```
machine-0: 18:50:01 INFO juju.status domain:status,id:ubuntu/2,kind:unit-workload,value:waiting waiting for machine
machine-0: 18:50:01 INFO juju.status kind:machine,value:started,domain:status,id:0
machine-0: 18:50:02 INFO juju.status kind:unit-workload-version,value:unknown,domain:status,id:ubuntu/2
machine-0: 18:50:02 INFO juju.status domain:status,id:ubuntu/2,kind:unit-agent,value:allocating
machine-0: 18:50:03 INFO juju.status domain:status,id:0,kind:machine,value:pending
machine-0: 18:50:04 INFO juju.status domain:status,id:0,kind:machine-instance,value:pending
machine-0: 18:50:05 INFO juju.status kind:machine,value:pending,domain:status,id:1
machine-0: 18:50:05 INFO juju.status value:pending,domain:status,id:1,kind:machine-instance
machine-0: 18:50:06 INFO juju.status id:2,kind:machine,value:pending,domain:status
machine-0: 18:50:06 INFO juju.status value:pending,domain:status,id:2,kind:machine-instance
machine-0: 18:50:15 INFO juju.status value:allocating,domain:status,id:0,kind:machine-instance starting
machine-0: 18:50:18 INFO juju.status value:allocating,domain:status,id:1,kind:machine-instance starting
machine-0: 18:50:20 INFO juju.status id:0,kind:machine-instance,value:allocating,domain:status acquiring LXD image
machine-0: 18:50:20 INFO juju.status domain:status,id:0,kind:machine-instance,value:allocating Creating container
machine-0: 18:50:22 INFO juju.status kind:machine-instance,value:allocating,domain:status,id:1 acquiring LXD image
machine-0: 18:50:23 INFO juju.status domain:status,id:1,kind:machine-instance,value:allocating Creating container
machine-0: 18:50:25 INFO juju.status id:2,kind:machine-instance,value:allocating,domain:status starting
machine-0: 18:50:30 INFO juju.status domain:status,id:2,kind:machine-instance,value:allocating acquiring LXD image
machine-0: 18:50:30 INFO juju.status kind:machine-instance,value:allocating,domain:status,id:2 Creating container
machine-0: 18:51:02 INFO juju.status kind:machine,value:started,domain:status,id:0
machine-0: 18:51:02 INFO juju.status id:0,kind:machine-instance,value:running,domain:status Container started
machine-0: 18:51:04 INFO juju.status id:0,kind:machine-lxd-profile,value:applied,domain:status
machine-0: 18:51:44 INFO juju.status kind:machine-instance,value:running,domain:status,id:0 Running
machine-0: 18:51:50 INFO juju.status domain:status,id:1,kind:machine-instance,value:running Container started
machine-0: 18:51:50 INFO juju.status domain:status,id:2,kind:machine-instance,value:running Container started
machine-0: 18:51:59 INFO juju.status id:1,kind:machine-lxd-profile,value:applied,domain:status
machine-0: 18:51:59 INFO juju.status domain:status,id:2,kind:machine-lxd-profile,value:applied
machine-0: 18:52:02 INFO juju.status kind:machine,value:started,domain:status,id:0
machine-0: 18:52:50 INFO juju.status id:1,kind:machine-instance,value:running,domain:status Running
machine-0: 18:52:52 INFO juju.status domain:status,id:2,kind:machine-instance,value:running Running
machine-0: 18:53:03 INFO juju.status kind:machine,value:started,domain:status,id:0
machine-0: 18:54:07 INFO juju.status kind:machine,value:started,domain:status,id:0
machine-0: 18:55:09 INFO juju.status domain:status,id:0,kind:machine,value:started
machine-0: 18:56:10 INFO juju.status id:0,kind:machine,value:started,domain:status
machine-0: 18:57:09 INFO juju.status id:ubuntu/0,kind:unit-workload,value:waiting,domain:status installing agent
machine-0: 18:57:10 INFO juju.status domain:status,id:0,kind:machine,value:started
machine-0: 18:57:16 INFO juju.status domain:status,id:0,kind:machine,value:started
machine-0: 18:57:22 INFO juju.status id:ubuntu/0,kind:unit-workload,value:waiting,domain:status agent initialising
machine-0: 18:58:01 INFO juju.status kind:unit-workload,value:waiting,domain:status,id:ubuntu/2 installing agent
machine-0: 18:58:02 INFO juju.status domain:status,id:ubuntu/1,kind:unit-workload,value:waiting installing agent
machine-0: 18:58:11 INFO juju.status value:started,domain:status,id:0,kind:machine
machine-0: 18:58:23 INFO juju.status id:2,kind:machine,value:started,domain:status
machine-0: 18:58:24 INFO juju.status domain:status,id:ubuntu/2,kind:unit-workload,value:waiting agent initialising
machine-0: 18:58:24 INFO juju.status value:started,domain:status,id:1,kind:machine
machine-0: 18:58:25 INFO juju.status value:waiting,domain:status,id:ubuntu/1,kind:unit-workload agent initialising
```

You may also use json format to see the exact json objects being used:

```
juju debug-log -m controller --include-module juju.status  --format json --replay
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-5551

