### PR TITLE
Use docker v2 manifest format with podman push.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -144,7 +144,7 @@ build_push_operator_image() {
             --platform="$build_multi_osarch" \
             "${BUILD_DIR}"
         if [[ "$push_image" = true ]]; then
-            "$DOCKER_BIN" manifest push "$(operator_image_path)" "docker://$(operator_image_path)"
+            "$DOCKER_BIN" manifest push -f v2s2 "$(operator_image_path)" "docker://$(operator_image_path)"
         fi
     else
         echo "unknown OCI_BUILDER=${OCI_BUILDER} expected docker or podman"


### PR DESCRIPTION
Juju docker registry client does not support oci manifest format and fails to upgrade models.

`ERROR cannot get architecture for jujud-operator:3.4.0: can not get manifests for jujud-operator:3.4.0: manifest response version "application/vnd.oci.image.index.v1+json" not supported (not supported)`

This forces podman to push docker v2 manifests until we move to a well-supported oci registry client that has oci manifest support among other features.

## QA steps

push image with podman and check it is a docker v2 manifest not an oci manifest.

## Documentation changes

N/A

## Links

https://pastebin.ubuntu.com/p/tfRX3BVFq2/

