### PR TITLE
Fix LP, avoid panic on nil pointer.

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -373,8 +373,9 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 		bindings, err := v.newStateBindings(v.state, arg.EndpointBindings)
 		if err != nil {
 			errs = append(errs, err)
+		} else {
+			dt.endpoints = bindings.Map()
 		}
-		dt.endpoints = bindings.Map()
 	}
 	// resolve and validate resources
 	resources, pendingResourceUploads, resolveResErr := v.resolveResources(dt.charmURL, dt.origin, dt.resources, resolvedCharm.Meta().Resources)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -240,6 +240,55 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 	})
 }
 
+func (s *validatorSuite) TestValidateEndpointBindingFail(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSimpleValidate()
+	// resolveCharm
+	curl := charm.MustParseURL("testcharm")
+	resultURL := charm.MustParseURL("ch:amd64/jammy/testcharm-4")
+	origin := corecharm.Origin{
+		Source:   "charm-hub",
+		Channel:  &charm.Channel{Risk: "stable"},
+		Platform: corecharm.Platform{Architecture: "amd64"},
+	}
+	resolvedOrigin := corecharm.Origin{
+		Source:   "charm-hub",
+		Type:     "charm",
+		Channel:  &charm.Channel{Track: "default", Risk: "stable"},
+		Platform: corecharm.Platform{Architecture: "amd64", OS: "ubuntu", Channel: "22.04"},
+		Revision: intptr(4),
+	}
+	// getCharm
+	charmID := corecharm.CharmID{URL: curl, Origin: origin}
+	resolvedData := getResolvedData(resultURL, resolvedOrigin)
+	s.repo.EXPECT().ResolveForDeploy(charmID).Return(resolvedData, nil)
+	s.repo.EXPECT().ResolveResources(nil, corecharm.CharmID{URL: resultURL, Origin: resolvedOrigin}).Return(nil, nil)
+	s.model.EXPECT().UUID().Return("")
+
+	// state bindings
+	endpointMap := map[string]string{"to": "from"}
+	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("arm64")}, nil)
+	s.state.EXPECT().Charm(gomock.Any()).Return(nil, errors.NotFoundf("charm"))
+
+	s.repoFactory.EXPECT().GetCharmRepository(gomock.Any()).Return(s.repo, nil).AnyTimes()
+	v := &deployFromRepositoryValidator{
+		model:       s.model,
+		state:       s.state,
+		repoFactory: s.repoFactory,
+		newStateBindings: func(st state.EndpointBinding, givenMap map[string]string) (Bindings, error) {
+			return nil, errors.NotFoundf("space")
+		},
+	}
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName:        "testcharm",
+		EndpointBindings: endpointMap,
+	}
+	_, errs := v.validate(arg)
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], jc.ErrorIs, errors.NotFound)
+}
+
 func (s *validatorSuite) expectSimpleValidate() {
 	// createOrigin
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{}, nil)


### PR DESCRIPTION
Don't use a return value after an error has been found.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Follow steps in the bug, or the new unit test produces the same panic if the change to validate() does not exist.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2055868

**Jira card:** JUJU-5656

