### PR TITLE
Add extra uniter debugging for resolving next actions

### DIFF
--- a/worker/uniter/actions/resolver.go
+++ b/worker/uniter/actions/resolver.go
@@ -21,6 +21,7 @@ var _ logger = struct{}{}
 // Logger represents the logging methods used by the actions resolver.
 type Logger interface {
 	Infof(string, ...interface{})
+	Debugf(string, ...interface{})
 }
 
 type actionsResolver struct {
@@ -57,11 +58,16 @@ func (r *actionsResolver) NextOp(
 	// deferred until the unit is running. If the remote charm needs
 	// updating, hold off on action running.
 	if remoteState.ActionsBlocked || localState.OutdatedRemoteCharm {
+		r.logger.Infof("actions are blocked=%v; outdated remote charm=%v - have pending actions: %v", remoteState.ActionsBlocked, localState.OutdatedRemoteCharm, remoteState.ActionsPending)
+		if localState.ActionId == nil {
+			r.logger.Debugf("actions are blocked, no in flight actions")
+			return nil, resolver.ErrNoOperation
+		}
 		// If we were somehow running an action during remote container changes/restart
 		// we need to fail it and move on.
+		r.logger.Infof("incomplete action %v is blocked", *localState.ActionId)
 		if localState.Kind == operation.RunAction {
 			if localState.Hook != nil {
-				r.logger.Infof("found incomplete action %v; ignoring", localState.ActionId)
 				r.logger.Infof("recommitting prior %q hook", localState.Hook.Kind)
 				return opFactory.NewSkipHook(*localState.Hook)
 			}
@@ -76,6 +82,9 @@ func (r *actionsResolver) NextOp(
 	nextActionId, err := nextAction(remoteState.ActionsPending, localState.CompletedActions)
 	if err != nil && err != resolver.ErrNoOperation {
 		return nil, err
+	}
+	if nextActionId == "" {
+		r.logger.Debugf("no next action from pending=%v; completed=%v", remoteState.ActionsPending, localState.CompletedActions)
 	}
 
 	defer func() {
@@ -105,7 +114,7 @@ func (r *actionsResolver) NextOp(
 			return opFactory.NewSkipHook(*localState.Hook)
 		}
 
-		r.logger.Infof("%q hook is nil", operation.RunAction)
+		r.logger.Infof("%q hook is nil, so running action %v", operation.RunAction, nextActionId)
 		// If the next action is the same as what the uniter is
 		// currently running then this means that the uniter was
 		// some how interrupted (killed) when running the action
@@ -114,6 +123,7 @@ func (r *actionsResolver) NextOp(
 		// is fail the action, since rerunning an arbitrary
 		// command can potentially be hazardous.
 		if nextActionId == *localState.ActionId {
+			r.logger.Debugf("unit agent was interrupted while running action %v", *localState.ActionId)
 			return opFactory.NewFailAction(*localState.ActionId)
 		}
 

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -377,6 +377,7 @@ func (w *RemoteStateWatcher) setUp(unitTag names.UnitTag) (err error) {
 			}
 		}
 	}
+	w.logger.Debugf("starting remote state watcher, actions for %s; blocked=%v", w.unit.Tag(), w.current.ActionsBlocked)
 	return nil
 }
 
@@ -1317,6 +1318,7 @@ func (w *RemoteStateWatcher) actionsChanged(actions []string) {
 
 func (w *RemoteStateWatcher) containerRunningStatus(runningStatus ContainerRunningStatus) {
 	w.mu.Lock()
+	w.logger.Debugf("running status update for %s(provider-id=%s): %+v", w.unit.Tag(), w.current.ProviderID, runningStatus)
 	w.current.ActionsBlocked = !runningStatus.Running
 	w.current.ContainerRunningStatus = &runningStatus
 	w.mu.Unlock()


### PR DESCRIPTION
This PR added extra logging around how the unit agent resolves next operations to run, and in particular actions.
We've has cases of actions getting stuck and not enough logging to understand why. This extra logging might help next time it happens.

## QA steps

deploy a k8s charm and run an action on it

## Links

**Jira card:** JUJU-5685

