### PR TITLE
Ensure we wait for startup correctly

### DIFF
--- a/internal/objectstore/s3objectstore.go
+++ b/internal/objectstore/s3objectstore.go
@@ -274,9 +274,6 @@ func (t *s3ObjectStore) Remove(ctx context.Context, path string) error {
 }
 
 func (t *s3ObjectStore) loop() error {
-	// Report the initial started state.
-	t.reportInternalState(stateStarted)
-
 	// Ensure the namespace directory exists, along with the tmp directory.
 	if err := t.ensureDirectories(); err != nil {
 		return errors.Annotatef(err, "ensuring file store directories exist")
@@ -326,6 +323,9 @@ func (t *s3ObjectStore) loop() error {
 		// If we allow draining, then we can attempt to use the file accessor.
 		fileFallback = useFileAccessor
 	}
+
+	// Report the initial started state.
+	t.reportInternalState(stateStarted)
 
 	// Sequence the get request with the put, remove requests.
 	for {


### PR DESCRIPTION
Fixes intermittent failure within the objectstore S3 tests. The changes move the internal state call until we've started up the object store. Otherwise, there is a race between the test code and the implementation around what gets called or not.

<!-- Why this change is needed and what it does. -->

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ go test -v ./internal/objectstore -check.v -count=10
```

