### PR TITLE
[JUJU-5694] Fix regression with deploy

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -466,11 +466,6 @@ func compatibilityApplicationDeployArgs(arg params.ApplicationDeploy) (params.Ap
 	if err != nil {
 		return arg, err
 	}
-	curl, err := charm.ParseURL(arg.CharmURL)
-	if err != nil {
-		return arg, err
-	}
-	arg.CharmURL = curl.WithSeries(originSeries).String()
 	origin.Series = originSeries
 	arg.Series = originSeries
 	return arg, nil

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -304,11 +304,6 @@ func compatibilityAddCharmWithAuthArg(arg params.AddCharmWithAuth) (params.AddCh
 	if err != nil {
 		return arg, err
 	}
-	curl, err := charm.ParseURL(arg.URL)
-	if err != nil {
-		return arg, err
-	}
-	arg.URL = curl.WithSeries(originSeries).String()
 	arg.Origin.Series = originSeries
 	arg.Series = originSeries
 	return arg, nil

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -297,7 +297,7 @@ func (s *charmsMockSuite) TestAddCharmWithLocalSource(c *gc.C) {
 		Force: false,
 	}
 	_, err = api.AddCharm(args)
-	c.Assert(err, gc.ErrorMatches, `unknown schema for charm URL "local:jammy/testme"`)
+	c.Assert(err, gc.ErrorMatches, `unknown schema for charm URL "local:testme"`)
 }
 
 func (s *charmsMockSuite) TestAddCharm(c *gc.C) {


### PR DESCRIPTION
Fix a regression in charm deploy

A fix was previously made here https://github.com/juju/juju/pull/16692
to increase compatibility with 2.9 controllers and 3.x clients by adding
a compatibility layer

However, there is an edge case with charm url which we see when
deploying some local charms with pylibjuju, causing deploys to be
impossible

Sometimes pylibjuju uploads local charms in such a way that the
resulting charm url in Mongo does not include a series. Since the
compatibility layer ensures a series is present in curls when we deploy,
this charm becomes impossible to deploy

We considered a few approaches to this. The best is to drop this
mutation to the charm url, restoring the behavior partially to 2.9.46
Series in mongo charm urls, even in 2.9 is a very legacy feature which
we do not think is actually required anywhere.

To prevent such a bug happening again, we will add pylibjuju smoke tests to the github actions suite.

## QA steps

This PR partially restores the functionality to 2.9.46, so the most likely place for something to break is incompatibility with 3.x clients. However, the most important support contract is with 2.9.x versions. Both are covered approximately equally in QA steps

### Matching client + controller (up to minor version)

Ensure a local charm, with no series in it's metadata.yaml exists at `/home/jack/charms/ubuntu`

Deploy a controller from this PR

#### Deploy charms with python-libjuju 
```
$ pip install juju=2.9.46.1
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> await m.deploy("/home/jack/charms/ubuntu")
<Application entity_id="ubuntu">
>>> await m.deploy("/home/jack/charms/ubuntu", series="jammy", application_name="ubuntu-jammy")
<Application entity_id="ubuntu-jammy">
>>> await m.deploy("ubuntu", application_name="ubuntu-ch")
<Application entity_id="ubuntu-ch">
>>> await m.deploy("ubuntu", series="jammy",  application_name="ubuntu-ch-jammy")
<Application entity_id="ubuntu-ch-jammy">
>>> 
exiting asyncio REPL...

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd         localhost/localhost  2.9.48.1  unsupported  11:27:04Z

App              Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           20.04    active      1  ubuntu                   0  no       
ubuntu-ch        20.04    active      1  ubuntu  latest/stable   24  no       
ubuntu-ch-jammy  22.04    active      1  ubuntu  latest/stable   24  no       
ubuntu-jammy     22.04    active      1  ubuntu                   1  no       

Unit                Workload  Agent  Machine  Public address  Ports  Message
ubuntu-ch-jammy/0*  active    idle   3        10.219.211.187         
ubuntu-ch/0*        active    idle   2        10.219.211.153         
ubuntu-jammy/0*     active    idle   1        10.219.211.175         
ubuntu/0*           active    idle   0        10.219.211.196         

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.219.211.196  juju-cdcf11-0  focal       Running
1        started  10.219.211.175  juju-cdcf11-1  jammy       Running
2        started  10.219.211.153  juju-cdcf11-2  focal       Running
3        started  10.219.211.187  juju-cdcf11-3  jammy       Running
```

#### Juju cli client can deploy

```
$ juju deploy ubuntu ubu
Located charm "ubuntu" in charm-hub, revision 24
Deploying "ubu" from charm-hub charm "ubuntu", revision 24 in channel stable on focal

$ juju deploy ubuntu ubu2 --series jammy
Located charm "ubuntu" in charm-hub, revision 24
Deploying "ubu2" from charm-hub charm "ubuntu", revision 24 in channel stable on jammy

$ juju deploy ~/charms/ubuntu ubu-local
Located local charm "ubuntu", revision 0
Deploying "ubu-local" from local charm "ubuntu", revision 0 on focal

$ juju deploy ~/charms/ubuntu ubu-local2 --series jammy
Located local charm "ubuntu", revision 0
Deploying "ubu-local2" from local charm "ubuntu", revision 0 on jammy

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd         localhost/localhost  2.9.48.1  unsupported  11:18:09Z

App         Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu         20.04    active      1  ubuntu  stable    24  no       
ubu2        22.04    active      1  ubuntu  stable    24  no       
ubu-local   20.04    active      1  ubuntu             0  no       
ubu-local2  22.04    active      1  ubuntu             0  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
ubu2/0*        active    idle   1        10.219.211.106         
ubu-local2/0*  active    idle   3        10.219.211.87          
ubu-local/0*   active    idle   2        10.219.211.184         
ubu/0*         active    idle   0        10.219.211.101         

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.219.211.101  juju-7dcde0-0  focal       Running
1        started  10.219.211.106  juju-7dcde0-1  jammy       Running
2        started  10.219.211.184  juju-7dcde0-2  focal       Running
3        started  10.219.211.87   juju-7dcde0-3  jammy       Running
```

### Compatibility with 3.x

QA steps copied from https://github.com/juju/juju/pull/16692

- `juju` refers to the compiled code under test; `juju_34` is the juju snap with channel 3.4/stable.

```bash
#
# Bootstrap a juju 3.4 controller for later upgrade and migration of a 2.9 model.
# 
$ juju_34 bootstrap localhost destination

# 
# Bootstrap a controller to test the changes
# 
$ juju bootstrap localhost testing

# 
# Run various commands requiring series and base, including charms with and without 
# 
$ juju_34 add-model moveme
$ juju_34 deploy juju-qa-test --revision 23 --channel edge
$ juju_34 deploy ./tests/suites/deploy/charms/lxd-profile-alt
$ juju_34 deploy postgresql
$ juju_34 add-machine --base ubuntu@20.04 
$ juju_34 refresh lxd-profile-alt --path  ./tests/suites/deploy/charms/lxd-profile-alt

# Verify the juju-qa-test resource was correctly downloaded, check the application status for an output change.
$ juju_34 config juju-qa-test foo-file=true

# Update the base of an application for the next unit added.
$ juju_34 set-application-base juju-qa-test ubuntu@20.04

# Migrate to the 3.3. controller & upgrade.
$ juju_34 migrate moveme destination
$ juju_34 switch destination
$ juju_34 upgrade-model

# Ensure base change successful, validate the new unit is using ubuntu@20.04
$ juju_34 add-unit juju-qa-test
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2058311
