### PR TITLE
Add user permissions creating user

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -228,9 +228,9 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(
 		b.adminUser.Name(),
 		auth.NewPassword(info.Password),
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        coredatabase.ControllerNS,
 			},

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	ccbootstrap "github.com/juju/juju/domain/controllerconfig/bootstrap"
 	credbootstrap "github.com/juju/juju/domain/credential/bootstrap"
@@ -224,7 +225,11 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 
 	// Add initial Admin user to the database. This will return Admin user UUID
 	// and a function to insert it into the database.
-	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(b.adminUser.Name(), auth.NewPassword(info.Password))
+	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(
+		b.adminUser.Name(),
+		auth.NewPassword(info.Password),
+		permission.SuperuserAccess,
+	)
 
 	controllerModelUUID := model.UUID(
 		stateParams.ControllerModelConfig.UUID(),

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -228,13 +228,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(
 		b.adminUser.Name(),
 		auth.NewPassword(info.Password),
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        coredatabase.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 
 	controllerModelUUID := model.UUID(

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -228,7 +228,13 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(
 		b.adminUser.Name(),
 		auth.NewPassword(info.Password),
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        coredatabase.ControllerNS,
+			},
+		},
 	)
 
 	controllerModelUUID := model.UUID(

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -413,6 +413,7 @@ func (s *loginSuite) infoForNewUser(c *gc.C, info *api.Info) *api.Info {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -663,6 +664,7 @@ func (s *loginSuite) TestOtherModel(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -829,6 +831,7 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (names.UserTag, par
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -907,6 +910,7 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1041,6 +1045,7 @@ func (s *loginV3Suite) TestClientLoginToControllerNoAccessToControllerModel(c *g
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -19,6 +19,7 @@ import (
 	servertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/juju/testing"
@@ -59,6 +60,7 @@ func (s *auditConfigSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -151,6 +153,7 @@ func (s *auditConfigSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) 
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -201,6 +204,7 @@ func (s *auditConfigSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	internalpassword "github.com/juju/juju/internal/password"
@@ -42,6 +43,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 		DisplayName: "Bob Brown",
 		Password:    ptr(auth.NewPassword("password")),
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	user, err := userService.GetUser(context.Background(), userUUID)

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/apiserver/authentication"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/internal/password"
@@ -93,6 +94,7 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -115,6 +117,7 @@ func (s *userAuthenticatorSuite) TestDisabledUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -138,6 +141,7 @@ func (s *userAuthenticatorSuite) TestRemovedUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")
@@ -161,6 +165,7 @@ func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -181,6 +186,7 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 		Name:        "bob",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -216,6 +222,7 @@ func (s *userAuthenticatorSuite) TestInvalidMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -245,6 +252,7 @@ func (s *userAuthenticatorSuite) TestDisabledMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -276,6 +284,7 @@ func (s *userAuthenticatorSuite) TestRemovedMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
 	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -528,6 +529,7 @@ func (s *charmsSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/environs/config"
@@ -424,6 +425,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(userPassword)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -191,6 +191,7 @@ func (s *clientWatchSuite) TestClientWatchAllReadPermission(c *gc.C) {
 		DisplayName: "Fred Flintstone",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("ro-password")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -128,6 +128,7 @@ func (api *UserManagerAPI) addOneUser(ctx context.Context, arg params.AddUser) p
 		Name:        arg.Username,
 		DisplayName: arg.DisplayName,
 		CreatorUUID: api.apiUser.UUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	}
 	if arg.Password != "" {
 		pass := auth.NewPassword(arg.Password)

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -65,6 +65,7 @@ func (s *userManagerSuite) TestAddUser(c *gc.C) {
 		DisplayName: "Foo Bar",
 		Password:    &pass,
 		CreatorUUID: s.apiUser.UUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	}).Return(newUserUUID(c), nil, nil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
@@ -101,6 +102,7 @@ func (s *userManagerSuite) TestAddUserWithSecretKey(c *gc.C) {
 		Name:        "foobar",
 		DisplayName: "Foo Bar",
 		CreatorUUID: s.apiUser.UUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	}).Return(newUserUUID(c), []byte("secret-key"), nil)
 
 	args := params.AddUsers{

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -46,6 +46,7 @@ func (s *introspectionSuite) TestAccess(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -71,6 +72,7 @@ func (s *introspectionSuite) TestAccessDenied(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -21,6 +21,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -563,6 +564,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/websocket/websockettest"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -71,6 +72,7 @@ func (s *pubsubSuite) TestRejectsUserLogins(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/ratelimit_test.go
+++ b/apiserver/ratelimit_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/api"
 	corecontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -111,6 +112,7 @@ func (s *rateLimitSuite) infoForNewUser(c *gc.C, info *api.Info, name string) *a
 		Name:        userTag.Name(),
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/user/errors"
 	"github.com/juju/juju/domain/user/service"
@@ -53,6 +54,7 @@ func (s *registrationSuite) SetUpTest(c *gc.C) {
 	s.userUUID, _, err = s.userService.AddUser(context.Background(), service.AddUserArg{
 		Name:        "bob",
 		CreatorUUID: s.AdminUserUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/tools_integration_test.go
+++ b/apiserver/tools_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	apiauthentication "github.com/juju/juju/api/authentication"
 	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/internal/auth"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -133,6 +134,7 @@ func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostWithLocalLogin(c *gc.C) 
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -26,6 +26,7 @@ import (
 
 	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/user/service"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
@@ -347,6 +348,7 @@ func (s *toolsSuite) TestMigrateToolsForUser(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -8,15 +8,29 @@ import (
 	"github.com/juju/names/v5"
 )
 
+// AccessChange represents a change in access level.
 type AccessChange string
 
 const (
-	Grant  AccessChange = "grant"
+	// Grant represents a change in access level to grant.
+	Grant AccessChange = "grant"
+
+	// Revoke represents a change in access level to revoke.
 	Revoke AccessChange = "revoke"
 )
 
 // Access represents a level of access.
 type Access string
+
+// ModelAccess represents a level of access for a model.
+// TODO (stickupkid): Remove the alias and make a new type. Using types to
+// define the scope access permission will remove accidental usage.
+type ModelAccess = Access
+
+// ControllerAccess represents a level of access for a controller.
+// TODO (stickupkid): Remove the alias and make a new type. Using types to
+// define the scope access permission will remove accidental usage.
+type ControllerAccess = Access
 
 const (
 	// NoAccess allows a user no permissions at all.
@@ -26,30 +40,40 @@ const (
 
 	// ReadAccess allows a user to read information about a permission subject,
 	// without being able to make any changes.
-	ReadAccess Access = "read"
+	ReadAccess ModelAccess = "read"
 
 	// WriteAccess allows a user to make changes to a permission subject.
-	WriteAccess Access = "write"
+	WriteAccess ModelAccess = "write"
 
 	// ConsumeAccess allows a user to consume a permission subject.
-	ConsumeAccess Access = "consume"
+	ConsumeAccess ModelAccess = "consume"
 
 	// AdminAccess allows a user full control over the subject.
-	AdminAccess Access = "admin"
+	AdminAccess ModelAccess = "admin"
 
 	// Controller permissions
 
 	// LoginAccess allows a user to log-ing into the subject.
-	LoginAccess Access = "login"
+	LoginAccess ControllerAccess = "login"
 
 	// AddModelAccess allows user to add new models in subjects supporting it.
-	AddModelAccess Access = "add-model"
+	AddModelAccess ControllerAccess = "add-model"
 
 	// SuperuserAccess allows user unrestricted permissions in the subject.
-	SuperuserAccess Access = "superuser"
+	SuperuserAccess ControllerAccess = "superuser"
 )
 
-var AllAccessLevels = []Access{NoAccess, ReadAccess, WriteAccess, ConsumeAccess, AdminAccess, LoginAccess, AddModelAccess, SuperuserAccess}
+// AllAccessLevels is a list of all access levels.
+var AllAccessLevels = []Access{
+	NoAccess,
+	ReadAccess,
+	WriteAccess,
+	ConsumeAccess,
+	AdminAccess,
+	LoginAccess,
+	AddModelAccess,
+	SuperuserAccess,
+}
 
 // Validate returns error if the current is not a valid access level.
 func (a Access) Validate() error {

--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -22,45 +22,31 @@ const (
 // Access represents a level of access.
 type Access string
 
-// ModelAccess represents a level of access for a model.
-// TODO (stickupkid): Remove the alias and make a new type. Using types to
-// define the scope access permission will remove accidental usage.
-type ModelAccess = Access
-
-// ControllerAccess represents a level of access for a controller.
-// TODO (stickupkid): Remove the alias and make a new type. Using types to
-// define the scope access permission will remove accidental usage.
-type ControllerAccess = Access
-
 const (
 	// NoAccess allows a user no permissions at all.
 	NoAccess Access = ""
 
-	// Model Permissions
-
 	// ReadAccess allows a user to read information about a permission subject,
 	// without being able to make any changes.
-	ReadAccess ModelAccess = "read"
+	ReadAccess Access = "read"
 
 	// WriteAccess allows a user to make changes to a permission subject.
-	WriteAccess ModelAccess = "write"
+	WriteAccess Access = "write"
 
 	// ConsumeAccess allows a user to consume a permission subject.
-	ConsumeAccess ModelAccess = "consume"
+	ConsumeAccess Access = "consume"
 
 	// AdminAccess allows a user full control over the subject.
-	AdminAccess ModelAccess = "admin"
-
-	// Controller permissions
+	AdminAccess Access = "admin"
 
 	// LoginAccess allows a user to log-ing into the subject.
-	LoginAccess ControllerAccess = "login"
+	LoginAccess Access = "login"
 
 	// AddModelAccess allows user to add new models in subjects supporting it.
-	AddModelAccess ControllerAccess = "add-model"
+	AddModelAccess Access = "add-model"
 
 	// SuperuserAccess allows user unrestricted permissions in the subject.
-	SuperuserAccess ControllerAccess = "superuser"
+	SuperuserAccess Access = "superuser"
 )
 
 // AllAccessLevels is a list of all access levels.

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package permission
+
+import "fmt"
+
+// UserPermissionAccess represents the access a user has to a permission.
+type UserPermissionAccess struct {
+	// Access is the level of access the user has to the permission.
+	Access Access
+	// ID represents the unique identifier for the permission.
+	// This is used to identify the permission in the system.
+	ID ID
+}
+
+// Validate returns an error if the UserPermissionAccess is invalid.
+func (a UserPermissionAccess) Validate() error {
+	if err := a.Access.Validate(); err != nil {
+		return fmt.Errorf("invalid access: %w", err)
+	}
+	if err := a.ID.Validate(); err != nil {
+		return fmt.Errorf("invalid id: %w", err)
+	}
+	return nil
+}

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -3,24 +3,46 @@
 
 package permission
 
-import "fmt"
+import (
+	"github.com/juju/errors"
+)
 
-// UserPermissionAccess represents the access a user has to a permission.
-type UserPermissionAccess struct {
-	// Access is the level of access the user has to the permission.
+type AccessSpec struct {
+	Target ID
 	Access Access
-	// ID represents the unique identifier for the permission.
-	// This is used to identify the permission in the system.
-	ID ID
 }
 
-// Validate returns an error if the UserPermissionAccess is invalid.
-func (a UserPermissionAccess) Validate() error {
-	if err := a.Access.Validate(); err != nil {
-		return fmt.Errorf("invalid access: %w", err)
+// Validate validates that the access and target specified in the
+// spec are values allowed together and that the User is not an
+// empty string. If any of these are untrue, a NotValid error is
+// returned.
+func (u AccessSpec) Validate() error {
+	if err := u.Target.Validate(); err != nil {
+		return err
 	}
-	if err := a.ID.Validate(); err != nil {
-		return fmt.Errorf("invalid id: %w", err)
+	if err := u.Target.ValidateAccess(u.Access); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UserAccessSpec defines the attributes that can be set when adding a new
+// user access.
+type UserAccessSpec struct {
+	AccessSpec
+	User string
+}
+
+// Validate validates that the access and target specified in the
+// spec are values allowed together and that the User is not an
+// empty string. If any of these are untrue, a NotValid error is
+// returned.
+func (u UserAccessSpec) Validate() error {
+	if u.User == "" {
+		return errors.NotValidf("empty user")
+	}
+	if err := u.AccessSpec.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -5,8 +5,11 @@ package permission
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/database"
 )
 
+// AccessSpec defines the attributes that can be set when adding a new
+// access.
 type AccessSpec struct {
 	Target ID
 	Access Access
@@ -45,4 +48,16 @@ func (u UserAccessSpec) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// ControllerForAccess is the access spec for the controller
+// login access.
+func ControllerForAccess(access Access) AccessSpec {
+	return AccessSpec{
+		Access: access,
+		Target: ID{
+			ObjectType: Controller,
+			Key:        database.ControllerNS,
+		},
+	}
 }

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -5,7 +5,6 @@ package permission
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/database"
 )
 
 // AccessSpec defines the attributes that can be set when adding a new
@@ -57,7 +56,12 @@ func ControllerForAccess(access Access) AccessSpec {
 		Access: access,
 		Target: ID{
 			ObjectType: Controller,
-			Key:        database.ControllerNS,
+			// This should be controllerNS from the core/database package, but
+			// using that import will cause the whole of the core/database
+			// package into the api client package.
+			// For now I've created a test to ensure that the value is correct.
+			// TODO (stickupkid): Move controllerNS to a namespace package.
+			Key: "controller",
 		},
 	}
 }

--- a/core/permission/user_test.go
+++ b/core/permission/user_test.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package permission_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/permission"
+)
+
+type userSuite struct{}
+
+var _ = gc.Suite(&userSuite{})
+
+func (s *userSuite) TestControllerForAccess(c *gc.C) {
+	spec := permission.ControllerForAccess(permission.ReadAccess)
+	c.Assert(spec.Target.Key, gc.Equals, database.ControllerNS)
+}

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -580,7 +581,13 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -664,7 +671,13 @@ func (s *stateSuite) TestDeleteCloudInUse(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -581,13 +580,7 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -671,13 +664,7 @@ func (s *stateSuite) TestDeleteCloudInUse(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -581,9 +581,9 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},
@@ -671,9 +671,9 @@ func (s *stateSuite) TestDeleteCloudInUse(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
@@ -579,6 +580,7 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -662,6 +664,7 @@ func (s *stateSuite) TestDeleteCloudInUse(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		"test user",
 		userUUID,
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -40,9 +40,9 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -38,6 +39,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
@@ -40,13 +39,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
@@ -39,7 +40,13 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -64,7 +65,13 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return userUUID

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
@@ -63,6 +64,7 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return userUUID

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -65,13 +64,7 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return userUUID

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -65,9 +65,9 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -37,9 +37,9 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.UserPermissionAccess{
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.AccessSpec{
 		Access: permission.SuperuserAccess,
-		ID: permission.ID{
+		Target: permission.ID{
 			ObjectType: permission.Controller,
 			Key:        database.ControllerNS,
 		},

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	credentialbootstrap "github.com/juju/juju/domain/credential/bootstrap"
@@ -35,7 +36,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName)
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.SuperuserAccess)
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -36,7 +37,13 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.SuperuserAccess)
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.UserPermissionAccess{
+		Access: permission.SuperuserAccess,
+		ID: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        database.ControllerNS,
+		},
+	})
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -37,13 +36,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.AccessSpec{
-		Access: permission.SuperuserAccess,
-		Target: permission.ID{
-			ObjectType: permission.Controller,
-			Key:        database.ControllerNS,
-		},
-	})
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess))
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -56,9 +56,9 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -16,6 +16,7 @@ import (
 	corecredential "github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	dbcloud "github.com/juju/juju/domain/cloud/state"
 	"github.com/juju/juju/domain/credential"
@@ -54,6 +55,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -55,7 +56,13 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -56,13 +55,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	cloudstate "github.com/juju/juju/domain/cloud/state"
 	"github.com/juju/juju/domain/credential"
@@ -40,6 +41,7 @@ func CreateTestModel(
 		"test-user",
 		"test-user",
 		userUUID,
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/permission/errors/errors.go
+++ b/domain/permission/errors/errors.go
@@ -9,4 +9,12 @@ const (
 	// AlreadyExists describes an error that occurs when the user being
 	// created already exists.
 	AlreadyExists = errors.ConstError("permission already exists")
+
+	// TargetInvalid describes an error that occurs when the target of the
+	// permission is invalid.
+	TargetInvalid = errors.ConstError("permission target invalid")
+
+	// TargetAlreadyExists describes an error that occurs when the target of
+	// the permission already exists.
+	TargetAlreadyExists = errors.ConstError("permission target already exists")
 )

--- a/domain/permission/service/service.go
+++ b/domain/permission/service/service.go
@@ -19,7 +19,7 @@ type State interface {
 	// CreatePermission gives the user access per the provided spec.
 	// It requires the user/target combination has not already been
 	// created.
-	CreatePermission(ctx context.Context, uuid uuid.UUID, spec permission.UserAccessSpec) (corepermission.UserAccess, error)
+	CreatePermission(ctx context.Context, uuid uuid.UUID, spec corepermission.UserAccessSpec) (corepermission.UserAccess, error)
 
 	// DeletePermission removes the given subject's (user) access to the
 	// given target.
@@ -68,7 +68,7 @@ func NewService(st State) *Service {
 
 // CreatePermission gives the user access per the provided spec. All errors
 // are passed through from the spec validation and state layer.
-func (s *Service) CreatePermission(ctx context.Context, spec permission.UserAccessSpec) (corepermission.UserAccess, error) {
+func (s *Service) CreatePermission(ctx context.Context, spec corepermission.UserAccessSpec) (corepermission.UserAccess, error) {
 	if err := spec.Validate(); err != nil {
 		return corepermission.UserAccess{}, errors.Trace(err)
 	}

--- a/domain/permission/service/service_test.go
+++ b/domain/permission/service/service_test.go
@@ -33,15 +33,17 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *serviceSuite) TestCreatePermission(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.state.EXPECT().CreatePermission(gomock.Any(), gomock.AssignableToTypeOf(uuid.UUID{}), gomock.AssignableToTypeOf(permission.UserAccessSpec{})).Return(corepermission.UserAccess{}, nil)
+	s.state.EXPECT().CreatePermission(gomock.Any(), gomock.AssignableToTypeOf(uuid.UUID{}), gomock.AssignableToTypeOf(corepermission.UserAccessSpec{})).Return(corepermission.UserAccess{}, nil)
 
-	spec := permission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "testme",
-		Target: corepermission.ID{
-			ObjectType: corepermission.Cloud,
-			Key:        "aws",
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				ObjectType: corepermission.Cloud,
+				Key:        "aws",
+			},
+			Access: corepermission.AddModelAccess,
 		},
-		Access: corepermission.AddModelAccess,
 	}
 	_, err := NewService(s.state).CreatePermission(context.Background(), spec)
 	c.Assert(err, jc.ErrorIsNil)
@@ -50,13 +52,15 @@ func (s *serviceSuite) TestCreatePermission(c *gc.C) {
 func (s *serviceSuite) TestCreatePermissionError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	spec := permission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "testme",
-		Target: corepermission.ID{
-			ObjectType: corepermission.Cloud,
-			Key:        "aws",
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				ObjectType: corepermission.Cloud,
+				Key:        "aws",
+			},
+			Access: corepermission.ReadAccess,
 		},
-		Access: corepermission.ReadAccess,
 	}
 	_, err := NewService(s.state).CreatePermission(context.Background(), spec)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)

--- a/domain/permission/service/state_mock_test.go
+++ b/domain/permission/service/state_mock_test.go
@@ -43,7 +43,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // CreatePermission mocks base method.
-func (m *MockState) CreatePermission(arg0 context.Context, arg1 uuid.UUID, arg2 permission0.UserAccessSpec) (permission.UserAccess, error) {
+func (m *MockState) CreatePermission(arg0 context.Context, arg1 uuid.UUID, arg2 permission.UserAccessSpec) (permission.UserAccess, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(permission.UserAccess)

--- a/domain/permission/state/state.go
+++ b/domain/permission/state/state.go
@@ -105,7 +105,7 @@ func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissio
 	// * spec.Target.Key as grant_on
 	newPermission := `
 INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
-VALUES ($Permission.uuid, $Permission.permission_type_id, $Permission.grant_on, $Permission.grant_to)
+VALUES ($addUserPermission.uuid, $addUserPermission.permission_type_id, $addUserPermission.grant_on, $addUserPermission.grant_to)
 `
 	insertPermissionStmt, err := sqlair.Prepare(newPermission, addUserPermission{})
 	if err != nil {

--- a/domain/permission/state/state.go
+++ b/domain/permission/state/state.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/domain/permission"
 	permissionerrors "github.com/juju/juju/domain/permission/errors"
 	usererrors "github.com/juju/juju/domain/user/errors"
-	databaseutils "github.com/juju/juju/internal/database"
+	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -57,49 +57,24 @@ func (s *State) CreatePermission(ctx context.Context, newPermissionUUID uuid.UUI
 		return userAccess, errors.Trace(err)
 	}
 
-	// Insert a permission doc with
-	// * permissionObjectAccess as permission_type_id
-	// * uuid of the user (spec.User) as grant_to
-	// * spec.Target.Key as grant_on
-	newPermission := `
-INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
-VALUES ($M.uuid, $M.access_type_id, $M.grant_on, $M.grant_to)
-`
-	insertPermissionStmt, err := sqlair.Prepare(newPermission, sqlair.M{})
-	if err != nil {
-		return userAccess, errors.Trace(err)
-	}
-
-	m := make(sqlair.M, 2)
-	m["grant_on"] = spec.Target.Key
-	m["uuid"] = newPermissionUUID.String()
-
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		user, err := findUser(ctx, tx, spec.User)
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		if err := AddUserPermission(ctx, tx, AddUserPermissionArgs{
+			PermissionUUID: newPermissionUUID.String(),
+			UserUUID:       user.UUID,
+			User:           spec.User,
+			Access:         spec.Access,
+			Target:         spec.Target,
+		}); err != nil {
+			return errors.Trace(err)
+		}
+
 		userAccess = user.toCoreUserAccess()
-		m["grant_to"] = user.UUID
 
-		accessTypeID, err := s.objectAccessID(ctx, tx, spec.Access, spec.Target.ObjectType)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		m["access_type_id"] = accessTypeID
-
-		if err = s.validateTargetExists(ctx, tx, spec.Target.Key); err != nil {
-			return errors.Trace(err)
-		}
-
-		// No IsErrConstraintForeignKey should be seen as both foreign keys
-		// have been checked.
-		err = tx.Query(ctx, insertPermissionStmt, m).Run()
-		if databaseutils.IsErrConstraintUnique(err) {
-			return errors.Annotatef(permissionerrors.AlreadyExists, "%q on %q", spec.User, spec.Target.Key)
-		} else if err != nil {
-			return errors.Annotatef(err, "adding permission %q for %q on %q", spec.Access, spec.User, spec.Target.Key)
-		}
 		return nil
 	})
 	if err != nil {
@@ -110,6 +85,141 @@ VALUES ($M.uuid, $M.access_type_id, $M.grant_on, $M.grant_to)
 	userAccess.PermissionID = newPermissionUUID.String()
 	userAccess.Object = objectTag(spec.Target)
 	return userAccess, nil
+}
+
+// AddUserPermissionArgs is a specification for adding a user permission.
+type AddUserPermissionArgs struct {
+	PermissionUUID string
+	UserUUID       string
+	User           string
+	Access         corepermission.Access
+	Target         corepermission.ID
+}
+
+// AddUserPermission adds a permission for the given user on the given target.
+func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissionArgs) error {
+	// Insert a permission doc with
+	// * permissionObjectAccess as permission_type_id
+	// * uuid of the user (spec.User) as grant_to
+	// * spec.Target.Key as grant_on
+	newPermission := `
+INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
+VALUES ($Permission.uuid, $Permission.permission_type_id, $Permission.grant_on, $Permission.grant_to)
+`
+	insertPermissionStmt, err := sqlair.Prepare(newPermission, Permission{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	perm := Permission{
+		UUID:    spec.PermissionUUID,
+		GrantOn: spec.Target.Key,
+		GrantTo: spec.UserUUID,
+	}
+
+	accessTypeID, err := objectAccessID(ctx, tx, spec.Access, spec.Target.ObjectType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	perm.PermissionType = accessTypeID
+
+	if err = validateTargetExists(ctx, tx, spec.Target.Key); err != nil {
+		return errors.Trace(err)
+	}
+
+	// No IsErrConstraintForeignKey should be seen as both foreign keys
+	// have been checked.
+	err = tx.Query(ctx, insertPermissionStmt, perm).Run()
+	if internaldatabase.IsErrConstraintUnique(err) {
+		return errors.Annotatef(permissionerrors.AlreadyExists, "%q on %q", spec.User, spec.Target.Key)
+	} else if err != nil {
+		return errors.Annotatef(err, "adding permission %q for %q on %q", spec.Access, spec.User, spec.Target.Key)
+	}
+
+	return nil
+}
+
+// DeletePermission removes the given subject's (user) access to the
+// given target.
+// If the specified subject does not exist, a usererrors.NotFound is
+// returned.
+// If the permission does not exist, no error is returned.
+func (s *State) DeletePermission(ctx context.Context, subject string, target corepermission.ID) error {
+	// TODO: is target.Key sufficient to Delete a permission?
+	db, err := s.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	m := make(sqlair.M, 1)
+	m["grant_on"] = target.Key
+
+	// The combination of grant_to and grant_on are guaranteed to be
+	// unique, thus it is all that is deleted to select the row to be
+	// deleted.
+	deletePermission := `
+DELETE 
+FROM permission 
+WHERE grant_to = $M.grant_to AND grant_on = $M.grant_on
+`
+	deletePermissionStmt, err := sqlair.Prepare(deletePermission, m)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		userUUID, err := userUUIDForName(ctx, tx, subject)
+		if err != nil {
+			return errors.Annotatef(usererrors.NotFound, "looking up UUID for user %q", subject)
+		}
+		m["grant_to"] = userUUID
+
+		err = tx.Query(ctx, deletePermissionStmt, m).Run()
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Annotatef(err, "deleting permission of %q on %q", subject, target.Key)
+		}
+		return nil
+	})
+	return errors.Trace(domain.CoerceError(err))
+}
+
+// UpsertPermission updates the permission on the target for the given
+// subject (user). The api user must have Admin permission on the target. If a
+// subject does not exist, it is created using the subject and api user. Access
+// can be granted or revoked.
+func (s *State) UpsertPermission(ctx context.Context, args permission.UpsertPermissionArgs) error {
+	return errors.NotImplementedf("UpsertPermission")
+}
+
+// ReadUserAccessForTarget returns the subject's (user) access for the
+// given user on the given target.
+func (s *State) ReadUserAccessForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.UserAccess, error) {
+	return corepermission.UserAccess{}, errors.NotImplementedf("ReadUserAccessForTarget")
+}
+
+// ReadUserAccessLevelForTarget returns the subject's (user) access level
+// for the given user on the given target.
+func (s *State) ReadUserAccessLevelForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.Access, error) {
+	return corepermission.NoAccess, errors.NotImplementedf("ReadUserAccessLevelForTarget")
+}
+
+// ReadAllUserAccessForUser returns a slice of the user access the given
+// subject's (user) has for any access type.
+func (s *State) ReadAllUserAccessForUser(ctx context.Context, subject string) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllUserAccessForUser")
+}
+
+// ReadAllUserAccessForTarget return a slice of user access for all users
+// with access to the given target.
+func (s *State) ReadAllUserAccessForTarget(ctx context.Context, target corepermission.ID) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllUserAccessForTarget")
+}
+
+// ReadAllAccessTypeForUser return a slice of user access for the subject
+// (user) specified and of the given access type.
+// E.G. All clouds the user has access to.
+func (s *State) ReadAllAccessTypeForUser(ctx context.Context, subject string, access_type corepermission.ObjectType) ([]corepermission.UserAccess, error) {
+	return nil, errors.NotImplementedf("ReadAllAccessTypeForUser")
 }
 
 // findUser finds the user provided exists, hasn't been removed and is not
@@ -146,11 +256,73 @@ WHERE  u.removed = false AND u.name = $M.name`
 	return result, nil
 }
 
+// userUUIDForName returns the user UUID for the associated name
+// if the user is active.
+// Method borrowed from the user domain state.
+func userUUIDForName(
+	ctx context.Context, tx *sqlair.TX, name string,
+) (string, error) {
+	stmt, err := sqlair.Prepare(
+		`SELECT &M.uuid FROM user WHERE name = $M.name`, sqlair.M{})
+
+	if err != nil {
+		return "", errors.Annotate(err, "preparing user UUID statement")
+	}
+
+	var inOut = sqlair.M{"name": name}
+	err = tx.Query(ctx, stmt, inOut).Get(&inOut)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", errors.Annotatef(usererrors.NotFound, "active user %q", name)
+		}
+		return "", errors.Annotatef(err, "getting user %q", name)
+	}
+
+	uuid, _ := inOut["uuid"].(string)
+	return uuid, nil
+}
+
+func objectAccessID(
+	ctx context.Context,
+	tx *sqlair.TX,
+	access corepermission.Access,
+	objectType corepermission.ObjectType,
+) (int64, error) {
+	// id of spec.Access from permission_access_type as access_type_id
+	// id of spec.Target.ObjectType from permission_object_type as object_type_id
+	// Use access_type_id and object_type_id to validate row from permission_object_access
+	objectAccessIDExists := `
+SELECT permission_access_type.id AS &M.access_type_id
+FROM permission_object_access
+LEFT JOIN permission_object_type
+	ON permission_object_type.type = $M.object_type
+LEFT JOIN permission_access_type
+	ON permission_access_type.type = $M.access_type
+WHERE permission_object_access.access_type_id = permission_access_type.id
+	AND permission_object_access.object_type_id = permission_object_type.id
+`
+
+	// Validate the access type is allowed for the target type.
+	objectAccessIDStmt, err := sqlair.Prepare(objectAccessIDExists, sqlair.M{})
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	var resultM = sqlair.M{}
+	err = tx.Query(ctx, objectAccessIDStmt, sqlair.M{"access_type": access, "object_type": objectType}).Get(&resultM)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return -1, errors.Annotatef(err, "mismatch in %q, %q", access, objectType)
+	} else if err != nil {
+		return -1, errors.Annotatef(err, "getting id for pair %q, %q", access, objectType)
+	}
+	return resultM["access_type_id"].(int64), nil
+}
+
 // validateTargetExists validates that the target of the permission
 // exists. An error is returned if not. Unless we have a controller
 // target, search for grant_on as a cloud.name and a model_list.uuid.
 // It must be one of those.
-func (s *State) validateTargetExists(
+func validateTargetExists(
 	ctx context.Context,
 	tx *sqlair.TX,
 	targetKey string,
@@ -210,149 +382,4 @@ func objectTag(id corepermission.ID) (result names.Tag) {
 		result = names.NewApplicationOfferTag(id.Key)
 	}
 	return
-}
-
-func (s *State) objectAccessID(
-	ctx context.Context,
-	tx *sqlair.TX,
-	access corepermission.Access,
-	objectType corepermission.ObjectType,
-) (int64, error) {
-	// id of spec.Access from permission_access_type as access_type_id
-	// id of spec.Target.ObjectType from permission_object_type as object_type_id
-	// Use access_type_id and object_type_id to validate row from permission_object_access
-	objectAccessIDExists := `
-SELECT permission_access_type.id AS &M.access_type_id
-FROM permission_object_access
-LEFT JOIN permission_object_type
-	ON permission_object_type.type = $M.object_type
-LEFT JOIN permission_access_type
-	ON permission_access_type.type = $M.access_type
-WHERE permission_object_access.access_type_id = permission_access_type.id
-	AND permission_object_access.object_type_id = permission_object_type.id
-`
-
-	// Validate the access type is allowed for the target type.
-	objectAccessIDStmt, err := sqlair.Prepare(objectAccessIDExists, sqlair.M{})
-	if err != nil {
-		return -1, errors.Trace(err)
-	}
-
-	var resultM = sqlair.M{}
-	err = tx.Query(ctx, objectAccessIDStmt, sqlair.M{"access_type": access, "object_type": objectType}).Get(&resultM)
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
-		return -1, errors.Annotatef(err, "mismatch in %q, %q", access, objectType)
-	} else if err != nil {
-		return -1, errors.Annotatef(err, "getting id for pair %q, %q", access, objectType)
-	}
-	return resultM["access_type_id"].(int64), nil
-}
-
-// DeletePermission removes the given subject's (user) access to the
-// given target.
-// If the specified subject does not exist, a usererrors.NotFound is
-// returned.
-// If the permission does not exist, no error is returned.
-func (s *State) DeletePermission(ctx context.Context, subject string, target corepermission.ID) error {
-	// TODO: is target.Key sufficient to Delete a permission?
-	db, err := s.DB()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	m := make(sqlair.M, 1)
-	m["grant_on"] = target.Key
-
-	// The combination of grant_to and grant_on are guaranteed to be
-	// unique, thus it is all that is deleted to select the row to be
-	// deleted.
-	deletePermission := `
-DELETE 
-FROM permission 
-WHERE grant_to = $M.grant_to AND grant_on = $M.grant_on
-`
-	deletePermissionStmt, err := sqlair.Prepare(deletePermission, m)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		userUUID, err := s.userUUIDForName(ctx, tx, subject)
-		if err != nil {
-			return errors.Annotatef(usererrors.NotFound, "looking up UUID for user %q", subject)
-		}
-		m["grant_to"] = userUUID
-
-		err = tx.Query(ctx, deletePermissionStmt, m).Run()
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "deleting permission of %q on %q", subject, target.Key)
-		}
-		return nil
-	})
-	return errors.Trace(domain.CoerceError(err))
-}
-
-// userUUIDForName returns the user UUID for the associated name
-// if the user is active.
-// Method borrowed from the user domain state.
-func (s *State) userUUIDForName(
-	ctx context.Context, tx *sqlair.TX, name string,
-) (string, error) {
-	stmt, err := sqlair.Prepare(
-		`SELECT &M.uuid FROM user WHERE name = $M.name`, sqlair.M{})
-
-	if err != nil {
-		return "", errors.Annotate(err, "preparing user UUID statement")
-	}
-
-	var inOut = sqlair.M{"name": name}
-	err = tx.Query(ctx, stmt, inOut).Get(&inOut)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return "", errors.Annotatef(usererrors.NotFound, "active user %q", name)
-		}
-		return "", errors.Annotatef(err, "getting user %q", name)
-	}
-
-	uuid, _ := inOut["uuid"].(string)
-	return uuid, nil
-}
-
-// UpsertPermission updates the permission on the target for the given
-// subject (user). The api user must have Admin permission on the target. If a
-// subject does not exist, it is created using the subject and api user. Access
-// can be granted or revoked.
-func (s *State) UpsertPermission(ctx context.Context, args permission.UpsertPermissionArgs) error {
-	return errors.NotImplementedf("UpsertPermission")
-}
-
-// ReadUserAccessForTarget returns the subject's (user) access for the
-// given user on the given target.
-func (s *State) ReadUserAccessForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.UserAccess, error) {
-	return corepermission.UserAccess{}, errors.NotImplementedf("ReadUserAccessForTarget")
-}
-
-// ReadUserAccessLevelForTarget returns the subject's (user) access level
-// for the given user on the given target.
-func (s *State) ReadUserAccessLevelForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.Access, error) {
-	return corepermission.NoAccess, errors.NotImplementedf("ReadUserAccessLevelForTarget")
-}
-
-// ReadAllUserAccessForUser returns a slice of the user access the given
-// subject's (user) has for any access type.
-func (s *State) ReadAllUserAccessForUser(ctx context.Context, subject string) ([]corepermission.UserAccess, error) {
-	return nil, errors.NotImplementedf("ReadAllUserAccessForUser")
-}
-
-// ReadAllUserAccessForTarget return a slice of user access for all users
-// with access to the given target.
-func (s *State) ReadAllUserAccessForTarget(ctx context.Context, target corepermission.ID) ([]corepermission.UserAccess, error) {
-	return nil, errors.NotImplementedf("ReadAllUserAccessForTarget")
-}
-
-// ReadAllAccessTypeForUser return a slice of user access for the subject
-// (user) specified and of the given access type.
-// E.G. All clouds the user has access to.
-func (s *State) ReadAllAccessTypeForUser(ctx context.Context, subject string, access_type corepermission.ObjectType) ([]corepermission.UserAccess, error) {
-	return nil, errors.NotImplementedf("ReadAllAccessTypeForUser")
 }

--- a/domain/permission/state/state.go
+++ b/domain/permission/state/state.go
@@ -6,6 +6,7 @@ package state
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
@@ -364,9 +365,9 @@ SELECT &M.found_it FROM (
 	// Any answer other than 1 is an error. The targetKey should exist
 	// as a unique identifier across the controller namespace.
 	if len(foundIt) == 0 {
-		return errors.Annotatef(err, "permission target %q does not exist", targetKey)
+		return fmt.Errorf("%q %w", targetKey, permissionerrors.TargetInvalid)
 	}
-	return errors.Annotatef(err, "permission target %q is not unique", targetKey)
+	return fmt.Errorf("%q %w", targetKey, permissionerrors.TargetAlreadyExists)
 }
 
 func objectTag(id corepermission.ID) (result names.Tag) {

--- a/domain/permission/state/state_test.go
+++ b/domain/permission/state/state_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corepermission "github.com/juju/juju/core/permission"
-	"github.com/juju/juju/domain/permission"
 	permissionerrors "github.com/juju/juju/domain/permission/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	usererrors "github.com/juju/juju/domain/user/errors"
@@ -36,13 +35,15 @@ func (s *stateSuite) TestCreatePermissionModel(c *gc.C) {
 	s.ensureUser(c, "123", "bob", "42")
 	s.ensureCloud(c, "test-cloud")
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "model-uuid",
-			ObjectType: corepermission.Model,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "model-uuid",
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.WriteAccess,
 		},
-		Access: corepermission.WriteAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -66,13 +67,15 @@ func (s *stateSuite) TestCreatePermissionCloud(c *gc.C) {
 	s.ensureUser(c, "123", "bob", "42")
 	s.ensureCloud(c, "test-cloud")
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "test-cloud",
-			ObjectType: corepermission.Cloud,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "test-cloud",
+				ObjectType: corepermission.Cloud,
+			},
+			Access: corepermission.AddModelAccess,
 		},
-		Access: corepermission.AddModelAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -94,13 +97,15 @@ func (s *stateSuite) TestCreatePermissionController(c *gc.C) {
 	s.ensureUser(c, "42", "admin", "42") // model owner
 	s.ensureUser(c, "123", "bob", "42")
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "controller",
-			ObjectType: corepermission.Controller,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "controller",
+				ObjectType: corepermission.Controller,
+			},
+			Access: corepermission.SuperuserAccess,
 		},
-		Access: corepermission.SuperuserAccess,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -122,13 +127,15 @@ func (s *stateSuite) TestCreatePermissionForModelWithBadInfo(c *gc.C) {
 	s.ensureUser(c, "42", "admin", "42") // model owner
 	s.ensureUser(c, "123", "bob", "42")
 
-	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "foo-bar",
-			ObjectType: corepermission.Model,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "foo-bar",
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.ReadAccess,
 		},
-		Access: corepermission.ReadAccess,
 	})
 	c.Assert(err, jc.ErrorIs, permissionerrors.TargetInvalid)
 }
@@ -140,13 +147,15 @@ func (s *stateSuite) TestCreatePermissionForControllerWithBadInfo(c *gc.C) {
 	s.ensureUser(c, "42", "admin", "42") // model owner
 	s.ensureUser(c, "123", "bob", "42")
 
-	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "foo-bar",
-			ObjectType: corepermission.Controller,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "foo-bar",
+				ObjectType: corepermission.Controller,
+			},
+			Access: corepermission.SuperuserAccess,
 		},
-		Access: corepermission.SuperuserAccess,
 	})
 	c.Assert(err, jc.ErrorIs, permissionerrors.TargetInvalid)
 }
@@ -186,13 +195,15 @@ FROM permission
 
 func (s *stateSuite) TestCreatePermissionErrorNoUser(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), permission.UserAccessSpec{
+	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "model-uuid",
-			ObjectType: corepermission.Model,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "model-uuid",
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.WriteAccess,
 		},
-		Access: corepermission.WriteAccess,
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.NotFound)
 }
@@ -205,13 +216,15 @@ func (s *stateSuite) TestCreatePermissionErrorDuplicate(c *gc.C) {
 	s.ensureUser(c, "42", "admin", "42") // model owner
 	s.ensureUser(c, "123", "bob", "42")
 
-	spec := permission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "bob",
-		Target: corepermission.ID{
-			Key:        "model-uuid",
-			ObjectType: corepermission.Model,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "model-uuid",
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.ReadAccess,
 		},
-		Access: corepermission.ReadAccess,
 	}
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIsNil)
@@ -259,10 +272,12 @@ func (s *stateSuite) TestDeletePermission(c *gc.C) {
 		Key:        "model-uuid",
 		ObjectType: corepermission.Model,
 	}
-	spec := permission.UserAccessSpec{
-		User:   "bob",
-		Target: target,
-		Access: corepermission.ReadAccess,
+	spec := corepermission.UserAccessSpec{
+		User: "bob",
+		AccessSpec: corepermission.AccessSpec{
+			Target: target,
+			Access: corepermission.ReadAccess,
+		},
 	}
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/permission/state/types.go
+++ b/domain/permission/state/types.go
@@ -45,9 +45,9 @@ func (u User) toCoreUserAccess() permission.UserAccess {
 	}
 }
 
-// Permission represents a permission in the system where the values overlap
-// with corepermission.Permission.
-type Permission struct {
+// addUserPermission represents a permission in the system where the values
+// overlap with corepermission.Permission.
+type addUserPermission struct {
 	// UUID is the unique identifier for the permission.
 	UUID string `db:"uuid"`
 

--- a/domain/permission/state/types.go
+++ b/domain/permission/state/types.go
@@ -44,3 +44,19 @@ func (u User) toCoreUserAccess() permission.UserAccess {
 		DateCreated: u.CreatedAt,
 	}
 }
+
+// Permission represents a permission in the system where the values overlap
+// with corepermission.Permission.
+type Permission struct {
+	// UUID is the unique identifier for the permission.
+	UUID string `db:"uuid"`
+
+	// PermissionType is the type of permission.
+	PermissionType int64 `db:"permission_type_id"`
+
+	// GrantOn is the tag that the permission is granted on.
+	GrantOn string `db:"grant_on"`
+
+	// GrantTo is the tag that the permission is granted to.
+	GrantTo string `db:"grant_to"`
+}

--- a/domain/permission/types.go
+++ b/domain/permission/types.go
@@ -43,28 +43,3 @@ func (args UpsertPermissionArgs) Validate() error {
 	}
 	return nil
 }
-
-// UserAccessSpec defines the attributes that can be set when adding a new
-// user access.
-type UserAccessSpec struct {
-	User   string
-	Target permission.ID
-	Access permission.Access
-}
-
-// Validate validates that the access and target specified in the
-// spec are values allowed together and that the User is not an
-// empty string. If any of these are untrue, a NotValid error is
-// returned.
-func (u UserAccessSpec) Validate() error {
-	if u.User == "" {
-		return errors.NotValidf("empty user")
-	}
-	if err := u.Target.Validate(); err != nil {
-		return err
-	}
-	if err := u.Target.ValidateAccess(u.Access); err != nil {
-		return err
-	}
-	return nil
-}

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	coresecrets "github.com/juju/juju/core/secrets"
@@ -57,13 +56,7 @@ func (s *stateSuite) createModel(c *gc.C) coremodel.UUID {
 		userUUID,
 		// TODO (stickupkid): This should be AdminAccess, but we don't have
 		// a model to set the user as the owner of.
-		permission.AccessSpec{
-			Access: permission.SuperuserAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -57,9 +57,9 @@ func (s *stateSuite) createModel(c *gc.C) coremodel.UUID {
 		userUUID,
 		// TODO (stickupkid): This should be AdminAccess, but we don't have
 		// a model to set the user as the owner of.
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.SuperuserAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/permission"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain"
@@ -53,6 +54,9 @@ func (s *stateSuite) createModel(c *gc.C) coremodel.UUID {
 		userName,
 		userName,
 		userUUID,
+		// TODO (stickupkid): This should be AdminAccess, but we don't have
+		// a model to set the user as the owner of.
+		permission.SuperuserAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	coresecrets "github.com/juju/juju/core/secrets"
@@ -56,7 +57,13 @@ func (s *stateSuite) createModel(c *gc.C) coremodel.UUID {
 		userUUID,
 		// TODO (stickupkid): This should be AdminAccess, but we don't have
 		// a model to set the user as the owner of.
-		permission.SuperuserAccess,
+		permission.UserPermissionAccess{
+			Access: permission.SuperuserAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	cloudstate "github.com/juju/juju/domain/cloud/state"
@@ -76,7 +77,7 @@ func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory
 
 func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 	password := auth.NewPassword("dummy-secret")
-	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password)
+	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.SuperuserAccess)
 	s.AdminUserUUID = uuid
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -78,9 +78,9 @@ func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory
 
 func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 	password := auth.NewPassword("dummy-secret")
-	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.UserPermissionAccess{
+	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.AccessSpec{
 		Access: permission.SuperuserAccess,
-		ID: permission.ID{
+		Target: permission.ID{
 			ObjectType: permission.Controller,
 			Key:        database.ControllerNS,
 		},

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -77,7 +78,13 @@ func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory
 
 func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 	password := auth.NewPassword("dummy-secret")
-	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.SuperuserAccess)
+	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.UserPermissionAccess{
+		Access: permission.SuperuserAccess,
+		ID: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        database.ControllerNS,
+		},
+	})
 	s.AdminUserUUID = uuid
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -78,13 +77,11 @@ func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory
 
 func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 	password := auth.NewPassword("dummy-secret")
-	uuid, fn := userbootstrap.AddUserWithPassword(coreuser.AdminUserName, password, permission.AccessSpec{
-		Access: permission.SuperuserAccess,
-		Target: permission.ID{
-			ObjectType: permission.Controller,
-			Key:        database.ControllerNS,
-		},
-	})
+	uuid, fn := userbootstrap.AddUserWithPassword(
+		coreuser.AdminUserName,
+		password,
+		permission.ControllerForAccess(permission.SuperuserAccess),
+	)
 	s.AdminUserUUID = uuid
 	err := fn(context.Background(), s.ControllerTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -26,7 +26,7 @@ import (
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUser(name string, access permission.UserPermissionAccess) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUser(name string, access permission.AccessSpec) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	if err := domainuser.ValidateUserName(name); err != nil {
 		return user.UUID(""), func(context.Context, database.TxnRunner) error {
 			return fmt.Errorf("validating bootstrap add user %q: %w", name, err)
@@ -58,7 +58,7 @@ func AddUser(name string, access permission.UserPermissionAccess) (user.UUID, fu
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUserWithPassword(name string, password auth.Password, access permission.UserPermissionAccess) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUserWithPassword(name string, password auth.Password, access permission.AccessSpec) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	defer password.Destroy()
 
 	if err := domainuser.ValidateUserName(name); err != nil {

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	domainuser "github.com/juju/juju/domain/user"
 	"github.com/juju/juju/domain/user/state"
@@ -25,7 +26,7 @@ import (
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUser(name string) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUser(name string, access permission.Access) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	if err := domainuser.ValidateUserName(name); err != nil {
 		return user.UUID(""), func(context.Context, database.TxnRunner) error {
 			return fmt.Errorf("validating bootstrap add user %q: %w", name, err)
@@ -41,7 +42,7 @@ func AddUser(name string) (user.UUID, func(context.Context, database.TxnRunner) 
 
 	return uuid, func(ctx context.Context, db database.TxnRunner) error {
 		err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			return state.AddUser(ctx, tx, uuid, name, "", uuid)
+			return state.AddUser(ctx, tx, uuid, name, "", uuid, access)
 		})
 
 		if err != nil {
@@ -57,7 +58,7 @@ func AddUser(name string) (user.UUID, func(context.Context, database.TxnRunner) 
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUserWithPassword(name string, password auth.Password) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUserWithPassword(name string, password auth.Password, access permission.Access) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	defer password.Destroy()
 
 	if err := domainuser.ValidateUserName(name); err != nil {
@@ -99,14 +100,12 @@ func AddUserWithPassword(name string, password auth.Password) (user.UUID, func(c
 	return uuid, func(ctx context.Context, db database.TxnRunner) error {
 		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err = state.AddUserWithPassword(
-				ctx,
-				tx,
+				ctx, tx,
 				uuid,
-				name,
-				name,
+				name, name,
 				uuid,
-				pwHash,
-				salt,
+				access,
+				pwHash, salt,
 			); err != nil {
 				return fmt.Errorf("adding bootstrap user %q with password: %w",
 					name, err,

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -26,7 +26,7 @@ import (
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUser(name string, access permission.Access) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUser(name string, access permission.UserPermissionAccess) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	if err := domainuser.ValidateUserName(name); err != nil {
 		return user.UUID(""), func(context.Context, database.TxnRunner) error {
 			return fmt.Errorf("validating bootstrap add user %q: %w", name, err)
@@ -58,7 +58,7 @@ func AddUser(name string, access permission.Access) (user.UUID, func(context.Con
 //
 // If the username passed to this function is invalid an error satisfying
 // [github.com/juju/juju/domain/user/errors.UsernameNotValid] is returned.
-func AddUserWithPassword(name string, password auth.Password, access permission.Access) (user.UUID, func(context.Context, database.TxnRunner) error) {
+func AddUserWithPassword(name string, password auth.Password, access permission.UserPermissionAccess) (user.UUID, func(context.Context, database.TxnRunner) error) {
 	defer password.Destroy()
 
 	if err := domainuser.ValidateUserName(name); err != nil {

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/auth"
@@ -22,7 +23,13 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUser("admin", permission.SuperuserAccess)
+	uuid, addAdminUser := AddUser("admin", permission.UserPermissionAccess{
+		Access: permission.SuperuserAccess,
+		ID: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        database.ControllerNS,
+		},
+	})
 	err := addAdminUser(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)
@@ -37,7 +44,13 @@ SELECT name FROM user WHERE name = ?`, "admin")
 
 func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"), permission.SuperuserAccess)
+	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"), permission.UserPermissionAccess{
+		Access: permission.SuperuserAccess,
+		ID: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        database.ControllerNS,
+		},
+	})
 	err := addAdminUser(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -23,9 +23,9 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUser("admin", permission.UserPermissionAccess{
+	uuid, addAdminUser := AddUser("admin", permission.AccessSpec{
 		Access: permission.SuperuserAccess,
-		ID: permission.ID{
+		Target: permission.ID{
 			ObjectType: permission.Controller,
 			Key:        database.ControllerNS,
 		},
@@ -44,9 +44,9 @@ SELECT name FROM user WHERE name = ?`, "admin")
 
 func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"), permission.UserPermissionAccess{
+	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"), permission.AccessSpec{
 		Access: permission.SuperuserAccess,
-		ID: permission.ID{
+		Target: permission.ID{
 			ObjectType: permission.Controller,
 			Key:        database.ControllerNS,
 		},

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/permission"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/auth"
 )
@@ -21,7 +22,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUser("admin")
+	uuid, addAdminUser := AddUser("admin", permission.SuperuserAccess)
 	err := addAdminUser(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)
@@ -36,7 +37,7 @@ SELECT name FROM user WHERE name = ?`, "admin")
 
 func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 	ctx := context.Background()
-	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"))
+	uuid, addAdminUser := AddUserWithPassword("admin", auth.NewPassword("password"), permission.SuperuserAccess)
 	err := addAdminUser(ctx, s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)

--- a/domain/user/errors/errors.go
+++ b/domain/user/errors/errors.go
@@ -45,4 +45,7 @@ const (
 	// ActivationKeyNotValid describes an error that occurs when the activation
 	// key is not valid.
 	ActivationKeyNotValid = errors.ConstError("activation key not valid")
+
+	// PermissionNotValid is used when a permission has failed validation.
+	PermissionNotValid = errors.ConstError("permission not valid")
 )

--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -32,7 +32,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.Access,
+		permission permission.UserPermissionAccess,
 	) error
 
 	// AddUserWithPasswordHash will add a new user to the database with the
@@ -46,7 +46,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.Access,
+		permission permission.UserPermissionAccess,
 		passwordHash string,
 		passwordSalt []byte,
 	) error
@@ -62,7 +62,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.Access,
+		permission permission.UserPermissionAccess,
 		activationKey []byte,
 	) error
 

--- a/domain/user/service/service.go
+++ b/domain/user/service/service.go
@@ -32,7 +32,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.UserPermissionAccess,
+		permission permission.AccessSpec,
 	) error
 
 	// AddUserWithPasswordHash will add a new user to the database with the
@@ -46,7 +46,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.UserPermissionAccess,
+		permission permission.AccessSpec,
 		passwordHash string,
 		passwordSalt []byte,
 	) error
@@ -62,7 +62,7 @@ type State interface {
 		name string,
 		displayName string,
 		creatorUUID user.UUID,
-		permission permission.UserPermissionAccess,
+		permission permission.AccessSpec,
 		activationKey []byte,
 	) error
 

--- a/domain/user/service/service_test.go
+++ b/domain/user/service/service_test.go
@@ -100,9 +100,9 @@ func (s *serviceSuite) TestAddUserWithPassword(c *gc.C) {
 		DisplayName: "display",
 		Password:    &pass,
 		CreatorUUID: creatorUUID,
-		Permission: permission.UserPermissionAccess{
+		Permission: permission.AccessSpec{
 			Access: permission.ReadAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Controller,
 				Key:        database.ControllerNS,
 			},

--- a/domain/user/service/service_test.go
+++ b/domain/user/service/service_test.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/user/errors"
@@ -100,13 +99,7 @@ func (s *serviceSuite) TestAddUserWithPassword(c *gc.C) {
 		DisplayName: "display",
 		Password:    &pass,
 		CreatorUUID: creatorUUID,
-		Permission: permission.AccessSpec{
-			Access: permission.ReadAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        database.ControllerNS,
-			},
-		},
+		Permission:  permission.ControllerForAccess(permission.ReadAccess),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/user/service/service_test.go
+++ b/domain/user/service/service_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/user/errors"
@@ -99,7 +100,13 @@ func (s *serviceSuite) TestAddUserWithPassword(c *gc.C) {
 		DisplayName: "display",
 		Password:    &pass,
 		CreatorUUID: creatorUUID,
-		Permission:  permission.ReadAccess,
+		Permission: permission.UserPermissionAccess{
+			Access: permission.ReadAccess,
+			ID: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        database.ControllerNS,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/user/service/service_test.go
+++ b/domain/user/service/service_test.go
@@ -62,6 +62,7 @@ func (s *serviceSuite) TestAddUserAlreadyExists(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.AlreadyExists)
 }
@@ -77,6 +78,7 @@ func (s *serviceSuite) TestAddUserCreatorUUIDNotFound(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.CreatorUUIDNotFound)
 }
@@ -88,8 +90,10 @@ func (s *serviceSuite) TestAddUserWithPassword(c *gc.C) {
 	userUUID := newUUID(c)
 	creatorUUID := newUUID(c)
 
+	perms := permission.ControllerForAccess(permission.LoginAccess)
+
 	s.state.EXPECT().AddUserWithPasswordHash(
-		gomock.Any(), userUUID, "valid", "display", creatorUUID, permission.ReadAccess, gomock.Any(), gomock.Any()).Return(nil)
+		gomock.Any(), userUUID, "valid", "display", creatorUUID, perms, gomock.Any(), gomock.Any()).Return(nil)
 
 	pass := auth.NewPassword("password")
 
@@ -99,7 +103,7 @@ func (s *serviceSuite) TestAddUserWithPassword(c *gc.C) {
 		DisplayName: "display",
 		Password:    &pass,
 		CreatorUUID: creatorUUID,
-		Permission:  permission.ControllerForAccess(permission.ReadAccess),
+		Permission:  perms,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -122,6 +126,7 @@ func (s *serviceSuite) TestAddUserWithPasswordNotValid(c *gc.C) {
 		DisplayName: "display",
 		Password:    &badPass,
 		CreatorUUID: creatorUUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	c.Assert(err, jc.ErrorIs, auth.ErrPasswordNotValid)
 }

--- a/domain/user/service/state_mock_test.go
+++ b/domain/user/service/state_mock_test.go
@@ -43,7 +43,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddUser mocks base method.
-func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess) error {
+func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.AccessSpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUser", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
@@ -57,7 +57,7 @@ func (mr *MockStateMockRecorder) AddUser(arg0, arg1, arg2, arg3, arg4, arg5 any)
 }
 
 // AddUserWithActivationKey mocks base method.
-func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess, arg6 []byte) error {
+func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.AccessSpec, arg6 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserWithActivationKey", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
@@ -71,7 +71,7 @@ func (mr *MockStateMockRecorder) AddUserWithActivationKey(arg0, arg1, arg2, arg3
 }
 
 // AddUserWithPasswordHash mocks base method.
-func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess, arg6 string, arg7 []byte) error {
+func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.AccessSpec, arg6 string, arg7 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserWithPasswordHash", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)

--- a/domain/user/service/state_mock_test.go
+++ b/domain/user/service/state_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
 	auth "github.com/juju/juju/internal/auth"
 	gomock "go.uber.org/mock/gomock"
@@ -42,45 +43,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddUser mocks base method.
-func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID) error {
+func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUser", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "AddUser", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddUser indicates an expected call of AddUser.
-func (mr *MockStateMockRecorder) AddUser(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockStateMockRecorder) AddUser(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUser", reflect.TypeOf((*MockState)(nil).AddUser), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUser", reflect.TypeOf((*MockState)(nil).AddUser), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // AddUserWithActivationKey mocks base method.
-func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 []byte) error {
+func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access, arg6 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUserWithActivationKey", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "AddUserWithActivationKey", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddUserWithActivationKey indicates an expected call of AddUserWithActivationKey.
-func (mr *MockStateMockRecorder) AddUserWithActivationKey(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockStateMockRecorder) AddUserWithActivationKey(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserWithActivationKey", reflect.TypeOf((*MockState)(nil).AddUserWithActivationKey), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserWithActivationKey", reflect.TypeOf((*MockState)(nil).AddUserWithActivationKey), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // AddUserWithPasswordHash mocks base method.
-func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 string, arg6 []byte) error {
+func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access, arg6 string, arg7 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUserWithPasswordHash", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "AddUserWithPasswordHash", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddUserWithPasswordHash indicates an expected call of AddUserWithPasswordHash.
-func (mr *MockStateMockRecorder) AddUserWithPasswordHash(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockStateMockRecorder) AddUserWithPasswordHash(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserWithPasswordHash", reflect.TypeOf((*MockState)(nil).AddUserWithPasswordHash), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserWithPasswordHash", reflect.TypeOf((*MockState)(nil).AddUserWithPasswordHash), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // DisableUserAuthentication mocks base method.

--- a/domain/user/service/state_mock_test.go
+++ b/domain/user/service/state_mock_test.go
@@ -43,7 +43,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddUser mocks base method.
-func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access) error {
+func (m *MockState) AddUser(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUser", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
@@ -57,7 +57,7 @@ func (mr *MockStateMockRecorder) AddUser(arg0, arg1, arg2, arg3, arg4, arg5 any)
 }
 
 // AddUserWithActivationKey mocks base method.
-func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access, arg6 []byte) error {
+func (m *MockState) AddUserWithActivationKey(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess, arg6 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserWithActivationKey", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
@@ -71,7 +71,7 @@ func (mr *MockStateMockRecorder) AddUserWithActivationKey(arg0, arg1, arg2, arg3
 }
 
 // AddUserWithPasswordHash mocks base method.
-func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.Access, arg6 string, arg7 []byte) error {
+func (m *MockState) AddUserWithPasswordHash(arg0 context.Context, arg1 user.UUID, arg2, arg3 string, arg4 user.UUID, arg5 permission.UserPermissionAccess, arg6 string, arg7 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserWithPasswordHash", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)

--- a/domain/user/service/types.go
+++ b/domain/user/service/types.go
@@ -30,5 +30,5 @@ type AddUserArg struct {
 
 	// Permissions are the permissions to grant to the user upon creation.
 	// If no permission is passed, then NoAccess is set.
-	Permission permission.Access
+	Permission permission.UserPermissionAccess
 }

--- a/domain/user/service/types.go
+++ b/domain/user/service/types.go
@@ -30,5 +30,5 @@ type AddUserArg struct {
 
 	// Permissions are the permissions to grant to the user upon creation.
 	// If no permission is passed, then NoAccess is set.
-	Permission permission.UserPermissionAccess
+	Permission permission.AccessSpec
 }

--- a/domain/user/service/types.go
+++ b/domain/user/service/types.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/auth"
 )
@@ -26,4 +27,8 @@ type AddUserArg struct {
 
 	// CreatorUUID identifies the user that requested this creation.
 	CreatorUUID user.UUID
+
+	// Permissions are the permissions to grant to the user upon creation.
+	// If no permission is passed, then NoAccess is set.
+	Permission permission.Access
 }

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -50,7 +50,7 @@ func (st *State) AddUser(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.Access,
+	permission permission.UserPermissionAccess,
 ) error {
 	db, err := st.DB()
 	if err != nil {
@@ -72,7 +72,7 @@ func (st *State) AddUserWithPasswordHash(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.Access,
+	permission permission.UserPermissionAccess,
 	passwordHash string,
 	salt []byte,
 ) error {
@@ -97,7 +97,7 @@ func (st *State) AddUserWithActivationKey(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.Access,
+	permission permission.UserPermissionAccess,
 	activationKey []byte,
 ) error {
 	db, err := st.DB()
@@ -612,7 +612,7 @@ func AddUserWithPassword(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.Access,
+	permission permission.UserPermissionAccess,
 	passwordHash string,
 	salt []byte,
 ) error {
@@ -676,7 +676,7 @@ func AddUser(
 	name string,
 	displayName string,
 	creatorUuid user.UUID,
-	access permission.Access,
+	access permission.UserPermissionAccess,
 ) error {
 	permissionUUID, err := internaluuid.NewUUID()
 	if err != nil {
@@ -707,21 +707,14 @@ VALUES      ($M.uuid, $M.name, $M.display_name, $M.created_by_uuid, $M.created_a
 		return errors.Annotatef(err, "adding user %q", name)
 	}
 
-	// No point in adding permissions if we require no access.
-	if access == permission.NoAccess {
-		return nil
-	}
-
 	err = permissionstate.AddUserPermission(ctx, tx, permissionstate.AddUserPermissionArgs{
 		PermissionUUID: permissionUUID.String(),
 		UserUUID:       uuid.String(),
 		User:           name,
-		Access:         access,
-		Target: permission.ID{
-			ObjectType: permission.Controller,
-			Key:        database.ControllerNS,
-		},
+		Access:         access.Access,
+		Target:         access.ID,
 	})
+	fmt.Println("???", err)
 	if err != nil {
 		return errors.Annotatef(err, "adding permission for user %q", name)
 	}

--- a/domain/user/state/state.go
+++ b/domain/user/state/state.go
@@ -50,7 +50,7 @@ func (st *State) AddUser(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.UserPermissionAccess,
+	permission permission.AccessSpec,
 ) error {
 	db, err := st.DB()
 	if err != nil {
@@ -72,7 +72,7 @@ func (st *State) AddUserWithPasswordHash(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.UserPermissionAccess,
+	permission permission.AccessSpec,
 	passwordHash string,
 	salt []byte,
 ) error {
@@ -97,7 +97,7 @@ func (st *State) AddUserWithActivationKey(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.UserPermissionAccess,
+	permission permission.AccessSpec,
 	activationKey []byte,
 ) error {
 	db, err := st.DB()
@@ -612,7 +612,7 @@ func AddUserWithPassword(
 	name string,
 	displayName string,
 	creatorUUID user.UUID,
-	permission permission.UserPermissionAccess,
+	permission permission.AccessSpec,
 	passwordHash string,
 	salt []byte,
 ) error {
@@ -676,7 +676,7 @@ func AddUser(
 	name string,
 	displayName string,
 	creatorUuid user.UUID,
-	access permission.UserPermissionAccess,
+	access permission.AccessSpec,
 ) error {
 	permissionUUID, err := internaluuid.NewUUID()
 	if err != nil {
@@ -710,11 +710,9 @@ VALUES      ($M.uuid, $M.name, $M.display_name, $M.created_by_uuid, $M.created_a
 	err = permissionstate.AddUserPermission(ctx, tx, permissionstate.AddUserPermissionArgs{
 		PermissionUUID: permissionUUID.String(),
 		UserUUID:       uuid.String(),
-		User:           name,
 		Access:         access.Access,
-		Target:         access.ID,
+		Target:         access.Target,
 	})
-	fmt.Println("???", err)
 	if err != nil {
 		return errors.Annotatef(err, "adding permission for user %q", name)
 	}

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	usererrors "github.com/juju/juju/domain/user/errors"
@@ -112,7 +113,7 @@ func (s *stateSuite) TestBootstrapAddUserWithPassword(c *gc.C) {
 		err = AddUserWithPassword(
 			context.Background(), tx, adminUUID,
 			"admin", "admin",
-			adminUUID, "passwordHash", salt,
+			adminUUID, permission.LoginAccess, "passwordHash", salt,
 		)
 		return err
 	})
@@ -155,6 +156,7 @@ func (s *stateSuite) TestAddUserAlreadyExists(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -165,6 +167,7 @@ func (s *stateSuite) TestAddUserAlreadyExists(c *gc.C) {
 		context.Background(), adminCloneUUID,
 		"admin", "admin",
 		adminCloneUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.AlreadyExists)
 }
@@ -185,6 +188,7 @@ func (s *stateSuite) TestAddUserCreatorNotFound(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		nonExistingUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.CreatorUUIDNotFound)
 }
@@ -203,7 +207,9 @@ func (s *stateSuite) TestGetUser(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -229,6 +235,7 @@ func (s *stateSuite) TestGetRemovedUser(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -242,7 +249,9 @@ func (s *stateSuite) TestGetRemovedUser(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), userToRemoveUUID,
 		"userToRemove", "userToRemove",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -288,7 +297,9 @@ func (s *stateSuite) TestGetUserByName(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -316,6 +327,7 @@ func (s *stateSuite) TestGetRemovedUserByName(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -327,6 +339,7 @@ func (s *stateSuite) TestGetRemovedUserByName(c *gc.C) {
 		context.Background(), userToRemoveUUID,
 		"userToRemove", "userToRemove",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -352,6 +365,7 @@ func (s *stateSuite) TestGetUserByNameMultipleUsers(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -370,7 +384,9 @@ func (s *stateSuite) TestGetUserByNameMultipleUsers(c *gc.C) {
 		context.Background(),
 		admin2UUID,
 		"admin", "admin2",
-		admin2UUID, "passwordHash", salt,
+		admin2UUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -409,7 +425,9 @@ func (s *stateSuite) TestGetUserWithAuthInfoByName(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -439,7 +457,13 @@ func (s *stateSuite) TestGetUserByAuth(c *gc.C) {
 	passwordHash, err := auth.HashPassword(auth.NewPassword("password"), salt)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.AddUserWithPasswordHash(context.Background(), adminUUID, "admin", "admin", adminUUID, passwordHash, salt)
+	err = st.AddUserWithPasswordHash(
+		context.Background(),
+		adminUUID,
+		"admin", "admin",
+		adminUUID,
+		permission.LoginAccess,
+		passwordHash, salt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Get the user.
@@ -465,7 +489,9 @@ func (s *stateSuite) TestGetUserByAuthWithInvalidSalt(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", []byte{},
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", []byte{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -489,7 +515,13 @@ func (s *stateSuite) TestGetUserByAuthDisabled(c *gc.C) {
 	passwordHash, err := auth.HashPassword(auth.NewPassword("password"), salt)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.AddUserWithPasswordHash(context.Background(), adminUUID, "admin", "admin", adminUUID, passwordHash, salt)
+	err = st.AddUserWithPasswordHash(
+		context.Background(),
+		adminUUID,
+		"admin", "admin",
+		adminUUID,
+		permission.LoginAccess,
+		passwordHash, salt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.DisableUserAuthentication(context.Background(), "admin")
@@ -524,7 +556,9 @@ func (s *stateSuite) TestGetUserByAuthUnauthorized(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, passwordHash, salt,
+		adminUUID,
+		permission.LoginAccess,
+		passwordHash, salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -555,6 +589,7 @@ func (s *stateSuite) TestRemoveUser(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -566,6 +601,7 @@ func (s *stateSuite) TestRemoveUser(c *gc.C) {
 		context.Background(), userToRemoveUUID,
 		"userToRemove", "userToRemove",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -605,7 +641,9 @@ func (s *stateSuite) TestGetAllUsersWihAuthInfo(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), admin1UUID,
 		"admin1", "admin1",
-		admin1UUID, "passwordHash", salt,
+		admin1UUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -619,7 +657,9 @@ func (s *stateSuite) TestGetAllUsersWihAuthInfo(c *gc.C) {
 	err = st.AddUserWithActivationKey(
 		context.Background(), admin2UUID,
 		"admin2", "admin2",
-		admin2UUID, admin2ActivationKey,
+		admin2UUID,
+		permission.LoginAccess,
+		admin2ActivationKey,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -663,7 +703,13 @@ func (s *stateSuite) TestUserWithAuthInfo(c *gc.C) {
 	salt, err := auth.NewSalt()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.AddUserWithPasswordHash(context.Background(), uuid, name, name, uuid, "passwordHash", salt)
+	err = st.AddUserWithPasswordHash(
+		context.Background(),
+		uuid,
+		name, name,
+		uuid,
+		permission.LoginAccess,
+		"passwordHash", salt)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.DisableUserAuthentication(context.Background(), name)
@@ -693,7 +739,9 @@ func (s *stateSuite) TestSetPasswordHash(c *gc.C) {
 	err = st.AddUserWithActivationKey(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, newActivationKey,
+		adminUUID,
+		permission.LoginAccess,
+		newActivationKey,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -758,7 +806,9 @@ func (s *stateSuite) TestSetPasswordHashTwice(c *gc.C) {
 	err = st.AddUserWithActivationKey(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, newActivationKey,
+		adminUUID,
+		permission.LoginAccess,
+		newActivationKey,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -806,7 +856,9 @@ func (s *stateSuite) TestAddUserWithPasswordHash(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -842,7 +894,9 @@ func (s *stateSuite) TestAddUserWithPasswordWhichCreatorDoesNotExist(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		nonExistedCreatorUuid, "passwordHash", salt,
+		nonExistedCreatorUuid,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.CreatorUUIDNotFound)
 }
@@ -861,7 +915,9 @@ func (s *stateSuite) TestAddUserWithActivationKey(c *gc.C) {
 	err = st.AddUserWithActivationKey(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, adminActivationKey,
+		adminUUID,
+		permission.LoginAccess,
+		adminActivationKey,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -885,6 +941,7 @@ func (s *stateSuite) TestGetActivationKeyNotFound(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
+		permission.LoginAccess,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -911,7 +968,9 @@ func (s *stateSuite) TestAddUserWithActivationKeyWhichCreatorDoesNotExist(c *gc.
 	err = st.AddUserWithActivationKey(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		nonExistedCreatorUuid, newActivationKey,
+		nonExistedCreatorUuid,
+		permission.LoginAccess,
+		newActivationKey,
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.CreatorUUIDNotFound)
 }
@@ -931,7 +990,9 @@ func (s *stateSuite) TestSetActivationKey(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -984,7 +1045,9 @@ func (s *stateSuite) TestDisableUserAuthentication(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1024,7 +1087,9 @@ func (s *stateSuite) TestEnableUserAuthentication(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1069,7 +1134,9 @@ func (s *stateSuite) TestUpdateLastLogin(c *gc.C) {
 	err = st.AddUserWithPasswordHash(
 		context.Background(), adminUUID,
 		"admin", "admin",
-		adminUUID, "passwordHash", salt,
+		adminUUID,
+		permission.LoginAccess,
+		"passwordHash", salt,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1099,7 +1166,7 @@ func (s *stateSuite) TestGetUserUUIDByName(c *gc.C) {
 	uuid, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.AddUser(context.Background(), uuid, "dnuof", "", uuid)
+	err = st.AddUser(context.Background(), uuid, "dnuof", "", uuid, permission.LoginAccess)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.TxnRunner().Txn(context.Background(),

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -211,9 +211,9 @@ func (s *stateSuite) TestAddUserWithInvalidPermissions(c *gc.C) {
 		context.Background(), adminUUID,
 		"admin", "admin",
 		adminUUID,
-		permission.UserPermissionAccess{
+		permission.AccessSpec{
 			Access: permission.ReadAccess,
-			ID: permission.ID{
+			Target: permission.ID{
 				ObjectType: permission.Model,
 				Key:        "foo-bar",
 			},
@@ -1222,10 +1222,10 @@ func (s *stateSuite) TestGetUserUUIDByNameNotFound(c *gc.C) {
 	c.Check(err, jc.ErrorIs, usererrors.NotFound)
 }
 
-func controllerLoginAccess() permission.UserPermissionAccess {
-	return permission.UserPermissionAccess{
+func controllerLoginAccess() permission.AccessSpec {
+	return permission.AccessSpec{
 		Access: permission.LoginAccess,
-		ID: permission.ID{
+		Target: permission.ID{
 			ObjectType: permission.Controller,
 			Key:        coredatabase.ControllerNS,
 		},

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/core/permission"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	storageservice "github.com/juju/juju/domain/storage/service"
@@ -277,6 +278,7 @@ func (w *bootstrapWorker) seedInitialUsers(ctx context.Context) error {
 		DisplayName: "Juju Metrics",
 		Password:    &password,
 		CreatorUUID: adminUser.UUID,
+		Permission:  permission.ControllerForAccess(permission.LoginAccess),
 	})
 	// User already exists, we don't need to do anything in this scenario.
 	if errors.Is(err, usererrors.AlreadyExists) {


### PR DESCRIPTION
Adding permissions to users when adding a user allows us to setup
permissions easily and conveniently. The problem is that permissions
aren't modeled nicely. 

Consider;

 - Read, Write, Consume and Admin are model access
 - Login, AddModel, and Superuser are controller access

We should prevent Access from being a blanket string, instead it
should be a tree of types.

    type Access string
    type ModelAccess Access
    type ControllerAccess Access

Then we can add:

    func (a ModelAccess) Access() Accesss

This shouldn't be the final form, but it's a better representation
of the type access.

For now, I've just made aliases.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

## Links

**Jira card:** JUJU-5691

