### PR TITLE
Pass controller and model txn runners in bootstrap

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -58,7 +58,7 @@ type DqliteInitializerFunc func(
 	mgr database.BootstrapNodeManager,
 	modelUUID model.UUID,
 	logger database.Logger,
-	concerns ...database.BootstrapOpt,
+	options ...database.BootstrapOpt,
 ) error
 
 // Logger describes methods for emitting log output.

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -580,11 +580,17 @@ func (e *fakeEnviron) Provider() environs.EnvironProvider {
 	return e.provider
 }
 
-func bootstrapDqliteWithDummyCloudType(ctx context.Context, mgr database.BootstrapNodeManager, logger database.Logger, concerns ...database.BootstrapConcern) error {
+func bootstrapDqliteWithDummyCloudType(
+	ctx context.Context,
+	mgr database.BootstrapNodeManager,
+	modelUUID model.UUID,
+	logger database.Logger,
+	opts ...database.BootstrapOpt,
+) error {
 	// The dummy cloud type needs to be inserted before the other operations.
-	concerns = append([]database.BootstrapConcern{
-		database.BootstrapControllerInitConcern(database.EmptyInit, jujujujutesting.InsertDummyCloudType),
-	}, concerns...)
+	opts = append([]database.BootstrapOpt{
+		jujujujutesting.InsertDummyCloudType,
+	}, opts...)
 
-	return database.BootstrapDqlite(ctx, mgr, logger, concerns...)
+	return database.BootstrapDqlite(ctx, mgr, modelUUID, logger, opts...)
 }

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -44,7 +44,7 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	s.ServiceFactorySuite.SetUpTest(c)
 
 	controllerConfig := coretesting.FakeControllerConfig()
-	err := controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), s.TxnRunner())
+	err := controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.clock = testclock.NewClock(time.Now())

--- a/cmd/jujud-controller/agent/agenttest/agent.go
+++ b/cmd/jujud-controller/agent/agenttest/agent.go
@@ -24,6 +24,7 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud-controller/util"
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -236,6 +237,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	err = database.BootstrapDqlite(
 		context.Background(),
 		database.NewNodeManager(conf, true, logger, coredatabase.NoopSlowQueryLogger{}),
+		model.MustNewUUID(),
 		logger,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud-controller/agent/agenttest/agent.go
+++ b/cmd/jujud-controller/agent/agenttest/agent.go
@@ -24,7 +24,7 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud-controller/util"
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
-	"github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -237,7 +237,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	err = database.BootstrapDqlite(
 		context.Background(),
 		database.NewNodeManager(conf, true, logger, coredatabase.NoopSlowQueryLogger{}),
-		model.MustNewUUID(),
+		modeltesting.GenModelUUID(c),
 		logger,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud-controller/agent/bootstrap_test.go
+++ b/cmd/jujud-controller/agent/bootstrap_test.go
@@ -600,13 +600,14 @@ func nullContext() environs.BootstrapContext {
 func bootstrapDqliteWithDummyCloudType(
 	ctx context.Context,
 	mgr database.BootstrapNodeManager,
+	modelUUID model.UUID,
 	logger database.Logger,
-	concerns ...database.BootstrapConcern,
+	opts ...database.BootstrapOpt,
 ) error {
 	// The dummy cloud type needs to be inserted before the other operations.
-	concerns = append([]database.BootstrapConcern{
-		database.BootstrapControllerInitConcern(database.EmptyInit, jujutesting.InsertDummyCloudType),
-	}, concerns...)
+	opts = append([]database.BootstrapOpt{
+		jujutesting.InsertDummyCloudType,
+	}, opts...)
 
-	return database.BootstrapDqlite(ctx, mgr, logger, concerns...)
+	return database.BootstrapDqlite(ctx, mgr, modelUUID, logger, opts...)
 }

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -21,7 +21,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
-	"github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -171,7 +171,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	err = database.BootstrapDqlite(
 		context.Background(),
 		database.NewNodeManager(conf, true, logger, coredatabase.NoopSlowQueryLogger{}),
-		model.MustNewUUID(),
+		modeltesting.GenModelUUID(c),
 		logger,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -21,6 +21,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -170,6 +171,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	err = database.BootstrapDqlite(
 		context.Background(),
 		database.NewNodeManager(conf, true, logger, coredatabase.NoopSlowQueryLogger{}),
+		model.MustNewUUID(),
 		logger,
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -85,15 +85,6 @@ func NewUUID() (UUID, error) {
 	return UUID(uuid.String()), nil
 }
 
-// MustNewUUID is a convenience function for generating a new model uuid.
-func MustNewUUID() UUID {
-	uuid, err := NewUUID()
-	if err != nil {
-		panic(err)
-	}
-	return uuid
-}
-
 // String implements the stringer interface for UUID.
 func (u UUID) String() string {
 	return string(u)

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -85,6 +85,15 @@ func NewUUID() (UUID, error) {
 	return UUID(uuid.String()), nil
 }
 
+// MustNewUUID is a convenience function for generating a new model uuid.
+func MustNewUUID() UUID {
+	uuid, err := NewUUID()
+	if err != nil {
+		panic(err)
+	}
+	return uuid
+}
+
 // String implements the stringer interface for UUID.
 func (u UUID) String() string {
 	return string(u)

--- a/domain/cloud/bootstrap/bootstrap_test.go
+++ b/domain/cloud/bootstrap/bootstrap_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestInsertCloud(c *gc.C) {
 	cld := cloud.Cloud{Name: "cirrus", Type: "ec2", AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType}}
-	err := InsertCloud(cld)(context.Background(), s.TxnRunner())
+	err := InsertCloud(cld)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var name string
@@ -39,7 +39,7 @@ func (s *bootstrapSuite) TestSetCloudDefaultsNoExist(c *gc.C) {
 		"HTTP_PROXY": "[2001:0DB8::1]:80",
 	})
 
-	err := set(context.Background(), s.TxnRunner())
+	err := set(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIs, clouderrors.NotFound)
 
 	var count int
@@ -56,14 +56,14 @@ func (s *bootstrapSuite) TestSetCloudDefaults(c *gc.C) {
 		Type:      "ec2",
 		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
 	}
-	err := InsertCloud(cld)(context.Background(), s.TxnRunner())
+	err := InsertCloud(cld)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIsNil)
 
 	set := SetCloudDefaults("cirrus", map[string]any{
 		"HTTP_PROXY": "[2001:0DB8::1]:80",
 	})
 
-	err = set(context.Background(), s.TxnRunner())
+	err = set(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIsNil)
 
 	st := state.NewState(s.TxnRunnerFactory())
@@ -82,14 +82,14 @@ func (s *bootstrapSuite) TestSetCloudDefaultsOverides(c *gc.C) {
 		Type:      "ec2",
 		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
 	}
-	err := InsertCloud(cld)(context.Background(), s.TxnRunner())
+	err := InsertCloud(cld)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIsNil)
 
 	set := SetCloudDefaults("cirrus", map[string]any{
 		"HTTP_PROXY": "[2001:0DB8::1]:80",
 	})
 
-	err = set(context.Background(), s.TxnRunner())
+	err = set(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIsNil)
 
 	st := state.NewState(s.TxnRunnerFactory())
@@ -105,7 +105,7 @@ func (s *bootstrapSuite) TestSetCloudDefaultsOverides(c *gc.C) {
 		"foo": "bar",
 	})
 
-	err = set(context.Background(), s.TxnRunner())
+	err = set(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Check(err, jc.ErrorIsNil)
 
 	st = state.NewState(s.TxnRunnerFactory())

--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	cfg := controller.Config{controller.CACertKey: testing.CACert}
-	err := InsertInitialControllerConfig(cfg)(context.Background(), s.TxnRunner())
+	err := InsertInitialControllerConfig(cfg)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var cert string

--- a/domain/controllerconfig/controllerconfig_test.go
+++ b/domain/controllerconfig/controllerconfig_test.go
@@ -47,7 +47,7 @@ func (s *controllerconfigSuite) TestControllerConfigRoundTrips(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bootstrap.InsertInitialControllerConfig(cfgIn)(ctx.Background(), s.TxnRunner())
+	err = bootstrap.InsertInitialControllerConfig(cfgIn)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfgOut, err := srv.ControllerConfig(ctx.Background())

--- a/domain/credential/bootstrap/bootstrap.go
+++ b/domain/credential/bootstrap/bootstrap.go
@@ -14,12 +14,13 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/state"
+	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/uuid"
 )
 
 // InsertCredential inserts  a cloud credential into dqlite.
-func InsertCredential(id corecredential.ID, cred cloud.Credential) func(context.Context, database.TxnRunner) error {
-	return func(ctx context.Context, db database.TxnRunner) error {
+func InsertCredential(id corecredential.ID, cred cloud.Credential) internaldatabase.BootstrapOpt {
+	return func(ctx context.Context, controller, model database.TxnRunner) error {
 		if id.IsZero() {
 			return nil
 		}
@@ -28,7 +29,7 @@ func InsertCredential(id corecredential.ID, cred cloud.Credential) func(context.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), id, credential.CloudCredentialInfo{
 				AuthType:      string(cred.AuthType()),
 				Attributes:    cred.Attributes(),

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	ctx := context.Background()
 	cld := cloud.Cloud{Name: "cirrus", Type: "ec2", AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType}}
-	err := cloudbootstrap.InsertCloud(cld)(ctx, s.TxnRunner())
+	err := cloudbootstrap.InsertCloud(cld)(ctx, s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	userUUID, err := user.NewUUID()
@@ -50,7 +50,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		Name:  "foo",
 	}
 
-	err = InsertCredential(id, cred)(ctx, s.TxnRunner())
+	err = InsertCredential(id, cred)(ctx, s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var owner, cloudName string

--- a/domain/machine/bootstrap/bootstrap.go
+++ b/domain/machine/bootstrap/bootstrap.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/life"
+	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/uuid"
 )
 
 // InsertMachine inserts a machine during bootstrap.
 // TODO - this just creates a minimal row for now.
-func InsertMachine(machineId string) func(context.Context, database.TxnRunner) error {
-	return func(ctx context.Context, db database.TxnRunner) error {
+func InsertMachine(machineId string) internaldatabase.BootstrapOpt {
+	return func(ctx context.Context, controller, model database.TxnRunner) error {
 
 		createMachine := `
 INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
@@ -43,7 +44,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 			return errors.Trace(err)
 		}
 
-		return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(model.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			createParams := sqlair.M{
 				"machine_uuid":  machineUUID.String(),
 				"net_node_uuid": nodeUUID.String(),

--- a/domain/machine/bootstrap/bootstrap_test.go
+++ b/domain/machine/bootstrap/bootstrap_test.go
@@ -19,7 +19,7 @@ type bootstrapSuite struct {
 var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestInsertBootstrapMachine(c *gc.C) {
-	err := InsertMachine("666")(context.Background(), s.TxnRunner())
+	err := InsertMachine("666")(context.Background(), s.NoopTxnRunner(), s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var machineId string

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -37,7 +37,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
 	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess))
-	err := fn(context.Background(), s.ControllerTxnRunner())
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid
 
@@ -48,7 +48,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 		AuthTypes: cloud.AuthTypes{cloud.EmptyAuthType},
 	})
 
-	err = fn(context.Background(), s.ControllerTxnRunner())
+	err = fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.credentialName = "test"
@@ -60,7 +60,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 		cloud.NewCredential(cloud.EmptyAuthType, nil),
 	)
 
-	err = fn(context.Background(), s.ControllerTxnRunner())
+	err = fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -77,7 +77,7 @@ func (s *bootstrapSuite) TestUUIDIsCreated(c *gc.C) {
 		Owner: s.adminUserUUID,
 	})
 
-	err := fn(context.Background(), s.ControllerTxnRunner())
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(uuid.String() == "", jc.IsFalse)
@@ -99,7 +99,7 @@ func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
 		UUID:  modelUUID,
 	})
 
-	err := fn(context.Background(), s.ControllerTxnRunner())
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(uuid, gc.Equals, modelUUID)
@@ -120,6 +120,6 @@ func (s *modelBootstrapSuite) TestCreateReadOnlyModel(c *gc.C) {
 		CloudRegion: "myregion",
 	})
 
-	err := fn(context.Background(), s.ModelTxnRunner())
+	err := fn(context.Background(), s.NoopTxnRunner(), s.ModelTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -45,7 +45,7 @@ func (s *bootstrapSuite) TestSetModelConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = SetModelConfig(cfg, defaults)(context.Background(), s.TxnRunner())
+	err = SetModelConfig(cfg, defaults)(context.Background(), s.NoopTxnRunner(), s.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	rows, err := s.DB().Query("SELECT * FROM model_config")

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -83,7 +83,7 @@ func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 		permission.ControllerForAccess(permission.SuperuserAccess),
 	)
 	s.AdminUserUUID = uuid
-	err := fn(context.Background(), s.ControllerTxnRunner())
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -101,7 +101,7 @@ func (s *ServiceFactorySuite) SeedCloudAndCredential(c *gc.C) {
 				Name: "dummy-region",
 			},
 		},
-	})(context.Background(), s.ControllerTxnRunner())
+	})(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.CredentialID = credential.ID{
@@ -115,7 +115,7 @@ func (s *ServiceFactorySuite) SeedCloudAndCredential(c *gc.C) {
 			"username": "dummy",
 			"password": "secret",
 		}),
-	)(context.Background(), s.ControllerTxnRunner())
+	)(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -132,7 +132,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	}
 
 	uuid, fn := modelbootstrap.CreateModel(controllerArgs)
-	err := fn(context.Background(), s.ControllerTxnRunner())
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.ControllerModelUUID = uuid
 
@@ -146,7 +146,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	}
 
 	uuid, fn = modelbootstrap.CreateModel(modelArgs)
-	err = fn(context.Background(), s.ControllerTxnRunner())
+	err = fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.DefaultModelUUID = uuid
 }

--- a/domain/testing/controllerconfigsuite.go
+++ b/domain/testing/controllerconfigsuite.go
@@ -5,7 +5,10 @@ package testing
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -23,7 +26,17 @@ func SeedControllerConfig(
 	config controller.Config,
 	provider ControllerTxnProvider,
 ) controller.Config {
-	err := bootstrap.InsertInitialControllerConfig(config)(context.Background(), provider.ControllerTxnRunner())
+	err := bootstrap.InsertInitialControllerConfig(config)(context.Background(), provider.ControllerTxnRunner(), noopTxnRunner{})
 	c.Assert(err, jc.ErrorIsNil)
 	return config
+}
+
+type noopTxnRunner struct{}
+
+func (noopTxnRunner) Txn(context.Context, func(context.Context, *sqlair.TX) error) error {
+	return errors.NotImplemented
+}
+
+func (noopTxnRunner) StdTxn(context.Context, func(context.Context, *sql.Tx) error) error {
+	return errors.NotImplemented
 }

--- a/domain/user/bootstrap/bootstrap_test.go
+++ b/domain/user/bootstrap/bootstrap_test.go
@@ -30,7 +30,7 @@ func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 			Key:        database.ControllerNS,
 		},
 	})
-	err := addAdminUser(ctx, s.TxnRunner())
+	err := addAdminUser(ctx, s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)
 
@@ -51,7 +51,7 @@ func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 			Key:        database.ControllerNS,
 		},
 	})
-	err := addAdminUser(ctx, s.TxnRunner())
+	err := addAdminUser(ctx, s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid.Validate(), jc.ErrorIsNil)
 

--- a/internal/database/bootstrap_test.go
+++ b/internal/database/bootstrap_test.go
@@ -15,7 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/database"
-	"github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/client"
@@ -77,7 +77,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 		})
 	}
 
-	err := BootstrapDqlite(context.Background(), mgr, model.MustNewUUID(), stubLogger{}, check)
+	err := BootstrapDqlite(context.Background(), mgr, modeltesting.GenModelUUID(c), stubLogger{}, check)
 	c.Assert(err, jc.ErrorIsNil)
 
 }

--- a/internal/database/bootstrap_test.go
+++ b/internal/database/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/client"
@@ -31,8 +32,8 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 
 	// check tests the variadic operation functionality
 	// and ensures that bootstrap applied the DDL.
-	check := func(ctx context.Context, db database.TxnRunner) error {
-		return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	check := func(ctx context.Context, controller, model database.TxnRunner) error {
+		return controller.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			rows, err := tx.QueryContext(ctx, "SELECT COUNT(*) FROM lease_type")
 			if err != nil {
 				return err
@@ -76,7 +77,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 		})
 	}
 
-	err := BootstrapDqlite(context.Background(), mgr, stubLogger{}, BootstrapControllerConcern(check))
+	err := BootstrapDqlite(context.Background(), mgr, model.MustNewUUID(), stubLogger{}, check)
 	c.Assert(err, jc.ErrorIsNil)
 
 }


### PR DESCRIPTION
During bootstrap we need to access both the controller (global db) and the model (controller model db). To prevent the need for hacks to get that information, this revisits the bootstrap concerns and moves back to bootstrap options. The options take the controller and the model. Thus you can access any part of each model during bootstrap.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
```

## Links

**Jira card:** JUJU-5645

