### PR TITLE
Wire through rootless charm/workloads for k8s.

### DIFF
--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -132,6 +132,7 @@ func convertCharmMeta(meta *params.CharmMeta) (*charm.Meta, error) {
 		MinJujuVersion: minVersion,
 		Containers:     containers,
 		Assumes:        meta.AssumesExpr,
+		CharmUser:      charm.RunAs(meta.CharmUser),
 	}
 	return result, nil
 }
@@ -410,6 +411,8 @@ func convertCharmContainers(input map[string]params.CharmContainer) (map[string]
 		containers[k] = charm.Container{
 			Resource: v.Resource,
 			Mounts:   convertCharmMounts(v.Mounts),
+			Uid:      v.Uid,
+			Gid:      v.Gid,
 		}
 	}
 	if len(containers) == 0 {

--- a/api/common/charms/common_test.go
+++ b/api/common/charms/common_test.go
@@ -69,6 +69,8 @@ func (s *suite) TestCharmInfo(c *gc.C) {
 							Location: "/cockroach/cockroach-data",
 						},
 					},
+					Uid: 5000,
+					Gid: 5001,
 				},
 			},
 			Storage: map[string]params.CharmStorage{
@@ -76,6 +78,7 @@ func (s *suite) TestCharmInfo(c *gc.C) {
 					Type: "filesystem",
 				},
 			},
+			CharmUser: "root",
 		},
 		Manifest: &params.CharmManifest{
 			Bases: []params.CharmBase{
@@ -133,6 +136,8 @@ func (s *suite) TestCharmInfo(c *gc.C) {
 							Location: "/cockroach/cockroach-data",
 						},
 					},
+					Uid: 5000,
+					Gid: 5001,
 				},
 			},
 			Storage: map[string]charm.Storage{
@@ -140,6 +145,7 @@ func (s *suite) TestCharmInfo(c *gc.C) {
 					Type: "filesystem",
 				},
 			},
+			CharmUser: charm.RunAsRoot,
 		},
 		Manifest: &charm.Manifest{
 			Bases: []charm.Base{

--- a/apiserver/common/charms/appcharminfo_test.go
+++ b/apiserver/common/charms/appcharminfo_test.go
@@ -5,6 +5,7 @@ package charms_test
 
 import (
 	"github.com/juju/charm/v12"
+	"github.com/juju/charm/v12/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"go.uber.org/mock/gomock"
@@ -82,4 +83,103 @@ func (s *appCharmInfoSuite) TestPermissionDenied(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	_, err = api.ApplicationCharmInfo(params.Entity{Tag: names.NewApplicationTag("foo").String()})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *appCharmInfoSuite) TestSidecarCharm(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	st := mocks.NewMockState(ctrl)
+	model := mocks.NewMockModel(ctrl)
+	st.EXPECT().Model().Return(model, nil)
+	app := mocks.NewMockApplication(ctrl)
+	st.EXPECT().Application("foo").Return(app, nil)
+
+	ch := mocks.NewMockCharm(ctrl)
+	app.EXPECT().Charm().Return(ch, false, nil)
+
+	// The convertCharm logic is tested in the CharmInfo tests, so just test
+	// the minimal set of fields here.
+	ch.EXPECT().URL().Return("ch:foo-1")
+	ch.EXPECT().Revision().Return(1)
+	ch.EXPECT().Config().Return(&charm.Config{})
+	ch.EXPECT().Meta().Return(&charm.Meta{
+		Name:      "foo",
+		CharmUser: charm.RunAsRoot,
+		Containers: map[string]charm.Container{
+			"my-container": {
+				Resource: "my-image",
+				Mounts: []charm.Mount{{
+					Storage:  "my-storage",
+					Location: "/my/storage/location",
+				}},
+				Uid: 5000,
+				Gid: 5001,
+			},
+		},
+		Storage: map[string]charm.Storage{
+			"my-storage": {
+				Name: "my-storage",
+				Type: charm.StorageFilesystem,
+			},
+		},
+		Resources: map[string]resource.Meta{
+			"my-image": {
+				Name:        "my-image",
+				Type:        resource.TypeContainerImage,
+				Description: "my container image",
+			},
+		},
+	})
+	ch.EXPECT().Actions().Return(&charm.Actions{})
+	ch.EXPECT().Metrics().Return(&charm.Metrics{})
+	ch.EXPECT().Manifest().Return(&charm.Manifest{})
+	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
+
+	authorizer := facademocks.NewMockAuthorizer(ctrl)
+	authorizer.EXPECT().AuthController().Return(true)
+
+	// Make the ApplicationCharmInfo call
+	api, err := charms.NewApplicationCharmInfoAPI(st, authorizer)
+	c.Assert(err, gc.IsNil)
+	charmInfo, err := api.ApplicationCharmInfo(params.Entity{Tag: names.NewApplicationTag("foo").String()})
+	c.Assert(err, gc.IsNil)
+
+	c.Check(charmInfo, gc.DeepEquals, params.Charm{
+		URL:      "ch:foo-1",
+		Revision: 1,
+		Meta: &params.CharmMeta{
+			Name: "foo",
+			Storage: map[string]params.CharmStorage{
+				"my-storage": {
+					Name: "my-storage",
+					Type: "filesystem",
+				},
+			},
+			Containers: map[string]params.CharmContainer{
+				"my-container": {
+					Resource: "my-image",
+					Mounts: []params.CharmMount{{
+						Storage:  "my-storage",
+						Location: "/my/storage/location",
+					}},
+					Uid: 5000,
+					Gid: 5001,
+				},
+			},
+			Resources: map[string]params.CharmResourceMeta{
+				"my-image": {
+					Name:        "my-image",
+					Type:        "oci-image",
+					Description: "my container image",
+				},
+			},
+			MinJujuVersion: "0.0.0",
+			CharmUser:      "root",
+		},
+		Config:   map[string]params.CharmOption{},
+		Actions:  &params.CharmActions{},
+		Metrics:  &params.CharmMetrics{},
+		Manifest: &params.CharmManifest{},
+	})
 }

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -161,6 +161,7 @@ func convertCharmMeta(meta *charm.Meta) *params.CharmMeta {
 		MinJujuVersion: meta.MinJujuVersion.String(),
 		Containers:     convertCharmContainers(meta.Containers),
 		AssumesExpr:    meta.Assumes,
+		CharmUser:      string(meta.CharmUser),
 	}
 }
 
@@ -409,6 +410,8 @@ func convertCharmContainers(input map[string]charm.Container) map[string]params.
 		containers[k] = params.CharmContainer{
 			Resource: v.Resource,
 			Mounts:   convertCharmMounts(v.Mounts),
+			Uid:      v.Uid,
+			Gid:      v.Gid,
 		}
 	}
 	if len(containers) == 0 {

--- a/apiserver/common/charms/package_test.go
+++ b/apiserver/common/charms/package_test.go
@@ -6,11 +6,11 @@ package charms_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package mocks -destination mocks/mocks.go github.com/juju/juju/apiserver/common/charms State,Application,Charm,Model
 
 func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7284,6 +7284,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -7292,6 +7295,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -7406,6 +7412,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -8888,6 +8897,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -8896,6 +8908,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -9010,6 +9025,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -9822,6 +9840,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -9830,6 +9851,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -9944,6 +9968,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -12005,6 +12032,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -12013,6 +12043,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -12127,6 +12160,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -13506,6 +13542,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -13514,6 +13553,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -13628,6 +13670,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",
@@ -15323,6 +15368,9 @@
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
                         "mounts": {
                             "type": "array",
                             "items": {
@@ -15331,6 +15379,9 @@
                         },
                         "resource": {
                             "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -15445,6 +15496,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "charm-user": {
+                            "type": "string"
                         },
                         "containers": {
                             "type": "object",

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -4,14 +4,18 @@ ARG TARGETARCH
 
 # Add the syslog user for audit logging.
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin syslog
-# Add the juju user for rootless agents.
-# 170 uid/gid must be updated here and in caas/kubernetes/provider/constants/constants.go
+# Add the juju and sjuju user for rootless agents.
+# 170 and 171 uid/gid must be updated here and in caas/kubernetes/provider/constants/constants.go
 RUN groupadd --gid 170 juju
 RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
+RUN groupadd --gid 171 sjuju
+RUN useradd --uid 171 --gid 171 --no-create-home --shell /usr/bin/bash sjuju
+RUN mkdir -p /etc/sudoers.d && echo "sjuju ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sjuju
 
 # Some Python dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    sudo \
     python3-yaml \
     python3-pip \
     python3-distutils \

--- a/caas/application.go
+++ b/caas/application.go
@@ -139,8 +139,8 @@ type ApplicationConfig struct {
 	// After the application is created, InitialScale has no effect.
 	InitialScale int
 
-	// Rootless is true if the application should be run without root priviledges.
-	Rootless bool
+	// CharmUser controls what user the charm/unit agent runs as.
+	CharmUser RunAs
 }
 
 // ContainerConfig describes a container that is deployed alonside the uniter/charm container.
@@ -153,6 +153,12 @@ type ContainerConfig struct {
 
 	// Mounts to storage that are to be provided within this container.
 	Mounts []MountConfig
+
+	// Uid to run as. Default to 0 or root.
+	Uid int
+
+	// Gid to run as. Default to 0 or root.
+	Gid int
 }
 
 // MountConfig describes a storage that should be mounted to a container.
@@ -163,3 +169,12 @@ type MountConfig struct {
 	// Path is the mount point inside the container.
 	Path string
 }
+
+// RunAs defines which user to run a certain process as.
+type RunAs string
+
+const (
+	RunAsRoot    RunAs = "root"
+	RunAsSudoer  RunAs = "sudoer"
+	RunAsNonRoot RunAs = "non-root"
+)

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -74,6 +74,7 @@ const (
 
 var (
 	containerAgentPebbleVersion = version.MustParse("2.9.37")
+	profileDirVersion           = version.MustParse("3.5-beta1")
 )
 
 type app struct {
@@ -1361,25 +1362,29 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			SubPath:   "containeragent/pebble",
 		},
 	}
-	if config.Rootless {
+	charmContainerExtraVolumeMounts = append(charmContainerExtraVolumeMounts, corev1.VolumeMount{
+		Name:      constants.CharmVolumeName,
+		MountPath: "/var/log/juju",
+		SubPath:   "containeragent/var/log/juju",
+	}, corev1.VolumeMount{
+		Name:      constants.CharmVolumeName,
+		MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+		SubPath:   "charm/bin/containeragent",
+		ReadOnly:  true,
+	}, corev1.VolumeMount{
+		Name:      constants.CharmVolumeName,
+		MountPath: paths.JujuExec(paths.OSUnixLike),
+		SubPath:   "charm/bin/containeragent",
+		ReadOnly:  true,
+	})
+
+	agentVersionNoBuild := config.AgentVersion
+	agentVersionNoBuild.Build = 0
+	if agentVersionNoBuild.Compare(profileDirVersion) >= 0 {
 		charmContainerExtraVolumeMounts = append(charmContainerExtraVolumeMounts, corev1.VolumeMount{
-			Name:      constants.CharmVolumeName,
-			MountPath: "/var/log/juju",
-			SubPath:   "containeragent/var/log/juju",
-		}, corev1.VolumeMount{
 			Name:      constants.CharmVolumeName,
 			MountPath: "/etc/profile.d/juju-introspection.sh",
 			SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
-			ReadOnly:  true,
-		}, corev1.VolumeMount{
-			Name:      constants.CharmVolumeName,
-			MountPath: paths.JujuIntrospect(paths.OSUnixLike),
-			SubPath:   "charm/bin/containeragent",
-			ReadOnly:  true,
-		}, corev1.VolumeMount{
-			Name:      constants.CharmVolumeName,
-			MountPath: paths.JujuExec(paths.OSUnixLike),
-			SubPath:   "charm/bin/containeragent",
 			ReadOnly:  true,
 		})
 	}
@@ -1477,7 +1482,18 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 		}, charmContainerExtraVolumeMounts...),
 	}
-	if config.Rootless {
+	switch config.CharmUser {
+	case caas.RunAsRoot:
+		charmContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(0),
+			RunAsGroup: pointer.Int64(0),
+		}
+	case caas.RunAsSudoer:
+		charmContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(constants.JujuSudoUserID),
+			RunAsGroup: pointer.Int64(constants.JujuSudoGroupID),
+		}
+	case caas.RunAsNonRoot:
 		charmContainer.SecurityContext = &corev1.SecurityContext{
 			RunAsUser:  pointer.Int64(constants.JujuUserID),
 			RunAsGroup: pointer.Int64(constants.JujuGroupID),
@@ -1504,6 +1520,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			}, {
 				Name:  "PEBBLE_SOCKET",
 				Value: "/charm/container/pebble.socket",
+			}, {
+				Name:  "PEBBLE",
+				Value: "/charm/container/pebble",
 			}},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler:        pebble.LivenessHandler(pebble.WorkloadHealthCheckPort(i)),
@@ -1521,10 +1540,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				SuccessThreshold:    containerProbeSuccess,
 				FailureThreshold:    containerReadinessProbeFailure,
 			},
-			// Run Pebble as root (because it's a service manager).
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(0),
-				RunAsGroup: pointer.Int64(0),
+				RunAsUser:  pointer.Int64(int64(v.Uid)),
+				RunAsGroup: pointer.Int64(int64(v.Gid)),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -1539,12 +1557,6 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 					SubPath:   fmt.Sprintf("charm/containers/%s", v.Name),
 				},
 			},
-		}
-		if config.Rootless {
-			container.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(constants.JujuUserID),
-				RunAsGroup: pointer.Int64(constants.JujuGroupID),
-			}
 		}
 		if v.Image.Password != "" {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: a.imagePullSecretName(v.Name)})
@@ -1577,7 +1589,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		}
 	}
 
-	if config.Rootless {
+	if agentVersionNoBuild.Compare(profileDirVersion) >= 0 {
 		containerAgentArgs = append(containerAgentArgs, "--profile-dir", "/containeragent/etc/profile.d")
 		charmInitAdditionalMounts = append(charmInitAdditionalMounts, corev1.VolumeMount{
 			Name:      constants.CharmVolumeName,
@@ -1644,11 +1656,21 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 		}, charmInitAdditionalMounts...),
 	}
-	if config.Rootless {
+	switch config.CharmUser {
+	case caas.RunAsRoot:
 		charmInitContainer.SecurityContext = &corev1.SecurityContext{
-			RunAsUser:              pointer.Int64(constants.JujuUserID),
-			RunAsGroup:             pointer.Int64(constants.JujuGroupID),
-			ReadOnlyRootFilesystem: pointer.Bool(true),
+			RunAsUser:  pointer.Int64(0),
+			RunAsGroup: pointer.Int64(0),
+		}
+	case caas.RunAsSudoer:
+		charmInitContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(constants.JujuSudoUserID),
+			RunAsGroup: pointer.Int64(constants.JujuSudoGroupID),
+		}
+	case caas.RunAsNonRoot:
+		charmInitContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(constants.JujuUserID),
+			RunAsGroup: pointer.Int64(constants.JujuGroupID),
 		}
 	}
 
@@ -1673,11 +1695,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 	if err != nil {
 		return nil, errors.Annotate(err, "processing constraints")
 	}
-	if config.Rootless {
-		spec.SecurityContext = &corev1.PodSecurityContext{
-			FSGroup:            pointer.Int64(constants.JujuFSGroupID),
-			SupplementalGroups: []int64{constants.JujuFSGroupID},
-		}
+	spec.SecurityContext = &corev1.PodSecurityContext{
+		FSGroup:            pointer.Int64(constants.JujuFSGroupID),
+		SupplementalGroups: []int64{constants.JujuFSGroupID},
 	}
 	return spec, nil
 }

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -57,7 +57,7 @@ type applicationSuite struct {
 	applier      *resourcesmocks.MockApplier
 }
 
-const defaultAgentVersion = "2.9.37"
+const defaultAgentVersion = "3.5-beta1"
 
 var _ = gc.Suite(&applicationSuite{})
 
@@ -440,13 +440,24 @@ func getPodSpec() corev1.PodSpec {
 		AutomountServiceAccountToken:  pointer.BoolPtr(true),
 		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
 		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup:            int64Ptr(170),
+			SupplementalGroups: []int64{170},
+		},
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           "operator/image-path:1.1.1",
 			WorkingDir:      jujuDataDir,
 			Command:         []string{"/opt/containeragent"},
-			Args:            []string{"init", "--containeragent-pebble-dir", "/containeragent/pebble", "--charm-modified-version", "9001", "--data-dir", "/var/lib/juju", "--bin-dir", "/charm/bin"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+			},
 			Env: []corev1.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAMES",
@@ -498,6 +509,11 @@ func getPodSpec() corev1.PodSpec {
 					Name:      "charm-data",
 					MountPath: "/containeragent/pebble",
 					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
 				},
 			},
 		}},
@@ -588,6 +604,29 @@ func getPodSpec() corev1.PodSpec {
 					SubPath:   "containeragent/pebble",
 				},
 				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
 					Name:      "gitlab-database-appuuid",
 					MountPath: "path/to/here",
 				},
@@ -606,6 +645,10 @@ func getPodSpec() corev1.PodSpec {
 				{
 					Name:  "PEBBLE_SOCKET",
 					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
 				},
 			},
 			LivenessProbe: &corev1.Probe{
@@ -669,6 +712,10 @@ func getPodSpec() corev1.PodSpec {
 				{
 					Name:  "PEBBLE_SOCKET",
 					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
 				},
 			},
 			LivenessProbe: &corev1.Probe{
@@ -741,7 +788,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "2.9.37",
+						"juju.is/version": "3.5-beta1",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -764,7 +811,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "2.9.37",
+						"juju.is/version":  "3.5-beta1",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -778,7 +825,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "2.9.37"},
+							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
 						Spec: getPodSpec(),
 					},
@@ -853,7 +900,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "2.9.37",
+						"juju.is/version": "3.5-beta1",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -876,7 +923,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "2.9.37",
+						"juju.is/version":  "3.5-beta1",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -890,7 +937,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "2.9.37"},
+							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
 						Spec: podSpec,
 					},
@@ -976,7 +1023,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "2.9.37",
+						"juju.is/version":  "3.5-beta1",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -988,7 +1035,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "2.9.37"},
+							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
 						Spec: podSpec,
 					},
@@ -1049,7 +1096,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "2.9.37",
+						"juju.is/version":  "3.5-beta1",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -1060,7 +1107,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "2.9.37"},
+							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
 						Spec: podSpec,
 					},
@@ -1197,7 +1244,6 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 
 // Test upgrades are performed by ensure. Regression bug for lp1997253
 func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
-
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, true, "2.9.34", func() {
 		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
@@ -1222,6 +1268,21 @@ func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
 			"--charm-modified-version", "9001",
 			"--data-dir", "/var/lib/juju",
 			"--bin-dir", "/charm/bin",
+		})
+	})
+
+	s.assertEnsure(c, app, false, constraints.Value{}, true, "3.5-beta1.1", func() {
+		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Assert(len(ss.Spec.Template.Spec.InitContainers), gc.Equals, 1)
+		c.Assert(ss.Spec.Template.Spec.InitContainers[0].Args, jc.DeepEquals, []string{
+			"init",
+			"--containeragent-pebble-dir", "/containeragent/pebble",
+			"--charm-modified-version", "9001",
+			"--data-dir", "/var/lib/juju",
+			"--bin-dir", "/charm/bin",
+			"--profile-dir", "/containeragent/etc/profile.d",
 		})
 	})
 }
@@ -2785,7 +2846,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "2.9.37",
+						"juju.is/version": "3.5-beta1",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -2821,7 +2882,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "2.9.37",
+						"juju.is/version":  "3.5-beta1",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -2835,7 +2896,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "2.9.37"},
+							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
 						Spec: ps,
 					},
@@ -2881,7 +2942,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "2.9.37"},
+			Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -2902,7 +2963,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "2.9.37"},
+			Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1668,7 +1668,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		ExistingContainers:   []string{apiServerContainerName},
 		// TODO(wallyworld) - use storage so the volumes don't need to be manually set up
 		//Filesystems: nil,
-		Rootless: true,
+		CharmUser: caas.RunAsNonRoot,
 	}
 	spec, err := controllerApp.ApplicationPodSpec(cfg)
 	if err != nil {

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -69,6 +69,11 @@ const (
 	JujuUserID = 170
 	// JujuGroupID is the juju group id for rootless juju agents.
 	JujuGroupID = 170
+	// JujuSudoUserID is the juju user id for rootless juju agents with sudo.
+	// NOTE: 171 uid/gid must be updated here and in caas/Dockerfile
+	JujuSudoUserID = 171
+	// JujuSudoGroupID is the juju group id for rootless juju agents with sudo.
+	JujuSudoGroupID = 171
 	// JujuFSGroupID is the group id for all fs entries written to k8s volumes.
 	JujuFSGroupID = 170
 )

--- a/rpc/params/charms.go
+++ b/rpc/params/charms.go
@@ -129,10 +129,9 @@ type CharmMeta struct {
 	Resources      map[string]CharmResourceMeta `json:"resources,omitempty"`
 	Terms          []string                     `json:"terms,omitempty"`
 	MinJujuVersion string                       `json:"min-juju-version,omitempty"`
-
-	Containers map[string]CharmContainer `json:"containers,omitempty"`
-
-	AssumesExpr *assumes.ExpressionTree `json:"assumes-expr,omitempty"`
+	Containers     map[string]CharmContainer    `json:"containers,omitempty"`
+	AssumesExpr    *assumes.ExpressionTree      `json:"assumes-expr,omitempty"`
+	CharmUser      string                       `json:"charm-user,omitempty"`
 }
 
 // Charm holds all the charm data that the client needs.
@@ -200,6 +199,8 @@ type CharmBase struct {
 type CharmContainer struct {
 	Resource string       `json:"resource,omitempty"`
 	Mounts   []CharmMount `json:"mounts,omitempty"`
+	Uid      int          `json:"uid,omitempty"`
+	Gid      int          `json:"gid,omitempty"`
 }
 
 // CharmMount mirrors charm.Mount

--- a/worker/caasapplicationprovisioner/ops_test.go
+++ b/worker/caasapplicationprovisioner/ops_test.go
@@ -571,6 +571,11 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 						Location: "/data",
 					}},
 				},
+				"rootless": {
+					Resource: "rootless-image",
+					Uid:      5000,
+					Gid:      5001,
+				},
 			},
 		},
 	}
@@ -581,6 +586,9 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 	oci := map[string]resources.DockerImageDetails{
 		"mysql-image": {
 			RegistryPath: "mysql/ubuntu:latest-22.04",
+		},
+		"rootless-image": {
+			RegistryPath: "rootless:foo-bar",
 		},
 	}
 	ensureParams := caas.ApplicationConfig{
@@ -599,6 +607,14 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 					Path:        "/data",
 				}},
 			},
+			"rootless": {
+				Name: "rootless",
+				Image: resources.DockerImageDetails{
+					RegistryPath: "rootless:foo-bar",
+				},
+				Uid: 5000,
+				Gid: 5001,
+			},
 		},
 		IntroductionSecret:   "123456789",
 		ControllerAddresses:  "1.2.3.1,1.2.3.2,1.2.3.3",
@@ -614,6 +630,7 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 		Devices:      []devices.KubernetesDeviceParams{},
 		Trust:        true,
 		InitialScale: 10,
+		CharmUser:    caas.RunAsRoot,
 	}
 	gomock.InOrder(
 		facade.EXPECT().ProvisioningInfo("test").Return(pi, nil),


### PR DESCRIPTION
To enable charms to run their workloads as a non-root user, this PR wires through the UID/GID configuration from the charm container metadata. When omitted, the default is to run the containers as root, which is the current behavior.

This PR also wires through the charm user configuration option from the charm metadata, although until there is sufficient support in pebble to authenticate juju/the charm, this is disabled. The mechanics of the rootless charm is already used for controllers.

## QA steps

- Bootstrap k8s.
- The controller should be rootless still.
- Deploy a charm with containers. It should still work (i.e. run as root).
- Add the following to the container of a charm:
```
uid: 5000
gid: 5000
```
- Deploy the charm, it should fail:
`ERROR attempting to deploy "./rootlesstest": parsing "metadata.yaml" file: parsing containers: container "rootless" has invalid uid 5000: uid cannot be in reserved range 1000-9999`
- Chose a uid/group outside the reserved range.
- Deploy again. Check it deploys and the pod has the container running as that user.
- The charm container should still run as root.
- Check the charm can connect the non-root containers pebble socket.

## Documentation changes

[Changes to charm metadata documentation.](https://discourse.charmhub.io/t/file-metadata-yaml/5213/35?u=hpidcock)

## Links

**Jira card:** JUJU-5124

#15848
#16675
