### PR TITLE
On model upgrades, only search for agents if different to controller

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -546,7 +546,7 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
-func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
+func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, ctrlModelVers string, dryRun bool) {
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
@@ -575,18 +575,19 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
 	st.EXPECT().ControllerConfig().Return(controllerCfg, nil)
 	model.EXPECT().Life().Return(state.Alive)
 	model.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
-	model.EXPECT().Type().Return(state.ModelTypeIAAS)
-	model.EXPECT().IsControllerModel().Return(false)
+	model.EXPECT().IsControllerModel().Return(false).AnyTimes()
 	s.statePool.EXPECT().ControllerModel().Return(ctrlModel, nil)
-	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("3.9.99"), nil)
-	s.toolsFinder.EXPECT().FindAgents(common.FindAgentsParams{
-		Number:        version.MustParse("3.9.99"),
-		ControllerCfg: controllerCfg, ModelType: state.ModelTypeIAAS}).Return(
-		[]*coretools.Tools{
-			{Version: version.MustParseBinary("3.9.99-ubuntu-amd64")},
-		}, nil,
-	)
-	model.EXPECT().IsControllerModel().Return(false).Times(2)
+	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse(ctrlModelVers), nil)
+	if ctrlModelVers != "3.9.99" {
+		model.EXPECT().Type().Return(state.ModelTypeIAAS)
+		s.toolsFinder.EXPECT().FindAgents(common.FindAgentsParams{
+			Number:        version.MustParse("3.9.99"),
+			ControllerCfg: controllerCfg, ModelType: state.ModelTypeIAAS}).Return(
+			[]*coretools.Tools{
+				{Version: version.MustParseBinary("3.9.99-ubuntu-amd64")},
+			}, nil,
+		)
+	}
 
 	// - check no upgrade series in process.
 	st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
@@ -619,11 +620,15 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
 }
 
 func (s *modelUpgradeSuite) TestUpgradeModelJuju3(c *gc.C) {
-	s.assertUpgradeModelJuju3(c, false)
+	s.assertUpgradeModelJuju3(c, "3.10.0", false)
+}
+
+func (s *modelUpgradeSuite) TestUpgradeModelJuju3SameAsController(c *gc.C) {
+	s.assertUpgradeModelJuju3(c, "3.9.99", false)
 }
 
 func (s *modelUpgradeSuite) TestUpgradeModelJuju3DryRun(c *gc.C) {
-	s.assertUpgradeModelJuju3(c, true)
+	s.assertUpgradeModelJuju3(c, "3.10.0", true)
 }
 
 func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
@@ -655,9 +660,9 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	model.EXPECT().Life().Return(state.Alive)
 	model.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
 	model.EXPECT().Type().Return(state.ModelTypeIAAS)
-	model.EXPECT().IsControllerModel().Return(false)
+	model.EXPECT().IsControllerModel().Return(false).AnyTimes()
 	s.statePool.EXPECT().ControllerModel().Return(ctrlModel, nil)
-	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("3.9.99"), nil)
+	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("3.10.0"), nil)
 	s.toolsFinder.EXPECT().FindAgents(common.FindAgentsParams{
 		Number:        version.MustParse("3.9.99"),
 		ControllerCfg: controllerCfg, ModelType: state.ModelTypeIAAS}).Return(
@@ -665,7 +670,6 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 			{Version: version.MustParseBinary("3.9.99-ubuntu-amd64")},
 		}, nil,
 	)
-	model.EXPECT().IsControllerModel().Return(false).Times(2)
 
 	// - check no upgrade series in process.
 	st.EXPECT().HasUpgradeSeriesLocks().Return(true, nil)
@@ -701,6 +705,37 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
+}
+
+func (s *modelUpgradeSuite) TestCannotUpgradePastControllerVersion(c *gc.C) {
+	ctrl, api := s.getModelUpgraderAPI(c)
+	defer ctrl.Finish()
+
+	modelUUID := coretesting.ModelTag.Id()
+	model := mocks.NewMockModel(ctrl)
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().Release().AnyTimes()
+
+	s.statePool.EXPECT().Get(modelUUID).AnyTimes().Return(st, nil)
+	st.EXPECT().Model().AnyTimes().Return(model, nil)
+	ctrlModel := mocks.NewMockModel(ctrl)
+
+	s.blockChecker.EXPECT().ChangeAllowed().Return(nil)
+
+	st.EXPECT().ControllerConfig().Return(controllerCfg, nil)
+	model.EXPECT().Life().Return(state.Alive)
+	model.EXPECT().AgentVersion().Return(version.MustParse("2.9.1"), nil)
+	model.EXPECT().IsControllerModel().Return(false)
+	s.statePool.EXPECT().ControllerModel().Return(ctrlModel, nil)
+	ctrlModel.EXPECT().AgentVersion().Return(version.MustParse("3.9.99"), nil)
+
+	_, err := api.UpgradeModel(
+		params.UpgradeModelParams{
+			ModelTag:      coretesting.ModelTag.String(),
+			TargetVersion: version.MustParse("3.12.0"),
+		},
+	)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade to a version "3.12.0" greater than that of the controller "3.9.99"`)
 }
 
 func (s *modelUpgradeSuite) TestAbortCurrentUpgrade(c *gc.C) {


### PR DESCRIPTION
When upgrading a model and we want to use the same version as the controller to upgrade to, there's no need to look up simplestreams since we know the agent version is valid - the controller is running it. So we check for that and bypass the lookup.

Also, there was a logic error in checking if the requested version is greater than the controller version. That's fixed and a test added.

## QA steps

I added extra logging (and removed it) to check that we don't call FindTools.

On k8s and vm:

bootstrap a 3.1 controller
add a model

bootstrap a new controller
migrate 3.1 model to new controller
juju upgrade-model

## Links

**Jira card:** JUJU-5705

