### PR TITLE
Credential rename from ID to Key

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -241,7 +241,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		Owner:        adminUserUUID,
 		Cloud:        stateParams.ControllerCloud.Name,
 		CloudRegion:  stateParams.ControllerCloudRegion,
-		Credential:   credential.IdFromTag(cloudCredTag),
+		Credential:   credential.KeyFromTag(cloudCredTag),
 		UUID:         controllerModelUUID,
 	}
 	_, controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
@@ -257,7 +257,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		addAdminUser,
 		ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
 		cloudbootstrap.InsertCloud(stateParams.ControllerCloud),
-		credbootstrap.InsertCredential(credential.IdFromTag(cloudCredTag), cloudCred),
+		credbootstrap.InsertCredential(credential.KeyFromTag(cloudCredTag), cloudCred),
 		cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 		controllerModelCreateFunc,
 		modelbootstrap.CreateReadOnlyModel(controllerModelArgs.AsReadOnly()),

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -119,6 +119,6 @@ func MakeCloudSpecCredentialContentWatcherForModel(st *state.State, credentialSe
 		if !exists {
 			return nil, nil
 		}
-		return credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
+		return credentialService.WatchCredential(ctx, credential.KeyFromTag(credentialTag))
 	}
 }

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -37,7 +37,7 @@ func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 	credentialService := credentialcommon.NewMockCredentialService(ctrl)
 	api := credentialcommon.NewCredentialManagerAPI(s.backend, credentialService)
 
-	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.IdFromTag(s.backend.tag), "not again")
+	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.KeyFromTag(s.backend.tag), "not again")
 
 	result, err := api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -54,7 +54,7 @@ func (s *CredentialSuite) TestInvalidateModelCredentialError(c *gc.C) {
 
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.IdFromTag(s.backend.tag), "not again")
+	credentialService.EXPECT().InvalidateCredential(gomock.Any(), credential.KeyFromTag(s.backend.tag), "not again")
 
 	result, err := api.InvalidateModelCredential(context.Background(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/credentialcommon/credentialcommon_mock.go
+++ b/apiserver/common/credentialcommon/credentialcommon_mock.go
@@ -42,7 +42,7 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -57,7 +57,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredential(arg0, arg1 any) *go
 }
 
 // InvalidateCredential mocks base method.
-func (m *MockCredentialService) InvalidateCredential(arg0 context.Context, arg1 credential.ID, arg2 string) error {
+func (m *MockCredentialService) InvalidateCredential(arg0 context.Context, arg1 credential.Key, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InvalidateCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/apiserver/common/mocks/credential_mock.go
+++ b/apiserver/common/mocks/credential_mock.go
@@ -43,7 +43,7 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -58,7 +58,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredential(arg0, arg1 any) *go
 }
 
 // WatchCredential mocks base method.
-func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.ID) (watcher.Watcher[struct{}], error) {
+func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.Key) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -127,8 +127,8 @@ type Model interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
-	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
+	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 }
 
 // CloudService provides access to clouds.

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -322,7 +322,7 @@ func cloudSpecForModel(
 	if !ok {
 		return cloudspec.CloudSpec{}, errors.NotValidf("cloud credential for %s is empty", m.UUID())
 	}
-	cred, err := credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
+	cred, err := credentialService.CloudCredential(ctx, credential.KeyFromTag(tag))
 	if err != nil {
 		return cloudspec.CloudSpec{}, errors.Trace(err)
 	}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -192,7 +192,7 @@ func (s *secretsSuite) assertAdminBackendConfigInfoDefault(
 		tag := names.NewCloudCredentialTag("test/fred/default")
 		model.EXPECT().CloudCredentialTag().Return(tag, true)
 		cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{"foo": "bar"})
-		credentialService.EXPECT().CloudCredential(gomock.Any(), credential.IdFromTag(tag)).Return(cred, nil)
+		credentialService.EXPECT().CloudCredential(gomock.Any(), credential.KeyFromTag(tag)).Return(cred, nil)
 	}
 
 	backendState.EXPECT().ListSecretBackends().Return([]*coresecrets.SecretBackend{{

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -207,7 +207,7 @@ func (api *AgentAPI) WatchCredentials(ctx context.Context, args params.Entities)
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		watch, err := api.credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
+		watch, err := api.credentialService.WatchCredential(ctx, credential.KeyFromTag(credentialTag))
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -286,7 +286,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	ch <- struct{}{}
 
 	nw := watchertest.NewMockNotifyWatcher(ch)
-	credentialService.EXPECT().WatchCredential(gomock.Any(), credential.IdFromTag(tag)).Return(nw, nil)
+	credentialService.EXPECT().WatchCredential(gomock.Any(), credential.KeyFromTag(tag)).Return(nw, nil)
 	api, err := s.agentAPI(c, authorizer, credentialService)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := api.WatchCredentials(context.Background(), params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -21,7 +21,7 @@ func Register(registry facade.FacadeRegistry) {
 }
 
 type CredentialService interface {
-	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
+	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 }
 
 // NewAgentAPIV3 returns an object implementing version 3 of the Agent API

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -108,16 +108,16 @@ type testCredentialService struct {
 	*testing.Stub
 }
 
-func (c testCredentialService) InvalidateCredential(ctx context.Context, id credential.ID, reason string) error {
-	c.AddCall("InvalidateCredential", id, reason)
+func (c testCredentialService) InvalidateCredential(ctx context.Context, key credential.Key, reason string) error {
+	c.AddCall("InvalidateCredential", key, reason)
 	return c.NextErr()
 }
 
-func (c testCredentialService) CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error) {
+func (c testCredentialService) CloudCredential(ctx context.Context, _ credential.Key) (cloud.Credential, error) {
 	return cloud.NewEmptyCredential(), nil
 }
 
-func (c testCredentialService) WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error) {
+func (c testCredentialService) WatchCredential(ctx context.Context, _ credential.Key) (watcher.NotifyWatcher, error) {
 	return apiservertesting.NewFakeNotifyWatcher(), nil
 }
 

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -31,7 +31,7 @@ type CredentialValidatorV2 interface {
 
 type CredentialService interface {
 	common.CredentialService
-	InvalidateCredential(ctx context.Context, id credential.ID, reason string) error
+	InvalidateCredential(ctx context.Context, key credential.Key, reason string) error
 }
 
 type CredentialValidatorAPI struct {
@@ -87,7 +87,7 @@ func (api *CredentialValidatorAPI) WatchCredential(ctx context.Context, tag para
 	}
 
 	result := params.NotifyWatchResult{}
-	watch, err := api.credentialService.WatchCredential(ctx, credential.IdFromTag(credentialTag))
+	watch, err := api.credentialService.WatchCredential(ctx, credential.KeyFromTag(credentialTag))
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
 		return result, nil
@@ -146,7 +146,7 @@ func (api *CredentialValidatorAPI) modelCredential(ctx context.Context) (*ModelC
 	}
 
 	result.Credential = modelCredentialTag
-	credential, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(modelCredentialTag))
+	credential, err := api.credentialService.CloudCredential(ctx, credential.KeyFromTag(modelCredentialTag))
 	if err != nil {
 		if !errors.Is(err, errors.NotFound) {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -107,7 +107,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.credentialService.CheckCalls(c, []testing.StubCall{
-		{"InvalidateCredential", []interface{}{credential.IdFromTag(credentialTag), "not again"}},
+		{"InvalidateCredential", []interface{}{credential.KeyFromTag(credentialTag), "not again"}},
 	})
 }
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -52,8 +52,8 @@ type CloudService interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
-	WatchCredential(ctx context.Context, id credential.ID) (watcher.NotifyWatcher, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
+	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 }
 
 // UnitRemover deletes a unit from the dqlite database.

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -46,14 +46,14 @@ type ModelCredentialService interface {
 
 // CredentialService provides access to the credential domain service.
 type CredentialService interface {
-	CloudCredential(ctx stdcontext.Context, id credential.ID) (cloud.Credential, error)
-	AllCloudCredentialsForOwner(ctx stdcontext.Context, owner string) (map[credential.ID]cloud.Credential, error)
+	CloudCredential(ctx stdcontext.Context, key credential.Key) (cloud.Credential, error)
+	AllCloudCredentialsForOwner(ctx stdcontext.Context, owner string) (map[credential.Key]cloud.Credential, error)
 	CloudCredentialsForOwner(ctx stdcontext.Context, owner, cloudName string) (map[string]cloud.Credential, error)
-	UpdateCloudCredential(ctx stdcontext.Context, id credential.ID, cred cloud.Credential) error
-	RemoveCloudCredential(ctx stdcontext.Context, id credential.ID) error
-	WatchCredential(ctx stdcontext.Context, id credential.ID) (watcher.NotifyWatcher, error)
-	CheckAndUpdateCredential(ctx stdcontext.Context, id credential.ID, cred cloud.Credential, force bool) ([]credentialservice.UpdateCredentialModelResult, error)
-	CheckAndRevokeCredential(ctx stdcontext.Context, id credential.ID, force bool) error
+	UpdateCloudCredential(ctx stdcontext.Context, key credential.Key, cred cloud.Credential) error
+	RemoveCloudCredential(ctx stdcontext.Context, key credential.Key) error
+	WatchCredential(ctx stdcontext.Context, key credential.Key) (watcher.NotifyWatcher, error)
+	CheckAndUpdateCredential(ctx stdcontext.Context, key credential.Key, cred cloud.Credential, force bool) ([]credentialservice.UpdateCredentialModelResult, error)
+	CheckAndRevokeCredential(ctx stdcontext.Context, key credential.Key, force bool) error
 }
 
 type User interface {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -633,9 +633,9 @@ func (s *cloudSuite) TestUpdateCredentials(c *gc.C) {
 		jujucloud.OAuth1AuthType,
 		map[string]string{"token": "foo:bar:baz"},
 	)
-	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.IdFromTag(tagTwo), cred, false).Return(
+	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.KeyFromTag(tagTwo), cred, false).Return(
 		nil, errors.New("cannot update credential \"three\": controller does not manage cloud \"badcloud\""))
-	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.IdFromTag(tagOne), cred, false).Return(
+	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.KeyFromTag(tagOne), cred, false).Return(
 		[]credentialservice.UpdateCredentialModelResult{}, nil)
 
 	results, err := s.api.UpdateCredentialsCheckModels(stdcontext.Background(), params.UpdateCredentialArgs{
@@ -685,7 +685,7 @@ func (s *cloudSuite) TestUpdateCredentialsAdminAccess(c *gc.C) {
 		attrs: map[string]string{}})
 
 	cred := jujucloud.Credential{}
-	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.IdFromTag(tag), cred, false).Return(
+	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.KeyFromTag(tag), cred, false).Return(
 		[]credentialservice.UpdateCredentialModelResult{}, nil)
 
 	results, err := s.api.UpdateCredentialsCheckModels(stdcontext.Background(), params.UpdateCredentialArgs{
@@ -708,7 +708,7 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *gc.C) {
 
 	cred := jujucloud.Credential{}
 
-	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.IdFromTag(tag), cred, false).Return(
+	s.credService.EXPECT().CheckAndUpdateCredential(gomock.Any(), credential.KeyFromTag(tag), cred, false).Return(
 		[]credentialservice.UpdateCredentialModelResult{{
 			ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			ModelName: "testModel1",
@@ -769,7 +769,7 @@ func (s *cloudSuite) TestRevokeCredentials(c *gc.C) {
 	_, tag := cloudCredentialTag(credParams{name: "three", owner: "bruce", cloudName: "meep", authType: jujucloud.EmptyAuthType,
 		attrs: map[string]string{}})
 
-	s.credService.EXPECT().CheckAndRevokeCredential(gomock.Any(), credential.IdFromTag(tag), false).Return(nil)
+	s.credService.EXPECT().CheckAndRevokeCredential(gomock.Any(), credential.KeyFromTag(tag), false).Return(nil)
 
 	results, err := s.api.RevokeCredentialsCheckModels(stdcontext.Background(), params.RevokeCredentialArgs{
 		Credentials: []params.RevokeCredentialArg{
@@ -796,7 +796,7 @@ func (s *cloudSuite) TestRevokeCredentialsAdminAccess(c *gc.C) {
 	_, tag := cloudCredentialTag(credParams{name: "three", owner: "julia", cloudName: "meep", authType: jujucloud.EmptyAuthType,
 		attrs: map[string]string{}})
 
-	s.credService.EXPECT().CheckAndRevokeCredential(gomock.Any(), credential.IdFromTag(tag), false).Return(nil)
+	s.credService.EXPECT().CheckAndRevokeCredential(gomock.Any(), credential.KeyFromTag(tag), false).Return(nil)
 
 	results, err := s.api.RevokeCredentialsCheckModels(stdcontext.Background(), params.RevokeCredentialArgs{
 		Credentials: []params.RevokeCredentialArg{
@@ -1018,7 +1018,7 @@ func (s *cloudSuite) TestCredentialContentsAllNoSecrets(c *gc.C) {
 		}})
 
 	credentialTwo.Invalid = true
-	creds := map[credential.ID]jujucloud.Credential{
+	creds := map[credential.Key]jujucloud.Credential{
 		{Cloud: "meep", Owner: "bruce", Name: "one"}: credentialOne,
 		{Cloud: "meep", Owner: "bruce", Name: "two"}: credentialTwo,
 	}

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -160,10 +160,10 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // AllCloudCredentialsForOwner mocks base method.
-func (m *MockCredentialService) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.ID]cloud0.Credential, error) {
+func (m *MockCredentialService) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.Key]cloud0.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllCloudCredentialsForOwner", arg0, arg1)
-	ret0, _ := ret[0].(map[credential.ID]cloud0.Credential)
+	ret0, _ := ret[0].(map[credential.Key]cloud0.Credential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -175,7 +175,7 @@ func (mr *MockCredentialServiceMockRecorder) AllCloudCredentialsForOwner(arg0, a
 }
 
 // CheckAndRevokeCredential mocks base method.
-func (m *MockCredentialService) CheckAndRevokeCredential(arg0 context.Context, arg1 credential.ID, arg2 bool) error {
+func (m *MockCredentialService) CheckAndRevokeCredential(arg0 context.Context, arg1 credential.Key, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckAndRevokeCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -189,7 +189,7 @@ func (mr *MockCredentialServiceMockRecorder) CheckAndRevokeCredential(arg0, arg1
 }
 
 // CheckAndUpdateCredential mocks base method.
-func (m *MockCredentialService) CheckAndUpdateCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud0.Credential, arg3 bool) ([]service.UpdateCredentialModelResult, error) {
+func (m *MockCredentialService) CheckAndUpdateCredential(arg0 context.Context, arg1 credential.Key, arg2 cloud0.Credential, arg3 bool) ([]service.UpdateCredentialModelResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckAndUpdateCredential", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]service.UpdateCredentialModelResult)
@@ -204,7 +204,7 @@ func (mr *MockCredentialServiceMockRecorder) CheckAndUpdateCredential(arg0, arg1
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud0.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud0.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud0.Credential)
@@ -234,7 +234,7 @@ func (mr *MockCredentialServiceMockRecorder) CloudCredentialsForOwner(arg0, arg1
 }
 
 // RemoveCloudCredential mocks base method.
-func (m *MockCredentialService) RemoveCloudCredential(arg0 context.Context, arg1 credential.ID) error {
+func (m *MockCredentialService) RemoveCloudCredential(arg0 context.Context, arg1 credential.Key) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveCloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -248,7 +248,7 @@ func (mr *MockCredentialServiceMockRecorder) RemoveCloudCredential(arg0, arg1 an
 }
 
 // UpdateCloudCredential mocks base method.
-func (m *MockCredentialService) UpdateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud0.Credential) error {
+func (m *MockCredentialService) UpdateCloudCredential(arg0 context.Context, arg1 credential.Key, arg2 cloud0.Credential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -262,7 +262,7 @@ func (mr *MockCredentialServiceMockRecorder) UpdateCloudCredential(arg0, arg1, a
 }
 
 // WatchCredential mocks base method.
-func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.ID) (watcher.Watcher[struct{}], error) {
+func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.Key) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])

--- a/apiserver/facades/client/cloud/mocks/credential_mock.go
+++ b/apiserver/facades/client/cloud/mocks/credential_mock.go
@@ -43,7 +43,7 @@ func (m *MockCredentialValidator) EXPECT() *MockCredentialValidatorMockRecorder 
 }
 
 // Validate mocks base method.
-func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 service.CredentialValidationContext, arg2 credential.ID, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
+func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 service.CredentialValidationContext, arg2 credential.Key, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]error)

--- a/apiserver/facades/client/credentialmanager/client_integration_test.go
+++ b/apiserver/facades/client/credentialmanager/client_integration_test.go
@@ -44,12 +44,12 @@ func (s *CredentialManagerIntegrationSuite) TestInvalidateModelCredential(c *gc.
 	c.Assert(set, jc.IsTrue)
 
 	credService := s.ControllerServiceFactory(c).Credential()
-	cred, err := credService.CloudCredential(ctx.Background(), credential.IdFromTag(tag))
+	cred, err := credService.CloudCredential(ctx.Background(), credential.KeyFromTag(tag))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cred.Invalid, jc.IsFalse)
 
 	c.Assert(s.client.InvalidateModelCredential(ctx.Background(), "no reason really"), jc.ErrorIsNil)
-	cred, err = credService.CloudCredential(ctx.Background(), credential.IdFromTag(tag))
+	cred, err = credService.CloudCredential(ctx.Background(), credential.KeyFromTag(tag))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cred.Invalid, jc.IsTrue)
 }

--- a/apiserver/facades/client/credentialmanager/client_test.go
+++ b/apiserver/facades/client/credentialmanager/client_test.go
@@ -118,7 +118,7 @@ type testCredentialService struct {
 	*testing.Stub
 }
 
-func (b *testCredentialService) InvalidateCredential(ctx context.Context, id credential.ID, reason string) error {
-	b.AddCall("InvalidateCredential", id, reason)
+func (b *testCredentialService) InvalidateCredential(ctx context.Context, key credential.Key, reason string) error {
+	b.AddCall("InvalidateCredential", key, reason)
 	return b.NextErr()
 }

--- a/apiserver/facades/controller/migrationtarget/credential_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/credential_mock_test.go
@@ -43,7 +43,7 @@ func (m *MockCredentialValidator) EXPECT() *MockCredentialValidatorMockRecorder 
 }
 
 // Validate mocks base method.
-func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 service.CredentialValidationContext, arg2 credential.ID, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
+func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 service.CredentialValidationContext, arg2 credential.Key, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]error)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -486,7 +486,7 @@ func (api *API) CheckMachines(ctx context.Context, args params.ModelArgs) (param
 		return params.ErrorResults{}, nil
 	}
 
-	storedCredential, err := api.credentialService.CloudCredential(ctx, credential.IdFromTag(credentialTag))
+	storedCredential, err := api.credentialService.CloudCredential(ctx, credential.KeyFromTag(credentialTag))
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -501,7 +501,7 @@ func (api *API) CheckMachines(ctx context.Context, args params.ModelArgs) (param
 	cred := jujucloud.NewCredential(storedCredential.AuthType(), storedCredential.Attributes())
 
 	var result params.ErrorResults
-	modelErrors, err := api.credentialValidator.Validate(ctx, callCtx, credential.IdFromTag(credentialTag), &cred, cloud.Type != "manual")
+	modelErrors, err := api.credentialValidator.Validate(ctx, callCtx, credential.KeyFromTag(credentialTag), &cred, cloud.Type != "manual")
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -582,8 +582,8 @@ func (s *Suite) TestCheckMachinesManualCloud(c *gc.C) {
 	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
 	tag := names.NewCloudCredentialTag(
 		fmt.Sprintf("manual/%s/dummy-credential", owner.Name()))
-	s.credentialService.EXPECT().CloudCredential(gomock.Any(), credential.IdFromTag(tag)).Return(cred, nil)
-	s.credentialValidator.EXPECT().Validate(gomock.Any(), gomock.Any(), credential.IdFromTag(tag), &cred, false)
+	s.credentialService.EXPECT().CloudCredential(gomock.Any(), credential.KeyFromTag(tag)).Return(cred, nil)
+	s.credentialValidator.EXPECT().Validate(gomock.Any(), gomock.Any(), credential.KeyFromTag(tag), &cred, false)
 
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		CloudName:       "manual",

--- a/apiserver/testing/credential.go
+++ b/apiserver/testing/credential.go
@@ -24,14 +24,14 @@ type credentialGetter struct {
 	cred *cloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ context.Context, id credential.ID) (cloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ context.Context, key credential.Key) (cloud.Credential, error) {
 	if c.cred == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", key)
 	}
 	return *c.cred, nil
 }
 
-func (c credentialGetter) InvalidateCredential(_ context.Context, _ credential.ID, _ string) error {
+func (c credentialGetter) InvalidateCredential(_ context.Context, _ credential.Key, _ string) error {
 	return nil
 }
 

--- a/cmd/jujud-controller/agent/bootstrap.go
+++ b/cmd/jujud-controller/agent/bootstrap.go
@@ -175,9 +175,9 @@ type credentialGetter struct {
 	cred *jujucloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ stdcontext.Context, id credential.ID) (jujucloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ stdcontext.Context, key credential.Key) (jujucloud.Credential, error) {
 	if c.cred == nil {
-		return jujucloud.Credential{}, errors.NotFoundf("credential %q", id)
+		return jujucloud.Credential{}, errors.NotFoundf("credential %q", key)
 	}
 	return *c.cred, nil
 }

--- a/cmd/jujud-controller/agent/machine_legacy_test.go
+++ b/cmd/jujud-controller/agent/machine_legacy_test.go
@@ -301,13 +301,13 @@ func (s *MachineLegacySuite) TestWorkersForHostedModelWithDeletedCredential(c *g
 	})
 
 	ctx := context.Background()
-	id := credential.ID{
+	key := credential.Key{
 		Cloud: "dummy",
 		Owner: "admin",
 		Name:  "another",
 	}
 	serviceFactory := s.ControllerServiceFactory(c)
-	err := serviceFactory.Credential().UpdateCloudCredential(ctx, id, cloud.NewCredential(cloud.UserPassAuthType, nil))
+	err := serviceFactory.Credential().UpdateCloudCredential(ctx, key, cloud.NewCredential(cloud.UserPassAuthType, nil))
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
@@ -330,7 +330,7 @@ func (s *MachineLegacySuite) TestWorkersForHostedModelWithDeletedCredential(c *g
 	uuid := st.ModelUUID()
 
 	// remove cloud credential used by this model but keep model reference to it
-	err = serviceFactory.Credential().RemoveCloudCredential(ctx, id)
+	err = serviceFactory.Credential().RemoveCloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 
 	tracker := agenttest.NewEngineTracker()

--- a/core/credential/credential.go
+++ b/core/credential/credential.go
@@ -10,67 +10,67 @@ import (
 	"github.com/juju/names/v5"
 )
 
-// ID represents the id of a cloud credential.
-type ID struct {
-	// Cloud is the cloud name that the credential applies to. Id is valid when
+// Key represents the natural key of a cloud credential.
+type Key struct {
+	// Cloud is the cloud name that the credential applies to. Key is valid when
 	// this value is set.
 	Cloud string
 
-	// Owner is the owner of the credential. Id is valid when this value is set.
+	// Owner is the owner of the credential. Key is valid when this value is set.
 	Owner string
 
 	// Name is the name of the credential. Is is valid when this value is set.
 	Name string
 }
 
-// IdFromTag provides a utility for converting a CloudCredentialTag into a Id
-// struct. If the tags IsZero() returns true then a zero value Id struct is
+// KeyFromTag provides a utility for converting a CloudCredentialTag into a Key
+// struct. If the tags IsZero() returns true then a zero value Key struct is
 // returned.
-func IdFromTag(tag names.CloudCredentialTag) ID {
+func KeyFromTag(tag names.CloudCredentialTag) Key {
 	if tag.IsZero() {
-		return ID{}
+		return Key{}
 	}
 
-	return ID{
+	return Key{
 		Cloud: tag.Cloud().Id(),
 		Owner: tag.Owner().Name(),
 		Name:  tag.Name(),
 	}
 }
 
-// IsZero returns true if the ID struct is it's zero value with no values set.
-func (i ID) IsZero() bool {
-	return i == ID{}
+// IsZero returns true if the [Key] struct is it's zero value with no values set.
+func (k Key) IsZero() bool {
+	return k == Key{}
 }
 
 // String implements the stringer interface.
-func (i ID) String() string {
-	return fmt.Sprintf("%s/%s/%s", i.Cloud, i.Owner, i.Name)
+func (k Key) String() string {
+	return fmt.Sprintf("%s/%s/%s", k.Cloud, k.Owner, k.Name)
 }
 
-// Tag will convert this Id struct to a juju names CloudCredentialTag. Errors in
-// parsing of the tag will be returned. If the Id struct is it's zero value then
+// Tag will convert this Key struct to a juju names CloudCredentialTag. Errors in
+// parsing of the tag will be returned. If the Key struct is it's zero value then
 // a zero value Tag will be returned.
-func (i ID) Tag() (names.CloudCredentialTag, error) {
-	if i.IsZero() {
+func (k Key) Tag() (names.CloudCredentialTag, error) {
+	if k.IsZero() {
 		return names.CloudCredentialTag{}, nil
 	}
 	return names.ParseCloudCredentialTag(
-		fmt.Sprintf("%s-%s_%s_%s", names.CloudCredentialTagKind, i.Cloud, i.Owner, i.Name),
+		fmt.Sprintf("%s-%s_%s_%s", names.CloudCredentialTagKind, k.Cloud, k.Owner, k.Name),
 	)
 }
 
-// Validate is responsible for checking all of the fields of Id are in a set
-// state that is valid for use. You can also use IsZero() to test if the Id is
+// Validate is responsible for checking all of the fields of Key are in a set
+// state that is valid for use. You can also use IsZero() to test if the Key is
 // currently set to it's zero value.
-func (i ID) Validate() error {
-	if i.Cloud == "" {
+func (k Key) Validate() error {
+	if k.Cloud == "" {
 		return fmt.Errorf("%w cloud cannot be empty", errors.NotValid)
 	}
-	if i.Name == "" {
+	if k.Name == "" {
 		return fmt.Errorf("%w name cannot be empty", errors.NotValid)
 	}
-	if i.Owner == "" {
+	if k.Owner == "" {
 		return fmt.Errorf("%w owner cannot be empty", errors.NotValid)
 	}
 	return nil

--- a/core/credential/credential_test.go
+++ b/core/credential/credential_test.go
@@ -16,12 +16,12 @@ type typeSuite struct {
 
 var _ = gc.Suite(&typeSuite{})
 
-func (s *typeSuite) TestCredentialIdIsZero(c *gc.C) {
-	c.Assert(ID{}.IsZero(), jc.IsTrue)
+func (s *typeSuite) TestCredentialKeyIsZero(c *gc.C) {
+	c.Assert(Key{}.IsZero(), jc.IsTrue)
 }
 
-func (s *typeSuite) TestCredentialIdIsNotZero(c *gc.C) {
-	tests := []ID{
+func (s *typeSuite) TestCredentialKeyIsNotZero(c *gc.C) {
+	tests := []Key{
 		{
 			Owner: "wallyworld",
 		},
@@ -43,13 +43,13 @@ func (s *typeSuite) TestCredentialIdIsNotZero(c *gc.C) {
 	}
 }
 
-func (s *typeSuite) TestCredentialIdValidate(c *gc.C) {
+func (s *typeSuite) TestCredentialKeyValidate(c *gc.C) {
 	tests := []struct {
-		Id  ID
+		Key Key
 		Err error
 	}{
 		{
-			Id: ID{
+			Key: Key{
 				Cloud: "",
 				Name:  "wallyworld",
 				Owner: "wallyworld",
@@ -57,7 +57,7 @@ func (s *typeSuite) TestCredentialIdValidate(c *gc.C) {
 			Err: errors.NotValid,
 		},
 		{
-			Id: ID{
+			Key: Key{
 				Cloud: "my-cloud",
 				Name:  "",
 				Owner: "wallyworld",
@@ -65,7 +65,7 @@ func (s *typeSuite) TestCredentialIdValidate(c *gc.C) {
 			Err: errors.NotValid,
 		},
 		{
-			Id: ID{
+			Key: Key{
 				Cloud: "my-cloud",
 				Name:  "wallyworld",
 				Owner: "",
@@ -73,7 +73,7 @@ func (s *typeSuite) TestCredentialIdValidate(c *gc.C) {
 			Err: errors.NotValid,
 		},
 		{
-			Id: ID{
+			Key: Key{
 				Cloud: "my-cloud",
 				Name:  "wallyworld",
 				Owner: "wallyworld",
@@ -83,7 +83,7 @@ func (s *typeSuite) TestCredentialIdValidate(c *gc.C) {
 	}
 
 	for _, test := range tests {
-		err := test.Id.Validate()
+		err := test.Key.Validate()
 		if test.Err == nil {
 			c.Assert(err, jc.ErrorIsNil)
 		} else {

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -67,7 +67,7 @@ type Model struct {
 	// model. Credential must be for the same cloud as that of the model.
 	// Credential can be the zero value of the struct to not have a credential
 	// associated with the model.
-	Credential credential.ID
+	Credential credential.Key
 
 	// Owner is the uuid of the user that owns this model in the Juju controller.
 	Owner user.UUID

--- a/domain/credential/bootstrap/bootstrap.go
+++ b/domain/credential/bootstrap/bootstrap.go
@@ -19,9 +19,9 @@ import (
 )
 
 // InsertCredential inserts  a cloud credential into dqlite.
-func InsertCredential(id corecredential.ID, cred cloud.Credential) internaldatabase.BootstrapOpt {
+func InsertCredential(key corecredential.Key, cred cloud.Credential) internaldatabase.BootstrapOpt {
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
-		if id.IsZero() {
+		if key.IsZero() {
 			return nil
 		}
 
@@ -30,7 +30,7 @@ func InsertCredential(id corecredential.ID, cred cloud.Credential) internaldatab
 			return errors.Trace(err)
 		}
 		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), id, credential.CloudCredentialInfo{
+			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), key, credential.CloudCredentialInfo{
 				AuthType:      string(cred.AuthType()),
 				Attributes:    cred.Attributes(),
 				Revoked:       cred.Revoked,

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -44,13 +44,13 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
 
-	id := credential.ID{
+	key := credential.Key{
 		Cloud: "cirrus",
 		Owner: "fred",
 		Name:  "foo",
 	}
 
-	err = InsertCredential(id, cred)(ctx, s.TxnRunner(), s.NoopTxnRunner())
+	err = InsertCredential(key, cred)(ctx, s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var owner, cloudName string

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -28,7 +28,7 @@ func RegisterExport(coordinator Coordinator) {
 // ExportService provides a subset of the credential domain
 // service methods needed for credential export.
 type ExportService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
 }
 
 // exportOperation describes a way to execute a migration for
@@ -58,19 +58,19 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 		// Not set.
 		return nil
 	}
-	id := credential.ID{
+	key := credential.Key{
 		Cloud: credInfo.Cloud(),
 		Owner: credInfo.Owner(),
 		Name:  credInfo.Name(),
 	}
-	cred, err := e.service.CloudCredential(ctx, id)
+	cred, err := e.service.CloudCredential(ctx, key)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	model.SetCloudCredential(description.CloudCredentialArgs{
-		Owner:      names.NewUserTag(id.Owner),
-		Cloud:      names.NewCloudTag(id.Cloud),
-		Name:       id.Name,
+		Owner:      names.NewUserTag(key.Owner),
+		Cloud:      names.NewCloudTag(key.Cloud),
+		Name:       key.Name,
 		AuthType:   string(cred.AuthType()),
 		Attributes: cred.Attributes(),
 	})

--- a/domain/credential/modelmigration/export_test.go
+++ b/domain/credential/modelmigration/export_test.go
@@ -49,9 +49,9 @@ func (s *exportSuite) TestExport(c *gc.C) {
 		Name:  "foo",
 	})
 
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"foo": "bar"}, false)
-	s.service.EXPECT().CloudCredential(gomock.Any(), id).
+	s.service.EXPECT().CloudCredential(gomock.Any(), key).
 		Times(1).
 		Return(cred, nil)
 
@@ -73,8 +73,8 @@ func (s *exportSuite) TestExportNotFound(c *gc.C) {
 		Name:  "foo",
 	})
 
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.Any(), id).
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.Any(), key).
 		Times(1).
 		Return(cloud.Credential{}, errors.NotFound)
 

--- a/domain/credential/modelmigration/import_test.go
+++ b/domain/credential/modelmigration/import_test.go
@@ -76,9 +76,9 @@ func (s *importSuite) TestImport(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"hello": "world"})
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cloud.Credential{}, errors.NotFound)
-	s.service.EXPECT().UpdateCloudCredential(gomock.Any(), id, cred).Times(1)
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cloud.Credential{}, errors.NotFound)
+	s.service.EXPECT().UpdateCloudCredential(gomock.Any(), key, cred).Times(1)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -100,8 +100,8 @@ func (s *importSuite) TestImportExistingMatches(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"hello": "world"})
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -123,8 +123,8 @@ func (s *importSuite) TestImportExistingAuthTypeMisMatch(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{"hello": "world"})
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
@@ -146,8 +146,8 @@ func (s *importSuite) TestImportExistingAttributesMisMatch(c *gc.C) {
 		},
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"goodbye": "world"})
-	id := credential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), id).Times(1).Return(cred, nil)
+	key := credential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)

--- a/domain/credential/modelmigration/migrations_mock_test.go
+++ b/domain/credential/modelmigration/migrations_mock_test.go
@@ -78,7 +78,7 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockImportService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockImportService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)
@@ -93,7 +93,7 @@ func (mr *MockImportServiceMockRecorder) CloudCredential(arg0, arg1 any) *gomock
 }
 
 // UpdateCloudCredential mocks base method.
-func (m *MockImportService) UpdateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 cloud.Credential) error {
+func (m *MockImportService) UpdateCloudCredential(arg0 context.Context, arg1 credential.Key, arg2 cloud.Credential) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -130,7 +130,7 @@ func (m *MockExportService) EXPECT() *MockExportServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockExportService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockExportService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -69,7 +69,7 @@ type CredentialValidator interface {
 	Validate(
 		ctx stdcontext.Context,
 		validationContext CredentialValidationContext,
-		credentialID corecredential.ID,
+		credentialKey corecredential.Key,
 		credential *cloud.Credential,
 		checkCloudInstances bool,
 	) ([]error, error)
@@ -87,15 +87,15 @@ func NewCredentialValidator() CredentialValidator {
 func (v defaultCredentialValidator) Validate(
 	ctx stdcontext.Context,
 	validationContext CredentialValidationContext,
-	id corecredential.ID,
+	key corecredential.Key,
 	cred *cloud.Credential,
 	checkCloudInstances bool,
 ) (machineErrors []error, err error) {
-	if err := id.Validate(); err != nil {
+	if err := key.Validate(); err != nil {
 		return nil, fmt.Errorf("credential %w", err)
 	}
 
-	openParams, err := v.buildOpenParams(validationContext, id, cred)
+	openParams, err := v.buildOpenParams(validationContext, key, cred)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -211,13 +211,13 @@ var (
 )
 
 func (v defaultCredentialValidator) buildOpenParams(
-	ctx CredentialValidationContext, credentialID corecredential.ID, credential *cloud.Credential,
+	ctx CredentialValidationContext, credentialKey corecredential.Key, credential *cloud.Credential,
 ) (environs.OpenParams, error) {
 	fail := func(original error) (environs.OpenParams, error) {
 		return environs.OpenParams{}, original
 	}
 
-	err := v.validateCloudCredential(ctx.Cloud, credentialID)
+	err := v.validateCloudCredential(ctx.Cloud, credentialKey)
 	if err != nil {
 		return fail(errors.Trace(err))
 	}
@@ -238,11 +238,11 @@ func (v defaultCredentialValidator) buildOpenParams(
 // name against the provided cloud definition and credentials.
 func (v defaultCredentialValidator) validateCloudCredential(
 	cld cloud.Cloud,
-	credentialID corecredential.ID,
+	credentialKey corecredential.Key,
 ) error {
-	if !credentialID.IsZero() {
-		if credentialID.Cloud != cld.Name {
-			return errors.NotValidf("credential %q", credentialID)
+	if !credentialKey.IsZero() {
+		if credentialKey.Cloud != cld.Name {
+			return errors.NotValidf("credential %q", credentialKey)
 		}
 		return nil
 	}

--- a/domain/credential/service/modelcredential_test.go
+++ b/domain/credential/service/modelcredential_test.go
@@ -274,7 +274,7 @@ func (s *ModelCredentialSuite) TestValidateNewModelCredentialUnknownModelType(c 
 	results, err := v.Validate(
 		context.Background(),
 		s.context,
-		corecredential.ID{
+		corecredential.Key{
 			Cloud: "dummy",
 			Owner: "bob",
 			Name:  "default",
@@ -304,7 +304,7 @@ func (s *ModelCredentialSuite) TestValidateNewModelCredentialForIAASModel(c *gc.
 	results, err := v.Validate(
 		context.Background(),
 		s.context,
-		corecredential.ID{
+		corecredential.Key{
 			Cloud: "dummy",
 			Owner: "bob",
 			Name:  "default",
@@ -320,7 +320,7 @@ func (s *ModelCredentialSuite) TestValidateModelCredentialCloudMismatch(c *gc.C)
 	_, err := v.Validate(
 		context.Background(),
 		s.context,
-		corecredential.ID{
+		corecredential.Key{
 			Cloud: "other",
 			Owner: "bob",
 			Name:  "default",
@@ -369,7 +369,7 @@ func (s *ModelCredentialSuite) TestValidateNewModelCredentialForCAASModel(c *gc.
 	results, err := v.Validate(
 		context.Background(),
 		s.context,
-		corecredential.ID{
+		corecredential.Key{
 			Cloud: "dummy",
 			Owner: "bob",
 			Name:  "default",

--- a/domain/credential/service/providerservice.go
+++ b/domain/credential/service/providerservice.go
@@ -18,13 +18,13 @@ import (
 // ProviderState describes retrieval and persistence methods for storage.
 type ProviderState interface {
 	// CloudCredential returns the cloud credential for the given name, cloud, owner.
-	CloudCredential(ctx context.Context, id corecredential.ID) (credential.CloudCredentialResult, error)
+	CloudCredential(ctx context.Context, key corecredential.Key) (credential.CloudCredentialResult, error)
 
 	// WatchCredential returns a new NotifyWatcher watching for changes to the specified credential.
 	WatchCredential(
 		ctx context.Context,
 		getWatcher func(string, string, changestream.ChangeType) (watcher.NotifyWatcher, error),
-		id corecredential.ID,
+		key corecredential.Key,
 	) (watcher.NotifyWatcher, error)
 }
 
@@ -45,11 +45,11 @@ func NewProviderService(st ProviderState) *ProviderService {
 }
 
 // CloudCredential returns the cloud credential for the given tag.
-func (s *ProviderService) CloudCredential(ctx context.Context, id corecredential.ID) (cloud.Credential, error) {
-	if err := id.Validate(); err != nil {
+func (s *ProviderService) CloudCredential(ctx context.Context, key corecredential.Key) (cloud.Credential, error) {
+	if err := key.Validate(); err != nil {
 		return cloud.Credential{}, errors.Annotate(err, "invalid id getting cloud credential")
 	}
-	credInfo, err := s.st.CloudCredential(ctx, id)
+	credInfo, err := s.st.CloudCredential(ctx, key)
 	if err != nil {
 		return cloud.Credential{}, errors.Trace(err)
 	}
@@ -79,9 +79,9 @@ func NewWatchableProviderService(st ProviderState, watcherFactory WatcherFactory
 
 // WatchCredential returns a watcher that observes changes to the specified
 // credential.
-func (s *WatchableProviderService) WatchCredential(ctx context.Context, id corecredential.ID) (watcher.NotifyWatcher, error) {
-	if err := id.Validate(); err != nil {
+func (s *WatchableProviderService) WatchCredential(ctx context.Context, key corecredential.Key) (watcher.NotifyWatcher, error) {
+	if err := key.Validate(); err != nil {
 		return nil, errors.Annotatef(err, "invalid id watching cloud credential")
 	}
-	return s.st.WatchCredential(ctx, s.watcherFactory.NewValueWatcher, id)
+	return s.st.WatchCredential(ctx, s.watcherFactory.NewValueWatcher, key)
 }

--- a/domain/credential/service/providerservice_test.go
+++ b/domain/credential/service/providerservice_test.go
@@ -29,7 +29,7 @@ func (s *providerServiceSuite) service() *WatchableProviderService {
 func (s *providerServiceSuite) TestCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	cred := credential.CloudCredentialResult{
 		CloudCredentialInfo: credential.CloudCredentialInfo{
 			AuthType: string(cloud.UserPassAuthType),
@@ -39,9 +39,9 @@ func (s *providerServiceSuite) TestCloudCredential(c *gc.C) {
 			Label: "foo",
 		},
 	}
-	s.state.EXPECT().CloudCredential(gomock.Any(), id).Return(cred, nil)
+	s.state.EXPECT().CloudCredential(gomock.Any(), key).Return(cred, nil)
 
-	result, err := s.service().CloudCredential(context.Background(), id)
+	result, err := s.service().CloudCredential(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"hello": "world"}, false))
 }
@@ -49,8 +49,8 @@ func (s *providerServiceSuite) TestCloudCredential(c *gc.C) {
 func (s *providerServiceSuite) TestCloudCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	_, err := s.service().CloudCredential(context.Background(), id)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().CloudCredential(context.Background(), key)
 	c.Assert(err, gc.ErrorMatches, "invalid id getting cloud credential.*")
 }
 
@@ -59,10 +59,10 @@ func (s *providerServiceSuite) TestWatchCredential(c *gc.C) {
 
 	nw := watchertest.NewMockNotifyWatcher(nil)
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.state.EXPECT().WatchCredential(gomock.Any(), gomock.Any(), id).Return(nw, nil)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.state.EXPECT().WatchCredential(gomock.Any(), gomock.Any(), key).Return(nw, nil)
 
-	w, err := s.service().WatchCredential(context.Background(), id)
+	w, err := s.service().WatchCredential(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }
@@ -70,7 +70,7 @@ func (s *providerServiceSuite) TestWatchCredential(c *gc.C) {
 func (s *providerServiceSuite) TestWatchCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	_, err := s.service().WatchCredential(context.Background(), id)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().WatchCredential(context.Background(), key)
 	c.Assert(err, gc.ErrorMatches, "invalid id watching cloud credential.*")
 }

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -34,7 +34,7 @@ func (s *serviceSuite) service() *WatchableService {
 func (s *serviceSuite) TestUpdateCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	cred := credential.CloudCredentialInfo{
 		AuthType: string(cloud.UserPassAuthType),
 		Attributes: map[string]string{
@@ -42,10 +42,10 @@ func (s *serviceSuite) TestUpdateCloudCredential(c *gc.C) {
 		},
 		Label: "foo",
 	}
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, cred).Return(nil, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, cred).Return(nil, nil)
 
 	err := s.service().UpdateCloudCredential(
-		context.Background(), id,
+		context.Background(), key,
 		cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"hello": "world"}, false))
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -53,8 +53,8 @@ func (s *serviceSuite) TestUpdateCloudCredential(c *gc.C) {
 func (s *serviceSuite) TestUpdateCloudCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	err := s.service().UpdateCloudCredential(context.Background(), id, cloud.Credential{})
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().UpdateCloudCredential(context.Background(), key, cloud.Credential{})
 	c.Assert(err, gc.ErrorMatches, "invalid id updating cloud credential.*")
 }
 
@@ -95,7 +95,7 @@ func (s *serviceSuite) TestCloudCredentials(c *gc.C) {
 func (s *serviceSuite) TestCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	cred := credential.CloudCredentialResult{
 		CloudCredentialInfo: credential.CloudCredentialInfo{
 			AuthType: string(cloud.UserPassAuthType),
@@ -105,9 +105,9 @@ func (s *serviceSuite) TestCloudCredential(c *gc.C) {
 			Label: "foo",
 		},
 	}
-	s.state.EXPECT().CloudCredential(gomock.Any(), id).Return(cred, nil)
+	s.state.EXPECT().CloudCredential(gomock.Any(), key).Return(cred, nil)
 
-	result, err := s.service().CloudCredential(context.Background(), id)
+	result, err := s.service().CloudCredential(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"hello": "world"}, false))
 }
@@ -115,51 +115,51 @@ func (s *serviceSuite) TestCloudCredential(c *gc.C) {
 func (s *serviceSuite) TestCloudCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	_, err := s.service().CloudCredential(context.Background(), id)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().CloudCredential(context.Background(), key)
 	c.Assert(err, gc.ErrorMatches, "invalid id getting cloud credential.*")
 }
 
 func (s *serviceSuite) TestRemoveCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), id).Return(nil)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), key).Return(nil)
 
-	err := s.service().RemoveCloudCredential(context.Background(), id)
+	err := s.service().RemoveCloudCredential(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestRemoveCloudCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	err := s.service().RemoveCloudCredential(context.Background(), id)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().RemoveCloudCredential(context.Background(), key)
 	c.Assert(err, gc.ErrorMatches, "invalid id removing cloud credential.*")
 }
 
 func (s *serviceSuite) TestInvalidateCloudCredential(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.state.EXPECT().InvalidateCloudCredential(gomock.Any(), id, "gone bad").Return(nil)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.state.EXPECT().InvalidateCloudCredential(gomock.Any(), key, "gone bad").Return(nil)
 
-	err := s.service().InvalidateCredential(context.Background(), id, "gone bad")
+	err := s.service().InvalidateCredential(context.Background(), key, "gone bad")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestInvalidateCloudCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	err := s.service().InvalidateCredential(context.Background(), id, "nope")
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().InvalidateCredential(context.Background(), key, "nope")
 	c.Assert(err, gc.ErrorMatches, "invalid id invalidating cloud credential.*")
 }
 
 func (s *serviceSuite) TestAllCloudCredentials(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	credId := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	credId := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
 	credInfoResult := credential.CloudCredentialResult{
 		CloudCredentialInfo: credential.CloudCredentialInfo{
 			Label:      "foo",
@@ -169,12 +169,12 @@ func (s *serviceSuite) TestAllCloudCredentials(c *gc.C) {
 		CloudName: "cirrus",
 	}
 	s.state.EXPECT().AllCloudCredentialsForOwner(gomock.Any(), "fred").Return(
-		map[corecredential.ID]credential.CloudCredentialResult{credId: credInfoResult}, nil)
+		map[corecredential.Key]credential.CloudCredentialResult{credId: credInfoResult}, nil)
 
 	result, err := s.service().AllCloudCredentialsForOwner(context.Background(), "fred")
 	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewNamedCredential("foo", cloud.UserPassAuthType, map[string]string{"hello": "world"}, false)
-	c.Assert(result, jc.DeepEquals, map[corecredential.ID]cloud.Credential{credId: cred})
+	c.Assert(result, jc.DeepEquals, map[corecredential.Key]cloud.Credential{credId: cred})
 }
 
 func (s *serviceSuite) TestWatchCredential(c *gc.C) {
@@ -182,10 +182,10 @@ func (s *serviceSuite) TestWatchCredential(c *gc.C) {
 
 	nw := watchertest.NewMockNotifyWatcher(nil)
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred", Name: "foo"}
-	s.state.EXPECT().WatchCredential(gomock.Any(), gomock.Any(), id).Return(nw, nil)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred", Name: "foo"}
+	s.state.EXPECT().WatchCredential(gomock.Any(), gomock.Any(), key).Return(nw, nil)
 
-	w, err := s.service().WatchCredential(context.Background(), id)
+	w, err := s.service().WatchCredential(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }
@@ -193,8 +193,8 @@ func (s *serviceSuite) TestWatchCredential(c *gc.C) {
 func (s *serviceSuite) TestWatchCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	_, err := s.service().WatchCredential(context.Background(), id)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().WatchCredential(context.Background(), key)
 	c.Assert(err, gc.ErrorMatches, "invalid id watching cloud credential.*")
 }
 
@@ -202,16 +202,16 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialsNoModelsFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cred := credential.CloudCredentialInfo{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(nil, errors.NotFound)
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.NotFound)
 
 	var invalid = true
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, cred).Return(&invalid, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, cred).Return(&invalid, nil)
 
 	var legacyUpdated bool
 	service := s.service().
@@ -224,17 +224,17 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialsNoModelsFound(c *gc.C) {
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cloud.Credential{}, false)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cloud.Credential{}, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 0)
 	c.Assert(legacyUpdated, jc.IsTrue)
 }
 
-func (s *serviceSuite) TestCheckAndUpdateCredentialInvalidID(c *gc.C) {
+func (s *serviceSuite) TestCheckAndUpdateCredentialInvalidKey(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	_, err := s.service().CheckAndUpdateCredential(context.Background(), id, cloud.Credential{}, false)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	_, err := s.service().CheckAndUpdateCredential(context.Background(), key, cloud.Credential{}, false)
 	c.Assert(err, gc.ErrorMatches, "invalid id updating cloud credential.*")
 }
 
@@ -242,13 +242,13 @@ func (s *serviceSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(nil, errors.New("cannot get models"))
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.New("cannot get models"))
 
 	var legacyUpdated bool
 	service := s.service().
@@ -259,7 +259,7 @@ func (s *serviceSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 			return errors.NotImplemented
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cred, false)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, false)
 	c.Assert(err, gc.ErrorMatches, "cannot get models")
 	c.Assert(results, gc.HasLen, 0)
 	c.Assert(legacyUpdated, jc.IsFalse)
@@ -269,7 +269,7 @@ func (s *serviceSuite) TestUpdateCredentialsModelsFailedContext(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	id := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
@@ -307,18 +307,18 @@ func (s *serviceSuite) TestUpdateCredentialsModelsFailedContext(c *gc.C) {
 func (s *serviceSuite) TestUpdateCredentialsModelsFailedContextForce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
 
 	var invalid = true
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, credential.CloudCredentialInfo{}).Return(&invalid, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{}).Return(&invalid, nil)
 
 	contextError := errors.New("failed context")
 
@@ -333,7 +333,7 @@ func (s *serviceSuite) TestUpdateCredentialsModelsFailedContextForce(c *gc.C) {
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cloud.Credential{}, true)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cloud.Credential{}, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Assert(results[0].Errors, gc.HasLen, 1)
@@ -349,19 +349,19 @@ func (s *serviceSuite) TestUpdateCredentialsModels(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
 
 	var invalid = true
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, credential.CloudCredentialInfo{}).Return(&invalid, nil)
-	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), id, &cred, false).Return(nil, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{}).Return(&invalid, nil)
+	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), key, &cred, false).Return(nil, nil)
 
 	var legacyUpdated bool
 	service := s.service().
@@ -375,7 +375,7 @@ func (s *serviceSuite) TestUpdateCredentialsModels(c *gc.C) {
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cred, false)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []UpdateCredentialModelResult{{
 		ModelUUID: coremodel.UUID(jujutesting.ModelTag.Id()), ModelName: "mymodel",
@@ -387,21 +387,21 @@ func (s *serviceSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) 
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
 
 	var invalid = true
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, credential.CloudCredentialInfo{}).Return(&invalid, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{}).Return(&invalid, nil)
 
 	validationError := errors.New("cred error")
-	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), id, &cred, false).Return([]error{validationError}, nil)
+	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), key, &cred, false).Return([]error{validationError}, nil)
 
 	var legacyUpdated bool
 	service := s.service().
@@ -415,7 +415,7 @@ func (s *serviceSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) 
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cred, true)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []UpdateCredentialModelResult{{
 		ModelUUID: coremodel.UUID(jujutesting.ModelTag.Id()), ModelName: "mymodel", Errors: []error{validationError},
@@ -427,24 +427,24 @@ func (s *serviceSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) 
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 		"deadbeef-1bad-500d-9000-4b1d0d06f666":    "anothermodel",
 	}, nil)
 
 	validationError := errors.New("cred error")
 	calls := 0
-	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), id, &cred, false).DoAndReturn(
+	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), key, &cred, false).DoAndReturn(
 		func(
 			stdCtx context.Context,
 			ctx CredentialValidationContext,
-			credentialID corecredential.ID,
+			credentialKey corecredential.Key,
 			credential *cloud.Credential,
 			checkCloudInstances bool,
 		) ([]error, error) {
@@ -467,7 +467,7 @@ func (s *serviceSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) 
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cred, false)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, false)
 	c.Assert(err, gc.ErrorMatches, "credential is not valid for one or more models")
 	c.Assert(results, gc.HasLen, 2)
 	gotErrors := 0
@@ -493,27 +493,27 @@ func (s *serviceSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *g
 	defer s.setupMocks(c).Finish()
 
 	cred := cloud.Credential{}
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 		"deadbeef-1bad-500d-9000-4b1d0d06f666":    "anothermodel",
 	}, nil)
 
 	var invalid = true
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), id, credential.CloudCredentialInfo{}).Return(&invalid, nil)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{}).Return(&invalid, nil)
 
 	validationError := errors.New("cred error")
 	calls := 0
-	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), id, &cred, false).DoAndReturn(
+	s.validator.EXPECT().Validate(gomock.Any(), gomock.Any(), key, &cred, false).DoAndReturn(
 		func(
 			stdCtx context.Context,
 			ctx CredentialValidationContext,
-			credentialID corecredential.ID,
+			credentialID corecredential.Key,
 			credential *cloud.Credential,
 			checkCloudInstances bool,
 		) ([]error, error) {
@@ -536,7 +536,7 @@ func (s *serviceSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *g
 			return nil
 		})
 
-	results, err := service.CheckAndUpdateCredential(context.Background(), id, cred, true)
+	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 2)
 	gotErrors := 0
@@ -561,13 +561,13 @@ func (s *serviceSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *g
 func (s *serviceSuite) TestRevokeCredentialsModelsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(nil, errors.New("cannot get models"))
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.New("cannot get models"))
 
 	var legacyUpdated bool
 	service := s.service().
@@ -575,7 +575,7 @@ func (s *serviceSuite) TestRevokeCredentialsModelsError(c *gc.C) {
 			return errors.NotImplemented
 		})
 
-	err := service.CheckAndRevokeCredential(context.Background(), id, false)
+	err := service.CheckAndRevokeCredential(context.Background(), key, false)
 	c.Assert(err, gc.ErrorMatches, "cannot get models")
 	c.Assert(legacyUpdated, jc.IsFalse)
 }
@@ -583,13 +583,13 @@ func (s *serviceSuite) TestRevokeCredentialsModelsError(c *gc.C) {
 func (s *serviceSuite) TestRevokeCredentialsHasModel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
 
@@ -601,7 +601,7 @@ func (s *serviceSuite) TestRevokeCredentialsHasModel(c *gc.C) {
 			return nil
 		})
 
-	err := service.CheckAndRevokeCredential(context.Background(), id, false)
+	err := service.CheckAndRevokeCredential(context.Background(), key, false)
 	c.Assert(err, gc.ErrorMatches, `cannot revoke credential cirrus/bob/foobar: it is still used by 1 model`)
 	c.Assert(legacyUpdated, jc.IsFalse)
 }
@@ -609,13 +609,13 @@ func (s *serviceSuite) TestRevokeCredentialsHasModel(c *gc.C) {
 func (s *serviceSuite) TestRevokeCredentialsHasModels(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 		"deadbeef-1bad-500d-9000-4b1d0d06f666":    "anothermodel",
 	}, nil)
@@ -628,7 +628,7 @@ func (s *serviceSuite) TestRevokeCredentialsHasModels(c *gc.C) {
 			return nil
 		})
 
-	err := service.CheckAndRevokeCredential(context.Background(), id, false)
+	err := service.CheckAndRevokeCredential(context.Background(), key, false)
 	c.Assert(err, gc.ErrorMatches, `cannot revoke credential cirrus/bob/foobar: it is still used by 2 models`)
 	c.Assert(legacyUpdated, jc.IsFalse)
 }
@@ -636,16 +636,16 @@ func (s *serviceSuite) TestRevokeCredentialsHasModels(c *gc.C) {
 func (s *serviceSuite) TestRevokeCredentialsHasModelForce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
-	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), id).Return(nil)
+	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), key).Return(nil)
 
 	var legacyUpdated bool
 	service := s.service().
@@ -655,7 +655,7 @@ func (s *serviceSuite) TestRevokeCredentialsHasModelForce(c *gc.C) {
 			return nil
 		})
 
-	err := service.CheckAndRevokeCredential(context.Background(), id, true)
+	err := service.CheckAndRevokeCredential(context.Background(), key, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(legacyUpdated, jc.IsTrue)
 }
@@ -663,17 +663,17 @@ func (s *serviceSuite) TestRevokeCredentialsHasModelForce(c *gc.C) {
 func (s *serviceSuite) TestRevokeCredentialsHasModelsForce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{
+	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: "bob",
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), id).Return(map[coremodel.UUID]string{
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 		"deadbeef-1bad-500d-9000-4b1d0d06f666":    "anothermodel",
 	}, nil)
-	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), id).Return(nil)
+	s.state.EXPECT().RemoveCloudCredential(gomock.Any(), key).Return(nil)
 
 	var legacyUpdated bool
 	service := s.service().
@@ -683,7 +683,7 @@ func (s *serviceSuite) TestRevokeCredentialsHasModelsForce(c *gc.C) {
 			return nil
 		})
 
-	err := service.CheckAndRevokeCredential(context.Background(), id, true)
+	err := service.CheckAndRevokeCredential(context.Background(), key, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(legacyUpdated, jc.IsTrue)
 }
@@ -691,7 +691,7 @@ func (s *serviceSuite) TestRevokeCredentialsHasModelsForce(c *gc.C) {
 func (s *serviceSuite) TestCheckAndRevokeCredentialInvalidID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := corecredential.ID{Cloud: "cirrus", Owner: "fred"}
-	err := s.service().CheckAndRevokeCredential(context.Background(), id, false)
+	key := corecredential.Key{Cloud: "cirrus", Owner: "fred"}
+	err := s.service().CheckAndRevokeCredential(context.Background(), key, false)
 	c.Assert(err, gc.ErrorMatches, "invalid id revoking cloud credential.*")
 }

--- a/domain/credential/service/state_mock_test.go
+++ b/domain/credential/service/state_mock_test.go
@@ -45,10 +45,10 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AllCloudCredentialsForOwner mocks base method.
-func (m *MockState) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.ID]credential0.CloudCredentialResult, error) {
+func (m *MockState) AllCloudCredentialsForOwner(arg0 context.Context, arg1 string) (map[credential.Key]credential0.CloudCredentialResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllCloudCredentialsForOwner", arg0, arg1)
-	ret0, _ := ret[0].(map[credential.ID]credential0.CloudCredentialResult)
+	ret0, _ := ret[0].(map[credential.Key]credential0.CloudCredentialResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -60,7 +60,7 @@ func (mr *MockStateMockRecorder) AllCloudCredentialsForOwner(arg0, arg1 any) *go
 }
 
 // CloudCredential mocks base method.
-func (m *MockState) CloudCredential(arg0 context.Context, arg1 credential.ID) (credential0.CloudCredentialResult, error) {
+func (m *MockState) CloudCredential(arg0 context.Context, arg1 credential.Key) (credential0.CloudCredentialResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(credential0.CloudCredentialResult)
@@ -90,7 +90,7 @@ func (mr *MockStateMockRecorder) CloudCredentialsForOwner(arg0, arg1, arg2 any) 
 }
 
 // InvalidateCloudCredential mocks base method.
-func (m *MockState) InvalidateCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 string) error {
+func (m *MockState) InvalidateCloudCredential(arg0 context.Context, arg1 credential.Key, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InvalidateCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -104,7 +104,7 @@ func (mr *MockStateMockRecorder) InvalidateCloudCredential(arg0, arg1, arg2 any)
 }
 
 // ModelsUsingCloudCredential mocks base method.
-func (m *MockState) ModelsUsingCloudCredential(arg0 context.Context, arg1 credential.ID) (map[model.UUID]string, error) {
+func (m *MockState) ModelsUsingCloudCredential(arg0 context.Context, arg1 credential.Key) (map[model.UUID]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelsUsingCloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(map[model.UUID]string)
@@ -119,7 +119,7 @@ func (mr *MockStateMockRecorder) ModelsUsingCloudCredential(arg0, arg1 any) *gom
 }
 
 // RemoveCloudCredential mocks base method.
-func (m *MockState) RemoveCloudCredential(arg0 context.Context, arg1 credential.ID) error {
+func (m *MockState) RemoveCloudCredential(arg0 context.Context, arg1 credential.Key) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveCloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -133,7 +133,7 @@ func (mr *MockStateMockRecorder) RemoveCloudCredential(arg0, arg1 any) *gomock.C
 }
 
 // UpsertCloudCredential mocks base method.
-func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1 credential.ID, arg2 credential0.CloudCredentialInfo) (*bool, error) {
+func (m *MockState) UpsertCloudCredential(arg0 context.Context, arg1 credential.Key, arg2 credential0.CloudCredentialInfo) (*bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertCloudCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*bool)
@@ -148,7 +148,7 @@ func (mr *MockStateMockRecorder) UpsertCloudCredential(arg0, arg1, arg2 any) *go
 }
 
 // WatchCredential mocks base method.
-func (m *MockState) WatchCredential(arg0 context.Context, arg1 func(string, string, changestream.ChangeType) (watcher.Watcher[struct{}], error), arg2 credential.ID) (watcher.Watcher[struct{}], error) {
+func (m *MockState) WatchCredential(arg0 context.Context, arg1 func(string, string, changestream.ChangeType) (watcher.Watcher[struct{}], error), arg2 credential.Key) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])

--- a/domain/credential/service/validator_mock_test.go
+++ b/domain/credential/service/validator_mock_test.go
@@ -42,7 +42,7 @@ func (m *MockCredentialValidator) EXPECT() *MockCredentialValidatorMockRecorder 
 }
 
 // Validate mocks base method.
-func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 CredentialValidationContext, arg2 credential.ID, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
+func (m *MockCredentialValidator) Validate(arg0 context.Context, arg1 CredentialValidationContext, arg2 credential.Key, arg3 *cloud.Credential, arg4 bool) ([]error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]error)

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -98,9 +98,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 		Revoked: true,
 		Label:   "foobar",
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -108,7 +108,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialNew(c *gc.C) {
 		CloudCredentialInfo: credInfo,
 		CloudName:           "stratus",
 	}
-	out, err := st.CloudCredential(ctx, id)
+	out, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, credResult)
 }
@@ -121,9 +121,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialNoValues(c *gc.C) {
 		Attributes: map[string]string{},
 		Label:      "foobar",
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -131,7 +131,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialNoValues(c *gc.C) {
 		CloudCredentialInfo: credInfo,
 		CloudName:           "stratus",
 	}
-	out, err := st.CloudCredential(ctx, id)
+	out, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, credResult)
 }
@@ -148,7 +148,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialMissingName(c *gc.C) {
 		Label: "foobar",
 	}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, corecredential.ID{Cloud: "stratus", Owner: s.userName}, credInfo)
+	_, err := st.UpsertCloudCredential(ctx, corecredential.Key{Cloud: "stratus", Owner: s.userName}, credInfo)
 	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
 }
 
@@ -165,9 +165,9 @@ func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
 		Invalid:       true,
 		InvalidReason: "because am testing you",
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	_, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, gc.ErrorMatches, "adding invalid credential not supported")
 }
 
@@ -182,9 +182,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 		},
 		Label: "foobar",
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -196,7 +196,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 		},
 		Label: "foobar",
 	}
-	existingInvalid, err = st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err = st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsFalse)
@@ -205,7 +205,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialExisting(c *gc.C) {
 		CloudCredentialInfo: credInfo,
 		CloudName:           "stratus",
 	}
-	out, err := st.CloudCredential(ctx, id)
+	out, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, credResult)
 }
@@ -221,9 +221,9 @@ func (s *credentialSuite) TestUpdateCloudCredentialInvalidAuthType(c *gc.C) {
 		},
 		Label: "foobar",
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	_, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(
 		`updating credential: validating credential "foobar" owned by "test-user" for cloud "stratus": supported auth-types ["access-key" "userpass"], "oauth2" not supported`))
 }
@@ -248,7 +248,7 @@ func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
 		},
 	}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "bobcred1"}, cred1Info)
+	_, err := st.UpsertCloudCredential(ctx, corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "bobcred1"}, cred1Info)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred2Info := credential.CloudCredentialInfo{
@@ -258,9 +258,9 @@ func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
 			"qux": "qux val",
 		},
 	}
-	_, err = st.UpsertCloudCredential(ctx, corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "bobcred2"}, cred2Info)
+	_, err = st.UpsertCloudCredential(ctx, corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "bobcred2"}, cred2Info)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.UpsertCloudCredential(ctx, corecredential.ID{Cloud: "stratus", Owner: "mary", Name: "foobar"}, cred2Info)
+	_, err = st.UpsertCloudCredential(ctx, corecredential.Key{Cloud: "stratus", Owner: "mary", Name: "foobar"}, cred2Info)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred1Info.Label = "bobcred1"
@@ -282,7 +282,7 @@ func (s *credentialSuite) TestCloudCredentials(c *gc.C) {
 	})
 }
 
-func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, id corecredential.ID) {
+func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, key corecredential.Key) {
 	credInfo := credential.CloudCredentialInfo{
 		AuthType: string(cloud.AccessKeyAuthType),
 		Attributes: map[string]string{
@@ -291,7 +291,7 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, id cor
 		},
 	}
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.IsNil)
 
@@ -304,7 +304,7 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, id cor
 	}
 	credInfo.Invalid = true
 	credInfo.InvalidReason = "because it is really really invalid"
-	existingInvalid, err = st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err = st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsFalse)
@@ -314,24 +314,24 @@ func (s *credentialSuite) assertCredentialInvalidated(c *gc.C, st *State, id cor
 		CloudCredentialInfo: credInfo,
 		CloudName:           "stratus",
 	}
-	out, err := st.CloudCredential(ctx, id)
+	out, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, jc.DeepEquals, credResult)
 }
 
 func (s *credentialSuite) TestInvalidateCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
-	s.assertCredentialInvalidated(c, st, corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"})
+	s.assertCredentialInvalidated(c, st, corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"})
 }
 
-func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, id corecredential.ID, credInfo credential.CloudCredentialInfo) {
+func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, key corecredential.Key, credInfo credential.CloudCredentialInfo) {
 	ctx := context.Background()
-	existingInvalid, err := st.UpsertCloudCredential(ctx, id, credInfo)
+	existingInvalid, err := st.UpsertCloudCredential(ctx, key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(existingInvalid, gc.NotNil)
 	c.Assert(*existingInvalid, jc.IsTrue)
 
-	out, err := st.CloudCredential(ctx, id)
+	out, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out.Invalid, jc.IsFalse)
 }
@@ -339,8 +339,8 @@ func (s *credentialSuite) assertCredentialMarkedValid(c *gc.C, st *State, id cor
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidExplicitly(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	// This call will ensure that there is an invalid credential to test with.
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
-	s.assertCredentialInvalidated(c, st, id)
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	s.assertCredentialInvalidated(c, st, key)
 
 	credInfo := credential.CloudCredentialInfo{
 		AuthType: string(cloud.UserPassAuthType),
@@ -349,14 +349,14 @@ func (s *credentialSuite) TestMarkInvalidCredentialAsValidExplicitly(c *gc.C) {
 			"password": "simple",
 		},
 	}
-	s.assertCredentialMarkedValid(c, st, id, credInfo)
+	s.assertCredentialMarkedValid(c, st, key, credInfo)
 }
 
 func (s *credentialSuite) TestMarkInvalidCredentialAsValidImplicitly(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	// This call will ensure that there is an invalid credential to test with.
-	s.assertCredentialInvalidated(c, st, id)
+	s.assertCredentialInvalidated(c, st, key)
 
 	credInfo := credential.CloudCredentialInfo{
 		AuthType: string(cloud.UserPassAuthType),
@@ -365,7 +365,7 @@ func (s *credentialSuite) TestMarkInvalidCredentialAsValidImplicitly(c *gc.C) {
 			"password": "simple",
 		},
 	}
-	s.assertCredentialMarkedValid(c, st, id, credInfo)
+	s.assertCredentialMarkedValid(c, st, key, credInfo)
 }
 
 func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
@@ -378,15 +378,15 @@ func (s *credentialSuite) TestRemoveCredentials(c *gc.C) {
 			"bar": "bar val",
 		},
 	}
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "bobcred1"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "bobcred1"}
 	ctx := context.Background()
-	_, err := st.UpsertCloudCredential(ctx, id, cred1Info)
+	_, err := st.UpsertCloudCredential(ctx, key, cred1Info)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.RemoveCloudCredential(ctx, id)
+	err = st.RemoveCloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.CloudCredential(ctx, id)
+	_, err = st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -398,7 +398,7 @@ func (s *credentialSuite) TestAllCloudCredentialsNotFound(c *gc.C) {
 	c.Assert(out, gc.IsNil)
 }
 
-func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, id corecredential.ID) credential.CloudCredentialInfo {
+func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, key corecredential.Key) credential.CloudCredentialInfo {
 	authType := cloud.AccessKeyAuthType
 	attributes := map[string]string{
 		"foo": "foo val",
@@ -406,17 +406,17 @@ func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, id corecrede
 	}
 
 	s.addCloud(c, cloud.Cloud{
-		Name:      id.Cloud,
+		Name:      key.Cloud,
 		Type:      "ec2",
 		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
 	})
 
 	credInfo := credential.CloudCredentialInfo{
-		Label:      id.Name,
+		Label:      key.Name,
 		AuthType:   string(authType),
 		Attributes: attributes,
 	}
-	_, err := st.UpsertCloudCredential(context.Background(), id, credInfo)
+	_, err := st.UpsertCloudCredential(context.Background(), key, credInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	return credInfo
 }
@@ -424,16 +424,16 @@ func (s *credentialSuite) createCloudCredential(c *gc.C, st *State, id corecrede
 func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	idOne := corecredential.ID{Cloud: "cirrus", Owner: s.userName, Name: "foobar"}
-	idTwo := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
-	one := s.createCloudCredential(c, st, idOne)
-	two := s.createCloudCredential(c, st, idTwo)
+	keyOne := corecredential.Key{Cloud: "cirrus", Owner: s.userName, Name: "foobar"}
+	keyTwo := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	one := s.createCloudCredential(c, st, keyOne)
+	two := s.createCloudCredential(c, st, keyTwo)
 
 	// We need to add mary here so that they are a valid user.
 	s.addOwner(c, "mary")
 
 	// Added to make sure it is not returned.
-	s.createCloudCredential(c, st, corecredential.ID{Cloud: "cumulus", Owner: "mary", Name: "foobar"})
+	s.createCloudCredential(c, st, corecredential.Key{Cloud: "cumulus", Owner: "mary", Name: "foobar"})
 
 	resultOne := credential.CloudCredentialResult{
 		CloudCredentialInfo: one,
@@ -445,23 +445,23 @@ func (s *credentialSuite) TestAllCloudCredentials(c *gc.C) {
 	}
 	out, err := st.AllCloudCredentialsForOwner(context.Background(), s.userName)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, jc.DeepEquals, map[corecredential.ID]credential.CloudCredentialResult{
-		idOne: resultOne, idTwo: resultTwo})
+	c.Assert(out, jc.DeepEquals, map[corecredential.Key]credential.CloudCredentialResult{
+		keyOne: resultOne, keyTwo: resultTwo})
 }
 
 func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
-	one := s.createCloudCredential(c, st, id)
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	one := s.createCloudCredential(c, st, key)
 	c.Assert(one.Invalid, jc.IsFalse)
 
 	ctx := context.Background()
 	reason := "testing, testing 1,2,3"
-	err := st.InvalidateCloudCredential(ctx, id, reason)
+	err := st.InvalidateCloudCredential(ctx, key, reason)
 	c.Assert(err, jc.ErrorIsNil)
 
-	updated, err := st.CloudCredential(ctx, id)
+	updated, err := st.CloudCredential(ctx, key)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(updated.Invalid, jc.IsTrue)
 	c.Assert(updated.InvalidReason, gc.Equals, reason)
@@ -470,9 +470,9 @@ func (s *credentialSuite) TestInvalidateCloudCredential(c *gc.C) {
 func (s *credentialSuite) TestInvalidateCloudCredentialNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	err := st.InvalidateCloudCredential(ctx, id, "reason")
+	err := st.InvalidateCloudCredential(ctx, key, "reason")
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -501,26 +501,26 @@ func (s *credentialSuite) watcherFunc(c *gc.C, expectedChangeValue string) watch
 func (s *credentialSuite) TestWatchCredentialNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
-	_, err := st.WatchCredential(ctx, s.watcherFunc(c, ""), id)
+	_, err := st.WatchCredential(ctx, s.watcherFunc(c, ""), key)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *credentialSuite) TestWatchCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
-	s.createCloudCredential(c, st, id)
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	s.createCloudCredential(c, st, key)
 
 	var uuid string
 	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		uuid, err = st.credentialUUID(ctx, tx, id)
+		uuid, err = st.credentialUUID(ctx, tx, key)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := st.WatchCredential(context.Background(), s.watcherFunc(c, uuid), id)
+	w, err := st.WatchCredential(context.Background(), s.watcherFunc(c, uuid), key)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, w) })
 
@@ -537,7 +537,7 @@ func (s *credentialSuite) TestWatchCredential(c *gc.C) {
 		Label:   "foobar",
 	}
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, err := st.UpsertCloudCredential(ctx, id, credInfo)
+		_, err := st.UpsertCloudCredential(ctx, key, credInfo)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -550,7 +550,7 @@ func (s *credentialSuite) TestNoModelsUsingCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	ctx := context.Background()
-	result, err := st.ModelsUsingCloudCredential(ctx, corecredential.ID{
+	result, err := st.ModelsUsingCloudCredential(ctx, corecredential.Key{
 		Cloud: "cirrus",
 		Owner: s.userName,
 		Name:  "foobar",
@@ -562,8 +562,8 @@ func (s *credentialSuite) TestNoModelsUsingCloudCredential(c *gc.C) {
 func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	id := corecredential.ID{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
-	one := s.createCloudCredential(c, st, id)
+	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
+	one := s.createCloudCredential(c, st, key)
 	c.Assert(one.Invalid, jc.IsFalse)
 
 	insertOne := func(ctx context.Context, tx *sql.Tx, modelUUID, name string) error {
@@ -603,7 +603,7 @@ func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := st.ModelsUsingCloudCredential(context.Background(), corecredential.ID{
+	result, err := st.ModelsUsingCloudCredential(context.Background(), corecredential.Key{
 		Cloud: "stratus",
 		Owner: s.userName,
 		Name:  "foobar",

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -52,7 +52,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.credentialName = "test"
-	fn = credentialbootstrap.InsertCredential(credential.ID{
+	fn = credentialbootstrap.InsertCredential(credential.Key{
 		Cloud: s.cloudName,
 		Name:  s.credentialName,
 		Owner: coreuser.AdminUserName,
@@ -68,7 +68,7 @@ func (s *bootstrapSuite) TestUUIDIsCreated(c *gc.C) {
 	uuid, fn := CreateModel(model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        s.cloudName,
-		Credential: credential.ID{
+		Credential: credential.Key{
 			Cloud: s.cloudName,
 			Name:  s.credentialName,
 			Owner: coreuser.AdminUserName,
@@ -89,7 +89,7 @@ func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
 	uuid, fn := CreateModel(model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        s.cloudName,
-		Credential: credential.ID{
+		Credential: credential.Key{
 			Cloud: s.cloudName,
 			Name:  s.credentialName,
 			Owner: coreuser.AdminUserName,

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -108,7 +108,7 @@ func (i importOperation) Execute(ctx context.Context, model description.Model) e
 		)
 	}
 
-	credential := credential.ID{}
+	credential := credential.Key{}
 	// CloudCredential could be nil
 	if model.CloudCredential() != nil {
 		credential.Name = model.CloudCredential().Name()

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -129,7 +129,7 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 		AgentVersion: jujuversion.Current,
 		Cloud:        "AWS",
 		CloudRegion:  "region1",
-		Credential: credential.ID{
+		Credential: credential.Key{
 			Name:  "my-credential",
 			Owner: "tlm",
 			Cloud: "AWS",
@@ -187,7 +187,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		AgentVersion: jujuversion.Current,
 		Cloud:        "AWS",
 		CloudRegion:  "region1",
-		Credential: credential.ID{
+		Credential: credential.Key{
 			Name:  "my-credential",
 			Owner: "tlm",
 			Cloud: "AWS",

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -47,10 +47,10 @@ type State interface {
 	// ModelCloudNameAndCredential returns the cloud name and credential id for a
 	// model identified by the model name and the owner. If no model exists for
 	// the provided name and user a [modelerrors.NotFound] error is returned.
-	ModelCloudNameAndCredential(context.Context, string, string) (string, credential.ID, error)
+	ModelCloudNameAndCredential(context.Context, string, string) (string, credential.Key, error)
 
 	// UpdateCredential updates a model's cloud credential.
-	UpdateCredential(context.Context, coremodel.UUID, credential.ID) error
+	UpdateCredential(context.Context, coremodel.UUID, credential.Key) error
 }
 
 // Service defines a service for interacting with the underlying state based
@@ -119,13 +119,13 @@ func agentVersionSelector() version.Number {
 // returned.
 func (s *Service) DefaultModelCloudNameAndCredential(
 	ctx context.Context,
-) (string, credential.ID, error) {
+) (string, credential.Key, error) {
 	cloudName, cred, err := s.st.ModelCloudNameAndCredential(
 		ctx, coremodel.ControllerModelName, coremodel.ControllerModelOwnerUsername,
 	)
 
 	if err != nil {
-		return "", credential.ID{}, fmt.Errorf("getting default model cloud name and credential: %w", err)
+		return "", credential.Key{}, fmt.Errorf("getting default model cloud name and credential: %w", err)
 	}
 	return cloudName, cred, nil
 }
@@ -254,16 +254,16 @@ func ModelTypeForCloud(
 func (s *Service) UpdateCredential(
 	ctx context.Context,
 	uuid coremodel.UUID,
-	id credential.ID,
+	key credential.Key,
 ) error {
 	if err := uuid.Validate(); err != nil {
 		return fmt.Errorf("updating cloud credential model uuid: %w", err)
 	}
-	if err := id.Validate(); err != nil {
+	if err := key.Validate(); err != nil {
 		return fmt.Errorf("updating cloud credential: %w", err)
 	}
 
-	return s.st.UpdateCredential(ctx, uuid, id)
+	return s.st.UpdateCredential(ctx, uuid, key)
 }
 
 // validateAgentVersion is responsible for checking that the agent version that

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -83,7 +83,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(), corecredential.ID{
+		context.Background(), corecredential.Key{
 			Cloud: "my-cloud",
 			Owner: "test-user",
 			Name:  "foobar",
@@ -102,7 +102,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 			AgentVersion: version.Current,
 			Cloud:        "my-cloud",
 			CloudRegion:  "my-region",
-			Credential: corecredential.ID{
+			Credential: corecredential.Key{
 				Cloud: "my-cloud",
 				Owner: "test-user",
 				Name:  "foobar",
@@ -123,7 +123,7 @@ func (m *stateSuite) TestGetModel(c *gc.C) {
 	c.Check(modelInfo, gc.Equals, coremodel.Model{
 		Cloud:       "my-cloud",
 		CloudRegion: "my-region",
-		Credential: corecredential.ID{
+		Credential: corecredential.Key{
 			Cloud: "my-cloud",
 			Owner: "test-user",
 			Name:  "foobar",
@@ -153,7 +153,7 @@ func (m *stateSuite) TestModelCloudNameAndCredential(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloud, gc.Equals, "my-cloud")
-	c.Assert(credentialKey, gc.Equals, corecredential.ID{
+	c.Assert(credentialKey, gc.Equals, corecredential.Key{
 		Cloud: "my-cloud",
 		Owner: "test-user",
 		Name:  "foobar",
@@ -364,7 +364,7 @@ func (m *stateSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(), corecredential.ID{
+		context.Background(), corecredential.Key{
 			Cloud: "my-cloud2",
 			Owner: "test-user",
 			Name:  "foobar1",
@@ -377,7 +377,7 @@ func (m *stateSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 	err = modelSt.UpdateCredential(
 		context.Background(),
 		m.uuid,
-		corecredential.ID{
+		corecredential.Key{
 			Cloud: "my-cloud2",
 			Owner: "test-user",
 			Name:  "foobar1",
@@ -411,7 +411,7 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 
 	credSt := credentialstate.NewState(m.TxnRunnerFactory())
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(), corecredential.ID{
+		context.Background(), corecredential.Key{
 			Cloud: "minikube",
 			Owner: "test-user",
 			Name:  "foobar",
@@ -428,7 +428,7 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 		coremodel.CAAS,
 		model.ModelCreationArgs{
 			Cloud: "minikube",
-			Credential: corecredential.ID{
+			Credential: corecredential.Key{
 				Cloud: "minikube",
 				Owner: "test-user",
 				Name:  "foobar",
@@ -501,7 +501,7 @@ func (m *stateSuite) TestListModels(c *gc.C) {
 			AgentVersion: version.Current,
 			Cloud:        "my-cloud",
 			CloudRegion:  "my-region",
-			Credential: corecredential.ID{
+			Credential: corecredential.Key{
 				Cloud: "my-cloud",
 				Owner: "test-user",
 				Name:  "foobar",
@@ -521,7 +521,7 @@ func (m *stateSuite) TestListModels(c *gc.C) {
 			AgentVersion: version.Current,
 			Cloud:        "my-cloud",
 			CloudRegion:  "my-region",
-			Credential: corecredential.ID{
+			Credential: corecredential.Key{
 				Cloud: "my-cloud",
 				Owner: "test-user",
 				Name:  "foobar",

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -69,7 +69,7 @@ func CreateTestModel(
 
 	credSt := credentialstate.NewState(txnRunner)
 	_, err = credSt.UpsertCloudCredential(
-		context.Background(), corecredential.ID{
+		context.Background(), corecredential.Key{
 			Cloud: "my-cloud",
 			Owner: "test-user",
 			Name:  "foobar",
@@ -88,7 +88,7 @@ func CreateTestModel(
 			AgentVersion: version.Current,
 			Cloud:        "my-cloud",
 			CloudRegion:  "my-region",
-			Credential: corecredential.ID{
+			Credential: corecredential.Key{
 				Cloud: "my-cloud",
 				Owner: "test-user",
 				Name:  "foobar",

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -31,7 +31,7 @@ type ModelCreationArgs struct {
 	// model. Credential must be for the same cloud as that of the model.
 	// Credential can be the zero value of the struct to not have a credential
 	// associated with the model.
-	Credential credential.ID
+	Credential credential.Key
 
 	// Name is the name of the model.
 	// Must not be empty for a valid struct.

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -65,7 +65,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
-				Credential: credential.ID{
+				Credential: credential.Key{
 					Owner: "wallyworld",
 				},
 				Name:  "my-awesome-model",
@@ -96,7 +96,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 			Args: ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
-				Credential: credential.ID{
+				Credential: credential.Key{
 					Cloud: "cloud",
 					Owner: "wallyworld",
 					Name:  "mycred",

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -44,7 +44,7 @@ type ServiceFactorySuite struct {
 	// CloudName is the name of the cloud made during the setup of this suite.
 	CloudName string
 
-	CredentialID credential.ID
+	CredentialKey credential.Key
 
 	// ControllerModelUUID is the unique id for the controller model. If not set
 	// will be set during test set up.
@@ -104,13 +104,13 @@ func (s *ServiceFactorySuite) SeedCloudAndCredential(c *gc.C) {
 	})(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.CredentialID = credential.ID{
+	s.CredentialKey = credential.Key{
 		Cloud: s.CloudName,
 		Name:  "default",
 		Owner: coreuser.AdminUserName,
 	}
 	err = credentialbootstrap.InsertCredential(
-		s.CredentialID,
+		s.CredentialKey,
 		cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 			"username": "dummy",
 			"password": "secret",
@@ -125,7 +125,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	controllerArgs := modeldomain.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        s.CloudName,
-		Credential:   s.CredentialID,
+		Credential:   s.CredentialKey,
 		Name:         coremodel.ControllerModelName,
 		Owner:        s.AdminUserUUID,
 		UUID:         s.ControllerModelUUID,
@@ -139,7 +139,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	modelArgs := modeldomain.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        s.CloudName,
-		Credential:   s.CredentialID,
+		Credential:   s.CredentialKey,
 		Name:         "test",
 		Owner:        s.AdminUserUUID,
 		UUID:         s.DefaultModelUUID,

--- a/environs/envcontext/callcontext_test.go
+++ b/environs/envcontext/callcontext_test.go
@@ -39,12 +39,12 @@ func (s *CallContextSuite) TestWithValidation(c *gc.C) {
 }
 
 func (s *CallContextSuite) TestNewCredentialInvalidator(c *gc.C) {
-	idGetter := func() (credential.ID, error) {
-		return credential.ID{Name: "foo"}, nil
+	keyGetter := func() (credential.Key, error) {
+		return credential.Key{Name: "foo"}, nil
 	}
 	called := ""
-	invalidate := func(ctx context.Context, id credential.ID, reason string) error {
-		c.Assert(id, jc.DeepEquals, credential.ID{Name: "foo"})
+	invalidate := func(ctx context.Context, key credential.Key, reason string) error {
+		c.Assert(key, jc.DeepEquals, credential.Key{Name: "foo"})
 		called = reason
 		return nil
 	}
@@ -53,7 +53,7 @@ func (s *CallContextSuite) TestNewCredentialInvalidator(c *gc.C) {
 		legacyCalled = reason
 		return nil
 	}
-	invalidator := NewCredentialInvalidator(idGetter, invalidate, legacyInvalidate)
+	invalidator := NewCredentialInvalidator(keyGetter, invalidate, legacyInvalidate)
 	err := invalidator.InvalidateModelCredential(context.Background(), "bad")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, gc.Equals, "bad")

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -40,7 +40,7 @@ type PrecheckBackend interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
 }
 
 // UpgradeService provides access to upgrade information.

--- a/internal/migration/precheck.go
+++ b/internal/migration/precheck.go
@@ -397,7 +397,7 @@ func (ctx *precheckSource) checkModel(stdCtx context.Context) error {
 		return errors.New("model is being imported as part of another migration")
 	}
 	if credTag, found := model.CloudCredentialTag(); found {
-		creds, err := ctx.credentialService.CloudCredential(stdCtx, credential.IdFromTag(credTag))
+		creds, err := ctx.credentialService.CloudCredential(stdCtx, credential.KeyFromTag(credTag))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -953,7 +953,7 @@ type fakeCredentialService struct {
 	credentialsErr error
 }
 
-func (b *fakeCredentialService) CloudCredential(_ context.Context, _ credential.ID) (cloud.Credential, error) {
+func (b *fakeCredentialService) CloudCredential(_ context.Context, _ credential.Key) (cloud.Credential, error) {
 	return b.credential, b.credentialsErr
 }
 

--- a/internal/worker/bootstrap/addressfinder.go
+++ b/internal/worker/bootstrap/addressfinder.go
@@ -97,7 +97,7 @@ func getEnviron(ctx context.Context, state SystemState, cloudService CloudServic
 func getEnvironCredential(ctx context.Context, controllerModel bootstrap.Model, credentialService CredentialService) (*cloud.Credential, error) {
 	var cred *cloud.Credential
 	if cloudCredentialTag, ok := controllerModel.CloudCredentialTag(); ok {
-		credentialValue, err := credentialService.CloudCredential(ctx, credential.IdFromTag(cloudCredentialTag))
+		credentialValue, err := credentialService.CloudCredential(ctx, credential.KeyFromTag(cloudCredentialTag))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -466,7 +466,7 @@ func (m *MockCredentialService) EXPECT() *MockCredentialServiceMockRecorder {
 }
 
 // CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.ID) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
 	ret0, _ := ret[0].(cloud.Credential)

--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -61,7 +61,7 @@ type ControllerConfigService interface {
 // CredentialService is the interface that is used to get the
 // cloud credential.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
 }
 
 // CloudService is the interface that is used to interact with the

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -101,7 +101,7 @@ var (
 	DefaultCredentialTag = names.NewCloudCredentialTag("dummy/admin/default")
 
 	// DefaultCredentialId is the default credential id for all models.
-	DefaultCredentialId = corecredential.IdFromTag(DefaultCredentialTag)
+	DefaultCredentialId = corecredential.KeyFromTag(DefaultCredentialTag)
 )
 
 // ApiServerSuite is a text fixture which spins up an apiserver on top of a controller model.
@@ -639,7 +639,7 @@ func (s *ApiServerSuite) SeedCAASCloud(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		return credentialstate.CreateCredential(ctx, tx, credUUID.String(), corecredential.ID{
+		return credentialstate.CreateCredential(ctx, tx, credUUID.String(), corecredential.Key{
 			Cloud: "caascloud",
 			Owner: "admin",
 			Name:  "dummy-credential",

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -35,7 +35,7 @@ type Model interface {
 
 // CredentialService provides access to credentials.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, id credential.ID) (cloud.Credential, error)
+	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
 }
 
 // CloudService provides access to clouds.
@@ -111,7 +111,7 @@ func CloudSpecForModel(
 	}
 	var cred cloud.Credential
 	if ok {
-		cred, err = credentialService.CloudCredential(ctx, credential.IdFromTag(tag))
+		cred, err = credentialService.CloudCredential(ctx, credential.KeyFromTag(tag))
 		if err != nil {
 			return environscloudspec.CloudSpec{}, errors.Trace(err)
 		}

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -60,9 +60,9 @@ type credentialGetter struct {
 	cred *cloud.Credential
 }
 
-func (c credentialGetter) CloudCredential(_ context.Context, id credential.ID) (cloud.Credential, error) {
+func (c credentialGetter) CloudCredential(_ context.Context, key credential.Key) (cloud.Credential, error) {
 	if c.cred == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", key)
 	}
 	return *c.cred, nil
 }

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -100,9 +100,9 @@ type MockCredentialService struct {
 	Credential *cloud.Credential
 }
 
-func (m *MockCredentialService) CloudCredential(ctx stdcontext.Context, id credential.ID) (cloud.Credential, error) {
+func (m *MockCredentialService) CloudCredential(ctx stdcontext.Context, key credential.Key) (cloud.Credential, error) {
 	if m.Credential == nil {
-		return cloud.Credential{}, errors.NotFoundf("credential %q", id)
+		return cloud.Credential{}, errors.NotFoundf("credential %q", key)
 	}
 	return *m.Credential, nil
 }


### PR DESCRIPTION
We had previously introduced a type for the credential natural key of cloud, name and owner and named this id. However this is more of a key in our system being a natural way for users to refer to credentials.

ID should be reserved for the unique id we assign the credential in the controller. This PR makes way for the credential ID to become it's own type.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is just a rename so if we compile and pass tests everything is fine.

## Documentation changes

N/A

## Links

N/A

