### PR TITLE
The storage Constraints struct is renamed to Directive.

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -818,14 +818,14 @@ func (b *CommitHookParamsBuilder) UpdateCharmState(state map[string]string) {
 }
 
 // AddStorage records a request for adding storage.
-func (b *CommitHookParamsBuilder) AddStorage(constraints map[string][]params.StorageConstraints) {
+func (b *CommitHookParamsBuilder) AddStorage(constraints map[string][]params.StorageDirectives) {
 	storageReqs := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
 		for _, one := range cons {
 			storageReqs = append(storageReqs, params.StorageAddParams{
 				UnitTag:     b.arg.Tag,
 				StorageName: storage,
-				Constraints: one,
+				Directives:  one,
 			})
 		}
 	}

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -52,7 +52,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 				Constraints:      constraints.MustParse("mem=4G"),
 				Placement:        []*instance.Placement{{"scope", "directive"}},
 				EndpointBindings: map[string]string{"foo": "bar"},
-				Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+				Storage:          map[string]storage.Directive{"data": {Pool: "pool"}},
 				AttachStorage:    []string{"storage-data-0"},
 				Resources:        map[string]string{"foo": "bar"},
 			},
@@ -75,7 +75,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 		Config:           map[string]string{"foo": "bar"},
 		Cons:             constraints.MustParse("mem=4G"),
 		Placement:        []*instance.Placement{{"scope", "directive"}},
-		Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+		Storage:          map[string]storage.Directive{"data": {Pool: "pool"}},
 		AttachStorage:    []string{"data/0"},
 		Resources:        map[string]string{"foo": "bar"},
 		EndpointBindings: map[string]string{"foo": "bar"},
@@ -105,7 +105,7 @@ func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
 				Constraints:      constraints.MustParse("mem=4G"),
 				Placement:        []*instance.Placement{{"scope", "directive"}},
 				EndpointBindings: map[string]string{"foo": "bar"},
-				Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+				Storage:          map[string]storage.Directive{"data": {Pool: "pool"}},
 				AttachStorage:    []string{"storage-data-0"},
 				Resources:        map[string]string{"foo": "bar"},
 			},
@@ -128,7 +128,7 @@ func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
 		Config:           map[string]string{"foo": "bar"},
 		Cons:             constraints.MustParse("mem=4G"),
 		Placement:        []*instance.Placement{{"scope", "directive"}},
-		Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+		Storage:          map[string]storage.Directive{"data": {Pool: "pool"}},
 		AttachStorage:    []string{"data/0"},
 		Resources:        map[string]string{"foo": "bar"},
 		EndpointBindings: map[string]string{"foo": "bar"},
@@ -229,7 +229,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		return &v
 	}
 
-	args := params.ApplicationSetCharm{
+	args := params.ApplicationSetCharmV2{
 		ApplicationName: "application",
 		CharmURL:        "ch:application-1",
 		CharmOrigin: &params.CharmOrigin{
@@ -245,7 +245,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		Force:              true,
 		ForceBase:          true,
 		ForceUnits:         true,
-		StorageConstraints: map[string]params.StorageConstraints{
+		StorageDirectives: map[string]params.StorageDirectives{
 			"a": {Pool: "radiant"},
 			"b": {Count: toUint64Ptr(123)},
 			"c": {Size: toUint64Ptr(123)},
@@ -257,7 +257,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(args.Force, gc.Equals, true)
 	c.Assert(args.ForceBase, gc.Equals, true)
 	c.Assert(args.ForceUnits, gc.Equals, true)
-	c.Assert(args.StorageConstraints, jc.DeepEquals, map[string]params.StorageConstraints{
+	c.Assert(args.StorageDirectives, jc.DeepEquals, map[string]params.StorageDirectives{
 		"a": {Pool: "radiant"},
 		"b": {Count: toUint64Ptr(123)},
 		"c": {Size: toUint64Ptr(123)},
@@ -280,7 +280,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		Force:              true,
 		ForceBase:          true,
 		ForceUnits:         true,
-		StorageConstraints: map[string]storage.Constraints{
+		StorageDirectives: map[string]storage.Directive{
 			"a": {Pool: "radiant"},
 			"b": {Count: 123},
 			"c": {Size: 123},

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -35,7 +35,7 @@ func (s *MachinemanagerSuite) TestAddMachines(c *gc.C) {
 
 	machines := []params.AddMachineParams{{
 		Base:  &params.Base{Name: "ubuntu", Channel: "22.04"},
-		Disks: []storage.Constraints{{Pool: "loop", Size: 1}},
+		Disks: []storage.Directive{{Pool: "loop", Size: 1}},
 	}, {
 		Base: &params.Base{Name: "ubuntu", Channel: "20.04"},
 	}}

--- a/api/client/storage/client_test.go
+++ b/api/client/storage/client_test.go
@@ -429,22 +429,22 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	size := uint64(42)
-	cons := params.StorageConstraints{
+	directives := params.StorageDirectives{
 		Pool: "value",
 		Size: &size,
 	}
 
 	errOut := "error"
 	unitStorages := []params.StorageAddParams{
-		{UnitTag: "u-a", StorageName: "one", Constraints: cons},
-		{UnitTag: "u-b", StorageName: errOut, Constraints: cons},
+		{UnitTag: "u-a", StorageName: "one", Directives: directives},
+		{UnitTag: "u-b", StorageName: errOut, Directives: directives},
 		{UnitTag: "u-b", StorageName: "nil-constraints"},
 	}
 
 	storageN := 3
 	expectedError := apiservererrors.ServerError(errors.NotValidf("storage directive"))
 	expectedDetails := &params.AddStorageDetails{[]string{"a/0", "b/1"}}
-	one := func(u, s string, attrs params.StorageConstraints) params.AddStorageResult {
+	one := func(u, s string, attrs params.StorageDirectives) params.AddStorageResult {
 		result := params.AddStorageResult{}
 		if s == errOut {
 			result.Error = expectedError
@@ -459,9 +459,9 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 	result := new(params.AddStorageResults)
 	results := params.AddStorageResults{
 		Results: []params.AddStorageResult{
-			one(unitStorages[0].UnitTag, unitStorages[0].StorageName, unitStorages[0].Constraints),
-			one(unitStorages[1].UnitTag, unitStorages[1].StorageName, unitStorages[1].Constraints),
-			one(unitStorages[2].UnitTag, unitStorages[2].StorageName, unitStorages[2].Constraints),
+			one(unitStorages[0].UnitTag, unitStorages[0].StorageName, unitStorages[0].Directives),
+			one(unitStorages[1].UnitTag, unitStorages[1].StorageName, unitStorages[1].Directives),
+			one(unitStorages[2].UnitTag, unitStorages[2].StorageName, unitStorages[2].Directives),
 		},
 	}
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,7 +29,7 @@ var facadeVersions = facades.FacadeVersions{
 	"AllModelWatcher":              {4},
 	"AllWatcher":                   {3},
 	"Annotations":                  {2},
-	"Application":                  {19},
+	"Application":                  {19, 20},
 	"ApplicationOffers":            {4},
 	"ApplicationScaler":            {1},
 	"Backups":                      {3},

--- a/apiserver/facades/agent/uniter/storage.go
+++ b/apiserver/facades/agent/uniter/storage.go
@@ -382,16 +382,16 @@ func validConstraints(
 		return emptyCons, errors.NotFoundf("storage %q", p.StorageName)
 	}
 
-	onlyCount := params.StorageConstraints{Count: p.Constraints.Count}
-	if p.Constraints != onlyCount {
+	onlyCount := params.StorageDirectives{Count: p.Directives.Count}
+	if p.Directives != onlyCount {
 		return emptyCons, errors.New("only count can be specified")
 	}
 
-	if p.Constraints.Count == nil || *p.Constraints.Count == 0 {
+	if p.Directives.Count == nil || *p.Directives.Count == 0 {
 		return emptyCons, errors.New("count must be specified")
 	}
 
-	result.Count = *p.Constraints.Count
+	result.Count = *p.Directives.Count
 	return result, nil
 }
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3536,7 +3536,7 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	b.OpenPortRange(allEndpoints, network.MustParsePortRange("7337/tcp")) // same port closed below; this should be a no-op
 	b.ClosePortRange(allEndpoints, network.MustParsePortRange("7337/tcp"))
 	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
-	b.AddStorage(map[string][]params.StorageConstraints{
+	b.AddStorage(map[string][]params.StorageDirectives{
 		"multi1to10": {{Count: &stCount}},
 	})
 	req, _ := b.Build()

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -328,7 +328,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -361,7 +361,7 @@ func (s *ApplicationSuite) TestSetCharmEverything(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err = s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err = s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName:    "postgresql",
 		CharmURL:           curl,
 		CharmOrigin:        createCharmOriginFromURL(curl),
@@ -380,7 +380,7 @@ func (s *ApplicationSuite) TestSetCharmWithBlockChange(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
 	defer s.setup(c).Finish()
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:something-else",
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
@@ -392,7 +392,7 @@ func (s *ApplicationSuite) TestSetCharmRejectCharmStore(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "cs:something-else",
 		CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
@@ -423,7 +423,7 @@ func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		ForceUnits:      true,
@@ -443,7 +443,7 @@ func (s *ApplicationSuite) TestSetCharmInvalidApplication(c *gc.C) {
 
 	s.backend.EXPECT().Application("badapplication").Return(nil, errors.NotFoundf(`application "badapplication"`))
 	curl := "ch:something-else"
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "badapplication",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -453,7 +453,7 @@ func (s *ApplicationSuite) TestSetCharmInvalidApplication(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `application "badapplication" not found`)
 }
 
-func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
+func (s *ApplicationSuite) TestSetCharmStorageDirectives(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
 
@@ -477,7 +477,7 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 
 	s.applicationService.EXPECT().UpdateApplicationCharm(gomock.Any(), "postgresql", applicationservice.UpdateCharmParams{
 		Charm: ch,
-		Storage: map[string]storage.Constraints{
+		Storage: map[string]storage.Directive{
 			"a": {},
 			"b": {Pool: "radiant"},
 			"c": {Size: 123},
@@ -488,10 +488,10 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	toUint64Ptr := func(v uint64) *uint64 {
 		return &v
 	}
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
-		StorageConstraints: map[string]params.StorageConstraints{
+		StorageDirectives: map[string]params.StorageDirectives{
 			"a": {},
 			"b": {Pool: "radiant"},
 			"c": {Size: toUint64Ptr(123)},
@@ -514,7 +514,7 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	app := s.expectDefaultApplication(ctrl)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -564,7 +564,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -585,7 +585,7 @@ func (s *ApplicationSuite) TestSetCharmDisallowDowngradeFormat(c *gc.C) {
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "postgresql")
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -613,7 +613,7 @@ func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -657,7 +657,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -681,7 +681,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 
 	s.model.EXPECT().AgentVersion().Return(version.Number{Major: 2, Minor: 5, Patch: 0}, nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -715,7 +715,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 		Storage: nil,
 	}).Return(nil)
 
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        curl,
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -756,7 +756,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	// Try to upgrade the charm
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
@@ -803,7 +803,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 	}).Return(nil)
 
 	// Try to upgrade the charm
-	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharm{
+	err := s.api.SetCharm(context.Background(), params.ApplicationSetCharmV2{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
 		CharmOrigin:     createCharmOriginFromURL(curl),
@@ -1451,7 +1451,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	curl := "ch:utopic/storage-block-10"
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
-	storageConstraints := map[string]storage.Constraints{
+	storageDirectives := map[string]storage.Directive{
 		"data": {
 			Count: 1,
 			Size:  1024,
@@ -1463,7 +1463,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
-		Storage:         storageConstraints,
+		Storage:         storageDirectives,
 	}
 	results, err := s.api.Deploy(context.Background(), params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
@@ -1473,7 +1473,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	c.Assert(s.deployParams["my-app"].Storage, gc.DeepEquals, storageConstraints)
+	c.Assert(s.deployParams["my-app"].Storage, gc.DeepEquals, storageDirectives)
 }
 
 func (s *ApplicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C) {
@@ -1993,7 +1993,7 @@ func (s *ApplicationSuite) TestDeployCAASModelInvalidStorage(c *gc.C) {
 			CharmURL:        "local:foo-0",
 			CharmOrigin:     &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
 			NumUnits:        1,
-			Storage: map[string]storage.Constraints{
+			Storage: map[string]storage.Directive{
 				"database": {},
 			},
 		}},
@@ -2030,7 +2030,7 @@ func (s *ApplicationSuite) TestDeployCAASModelDefaultStorageClass(c *gc.C) {
 			CharmURL:        "local:foo-0",
 			CharmOrigin:     &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
 			NumUnits:        1,
-			Storage: map[string]storage.Constraints{
+			Storage: map[string]storage.Directive{
 				"database": {},
 			},
 		}},

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -45,7 +45,7 @@ type DeployApplicationParams struct {
 	// Placement is a list of placement directives which may be used
 	// instead of a machine spec.
 	Placement        []*instance.Placement
-	Storage          map[string]storage.Constraints
+	Storage          map[string]storage.Directive
 	Devices          map[string]devices.Constraints
 	AttachStorage    []names.StorageTag
 	EndpointBindings map[string]string
@@ -132,7 +132,7 @@ func DeployApplication(
 		Name:              args.ApplicationName,
 		Charm:             args.Charm,
 		CharmOrigin:       origin,
-		Storage:           stateStorageConstraints(args.Storage),
+		Storage:           stateStorageDirectives(args.Storage),
 		Devices:           stateDeviceConstraints(args.Devices),
 		AttachStorage:     args.AttachStorage,
 		ApplicationConfig: args.ApplicationConfig,
@@ -161,7 +161,7 @@ func DeployApplication(
 	}
 	app, err := st.AddApplication(asa, store)
 
-	// Dual write storage constraints to dqlite.
+	// Dual write storage directives to dqlite.
 	if err == nil {
 		err = applicationService.CreateApplication(ctx, args.ApplicationName, applicationservice.AddApplicationParams{
 			Charm:   args.Charm,
@@ -239,7 +239,7 @@ func saveMachineInfo(ctx context.Context, machineService MachineService, machine
 	return nil
 }
 
-func stateStorageConstraints(cons map[string]storage.Constraints) map[string]state.StorageConstraints {
+func stateStorageDirectives(cons map[string]storage.Directive) map[string]state.StorageConstraints {
 	result := make(map[string]state.StorageConstraints)
 	for name, cons := range cons {
 		result[name] = state.StorageConstraints{

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -158,7 +158,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 		NumUnits:          dt.numUnits,
 		Placement:         dt.placement,
 		Resources:         pendingIDs,
-		Storage:           stateStorageConstraints(dt.storage),
+		Storage:           stateStorageDirectives(dt.storage),
 	}, api.store)
 
 	if addApplicationErr == nil {
@@ -275,7 +275,7 @@ type deployTemplate struct {
 	origin                 corecharm.Origin
 	placement              []*instance.Placement
 	resources              map[string]string
-	storage                map[string]storage.Constraints
+	storage                map[string]storage.Directive
 	pendingResourceUploads []*params.PendingResourceUpload
 	resolvedResources      []resource.Resource
 }

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -17,12 +17,23 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Application", 19, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
 		return newFacadeV19(stdCtx, ctx) // Added new DeployFromRepository
 	}, reflect.TypeOf((*APIv19)(nil)))
+	registry.MustRegister("Application", 20, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		return newFacadeV20(stdCtx, ctx) // Remove remote space, rename storage constraint to storage directive
+	}, reflect.TypeOf((*APIv20)(nil)))
 }
 
 func newFacadeV19(stdCtx context.Context, ctx facade.ModelContext) (*APIv19, error) {
+	api, err := newFacadeV20(stdCtx, ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv19{APIv20: api}, nil
+}
+
+func newFacadeV20(stdCtx context.Context, ctx facade.ModelContext) (*APIv20, error) {
 	api, err := newFacadeBase(stdCtx, ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv19{APIBase: api}, nil
+	return &APIv20{APIBase: api}, nil
 }

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -140,7 +140,7 @@ func (b *BundleAPI) GetChangesMapArgs(ctx context.Context, args params.BundleCha
 			return err
 		},
 		verifyStorage: func(s string) error {
-			_, err := storage.ParseConstraints(s)
+			_, err := storage.ParseDirective(s)
 			return err
 		},
 		verifyDevices: func(s string) error {
@@ -535,10 +535,10 @@ func (b *BundleAPI) bundleDataApplications(
 		if result := b.constraints(application.Constraints()); len(result) != 0 {
 			newApplication.Constraints = strings.Join(result, " ")
 		}
-		if cons := application.StorageConstraints(); len(cons) != 0 {
+		if cons := application.StorageDirectives(); len(cons) != 0 {
 			newApplication.Storage = make(map[string]string)
 			for name, constr := range cons {
-				if newApplication.Storage[name], err = storage.ToString(storage.Constraints{
+				if newApplication.Storage[name], err = storage.ToString(storage.Directive{
 					Pool:  constr.Pool(),
 					Size:  constr.Size(),
 					Count: constr.Count(),

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -539,8 +539,8 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 		CloudRegion: "some-region"})
 
 	args := s.minimalApplicationArgs(description.IAAS)
-	// Add storage constraints to the app
-	args.StorageConstraints = map[string]description.StorageConstraintArgs{
+	// Add storage directives to the app
+	args.StorageDirectives = map[string]description.StorageDirectiveArgs{
 		"storage1": {
 			Pool:  "pool1",
 			Size:  1024,

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -157,8 +157,8 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *gc.C) {
 			Jobs: []model.MachineJob{model.JobHostUnits},
 		}
 	}
-	apiParams[0].Disks = []storage.Constraints{{Size: 1, Count: 2}, {Size: 2, Count: 1}}
-	apiParams[1].Disks = []storage.Constraints{{Size: 1, Count: 2, Pool: "three"}}
+	apiParams[0].Disks = []storage.Directive{{Size: 1, Count: 2}, {Size: 2, Count: 1}}
+	apiParams[1].Disks = []storage.Directive{{Size: 1, Count: 2, Pool: "three"}}
 
 	m1 := mocks.NewMockMachine(ctrl)
 	m1.EXPECT().Id().Return("666").AnyTimes()

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -456,7 +456,7 @@ func (a *StorageAPI) addToUnit(ctx stdcontext.Context, args params.StoragesAddPa
 		return params.AddStorageResults{}, errors.Trace(err)
 	}
 
-	paramsToState := func(p params.StorageConstraints) state.StorageConstraints {
+	paramsToState := func(p params.StorageDirectives) state.StorageConstraints {
 		s := state.StorageConstraints{Pool: p.Pool}
 		if p.Size != nil {
 			s.Size = *p.Size
@@ -476,7 +476,7 @@ func (a *StorageAPI) addToUnit(ctx stdcontext.Context, args params.StoragesAddPa
 		}
 
 		storageTags, err := a.storageAccess.AddStorageForUnit(
-			u, one.StorageName, paramsToState(one.Constraints),
+			u, one.StorageName, paramsToState(one.Directives),
 		)
 		if err != nil {
 			result[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1990,8 +1990,8 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv19 provides the Application API facade for version 19.",
-        "Version": 19,
+        "Description": "APIv20 provides the Application API facade for version 20.",
+        "Version": 20,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -2251,7 +2251,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/ApplicationSetCharm"
+                            "$ref": "#/definitions/ApplicationSetCharmV2"
                         }
                     },
                     "description": "SetCharm sets the charm for a given for the application."
@@ -2556,7 +2556,7 @@
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
-                                    "$ref": "#/definitions/Constraints"
+                                    "$ref": "#/definitions/Directive"
                                 }
                             }
                         }
@@ -2885,7 +2885,7 @@
                         "life"
                     ]
                 },
-                "ApplicationSetCharm": {
+                "ApplicationSetCharmV2": {
                     "type": "object",
                     "properties": {
                         "application": {
@@ -2939,11 +2939,11 @@
                                 }
                             }
                         },
-                        "storage-constraints": {
+                        "storage-directives": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
-                                    "$ref": "#/definitions/StorageConstraints"
+                                    "$ref": "#/definitions/StorageDirectives"
                                 }
                             }
                         }
@@ -3195,21 +3195,26 @@
                 "Constraints": {
                     "type": "object",
                     "properties": {
+                        "Attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "Count": {
                             "type": "integer"
                         },
-                        "Pool": {
+                        "Type": {
                             "type": "string"
-                        },
-                        "Size": {
-                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "Pool",
-                        "Size",
-                        "Count"
+                        "Type",
+                        "Count",
+                        "Attributes"
                     ]
                 },
                 "ConsumeApplicationArg": {
@@ -3329,14 +3334,6 @@
                                 "$ref": "#/definitions/Placement"
                             }
                         },
-                        "Storage": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "$ref": "#/definitions/Constraints"
-                                }
-                            }
-                        },
                         "Trust": {
                             "type": "boolean"
                         },
@@ -3370,6 +3367,14 @@
                         },
                         "revision": {
                             "type": "integer"
+                        },
+                        "storage": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Directive"
+                                }
+                            }
                         }
                     },
                     "additionalProperties": false,
@@ -3382,7 +3387,7 @@
                         "Devices",
                         "DryRun",
                         "Placement",
-                        "Storage",
+                        "storage",
                         "Trust"
                     ]
                 },
@@ -3696,6 +3701,26 @@
                     "additionalProperties": false,
                     "required": [
                         "units"
+                    ]
+                },
+                "Directive": {
+                    "type": "object",
+                    "properties": {
+                        "Count": {
+                            "type": "integer"
+                        },
+                        "Pool": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Pool",
+                        "Size",
+                        "Count"
                     ]
                 },
                 "EndpointRelationData": {
@@ -4130,7 +4155,7 @@
                         "constraints"
                     ]
                 },
-                "StorageConstraints": {
+                "StorageDirectives": {
                     "type": "object",
                     "properties": {
                         "count": {
@@ -22744,7 +22769,7 @@
                         "disks": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Constraints"
+                                "$ref": "#/definitions/Directive"
                             }
                         },
                         "hardware-characteristics": {
@@ -22877,26 +22902,6 @@
                         "channel"
                     ]
                 },
-                "Constraints": {
-                    "type": "object",
-                    "properties": {
-                        "Count": {
-                            "type": "integer"
-                        },
-                        "Pool": {
-                            "type": "string"
-                        },
-                        "Size": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "Pool",
-                        "Size",
-                        "Count"
-                    ]
-                },
                 "DestroyMachineInfo": {
                     "type": "object",
                     "properties": {
@@ -22982,6 +22987,26 @@
                     "additionalProperties": false,
                     "required": [
                         "machine-tags"
+                    ]
+                },
+                "Directive": {
+                    "type": "object",
+                    "properties": {
+                        "Count": {
+                            "type": "integer"
+                        },
+                        "Pool": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Pool",
+                        "Size",
+                        "Count"
                     ]
                 },
                 "Entities": {
@@ -38015,7 +38040,7 @@
                             "type": "string"
                         },
                         "storage": {
-                            "$ref": "#/definitions/StorageConstraints"
+                            "$ref": "#/definitions/StorageDirectives"
                         },
                         "unit": {
                             "type": "string"
@@ -38084,21 +38109,6 @@
                     "required": [
                         "ids"
                     ]
-                },
-                "StorageConstraints": {
-                    "type": "object",
-                    "properties": {
-                        "count": {
-                            "type": "integer"
-                        },
-                        "pool": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
                 },
                 "StorageDetachmentParams": {
                     "type": "object",
@@ -38204,6 +38214,21 @@
                             "items": {
                                 "$ref": "#/definitions/StorageDetailsResult"
                             }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDirectives": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -44725,7 +44750,7 @@
                             "type": "string"
                         },
                         "storage": {
-                            "$ref": "#/definitions/StorageConstraints"
+                            "$ref": "#/definitions/StorageDirectives"
                         },
                         "unit": {
                             "type": "string"
@@ -44855,7 +44880,7 @@
                     },
                     "additionalProperties": false
                 },
-                "StorageConstraints": {
+                "StorageDirectives": {
                     "type": "object",
                     "properties": {
                         "count": {

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -322,7 +322,7 @@ func verifyBaseBundle(base BundleDataSource) error {
 
 func verifyBundle(data *charm.BundleData, bundleDir string, verifyConstraints func(string) error) error {
 	verifyStorage := func(s string) error {
-		_, err := storage.ParseConstraints(s)
+		_, err := storage.ParseDirective(s)
 		return err
 	}
 	verifyDevices := func(s string) error {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -279,13 +279,13 @@ type DeployCommand struct {
 	// TODO(axw) move this to UnitCommandBase once we support --storage
 	// on add-unit too.
 	//
-	// Storage is a map of storage constraints, keyed on the storage name
+	// Storage is a map of storage directives, keyed on the storage name
 	// defined in charm storage metadata.
-	Storage map[string]storage.Constraints
+	Storage map[string]storage.Directive
 
-	// BundleStorage maps application names to maps of storage constraints keyed on
+	// BundleStorage maps application names to maps of storage directives keyed on
 	// the storage name defined in that application's charm storage metadata.
-	BundleStorage map[string]map[string]storage.Constraints
+	BundleStorage map[string]map[string]storage.Directive
 
 	// Devices is a mapping of device constraints, keyed on the device name
 	// defined in charm devices metadata.
@@ -645,7 +645,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.Revision, "revision", -1, "The revision to deploy")
 	f.BoolVar(&c.DryRun, "dry-run", false, "Just show what the deploy would do")
 	f.BoolVar(&c.Force, "force", false, "Allow a charm/bundle to be deployed which bypasses checks such as supported base or LXD profile allow list")
-	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage constraints")
+	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage directives")
 	f.Var(devicesFlag{&c.Devices, &c.BundleDevices}, "device", "Charm device constraints")
 	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -430,7 +430,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 		charmDir.Meta(),
 
 		false, 1, nil, "", nil,
-		map[string]storage.Constraints{
+		map[string]storage.Directive{
 			"data": {
 				Pool:  "machinescoped",
 				Size:  1024,
@@ -1624,7 +1624,7 @@ func withCharmDeployableWithStorage(
 	attachStorage []string,
 	configYAML string,
 	config map[string]string,
-	storage map[string]storage.Constraints,
+	storage map[string]storage.Directive,
 ) {
 	withCharmDeployableWithDevicesAndStorage(
 		fakeAPI,
@@ -1657,7 +1657,7 @@ func withCharmDeployableWithDevicesAndStorage(
 	attachStorage []string,
 	configYAML string,
 	config map[string]string,
-	storage map[string]storage.Constraints,
+	storage map[string]storage.Directive,
 	devices map[string]devices.Constraints,
 ) {
 	deployURL := *url

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -45,7 +45,7 @@ type deployBundle struct {
 
 	useExistingMachines bool
 	bundleMachines      map[string]string
-	bundleStorage       map[string]map[string]storage.Constraints
+	bundleStorage       map[string]map[string]storage.Directive
 	bundleDevices       map[string]map[string]devices.Constraints
 
 	targetModelName string

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -284,7 +284,7 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "ubuntu", "22.04")
 	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "ubuntu", "22.04")
-	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Constraints{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
+	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Directive{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
 	s.assertDeployArgsConfig(c, "mariadb", map[string]interface{}{"dataset-size": "70%"})
 
 	c.Check(s.output.String(), gc.Equals, ""+
@@ -527,7 +527,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleStorage(c *gc.C) {
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "22.04")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "22.04")
-	s.assertDeployArgsStorage(c, "mysql", map[string]storage.Constraints{"database": {Pool: "mysql-pv", Size: 0x14, Count: 0x1}})
+	s.assertDeployArgsStorage(c, "mysql", map[string]storage.Directive{"database": {Pool: "mysql-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"mysql\" in charm-hub, channel stable\n"+
@@ -2123,7 +2123,7 @@ func (s *BundleDeployRepositorySuite) assertDeployArgs(c *gc.C, curl, appName, o
 	c.Assert(arg.CharmOrigin.Base.Channel.Track, gc.Equals, channel, gc.Commentf("%s", pretty.Sprint(arg)))
 }
 
-func (s *BundleDeployRepositorySuite) assertDeployArgsStorage(c *gc.C, appName string, storage map[string]storage.Constraints) {
+func (s *BundleDeployRepositorySuite) assertDeployArgsStorage(c *gc.C, appName string, storage map[string]storage.Directive) {
 	arg, found := s.deployArgs[appName]
 	c.Assert(found, jc.IsTrue, gc.Commentf("Application %q not found in deploy args", appName))
 	c.Assert(arg.Storage, gc.DeepEquals, storage)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -47,7 +47,7 @@ type deployCharm struct {
 	placementSpec    string
 	resources        map[string]string
 	baseFlag         corebase.Base
-	storage          map[string]storage.Constraints
+	storage          map[string]storage.Directive
 	trust            bool
 
 	validateCharmBaseWithName             func(base corebase.Base, name string, imageStream string) error

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -410,7 +410,7 @@ type DeployerConfig struct {
 	BundleDevices        map[string]map[string]devices.Constraints
 	BundleMachines       map[string]string
 	BundleOverlayFile    []string
-	BundleStorage        map[string]map[string]storage.Constraints
+	BundleStorage        map[string]map[string]storage.Directive
 	Channel              charm.Channel
 	CharmOrBundle        string
 	DefaultCharmSchema   charm.Schema
@@ -430,7 +430,7 @@ type DeployerConfig struct {
 	Resources            map[string]string
 	Revision             int
 	Base                 corebase.Base
-	Storage              map[string]storage.Constraints
+	Storage              map[string]storage.Directive
 	Trust                bool
 	UseExisting          bool
 }
@@ -460,8 +460,8 @@ type factory struct {
 	configOptions      common.ConfigFlag
 	constraints        constraints.Value
 	modelConstraints   constraints.Value
-	storage            map[string]storage.Constraints
-	bundleStorage      map[string]map[string]storage.Constraints
+	storage            map[string]storage.Directive
+	bundleStorage      map[string]map[string]storage.Directive
 	devices            map[string]devices.Constraints
 	bundleDevices      map[string]map[string]devices.Constraints
 	resources          map[string]string

--- a/cmd/juju/application/flags.go
+++ b/cmd/juju/application/flags.go
@@ -15,8 +15,8 @@ import (
 )
 
 type storageFlag struct {
-	stores       *map[string]storage.Constraints
-	bundleStores *map[string]map[string]storage.Constraints
+	stores       *map[string]storage.Directive
+	bundleStores *map[string]map[string]storage.Directive
 }
 
 // Set implements gnuflag.Value.Set.
@@ -24,37 +24,37 @@ func (f storageFlag) Set(s string) error {
 	fields := strings.SplitN(s, "=", 2)
 	if len(fields) < 2 {
 		if f.bundleStores != nil {
-			return errors.New("expected [<application>:]<store>=<constraints>")
+			return errors.New("expected [<application>:]<store>=<directive>")
 		}
-		return errors.New("expected <store>=<constraints>")
+		return errors.New("expected <store>=<directive>")
 	}
 	var applicationName, storageName string
 	if colon := strings.IndexRune(fields[0], ':'); colon >= 0 {
 		if f.bundleStores == nil {
-			return errors.New("expected <store>=<constraints>")
+			return errors.New("expected <store>=<directive>")
 		}
 		applicationName = fields[0][:colon]
 		storageName = fields[0][colon+1:]
 	} else {
 		storageName = fields[0]
 	}
-	cons, err := storage.ParseConstraints(fields[1])
+	cons, err := storage.ParseDirective(fields[1])
 	if err != nil {
-		return errors.Annotate(err, "cannot parse disk constraints")
+		return errors.Annotate(err, "cannot parse disk storage directive")
 	}
-	var stores map[string]storage.Constraints
+	var stores map[string]storage.Directive
 	if applicationName != "" {
 		if *f.bundleStores == nil {
-			*f.bundleStores = make(map[string]map[string]storage.Constraints)
+			*f.bundleStores = make(map[string]map[string]storage.Directive)
 		}
 		stores = (*f.bundleStores)[applicationName]
 		if stores == nil {
-			stores = make(map[string]storage.Constraints)
+			stores = make(map[string]storage.Directive)
 			(*f.bundleStores)[applicationName] = stores
 		}
 	} else {
 		if *f.stores == nil {
-			*f.stores = make(map[string]storage.Constraints)
+			*f.stores = make(map[string]storage.Directive)
 		}
 		stores = *f.stores
 	}

--- a/cmd/juju/application/flags_test.go
+++ b/cmd/juju/application/flags_test.go
@@ -52,37 +52,37 @@ func (FlagSuite) TestStringMapDupVal(c *gc.C) {
 }
 
 func (FlagSuite) TestStorageFlag(c *gc.C) {
-	var stores map[string]storage.Constraints
+	var stores map[string]storage.Directive
 	flag := storageFlag{&stores, nil}
 	err := flag.Set("foo=bar")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stores, jc.DeepEquals, map[string]storage.Constraints{
+	c.Assert(stores, jc.DeepEquals, map[string]storage.Directive{
 		"foo": {Pool: "bar", Count: 1},
 	})
 }
 
 func (FlagSuite) TestStorageFlagErrors(c *gc.C) {
-	flag := storageFlag{new(map[string]storage.Constraints), nil}
+	flag := storageFlag{new(map[string]storage.Directive), nil}
 	err := flag.Set("foo")
-	c.Assert(err, gc.ErrorMatches, `expected <store>=<constraints>`)
+	c.Assert(err, gc.ErrorMatches, `expected <store>=<directive>`)
 	err = flag.Set("foo:bar=baz")
-	c.Assert(err, gc.ErrorMatches, `expected <store>=<constraints>`)
+	c.Assert(err, gc.ErrorMatches, `expected <store>=<directive>`)
 	err = flag.Set("foo=")
-	c.Assert(err, gc.ErrorMatches, `cannot parse disk constraints: storage constraints require at least one field to be specified`)
+	c.Assert(err, gc.ErrorMatches, `cannot parse disk storage directive: storage directives require at least one field to be specified`)
 }
 
 func (FlagSuite) TestStorageFlagBundleStorage(c *gc.C) {
-	var stores map[string]storage.Constraints
-	var bundleStores map[string]map[string]storage.Constraints
+	var stores map[string]storage.Directive
+	var bundleStores map[string]map[string]storage.Directive
 	flag := storageFlag{&stores, &bundleStores}
 	err := flag.Set("foo=bar")
 	c.Assert(err, jc.ErrorIsNil)
 	err = flag.Set("app:baz=qux")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stores, jc.DeepEquals, map[string]storage.Constraints{
+	c.Assert(stores, jc.DeepEquals, map[string]storage.Directive{
 		"foo": {Pool: "bar", Count: 1},
 	})
-	c.Assert(bundleStores, jc.DeepEquals, map[string]map[string]storage.Constraints{
+	c.Assert(bundleStores, jc.DeepEquals, map[string]map[string]storage.Directive{
 		"app": {
 			"baz": {Pool: "qux", Count: 1},
 		},
@@ -90,9 +90,9 @@ func (FlagSuite) TestStorageFlagBundleStorage(c *gc.C) {
 }
 
 func (FlagSuite) TestStorageFlagBundleStorageErrors(c *gc.C) {
-	flag := storageFlag{new(map[string]storage.Constraints), new(map[string]map[string]storage.Constraints)}
+	flag := storageFlag{new(map[string]storage.Directive), new(map[string]map[string]storage.Directive)}
 	err := flag.Set("foo")
-	c.Assert(err, gc.ErrorMatches, `expected \[<application>\:]<store>=<constraints>`)
+	c.Assert(err, gc.ErrorMatches, `expected \[<application>\:]<store>=<directive>`)
 }
 
 func (FlagSuite) TestAttachStorageFlag(c *gc.C) {

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -149,9 +149,9 @@ type refreshCommand struct {
 	// and/or specified files containing key values.
 	ConfigOptions common.ConfigFlag
 
-	// Storage is a map of storage constraints, keyed on the storage name
+	// Storage is a map of storage directives, keyed on the storage name
 	// defined in charm storage metadata, to add or update during upgrade.
-	Storage map[string]storage.Constraints
+	Storage map[string]storage.Directive
 
 	// Trust signifies that the charm should have access to trusted credentials.
 	// That is, hooks run by the charm can access cloud credentials and other
@@ -186,10 +186,10 @@ repeated more than once to upload more than one resource.
 
 Where bar and baz are resources named in the metadata for the foo charm.
 
-Storage constraints may be added or updated at upgrade time by specifying
+Storage directives may be added or updated at upgrade time by specifying
 the --storage option, with the same format as specified in "juju deploy".
 If new required storage is added by the new charm revision, then you must
-specify constraints or the defaults will be applied.
+specify directives or the defaults will be applied.
 
   juju refresh foo --storage cache=ssd,10G
 
@@ -267,7 +267,7 @@ func (c *refreshCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.CharmPath, "path", "", "Refresh to a charm located at path")
 	f.IntVar(&c.Revision, "revision", -1, "Explicit revision of current charm")
 	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
-	f.Var(storageFlag{&c.Storage, nil}, "storage", "Charm storage constraints")
+	f.Var(storageFlag{&c.Storage, nil}, "storage", "Charm storage directives")
 	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
 	f.Var(newOptBoolValue(&c.Trust), "trust", "Allows charm to run hooks that require access credentials")
@@ -504,7 +504,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		ForceBase:          c.ForceBase,
 		ForceUnits:         c.ForceUnits,
 		ResourceIDs:        resourceIDs,
-		StorageConstraints: c.Storage,
+		StorageDirectives:  c.Storage,
 		EndpointBindings:   c.Bindings,
 	}
 

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -251,7 +251,7 @@ func (s *BaseRefreshSuite) refreshCommand() cmd.Command {
 	return cmd
 }
 
-func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
+func (s *RefreshSuite) TestStorageDirectives(c *gc.C) {
 	_, err := s.runRefresh(c, "foo", "--storage", "bar=baz")
 	c.Assert(err, jc.ErrorIsNil)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
@@ -268,7 +268,7 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 				Base:         s.testBase,
 			},
 		},
-		StorageConstraints: map[string]storage.Constraints{
+		StorageDirectives: map[string]storage.Directive{
 			"bar": {Pool: "baz", Count: 1},
 		},
 		ConfigSettings:   map[string]string{},

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -59,7 +59,7 @@ To control which instance type is provisioned, use the --constraints and
 the OS, separated by @. For example, --base ubuntu@22.04.
 
 To add storage volumes to the instance, provide a whitespace-delimited
-list of storage constraints to the --disks option. 
+list of storage directives to the --disks option. 
 
 Add "placement directives" as an argument give Juju additional information 
 about how to allocate the machine in the cloud. For example, one can direct 
@@ -171,7 +171,7 @@ type addCommand struct {
 	// NumMachines is the number of machines to add.
 	NumMachines int
 	// Disks describes disks that are to be attached to the machine.
-	Disks []storage.Constraints
+	Disks []storage.Directive
 	// PrivateKey is the path for a file containing the private key required
 	// by the server
 	PrivateKey string
@@ -201,7 +201,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Base, "base", "", "The operating system base to install on the new machine(s)")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Machine constraints that overwrite those available from 'juju model-constraints' and provider's defaults")
-	f.Var(disksFlag{&c.Disks}, "disks", "Storage constraints for disks to attach to the machine(s)")
+	f.Var(disksFlag{&c.Disks}, "disks", "Storage directives for disks to attach to the machine(s)")
 	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use during the connection")
 	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to add to the remote authorized keys")
 }

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -214,7 +214,7 @@ func (s *AddMachineSuite) TestAddMachineWithDisks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fakeAddMachine.args, gc.HasLen, 1)
 	param := s.fakeAddMachine.args[0]
-	c.Assert(param.Disks, gc.DeepEquals, []storage.Constraints{
+	c.Assert(param.Disks, gc.DeepEquals, []storage.Directive{
 		{Size: 1024, Count: 2},
 		{Size: 2048, Count: 1},
 	})

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -75,6 +75,6 @@ func NewUpgradeMachineCommandForTest(statusAPI StatusAPI, upgradeAPI UpgradeMach
 	return modelcmd.Wrap(command)
 }
 
-func NewDisksFlag(disks *[]storage.Constraints) *disksFlag {
+func NewDisksFlag(disks *[]storage.Directive) *disksFlag {
 	return &disksFlag{disks}
 }

--- a/cmd/juju/machine/flags.go
+++ b/cmd/juju/machine/flags.go
@@ -13,15 +13,15 @@ import (
 )
 
 type disksFlag struct {
-	disks *[]storage.Constraints
+	disks *[]storage.Directive
 }
 
 // Set implements gnuflag.Value.Set.
 func (f disksFlag) Set(s string) error {
 	for _, field := range strings.Fields(s) {
-		cons, err := storage.ParseConstraints(field)
+		cons, err := storage.ParseDirective(field)
 		if err != nil {
-			return errors.Annotate(err, "cannot parse disk constraints")
+			return errors.Annotate(err, "cannot parse disk storage directives")
 		}
 		*f.disks = append(*f.disks, cons)
 	}

--- a/cmd/juju/machine/flags_test.go
+++ b/cmd/juju/machine/flags_test.go
@@ -19,21 +19,21 @@ type FlagsSuite struct {
 var _ = gc.Suite(&FlagsSuite{})
 
 func (*FlagsSuite) TestDisksFlagErrors(c *gc.C) {
-	var disks []storage.Constraints
+	var disks []storage.Directive
 	f := machine.NewDisksFlag(&disks)
 	err := f.Set("-1")
-	c.Assert(err, gc.ErrorMatches, `cannot parse disk constraints: cannot parse count: count must be greater than zero, got "-1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot parse disk storage directives: cannot parse count: count must be greater than zero, got "-1"`)
 	c.Assert(disks, gc.HasLen, 0)
 }
 
 func (*FlagsSuite) TestDisksFlag(c *gc.C) {
-	var disks []storage.Constraints
+	var disks []storage.Directive
 	f := machine.NewDisksFlag(&disks)
 	err := f.Set("crystal,1G")
 	c.Assert(err, jc.ErrorIsNil)
 	err = f.Set("2,2G")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(disks, gc.DeepEquals, []storage.Constraints{
+	c.Assert(disks, gc.DeepEquals, []storage.Directive{
 		{Pool: "crystal", Size: 1024, Count: 1},
 		{Size: 2048, Count: 2},
 	})

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -69,13 +69,13 @@ var errorTsts = []tstData{
 	},
 	{
 		args:        []string{"tst/123", "data="},
-		expectedErr: `storage constraints require at least one field to be specified`,
-		visibleErr:  `cannot parse constraints for storage "data": storage constraints require at least one field to be specified`,
+		expectedErr: `storage directives require at least one field to be specified`,
+		visibleErr:  `cannot parse directive for storage "data": storage directives require at least one field to be specified`,
 	},
 	{
 		args:        []string{"tst/123", "data=-676"},
 		expectedErr: `count must be greater than zero, got "-676"`,
-		visibleErr:  `cannot parse constraints for storage "data": cannot parse count: count must be greater than zero, got "-676"`,
+		visibleErr:  `cannot parse directive for storage "data": cannot parse count: count must be greater than zero, got "-676"`,
 	},
 	{
 		args:        []string{"tst/123", "data=676", "data=676"},

--- a/doc/storage-model.txt
+++ b/doc/storage-model.txt
@@ -79,7 +79,7 @@ namespace juju.juju.state <<Database>> {
 		FilesystemType : string
 	}
 
-	class StorageConstraints {
+	class StorageDirectives {
 		StorageName : string
 		Size : int
 		Count : int
@@ -108,10 +108,10 @@ namespace juju.juju.state <<Database>> {
 
 	Unit "1" *-- "*" StorageInstance : owns (non-shared) >
 	Unit "1" *-- "*" StorageAttachment : has
-	Unit "1" *-- "*" StorageConstraints : records >
+	Unit "1" *-- "*" StorageDirectives : records >
 
 	application "1" *-- "*" StorageInstance : owns (shared) >
-	application "1" *-- "*" StorageConstraints : records >
+	application "1" *-- "*" StorageDirectives : records >
 	application "1" -- "1" juju.charm.Charm
 
 	StorageInstance --* StoragePool

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -14,6 +14,6 @@ const (
 	// ApplicationHasUnits describes an error that occurs when the application being deleted still
 	// has associated units.
 	ApplicationHasUnits = errors.ConstError("application has units")
-	// MissingStorageConstraints describes an error that occurs when expected storage constraints are missing.
-	MissingStorageConstraints = errors.ConstError("no storage constraints specified")
+	// MissingStorageDirective describes an error that occurs when expected storage directives are missing.
+	MissingStorageDirective = errors.ConstError("no storage directive specified")
 )

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -18,8 +18,8 @@ type Charm interface {
 type AddApplicationParams struct {
 	// Charm is the application's charm.
 	Charm Charm
-	// Storage contains the application's storage constraints.
-	Storage map[string]storage.Constraints
+	// Storage contains the application's storage directives.
+	Storage map[string]storage.Directive
 }
 
 // AddUnitParams contains parameters for adding a unit to the model.
@@ -45,11 +45,11 @@ type UpdateCharmParams struct {
 	// upgraded to use it.
 	Charm Charm
 
-	// Storage contains the storage constraints to add or update when
+	// Storage contains the storage directives to add or update when
 	// upgrading the charm.
 	//
 	// Any existing storage instances for the named stores will be
-	// unaffected; the storage constraints will only be used for
+	// unaffected; the storage directives will only be used for
 	// provisioning new storage instances.
-	Storage map[string]storage.Constraints
+	Storage map[string]storage.Directive
 }

--- a/domain/application/service/service_test.go
+++ b/domain/application/service/service_test.go
@@ -128,7 +128,7 @@ func (s *serviceSuite) TestCreateWithStorageBlockDefaultSource(c *gc.C) {
 	}
 	err := s.service.CreateApplication(context.Background(), "666", AddApplicationParams{
 		Charm: s.charm,
-		Storage: map[string]storage.Constraints{
+		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
 	}, a)
@@ -194,14 +194,14 @@ func (s *serviceSuite) TestCreateWithStorageFilesystemDefaultSource(c *gc.C) {
 	}
 	err := s.service.CreateApplication(context.Background(), "666", AddApplicationParams{
 		Charm: s.charm,
-		Storage: map[string]storage.Constraints{
+		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
 	}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestCreateWithSharedStorageMissingConstraints(c *gc.C) {
+func (s *serviceSuite) TestCreateWithSharedStorageMissingDirectives(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
@@ -221,8 +221,8 @@ func (s *serviceSuite) TestCreateWithSharedStorageMissingConstraints(c *gc.C) {
 	err := s.service.CreateApplication(context.Background(), "666", AddApplicationParams{
 		Charm: s.charm,
 	}, a)
-	c.Assert(err, jc.ErrorIs, storageerrors.MissingSharedStorageConstraintError)
-	c.Assert(err, gc.ErrorMatches, `adding default storage constraints: no storage constraints specified for shared charm storage "data"`)
+	c.Assert(err, jc.ErrorIs, storageerrors.MissingSharedStorageDirectiveError)
+	c.Assert(err, gc.ErrorMatches, `adding default storage directives: no storage directive specified for shared charm storage "data"`)
 }
 
 func (s *serviceSuite) TestCreateWithStorageValidates(c *gc.C) {
@@ -246,11 +246,11 @@ func (s *serviceSuite) TestCreateWithStorageValidates(c *gc.C) {
 	}
 	err := s.service.CreateApplication(context.Background(), "666", AddApplicationParams{
 		Charm: s.charm,
-		Storage: map[string]storage.Constraints{
+		Storage: map[string]storage.Directive{
 			"logs": {Count: 2},
 		},
 	}, a)
-	c.Assert(err, gc.ErrorMatches, `invalid storage constraints: charm "mine" has no store called "logs"`)
+	c.Assert(err, gc.ErrorMatches, `invalid storage directives: charm "mine" has no store called "logs"`)
 }
 
 func (s *serviceSuite) TestCreateApplicationError(c *gc.C) {

--- a/domain/storage/defaults_test.go
+++ b/domain/storage/defaults_test.go
@@ -31,8 +31,8 @@ func makeStorageDefaults(b, f string) domainstorage.StorageDefaults {
 	return result
 }
 
-func (s *defaultsSuite) assertAddApplicationStorageConstraintsDefaults(c *gc.C, pool string, cons, expect map[string]storage.Constraints) {
-	err := domainstorage.StorageConstraintsWithDefaults(
+func (s *defaultsSuite) assertAddApplicationStorageDirectivesDefaults(c *gc.C, pool string, cons, expect map[string]storage.Directive) {
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"data":    {Name: "data", Type: charm.StorageBlock, CountMin: 1, CountMax: -1},
 			"allecto": {Name: "allecto", Type: charm.StorageBlock, CountMin: 0, CountMax: -1},
@@ -45,81 +45,81 @@ func (s *defaultsSuite) assertAddApplicationStorageConstraintsDefaults(c *gc.C, 
 	c.Assert(cons, jc.DeepEquals, expect)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsNoConstraintsUsed(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("", 0, 0),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesNoConstraintsUsed(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("", 0, 0),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop", 1024, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop", 1024, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsJustCount(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("", 0, 1),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesJustCount(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("", 0, 1),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop-pool", 1024, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop-pool", 1024, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsDefaultPool(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("", 2048, 1),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesDefaultPool(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("", 2048, 1),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop-pool", 2048, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop-pool", 2048, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsConstraintPool(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("loop-pool", 2048, 1),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesConstraintPool(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("loop-pool", 2048, 1),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop-pool", 2048, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop-pool", 2048, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsNoUserDefaultPool(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("", 2048, 1),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesNoUserDefaultPool(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("", 2048, 1),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop", 2048, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop", 2048, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsDefaultSizeFallback(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data": makeStorageCons("loop-pool", 0, 1),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesDefaultSizeFallback(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"data": makeStorageDirective("loop-pool", 0, 1),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":    makeStorageCons("loop-pool", 1024, 1),
-		"allecto": makeStorageCons("loop", 1024, 0),
+	expectedCons := map[string]storage.Directive{
+		"data":    makeStorageDirective("loop-pool", 1024, 1),
+		"allecto": makeStorageDirective("loop", 1024, 0),
 	}
-	s.assertAddApplicationStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+	s.assertAddApplicationStorageDirectivesDefaults(c, "loop-pool", storageCons, expectedCons)
 }
 
-func (s *defaultsSuite) TestAddApplicationStorageConstraintsDefaultSizeFromCharm(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"multi1to10": makeStorageCons("loop", 0, 3),
+func (s *defaultsSuite) TestAddApplicationStorageDirectivesDefaultSizeFromCharm(c *gc.C) {
+	storageCons := map[string]storage.Directive{
+		"multi1to10": makeStorageDirective("loop", 0, 3),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"multi1to10": makeStorageCons("loop", 1024, 3),
-		"multi2up":   makeStorageCons("loop", 2048, 2),
+	expectedCons := map[string]storage.Directive{
+		"multi1to10": makeStorageDirective("loop", 1024, 3),
+		"multi2up":   makeStorageDirective("loop", 2048, 2),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"multi1to10": {Name: "multi1to10", Type: charm.StorageBlock, CountMin: 1, CountMax: 10},
 			"multi2up":   {Name: "multi2up", Type: charm.StorageBlock, CountMin: 2, CountMax: -1, MinimumSize: 2 * 1024},
@@ -133,12 +133,12 @@ func (s *defaultsSuite) TestAddApplicationStorageConstraintsDefaultSizeFromCharm
 }
 
 func (s *defaultsSuite) TestProviderFallbackToType(c *gc.C) {
-	storageCons := map[string]storage.Constraints{}
-	expectedCons := map[string]storage.Constraints{
-		"data":  makeStorageCons("loop", 1024, 1),
-		"files": makeStorageCons("rootfs", 1024, 1),
+	storageCons := map[string]storage.Directive{}
+	expectedCons := map[string]storage.Directive{
+		"data":  makeStorageDirective("loop", 1024, 1),
+		"files": makeStorageDirective("rootfs", 1024, 1),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"data":  {Name: "data", Type: charm.StorageBlock, CountMin: 1, CountMax: 1},
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 1},
@@ -152,11 +152,11 @@ func (s *defaultsSuite) TestProviderFallbackToType(c *gc.C) {
 }
 
 func (s *defaultsSuite) TestProviderFallbackToTypeCaas(c *gc.C) {
-	storageCons := map[string]storage.Constraints{}
-	expectedCons := map[string]storage.Constraints{
-		"files": makeStorageCons("kubernetes", 1024, 1),
+	storageCons := map[string]storage.Directive{}
+	expectedCons := map[string]storage.Directive{
+		"files": makeStorageDirective("kubernetes", 1024, 1),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 1},
 		},
@@ -169,12 +169,12 @@ func (s *defaultsSuite) TestProviderFallbackToTypeCaas(c *gc.C) {
 }
 
 func (s *defaultsSuite) TestProviderFallbackToTypeWithoutConstraints(c *gc.C) {
-	storageCons := map[string]storage.Constraints{}
-	expectedCons := map[string]storage.Constraints{
-		"data":  makeStorageCons("loop", 1024, 1),
-		"files": makeStorageCons("rootfs", 1024, 1),
+	storageCons := map[string]storage.Directive{}
+	expectedCons := map[string]storage.Directive{
+		"data":  makeStorageDirective("loop", 1024, 1),
+		"files": makeStorageDirective("rootfs", 1024, 1),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"data":  {Name: "data", Type: charm.StorageBlock, CountMin: 1, CountMax: 1},
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 1},
@@ -188,11 +188,11 @@ func (s *defaultsSuite) TestProviderFallbackToTypeWithoutConstraints(c *gc.C) {
 }
 
 func (s *defaultsSuite) TestProviderFallbackToTypeWithoutConstraintsCaas(c *gc.C) {
-	storageCons := map[string]storage.Constraints{}
-	expectedCons := map[string]storage.Constraints{
-		"files": makeStorageCons("kubernetes", 1024, 1),
+	storageCons := map[string]storage.Directive{}
+	expectedCons := map[string]storage.Directive{
+		"files": makeStorageDirective("kubernetes", 1024, 1),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 1},
 		},
@@ -205,15 +205,15 @@ func (s *defaultsSuite) TestProviderFallbackToTypeWithoutConstraintsCaas(c *gc.C
 }
 
 func (s *defaultsSuite) TestProviderFallbackToDefaults(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"data":  makeStorageCons("", 2048, 1),
-		"files": makeStorageCons("", 4096, 2),
+	storageCons := map[string]storage.Directive{
+		"data":  makeStorageDirective("", 2048, 1),
+		"files": makeStorageDirective("", 4096, 2),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"data":  makeStorageCons("ebs", 2048, 1),
-		"files": makeStorageCons("tmpfs", 4096, 2),
+	expectedCons := map[string]storage.Directive{
+		"data":  makeStorageDirective("ebs", 2048, 1),
+		"files": makeStorageDirective("tmpfs", 4096, 2),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"data":  {Name: "data", Type: charm.StorageBlock, CountMin: 1, CountMax: 2},
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 2},
@@ -227,13 +227,13 @@ func (s *defaultsSuite) TestProviderFallbackToDefaults(c *gc.C) {
 }
 
 func (s *defaultsSuite) TestProviderFallbackToDefaultsCaas(c *gc.C) {
-	storageCons := map[string]storage.Constraints{
-		"files": makeStorageCons("", 4096, 2),
+	storageCons := map[string]storage.Directive{
+		"files": makeStorageDirective("", 4096, 2),
 	}
-	expectedCons := map[string]storage.Constraints{
-		"files": makeStorageCons("tmpfs", 4096, 2),
+	expectedCons := map[string]storage.Directive{
+		"files": makeStorageDirective("tmpfs", 4096, 2),
 	}
-	err := domainstorage.StorageConstraintsWithDefaults(
+	err := domainstorage.StorageDirectivesWithDefaults(
 		map[string]charm.Storage{
 			"files": {Name: "files", Type: charm.StorageFilesystem, CountMin: 1, CountMax: 2},
 		},

--- a/domain/storage/errors/errors.go
+++ b/domain/storage/errors/errors.go
@@ -23,8 +23,8 @@ const (
 	ErrNoDefaultStoragePool = errors.ConstError("no storage pool specified and no default available")
 )
 
-// These errors are used for storage constraints operations.
+// These errors are used for storage directives operations.
 const (
-	// MissingSharedStorageConstraintError is used when a storage constraint for shared storage is not provided.
-	MissingSharedStorageConstraintError = errors.ConstError("no storage constraints specified")
+	// MissingSharedStorageDirectiveError is used when a storage directive for shared storage is not provided.
+	MissingSharedStorageDirectiveError = errors.ConstError("no storage directive specified")
 )

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v4 v4.0.0
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v5 v5.0.1
+	github.com/juju/description/v5 v5.0.3
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v5 v5.0.1 h1:8GKoJSVcvYr4FtsEIi9EnqhTe7TU69w9tgQF7/DZX0o=
-github.com/juju/description/v5 v5.0.1/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
+github.com/juju/description/v5 v5.0.3 h1:YrFPByKv7aBb8PxQPKeMIVe2OPCbR4ED6+RgNnZm91I=
+github.com/juju/description/v5 v5.0.3/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/internal/bundle/changes/changes.go
+++ b/internal/bundle/changes/changes.go
@@ -544,7 +544,7 @@ type AddApplicationParams struct {
 	Options map[string]interface{} `json:"options,omitempty"`
 	// Constraints holds the optional application constraints.
 	Constraints string `json:"constraints,omitempty"`
-	// Storage holds the optional storage constraints.
+	// Storage holds the optional storage directives.
 	Storage map[string]string `json:"storage,omitempty"`
 	// Devices holds the optional devices constraints.
 	Devices map[string]string `json:"devices,omitempty"`

--- a/internal/provider/ec2/image.go
+++ b/internal/provider/ec2/image.go
@@ -20,7 +20,7 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 		imagesByStorage[image.Storage] = append(imagesByStorage[image.Storage], image)
 	}
 	logger.Debugf("images by storage type %+v", imagesByStorage)
-	// If a storage constraint has been specified, use that or else default to ssd.
+	// If a storage directive has been specified, use that or else default to ssd.
 	storageTypes := []string{ssdStorage}
 	if ic != nil && len(ic.Storage) > 0 {
 		storageTypes = ic.Storage

--- a/internal/storage/directive_test.go
+++ b/internal/storage/directive_test.go
@@ -11,90 +11,90 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type ConstraintsSuite struct {
+type DirectiveSuite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&ConstraintsSuite{})
+var _ = gc.Suite(&DirectiveSuite{})
 
-func (s *ConstraintsSuite) TestParseConstraintsStoragePool(c *gc.C) {
-	s.testParse(c, "pool,1M", storage.Constraints{
+func (s *DirectiveSuite) TestParseConstraintsStoragePool(c *gc.C) {
+	s.testParse(c, "pool,1M", storage.Directive{
 		Pool:  "pool",
 		Count: 1,
 		Size:  1,
 	})
-	s.testParse(c, "pool,", storage.Constraints{
+	s.testParse(c, "pool,", storage.Directive{
 		Pool:  "pool",
 		Count: 1,
 	})
-	s.testParse(c, "1M", storage.Constraints{
+	s.testParse(c, "1M", storage.Directive{
 		Size:  1,
 		Count: 1,
 	})
 }
 
-func (s *ConstraintsSuite) TestParseConstraintsCountSize(c *gc.C) {
-	s.testParse(c, "p,1G", storage.Constraints{
+func (s *DirectiveSuite) TestParseConstraintsCountSize(c *gc.C) {
+	s.testParse(c, "p,1G", storage.Directive{
 		Pool:  "p",
 		Count: 1,
 		Size:  1024,
 	})
-	s.testParse(c, "p,1,0.5T", storage.Constraints{
+	s.testParse(c, "p,1,0.5T", storage.Directive{
 		Pool:  "p",
 		Count: 1,
 		Size:  1024 * 512,
 	})
-	s.testParse(c, "p,0.125P,3", storage.Constraints{
+	s.testParse(c, "p,0.125P,3", storage.Directive{
 		Pool:  "p",
 		Count: 3,
 		Size:  1024 * 1024 * 128,
 	})
 }
 
-func (s *ConstraintsSuite) TestParseConstraintsOptions(c *gc.C) {
-	s.testParse(c, "p,1M,", storage.Constraints{
+func (s *DirectiveSuite) TestParseConstraintsOptions(c *gc.C) {
+	s.testParse(c, "p,1M,", storage.Directive{
 		Pool:  "p",
 		Count: 1,
 		Size:  1,
 	})
 }
 
-func (s *ConstraintsSuite) TestParseConstraintsCountRange(c *gc.C) {
+func (s *DirectiveSuite) TestParseConstraintsCountRange(c *gc.C) {
 	s.testParseError(c, "p,0,100M", `cannot parse count: count must be greater than zero, got "0"`)
 	s.testParseError(c, "p,00,100M", `cannot parse count: count must be greater than zero, got "00"`)
 	s.testParseError(c, "p,-1,100M", `cannot parse count: count must be greater than zero, got "-1"`)
-	s.testParseError(c, "", `storage constraints require at least one field to be specified`)
-	s.testParseError(c, ",", `storage constraints require at least one field to be specified`)
+	s.testParseError(c, "", `storage directives require at least one field to be specified`)
+	s.testParseError(c, ",", `storage directives require at least one field to be specified`)
 }
 
-func (s *ConstraintsSuite) TestParseConstraintsSizeRange(c *gc.C) {
+func (s *DirectiveSuite) TestParseConstraintsSizeRange(c *gc.C) {
 	s.testParseError(c, "p,-100M", `cannot parse size: expected a non-negative number, got "-100M"`)
 }
 
-func (s *ConstraintsSuite) TestParseMultiplePoolNames(c *gc.C) {
+func (s *DirectiveSuite) TestParseMultiplePoolNames(c *gc.C) {
 	s.testParseError(c, "pool1,anyoldjunk", `pool name is already set to "pool1", new value "anyoldjunk" not valid`)
 	s.testParseError(c, "pool1,pool2", `pool name is already set to "pool1", new value "pool2" not valid`)
 	s.testParseError(c, "pool1,pool2,pool3", `pool name is already set to "pool1", new value "pool2" not valid`)
 }
 
-func (s *ConstraintsSuite) TestParseConstraintsUnknown(c *gc.C) {
+func (s *DirectiveSuite) TestParseConstraintsUnknown(c *gc.C) {
 	// Regression test for #1855181
-	s.testParseError(c, "p,100M database-b", `unrecognized storage constraint "100M database-b" not valid`)
-	s.testParseError(c, "p,$1234", `unrecognized storage constraint "\$1234" not valid`)
+	s.testParseError(c, "p,100M database-b", `unrecognized storage directive "100M database-b" not valid`)
+	s.testParseError(c, "p,$1234", `unrecognized storage directive "\$1234" not valid`)
 }
 
-func (*ConstraintsSuite) testParse(c *gc.C, s string, expect storage.Constraints) {
-	cons, err := storage.ParseConstraints(s)
+func (*DirectiveSuite) testParse(c *gc.C, s string, expect storage.Directive) {
+	cons, err := storage.ParseDirective(s)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cons, gc.DeepEquals, expect)
 }
 
-func (*ConstraintsSuite) testParseError(c *gc.C, s, expectErr string) {
-	_, err := storage.ParseConstraints(s)
+func (*DirectiveSuite) testParseError(c *gc.C, s, expectErr string) {
+	_, err := storage.ParseDirective(s)
 	c.Check(err, gc.ErrorMatches, expectErr)
 }
 
-func (s *ConstraintsSuite) TestValidPoolName(c *gc.C) {
+func (s *DirectiveSuite) TestValidPoolName(c *gc.C) {
 	c.Assert(storage.IsValidPoolName("pool"), jc.IsTrue)
 	c.Assert(storage.IsValidPoolName("p-ool"), jc.IsTrue)
 	c.Assert(storage.IsValidPoolName("p-00l"), jc.IsTrue)
@@ -105,29 +105,29 @@ func (s *ConstraintsSuite) TestValidPoolName(c *gc.C) {
 	c.Assert(storage.IsValidPoolName("p?0?l"), jc.IsTrue)
 }
 
-func (s *ConstraintsSuite) TestInvalidPoolName(c *gc.C) {
+func (s *DirectiveSuite) TestInvalidPoolName(c *gc.C) {
 	c.Assert(storage.IsValidPoolName("7ool"), jc.IsFalse)
 	c.Assert(storage.IsValidPoolName("/ool"), jc.IsFalse)
 	c.Assert(storage.IsValidPoolName("-00l"), jc.IsFalse)
 	c.Assert(storage.IsValidPoolName("*00l"), jc.IsFalse)
 }
 
-func (s *ConstraintsSuite) TestParseStorageConstraints(c *gc.C) {
-	s.testParseStorageConstraints(c,
+func (s *DirectiveSuite) TestParseStorageDirectives(c *gc.C) {
+	s.testParseStorageDirectives(c,
 		[]string{"data=p,1M,"}, true,
-		map[string]storage.Constraints{"data": {
+		map[string]storage.Directive{"data": {
 			Pool:  "p",
 			Count: 1,
 			Size:  1,
 		}})
-	s.testParseStorageConstraints(c,
+	s.testParseStorageDirectives(c,
 		[]string{"data"}, false,
-		map[string]storage.Constraints{"data": {
+		map[string]storage.Directive{"data": {
 			Count: 1,
 		}})
-	s.testParseStorageConstraints(c,
+	s.testParseStorageDirectives(c,
 		[]string{"data=3", "cache"}, false,
-		map[string]storage.Constraints{
+		map[string]storage.Directive{
 			"data": {
 				Count: 3,
 			},
@@ -137,30 +137,30 @@ func (s *ConstraintsSuite) TestParseStorageConstraints(c *gc.C) {
 		})
 }
 
-func (s *ConstraintsSuite) TestParseStorageConstraintsErrors(c *gc.C) {
-	s.testStorageConstraintsError(c,
+func (s *DirectiveSuite) TestParseStorageDirectivesErrors(c *gc.C) {
+	s.testStorageDirectivesError(c,
 		[]string{"data"}, true,
-		`.*where "constraints" must be specified.*`)
-	s.testStorageConstraintsError(c,
+		`.*where "directive" must be specified.*`)
+	s.testStorageDirectivesError(c,
 		[]string{"data=p,=1M,"}, false,
-		`.*expected "name=constraints" or "name", got .*`)
-	s.testStorageConstraintsError(c,
+		`.*expected "name=directive" or "name", got .*`)
+	s.testStorageDirectivesError(c,
 		[]string{"data", "data"}, false,
 		`storage "data" specified more than once`)
-	s.testStorageConstraintsError(c,
+	s.testStorageDirectivesError(c,
 		[]string{"data=-1"}, false,
-		`.*cannot parse constraints for storage "data".*`)
-	s.testStorageConstraintsError(c,
+		`.*cannot parse directive for storage "data".*`)
+	s.testStorageDirectivesError(c,
 		[]string{"data="}, false,
-		`.*cannot parse constraints for storage "data".*`)
+		`.*cannot parse directive for storage "data".*`)
 }
 
-func (*ConstraintsSuite) testParseStorageConstraints(c *gc.C,
+func (*DirectiveSuite) testParseStorageDirectives(c *gc.C,
 	s []string,
 	mustHave bool,
-	expect map[string]storage.Constraints,
+	expect map[string]storage.Directive,
 ) {
-	cons, err := storage.ParseConstraintsMap(s, mustHave)
+	cons, err := storage.ParseDirectivesMap(s, mustHave)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(len(cons), gc.Equals, len(expect))
 	for k, v := range expect {
@@ -168,13 +168,13 @@ func (*ConstraintsSuite) testParseStorageConstraints(c *gc.C,
 	}
 }
 
-func (*ConstraintsSuite) testStorageConstraintsError(c *gc.C, s []string, mustHave bool, e string) {
-	_, err := storage.ParseConstraintsMap(s, mustHave)
+func (*DirectiveSuite) testStorageDirectivesError(c *gc.C, s []string, mustHave bool, e string) {
+	_, err := storage.ParseDirectivesMap(s, mustHave)
 	c.Check(err, gc.ErrorMatches, e)
 }
 
-func (s *ConstraintsSuite) TestToString(c *gc.C) {
-	_, err := storage.ToString(storage.Constraints{})
+func (s *DirectiveSuite) TestToString(c *gc.C) {
+	_, err := storage.ToString(storage.Directive{})
 	c.Assert(err, gc.ErrorMatches, "must provide one of pool or size or count")
 
 	for _, t := range []struct {
@@ -191,7 +191,7 @@ func (s *ConstraintsSuite) TestToString(c *gc.C) {
 		{"", 1, 0, "1"},
 		{"", 1, 1024, "1,1024M"},
 	} {
-		str, err := storage.ToString(storage.Constraints{
+		str, err := storage.ToString(storage.Directive{
 			Pool:  t.pool,
 			Size:  t.size,
 			Count: t.count,
@@ -203,7 +203,7 @@ func (s *ConstraintsSuite) TestToString(c *gc.C) {
 		if t.count == 0 {
 			t.count = 1
 		}
-		s.testParse(c, str, storage.Constraints{
+		s.testParse(c, str, storage.Directive{
 			Pool:  t.pool,
 			Size:  t.size,
 			Count: t.count,

--- a/internal/storage/interface.go
+++ b/internal/storage/interface.go
@@ -221,7 +221,7 @@ type VolumeImporter interface {
 }
 
 // VolumeParams is a fully specified set of parameters for volume creation,
-// derived from one or more of user-specified storage constraints, a
+// derived from one or more of user-specified storage directives, a
 // storage pool definition, and charm storage metadata.
 type VolumeParams struct {
 	// Tag is a unique tag name assigned by Juju for the requested volume.
@@ -296,7 +296,7 @@ type AttachmentParams struct {
 }
 
 // FilesystemParams is a fully specified set of parameters for filesystem creation,
-// derived from one or more of user-specified storage constraints, a
+// derived from one or more of user-specified storage directives, a
 // storage pool definition, and charm storage metadata.
 type FilesystemParams struct {
 	// Tag is a unique tag assigned by Juju for the requested filesystem.

--- a/internal/storage/kubernetes.go
+++ b/internal/storage/kubernetes.go
@@ -4,7 +4,7 @@
 package storage
 
 // KubernetesFilesystemParams is a fully specified set of parameters for filesystem creation,
-// derived from one or more of user-specified storage constraints, a
+// derived from one or more of user-specified storage directives, a
 // storage pool definition, and charm storage metadata.
 type KubernetesFilesystemParams struct {
 	// StorageName is the name of the storage as specified in the charm.

--- a/internal/storage/provider/rootfs.go
+++ b/internal/storage/provider/rootfs.go
@@ -111,7 +111,7 @@ type rootfsFilesystemSource struct {
 func ensureDir(d dirFuncs, path string) error {
 	// If path already exists, we check that it is empty.
 	// It is up to the storage provisioner to ensure that any
-	// shared storage constraints and attachments with the same
+	// shared storage directives and attachments with the same
 	// path are validated etc. So the check here is more a sanity check.
 	fi, err := d.lstat(path)
 	if err == nil {

--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -271,11 +271,11 @@ type HookContext struct {
 	// a charm's workload status, or if the charm has already taken care of it.
 	hasRunStatusSet bool
 
-	// storageAddConstraints is a collection of storage constraints
+	// storageAddDirectives is a collection of storage directives
 	// keyed on storage name as specified in the charm.
 	// This collection will be added to the unit on successful
 	// hook run, so the actual add will happen in a flush.
-	storageAddConstraints map[string][]params.StorageConstraints
+	storageAddDirectives map[string][]params.StorageDirectives
 
 	// clock is used for any time operations.
 	clock Clock
@@ -719,19 +719,19 @@ func (c *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachm
 	return ctxStorageAttachment, nil
 }
 
-// AddUnitStorage saves storage constraints in the context.
+// AddUnitStorage saves storage directives in the context.
 // Implements jujuc.HookContext.ContextStorage, part of runner.Context.
-func (c *HookContext) AddUnitStorage(cons map[string]params.StorageConstraints) error {
-	// All storage constraints are accumulated before context is flushed.
-	if c.storageAddConstraints == nil {
-		c.storageAddConstraints = make(
-			map[string][]params.StorageConstraints,
+func (c *HookContext) AddUnitStorage(cons map[string]params.StorageDirectives) error {
+	// All storage directives are accumulated before context is flushed.
+	if c.storageAddDirectives == nil {
+		c.storageAddDirectives = make(
+			map[string][]params.StorageDirectives,
 			len(cons))
 	}
 	for storage, newConstraints := range cons {
 		// Multiple calls for the same storage are accumulated as well.
-		c.storageAddConstraints[storage] = append(
-			c.storageAddConstraints[storage],
+		c.storageAddDirectives[storage] = append(
+			c.storageAddDirectives[storage],
 			newConstraints)
 	}
 	return nil
@@ -1497,8 +1497,8 @@ func (c *HookContext) doFlush(process string) error {
 		}
 	}
 
-	if len(c.storageAddConstraints) > 0 {
-		b.AddStorage(c.storageAddConstraints)
+	if len(c.storageAddDirectives) > 0 {
+		b.AddStorage(c.storageAddDirectives)
 	}
 
 	// Before saving the secret metadata to Juju, save the content to an external

--- a/internal/worker/uniter/runner/context/context_test.go
+++ b/internal/worker/uniter/runner/context/context_test.go
@@ -562,59 +562,59 @@ func (s *InterfaceSuite) TestRequestRebootNowNoProcess(c *gc.C) {
 	c.Assert(priority, gc.Equals, jujuc.RebootNow)
 }
 
-func (s *InterfaceSuite) TestStorageAddConstraints(c *gc.C) {
-	expected := map[string][]params.StorageConstraints{
+func (s *InterfaceSuite) TestStorageAddDirectives(c *gc.C) {
+	expected := map[string][]params.StorageDirectives{
 		"data": {
-			params.StorageConstraints{},
+			params.StorageDirectives{},
 		},
 	}
 
 	ctx := &context.HookContext{}
-	addStorageToContext(ctx, "data", params.StorageConstraints{})
+	addStorageToContext(ctx, "data", params.StorageDirectives{})
 	assertStorageAddInContext(c, ctx, expected)
 }
 
 var two = uint64(2)
 
-func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
-	expected := map[string][]params.StorageConstraints{
+func (s *InterfaceSuite) TestStorageAddDirectivesSameStorage(c *gc.C) {
+	expected := map[string][]params.StorageDirectives{
 		"data": {
-			params.StorageConstraints{},
-			params.StorageConstraints{Count: &two},
+			params.StorageDirectives{},
+			params.StorageDirectives{Count: &two},
 		},
 	}
 
 	ctx := &context.HookContext{}
-	addStorageToContext(ctx, "data", params.StorageConstraints{})
-	addStorageToContext(ctx, "data", params.StorageConstraints{Count: &two})
+	addStorageToContext(ctx, "data", params.StorageDirectives{})
+	addStorageToContext(ctx, "data", params.StorageDirectives{Count: &two})
 	assertStorageAddInContext(c, ctx, expected)
 }
 
-func (s *InterfaceSuite) TestStorageAddConstraintsDifferentStorage(c *gc.C) {
-	expected := map[string][]params.StorageConstraints{
-		"data": {params.StorageConstraints{}},
+func (s *InterfaceSuite) TestStorageAddDirectivesDifferentStorage(c *gc.C) {
+	expected := map[string][]params.StorageDirectives{
+		"data": {params.StorageDirectives{}},
 		"diff": {
-			params.StorageConstraints{Count: &two}},
+			params.StorageDirectives{Count: &two}},
 	}
 
 	ctx := &context.HookContext{}
-	addStorageToContext(ctx, "data", params.StorageConstraints{})
-	addStorageToContext(ctx, "diff", params.StorageConstraints{Count: &two})
+	addStorageToContext(ctx, "data", params.StorageDirectives{})
+	addStorageToContext(ctx, "diff", params.StorageDirectives{Count: &two})
 	assertStorageAddInContext(c, ctx, expected)
 }
 
 func addStorageToContext(ctx *context.HookContext,
 	name string,
-	cons params.StorageConstraints,
+	cons params.StorageDirectives,
 ) {
-	addOne := map[string]params.StorageConstraints{name: cons}
+	addOne := map[string]params.StorageDirectives{name: cons}
 	_ = ctx.AddUnitStorage(addOne)
 }
 
 func assertStorageAddInContext(c *gc.C,
-	ctx *context.HookContext, expected map[string][]params.StorageConstraints,
+	ctx *context.HookContext, expected map[string][]params.StorageDirectives,
 ) {
-	obtained := context.StorageAddConstraints(ctx)
+	obtained := context.StorageAddDirectives(ctx)
 	c.Assert(len(obtained), gc.Equals, len(expected))
 	for k, v := range obtained {
 		c.Assert(v, jc.SameContents, expected[k])

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -217,8 +217,8 @@ func WithActionContext(ctx *HookContext, in map[string]interface{}, cancel <-cha
 	}
 }
 
-func StorageAddConstraints(ctx *HookContext) map[string][]params.StorageConstraints {
-	return ctx.storageAddConstraints
+func StorageAddDirectives(ctx *HookContext) map[string][]params.StorageDirectives {
+	return ctx.storageAddDirectives
 }
 
 // ModelHookContextParams encapsulates the parameters for a NewModelHookContext call.

--- a/internal/worker/uniter/runner/context/storage_test.go
+++ b/internal/worker/uniter/runner/context/storage_test.go
@@ -28,7 +28,7 @@ func (s *StorageSuite) TestAddUnitStorage(c *gc.C) {
 
 	count := uint64(1)
 	s.assertUnitStorageAdded(c, ctrl,
-		map[string]params.StorageConstraints{
+		map[string]params.StorageDirectives{
 			"allecto": {Count: &count}})
 }
 
@@ -38,13 +38,13 @@ func (s *StorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
 
 	count := uint64(1)
 	s.assertUnitStorageAdded(c, ctrl,
-		map[string]params.StorageConstraints{
+		map[string]params.StorageDirectives{
 			"multi2up": {Count: &count}},
-		map[string]params.StorageConstraints{
+		map[string]params.StorageDirectives{
 			"multi1to10": {Count: &count}})
 }
 
-func (s *StorageSuite) assertUnitStorageAdded(c *gc.C, ctrl *gomock.Controller, cons ...map[string]params.StorageConstraints) {
+func (s *StorageSuite) assertUnitStorageAdded(c *gc.C, ctrl *gomock.Controller, cons ...map[string]params.StorageDirectives) {
 	// Get the context.
 	ctx := s.getHookContext(c, ctrl, coretesting.ModelTag.Id(), -1, "", names.StorageTag{})
 	c.Assert(ctx.UnitName(), gc.Equals, s.unit.Name())
@@ -57,7 +57,7 @@ func (s *StorageSuite) assertUnitStorageAdded(c *gc.C, ctrl *gomock.Controller, 
 			arg.AddStorage = append(arg.AddStorage, params.StorageAddParams{
 				UnitTag:     s.unit.Tag().String(),
 				StorageName: storage,
-				Constraints: scons,
+				Directives:  scons,
 			})
 		}
 		err := ctx.AddUnitStorage(one)
@@ -82,7 +82,7 @@ func (s *StorageSuite) TestRunHookAddStorageOnFailure(c *gc.C) {
 
 	size := uint64(1)
 	err := ctx.AddUnitStorage(
-		map[string]params.StorageConstraints{
+		map[string]params.StorageDirectives{
 			"allecto": {Size: &size},
 		})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/jujuc/context.go
+++ b/internal/worker/uniter/runner/jujuc/context.go
@@ -308,8 +308,8 @@ type ContextStorage interface {
 	// was not found or is not available.
 	HookStorage() (ContextStorageAttachment, error)
 
-	// AddUnitStorage saves storage constraints in the context.
-	AddUnitStorage(map[string]params.StorageConstraints) error
+	// AddUnitStorage saves storage directives in the context.
+	AddUnitStorage(map[string]params.StorageDirectives) error
 }
 
 // ContextResources exposes the functionality needed by the

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/storage.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/storage.go
@@ -19,7 +19,7 @@ import (
 type Storage struct {
 	Storage    map[names.StorageTag]jujuc.ContextStorageAttachment
 	StorageTag names.StorageTag
-	Added      map[string]params.StorageConstraints
+	Added      map[string]params.StorageDirectives
 }
 
 // SetAttachment adds the attachment to the storage.
@@ -58,17 +58,17 @@ func (s *Storage) SetStorageTag(id string) {
 }
 
 // SetUnitStorage sets storage that should be added.
-func (s *Storage) SetUnitStorage(name string, constraints params.StorageConstraints) {
+func (s *Storage) SetUnitStorage(name string, constraints params.StorageDirectives) {
 	if s.Added == nil {
-		s.Added = make(map[string]params.StorageConstraints)
+		s.Added = make(map[string]params.StorageDirectives)
 	}
 	s.Added[name] = constraints
 }
 
 // AddUnitStorage sets storage that should be added.
-func (s *Storage) AddUnitStorage(all map[string]params.StorageConstraints) {
+func (s *Storage) AddUnitStorage(all map[string]params.StorageDirectives) {
 	if s.Added == nil {
-		s.Added = make(map[string]params.StorageConstraints)
+		s.Added = make(map[string]params.StorageDirectives)
 	}
 	for k, v := range all {
 		s.Added[k] = v
@@ -117,7 +117,7 @@ func (c *ContextStorage) HookStorage() (jujuc.ContextStorageAttachment, error) {
 }
 
 // AddUnitStorage implements jujuc.ContextStorage.
-func (c *ContextStorage) AddUnitStorage(all map[string]params.StorageConstraints) error {
+func (c *ContextStorage) AddUnitStorage(all map[string]params.StorageDirectives) error {
 	c.stub.AddCall("AddUnitStorage", all)
 	c.info.AddUnitStorage(all)
 	return c.stub.NextErr()

--- a/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -64,7 +64,7 @@ func (mr *MockContextMockRecorder) ActionParams() *gomock.Call {
 }
 
 // AddUnitStorage mocks base method.
-func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageConstraints) error {
+func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageDirectives) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUnitStorage", arg0)
 	ret0, _ := ret[0].(error)

--- a/internal/worker/uniter/runner/jujuc/restricted.go
+++ b/internal/worker/uniter/runner/jujuc/restricted.go
@@ -144,7 +144,7 @@ func (*RestrictedContext) HookStorage() (ContextStorageAttachment, error) {
 }
 
 // AddUnitStorage implements hooks.Context.
-func (*RestrictedContext) AddUnitStorage(map[string]params.StorageConstraints) error {
+func (*RestrictedContext) AddUnitStorage(map[string]params.StorageDirectives) error {
 	return ErrRestrictedContext
 }
 

--- a/internal/worker/uniter/runner/jujuc/storage-add.go
+++ b/internal/worker/uniter/runner/jujuc/storage-add.go
@@ -16,7 +16,7 @@ import (
 type StorageAddCommand struct {
 	cmd.CommandBase
 	ctx Context
-	all map[string]params.StorageConstraints
+	all map[string]params.StorageDirectives
 }
 
 // NewStorageAddCommand makes a jujuc storage-add command.
@@ -47,18 +47,18 @@ func (s *StorageAddCommand) Init(args []string) error {
 		return errors.New("storage add requires a storage directive")
 	}
 
-	constraintsMap, err := storage.ParseConstraintsMap(args, false)
+	constraintsMap, err := storage.ParseDirectivesMap(args, false)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	s.all = make(map[string]params.StorageConstraints, len(constraintsMap))
+	s.all = make(map[string]params.StorageDirectives, len(constraintsMap))
 	for k, v := range constraintsMap {
 		cons := v
-		if cons != (storage.Constraints{Count: cons.Count}) {
+		if cons != (storage.Directive{Count: cons.Count}) {
 			return errors.Errorf("only count can be specified for %q", k)
 		}
-		s.all[k] = params.StorageConstraints{Count: &cons.Count}
+		s.all[k] = params.StorageDirectives{Count: &cons.Count}
 	}
 	return nil
 }

--- a/internal/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/internal/worker/uniter/runner/jujuc/storage-add_test.go
@@ -57,7 +57,7 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 	tests := []tstData{
 		{[]string{}, 1, "storage add requires a storage directive"},
 		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
-		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
+		{[]string{"data="}, 1, ".*storage directives require at least one.*"},
 		{[]string{"data=pool"}, 1, `.*only count can be specified for "data".*`},
 		{[]string{"data=pool,1M"}, 1, `.*only count can be specified for "data".*`},
 		{[]string{"data=1M"}, 1, `.*only count can be specified for "data".*`},

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -81,7 +81,7 @@ func (mr *MockContextMockRecorder) ActionParams() *gomock.Call {
 }
 
 // AddUnitStorage mocks base method.
-func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageConstraints) error {
+func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageDirectives) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUnitStorage", arg0)
 	ret0, _ := ret[0].(error)

--- a/internal/worker/uniter/uniter_test.go
+++ b/internal/worker/uniter/uniter_test.go
@@ -1392,7 +1392,7 @@ storage:
 `[1:])
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	storageConstraints := map[string]state.StorageConstraints{
+	storageDirectives := map[string]state.StorageConstraints{
 		"wp-content": {Count: 1},
 	}
 	s.runUniterTests(c, []uniterTest{
@@ -1400,7 +1400,7 @@ storage:
 			"test that storage-attached is called",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
-			createApplicationAndUnit{storage: storageConstraints},
+			createApplicationAndUnit{storage: storageDirectives},
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
@@ -1410,7 +1410,7 @@ storage:
 			"test that storage-detaching is called before stop",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
-			createApplicationAndUnit{storage: storageConstraints},
+			createApplicationAndUnit{storage: storageDirectives},
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
@@ -1425,7 +1425,7 @@ storage:
 			"test that storage-detaching is called only if previously attached",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
-			createApplicationAndUnit{storage: storageConstraints},
+			createApplicationAndUnit{storage: storageDirectives},
 			// provision and destroy the storage before the uniter starts,
 			// to ensure it never sees the storage as attached
 			provisionStorage{},
@@ -1441,7 +1441,7 @@ storage:
 			"test that delay-provisioned storage does not block forever",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
-			createApplicationAndUnit{storage: storageConstraints},
+			createApplicationAndUnit{storage: storageDirectives},
 			startUniter{},
 			// no hooks should be run, as storage isn't provisioned
 			waitHooks{},
@@ -1452,7 +1452,7 @@ storage:
 			"test that unprovisioned storage does not block unit termination",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},
-			createApplicationAndUnit{storage: storageConstraints},
+			createApplicationAndUnit{storage: storageDirectives},
 			unitDying,
 			startUniter{},
 			// no hooks should be run, and unit agent should terminate

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -59,7 +59,7 @@ type ApplicationDeploy struct {
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Policy           string                         `json:"policy,omitempty"`
-	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
+	Storage          map[string]storage.Directive   `json:"storage,omitempty"`
 	Devices          map[string]devices.Constraints `json:"devices,omitempty"`
 	AttachStorage    []string                       `json:"attach-storage,omitempty"`
 	EndpointBindings map[string]string              `json:"endpoint-bindings,omitempty"`
@@ -84,8 +84,8 @@ type ApplicationUpdate struct {
 	Generation string `json:"generation"`
 }
 
-// ApplicationSetCharm sets the charm for a given application.
-type ApplicationSetCharm struct {
+// ApplicationSetCharmV2 sets the charm for a given application.
+type ApplicationSetCharmV2 struct {
 	// ApplicationName is the name of the application to set the charm on.
 	ApplicationName string `json:"application"`
 
@@ -127,15 +127,24 @@ type ApplicationSetCharm struct {
 	// the upgrade.
 	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
 
-	// StorageConstraints is a map of storage names to storage constraints to
-	// update during the upgrade. This field is only understood by Application
-	// facade version 2 and greater.
-	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
+	// StorageDirectives is a map of storage names to storage directives to
+	// update during the upgrade.
+	StorageDirectives map[string]StorageDirectives `json:"storage-directives,omitempty"`
 
 	// EndpointBindings is a map of operator-defined endpoint names to
 	// space names to be merged with any existing endpoint bindings. This
 	// field is only understood by Application facade version 10 and greater.
 	EndpointBindings map[string]string `json:"endpoint-bindings,omitempty"`
+}
+
+// ApplicationSetCharmV1 sets the charm for a given application.
+type ApplicationSetCharmV1 struct {
+	ApplicationSetCharmV2 `json:",inline"`
+
+	// StorageDirectives is a map of storage names to storage directives to
+	// update during the upgrade. This field is only understood by Application
+	// facade version < 20. After that it is renamed to "storage-directives" on the wire.
+	StorageDirectives map[string]StorageDirectives `json:"storage-constraints,omitempty"`
 }
 
 // ApplicationExpose holds the parameters for making the application Expose call.
@@ -617,9 +626,9 @@ type DeployFromRepositoryArg struct {
 	// resource to use if default revision is not desired.
 	Resources map[string]string `json:"resources,omitempty"`
 
-	// Storage contains Constraints specifying how storage should be
+	// Storage contains Directives specifying how storage should be
 	// handled.
-	Storage map[string]storage.Constraints
+	Storage map[string]storage.Directive `json:"storage"`
 
 	//  Trust allows charm to run hooks that require access credentials
 	Trust bool

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -225,7 +225,7 @@ type AddMachineParams struct {
 
 	// Disks describes constraints for disks that must be attached to
 	// the machine when it is provisioned.
-	Disks []storage.Constraints `json:"disks,omitempty"`
+	Disks []storage.Directive `json:"disks,omitempty"`
 
 	// If Placement is non-nil, it contains a placement directive
 	// that will be used to decide how to instantiate the machine.

--- a/rpc/params/storage.go
+++ b/rpc/params/storage.go
@@ -851,8 +851,8 @@ type FilesystemDetailsListResults struct {
 	Results []FilesystemDetailsListResult `json:"results,omitempty"`
 }
 
-// StorageConstraints contains constraints for storage instance.
-type StorageConstraints struct {
+// StorageDirectives contains directives for storage instance.
+type StorageDirectives struct {
 	// Pool is the name of the storage pool from which to provision the
 	// storage instance.
 	Pool string `json:"pool,omitempty"`
@@ -872,8 +872,8 @@ type StorageAddParams struct {
 	// StorageName is the name of the storage as specified in the charm.
 	StorageName string `json:"name"`
 
-	// Constraints are specified storage constraints.
-	Constraints StorageConstraints `json:"storage"`
+	// Directives are specified storage directives.
+	Directives StorageDirectives `json:"storage"`
 }
 
 // StoragesAddParams holds storage details to add to units dynamically.

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -734,10 +734,10 @@ func (e *exporter) readAllStorageConstraints() error {
 	return nil
 }
 
-func (e *exporter) storageConstraints(doc storageConstraintsDoc) map[string]description.StorageConstraintArgs {
-	result := make(map[string]description.StorageConstraintArgs)
+func (e *exporter) storageDirectives(doc storageConstraintsDoc) map[string]description.StorageDirectiveArgs {
+	result := make(map[string]description.StorageDirectiveArgs)
 	for key, value := range doc.Constraints {
-		result[key] = description.StorageConstraintArgs{
+		result[key] = description.StorageDirectiveArgs{
 			Pool:  value.Pool,
 			Size:  value.Size,
 			Count: value.Count,
@@ -838,7 +838,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		args.CloudService = e.cloudService(cloudService)
 	}
 	if constraints, found := e.modelStorageConstraints[storageConstraintsKey]; found {
-		args.StorageConstraints = e.storageConstraints(constraints)
+		args.StorageDirectives = e.storageDirectives(constraints)
 	}
 
 	if ps := application.ProvisioningState(); ps != nil {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1989,7 +1989,7 @@ func (s *MigrationExportSuite) TestStorage(c *gc.C) {
 
 	apps := model.Applications()
 	c.Assert(apps, gc.HasLen, 1)
-	constraints := apps[0].StorageConstraints()
+	constraints := apps[0].StorageDirectives()
 	c.Assert(constraints, gc.HasLen, 2)
 	cons, found := constraints["data"]
 	c.Assert(found, jc.IsTrue)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -899,7 +899,7 @@ func (i *importer) application(a description.Application, ctrlCfg controller.Con
 		applicationDoc:     appDoc,
 		statusDoc:          appStatusDoc,
 		constraints:        i.constraints(a.Constraints()),
-		storage:            i.storageConstraints(a.StorageConstraints()),
+		storage:            i.storageConstraints(a.StorageDirectives()),
 		charmConfig:        a.CharmConfig(),
 		applicationConfig:  a.ApplicationConfig(),
 		leadershipSettings: a.LeadershipSettings(),
@@ -1084,7 +1084,7 @@ func (i *importer) appResourceOps(app description.Application) []txn.Op {
 	return result
 }
 
-func (i *importer) storageConstraints(cons map[string]description.StorageConstraint) map[string]StorageConstraints {
+func (i *importer) storageConstraints(cons map[string]description.StorageDirective) map[string]StorageConstraints {
 	if len(cons) == 0 {
 		return nil
 	}
@@ -2341,7 +2341,7 @@ func (i *importer) storageInstanceConstraints(storage description.Storage) stora
 					continue
 				}
 				storageName, _ := names.StorageName(storage.Tag().Id())
-				appStorageCons, ok := app.StorageConstraints()[storageName]
+				appStorageCons, ok := app.StorageDirectives()[storageName]
 				if ok {
 					cons.Pool = appStorageCons.Pool()
 					cons.Size = appStorageCons.Size()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2365,7 +2365,7 @@ func (s *MigrationImportSuite) TestStorageInstanceConstraintsFallback(c *gc.C) {
 		storages["version"] = 2
 
 		app := applications["applications"].([]interface{})[0].(map[interface{}]interface{})
-		sc := app["storage-constraints"].(map[interface{}]interface{})
+		sc := app["storage-directives"].(map[interface{}]interface{})
 		delete(sc, "data")
 		sc["allecto"].(map[interface{}]interface{})["pool"] = "modelscoped-block"
 

--- a/state/mocks/description_mock.go
+++ b/state/mocks/description_mock.go
@@ -610,18 +610,18 @@ func (mr *MockApplicationMockRecorder) StatusHistory() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusHistory", reflect.TypeOf((*MockApplication)(nil).StatusHistory))
 }
 
-// StorageConstraints mocks base method.
-func (m *MockApplication) StorageConstraints() map[string]description.StorageConstraint {
+// StorageDirectives mocks base method.
+func (m *MockApplication) StorageDirectives() map[string]description.StorageDirective {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageConstraints")
-	ret0, _ := ret[0].(map[string]description.StorageConstraint)
+	ret := m.ctrl.Call(m, "StorageDirectives")
+	ret0, _ := ret[0].(map[string]description.StorageDirective)
 	return ret0
 }
 
-// StorageConstraints indicates an expected call of StorageConstraints.
-func (mr *MockApplicationMockRecorder) StorageConstraints() *gomock.Call {
+// StorageDirectives indicates an expected call of StorageDirectives.
+func (mr *MockApplicationMockRecorder) StorageDirectives() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageConstraints", reflect.TypeOf((*MockApplication)(nil).StorageConstraints))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageDirectives", reflect.TypeOf((*MockApplication)(nil).StorageDirectives))
 }
 
 // Subordinate mocks base method.

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -575,9 +575,9 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 	err = application.SetPassword(params.Password)
 	c.Assert(err, jc.ErrorIsNil)
 	if factory.applicationService != nil {
-		cons := make(map[string]storage.Constraints)
+		directives := make(map[string]storage.Directive)
 		for name, sc := range params.Storage {
-			cons[name] = storage.Constraints{
+			directives[name] = storage.Directive{
 				Pool:  sc.Pool,
 				Size:  sc.Size,
 				Count: sc.Count,
@@ -585,7 +585,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		}
 		err = factory.applicationService.CreateApplication(context.Background(), params.Name, applicationservice.AddApplicationParams{
 			Charm:   params.Charm,
-			Storage: cons,
+			Storage: directives,
 		})
 		c.Assert(err, jc.ErrorIsNil)
 	}


### PR DESCRIPTION
Some time ago, the terminology "storage constraints" was used internally when we should have used "storage directive". This PR does that rename, primarily renaming the Constraints struct in `internal/storage` to "Directive".

This is mostly a mechanical change. Legacy state is left untouched and still uses constraints terminology. Legacy state will be going away soon.

The only non mechanical bit is model imports for migration. We use an updated `juju/description` package to supply the storage directives from an imported model, for both legacy models and newer ones.

## QA steps

bootstrap 
deploy postgresql with storage for pgdata
refresh the charm with different storage directive
add a unit, ensure new storage is used

repeat above with an older juju cli

I wanted to migrate a 3.x model to check that storage directives come across but we don't support migrating from 3.x to 4.x yet.

## Links

**Jira card:** JUJU-5706

