### PR TITLE
Fix secret_k8s test suite for CI

### DIFF
--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -10,7 +10,7 @@ run_secrets() {
 	# TODO(anvial): remove the revision flag once we update hello-kubecon charm
 	#  (https://discourse.charmhub.io/t/old-ingress-relation-removal/12944)
 	#  or we choose an alternative pair of charms to integrate.
-	juju --show-log deploy nginx-ingress-integrator nginx --channel=edge --revision=89
+	juju --show-log deploy nginx-ingress-integrator nginx --channel=latest/stable --revision=83
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster
 

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,7 +7,7 @@ run_secrets() {
 	juju --show-log add-model "$model_name" --config secret-backend=auto
 
 	juju --show-log deploy hello-kubecon hello
-	juju --show-log deploy nginx-ingress-integrator nginx
+	juju --show-log deploy nginx-ingress-integrator nginx --revision=89
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster
 

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,6 +7,9 @@ run_secrets() {
 	juju --show-log add-model "$model_name" --config secret-backend=auto
 
 	juju --show-log deploy hello-kubecon hello
+	# TODO(anvial): remove the revision flag once we update hello-kubecon charm
+	#  (https://discourse.charmhub.io/t/old-ingress-relation-removal/12944)
+	#  or we choose an alternative pair of charms to integrate.
 	juju --show-log deploy nginx-ingress-integrator nginx --revision=89
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -10,7 +10,7 @@ run_secrets() {
 	# TODO(anvial): remove the revision flag once we update hello-kubecon charm
 	#  (https://discourse.charmhub.io/t/old-ingress-relation-removal/12944)
 	#  or we choose an alternative pair of charms to integrate.
-	juju --show-log deploy nginx-ingress-integrator nginx --revision=89
+	juju --show-log deploy nginx-ingress-integrator nginx --channel=edge --revision=89
 	juju --show-log integrate nginx hello
 	juju --show-log trust nginx --scope=cluster
 


### PR DESCRIPTION
This PR provides a quick fix to pass the CI. We need to consider an alternate solution by switching to another pair of k8s charms in this test: juju-qa-source, juju-qa-sink (for example).

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd tests
./main.sh -v -p k8s -c microk8s secrets_k8
```
