### PR TITLE
[JUJU-5718] Fix a regression when deploying with certain clients

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1382,11 +1382,11 @@ func (s *applicationSuite) setupApplicationDeploy(c *gc.C, args string) (*charm.
 func createCharmOriginFromURL(c *gc.C, curl *charm.URL) *params.CharmOrigin {
 	switch curl.Schema {
 	case "cs":
-		return &params.CharmOrigin{Source: "charm-store", Series: "quantal"}
+		return &params.CharmOrigin{Source: "charm-store", Series: curl.Series}
 	case "local":
-		return &params.CharmOrigin{Source: "local", Series: "quantal"}
+		return &params.CharmOrigin{Source: "local", Series: curl.Series}
 	default:
-		return &params.CharmOrigin{Source: "charm-hub", Series: "quantal"}
+		return &params.CharmOrigin{Source: "charm-hub", Series: curl.Series}
 	}
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1182,9 +1182,9 @@ func (s *ApplicationSuite) TestDeployAttachStorage(c *gc.C) {
 	results, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
-	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.ErrorMatches, "AttachStorage is non-empty, but NumUnits is 2")
-	c.Assert(results.Results[2].Error, gc.ErrorMatches, `"volume-baz-0" is not a valid volume tag`)
+	c.Check(results.Results[0].Error, gc.IsNil)
+	c.Check(results.Results[1].Error, gc.ErrorMatches, "AttachStorage is non-empty, but NumUnits is 2")
+	c.Check(results.Results[2].Error, gc.ErrorMatches, `"volume-baz-0" is not a valid volume tag`)
 }
 
 func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
@@ -1226,13 +1226,13 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	results, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
-	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.IsNil)
-	c.Assert(results.Results[2].Error, gc.IsNil)
+	c.Check(results.Results[0].Error, gc.IsNil)
+	c.Check(results.Results[1].Error, gc.IsNil)
+	c.Check(results.Results[2].Error, gc.IsNil)
 
-	c.Assert(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
-	c.Assert(s.deployParams["bar"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-store"))
-	c.Assert(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
+	c.Check(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
+	c.Check(s.deployParams["bar"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-store"))
+	c.Check(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
 }
 
 // Some clients we need to support deploy applications without any OS data in the
@@ -1279,13 +1279,13 @@ func (s *ApplicationSuite) TestDeploySeriesInArgOnly(c *gc.C) {
 	results, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
-	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.IsNil)
-	c.Assert(results.Results[2].Error, gc.IsNil)
+	c.Check(results.Results[0].Error, gc.IsNil)
+	c.Check(results.Results[1].Error, gc.IsNil)
+	c.Check(results.Results[2].Error, gc.IsNil)
 
-	c.Assert(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
-	c.Assert(s.deployParams["bar"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-store"))
-	c.Assert(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
+	c.Check(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
+	c.Check(s.deployParams["bar"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-store"))
+	c.Check(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
 }
 
 func (s *ApplicationSuite) TestDeployInconsistentSeries(c *gc.C) {
@@ -1407,17 +1407,17 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 	results, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 4)
-	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.IsNil)
-	c.Assert(results.Results[2].Error, gc.ErrorMatches, "AttachStorage may not be specified for container models")
-	c.Assert(results.Results[3].Error, gc.ErrorMatches, "only 1 placement directive is supported for container models, got 2")
+	c.Check(results.Results[0].Error, gc.IsNil)
+	c.Check(results.Results[1].Error, gc.IsNil)
+	c.Check(results.Results[2].Error, gc.ErrorMatches, "AttachStorage may not be specified for container models")
+	c.Check(results.Results[3].Error, gc.ErrorMatches, "only 1 placement directive is supported for container models, got 2")
 
-	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "loadbalancer")
+	c.Check(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "loadbalancer")
 	// Check parsing of k8s service annotations.
-	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-annotations"], jc.DeepEquals, map[string]string{"a": "b", "c": ""})
-	c.Assert(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "cluster")
-	c.Assert(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-ingress-ssl-redirect"], gc.Equals, true)
-	c.Assert(s.deployParams["foobar"].CharmConfig, jc.DeepEquals, charm.Settings{"intOption": int64(2)})
+	c.Check(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-annotations"], jc.DeepEquals, map[string]string{"a": "b", "c": ""})
+	c.Check(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "cluster")
+	c.Check(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-ingress-ssl-redirect"], gc.Equals, true)
+	c.Check(s.deployParams["foobar"].CharmConfig, jc.DeepEquals, charm.Settings{"intOption": int64(2)})
 }
 
 func (s *ApplicationSuite) TestDeployCAASInvalidServiceType(c *gc.C) {
@@ -1747,8 +1747,9 @@ func (s *ApplicationSuite) TestGetUnifiedSeries(c *gc.C) {
 		c.Logf("Test %d: %s", i, t.desc)
 		unified, err := application.GetUnifiedSeries(t.param)
 		if t.errMatch == "" {
-			c.Check(err, jc.ErrorIsNil)
-			c.Check(unified, gc.Equals, t.unified)
+			if c.Check(err, jc.ErrorIsNil) {
+				c.Check(unified, gc.Equals, t.unified)
+			}
 		} else {
 			c.Check(err, gc.ErrorMatches, t.errMatch)
 		}
@@ -2829,7 +2830,7 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	result, err := s.api.ApplicationsInfo(params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
-	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.ApplicationResult{
+	c.Check(*result.Results[0].Result, gc.DeepEquals, params.ApplicationResult{
 		Tag:         "application-postgresql",
 		Charm:       "charm-postgresql",
 		Series:      "quantal",
@@ -2842,8 +2843,8 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 			"juju-info": "myspace",
 		},
 	})
-	c.Assert(result.Results[1].Error, gc.ErrorMatches, `application "wordpress" not found`)
-	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"unit-postgresql-0" is not a valid application tag`)
+	c.Check(result.Results[1].Error, gc.ErrorMatches, `application "wordpress" not found`)
+	c.Check(result.Results[2].Error, gc.ErrorMatches, `"unit-postgresql-0" is not a valid application tag`)
 }
 
 func (s *ApplicationSuite) TestApplicationMergeBindingsErr(c *gc.C) {
@@ -2938,33 +2939,34 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 	result, err := s.api.UnitsInfo(params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(entities))
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.UnitResult{
-		Tag:             "unit-postgresql-0",
-		WorkloadVersion: "666",
-		Machine:         "0",
-		OpenedPorts:     []string{"100-102/tcp"},
-		PublicAddress:   "10.0.0.1",
-		Charm:           "cs:postgresql-42",
-		Leader:          true,
-		Life:            state.Alive.String(),
-		RelationData: []params.EndpointRelationData{{
-			RelationId:      101,
-			Endpoint:        "db",
-			CrossModel:      true,
-			RelatedEndpoint: "server",
-			ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
-			UnitRelationData: map[string]params.RelationData{
-				"gitlab/2": {
-					InScope:  true,
-					UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+	if c.Check(result.Results[0].Error, gc.IsNil) {
+		c.Check(*result.Results[0].Result, gc.DeepEquals, params.UnitResult{
+			Tag:             "unit-postgresql-0",
+			WorkloadVersion: "666",
+			Machine:         "0",
+			OpenedPorts:     []string{"100-102/tcp"},
+			PublicAddress:   "10.0.0.1",
+			Charm:           "cs:postgresql-42",
+			Leader:          true,
+			Life:            state.Alive.String(),
+			RelationData: []params.EndpointRelationData{{
+				RelationId:      101,
+				Endpoint:        "db",
+				CrossModel:      true,
+				RelatedEndpoint: "server",
+				ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
+				UnitRelationData: map[string]params.RelationData{
+					"gitlab/2": {
+						InScope:  true,
+						UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+					},
 				},
-			},
-		}},
-		ProviderId: "provider-id",
-		Address:    "192.168.1.1",
-	})
-	c.Assert(result.Results[1].Error, jc.DeepEquals, &params.Error{
+			}},
+			ProviderId: "provider-id",
+			Address:    "192.168.1.1",
+		})
+	}
+	c.Check(result.Results[1].Error, jc.DeepEquals, &params.Error{
 		Code:    "not found",
 		Message: `unit "mysql/0" not found`,
 	})
@@ -3003,33 +3005,34 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 	result, err := s.api.UnitsInfo(params.Entities{Entities: entities})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 2)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.UnitResult{
-		Tag:             "unit-postgresql-0",
-		WorkloadVersion: "666",
-		Machine:         "0",
-		OpenedPorts:     []string{"100-102/tcp"},
-		PublicAddress:   "10.0.0.1",
-		Charm:           "cs:postgresql-42",
-		Leader:          true,
-		Life:            state.Alive.String(),
-		RelationData: []params.EndpointRelationData{{
-			RelationId:      101,
-			Endpoint:        "db",
-			CrossModel:      true,
-			RelatedEndpoint: "server",
-			ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
-			UnitRelationData: map[string]params.RelationData{
-				"gitlab/2": {
-					InScope:  true,
-					UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+	if c.Check(result.Results[0].Error, gc.IsNil) {
+		c.Check(*result.Results[0].Result, gc.DeepEquals, params.UnitResult{
+			Tag:             "unit-postgresql-0",
+			WorkloadVersion: "666",
+			Machine:         "0",
+			OpenedPorts:     []string{"100-102/tcp"},
+			PublicAddress:   "10.0.0.1",
+			Charm:           "cs:postgresql-42",
+			Leader:          true,
+			Life:            state.Alive.String(),
+			RelationData: []params.EndpointRelationData{{
+				RelationId:      101,
+				Endpoint:        "db",
+				CrossModel:      true,
+				RelatedEndpoint: "server",
+				ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
+				UnitRelationData: map[string]params.RelationData{
+					"gitlab/2": {
+						InScope:  true,
+						UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+					},
 				},
-			},
-		}},
-		ProviderId: "provider-id",
-		Address:    "192.168.1.1",
-	})
-	c.Assert(*result.Results[1].Result, gc.DeepEquals, params.UnitResult{
+			}},
+			ProviderId: "provider-id",
+			Address:    "192.168.1.1",
+		})
+	}
+	c.Check(*result.Results[1].Result, gc.DeepEquals, params.UnitResult{
 		Tag:             "unit-postgresql-1",
 		WorkloadVersion: "666",
 		Machine:         "1",
@@ -3195,12 +3198,12 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.URL, gc.Equals, curl)
+	c.Check(result.URL, gc.Equals, curl)
 
 	latest := "latest"
 	branch := "foo"
 
-	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
+	c.Check(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
 		Risk:         "stable",
 		Revision:     &rev,
@@ -3237,9 +3240,9 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOriginMissingOS(c *gc.C) {
 	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.URL, gc.Equals, curl)
+	c.Check(result.URL, gc.Equals, curl)
 
-	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
+	c.Check(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
 		Architecture: "amd64",
 		OS:           "ubuntu",

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -11,6 +11,7 @@ var (
 	ParseSettingsCompatible = parseSettingsCompatible
 	NewStateStorage         = &newStateStorage
 	GetStorageState         = getStorageState
+	GetUnifiedSeries        = getUnifiedSeries
 )
 
 func GetState(st *state.State) Backend {

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -368,6 +368,87 @@ func (s *charmsMockSuite) TestAddCharm(c *gc.C) {
 	})
 }
 
+// NOTE: I am not aware of any clients that add charms like this, however we have had
+// trouble with application deploy where old clients (juju 2.8, pylibjuju bundle + local charm)
+// depoy applications in this style. It is not something we can rule out for AddCharm
+func (s *charmsMockSuite) TestAddCharmSeriesInArgOnly(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.state.EXPECT().ControllerConfig().Return(controller.Config{}, nil)
+
+	curl, err := charm.ParseURL("cs:jammy/testme-8")
+	c.Assert(err, jc.ErrorIsNil)
+
+	origin := corecharm.Origin{
+		Source: "charm-store",
+		Channel: &charm.Channel{
+			Risk: "stable",
+		},
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}
+
+	s.downloader.EXPECT().DownloadAndStore(curl, origin, nil, false).Return(origin, nil)
+
+	api := s.api(c)
+
+	args := params.AddCharmWithOrigin{
+		URL: curl.String(),
+		Origin: params.CharmOrigin{
+			Source:       "charm-store",
+			Risk:         "stable",
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+		Series: "jammy",
+		Force:  false,
+	}
+	obtained, err := api.AddCharm(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.DeepEquals, params.CharmOriginResult{
+		Origin: params.CharmOrigin{
+			Source:       "charm-store",
+			Risk:         "stable",
+			Architecture: "amd64",
+			Base: params.Base{
+				Name:    "ubuntu",
+				Channel: "22.04/stable",
+			},
+			Series:  "jammy",
+			OS:      "ubuntu",
+			Channel: "22.04",
+		},
+	})
+}
+
+func (s *charmsMockSuite) TestAddCharmInconsistantSeries(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl, err := charm.ParseURL("cs:jammy/testme-8")
+	c.Assert(err, jc.ErrorIsNil)
+
+	api := s.api(c)
+
+	args := params.AddCharmWithOrigin{
+		URL: curl.String(),
+		Origin: params.CharmOrigin{
+			Source:       "charm-store",
+			Risk:         "stable",
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+			Series:       "focal",
+		},
+		Series: "jammy",
+		Force:  false,
+	}
+	_, err = api.AddCharm(args)
+	c.Assert(err, gc.ErrorMatches, `.*inconsistent values for series detected.*`)
+}
+
 func (s *charmsMockSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.state.EXPECT().ControllerConfig().Return(controller.Config{}, nil)
@@ -600,6 +681,66 @@ func (s *charmsMockSuite) TestQueueAsyncCharmDownloadResolvesAgainOriginForAlrea
 			Channel: "22.04",
 		},
 	}, gc.Commentf("expected to get back the origin recorded by the application"))
+}
+
+var unifiedSeriesTests = []struct {
+	desc     string
+	param    params.AddCharmWithAuth
+	unified  string
+	errMatch string
+}{
+	{
+		desc:    "Series only",
+		param:   params.AddCharmWithAuth{Series: "focal", URL: "ch:foo"},
+		unified: "focal",
+	},
+	{
+		desc: "All present",
+		param: params.AddCharmWithAuth{
+			Series: "focal",
+			URL:    "ch:focal/foo",
+			Origin: params.CharmOrigin{Series: "focal", Base: params.Base{Name: "ubuntu", Channel: "20.04"}},
+		},
+		unified: "focal",
+	},
+	{
+		desc: "Clash",
+		param: params.AddCharmWithAuth{
+			Series: "jammy",
+			URL:    "ch:foo",
+			Origin: params.CharmOrigin{Series: "focal"},
+		},
+		errMatch: `.*inconsistent values for series detected. argument: "jammy", charm origin series: "focal".*`,
+	},
+	{
+		desc: "Clash with base",
+		param: params.AddCharmWithAuth{
+			Series: "jammy",
+			URL:    "ch:foo",
+			Origin: params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04"}},
+		},
+		errMatch: `.*inconsistent values for series detected. argument: "jammy".* charm origin base: "ubuntu@20.04".*`,
+	},
+	{
+		desc: "No series",
+		param: params.AddCharmWithAuth{
+			URL: "ch:foo",
+		},
+		errMatch: `unable to determine series for "ch:foo"`,
+	},
+}
+
+func (s *charmsMockSuite) TestGetUnifiedSeries(c *gc.C) {
+	for i, t := range unifiedSeriesTests {
+		c.Logf("Test %d: %s", i, t.desc)
+		unified, err := charms.GetUnifiedSeries(t.param)
+		if t.errMatch == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(unified, gc.Equals, t.unified)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.errMatch)
+		}
+	}
 }
 
 func (s *charmsMockSuite) TestCheckCharmPlacementWithSubordinate(c *gc.C) {

--- a/apiserver/facades/client/charms/export_test.go
+++ b/apiserver/facades/client/charms/export_test.go
@@ -4,5 +4,6 @@
 package charms
 
 var (
-	NewFacadeV5 = newFacadeV5
+	NewFacadeV5      = newFacadeV5
+	GetUnifiedSeries = getUnifiedSeries
 )


### PR DESCRIPTION
We found that certain old clients would deploy an application without a base or series in the charm origin (juju 2.8 does not understand the concept of a charm origin, pylibjuju 3.0, does not fill in the series or base attributes). Instead, the series would only be provided with the 'series' param (and the charm url)

In this case, we would attempt to parse the base in the origin, expecting it to be there, and fail.

We resolve this by taking another approach. We assume nothing about the
arg provided, look for all the series provided, and return them if
they're equal

This ensure that no matter what client we use, so long as it sends an OS
(if it doesn't there's nothing we can do, this is a legitmate failure)
and if multiple series/bases are present, so long as they match
(non-matching series would also be a legitmate failure).

As a flyby, use `c.Check` in out `application_unit_test` test file.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure a local charm, with no series in it's metadata.yaml exists at /home/jack/charms/ubuntu

Ensure a bundle exists a `/home/jack/juju/bundle.yaml` with content:
```
applications:
  ubuntu:
    charm: /home/jack/charms/ubuntu
    num_units: 1
```

Deploy a controller from this PR

### Verify pylibjuju 2.9.46.1 can deploy a bundle with a local charm
```
$ pip install juju=2.9.46.1
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> await m.deploy("/home/jack/juju/bundle.yaml")
[<Application entity_id="ubuntu">]
>>> 
exiting asyncio REPL...

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd-2.9.48  localhost/localhost  2.9.48.1  unsupported  11:14:03Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu  stable     0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.30          

Machine  State    Address        Inst id        Series  AZ  Message
0        started  10.219.211.30  juju-dbc02a-0  focal       Running
```

### Verify pylibjuju 3.0.4 can deploy applications

```
$ pip install juju==3.0.4
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> await m.deploy("/home/jack/charms/ubuntu")
<Application entity_id="ubuntu">
>>> 
exiting asyncio REPL...

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd-2.9.48  localhost/localhost  2.9.48.1  unsupported  17:33:59Z

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu             4  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.158         

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.219.211.158  juju-fe6ef8-0  focal       Running
```

The following QA steps are 'borrowed' from https://github.com/juju/juju/pull/17061

### Matching client + controller (up to minor version)

Ensure a local charm, with no series in it's metadata.yaml exists at `/home/jack/charms/ubuntu`

Deploy a controller from this PR

#### Deploy charms with python-libjuju 
```
$ pip install juju=2.9.46.1
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> await m.deploy("/home/jack/charms/ubuntu")
<Application entity_id="ubuntu">
>>> await m.deploy("/home/jack/charms/ubuntu", series="jammy", application_name="ubuntu-jammy")
<Application entity_id="ubuntu-jammy">
>>> await m.deploy("ubuntu", application_name="ubuntu-ch")
<Application entity_id="ubuntu-ch">
>>> await m.deploy("ubuntu", series="jammy",  application_name="ubuntu-ch-jammy")
<Application entity_id="ubuntu-ch-jammy">
>>> 
exiting asyncio REPL...

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd         localhost/localhost  2.9.48.1  unsupported  11:27:04Z

App              Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           20.04    active      1  ubuntu                   0  no       
ubuntu-ch        20.04    active      1  ubuntu  latest/stable   24  no       
ubuntu-ch-jammy  22.04    active      1  ubuntu  latest/stable   24  no       
ubuntu-jammy     22.04    active      1  ubuntu                   1  no       

Unit                Workload  Agent  Machine  Public address  Ports  Message
ubuntu-ch-jammy/0*  active    idle   3        10.219.211.187         
ubuntu-ch/0*        active    idle   2        10.219.211.153         
ubuntu-jammy/0*     active    idle   1        10.219.211.175         
ubuntu/0*           active    idle   0        10.219.211.196         

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.219.211.196  juju-cdcf11-0  focal       Running
1        started  10.219.211.175  juju-cdcf11-1  jammy       Running
2        started  10.219.211.153  juju-cdcf11-2  focal       Running
3        started  10.219.211.187  juju-cdcf11-3  jammy       Running
```

#### Juju cli client can deploy

```
$ juju deploy ubuntu ubu
Located charm "ubuntu" in charm-hub, revision 24
Deploying "ubu" from charm-hub charm "ubuntu", revision 24 in channel stable on focal

$ juju deploy ubuntu ubu2 --series jammy
Located charm "ubuntu" in charm-hub, revision 24
Deploying "ubu2" from charm-hub charm "ubuntu", revision 24 in channel stable on jammy

$ juju deploy ~/charms/ubuntu ubu-local
Located local charm "ubuntu", revision 0
Deploying "ubu-local" from local charm "ubuntu", revision 0 on focal

$ juju deploy ~/charms/ubuntu ubu-local2 --series jammy
Located local charm "ubuntu", revision 0
Deploying "ubu-local2" from local charm "ubuntu", revision 0 on jammy

$ juju status
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd         localhost/localhost  2.9.48.1  unsupported  11:18:09Z

App         Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu         20.04    active      1  ubuntu  stable    24  no       
ubu2        22.04    active      1  ubuntu  stable    24  no       
ubu-local   20.04    active      1  ubuntu             0  no       
ubu-local2  22.04    active      1  ubuntu             0  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
ubu2/0*        active    idle   1        10.219.211.106         
ubu-local2/0*  active    idle   3        10.219.211.87          
ubu-local/0*   active    idle   2        10.219.211.184         
ubu/0*         active    idle   0        10.219.211.101         

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.219.211.101  juju-7dcde0-0  focal       Running
1        started  10.219.211.106  juju-7dcde0-1  jammy       Running
2        started  10.219.211.184  juju-7dcde0-2  focal       Running
3        started  10.219.211.87   juju-7dcde0-3  jammy       Running
```

### Compatibility with 3.x

QA steps copied from https://github.com/juju/juju/pull/16692

- `juju` refers to the compiled code under test; `juju_34` is the juju snap with channel 3.4/stable.

```bash
#
# Bootstrap a juju 3.4 controller for later upgrade and migration of a 2.9 model.
# 
$ juju_34 bootstrap localhost destination

# 
# Bootstrap a controller to test the changes
# 
$ juju bootstrap localhost testing

# 
# Run various commands requiring series and base, including charms with and without 
# 
$ juju_34 add-model moveme
$ juju_34 deploy juju-qa-test --revision 23 --channel edge
$ juju_34 deploy ./tests/suites/deploy/charms/lxd-profile-alt
$ juju_34 deploy postgresql
$ juju_34 add-machine --base ubuntu@20.04 
$ juju_34 refresh lxd-profile-alt --path  ./tests/suites/deploy/charms/lxd-profile-alt

# Verify the juju-qa-test resource was correctly downloaded, check the application status for an output change.
$ juju_34 config juju-qa-test foo-file=true

# Update the base of an application for the next unit added.
$ juju_34 set-application-base juju-qa-test ubuntu@20.04

# Migrate to the 3.3. controller & upgrade.
$ juju_34 migrate moveme destination
$ juju_34 switch destination
$ juju_34 upgrade-model

# Ensure base change successful, validate the new unit is using ubuntu@20.04
$ juju_34 add-unit juju-qa-test
```