### PR TITLE
Change some test bundles to include track in channel to fix ci

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -2,7 +2,7 @@ default-base: ubuntu@20.04/stable
 applications:
   influxdb:
     charm: influxdb
-    channel: stable
+    channel: latest/stable
     revision: -1
     num_units: 1
     to:
@@ -10,11 +10,11 @@ applications:
     constraints: arch=amd64
   telegraf:
     charm: telegraf
-    channel: stable
+    channel: latest/stable
     revision: -1
   juju-qa-test:
     charm: juju-qa-test
-    channel: candidate
+    channel: latest/candidate
     revision: -1
     resources:
       foo-file: 2

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -2,17 +2,17 @@ default-base: ubuntu@20.04/stable
 applications:
   influxdb:
     charm: influxdb
-    channel: stable
+    channel: latest/stable
     num_units: 1
     to:
     - "0"
     constraints: arch=amd64
   telegraf:
     charm: telegraf
-    channel: stable
+    channel: latest/stable
   juju-qa-test:
     charm: juju-qa-test
-    channel: candidate
+    channel: latest/candidate
     num_units: 1
     resources:
       foo-file: 2


### PR DESCRIPTION
This PR tweaks some deploy test bundles to add the track to the channel attribute so that ci passes, as we now emit `track/risk`.

