### PR TITLE
Fix refresh bash tests to look for correct charm channel

### DIFF
--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -104,7 +104,7 @@ run_refresh_channel_no_new_revision() {
 
 	juju refresh juju-qa-fixed-rev --channel edge
 
-	wait_for "juju-qa-fixed-rev" "$(charm_channel "juju-qa-fixed-rev" "edge")"
+	wait_for "juju-qa-fixed-rev" "$(charm_channel "juju-qa-fixed-rev" "latest/edge")"
 	wait_for "juju-qa-fixed-rev" "$(charm_rev "juju-qa-fixed-rev" "${cs_revision}")"
 	wait_for "juju-qa-fixed-rev" "$(idle_condition "juju-qa-fixed-rev")"
 
@@ -126,7 +126,7 @@ run_refresh_revision() {
 	# refresh to a revision not at the tip of the stable channel
 	juju refresh juju-qa-test --revision 23
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "23")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	# do a generic refresh, should pick up revision from latest stable
@@ -138,7 +138,7 @@ run_refresh_revision() {
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	destroy_model "${model_name}"

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -25,7 +25,7 @@ run_refresh_switch_local_to_ch_channel() {
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
-	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "latest/edge")"
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	destroy_model "${model_name}"


### PR DESCRIPTION
More ci test fixes - the refresh tests were checking for the wrong charm channel - it needs to be fully qualified with track/risk.