### PR TITLE
Wire up PEBBLE_COPY_ONCE for workload containers.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -75,6 +75,7 @@ const (
 var (
 	containerAgentPebbleVersion = version.MustParse("2.9.37")
 	profileDirVersion           = version.MustParse("3.5-beta1")
+	pebbleCopyOnceVersion       = version.MustParse("3.5-beta1")
 )
 
 type app struct {
@@ -1500,6 +1501,20 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		}
 	}
 
+	containerExtraEnv := []corev1.EnvVar{{
+		Name:  "PEBBLE_SOCKET",
+		Value: "/charm/container/pebble.socket",
+	}}
+	if agentVersionNoBuild.Compare(pebbleCopyOnceVersion) >= 0 {
+		containerExtraEnv = append(containerExtraEnv, corev1.EnvVar{
+			Name:  "PEBBLE",
+			Value: "/charm/container/pebble",
+		}, corev1.EnvVar{
+			Name:  "PEBBLE_COPY_ONCE",
+			Value: constants.DefaultPebbleDir,
+		})
+	}
+
 	containerSpecs := []corev1.Container{charmContainer}
 	for i, v := range containers {
 		container := corev1.Container{
@@ -1514,16 +1529,10 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				"--http", fmt.Sprintf(":%s", pebble.WorkloadHealthCheckPort(i)),
 				"--verbose",
 			},
-			Env: []corev1.EnvVar{{
+			Env: append([]corev1.EnvVar{{
 				Name:  "JUJU_CONTAINER_NAME",
 				Value: v.Name,
-			}, {
-				Name:  "PEBBLE_SOCKET",
-				Value: "/charm/container/pebble.socket",
-			}, {
-				Name:  "PEBBLE",
-				Value: "/charm/container/pebble",
-			}},
+			}}, containerExtraEnv...),
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler:        pebble.LivenessHandler(pebble.WorkloadHealthCheckPort(i)),
 				InitialDelaySeconds: containerProbeInitialDelay,

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -650,6 +650,10 @@ func getPodSpec() corev1.PodSpec {
 					Name:  "PEBBLE",
 					Value: "/charm/container/pebble",
 				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -716,6 +720,10 @@ func getPodSpec() corev1.PodSpec {
 				{
 					Name:  "PEBBLE",
 					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
 				},
 			},
 			LivenessProbe: &corev1.Probe{

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
-	github.com/canonical/pebble v1.9.0
+	github.com/canonical/pebble v1.9.1
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSHqxGeY/669Mhh5ea43dn1mRDnk8=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
-github.com/canonical/pebble v1.9.0 h1:FWVEh1fg3aaW2HNue2Z2eYMwkJEQT8mgMFW3R5Iocn4=
-github.com/canonical/pebble v1.9.0/go.mod h1:9Qkjmq298g0+9SvM2E5eekkEN4pjHDWhgg9eB2I0tjk=
+github.com/canonical/pebble v1.9.1 h1:fPzOPLmbLnttnwIW0fuLfe3D11jIE68J6o0Euy5CDZY=
+github.com/canonical/pebble v1.9.1/go.mod h1:9Qkjmq298g0+9SvM2E5eekkEN4pjHDWhgg9eB2I0tjk=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
Wire up PEBBLE_COPY_ONCE for workload containers when they are run on an upgraded (3.5-beta1) model.
This also fixes a mistake with setting PEBBLE env var when we have not yet upgraded to 3.5.

Also upgrades pebble to v1.9.1 to get a PEBBLE_COPY_ONCE bug fix.

## QA steps

- Bootstrap k8s
- Add a model
- Deploy a k8s charm with a workload container
- Check the workload container pod spec in k8s for the PEBBLE_COPY_ONCE env var.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5709

