### PR TITLE
Skips test for pebble notices

### DIFF
--- a/tests/suites/sidecar/sidecar.sh
+++ b/tests/suites/sidecar/sidecar.sh
@@ -64,3 +64,9 @@ check_snappass() {
 		sleep 5
 	done
 }
+
+# This is a stub test, as pebble notices support were added only at 3.4 branch and above.
+# But we need to keep the test here to avoid breaking the test suite in jenkins.
+test_pebble_notices() {
+	echo "==> TEST SKIPPED: pebble notices"
+}

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -6,10 +6,11 @@ test_sidecar() {
 
 	set_verbosity
 
-	case "${BOOTSTRAP_PROVIDER:-}" in
+	case "${BOOTSTRAP_PROVIDER-}" in
 	"k8s")
 		test_deploy_and_remove_application
 		test_deploy_and_force_remove_application
+		test_pebble_notices
 		;;
 	*)
 		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"


### PR DESCRIPTION
This PR modifies the test suite to skip tests related to pebble notices. This is due to the fact that pebble notices support was added only in the 3.4 branch and above. To avoid breaking the test suite in Jenkins, these tests are now skipped.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd tests ; ./main.sh -v -p k8s -c microk8s sidecar test_pebble_notices
```

## Links

**Jira card:** JUJU-

