### PR TITLE
Adds wait-for login to check EC2 SG changes in CI test

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -331,3 +331,50 @@ wait_for_storage() {
 		sleep "${SHORT_TIMEOUT}"
 	fi
 }
+
+# wait_for_aws_ingress_cidrs_for_port_range blocks until the expected CIDRs
+# are present in the AWS security group rules for the specified port range.
+wait_for_aws_ingress_cidrs_for_port_range() {
+	local from_port to_port exp_cidrs cidr_type
+
+	from_port=${1}
+	to_port=${2}
+	exp_cidrs=${3}
+	cidr_type=${4}
+
+	ipV6Suffix=""
+	if [ "$cidr_type" = "ipv6" ]; then
+		ipV6Suffix="v6"
+	fi
+
+	# shellcheck disable=SC2086
+	secgrp_list=$(aws ec2 describe-security-groups --filters Name=ip-permission.from-port,Values=${from_port} Name=ip-permission.to-port,Values=${to_port})
+	# print the security group rules
+	# shellcheck disable=SC2086
+	got_cidrs=$(echo ${secgrp_list} | jq -r ".SecurityGroups[0].IpPermissions | .[] | select(.FromPort == ${from_port} and .ToPort == ${to_port}) | .Ip${ipV6Suffix}Ranges | .[] | .CidrIp${ipV6Suffix}" | sort | paste -sd, -)
+
+	attempt=0
+	# shellcheck disable=SC2046,SC2143
+	while [ "$attempt" -gt "3" ]; do
+		echo "[+] (attempt ${attempt}) polling security group rules"
+		# shellcheck disable=SC2086
+		secgrp_list=$(aws ec2 describe-security-groups --filters Name=ip-permission.from-port,Values=${from_port} Name=ip-permission.to-port,Values=${to_port})
+		# shellcheck disable=SC2086
+		got_cidrs=$(echo ${secgrp_list} | jq -r ".SecurityGroups[0].IpPermissions | .[] | select(.FromPort == ${from_port} and .ToPort == ${to_port}) | .Ip${ipV6Suffix}Ranges | .[] | .CidrIp${ipV6Suffix}" | sort | paste -sd, -)
+		sleep "${SHORT_TIMEOUT}"
+
+		if [ "$got_cidrs" == "$exp_cidrs" ]; then
+			break
+		fi
+
+		attempt=$((attempt + 1))
+	done
+
+	if [ "$got_cidrs" != "$exp_cidrs" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "expected generated EC2 ${cidr_type} ingress CIDRs for range [${from_port}, ${to_port}] to be:\n${exp_cidrs}\nGOT:\n${got_cidrs}")
+		exit 1
+	fi
+
+	echo "[+] security group rules for port range [${from_port}, ${to_port}] and CIDRs ${exp_cidrs} updated"
+}

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -355,7 +355,7 @@ wait_for_aws_ingress_cidrs_for_port_range() {
 
 	attempt=0
 	# shellcheck disable=SC2046,SC2143
-	while [ "$attempt" -gt "3" ]; do
+	while [ "$attempt" -lt "3" ]; do
 		echo "[+] (attempt ${attempt}) polling security group rules"
 		# shellcheck disable=SC2086
 		secgrp_list=$(aws ec2 describe-security-groups --filters Name=ip-permission.from-port,Values=${from_port} Name=ip-permission.to-port,Values=${to_port})


### PR DESCRIPTION
This PR adds wait_for logic for EC2 SG checks, because sometimes, one
attempt in 2 seconds, is it not enough to see changes in the aws cli tool
output.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd tests ; ./main.sh -v -p ec2 firewall run_expose_app_ec2
```

## Links

**Jira card:** JUJU-

