### PR TITLE
Shared domain state

### DIFF
--- a/domain/permission/state/shared.go
+++ b/domain/permission/state/shared.go
@@ -17,12 +17,12 @@ import (
 // SharedState holds the shared state for the permission domain. Methods
 // which are shared between multiple domains.
 type SharedState struct {
-	internaldatabase.StatementBase
+	statementBase internaldatabase.StatementBase
 }
 
 // NewSharedState creates a new SharedState.
 func NewSharedState(base internaldatabase.StatementBase) *SharedState {
-	return &SharedState{StatementBase: base}
+	return &SharedState{statementBase: base}
 }
 
 // AddUserPermissionArgs is a specification for adding a user permission.
@@ -34,8 +34,6 @@ type AddUserPermissionArgs struct {
 }
 
 // AddUserPermission adds a permission for the given user on the given target.
-// TODO (stickupkid): Work out if there is a better location for common
-// state functions.
 func (s SharedState) AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissionArgs) error {
 	// Insert a permission doc with
 	// * permissionObjectAccess as permission_type_id
@@ -45,22 +43,22 @@ func (s SharedState) AddUserPermission(ctx context.Context, tx *sqlair.TX, spec 
 INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
 VALUES ($addUserPermission.uuid, $addUserPermission.permission_type_id, $addUserPermission.grant_on, $addUserPermission.grant_to)
 `
-	insertPermissionStmt, err := s.Prepare(newPermission, addUserPermission{})
+	insertPermissionStmt, err := s.statementBase.Prepare(newPermission, addUserPermission{})
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	perm := addUserPermission{
-		UUID:    spec.PermissionUUID,
-		GrantOn: spec.Target.Key,
-		GrantTo: spec.UserUUID,
 	}
 
 	accessTypeID, err := objectAccessID(ctx, tx, spec.Access, spec.Target.ObjectType)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	perm.PermissionType = accessTypeID
+
+	perm := addUserPermission{
+		UUID:           spec.PermissionUUID,
+		GrantOn:        spec.Target.Key,
+		GrantTo:        spec.UserUUID,
+		PermissionType: accessTypeID,
+	}
 
 	if err = validateTargetExists(ctx, tx, spec.Target.Key); err != nil {
 		return errors.Trace(err)

--- a/domain/permission/state/shared.go
+++ b/domain/permission/state/shared.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	corepermission "github.com/juju/juju/core/permission"
+	permissionerrors "github.com/juju/juju/domain/permission/errors"
+	internaldatabase "github.com/juju/juju/internal/database"
+)
+
+// SharedState holds the shared state for the permission domain. Methods
+// which are shared between multiple domains.
+type SharedState struct {
+	internaldatabase.StatementBase
+}
+
+// NewSharedState creates a new SharedState.
+func NewSharedState(base internaldatabase.StatementBase) *SharedState {
+	return &SharedState{StatementBase: base}
+}
+
+// AddUserPermissionArgs is a specification for adding a user permission.
+type AddUserPermissionArgs struct {
+	PermissionUUID string
+	UserUUID       string
+	Access         corepermission.Access
+	Target         corepermission.ID
+}
+
+// AddUserPermission adds a permission for the given user on the given target.
+// TODO (stickupkid): Work out if there is a better location for common
+// state functions.
+func (s SharedState) AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissionArgs) error {
+	// Insert a permission doc with
+	// * permissionObjectAccess as permission_type_id
+	// * uuid of the user (spec.User) as grant_to
+	// * spec.Target.Key as grant_on
+	newPermission := `
+INSERT INTO permission (uuid, permission_type_id, grant_on, grant_to)
+VALUES ($addUserPermission.uuid, $addUserPermission.permission_type_id, $addUserPermission.grant_on, $addUserPermission.grant_to)
+`
+	insertPermissionStmt, err := s.Prepare(newPermission, addUserPermission{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	perm := addUserPermission{
+		UUID:    spec.PermissionUUID,
+		GrantOn: spec.Target.Key,
+		GrantTo: spec.UserUUID,
+	}
+
+	accessTypeID, err := objectAccessID(ctx, tx, spec.Access, spec.Target.ObjectType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	perm.PermissionType = accessTypeID
+
+	if err = validateTargetExists(ctx, tx, spec.Target.Key); err != nil {
+		return errors.Trace(err)
+	}
+
+	// No IsErrConstraintForeignKey should be seen as both foreign keys
+	// have been checked.
+	err = tx.Query(ctx, insertPermissionStmt, perm).Run()
+	if internaldatabase.IsErrConstraintUnique(err) {
+		return errors.Annotatef(permissionerrors.AlreadyExists, "%q on %q", spec.UserUUID, spec.Target.Key)
+	} else if err != nil {
+		return errors.Annotatef(err, "adding permission %q for %q on %q", spec.Access, spec.UserUUID, spec.Target.Key)
+	}
+
+	return nil
+}

--- a/domain/user/bootstrap/bootstrap.go
+++ b/domain/user/bootstrap/bootstrap.go
@@ -39,6 +39,8 @@ func AddUser(name string, access permission.AccessSpec) (user.UUID, internaldata
 			fmt.Errorf("generating bootstrap user %q uuid: %w", name, err))
 	}
 
+	state := state.NewSharedState(internaldatabase.DefaultStatementBase{})
+
 	return uuid, func(ctx context.Context, controller, model database.TxnRunner) error {
 		err := controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			return state.AddUser(ctx, tx, uuid, name, "", uuid, access)
@@ -86,6 +88,8 @@ func AddUserWithPassword(name string, password auth.Password, access permission.
 			"generating password hash for bootstrap add user %q with password: %w",
 			name, err))
 	}
+
+	state := state.NewSharedState(internaldatabase.DefaultStatementBase{})
 
 	return uuid, func(ctx context.Context, controller, model database.TxnRunner) error {
 		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {

--- a/domain/user/state/shared.go
+++ b/domain/user/state/shared.go
@@ -23,14 +23,14 @@ import (
 // This composes the permission state as it is shared between user and
 // permission domains.
 type SharedState struct {
-	internaldatabase.StatementBase
+	statementBase   internaldatabase.StatementBase
 	permissionState *permissionstate.SharedState
 }
 
 // NewSharedState creates a new SharedState.
 func NewSharedState(base internaldatabase.StatementBase) *SharedState {
 	return &SharedState{
-		StatementBase:   base,
+		statementBase:   base,
 		permissionState: permissionstate.NewSharedState(base),
 	}
 }
@@ -57,7 +57,7 @@ func (s *SharedState) AddUser(
 INSERT INTO user (uuid, name, display_name, created_by_uuid, created_at) 
 VALUES      ($M.uuid, $M.name, $M.display_name, $M.created_by_uuid, $M.created_at)`
 
-	insertAddUserStmt, err := s.Prepare(addUserQuery, sqlair.M{})
+	insertAddUserStmt, err := s.statementBase.Prepare(addUserQuery, sqlair.M{})
 	if err != nil {
 		return errors.Annotate(err, "preparing add user query")
 	}

--- a/domain/user/state/shared.go
+++ b/domain/user/state/shared.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/user"
+	permissionstate "github.com/juju/juju/domain/permission/state"
+	usererrors "github.com/juju/juju/domain/user/errors"
+	internaldatabase "github.com/juju/juju/internal/database"
+	internaluuid "github.com/juju/juju/internal/uuid"
+)
+
+// SharedState is the shared state for the user domain. Methods which are shared
+// between multiple domains.
+// This composes the permission state as it is shared between user and
+// permission domains.
+type SharedState struct {
+	internaldatabase.StatementBase
+	permissionState *permissionstate.SharedState
+}
+
+// NewSharedState creates a new SharedState.
+func NewSharedState(base internaldatabase.StatementBase) *SharedState {
+	return &SharedState{
+		StatementBase:   base,
+		permissionState: permissionstate.NewSharedState(base),
+	}
+}
+
+// AddUser adds a new user to the database. If the user already exists an error
+// that satisfies usererrors.AlreadyExists will be returned. If the creator does
+// not exist an error that satisfies usererrors.UserCreatorUUIDNotFound will be
+// returned.
+func (s *SharedState) AddUser(
+	ctx context.Context,
+	tx *sqlair.TX,
+	uuid user.UUID,
+	name string,
+	displayName string,
+	creatorUuid user.UUID,
+	access permission.AccessSpec,
+) error {
+	permissionUUID, err := internaluuid.NewUUID()
+	if err != nil {
+		return errors.Annotate(err, "generating permission UUID")
+	}
+
+	addUserQuery := `
+INSERT INTO user (uuid, name, display_name, created_by_uuid, created_at) 
+VALUES      ($M.uuid, $M.name, $M.display_name, $M.created_by_uuid, $M.created_at)`
+
+	insertAddUserStmt, err := s.Prepare(addUserQuery, sqlair.M{})
+	if err != nil {
+		return errors.Annotate(err, "preparing add user query")
+	}
+
+	err = tx.Query(ctx, insertAddUserStmt, sqlair.M{
+		"uuid":            uuid.String(),
+		"name":            name,
+		"display_name":    displayName,
+		"created_by_uuid": creatorUuid.String(),
+		"created_at":      time.Now(),
+	}).Run()
+	if internaldatabase.IsErrConstraintUnique(err) {
+		return errors.Annotatef(usererrors.AlreadyExists, "adding user %q", name)
+	} else if internaldatabase.IsErrConstraintForeignKey(err) {
+		return errors.Annotatef(usererrors.CreatorUUIDNotFound, "adding user %q", name)
+	} else if err != nil {
+		return errors.Annotatef(err, "adding user %q", name)
+	}
+
+	err = s.permissionState.AddUserPermission(ctx, tx, permissionstate.AddUserPermissionArgs{
+		PermissionUUID: permissionUUID.String(),
+		UserUUID:       uuid.String(),
+		Access:         access.Access,
+		Target:         access.Target,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "adding permission for user %q", name)
+	}
+
+	return nil
+}
+
+// AddUserWithPassword adds a new user to the database with the
+// provided password hash and salt. If the user already exists an error that
+// satisfies usererrors.AlreadyExists will be returned. if the creator does
+// not exist that satisfies usererrors.CreatorUUIDNotFound will be returned.
+func (s *SharedState) AddUserWithPassword(
+	ctx context.Context,
+	tx *sqlair.TX,
+	uuid user.UUID,
+	name string,
+	displayName string,
+	creatorUUID user.UUID,
+	permission permission.AccessSpec,
+	passwordHash string,
+	salt []byte,
+) error {
+	err := s.AddUser(ctx, tx, uuid, name, displayName, creatorUUID, permission)
+	if err != nil {
+		return errors.Annotatef(err, "adding user with uuid %q", uuid)
+	}
+
+	return errors.Trace(setPasswordHash(ctx, tx, name, passwordHash, salt))
+}

--- a/domain/user/state/state_test.go
+++ b/domain/user/state/state_test.go
@@ -110,9 +110,11 @@ func (s *stateSuite) TestBootstrapAddUserWithPassword(c *gc.C) {
 	salt, err := auth.NewSalt()
 	c.Assert(err, jc.ErrorIsNil)
 
+	state := NewSharedState(database.DefaultStatementBase{})
+
 	// Add user with no password authorization.
 	err = s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		err = AddUserWithPassword(
+		err = state.AddUserWithPassword(
 			context.Background(), tx, adminUUID,
 			"admin", "admin",
 			adminUUID, controllerLoginAccess(), "passwordHash", salt,

--- a/internal/database/statement.go
+++ b/internal/database/statement.go
@@ -110,3 +110,17 @@ func SqlairClauseAnd(columnValues map[string]any) (string, sqlair.M) {
 	}
 	return strings.Join(terms, " AND "), args
 }
+
+// Prepare prepares a SQLair query. If the query has been prepared previously it
+// is retrieved from the statement cache.
+type StatementBase interface {
+	Prepare(query string, typeSamples ...any) (*sqlair.Statement, error)
+}
+
+// DefaultStatementBase is a default implementation of the StatementBase
+// interface.
+type DefaultStatementBase struct{}
+
+func (DefaultStatementBase) Prepare(query string, typeSamples ...interface{}) (*sqlair.Statement, error) {
+	return sqlair.Prepare(query, typeSamples...)
+}


### PR DESCRIPTION
Each domain offers shared methods that other domains can use. With the advent of cached prepare statements, we also want to take advantage of the ability to reuse those statements without recreating them each transaction.

The concept is simple, create a shared state that can be composed together with other shared states (users + permissions) and allow others to consume them.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
```

## Links

**Jira card:** JUJU-

