### PR TITLE
Fix cmr between 3.x and 2.9 controllers

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -57,7 +57,7 @@ var facadeVersions = facades.FacadeVersions{
 	"CredentialManager":            {1},
 	"CredentialValidator":          {2},
 	"CrossController":              {1},
-	"CrossModelRelations":          {2},
+	"CrossModelRelations":          {2, 3},
 	"CrossModelSecrets":            {1},
 	"Deployer":                     {1},
 	"DiskManager":                  {2},

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -624,7 +624,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(result.ControllerTag, gc.Equals, s.State.ControllerTag().String())
 	c.Assert(result.ModelTag, gc.Equals, s.Model.ModelTag().String())
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
-		{Name: "CrossModelRelations", Versions: []int{2}},
+		{Name: "CrossModelRelations", Versions: []int{2, 3}},
 		{Name: "CrossModelSecrets", Versions: []int{1}},
 		{Name: "NotifyWatcher", Versions: []int{1}},
 		{Name: "OfferStatusWatcher", Versions: []int{1}},

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -38,6 +38,11 @@ type relationStatusWatcherFunc func(CrossModelRelationsState, names.RelationTag)
 type offerStatusWatcherFunc func(CrossModelRelationsState, string) (OfferWatcher, error)
 type consumedSecretsWatcherFunc func(CrossModelRelationsState, string) (state.StringsWatcher, error)
 
+// CrossModelRelationsAPIV2 provides access to the CrossModelRelations API V2 facade.
+type CrossModelRelationsAPIV2 struct {
+	*CrossModelRelationsAPI
+}
+
 // CrossModelRelationsAPI provides access to the CrossModelRelations API facade.
 type CrossModelRelationsAPI struct {
 	ctx        context.Context

--- a/apiserver/facades/controller/crossmodelrelations/register.go
+++ b/apiserver/facades/controller/crossmodelrelations/register.go
@@ -6,6 +6,8 @@ package crossmodelrelations
 import (
 	"reflect"
 
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/common/firewall"
@@ -15,8 +17,19 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("CrossModelRelations", 2, func(ctx facade.Context) (facade.Facade, error) {
-		return newStateCrossModelRelationsAPI(ctx) // Adds WatchRelationChanges, removes WatchRelationUnits
+		return newStateCrossModelRelationsAPIV2(ctx) // Adds WatchRelationChanges, removes WatchRelationUnits
+	}, reflect.TypeOf((*CrossModelRelationsAPIV2)(nil)))
+	registry.MustRegister("CrossModelRelations", 3, func(ctx facade.Context) (facade.Facade, error) {
+		return newStateCrossModelRelationsAPI(ctx) // Adds WatchConsumedSecretsChanges
 	}, reflect.TypeOf((*CrossModelRelationsAPI)(nil)))
+}
+
+func newStateCrossModelRelationsAPIV2(ctx facade.Context) (*CrossModelRelationsAPIV2, error) {
+	api, err := newStateCrossModelRelationsAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &CrossModelRelationsAPIV2{CrossModelRelationsAPI: api}, nil
 }
 
 // newStateCrossModelRelationsAPI creates a new server-side CrossModelRelations API facade

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -20491,7 +20491,7 @@
     {
         "Name": "CrossModelRelations",
         "Description": "CrossModelRelationsAPI provides access to the CrossModelRelations API facade.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -663,11 +663,9 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 
 	if w.secretChangesWatcher == nil {
 		w.secretChangesWatcher, err = w.remoteModelFacade.WatchConsumedSecretsChanges(applicationToken, relationToken, w.offerMacaroon)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, errors.NotImplemented) {
 			w.checkOfferPermissionDenied(err, "", "")
-			if !isNotFound(err) {
-				return errors.Annotate(err, "watching consumed secret changes")
-			}
+			return errors.Annotate(err, "watching consumed secret changes")
 		}
 		if err == nil {
 			if err := w.catacomb.Add(w.secretChangesWatcher); err != nil {


### PR DESCRIPTION
The remote relations worker ignores unimplemented consume remote secrets api which does not exist in 2.9. The facade version could have been revved to v3 so that's done so at some point v2 can be dropped, but it won't be for a while since earlier 3.x releases use it.

As a drive by, the preferred api error translate api is used.

## QA steps

bootstrap 2.9 and 3.3 controllers
deploy and offer juju-qa-dummy-source in 2.9
deploy and relate to offer juju-qa-dummy-sink in 3.3
check logs for errors as seen in bug

## Links

https://bugs.launchpad.net/bugs/2058763

**Jira card:** JUJU-5753

