### PR TITLE
Fix secret migration by using newer juju/description

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -620,7 +620,7 @@ func (b *BundleAPI) bundleDataApplications(
 		if result := b.constraints(application.Constraints()); len(result) != 0 {
 			newApplication.Constraints = strings.Join(result, " ")
 		}
-		if cons := application.StorageConstraints(); len(cons) != 0 {
+		if cons := application.StorageDirectives(); len(cons) != 0 {
 			newApplication.Storage = make(map[string]string)
 			for name, constr := range cons {
 				if newApplication.Storage[name], err = storage.ToString(storage.Constraints{

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -868,8 +868,8 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 		CloudRegion: "some-region"})
 
 	args := s.minimalApplicationArgs(description.IAAS)
-	// Add storage constraints to the app
-	args.StorageConstraints = map[string]description.StorageConstraintArgs{
+	// Add storage directives to the app
+	args.StorageDirectives = map[string]description.StorageDirectiveArgs{
 		"storage1": {
 			Pool:  "pool1",
 			Size:  1024,

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.14
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v5 v5.0.2
+	github.com/juju/description/v5 v5.0.4
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v5 v5.0.2 h1:gpObMHm3QAI/0mg8YG86L8z5rFXYgHFe3ukwPoNLSaE=
-github.com/juju/description/v5 v5.0.2/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
+github.com/juju/description/v5 v5.0.4 h1:qA35hRglZ47j1mmo9zUM9R+2WSDCH5dvL5ik7gA2aVE=
+github.com/juju/description/v5 v5.0.4/go.mod h1:TQsp2Z56EVab7onQY2/O6tLHznovAcckyLz/DgDfVPY=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -779,10 +779,10 @@ func (e *exporter) readAllStorageConstraints() error {
 	return nil
 }
 
-func (e *exporter) storageConstraints(doc storageConstraintsDoc) map[string]description.StorageConstraintArgs {
-	result := make(map[string]description.StorageConstraintArgs)
+func (e *exporter) storageConstraints(doc storageConstraintsDoc) map[string]description.StorageDirectiveArgs {
+	result := make(map[string]description.StorageDirectiveArgs)
 	for key, value := range doc.Constraints {
-		result[key] = description.StorageConstraintArgs{
+		result[key] = description.StorageDirectiveArgs{
 			Pool:  value.Pool,
 			Size:  value.Size,
 			Count: value.Count,
@@ -887,7 +887,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		args.CloudService = e.cloudService(cloudService)
 	}
 	if constraints, found := e.modelStorageConstraints[storageConstraintsKey]; found {
-		args.StorageConstraints = e.storageConstraints(constraints)
+		args.StorageDirectives = e.storageConstraints(constraints)
 	}
 
 	if ps := application.ProvisioningState(); ps != nil {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2176,7 +2176,7 @@ func (s *MigrationExportSuite) TestStorage(c *gc.C) {
 
 	apps := model.Applications()
 	c.Assert(apps, gc.HasLen, 1)
-	constraints := apps[0].StorageConstraints()
+	constraints := apps[0].StorageDirectives()
 	c.Assert(constraints, gc.HasLen, 2)
 	cons, found := constraints["data"]
 	c.Assert(found, jc.IsTrue)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -958,7 +958,7 @@ func (i *importer) application(a description.Application, ctrlCfg controller.Con
 		applicationDoc:     appDoc,
 		statusDoc:          appStatusDoc,
 		constraints:        i.constraints(a.Constraints()),
-		storage:            i.storageConstraints(a.StorageConstraints()),
+		storage:            i.storageConstraints(a.StorageDirectives()),
 		charmConfig:        a.CharmConfig(),
 		applicationConfig:  a.ApplicationConfig(),
 		leadershipSettings: a.LeadershipSettings(),
@@ -1162,7 +1162,7 @@ func (i *importer) appResourceOps(app description.Application) []txn.Op {
 	return result
 }
 
-func (i *importer) storageConstraints(cons map[string]description.StorageConstraint) map[string]StorageConstraints {
+func (i *importer) storageConstraints(cons map[string]description.StorageDirective) map[string]StorageConstraints {
 	if len(cons) == 0 {
 		return nil
 	}
@@ -2462,7 +2462,7 @@ func (i *importer) storageInstanceConstraints(storage description.Storage) stora
 					continue
 				}
 				storageName, _ := names.StorageName(storage.Tag().Id())
-				appStorageCons, ok := app.StorageConstraints()[storageName]
+				appStorageCons, ok := app.StorageDirectives()[storageName]
 				if ok {
 					cons.Pool = appStorageCons.Pool()
 					cons.Size = appStorageCons.Size()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2515,7 +2515,7 @@ func (s *MigrationImportSuite) TestStorageInstanceConstraintsFallback(c *gc.C) {
 		storages["version"] = 2
 
 		app := applications["applications"].([]interface{})[0].(map[interface{}]interface{})
-		sc := app["storage-constraints"].(map[interface{}]interface{})
+		sc := app["storage-directives"].(map[interface{}]interface{})
 		delete(sc, "data")
 		sc["allecto"].(map[interface{}]interface{})["pool"] = "modelscoped-block"
 

--- a/state/mocks/description_mock.go
+++ b/state/mocks/description_mock.go
@@ -610,18 +610,18 @@ func (mr *MockApplicationMockRecorder) StatusHistory() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusHistory", reflect.TypeOf((*MockApplication)(nil).StatusHistory))
 }
 
-// StorageConstraints mocks base method.
-func (m *MockApplication) StorageConstraints() map[string]description.StorageConstraint {
+// StorageDirectives mocks base method.
+func (m *MockApplication) StorageDirectives() map[string]description.StorageDirective {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageConstraints")
-	ret0, _ := ret[0].(map[string]description.StorageConstraint)
+	ret := m.ctrl.Call(m, "StorageDirectives")
+	ret0, _ := ret[0].(map[string]description.StorageDirective)
 	return ret0
 }
 
-// StorageConstraints indicates an expected call of StorageConstraints.
-func (mr *MockApplicationMockRecorder) StorageConstraints() *gomock.Call {
+// StorageDirectives indicates an expected call of StorageDirectives.
+func (mr *MockApplicationMockRecorder) StorageDirectives() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageConstraints", reflect.TypeOf((*MockApplication)(nil).StorageConstraints))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageDirectives", reflect.TypeOf((*MockApplication)(nil).StorageDirectives))
 }
 
 // Subordinate mocks base method.


### PR DESCRIPTION
Migrating a 3.1 model to later 3.x controller failed because the 3.1 secrets do not have "auto-prune" and this was expected. The upstream juju/description package was updated to fix this issue.

Using the newer upstream also needed a few renames - just the method/struct was renamed, not the content.

## QA steps

bootstrap 3.1
add a model
deploy a charm, create a secret for the app

bootstrap 3.3
migrate the model
check the secret comes across

previously the model migration would fail

## Links

https://bugs.launchpad.net/juju/+bug/2058860

**Jira card:** JUJU-5754

