### PR TITLE
Bugfix: socketlistener timeout

### DIFF
--- a/internal/socketlistener/socketlistener.go
+++ b/internal/socketlistener/socketlistener.go
@@ -58,10 +58,9 @@ func (config Config) Validate() error {
 
 // SocketListener is a socketlistener worker.
 type SocketListener struct {
-	config          Config
-	tomb            tomb.Tomb
-	listener        net.Listener
-	shutdownTimeout time.Duration
+	config   Config
+	tomb     tomb.Tomb
+	listener net.Listener
 }
 
 // NewSocketListener returns a socketlistener with the given config.
@@ -113,7 +112,7 @@ func (sl *SocketListener) run() error {
 	sl.tomb.Go(func() error {
 		// Wait for the tomb to start dying and then shut the server down.
 		<-sl.tomb.Dying()
-		ctx, cancel := context.WithTimeout(context.Background(), sl.shutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), sl.config.ShutdownTimeout)
 		defer cancel()
 		return srv.Shutdown(ctx)
 	})


### PR DESCRIPTION
The socketlistener had two fields called `shutdownTimeout`, one in its config struct and one as a first class field. The first class one was not getting set but getting used while the config one was ignored.

This commit fixes the bug and makes the test more robust.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

 go test -race ./internal/socketlistener/...

