### PR TITLE
Fixes the oauth2 login.

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -230,20 +230,22 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 	// If there are no account details or there's no logged-in
 	// user or the user is external, then trigger macaroon authentication
 	// by using an empty AccountDetails.
-	if accountDetails == nil || accountDetails.User == "" {
-		accountDetails = &jujuclient.AccountDetails{}
-	} else {
-		u := names.NewUserTag(accountDetails.User)
-		if !u.IsLocal() {
-			if len(accountDetails.Macaroons) == 0 {
-				accountDetails = &jujuclient.AccountDetails{}
-			} else {
-				// If the account has macaroon set, use those to login
-				// to avoid an unnecessary auth round trip.
-				// Used for embedded commands.
-				accountDetails = &jujuclient.AccountDetails{
-					User:      u.Id(),
-					Macaroons: accountDetails.Macaroons,
+	if accountDetails.Type == "" || accountDetails.Type == jujuclient.UserPassAccountDetailsType {
+		if accountDetails == nil || accountDetails.User == "" {
+			accountDetails = &jujuclient.AccountDetails{}
+		} else {
+			u := names.NewUserTag(accountDetails.User)
+			if !u.IsLocal() {
+				if len(accountDetails.Macaroons) == 0 {
+					accountDetails = &jujuclient.AccountDetails{}
+				} else {
+					// If the account has macaroon set, use those to login
+					// to avoid an unnecessary auth round trip.
+					// Used for embedded commands.
+					accountDetails = &jujuclient.AccountDetails{
+						User:      u.Id(),
+						Macaroons: accountDetails.Macaroons,
+					}
 				}
 			}
 		}

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -406,4 +407,59 @@ func addCookie(c *gc.C, jar http.CookieJar, mac *macaroon.Macaroon, url *url.URL
 	c.Assert(err, jc.ErrorIsNil)
 	cookie.Expires = time.Now().Add(time.Hour) // only persistent cookies are stored
 	jar.SetCookies(url, []*http.Cookie{cookie})
+}
+
+func (s *BaseCommandSuite) TestNewAPIRootWithOAuthLoginProvider(c *gc.C) {
+
+	// the apiOpen function records the login provider to be used
+	var loginProvider api.LoginProvider
+	apiOpen := func(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+		loginProvider = dialOpts.LoginProvider
+		return nil, errors.Trace(&params.Error{Code: params.CodeModelNotFound, Message: "model deadbeef2 not found"})
+	}
+
+	// we create a store that contains a single oauth2 device flow account with a test session
+	// token
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "foo"
+	store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"testing.invalid:1234"},
+	}
+	store.Models["foo"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/badmodel":  {ModelUUID: "deadbeef", ModelType: model.IAAS},
+			"admin/goodmodel": {ModelUUID: "deadbeef2", ModelType: model.IAAS},
+		},
+		CurrentModel: "admin/badmodel",
+	}
+	store.Accounts["foo"] = jujuclient.AccountDetails{
+		Type:         jujuclient.OAuth2DeviceFlowAccountDetailsType,
+		SessionToken: "test-session-token",
+	}
+
+	baseCmd := new(modelcmd.ModelCommandBase)
+	baseCmd.SetClientStore(store)
+	baseCmd.SetAPIOpen(apiOpen)
+	modelcmd.InitContexts(&cmd.Context{Stderr: io.Discard}, baseCmd)
+	modelcmd.SetRunStarted(baseCmd)
+
+	c.Assert(baseCmd.SetModelIdentifier("foo:admin/goodmodel", false), jc.ErrorIsNil)
+
+	// we call the NewAPIRoot method and expect it to return an error
+	_, err := baseCmd.NewAPIRoot()
+	c.Assert(err, gc.ErrorMatches, `model \"admin/goodmodel\" has been removed from the controller, run 'juju models' and switch to one of them.`)
+
+	// then we inspect the login provider to be used
+	// - we expect it to be a sessionTokenLoginProvider, which is not exported from the api
+	//   package, so we have to resort to a bit of reflect magic - we inspect it's fields
+	//   and one of them is expected to be the sessionToken.
+	val := reflect.ValueOf(loginProvider).Elem()
+	sessionTokenFound := false
+	for i := 0; i < val.NumField(); i++ {
+		sessionTokenFound = (val.Type().Field(i).Name == "sessionToken")
+		if sessionTokenFound {
+			break
+		}
+	}
+	c.Assert(sessionTokenFound, gc.Equals, true)
 }

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-var NewAPIContext = newAPIContext
+var (
+	NewAPIContext         = newAPIContext
+	ProcessAccountDetails = processAccountDetails
+)
 
 func Interactor(ctx *apiContext) httpbakery.Interactor {
 	return ctx.interactor

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/frankban/quicktest v1.14.6
 	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
 	github.com/go-logr/logr v1.4.1
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
+	github.com/frankban/quicktest v1.14.6
 	github.com/go-goose/goose/v5 v5.0.0-20230421180421-abaee9096e3a
 	github.com/go-logr/logr v1.4.1
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1

--- a/juju/api.go
+++ b/juju/api.go
@@ -144,16 +144,30 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 	}
 
 	// Process the account details obtained from login.
+	processAccountDetails(
+		st.AuthTag(),
+		apiInfo.Tag,
+		args.ControllerName,
+		st.ControllerAccess(),
+		args.Store, apiInfo.SkipLogin,
+	)
+
+	return st, nil
+}
+
+func processAccountDetails(authTag names.Tag, apiInfoTag names.Tag, controllerName string, controllerAccess string, store jujuclient.ClientStore, skipLogin bool) {
 	var accountDetails *jujuclient.AccountDetails
-	user, ok := st.AuthTag().(names.UserTag)
-	if !apiInfo.SkipLogin {
+	var err error
+
+	user, ok := authTag.(names.UserTag)
+	if !skipLogin {
 		if ok {
-			if accountDetails, err = args.Store.AccountDetails(args.ControllerName); err != nil {
+			if accountDetails, err = store.AccountDetails(controllerName); err != nil {
 				if !errors.Is(err, errors.NotFound) {
 					logger.Errorf("cannot load local account information: %v", err)
 				}
 			} else {
-				accountDetails.LastKnownAccess = st.ControllerAccess()
+				accountDetails.LastKnownAccess = controllerAccess
 			}
 		}
 		accountType := jujuclient.UserPassAccountDetailsType
@@ -161,25 +175,24 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 			accountType = accountDetails.Type
 		}
 		if accountType == "" || accountType == jujuclient.UserPassAccountDetailsType {
-			if ok && !user.IsLocal() && apiInfo.Tag == nil {
+			if ok && !user.IsLocal() && apiInfoTag == nil {
 				// We used macaroon auth to login; save the username
 				// that we've logged in as.
 				accountDetails = &jujuclient.AccountDetails{
 					Type:            jujuclient.UserPassAccountDetailsType,
 					User:            user.Id(),
-					LastKnownAccess: st.ControllerAccess(),
+					LastKnownAccess: controllerAccess,
 				}
-			} else if apiInfo.Tag == nil {
-				logger.Errorf("unexpected logged-in username %v", st.AuthTag())
+			} else if apiInfoTag == nil {
+				logger.Errorf("unexpected logged-in username %v", authTag)
 			}
 		}
 	}
 	if accountDetails != nil {
-		if err := args.Store.UpdateAccount(args.ControllerName, *accountDetails); err != nil {
+		if err := store.UpdateAccount(controllerName, *accountDetails); err != nil {
 			logger.Errorf("cannot update account information: %v", err)
 		}
 	}
-	return st, nil
 }
 
 // connectionInfo returns connection information suitable for

--- a/juju/api.go
+++ b/juju/api.go
@@ -160,16 +160,18 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		if accountDetails != nil {
 			accountType = accountDetails.Type
 		}
-		if ok && !user.IsLocal() && apiInfo.Tag == nil && accountType != jujuclient.OAuth2DeviceFlowAccountDetailsType {
-			// We used macaroon auth to login; save the username
-			// that we've logged in as.
-			accountDetails = &jujuclient.AccountDetails{
-				Type:            jujuclient.UserPassAccountDetailsType,
-				User:            user.Id(),
-				LastKnownAccess: st.ControllerAccess(),
+		if accountType == "" || accountType == jujuclient.UserPassAccountDetailsType {
+			if ok && !user.IsLocal() && apiInfo.Tag == nil {
+				// We used macaroon auth to login; save the username
+				// that we've logged in as.
+				accountDetails = &jujuclient.AccountDetails{
+					Type:            jujuclient.UserPassAccountDetailsType,
+					User:            user.Id(),
+					LastKnownAccess: st.ControllerAccess(),
+				}
+			} else if apiInfo.Tag == nil {
+				logger.Errorf("unexpected logged-in username %v", st.AuthTag())
 			}
-		} else if apiInfo.Tag == nil {
-			logger.Errorf("unexpected logged-in username %v", st.AuthTag())
 		}
 	}
 	if accountDetails != nil {

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -4,5 +4,6 @@
 package juju
 
 var (
-	ConnectionInfo = connectionInfo
+	ConnectionInfo        = connectionInfo
+	ProcessAccountDetails = processAccountDetails
 )


### PR DESCRIPTION
A bit of logic was missing to pass the account details through to where an oauth2 login provider is being created.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ x ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Manual QA with JIMM:
1) run a local JIMM instance
2) add a juju controller to JIMM
3) run `juju login <jimm dns>
4) inspect accounts.yaml to see the account type recorded as `oauth2-device`
5) run `juju models`, which should return an empty list, not an error



