### PR TITLE
Drop default lts series

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	k8sannotations "github.com/juju/juju/core/annotations"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
@@ -1632,24 +1631,15 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		c.broker.randomPrefix,
 	)
 
-	chSeries := version.DefaultSupportedLTS()
-	os, err := corebase.GetOSFromSeries(chSeries)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	ver, err := corebase.SeriesVersion(chSeries)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	defaultBase := version.DefaultSupportedLTSBase()
 	repo, err := docker.NewImageRepoDetails(c.pcfg.Controller.CAASImageRepo())
 	if err != nil {
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
 	charmBaseImage, err := podcfg.ImageForBase(repo.Repository, charm.Base{
-		Name: strings.ToLower(os.String()),
+		Name: strings.ToLower(defaultBase.OS),
 		Channel: charm.Channel{
-			Track: ver,
+			Track: defaultBase.Channel.Track,
 			Risk:  charm.Stable,
 		},
 	})

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -433,8 +433,8 @@ func (k *kubernetesClient) Bootstrap(
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
 
-	if args.BootstrapSeries != "" {
-		return nil, errors.NotSupportedf("set series for bootstrapping to kubernetes")
+	if !args.BootstrapBase.Empty() {
+		return nil, errors.NotSupportedf("set base for bootstrapping to kubernetes")
 	}
 
 	storageClass, err := k.validateOperatorStorage(ctx)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/assumes"
+	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -251,9 +252,9 @@ func (s *K8sBrokerSuite) TestBootstrapNoOperatorStorage(c *gc.C) {
 	ctx := envtesting.BootstrapContext(context.Background(), c)
 	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	bootstrapParams := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 
 	_, err := s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
@@ -272,9 +273,9 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	ctx := envtesting.BootstrapContext(context.Background(), c)
 	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	bootstrapParams := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 
 	sc := &storagev1.StorageClass{
@@ -294,7 +295,7 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	c.Assert(result.Arch, gc.Equals, "amd64")
 	c.Assert(result.CaasBootstrapFinalizer, gc.NotNil)
 
-	bootstrapParams.BootstrapSeries = "bionic"
+	bootstrapParams.BootstrapBase = corebase.MustParseBaseFromString("ubuntu@22.04")
 	_, err = s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
 	c.Assert(err, jc.ErrorIs, errors.NotSupported)
 }

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/juju/collections/set"
-
 	"github.com/juju/juju/controller"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
@@ -49,13 +47,13 @@ type BootstrapParams struct {
 	// in the controller model.
 	StoragePools map[string]storage.Attrs
 
-	// BootstrapSeries, if specified, is the series to use for the
+	// BootstrapBase, if specified, is the base to use for the
 	// initial bootstrap machine.
-	BootstrapSeries string
+	BootstrapBase corebase.Base
 
-	// SupportedBootstrapSeries is a supported set of series to use for
-	// validating against the bootstrap series.
-	SupportedBootstrapSeries set.Strings
+	// SupportedBootstrapBases is a list of supported bases to use for
+	// validating against the bootstrap base.
+	SupportedBootstrapBases []corebase.Base
 
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -698,33 +698,14 @@ func Bootstrap(
 		return errors.Annotate(err, "validating bootstrap parameters")
 	}
 
-	// TODO(stickupkid): Once environs doesn't have a dependency on series, we
-	// can remove this conversion.
-	var bootstrapSeries string
-	if !args.BootstrapBase.Empty() {
-		var err error
-		bootstrapSeries, err = corebase.GetSeriesFromBase(args.BootstrapBase)
-		if err != nil {
-			return errors.NotValidf("base %q", args.BootstrapBase)
-		}
-	}
-	supportedBootstrapSeries := set.NewStrings()
-	for _, base := range args.SupportedBootstrapBases {
-		s, err := corebase.GetSeriesFromBase(base)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		supportedBootstrapSeries.Add(s)
-	}
-
 	bootstrapParams := environs.BootstrapParams{
 		CloudName:                  args.Cloud.Name,
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
 		ModelConstraints:           args.ModelConstraints,
 		StoragePools:               args.StoragePools,
-		BootstrapSeries:            bootstrapSeries,
-		SupportedBootstrapSeries:   supportedBootstrapSeries,
+		BootstrapBase:              args.BootstrapBase,
+		SupportedBootstrapBases:    args.SupportedBootstrapBases,
 		Placement:                  args.Placement,
 		Force:                      args.Force,
 		ExtraAgentValuesForTesting: args.ExtraAgentValuesForTesting,

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -89,7 +89,8 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
+	series, err := base.GetSeriesFromBase(jujuversion.DefaultSupportedLTSBase())
+	c.Assert(err, jc.ErrorIsNil)
 
 	args := s.getArgs(c)
 	hostname := args.Host
@@ -132,7 +133,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 		SkipDetection:      true,
 		SkipProvisionAgent: true,
 	}.install(c).Restore()
-	_, err := sshprovisioner.ProvisionMachine(args)
+	_, err = sshprovisioner.ProvisionMachine(args)
 	c.Assert(err, gc.Equals, manual.ErrProvisioned)
 	defer fakeSSH{
 		Provisioned:              true,
@@ -146,8 +147,11 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
+	series, err := base.GetSeriesFromBase(jujuversion.DefaultSupportedLTSBase())
+	c.Assert(err, jc.ErrorIsNil)
+
 	defer fakeSSH{
-		Series:         jujuversion.DefaultSupportedLTS(),
+		Series:         series,
 		Arch:           arch.AMD64,
 		InitUbuntuUser: true,
 	}.install(c).Restore()
@@ -178,7 +182,7 @@ func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
 		Version: version.MustParseBinary("6.6.6-ubuntu-amd64"),
 		URL:     "https://example.org",
 	}}
-	err := icfg.SetTools(tools)
+	err = icfg.SetTools(tools)
 	c.Assert(err, jc.ErrorIsNil)
 
 	script, err := sshprovisioner.ProvisioningScript(icfg)

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -263,8 +263,8 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := jujuversion.DefaultSupportedLTS()
-	if coretesting.HostSeries(c) != defaultSeries {
+	defaultBase := jujuversion.DefaultSupportedLTSBase()
+	if coretesting.HostBase(c) != defaultBase {
 		toolsVersion.Release = "ubuntu"
 		name := envtools.StorageName(toolsVersion, toolsDir)
 		err := stor.Remove(name)

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -422,18 +422,16 @@ func constructRefreshBase(base RefreshBase) (transport.Base, error) {
 	}
 
 	var channel string
-	var err error
 	switch base.Channel {
 	case "":
 		channel = notAvailable
 	case "kubernetes":
 		// Kubernetes is not a valid channel for a base.
 		// Instead use the latest LTS version of ubuntu.
-		name = "ubuntu"
-		channel, err = corebase.SeriesVersion(version.DefaultSupportedLTS())
-		if err != nil {
-			return transport.Base{}, errors.NotValidf("invalid latest version")
-		}
+		b := version.DefaultSupportedLTSBase()
+		name = b.OS
+		// Use the track to ensure no risk sneaks in
+		channel = b.Channel.Track
 	default:
 		// If we have a series, we need to convert it to a stable version.
 		// If we have a version, then just pass that through.

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -1445,11 +1445,11 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1479,11 +1479,11 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G allocate-public-ip=false"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G allocate-public-ip=false"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1513,11 +1513,11 @@ func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1551,11 +1551,11 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 	c.Assert(s.invalidatedCredential, jc.IsFalse)
 	_, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, gc.NotNil)
@@ -1682,11 +1682,11 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	config["autocert-dns-name"] = "example.com"
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         config,
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        config,
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/provider/common/bootstrap.go
+++ b/internal/provider/common/bootstrap.go
@@ -88,27 +88,9 @@ func BootstrapInstance(
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	supportedBootstrapBase := make([]corebase.Base, len(args.SupportedBootstrapSeries))
-	for i, b := range args.SupportedBootstrapSeries.SortedValues() {
-		sb, err := corebase.GetBaseFromSeries(b)
-		if err != nil {
-			return nil, nil, nil, errors.Trace(err)
-		}
-		supportedBootstrapBase[i] = sb
-	}
-
-	var bootstrapBase corebase.Base
-	if args.BootstrapSeries != "" {
-		b, err := corebase.GetBaseFromSeries(args.BootstrapSeries)
-		if err != nil {
-			return nil, nil, nil, errors.Trace(err)
-		}
-		bootstrapBase = b
-	}
-
 	requestedBootstrapBase, err := corebase.ValidateBase(
-		supportedBootstrapBase,
-		bootstrapBase,
+		args.SupportedBootstrapBases,
+		args.BootstrapBase,
 		config.PreferredBase(env.Config()),
 	)
 	if !args.Force && err != nil {

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -241,7 +241,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return jujuversion.DefaultSupportedLTS(), nil })
+	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return corebase.GetSeriesFromBase(jujuversion.DefaultSupportedLTSBase()) })
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
 	// TODO(jam) I don't understand why we shouldn't do this.

--- a/internal/provider/gce/environ_test.go
+++ b/internal/provider/gce/environ_test.go
@@ -78,8 +78,8 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	result, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,8 +94,8 @@ func (s *environSuite) TestBootstrapInvalidCredentialError(c *gc.C) {
 	s.FakeConn.Err = gce.InvalidCredentialError
 	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(envtesting.BootstrapTestContext(c), s.CallCtx, params)
 	c.Check(err, gc.NotNil)
@@ -122,8 +122,8 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 
 	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         config,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        config,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,8 +151,8 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 func (s *environSuite) TestBootstrapCommon(c *gc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/provider/lxd/environ_test.go
+++ b/internal/provider/lxd/environ_test.go
@@ -91,8 +91,8 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 
 	ctx := cmdtesting.Context(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         coretesting.FakeControllerConfig(),
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		ControllerConfig:        coretesting.FakeControllerConfig(),
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 	result, err := s.Env.Bootstrap(environscmd.BootstrapContext(context.Background(), ctx), s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -109,8 +109,8 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
 	ctx := envtesting.BootstrapContext(context.Background(), c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         coretesting.FakeControllerConfig(),
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		ControllerConfig:        coretesting.FakeControllerConfig(),
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 	callCtx := envcontext.WithoutCredentialInvalidator(ctx)
 	_, err := s.Env.Bootstrap(ctx, callCtx, params)

--- a/internal/provider/maas/package_test.go
+++ b/internal/provider/maas/package_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/environs/envcontext"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -56,7 +57,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return base.GetSeriesFromBase(version.DefaultSupportedLTSBase()) })
 	s.callCtx = envcontext.WithCredentialInvalidator(context.Background(), func(context.Context, string) error {
 		s.invalidCredential = true
 		return nil

--- a/internal/provider/oci/environ_integration_test.go
+++ b/internal/provider/oci/environ_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
@@ -913,10 +914,10 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -933,11 +934,11 @@ func (s *environSuite) TestBootstrapFlexibleShape(c *gc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
-			BootstrapConstraints:     constraints.MustParse("cpu-cores=32"),
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+			BootstrapConstraints:    constraints.MustParse("cpu-cores=32"),
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -961,11 +962,11 @@ func (s *environSuite) TestBootstrapNoAllocatePublicIP(c *gc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
-			BootstrapConstraints:     constraints.MustParse("allocate-public-ip=false"),
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+			BootstrapConstraints:    constraints.MustParse("allocate-public-ip=false"),
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -991,10 +992,10 @@ func (s *environSuite) TestBootstrapNoMatchingTools(c *gc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, envcontext.WithoutCredentialInvalidator(context.Background()),
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("centos"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("centos"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, gc.ErrorMatches, "no matching agent binaries available")
 

--- a/internal/provider/vsphere/environ_test.go
+++ b/internal/provider/vsphere/environ_test.go
@@ -156,8 +156,8 @@ func (s *environSuite) TestAdoptResourcesPermissionError(c *gc.C) {
 func (s *environSuite) TestBootstrapPermissionError(c *gc.C) {
 	AssertInvalidatesCredential(c, s.client, func(ctx envcontext.ProviderCallContext) error {
 		_, err := s.env.Bootstrap(nil, ctx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 		return err
 	})

--- a/testing/base.go
+++ b/testing/base.go
@@ -22,6 +22,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/internal/wrench"
 	"github.com/juju/juju/juju/osenv"
@@ -279,4 +280,12 @@ func HostSeries(c *gc.C) string {
 	hostSeries, err := series.HostSeries()
 	c.Assert(err, jc.ErrorIsNil)
 	return hostSeries
+}
+
+func HostBase(c *gc.C) base.Base {
+	hostSeries, err := series.HostSeries()
+	c.Assert(err, jc.ErrorIsNil)
+	base, err := base.GetBaseFromSeries(hostSeries)
+	c.Assert(err, jc.ErrorIsNil)
+	return base
 }

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -4,7 +4,6 @@
 package testing
 
 import (
-	"github.com/juju/collections/set"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -36,10 +35,6 @@ func init() {
 }
 
 var (
-	// FakeSupportedJujuSeries is used to provide a series of canned results
-	// of series to test bootstrap code against.
-	FakeSupportedJujuSeries = set.NewStrings("focal", "jammy", jujuversion.DefaultSupportedLTS())
-
 	// FakeSupportedJujuBases is used to provide a list of canned results
 	// of a base to test bootstrap code against.
 	FakeSupportedJujuBases = []corebase.Base{

--- a/version/base.go
+++ b/version/base.go
@@ -5,12 +5,6 @@ package version
 
 import corebase "github.com/juju/juju/core/base"
 
-// DefaultSupportedLTS returns the latest LTS that Juju supports and is
-// compatible with.
-func DefaultSupportedLTS() string {
-	return "jammy"
-}
-
 // DefaultSupportedLTSBase returns the latest LTS base that Juju supports
 // and is compatible with.
 func DefaultSupportedLTSBase() corebase.Base {

--- a/version/base_test.go
+++ b/version/base_test.go
@@ -14,7 +14,7 @@ type seriesSuite struct {
 
 var _ = gc.Suite(&seriesSuite{})
 
-func (s *seriesSuite) TestDefaultSupportedLTS(c *gc.C) {
-	name := DefaultSupportedLTS()
-	c.Assert(name, gc.Equals, "jammy")
+func (s *seriesSuite) TestDefaultSupportedLTSBase(c *gc.C) {
+	b := DefaultSupportedLTSBase()
+	c.Assert(b.String(), gc.Equals, "ubuntu@22.04/stable")
 }


### PR DESCRIPTION
Remove DefaultSupportedLTS (i.e. the series)

Drop redundant usages, and replace the rest with `DefaultSupportedLTSBase()`

Also replace BootstrapSeries and SupportedBootstrapSeries in environs with bases

This lessens our dependence on series, replacing them with bases

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests pass

#### Bootstrap an lxd controller

```
juju bootstrap lxd lxd
```

#### Refresh a charm

```
$ juju deploy juju-qa-test --revision 25 --channel stable --base ubuntu@20.04
Deployed "juju-qa-test" from charm-hub charm "juju-qa-test", revision 25 in channel latest/stable on ubuntu@20.04/stable

$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd         localhost/localhost  4.0-beta3.1  14:36:40Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/1*  active    idle   2        10.219.211.106         hello

Machine  State    Address         Inst id        Base          AZ  Message
2        started  10.219.211.106  juju-cfca83-2  ubuntu@20.04      Running


$ juju refresh juju-qa-test
Added charm-hub charm "juju-qa-test", revision 26 in channel latest/stable, to the model
no change to endpoint in space "alpha": info

$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd         localhost/localhost  4.0-beta3.1  14:36:56Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   26  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/1*  active    idle   2        10.219.211.106         hello

Machine  State    Address         Inst id        Base          AZ  Message
2        started  10.219.211.106  juju-cfca83-2  ubuntu@20.04      Running
```