### PR TITLE
Remove curl series read from test factory

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -271,7 +271,10 @@ func (s *ApplicationSuite) TestCAASSetCharm(c *gc.C) {
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
-	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "mysql"})
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", CharmOrigin: &state.CharmOrigin{
+		Source:   "local",
+		Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
+	}})
 
 	// Add a compatible charm and force it.
 	sch := state.AddCustomCharm(c, st, "mysql-k8s", "metadata.yaml", metaBaseCAAS, "focal", 2)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/core/arch"
-	corebase "github.com/juju/juju/core/base"
 	coreconfig "github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -518,9 +517,6 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 	}
 	if params.CharmOrigin == nil {
 		curl := charm.MustParseURL(params.Charm.URL())
-		chSeries := curl.Series
-		base, err := corebase.GetBaseFromSeries(chSeries)
-		c.Assert(err, jc.ErrorIsNil)
 		var channel *state.Channel
 		var source string
 		// local charms cannot have a channel
@@ -535,8 +531,8 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 			Source:  source,
 			Platform: &state.Platform{
 				Architecture: curl.Architecture,
-				OS:           base.OS,
-				Channel:      base.Channel.String(),
+				OS:           "ubuntu",
+				Channel:      "12.10",
 			}}
 	}
 


### PR DESCRIPTION
Drop charm url series read in test factory

This will bring us a step closer removing series from charm url. We are very close to this in production code, but there's still a number of reads + writes in test code.

This is not strictly required, since this is just test code, but once we have removed all usgaes in test and production code, we can remove series from the charm url struct entirely

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

All unit tests should pass