### PR TITLE
Remove space retrieval on the allwatcher

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -413,29 +413,3 @@ func hostsPortsEqual(a, b []network.SpaceHostPorts) bool {
 	bPrime := dupeAndSort(b)
 	return reflect.DeepEqual(aPrime, bPrime)
 }
-
-func (st *State) ConvertSpaceHostPorts(sHPs network.SpaceHostPorts) (network.ProviderHostPorts, error) {
-	addrs := make(network.ProviderHostPorts, len(sHPs))
-	for i, sAddr := range sHPs {
-		var err error
-		if addrs[i], err = st.ConvertSpaceHostPort(sAddr); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return addrs, nil
-}
-
-func (st *State) ConvertSpaceHostPort(sHP network.SpaceHostPort) (network.ProviderHostPort, error) {
-	hp := network.ProviderHostPort{
-		ProviderAddress: network.ProviderAddress{MachineAddress: sHP.MachineAddress},
-		NetPort:         sHP.NetPort,
-	}
-	if sHP.SpaceID != "" {
-		space, err := st.Space(sHP.SpaceID)
-		if err != nil {
-			return hp, errors.Trace(err)
-		}
-		hp.SpaceName = network.SpaceName(space.Name())
-	}
-	return hp, nil
-}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -353,17 +353,6 @@ func (m *backingMachine) updated(ctx *allWatcherContext) error {
 			MachineAddress: addr.MachineAddress,
 		}
 
-		spaceID := addr.SpaceID
-		if spaceID != network.AlphaSpaceId && spaceID != "" {
-			// TODO: cache spaces
-			space, err := ctx.state.Space(spaceID)
-			if err != nil {
-				return errors.Annotatef(err, "retrieving space for ID %q", spaceID)
-			}
-			mAddr.SpaceName = network.SpaceName(space.Name())
-			mAddr.ProviderSpaceID = space.ProviderId()
-		}
-
 		info.Addresses = append(info.Addresses, mAddr)
 	}
 

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -164,9 +164,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	var addresses []network.ProviderAddress
 	for _, addr := range m.Addresses() {
 		addresses = append(addresses, network.ProviderAddress{
-			MachineAddress:  addr.MachineAddress,
-			SpaceName:       network.SpaceName(space.Name()),
-			ProviderSpaceID: space.ProviderId(),
+			MachineAddress: addr.MachineAddress,
 		})
 	}
 


### PR DESCRIPTION
We currently retrieve spaces in the allWatcher just to fill the machine addresses SpaceName and (Space)ProviderId. We remove this now that we are migrating the domain to dqlite.

Bonus: Remove two unused methods in the legacy state (`ConvertSpaceHostPort` and `ConvertSpaceHostPorts` which used the `Space()` method.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We are slowly removing things from the mongodb all watcher so nothing to QA.


## Links

**Jira card:** JUJU-5757

