### PR TITLE
Add support for Pebble change-update notice

### DIFF
--- a/testcharms/charms/pebble-notices/src/charm.py
+++ b/testcharms/charms/pebble-notices/src/charm.py
@@ -16,6 +16,24 @@ class PebbleNoticesCharm(ops.CharmBase):
         self.framework.observe(self.on["redis"].pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on["redis"].pebble_custom_notice, self._on_custom_notice)
 
+        # TODO(benhoyt): update to use pebble_change_updated once ops supports that:
+        #                https://github.com/canonical/operator/pull/1170
+        import os
+        import pathlib
+
+        dispatch_path = pathlib.Path(os.environ.get("JUJU_DISPATCH_PATH", ""))
+        event_name = dispatch_path.name.replace("-", "_")
+        logger.info(f"__init__: path={dispatch_path} event={event_name}")
+        if event_name == "redis_pebble_change_updated":
+            event = ops.PebbleNoticeEvent(
+                None,
+                self.unit.get_container(os.environ["JUJU_WORKLOAD_NAME"]),
+                os.environ["JUJU_NOTICE_ID"],
+                os.environ["JUJU_NOTICE_TYPE"],
+                os.environ["JUJU_NOTICE_KEY"],
+            )
+            self._on_change_updated(event)
+
     def _on_pebble_ready(self, event):
         self.unit.status = ops.ActiveStatus()
 
@@ -27,6 +45,19 @@ class PebbleNoticesCharm(ops.CharmBase):
 
         # Don't include the (arbitrary) ID in the status message
         self.unit.status = ops.MaintenanceStatus(f"notice type={notice_type} key={notice_key}")
+
+    def _on_change_updated(self, event):
+        notice_id = event.notice.id
+        notice_type = (
+            event.notice.type if isinstance(event.notice.type, str) else event.notice.type.value
+        )
+        notice_key = event.notice.key
+        logger.info(f"_on_change_updated: id={notice_id} type={notice_type} key={notice_key}")
+
+        change = event.workload.pebble.get_change(notice_key)
+        self.unit.status = ops.MaintenanceStatus(
+            f"notice type={notice_type} kind={change.kind} status={change.status}"
+        )
 
 
 if __name__ == "__main__":

--- a/testcharms/charms/pebble-notices/tests/unit/test_charm.py
+++ b/testcharms/charms/pebble-notices/tests/unit/test_charm.py
@@ -1,8 +1,10 @@
 import unittest
+import unittest.mock
 
 import ops
 import ops.testing
 from charm import PebbleNoticesCharm
+from ops import pebble
 
 
 class TestCharm(unittest.TestCase):
@@ -10,6 +12,7 @@ class TestCharm(unittest.TestCase):
         self.harness = ops.testing.Harness(PebbleNoticesCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self._next_notice_id = 1
 
     def test_pebble_ready(self):
         self.harness.container_pebble_ready("redis")
@@ -27,3 +30,68 @@ class TestCharm(unittest.TestCase):
             self.harness.model.unit.status,
             ops.MaintenanceStatus("notice type=custom key=ubuntu.com/bar/buzz"),
         )
+
+    @unittest.mock.patch("ops.testing._TestingPebbleClient.get_change")
+    def test_change_updated(self, mock_get_change):
+        # TODO(benhoyt): update to use pebble_change_updated once ops supports that:
+        #                https://github.com/canonical/operator/pull/1170
+
+        import os
+
+        os.environ["JUJU_DISPATCH_PATH"] = "hooks/redis-pebble-change-updated"
+        self.addCleanup(os.environ.__delitem__, "JUJU_DISPATCH_PATH")
+        self.addCleanup(os.environ.__delitem__, "JUJU_NOTICE_ID")
+        self.addCleanup(os.environ.__delitem__, "JUJU_NOTICE_TYPE")
+        self.addCleanup(os.environ.__delitem__, "JUJU_NOTICE_KEY")
+
+        mock_get_change.return_value = pebble.Change.from_dict(
+            {
+                "id": "1",
+                "kind": "exec",
+                "summary": "",
+                "status": "Doing",
+                "ready": False,
+                "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
+            }
+        )
+        self._pebble_notify_change_updated("redis", "123")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.MaintenanceStatus("notice type=change-update kind=exec status=Doing"),
+        )
+        mock_get_change.assert_called_once_with("123")
+
+        mock_get_change.reset_mock()
+        mock_get_change.return_value = pebble.Change.from_dict(
+            {
+                "id": "2",
+                "kind": "changeroo",
+                "summary": "",
+                "status": "Done",
+                "ready": True,
+                "spawn-time": "2024-01-28T14:37:02.247202105+13:00",
+                "ready-time": "2024-01-28T14:37:04.291517768+13:00",
+            }
+        )
+        self._pebble_notify_change_updated("redis", "42")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.MaintenanceStatus("notice type=change-update kind=changeroo status=Done"),
+        )
+        mock_get_change.assert_called_once_with("42")
+
+    def _pebble_notify_change_updated(self, container_name, notice_key):
+        import os
+
+        os.environ["JUJU_NOTICE_ID"] = notice_id = str(self._next_notice_id)
+        self._next_notice_id += 1
+        os.environ["JUJU_NOTICE_TYPE"] = notice_type = "change-update"
+        os.environ["JUJU_NOTICE_KEY"] = notice_key
+        event = ops.PebbleNoticeEvent(
+            None,
+            self.harness.model.unit.get_container(container_name),
+            notice_id,
+            notice_type,
+            notice_key,
+        )
+        self.harness.charm._on_change_updated(event)

--- a/tests/suites/sidecar/sidecar.sh
+++ b/tests/suites/sidecar/sidecar.sh
@@ -89,3 +89,24 @@ test_pebble_notices() {
 	# Clean up model
 	destroy_model "${model_name}"
 }
+
+test_pebble_change_updated() {
+	echo
+
+	# Ensure that a valid Juju controller exists
+	model_name="controller-model-sidecar"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Deploy Pebble Notices test application
+	juju deploy juju-qa-pebble-notices
+	wait_for "active" '.applications["juju-qa-pebble-notices"].units["juju-qa-pebble-notices/0"]["workload-status"].current'
+
+	# Check that charm is responding correctly to a change-update notice
+	juju ssh --container redis juju-qa-pebble-notices/0 /charm/bin/pebble exec -- echo foo
+	wait_for "maintenance" '.applications["juju-qa-pebble-notices"].units["juju-qa-pebble-notices/0"]["workload-status"].current'
+	wait_for "notice type=change-update kind=exec status=Done" '.applications["juju-qa-pebble-notices"].units["juju-qa-pebble-notices/0"]["workload-status"].message'
+
+	# Clean up model
+	destroy_model "${model_name}"
+}

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -11,6 +11,7 @@ test_sidecar() {
 		test_deploy_and_remove_application
 		test_deploy_and_force_remove_application
 		test_pebble_notices
+		test_pebble_change_updated
 		;;
 	*)
 		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"

--- a/worker/uniter/container/workload.go
+++ b/worker/uniter/container/workload.go
@@ -32,6 +32,7 @@ const (
 	// ReadyEvent is triggered when the container/pebble starts up.
 	ReadyEvent WorkloadEventType = iota
 	CustomNoticeEvent
+	ChangeUpdatedEvent
 )
 
 // WorkloadEvent contains information about the event type and data associated with
@@ -192,6 +193,14 @@ func (r *workloadHookResolver) NextOp(
 			case CustomNoticeEvent:
 				op, err = opFactory.NewRunHook(hook.Info{
 					Kind:         hooks.PebbleCustomNotice,
+					WorkloadName: evt.WorkloadName,
+					NoticeID:     evt.NoticeID,
+					NoticeType:   evt.NoticeType,
+					NoticeKey:    evt.NoticeKey,
+				})
+			case ChangeUpdatedEvent:
+				op, err = opFactory.NewRunHook(hook.Info{
+					Kind:         hooks.PebbleChangeUpdated,
 					WorkloadName: evt.WorkloadName,
 					NoticeID:     evt.NoticeID,
 					NoticeType:   evt.NoticeType,

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -92,7 +92,7 @@ func (hi Info) Validate() error {
 			return errors.Errorf("%q hook has a remote unit but no application", hi.Kind)
 		}
 		return nil
-	case hooks.PebbleCustomNotice:
+	case hooks.PebbleCustomNotice, hooks.PebbleChangeUpdated:
 		if hi.WorkloadName == "" {
 			return errors.Errorf("%q hook requires a workload name", hi.Kind)
 		}

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -53,6 +53,12 @@ var validateTests = []struct {
 		hook.Info{Kind: hooks.PebbleCustomNotice, WorkloadName: "test"},
 		`"pebble-custom-notice" hook requires a notice ID, type, and key`,
 	}, {
+		hook.Info{Kind: hooks.PebbleChangeUpdated},
+		`"pebble-change-updated" hook requires a workload name`,
+	}, {
+		hook.Info{Kind: hooks.PebbleChangeUpdated, WorkloadName: "test"},
+		`"pebble-change-updated" hook requires a notice ID, type, and key`,
+	}, {
 		hook.Info{Kind: hooks.PreSeriesUpgrade},
 		`"pre-series-upgrade" hook requires a target base`,
 	}, {

--- a/worker/uniter/pebblenotices.go
+++ b/worker/uniter/pebblenotices.go
@@ -136,6 +136,8 @@ func (n *pebbleNoticer) processNotice(containerName string, notice *client.Notic
 	switch notice.Type {
 	case client.CustomNotice:
 		eventType = container.CustomNoticeEvent
+	case client.ChangeUpdateNotice:
+		eventType = container.ChangeUpdatedEvent
 	default:
 		n.logger.Debugf("container %q: ignoring %s notice", containerName, notice.Type)
 		return nil

--- a/worker/uniter/pebblenotices_test.go
+++ b/worker/uniter/pebblenotices_test.go
@@ -113,6 +113,25 @@ func (s *pebbleNoticerSuite) TestWaitNotices(c *gc.C) {
 	})
 }
 
+func (s *pebbleNoticerSuite) TestChangeUpdate(c *gc.C) {
+	s.setUpWorker(c, []string{"c1"})
+	defer workertest.CleanKill(c, s.worker)
+
+	s.clients["c1"].AddNotice(c, &client.Notice{
+		ID:           "1",
+		Type:         "change-update",
+		Key:          "42",
+		LastRepeated: time.Now(),
+	})
+	s.waitWorkloadEvent(c, container.WorkloadEvent{
+		Type:         container.ChangeUpdatedEvent,
+		WorkloadName: "c1",
+		NoticeID:     "1",
+		NoticeType:   "change-update",
+		NoticeKey:    "42",
+	})
+}
+
 func (s *pebbleNoticerSuite) TestWaitNoticesError(c *gc.C) {
 	s.setUpWorker(c, []string{"c1"})
 	defer workertest.CleanKill(c, s.worker)

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -288,7 +288,7 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 		ctx.workloadName = hookInfo.WorkloadName
 		hookName = fmt.Sprintf("%s-%s", hookInfo.WorkloadName, hookName)
 		switch hookInfo.Kind {
-		case hooks.PebbleCustomNotice:
+		case hooks.PebbleCustomNotice, hooks.PebbleChangeUpdated:
 			ctx.noticeID = hookInfo.NoticeID
 			ctx.noticeType = hookInfo.NoticeType
 			ctx.noticeKey = hookInfo.NoticeKey


### PR DESCRIPTION
This wires up the `change-update` notice type in the right places, with the effect that we'll now respond to Pebble change-update notices by sending a `pebble-change-updated` event to the charm.

For reference, Pebble Notices support (for the "custom" notice type) was originally introduced in PR #16428.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Manual QA steps below (similar to the integration test):

```
# Pack and deploy the test charm
$ juju add-model t
$ cd testcharms/charms/pebble-notices
$ charmcraft pack
$ juju deploy ./juju-qa-pebble-notices_ubuntu-22.04-amd64.charm --resource redis-image=redis
$ juju status  # unit status should settle to "active" after pebble-ready

# Perform an exec (or any operation that records a change)
$ juju ssh --container redis juju-qa-pebble-notices/0 /charm/bin/pebble exec -- echo foo
$ juju status  # will now say status "maintenance" with message "notice type=change-update kind=exec status=Done"

# List notices:
$ juju ssh --container redis juju-qa-pebble-notices/0 /charm/bin/pebble notices
ID   User    Type           Key  First               Repeated            Occurrences
1    public  change-update  1    today at 02:15 UTC  today at 02:15 UTC  3

# Get notice details for the above notice ID
$ juju ssh --container redis juju-qa-pebble-notices/0 /charm/bin/pebble notice 1
id: "1"
user-id: null
type: change-update
key: "1"
first-occurred: 2024-04-04T02:15:46.249636939Z
last-occurred: 2024-04-04T02:15:46.297160558Z
last-repeated: 2024-04-04T02:15:46.297160558Z
occurrences: 3
last-data:
    kind: exec
expire-after: 168h0m0s

# Get tasks for corresponding change (the notice key "1" above)
$ juju ssh --container redis juju-qa-pebble-notices/0 /charm/bin/pebble tasks 1
Status  Spawn               Ready               Summary
Done    today at 02:15 UTC  today at 02:15 UTC  Execute command "echo"
```

## Documentation changes

Ben to add Juju SDK documentation for this (CHARMTECH-35).

## Links

Original spec: [JU048](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA/edit#).
