### PR TITLE
Remove checks on spaces bound to endpoints when deleting spaces

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -82,7 +82,6 @@ type ModelManagerBackend interface {
 	SetUserAccess(subject names.UserTag, target names.Tag, access permission.Access) (permission.UserAccess, error)
 	AllSpaces() ([]*state.Space, error)
 	AddSpace(string, network.Id, []string) (*state.Space, error)
-	AllEndpointBindingsSpaceNames() (set.Strings, error)
 	ConstraintsBySpaceName(string) ([]*state.Constraints, error)
 	// TODO(nvinuesa): This method is necessary only until the spaces
 	// migration to dqlite is finished:

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -962,11 +962,6 @@ func (st *mockState) AddSpace(name string, provider network.Id, subnetIds []stri
 	return nil, st.NextErr()
 }
 
-func (st *mockState) AllEndpointBindingsSpaceNames() (set.Strings, error) {
-	st.MethodCall(st, "AllEndpointBindingsSpaceNames")
-	return set.NewStrings(), nil
-}
-
 func (st *mockState) DefaultEndpointBindingSpace() (string, error) {
 	st.MethodCall(st, "DefaultEndpointBindingSpace")
 	return "alpha", nil

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -1165,21 +1165,6 @@ func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2 any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2)
 }
 
-// AllEndpointBindingsSpaceNames mocks base method.
-func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllEndpointBindingsSpaceNames")
-	ret0, _ := ret[0].(set.Strings)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames.
-func (mr *MockReloadSpacesStateMockRecorder) AllEndpointBindingsSpaceNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllEndpointBindingsSpaceNames", reflect.TypeOf((*MockReloadSpacesState)(nil).AllEndpointBindingsSpaceNames))
-}
-
 // AllSpaces mocks base method.
 func (m *MockReloadSpacesState) AllSpaces() ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -587,11 +587,6 @@ func (sb *StubBacking) SaveProviderSubnets(subnets []network.SubnetInfo, spaceID
 	return nil
 }
 
-func (sb *StubBacking) AllEndpointBindingsSpaceNames() (set.Strings, error) {
-	sb.MethodCall(sb, "AllEndpointBindingsSpaceNames")
-	return set.NewStrings(), nil
-}
-
 func (sb *StubBacking) DefaultEndpointBindingSpace() (string, error) {
 	sb.MethodCall(sb, "DefaultEndpointBindingSpace")
 	return "alpha", nil

--- a/environs/space/spaces_mock_test.go
+++ b/environs/space/spaces_mock_test.go
@@ -12,7 +12,6 @@ package space
 import (
 	reflect "reflect"
 
-	set "github.com/juju/collections/set"
 	network "github.com/juju/juju/core/network"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -53,21 +52,6 @@ func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []st
 func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2)
-}
-
-// AllEndpointBindingsSpaceNames mocks base method.
-func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllEndpointBindingsSpaceNames")
-	ret0, _ := ret[0].(set.Strings)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames.
-func (mr *MockReloadSpacesStateMockRecorder) AllEndpointBindingsSpaceNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllEndpointBindingsSpaceNames", reflect.TypeOf((*MockReloadSpacesState)(nil).AllEndpointBindingsSpaceNames))
 }
 
 // AllSpaces mocks base method.

--- a/environs/space/spaces_test.go
+++ b/environs/space/spaces_test.go
@@ -6,7 +6,6 @@ package space
 import (
 	"context"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -205,7 +204,6 @@ func (s *providerSpacesSuite) TestDeleteSpaces(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("1").Return(nil, nil)
 	mockState.EXPECT().Remove("1").Return(nil)
 
@@ -228,7 +226,6 @@ func (s *providerSpacesSuite) TestDeleteSpacesMatchesAlphaSpace(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 
 	provider := NewProviderSpaces(mockState)
 	provider.modelSpaceMap = map[network.Id]network.SpaceInfo{
@@ -252,7 +249,6 @@ func (s *providerSpacesSuite) TestDeleteSpacesMatchesDefaultBindingSpace(c *gc.C
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 
 	provider := NewProviderSpaces(mockState)
 	provider.modelSpaceMap = map[network.Id]network.SpaceInfo{
@@ -269,34 +265,11 @@ func (s *providerSpacesSuite) TestDeleteSpacesMatchesDefaultBindingSpace(c *gc.C
 	})
 }
 
-func (s *providerSpacesSuite) TestDeleteSpacesContainedInAllEndpointBindings(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings("1"), nil)
-
-	provider := NewProviderSpaces(mockState)
-	provider.modelSpaceMap = map[network.Id]network.SpaceInfo{
-		network.Id("1"): {
-			ID:   "1",
-			Name: "1",
-		},
-	}
-
-	warnings, err := provider.DeleteSpaces()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(warnings, gc.DeepEquals, []string{
-		`Unable to delete space "1". Space is used as a endpoint binding.`,
-	})
-}
-
 func (s *providerSpacesSuite) TestDeleteSpacesContainsConstraintsSpace(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	mockState := NewMockReloadSpacesState(ctrl)
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("1").Return([]Constraints{struct{}{}}, nil)
 
 	provider := NewProviderSpaces(mockState)
@@ -355,7 +328,6 @@ func (s *providerSpacesSuite) TestProviderSpacesRun(c *gc.C) {
 		},
 	})
 
-	mockState.EXPECT().AllEndpointBindingsSpaceNames().Return(set.NewStrings(), nil)
 	mockState.EXPECT().ConstraintsBySpaceName("space1").Return(nil, nil)
 
 	warnings, err := provider.DeleteSpaces()

--- a/state/model.go
+++ b/state/model.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
@@ -819,37 +818,6 @@ func (m *Model) AllEndpointBindings() (map[string]*Bindings, error) {
 	}
 
 	return appEndpointBindings, nil
-}
-
-// AllEndpointBindingsSpaceNames returns a set of spaces names for all the
-// endpoint bindings.
-func (st *State) AllEndpointBindingsSpaceNames() (set.Strings, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	allEndpointBindings, err := model.AllEndpointBindings()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	lookup, err := st.AllSpaceInfos()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	allEndpointBindingsSpaces := set.NewStrings()
-	for _, bindings := range allEndpointBindings {
-		bindingSpaceNames, err := bindings.MapWithSpaceNames(lookup)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		for _, spaceName := range bindingSpaceNames {
-			allEndpointBindingsSpaces.Add(spaceName)
-		}
-	}
-
-	return allEndpointBindingsSpaces, nil
 }
 
 // Users returns a slice of all users for this model.

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -510,25 +510,6 @@ func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 	c.Assert(listBindings[app.Name()].Map(), gc.DeepEquals, expected)
 }
 
-func (s *ModelSuite) TestAllEndpointBindingsSpaceNames(c *gc.C) {
-	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider")})
-	state.AddTestingApplicationWithBindings(
-		c, s.State, s.objectStore, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
-		map[string]string{"db": oneSpace.Id()})
-
-	spaceNames, err := s.State.AllEndpointBindingsSpaceNames()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spaceNames.Size(), gc.Equals, 2)
-	c.Assert(spaceNames.SortedValues(), gc.DeepEquals, []string{"alpha", "one"})
-}
-
-func (s *ModelSuite) TestAllEndpointBindingsSpaceNamesWithoutAnySpaces(c *gc.C) {
-	spaceNames, err := s.State.AllEndpointBindingsSpaceNames()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spaceNames.Size(), gc.Equals, 0)
-}
-
 // createTestModelConfig returns a new model config and its UUID for testing.
 func (s *ModelSuite) createTestModelConfig(c *gc.C) (*config.Config, string) {
 	return createTestModelConfig(c, s.modelTag.Id())


### PR DESCRIPTION
On the environs, when we reload spaces at bootstrap time, we remove the spaces that are not present in the substrate. Before doing this we check if the spaces were bound to an endpoint then the reload would fail. This check is useless because it's only used at bootstrap time.

Nonetheless, if we were to check this, we must do it using the referential integrity that the new dqlite schema provides, so we should have a foreign key violation when trying to delete a space used in endpoint bindings.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A, this was only checked during bootstrap for substrates that support spaces. Now the check is gone and will be re implemented when migrating application endpoint bindings to dqlite.


## Links

**Jira card:** JUJU-5757

