### PR TITLE
Model life

### DIFF
--- a/core/model/model.go
+++ b/core/model/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -46,6 +47,12 @@ func (m ModelType) IsValid() bool {
 type Model struct {
 	// Name returns the human friendly name of the model.
 	Name string
+
+	// Life is the current state of the model.
+	// Options are alive, dying, dead. Every model starts as alive, only
+	// during the destruction of the model it transitions to dying and then
+	// dead.
+	Life life.Value
 
 	// UUID is the universally unique identifier of the model.
 	UUID UUID

--- a/core/model/model_test.go
+++ b/core/model/model_test.go
@@ -23,9 +23,9 @@ func (*ModelSuite) TestValidateBranchName(c *gc.C) {
 		branchName string
 		valid      bool
 	}{
-		{"", false},
-		{GenerationMaster, false},
-		{"something else", true},
+		{branchName: "", valid: false},
+		{branchName: GenerationMaster, valid: false},
+		{branchName: "something else", valid: true},
 	} {
 		err := ValidateBranchName(t.branchName)
 		if t.valid {

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -573,8 +573,8 @@ func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 			return err
 		}
 		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO model_metadata (model_uuid, name, owner_uuid, model_type_id, cloud_uuid, cloud_credential_uuid)
-		SELECT %q, %q, %q, 0,
+		INSERT INTO model_metadata (model_uuid, name, owner_uuid, life_id, model_type_id, cloud_uuid, cloud_credential_uuid)
+		SELECT %q, %q, %q, 0, 0,
 			(SELECT uuid FROM cloud WHERE cloud.name="stratus"),
 			(SELECT uuid FROM cloud_credential cc WHERE cc.name="foobar")`,
 			modelUUID, name, s.userUUID),

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -132,6 +133,7 @@ func (m *stateSuite) TestGetModel(c *gc.C) {
 		Name:      "my-test-model",
 		Owner:     m.userUUID,
 		ModelType: coremodel.IAAS,
+		Life:      life.Alive,
 	})
 }
 

--- a/domain/schema/life.go
+++ b/domain/schema/life.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+import "github.com/juju/juju/core/database/schema"
+
+func lifeSchema() schema.Patch {
+	return schema.MakePatch(`
+CREATE TABLE life (
+    id    INT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT INTO life VALUES
+    (0, 'alive'), 
+    (1, 'dying'),
+    (2, 'dead');
+`)
+}

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -122,20 +122,6 @@ CREATE TABLE annotation_%[1]s (
 	}
 }
 
-func lifeSchema() schema.Patch {
-	return schema.MakePatch(`
-CREATE TABLE life (
-    id    INT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-
-INSERT INTO life VALUES
-    (0, 'alive'), 
-    (1, 'dying'),
-    (2, 'dead');
-`)
-}
-
 func changeLogModelNamespaceSchema() schema.Patch {
 	// Note: These should match exactly the values of the tableNamespaceID
 	// constants above.

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -125,6 +125,9 @@ func (s *schemaSuite) TestControllerTables(c *gc.C) {
 		"model_metadata",
 		"model_type",
 
+		// Life
+		"life",
+
 		// Controller config
 		"controller_config",
 
@@ -350,6 +353,10 @@ func (s *schemaSuite) TestControllerTriggers(c *gc.C) {
 		"trg_log_secret_backend_rotation_next_rotation_time_insert",
 		"trg_log_secret_backend_rotation_next_rotation_time_update",
 		"trg_log_secret_backend_rotation_next_rotation_time_delete",
+
+		"trg_log_model_metadata_insert",
+		"trg_log_model_metadata_update",
+		"trg_log_model_metadata_delete",
 	)
 
 	// These are additional triggers that are not change log triggers, but


### PR DESCRIPTION
Adds the life concept to the model metadata. This will be used as the basis to trigger the model watcher. Any changes to the model metadata allows us to trigger the model watcher.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

There is no wire-up of watchers yet, so just the creation of a model should suffice.


## Links

**Jira card:** JUJU-

