### PR TITLE
Remove panics from unimplemented secret service methods

### DIFF
--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -13,9 +13,9 @@ import (
 )
 
 func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI, consumer SecretConsumer) (*secrets.SecretConsumerMetadata, error) {
-	//TODO implement me
-	panic("implement me")
+	return nil, errors.NotFound
 	/*
+		consumerMetadata, err := getConsumerMetadata(...)
 		//if consumerMetadata.Label != "" {
 		//	return consumerMetadata, nil
 		//}
@@ -35,16 +35,17 @@ func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI,
 }
 
 func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string, consumer SecretConsumer) (*secrets.URI, error) {
-	//TODO implement me
-	panic("implement me")
+	return nil, errors.NotFound
 }
 
 func (s *SecretService) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, consumer SecretConsumer, md *secrets.SecretConsumerMetadata) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
-// TODO(secrets) - document and test
+// GetConsumedRevision returns the secret revision number for the specified consumer, possibly updating
+// the label associated with the secret for the consumer.
+// Only one of consumer app or unit name must be specified.
+// TODO(secrets) - test
 func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, consumer SecretConsumer, refresh, peek bool, labelToUpdate *string) (int, error) {
 	consumerInfo, err := s.GetSecretConsumer(ctx, uri, consumer)
 	if err != nil && !errors.Is(err, secreterrors.SecretNotFound) {
@@ -83,4 +84,11 @@ func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.UR
 		}
 	}
 	return wantRevision, nil
+}
+
+// ListConsumedSecrets returns the secret metadata and revision metadata for any secrets matching the specified consumer.
+// The result contains secrets consumed by any of the non nil consumer attributes.
+// The count of secret and revisions in the result must match.
+func (s *SecretService) ListConsumedSecrets(ctx context.Context, consumer SecretConsumer) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	return nil, nil, nil
 }

--- a/domain/secret/service/delete.go
+++ b/domain/secret/service/delete.go
@@ -14,12 +14,13 @@ import (
 )
 
 func (s *SecretService) DeleteCharmSecret(ctx context.Context, uri *secrets.URI, revisions []int, canDelete func(uri *secrets.URI) error) error {
-	panic("implement me")
+	return nil
 }
 
 // DeleteObsoleteUserSecrets deletes any obsolete user secret revisions that are marked as auto-prune.
 func (s *SecretService) DeleteObsoleteUserSecrets(ctx context.Context) error {
-	panic("implement me")
+	// TODO(secrets)
+	return nil
 }
 
 // DeleteUserSecret removes the specified user supplied secret.
@@ -76,7 +77,7 @@ func (s *SecretService) deleteSecret(
 		}
 		if len(revisions) == 0 {
 			// Remove all revisions.
-			revs, err := s.ListSecretRevisions(ctx, uri)
+			revs, err := s.listSecretRevisions(ctx, uri)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -115,4 +116,8 @@ func (s *SecretService) deleteSecret(
 	}
 
 	panic("implement me")
+}
+
+func (s *SecretService) listSecretRevisions(ctx context.Context, uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error) {
+	return nil, nil
 }

--- a/domain/secret/service/package_test.go
+++ b/domain/secret/service/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -18,8 +18,9 @@ type CreateSecretParams struct {
 
 	// One owner must be non-nil.
 
-	CharmOwner *CharmSecretOwner
-	ModelOwner *string
+	UnitOwner        *string
+	ApplicationOwner *string
+	ModelOwner       *string
 }
 
 // UpdateSecretParams are used to update a secret.
@@ -45,27 +46,30 @@ type SecretAccessParams struct {
 
 // ChangeSecretBackendParams are used to change the backend of a secret.
 type ChangeSecretBackendParams struct {
-	ValueRef *secrets.ValueRef
-	Data     secrets.SecretData
+	LeaderToken leadership.Token
+	ValueRef    *secrets.ValueRef
+	Data        secrets.SecretData
 }
 
 // SecretConsumer represents the consumer of a secret.
-// One of ApplicationName or UnitName must be non nil.
+// Exactly one of ApplicationName or UnitName must be non nil.
 type SecretConsumer struct {
 	ApplicationName *string
 	UnitName        *string
 }
 
 // SecretAccessor represents an entity that can access a secret.
-// One of ApplicationName, UnitName, or ModelUUID must be non nil.
+// Exactly one of ApplicationName, UnitName, or ModelUUID must be non nil.
 type SecretAccessor struct {
 	ApplicationName *string
 	UnitName        *string
 	ModelUUID       *string
 }
 
-// CharmSecretOwner represents the owner of a secret created by a charm.
-type CharmSecretOwner struct {
-	UnitName string
-	Leader   bool
+// CharmSecretOwners represents the owners of a secret created by a charm.
+// At least one owner is required to be non nil.
+// This is used to query or watch secrets for specified owners.
+type CharmSecretOwners struct {
+	UnitName        *string
+	ApplicationName *string
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -36,6 +36,12 @@ func NewSecretService(st State, logger Logger, adminConfigGetter BackendAdminCon
 // BackendAdminConfigGetter is a func used to get admin level secret backend config.
 type BackendAdminConfigGetter func(context.Context) (*provider.ModelBackendConfigInfo, error)
 
+// NotImplementedBackendConfigGetter is a not implemented secret backend getter.
+// TODO(secrets) - this is a placeholder
+var NotImplementedBackendConfigGetter = func(context.Context) (*provider.ModelBackendConfigInfo, error) {
+	return nil, errors.NotImplemented
+}
+
 // SecretService provides the API for working with secrets.
 type SecretService struct {
 	st                State
@@ -59,7 +65,7 @@ func (s *SecretService) CreateSecretURIs(ctx context.Context, count int) ([]*sec
 	return result, nil
 }
 func (s *SecretService) CreateSecret(ctx context.Context, uri *secrets.URI, params CreateSecretParams) (*secrets.SecretMetadata, error) {
-	panic("implement me")
+	return nil, errors.NotImplemented
 	/*
 		var nextRotateTime *time.Time
 		if params.RotatePolicy.WillRotate() {
@@ -70,7 +76,7 @@ func (s *SecretService) CreateSecret(ctx context.Context, uri *secrets.URI, para
 }
 
 func (s *SecretService) UpdateSecret(ctx context.Context, uri *secrets.URI, params UpdateSecretParams) (*secrets.SecretMetadata, error) {
-	panic("implement me")
+	return nil, errors.NotFound
 
 	// TODO(secrets)
 	/*
@@ -114,39 +120,59 @@ func (s *SecretService) UpdateSecret(ctx context.Context, uri *secrets.URI, para
 	//return md, nil
 }
 
-func (s *SecretService) GetSecretRevision(ctx context.Context, uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error) {
-	panic("implement me")
-}
-
-func (s *SecretService) ListSecretRevisions(ctx context.Context, uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error) {
-	panic("implement me")
-}
-
+// ListSecrets returns the secrets matching the specified terms.
+// If multiple values for a given term are specified, secrets matching any of the
+// values for that term are included.
 func (s *SecretService) ListSecrets(ctx context.Context, uri *secrets.URI,
 	revisions domainsecret.Revisions,
 	labels domainsecret.Labels, appOwners domainsecret.ApplicationOwners,
 	unitOwners domainsecret.UnitOwners, modelOwners domainsecret.ModelOwners,
 ) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
-	panic("implement me")
+	return nil, nil, nil
 }
 
-func (s *SecretService) ListCharmSecrets(ctx context.Context, owner CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
-	//TODO implement me
-	panic("implement me")
+// ListCharmSecrets returns the secret metadata and revision metadata for any secrets matching the specified owner.
+// The result contains secrets owned by any of the non nil owner attributes.
+// The count of secret and revisions in the result must match.
+func (s *SecretService) ListCharmSecrets(ctx context.Context, owner CharmSecretOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	// TODO(secrets)
+	return nil, nil, nil
 }
 
+// GetSecret returns the secret with the specified URI.
+// If returns [secreterrors.SecretNotFound] is there's no such secret.
 func (s *SecretService) GetSecret(ctx context.Context, uri *secrets.URI) (*secrets.SecretMetadata, error) {
-	panic("implement me")
+	return nil, errors.NotFound
 }
 
+// GetSecretRevision returns the secret revision for the specified URI.
+// If returns [secreterrors.SecretNotFound] is there's no such secret.
+// If returns [secreterrors.SecretRevisionNotFound] is there's no such secret revision.
+func (s *SecretService) GetSecretRevision(ctx context.Context, uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error) {
+	return nil, errors.NotFound
+}
+
+// GetUserSecretByLabel returns the user secret with the specified label.
+// If returns [secreterrors.SecretNotFound] is there's no such secret.
 func (s *SecretService) GetUserSecretByLabel(ctx context.Context, label string) (*secrets.SecretMetadata, error) {
-	panic("implement me")
+	return nil, errors.NotFound
 }
 
+// ListUserSecrets returns the secret metadata and revision metadata for any user secrets in the current model.
+// The count of secret and revisions in the result must match.
+func (s *SecretService) ListUserSecrets(ctx context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	// TODO(secrets)
+	return nil, nil, nil
+}
+
+// GetSecretValue returns the value of the specified secret revision.
+// If returns [secreterrors.SecretRevisionNotFound] is there's no such secret revision.
 func (s *SecretService) GetSecretValue(ctx context.Context, uri *secrets.URI, rev int) (secrets.SecretValue, *secrets.ValueRef, error) {
-	panic("implement me")
+	return nil, nil, errors.NotFound
 }
 
+// ChangeSecretBackend sets the secret backend where the specified secret revision is stored.
+// If returns [secreterrors.SecretRevisionNotFound] is there's no such secret revision.
 func (s *SecretService) ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params ChangeSecretBackendParams) error {
-	panic("implement me")
+	return nil
 }

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1,0 +1,201 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type serviceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&serviceSuite{})
+
+/*
+// TODO(secrets) - tests copied from facade which need to be re-implemented here
+func (s *serviceSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check().Return(nil)
+	s.expectGetAppOwnedOrUnitOwnedSecretMetadataNotFound()
+
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Label: "label"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *serviceSuite) TestGetSecretContentConsumerUpdateLabel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+	s.expectSecretAccessQuery(1)
+
+	s.expectGetAppOwnedOrUnitOwnedSecretMetadataNotFound()
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, names.NewUnitTag("mariadb/0")).Return(
+		&coresecrets.SecretConsumerMetadata{
+			Label:           "old-label",
+			CurrentRevision: 668,
+			LatestRevision:  668,
+		}, nil,
+	)
+	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(),
+		uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{
+			Label:           "new-label",
+			CurrentRevision: 668,
+			LatestRevision:  668,
+		}).Return(nil)
+
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Label: "new-label"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *serviceSuite) TestGetSecretContentConsumerFirstTimeUsingLabelFailed(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.expectGetAppOwnedOrUnitOwnedSecretMetadataNotFound()
+	s.secretsConsumer.EXPECT().GetURIByConsumerLabel(gomock.Any(), "label-1", names.NewUnitTag("mariadb/0")).Return(nil, errors.NotFoundf("secret"))
+
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{Label: "label-1"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `consumer label "label-1" not found`)
+}
+func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretSameLabel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+
+	s.expectSecretAccessQuery(1)
+
+	s.secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
+		UnitName:        ptr("mariadb/0"),
+		ApplicationName: ptr("mariadb"),
+	}).Return([]*coresecrets.SecretMetadata{
+		{
+			URI:            uri,
+			LatestRevision: 668,
+			Label:          "foo",
+			OwnerTag:       names.NewApplicationTag("mariadb").String(),
+		},
+	}, [][]*coresecrets.SecretRevisionMetadata{{
+		{
+			Revision: 668,
+		},
+	}}, nil)
+
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, s.authTag).
+		Return(nil, errors.NotFoundf("secret consumer"))
+	s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(&coresecrets.SecretMetadata{LatestRevision: 668}, nil)
+	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(),
+		uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{LatestRevision: 668, CurrentRevision: 668}).Return(nil)
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(context.Background(), params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Label: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	p := secretservice.UpdateSecretParams{
+		LeaderToken: s.token,
+		Label:       ptr("foobar"),
+	}
+	uri := coresecrets.NewURI()
+	expectURI := *uri
+	s.secretService.EXPECT().UpdateSecret(gomock.Any(), &expectURI, p).Return(
+		nil, fmt.Errorf("dup label %w", state.LabelExists),
+	)
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check().Return(nil)
+	s.secretService.EXPECT().GetSecret(context.Background(), uri).Return(&coresecrets.SecretMetadata{}, nil)
+	s.expectSecretAccessQuery(2)
+
+	results, err := s.facade.UpdateSecrets(context.Background(), params.UpdateSecretArgs{
+		Args: []params.UpdateSecretArg{{
+			URI: uri.String(),
+			UpsertSecretArg: params.UpsertSecretArg{
+				Label: ptr("foobar"),
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{
+			Error: &params.Error{Message: `secret with label "foobar" already exists`, Code: params.CodeAlreadyExists},
+		}},
+	})
+}
+func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	uri := coresecrets.NewURI()
+	s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(&coresecrets.SecretMetadata{
+		OwnerTag:       "application-mariadb",
+		RotatePolicy:   coresecrets.RotateNever,
+		LatestRevision: 667,
+	}, nil)
+
+	result, err := s.facade.SecretsRotated(context.Background(), params.SecretRotatedArgs{
+		Args: []params.SecretRotatedArg{{
+			URI:              uri.ID,
+			OriginalRevision: 666,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+*/


### PR DESCRIPTION
Recently a skeleton secret service was added. The yet to be implemented methods paniced. This caused issue with some workers. So the panics are replaced with nil returns etc.

Also, an empty test file was added with a bunch of stuff copied across from the facade commented out - this will be implemented later.

This is all in progress work - secrets will be broken until completed.

Driveby - remove obsolete test methods in uniter facade

## QA steps

bootstrap and check logs for panics

## Links

**Jira card:** JUJU-5795

