### PR TITLE
Add missing methods UpdateSpace and GetAllSubnets to network domain service

### DIFF
--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -49,28 +49,45 @@ func (s *SpaceService) AddSpace(ctx context.Context, name string, providerID net
 	return network.Id(uuid.String()), nil
 }
 
+// UpdateSpace updates the space name identified by the passed uuid.
+func (s *SpaceService) UpdateSpace(ctx context.Context, uuid string, name string) error {
+	return errors.Trace(s.st.UpdateSpace(ctx, uuid, name))
+}
+
 // Space returns a space from state that matches the input ID.
 // An error is returned if the space does not exist or if there was a problem
 // accessing its information.
 func (s *SpaceService) Space(ctx context.Context, uuid string) (*network.SpaceInfo, error) {
-	return s.st.GetSpace(ctx, uuid)
+	sp, err := s.st.GetSpace(ctx, uuid)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return sp, nil
 }
 
 // SpaceByName returns a space from state that matches the input name.
 // An error is returned that satisfied errors.NotFound if the space was not found
 // or an error static any problems fetching the given space.
 func (s *SpaceService) SpaceByName(ctx context.Context, name string) (*network.SpaceInfo, error) {
-	return s.st.GetSpaceByName(ctx, name)
+	sp, err := s.st.GetSpaceByName(ctx, name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return sp, nil
 }
 
 // GetAllSpaces returns all spaces for the model.
 func (s *SpaceService) GetAllSpaces(ctx context.Context) (network.SpaceInfos, error) {
-	return s.st.GetAllSpaces(ctx)
+	spaces, err := s.st.GetAllSpaces(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return spaces, nil
 }
 
 // Remove deletes a space identified by its uuid.
 func (s *SpaceService) Remove(ctx context.Context, uuid string) error {
-	return s.st.DeleteSpace(ctx, uuid)
+	return errors.Trace(s.st.DeleteSpace(ctx, uuid))
 }
 
 // SaveProviderSubnets loads subnets into state.

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -95,6 +95,15 @@ func (s *spaceSuite) TestAddSpace(c *gc.C) {
 	c.Assert(returnedUUID.String(), gc.Equals, expectedUUID)
 }
 
+func (s *spaceSuite) TestUpdateSpaceName(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	newName := "new-space-name"
+	s.st.EXPECT().UpdateSpace(gomock.Any(), network.AlphaSpaceId, newName).Return(nil)
+	err := NewSpaceService(s.st, s.logger).UpdateSpace(context.Background(), network.AlphaSpaceId, newName)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *spaceSuite) TestRetrieveSpaceByID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/network/service/subnet.go
+++ b/domain/network/service/subnet.go
@@ -41,6 +41,12 @@ func (s *SubnetService) AddSubnet(ctx context.Context, args network.SubnetInfo) 
 	return args.ID, nil
 }
 
+// GetAllSubnets returns all the subnets for the model.
+func (s *SubnetService) GetAllSubnets(ctx context.Context) (network.SubnetInfos, error) {
+	allSubnets, err := s.st.GetAllSubnets(ctx)
+	return allSubnets, errors.Trace(err)
+}
+
 // Subnet returns the subnet identified by the input UUID,
 // or an error if it is not found.
 func (s *SubnetService) Subnet(ctx context.Context, uuid string) (*network.SubnetInfo, error) {

--- a/domain/network/service/subnet_test.go
+++ b/domain/network/service/subnet_test.go
@@ -91,6 +91,23 @@ func (s *subnetSuite) TestAddSubnet(c *gc.C) {
 	c.Assert(returnedUUID, gc.Equals, expectedUUID)
 }
 
+func (s *subnetSuite) TestRetrieveAllSubnets(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subnetInfos := network.SubnetInfos{
+		{
+			CIDR:              "192.168.0.0/20",
+			ProviderId:        "provider-id-0",
+			ProviderNetworkId: "provider-network-id-0",
+			AvailabilityZones: []string{"az0"},
+		},
+	}
+	s.st.EXPECT().GetAllSubnets(gomock.Any()).Return(subnetInfos, nil)
+	subnets, err := NewSubnetService(s.st).GetAllSubnets(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnets, jc.SameContents, subnetInfos)
+}
+
 func (s *subnetSuite) TestRetrieveSubnetByID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
This small patch adds the two missing methods to the service layer. These methods were already implemented in the state layer, thus the only changes are on the service layer, and tests added.

Bonus: Trace errors on places where we missing them on the service layer.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Only new methods were added (still unused), so bootstrap and deploy should work as usual and unit tests should pass:

```
juju bootstrap localhost c
juju add-model m
juju deploy ubuntu
```

## Links


**Jira card:** JUJU-5759

