### PR TITLE
Fix subnet retrieval on space when empty subnets

### DIFF
--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -371,6 +371,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.ID, gc.Equals, spaceUUID.String())
 	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
+	c.Check(sp.Subnets, gc.IsNil)
 }
 
 func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {


### PR DESCRIPTION
When a space has no subnets, then the subnets field of the space struct is filled with one empty subnet (every field included the ID is empty, only the spaceName is set to the correct space). This is wrong, and it happens because of how we construct the space struct when we fetch no subnets in the method `ToSpaceInfos()`.

This patch fixes this and adds one check to the tests.

_Note: this was identified when wiring up the apiserver using the network domain in (WIP) https://github.com/juju/juju/pull/17126._


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Bootstrap and deploy:
```
juju bootstrap localhost c
juju add-model m
juju deploy ubuntu
```
And the tests:
```
TEST_PACKAGES="./domain/network/... -count=1 -race -check.vv" make run-go-tests
```

## Links


**Jira card:** JUJU-5759

