### PR TITLE
Implement access/state ReadAllAccessForUserAndObjectType and introduce v_permission

### DIFF
--- a/domain/access/service/permission.go
+++ b/domain/access/service/permission.go
@@ -107,18 +107,18 @@ func (s *PermissionService) ReadAllUserAccessForUser(ctx context.Context, subjec
 }
 
 // ReadAllAccessTypeForUser return a slice of user access for the user
-// specified and of the given access type. A NotValid error is returned if
+// specified and of the given object type. A NotValid error is returned if
 // the given access type does not exist, or the subject (user) is an empty
 // string.
 // E.G. All clouds the user has access to.
-func (s *PermissionService) ReadAllAccessTypeForUser(ctx context.Context, subject string, accessType corepermission.ObjectType) ([]corepermission.UserAccess, error) {
+func (s *PermissionService) ReadAllAccessForUserAndObjectType(ctx context.Context, subject string, objectType corepermission.ObjectType) ([]corepermission.UserAccess, error) {
 	if subject == "" {
 		return nil, errors.Trace(errors.NotValidf("empty subject"))
 	}
-	if err := accessType.Validate(); err != nil {
+	if err := objectType.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	userAccess, err := s.st.ReadAllAccessTypeForUser(ctx, subject, accessType)
+	userAccess, err := s.st.ReadAllAccessForUserAndObjectType(ctx, subject, objectType)
 	return userAccess, errors.Trace(err)
 }
 

--- a/domain/access/service/permission_test.go
+++ b/domain/access/service/permission_test.go
@@ -195,3 +195,24 @@ func (s *serviceSuite) TestReadAllUserAccessForUser(c *gc.C) {
 		"testme")
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *serviceSuite) TestReadAllAccessForUserAndObjectType(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.state.EXPECT().ReadAllAccessForUserAndObjectType(gomock.Any(), "testme", corepermission.Cloud).Return(nil, nil)
+
+	_, err := NewPermissionService(s.state).ReadAllAccessForUserAndObjectType(
+		context.Background(),
+		"testme",
+		corepermission.Cloud)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestReadAllAccessForUserAndObjectTypeError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := NewPermissionService(s.state).ReadAllAccessForUserAndObjectType(
+		context.Background(),
+		"testme",
+		"failme")
+	c.Assert(err, jc.ErrorIs, errors.NotValid, gc.Commentf("%+v", err))
+}

--- a/domain/access/service/service.go
+++ b/domain/access/service/service.go
@@ -159,9 +159,9 @@ type PermissionState interface {
 	ReadAllUserAccessForTarget(ctx context.Context, target permission.ID) ([]permission.UserAccess, error)
 
 	// ReadAllAccessTypeForUser return a slice of user access for the subject
-	// (user) specified and of the given access type.
+	// (user) specified and of the given object type.
 	// E.G. All clouds the user has access to.
-	ReadAllAccessTypeForUser(ctx context.Context, subject string, accessType permission.ObjectType) ([]permission.UserAccess, error)
+	ReadAllAccessForUserAndObjectType(ctx context.Context, subject string, objectType permission.ObjectType) ([]permission.UserAccess, error)
 }
 
 // Service provides the API for working with users.

--- a/domain/access/service/state_mock_test.go
+++ b/domain/access/service/state_mock_test.go
@@ -218,19 +218,19 @@ func (mr *MockStateMockRecorder) GetUserByName(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByName", reflect.TypeOf((*MockState)(nil).GetUserByName), arg0, arg1)
 }
 
-// ReadAllAccessTypeForUser mocks base method.
-func (m *MockState) ReadAllAccessTypeForUser(arg0 context.Context, arg1 string, arg2 permission.ObjectType) ([]permission.UserAccess, error) {
+// ReadAllAccessForUserAndObjectType mocks base method.
+func (m *MockState) ReadAllAccessForUserAndObjectType(arg0 context.Context, arg1 string, arg2 permission.ObjectType) ([]permission.UserAccess, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAllAccessTypeForUser", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ReadAllAccessForUserAndObjectType", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]permission.UserAccess)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadAllAccessTypeForUser indicates an expected call of ReadAllAccessTypeForUser.
-func (mr *MockStateMockRecorder) ReadAllAccessTypeForUser(arg0, arg1, arg2 any) *gomock.Call {
+// ReadAllAccessForUserAndObjectType indicates an expected call of ReadAllAccessForUserAndObjectType.
+func (mr *MockStateMockRecorder) ReadAllAccessForUserAndObjectType(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAllAccessTypeForUser", reflect.TypeOf((*MockState)(nil).ReadAllAccessTypeForUser), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAllAccessForUserAndObjectType", reflect.TypeOf((*MockState)(nil).ReadAllAccessForUserAndObjectType), arg0, arg1, arg2)
 }
 
 // ReadAllUserAccessForTarget mocks base method.
@@ -639,19 +639,19 @@ func (mr *MockPermissionStateMockRecorder) DeletePermission(arg0, arg1, arg2 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePermission", reflect.TypeOf((*MockPermissionState)(nil).DeletePermission), arg0, arg1, arg2)
 }
 
-// ReadAllAccessTypeForUser mocks base method.
-func (m *MockPermissionState) ReadAllAccessTypeForUser(arg0 context.Context, arg1 string, arg2 permission.ObjectType) ([]permission.UserAccess, error) {
+// ReadAllAccessForUserAndObjectType mocks base method.
+func (m *MockPermissionState) ReadAllAccessForUserAndObjectType(arg0 context.Context, arg1 string, arg2 permission.ObjectType) ([]permission.UserAccess, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAllAccessTypeForUser", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ReadAllAccessForUserAndObjectType", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]permission.UserAccess)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadAllAccessTypeForUser indicates an expected call of ReadAllAccessTypeForUser.
-func (mr *MockPermissionStateMockRecorder) ReadAllAccessTypeForUser(arg0, arg1, arg2 any) *gomock.Call {
+// ReadAllAccessForUserAndObjectType indicates an expected call of ReadAllAccessForUserAndObjectType.
+func (mr *MockPermissionStateMockRecorder) ReadAllAccessForUserAndObjectType(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAllAccessTypeForUser", reflect.TypeOf((*MockPermissionState)(nil).ReadAllAccessTypeForUser), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAllAccessForUserAndObjectType", reflect.TypeOf((*MockPermissionState)(nil).ReadAllAccessForUserAndObjectType), arg0, arg1, arg2)
 }
 
 // ReadAllUserAccessForTarget mocks base method.

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
 	corepermission "github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/user"
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -22,18 +22,25 @@ import (
 
 type permissionStateSuite struct {
 	schematesting.ControllerSuite
+
+	debug bool
 }
 
 var _ = gc.Suite(&permissionStateSuite{})
 
-func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
-	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user bob on the model
-	s.ensureModel(c, "model-uuid")
+func (s *permissionStateSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
 	s.ensureUser(c, "42", "admin", "42") // model owner
 	s.ensureUser(c, "123", "bob", "42")
+	s.ensureUser(c, "456", "sue", "42")
 	s.ensureCloud(c, "987", "test-cloud")
+	s.ensureCloud(c, "654", "another-cloud")
+	s.ensureModel(c, "default-model")
+	s.ensureModel(c, "model-uuid")
+}
+
+func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
 	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
@@ -61,12 +68,6 @@ func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
 func (s *permissionStateSuite) TestCreatePermissionCloud(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user bob on the model
-	s.ensureModel(c, "model-uuid")
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-	s.ensureCloud(c, "987", "test-cloud")
-
 	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
@@ -92,10 +93,6 @@ func (s *permissionStateSuite) TestCreatePermissionCloud(c *gc.C) {
 
 func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
 
 	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
@@ -123,10 +120,6 @@ func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 func (s *permissionStateSuite) TestCreatePermissionForModelWithBadInfo(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user Bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
@@ -142,10 +135,6 @@ func (s *permissionStateSuite) TestCreatePermissionForModelWithBadInfo(c *gc.C) 
 
 func (s *permissionStateSuite) TestCreatePermissionForControllerWithBadInfo(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user Bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
 
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
@@ -175,7 +164,7 @@ WHERE type = ?
 
 	// Find the permission
 	row := db.QueryRow(`
-SELECT uuid, permission_type_id, grant_to, grant_on 
+SELECT uuid, permission_type_id, grant_to, grant_on
 FROM permission
 `)
 	c.Assert(row.Err(), jc.ErrorIsNil)
@@ -196,7 +185,7 @@ FROM permission
 func (s *permissionStateSuite) TestCreatePermissionErrorNoUser(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
-		User: "bob",
+		User: "testme",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
 				Key:        "model-uuid",
@@ -210,11 +199,6 @@ func (s *permissionStateSuite) TestCreatePermissionErrorNoUser(c *gc.C) {
 
 func (s *permissionStateSuite) TestCreatePermissionErrorDuplicate(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user bob on the model
-	s.ensureModel(c, "model-uuid")
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
 
 	spec := corepermission.UserAccessSpec{
 		User: "bob",
@@ -262,11 +246,6 @@ WHERE permission_type_id = 1
 func (s *permissionStateSuite) TestDeletePermission(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user bob on the model
-	s.ensureModel(c, "model-uuid")
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-
 	target := corepermission.ID{
 		Key:        "model-uuid",
 		ObjectType: corepermission.Model,
@@ -299,17 +278,12 @@ func (s *permissionStateSuite) TestDeletePermissionFailUserNotFound(c *gc.C) {
 		Key:        "model-uuid",
 		ObjectType: corepermission.Model,
 	}
-	err := st.DeletePermission(context.Background(), "bob", target)
+	err := st.DeletePermission(context.Background(), "testme", target)
 	c.Assert(err, jc.ErrorIs, accesserrors.UserNotFound)
 }
 
 func (s *permissionStateSuite) TestDeletePermissionDoesNotExist(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user bob on the model
-	s.ensureModel(c, "model-uuid")
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
 
 	target := corepermission.ID{
 		Key:        "model-uuid",
@@ -323,10 +297,6 @@ func (s *permissionStateSuite) TestDeletePermissionDoesNotExist(c *gc.C) {
 
 func (s *permissionStateSuite) TestReadUserAccessForTarget(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
-
-	// Setup to add permissions for user bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
 
 	target := corepermission.ID{
 		Key:        "controller",
@@ -365,11 +335,6 @@ WHERE grant_to = 123
 func (s *permissionStateSuite) TestReadUserAccessLevelForTarget(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-	s.ensureCloud(c, "987", "test-cloud")
-
 	target := corepermission.ID{
 		Key:        "test-cloud",
 		ObjectType: corepermission.Cloud,
@@ -392,17 +357,15 @@ func (s *permissionStateSuite) TestReadUserAccessLevelForTarget(c *gc.C) {
 func (s *permissionStateSuite) TestReadAllUserAccessForUser(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	modelUUID := utils.MustNewUUID().String()
-	_ = s.twoUsersACloudAndAModel(c, st, modelUUID)
+	s.setupForRead(c, st)
 
 	userAccesses, err := st.ReadAllUserAccessForUser(context.Background(), "bob")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(userAccesses, gc.HasLen, 2)
+	c.Assert(userAccesses, gc.HasLen, 4)
 	for _, access := range userAccesses {
 		c.Assert(access.UserName, gc.Equals, "bob")
 		c.Assert(access.CreatedBy.Id(), gc.Equals, "admin")
-
 	}
 	accessOne := userAccesses[0]
 	c.Assert(accessOne.Access, gc.Equals, corepermission.AddModelAccess)
@@ -411,9 +374,11 @@ func (s *permissionStateSuite) TestReadAllUserAccessForUser(c *gc.C) {
 func (s *permissionStateSuite) TestReadAllUserAccessForTarget(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	modelUUID := utils.MustNewUUID().String()
-	targetCloud := s.twoUsersACloudAndAModel(c, st, modelUUID)
-
+	s.setupForRead(c, st)
+	targetCloud := corepermission.ID{
+		Key:        "test-cloud",
+		ObjectType: corepermission.Cloud,
+	}
 	userAccesses, err := st.ReadAllUserAccessForTarget(context.Background(), targetCloud)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -428,43 +393,14 @@ func (s *permissionStateSuite) TestReadAllUserAccessForTarget(c *gc.C) {
 	c.Check(accessZero.UserID, gc.Not(gc.Equals), accessOne.UserID)
 }
 
-func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectType(c *gc.C) {
-	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectTypeCloud(c *gc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-	s.ensureCloud(c, "987", "test-cloud")
-	s.ensureCloud(c, "654", "another-cloud")
-
-	target := corepermission.ID{
-		Key:        "test-cloud",
-		ObjectType: corepermission.Cloud,
-	}
-	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
-		User: "bob",
-		AccessSpec: corepermission.AccessSpec{
-			Target: target,
-			Access: corepermission.AddModelAccess,
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	anotherTarget := corepermission.ID{
-		Key:        "another-cloud",
-		ObjectType: corepermission.Cloud,
-	}
-	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
-		User: "bob",
-		AccessSpec: corepermission.AccessSpec{
-			Target: anotherTarget,
-			Access: corepermission.AddModelAccess,
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
+	s.setupForRead(c, st)
 
 	users, err := st.ReadAllAccessForUserAndObjectType(context.Background(), "bob", corepermission.Cloud)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(users, gc.HasLen, 2)
+	c.Assert(users, gc.HasLen, 2)
 
 	var foundTestCloud, foundAnotherCloud bool
 	for _, userAccess := range users {
@@ -480,31 +416,117 @@ func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectType(c *gc.C) {
 			foundAnotherCloud = true
 		}
 	}
+	c.Check(foundTestCloud && foundAnotherCloud, jc.IsTrue, gc.Commentf("%+v", users))
+}
 
-	c.Check(foundTestCloud && foundAnotherCloud, jc.IsTrue)
+func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectTypeModel(c *gc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	s.setupForRead(c, st)
+
+	users, err := st.ReadAllAccessForUserAndObjectType(context.Background(), "bob", corepermission.Model)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(users, gc.HasLen, 2)
+
+	var admin, write bool
+	for _, userAccess := range users {
+		c.Check(userAccess.UserTag.Id(), gc.Equals, "bob")
+		c.Check(userAccess.UserName, gc.Equals, "bob")
+		c.Check(userAccess.CreatedBy.Id(), gc.Equals, "admin")
+		c.Check(userAccess.UserID, gc.Equals, "123")
+		if userAccess.Access == corepermission.WriteAccess {
+			write = true
+			c.Check(userAccess.Object.Id(), gc.Equals, "default-model")
+		}
+		if userAccess.Access == corepermission.AdminAccess {
+			admin = true
+			c.Check(userAccess.Object.Id(), gc.Equals, "model-uuid")
+		}
+	}
+	c.Assert(admin && write, jc.IsTrue, gc.Commentf("%+v", users))
+}
+
+func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectTypeController(c *gc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
+
+	s.setupForRead(c, st)
+
+	users, err := st.ReadAllAccessForUserAndObjectType(context.Background(), "admin", corepermission.Controller)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(users, gc.HasLen, 1)
+	userAccess := users[0]
+	c.Check(userAccess.UserTag.Id(), gc.Equals, "admin", gc.Commentf("%+v", users))
+	c.Check(userAccess.UserName, gc.Equals, "admin", gc.Commentf("%+v", users))
+	c.Check(userAccess.CreatedBy.Id(), gc.Equals, "admin", gc.Commentf("%+v", users))
+	c.Check(userAccess.UserID, gc.Equals, "42", gc.Commentf("%+v", users))
+	c.Check(userAccess.Access, gc.Equals, corepermission.SuperuserAccess, gc.Commentf("%+v", users))
+}
+
+func (s *permissionStateSuite) printPermissions(c *gc.C) {
+	rows, _ := s.DB().Query(`
+SELECT uuid, permission_type_id, grant_to, grant_on 
+FROM permission
+--WHERE grant_to = "bob"
+`)
+	defer func() { _ = rows.Close() }()
+	var (
+		userUuid, grantTo, grantOn string
+		permissionTypeId           int
+	)
+
+	for rows.Next() {
+		err := rows.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("%q, %d, %q, %q", userUuid, permissionTypeId, grantTo, grantOn)
+	}
+
+}
+
+func (s *permissionStateSuite) printUsers(c *gc.C) {
+	rows, _ := s.DB().Query(`
+SELECT uuid, name, created_by_uuid
+FROM user
+`)
+	defer func() { _ = rows.Close() }()
+	var (
+		rowUUID, name string
+		creatorUUID   user.UUID
+	)
+
+	for rows.Next() {
+		err := rows.Scan(&rowUUID, &name, &creatorUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("%q, %q, %q", rowUUID, name, creatorUUID)
+	}
+
+}
+
+func (s *permissionStateSuite) printClouds(c *gc.C) {
+	rows, _ := s.DB().Query(`
+SELECT uuid, name
+FROM cloud
+`)
+	defer func() { _ = rows.Close() }()
+	var (
+		rowUUID, name string
+	)
+
+	for rows.Next() {
+		err := rows.Scan(&rowUUID, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("%q, %q", rowUUID, name)
+	}
+
 }
 
 func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectTypeNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	// Setup to add permissions for user bob on the model
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "123", "bob", "42")
-	s.ensureCloud(c, "987", "test-cloud")
-	s.ensureCloud(c, "654", "another-cloud")
-
 	_, err := st.ReadAllAccessForUserAndObjectType(context.Background(), "bob", corepermission.Cloud)
 	c.Assert(err, jc.ErrorIs, accesserrors.PermissionNotFound)
 }
 
-func (s *permissionStateSuite) twoUsersACloudAndAModel(c *gc.C, st *PermissionState, modelUUID string) corepermission.ID {
-	// Setup to add permissions for user bob and sue on the model and a cloud
-	s.ensureUser(c, "42", "admin", "42") // model owner
-	s.ensureUser(c, "456", "sue", "42")
-	s.ensureUser(c, "123", "bob", "42")
-	s.ensureCloud(c, "987", "test-cloud")
-	s.ensureModel(c, modelUUID)
-
+func (s *permissionStateSuite) setupForRead(c *gc.C, st *PermissionState) {
 	targetCloud := corepermission.ID{
 		Key:        "test-cloud",
 		ObjectType: corepermission.Cloud,
@@ -525,27 +547,71 @@ func (s *permissionStateSuite) twoUsersACloudAndAModel(c *gc.C, st *PermissionSt
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	targetModel := corepermission.ID{
-		Key:        modelUUID,
-		ObjectType: corepermission.Model,
-	}
 	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
-			Target: targetModel,
+			Target: corepermission.ID{
+				Key:        "model-uuid",
+				ObjectType: corepermission.Model,
+			},
 			Access: corepermission.AdminAccess,
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return targetCloud
+	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: "bob",
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "another-cloud",
+				ObjectType: corepermission.Cloud,
+			},
+			Access: corepermission.AddModelAccess,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: "bob",
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "default-model",
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.WriteAccess,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: "admin",
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        "controller",
+				ObjectType: corepermission.Controller,
+			},
+			Access: corepermission.SuperuserAccess,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	if s.debug {
+		s.printUsers(c)
+		s.printClouds(c)
+		s.printPermissions(c)
+	}
 }
 
-func (s *permissionStateSuite) ensureUser(c *gc.C, uuid, name, createdByUUID string) {
+func (s *permissionStateSuite) ensureUser(c *gc.C, userUUID, name, createdByUUID string) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 			INSERT INTO user (uuid, name, display_name, removed, created_by_uuid, created_at)
 			VALUES (?, ?, ?, ?, ?, ?)
-		`, uuid, name, name, false, createdByUUID, time.Now())
+		`, userUUID, name, name, false, createdByUUID, time.Now())
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO user_authentication ( user_uuid, disabled)
+			VALUES (?, ?)
+		`, userUUID, false)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -716,6 +716,14 @@ INSERT INTO permission_access_type VALUES
     (5, 'add-model'),
     (6, 'superuser');
 
+CREATE VIEW v_permission AS
+SELECT at.type AS access_type,
+       p.uuid AS uuid,
+       p.grant_on AS grant_on,
+       p.grant_to AS grant_to
+FROM   permission p
+       JOIN permission_access_type at ON at.id = p.permission_type_id;
+
 CREATE TABLE permission_object_type (
     id    INT PRIMARY KEY,
     type  TEXT NOT NULL

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -196,6 +196,9 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 
 		// Secret backends
 		"v_model_secret_backend",
+
+		// Permissions
+		"v_permission",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -185,19 +185,10 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 
 	// Ensure that each view is present.
 	expected := set.NewStrings(
-		// Users
 		"v_user_auth",
-
-		// Credentials
 		"v_cloud_credential",
-
-		// Models
 		"v_model",
-
-		// Secret backends
 		"v_model_secret_backend",
-
-		// Permissions
 		"v_permission",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())


### PR DESCRIPTION
Implement ReadAllAccessForUserAndObjectType after renaming it. A follow on to #17069.

Create a new permission view: v_permission to simplify gathering data used in the dbPermissionUser struct when reading permissions. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

New unit tests work and already existing unit tests continue to work. 

Bootstrap and deploy an application.

## Links

JUJU-5696
part of JUJU-5793

