### PR TITLE
Unblock model migration

### DIFF
--- a/apiserver/facades/agent/upgradesteps/register.go
+++ b/apiserver/facades/agent/upgradesteps/register.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 
@@ -15,6 +17,18 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("UpgradeSteps", 3, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
 		return newFacadeV3(ctx)
 	}, reflect.TypeOf((*UpgradeStepsAPI)(nil)))
+	registry.MustRegister("UpgradeSteps", 2, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		return newFacadeV2(ctx)
+	}, reflect.TypeOf((*UpgradeStepsAPIV2)(nil)))
+}
+
+// newFacadeV2 is used for API registration.
+func newFacadeV2(ctx facade.ModelContext) (*UpgradeStepsAPIV2, error) {
+	api, err := newFacadeV3(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &UpgradeStepsAPIV2{UpgradeStepsAPI: api}, nil
 }
 
 // newFacadeV3 is used for API registration.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -45553,7 +45553,7 @@
     },
     {
         "Name": "UpgradeSteps",
-        "Description": "UpgradeStepsAPI implements version 2 of the Upgrade Steps API,\nwhich adds WriteUniterState.",
+        "Description": "UpgradeStepsAPI implements version 3 of the Upgrade Steps API,\nwhich adds WriteUniterState.",
         "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",


### PR DESCRIPTION
Restore upgrade steps v2 facade

Model migration from 3.5 to 4.0 is broken because in a previous PR we bumped the version of the UpgradeSteps facade
The only change between v2 -> v3 was a KVM method was dropped because kvm container type is not supported in 4.0
Restore this method, to a no-op for non-KVM containers, and return an error for kvm container types

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Download a local charm with
```
$ juju download ubuntu
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

### Model migrations

Repeat the following steps bootstrapping controllers:
1) `lxd-src` from this PR; `lxd-dst` from this PR
2) `lxd-src` from 3.5; `lxd-dst` from this PR

```
$ juju add-model m
$ juju deploy ./ubuntu_r24.charm ubu-local
$ juju deploy ubuntu ubu-ch
$ juju status
 Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta3.1  15:08:57+01:00

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst
Migration started with ID "355633ec-fc28-47a0-8a86-ae3dcd975167:0"

$ juju status
ERROR Model "admin/m" has been migrated to controller "lxd-dst".
To access it run 'juju switch lxd-dst:admin/m'.

$ juju switch lxd-dst:m
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta3.1  15:10:10+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju add-unit ubu-local
$ juju add-unit ubu-ch
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta3.1  15:34:30+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch              active      2  ubuntu  latest/stable   24  no       
ubu-local           active      2  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-ch/1      active    idle   2        10.219.211.3           
ubu-local/0*  active    idle   1        10.219.211.111         
ubu-local/1   active    idle   3        10.219.211.40          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running
2        started  10.219.211.3    juju-975167-2  ubuntu@22.04      Running
3        started  10.219.211.40   juju-975167-3  ubuntu@22.04      Running
```