### PR TITLE
Support minikube env folder on juju snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,8 @@ apps:
       - dot-google
       - dot-kubernetes
       - dot-maas
+      - dot-minikube-cacrt
+      - dot-minikube-profiles
       - dot-openstack
       - dot-oracle
       # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
@@ -524,6 +526,16 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.maasrc
+        
+  dot-minikube-cacrt:
+    interface: personal-files
+    read:
+      - $HOME/.minikube/ca.crt
+        
+  dot-minikube-profiles:
+    interface: personal-files
+    read:
+      - $HOME/.minikube/profiles
 
   dot-oracle:
     interface: personal-files


### PR DESCRIPTION
Adds dot-minikube-cacrt and dot-minikube-profiles plug to support minikube env folder in the home directory by default.

_Note: The snapcraft team has approved the request for autoconnect on these plugs: https://forum.snapcraft.io/t/auto-connect-request-for-juju/38717/8, so the jenkins jobs for snap upload should not fail this time :crossed_fingers: _

## Checklist
- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2051154

**Jira card:** JUJU-5800

