### PR TITLE
cancelable API calls

### DIFF
--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -6,6 +6,7 @@ package watcher
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
@@ -23,6 +24,11 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.api.watcher")
+
+const (
+	// WatcherStopTimeout is the time to wait for a watcher to stop.
+	WatcherStopTimeout = time.Second * 60
+)
 
 // commonWatcher implements common watcher logic in one place to
 // reduce code duplication, but it's not in fact a complete watcher;
@@ -46,14 +52,14 @@ type commonWatcher struct {
 // watcherAPICall wraps up the information about what facade and what watcher
 // Id we are calling, and just gives us a simple way to call a common method
 // with a given return value.
-type watcherAPICall func(method string, result interface{}) error
+type watcherAPICall func(ctx context.Context, method string, result interface{}) error
 
 // makeWatcherAPICaller creates a watcherAPICall function for a given facade name
 // and watcherId.
 func makeWatcherAPICaller(caller base.APICaller, facadeName, watcherId string) watcherAPICall {
 	bestVersion := caller.BestFacadeVersion(facadeName)
-	return func(request string, result interface{}) error {
-		return caller.APICall(context.TODO(), facadeName, bestVersion,
+	return func(ctx context.Context, request string, result interface{}) error {
+		return caller.APICall(ctx, facadeName, bestVersion,
 			watcherId, request, nil, &result)
 	}
 }
@@ -76,6 +82,10 @@ func (w *commonWatcher) init() {
 // tomb when an error occurs.
 func (w *commonWatcher) commonLoop() {
 	defer close(w.in)
+
+	ctx, cancel := context.WithCancel(w.tomb.Context(context.Background()))
+	defer cancel()
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -88,15 +98,36 @@ func (w *commonWatcher) commonLoop() {
 		// the watcher will die with all resources cleaned up.
 		defer wg.Done()
 		<-w.tomb.Dying()
-		if err := w.call("Stop", nil); err != nil {
-			// Don't log an error if a watcher is stopped due to an agent restart,
-			// or if the entity being watched is already removed.
-			if !isAgentRestartError(err) &&
-				err.Error() != rpc.ErrShutdown.Error() && !params.IsCodeNotFound(err) {
-				logger.Errorf("error trying to stop watcher: %v", err)
-			}
+
+		// Give a reasonable amount of time for the watcher to stop. If it
+		// doesn't stop in time, log the error and return.
+		ctx, cancel := context.WithTimeout(context.Background(), WatcherStopTimeout)
+		defer cancel()
+
+		// We need to stop the watcher before returning, so that the
+		// server can clean up resources.
+		err := w.call(ctx, "Stop", nil)
+		if err == nil {
+			return
+		}
+
+		// If the deadline is exceeded whilst attempting to stop the watcher,
+		// give up and log the error as debug. This is indicative of a bad
+		// watcher, one that is not responding to the stop request.
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Debugf("timeout stopping watcher: %v", err)
+			return
+		}
+
+		// Don't log an error if a watcher is stopped due to an agent restart,
+		// or if the entity being watched is already removed.
+		if !isAgentRestartError(err) &&
+			err.Error() != rpc.ErrShutdown.Error() && !params.IsCodeNotFound(err) {
+			logger.Errorf("error trying to stop watcher: %v", err)
+			return
 		}
 	}()
+
 	wg.Add(1)
 	go func() {
 		// Because Next blocks until there are changes, we need to
@@ -105,9 +136,11 @@ func (w *commonWatcher) commonLoop() {
 		defer wg.Done()
 		for {
 			result := w.newResult()
-			err := w.call("Next", &result)
+			err := w.call(ctx, "Next", &result)
 			if err != nil {
-				if params.IsCodeStopped(err) || params.IsCodeNotFound(err) {
+				// If the call was canceled, stopped or not found, and the
+				// watcher is not alive, report it as a dying error.
+				if params.IsCodeStopped(err) || params.IsCodeNotFound(err) || errors.Is(err, context.Canceled) {
 					if w.tomb.Err() != tomb.ErrStillAlive {
 						// The watcher has been stopped at the client end, so we're
 						// expecting one of the above two kinds of error.

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -83,9 +83,6 @@ func (w *commonWatcher) init() {
 func (w *commonWatcher) commonLoop() {
 	defer close(w.in)
 
-	ctx, cancel := context.WithCancel(w.tomb.Context(context.Background()))
-	defer cancel()
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -127,6 +124,9 @@ func (w *commonWatcher) commonLoop() {
 			return
 		}
 	}()
+
+	ctx, cancel := context.WithCancel(w.tomb.Context(context.Background()))
+	defer cancel()
 
 	wg.Add(1)
 	go func() {

--- a/internal/rpcreflect/value.go
+++ b/internal/rpcreflect/value.go
@@ -106,9 +106,6 @@ func (v Value) Kill() {
 // Call implements MethodCaller.Call, which calls the method on the
 // root value and then calls the method on the object value.
 func (caller methodCaller) Call(ctx context.Context, objId string, arg reflect.Value) (reflect.Value, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	obj, err := caller.rootMethod.Call(caller.rootValue, objId)
 	if err != nil {
 		return reflect.Value{}, err

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -212,6 +212,11 @@ func (conn *Conn) Call(ctx context.Context, req Request, params, response interf
 		TraceFlags: traceFlags,
 	}
 	reqID := conn.send(call)
+	if reqID == 0 {
+		// If the request ID is 0, the connection is shutting down or has
+		// already shut down, then return the ErrShutdown error.
+		return ErrShutdown
+	}
 
 	select {
 	case <-ctx.Done():

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -854,7 +854,6 @@ func (*rpcSuite) TestTransformErrors(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "transformed: no error methods",
 	})
-
 }
 
 func (*rpcSuite) TestServerWaitsForOutstandingCalls(c *gc.C) {
@@ -886,6 +885,42 @@ func (*rpcSuite) TestServerWaitsForOutstandingCalls(c *gc.C) {
 	case <-time.After(25 * time.Millisecond):
 	}
 	start <- "xxx"
+}
+
+func (*rpcSuite) TestCancelsClientCall(c *gc.C) {
+	ready := make(chan struct{})
+	start := make(chan string)
+	root := &Root{
+		delayed: map[string]*DelayedMethods{
+			"1": {
+				ready: ready,
+				done:  start,
+			},
+		},
+	}
+	client, _, srvDone, _ := newRPCClientServer(c, root, nil, false)
+	defer closeClient(c, client, srvDone)
+
+	done := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var r stringVal
+		err := client.Call(ctx, rpc.Request{Type: "DelayedMethods", Version: 0, Id: "1", Action: "Delay"}, nil, &r)
+		c.Check(errors.Cause(err), jc.ErrorIs, context.Canceled)
+
+		done <- struct{}{}
+	}()
+	chanRead(c, ready, "DelayedMethods.Delay ready")
+
+	start <- "xxx"
+
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for client call to complete")
+	}
 }
 
 func chanRead(c *gc.C, ch <-chan struct{}, what string) {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -887,7 +887,7 @@ func (*rpcSuite) TestServerWaitsForOutstandingCalls(c *gc.C) {
 	start <- "xxx"
 }
 
-func (*rpcSuite) TestCancelsClientCall(c *gc.C) {
+func (*rpcSuite) TestClientCallCancelled(c *gc.C) {
 	ready := make(chan struct{})
 	start := make(chan string)
 	root := &Root{

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -172,6 +172,10 @@ type Conn struct {
 	// clientPending holds all pending client requests.
 	clientPending map[uint64]*Call
 
+	// tombstones holds the client request ids that have been
+	// cancelled.
+	tombstones map[uint64]struct{}
+
 	// closing is set when the connection is shutting down via
 	// Close.  When this is set, no more client or server requests
 	// will be initiated.
@@ -204,6 +208,7 @@ func NewConn(codec Codec, factory RecorderFactory) *Conn {
 	return &Conn{
 		codec:           codec,
 		clientPending:   make(map[uint64]*Call),
+		tombstones:      make(map[uint64]struct{}),
 		recorderFactory: ensureFactory(factory),
 	}
 }


### PR DESCRIPTION
If a watcher is incorrectly coded and refuses to stop _after_ the initial changes are sent (strings and notify watchers), and the Next call doesn't return any information, then the watcher will never stop. This manifested itself during a migration when the secrets pruner refused to stop because it used a testing watcher in production code and didn't do the right thing. This was identified by looking at the `juju_engine_report` and seeing that the `secrets-pruner` was not moving from dying to dead (stopping and stopped retrospectively). Originally thought to be an issue in the fortress, it turned out that a bad watcher was preventing the fortress from completing its evictions.

The following ensures a worker can give up a request and the worker attempting to stop won't be broken forever.

---

This also affects every release of Juju. It just happens that the watchers haven't brought down a migration in this way. It's entirely plausible that they could in the future.


<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd src
$ juju add-model default
$ juju bootstrap lxd dst
$ juju switch src
$ juju migrate src:default dst
```

Ensure that `src:default` has migrated to `dst`.

## Links

**Jira card:** JUJU-

