### PR TITLE
Allow multiple constraints flag

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -271,7 +271,7 @@ type DeployCommand struct {
 
 	ApplicationName  string
 	ConfigOptions    common.ConfigFlag
-	ConstraintsStr   string
+	ConstraintsStr   common.ConstraintsFlag
 	Constraints      constraints.Value
 	ModelConstraints constraints.Value
 	BindToSpaces     string
@@ -639,7 +639,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Trust, "trust", false, "Allows charm to run hooks that require access credentials")
 
 	f.Var(cmd.NewAppendStringsValue(&c.BundleOverlayFile), "overlay", "Bundles to overlay on the primary bundle, applied in order")
-	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set application constraints")
+	f.Var(&c.ConstraintsStr, "constraints", "Set application constraints")
 	f.StringVar(&c.Series, "series", "", "The series on which to deploy. DEPRECATED: use --base")
 	f.StringVar(&c.Base, "base", "", "The base on which to deploy")
 	f.IntVar(&c.Revision, "revision", -1, "The revision to deploy")
@@ -816,7 +816,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 	}
-	if c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr); err != nil {
+	if c.Constraints, err = common.ParseConstraints(ctx, strings.Join(c.ConstraintsStr, " ")); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -635,7 +635,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, charmURL, charmDir, false)
 	withCharmDeployable(s.fakeAPI, charmURL, defaultBase, charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
-	err := s.runDeployForState(c, charmDir.Path, "--constraints", "mem=2G cores=2", "--base", "ubuntu@22.04")
+	err := s.runDeployForState(c, charmDir.Path, "--constraints", "mem=2G", "--constraints", "cores=2", "--base", "ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:jammy/multi-series-1")
 	app, _ := s.AssertApplication(c, "multi-series", curl.String(), 1, 0)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -214,7 +214,7 @@ type bootstrapCommand struct {
 	Constraints              constraints.Value
 	ConstraintsStr           common.ConstraintsFlag
 	BootstrapConstraints     constraints.Value
-	BootstrapConstraintsStr  string
+	BootstrapConstraintsStr  common.BootstrapConstraintsFlag
 	BootstrapSeries          string
 	BootstrapBase            string
 	BootstrapImage           string
@@ -314,7 +314,7 @@ func (c *bootstrapCommand) setControllerName(controllerName string) {
 func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.Var(&c.ConstraintsStr, "constraints", "Set model constraints")
-	f.StringVar(&c.BootstrapConstraintsStr, "bootstrap-constraints", "", "Specify bootstrap machine constraints")
+	f.Var(&c.BootstrapConstraintsStr, "bootstrap-constraints", "Specify bootstrap machine constraints")
 	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine (deprecated use bootstrap-base)")
 	f.StringVar(&c.BootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
 	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine (requires --bootstrap-constraints specifying architecture)")
@@ -572,8 +572,8 @@ func (c *bootstrapCommand) parseConstraints(ctx *cmd.Context) (err error) {
 		}
 		c.Constraints = cons
 	}
-	if c.BootstrapConstraintsStr != "" {
-		cons, aliases, err := constraints.ParseWithAliases(c.BootstrapConstraintsStr)
+	if c.BootstrapConstraintsStr.String() != "" {
+		cons, aliases, err := constraints.ParseWithAliases(strings.Join(c.BootstrapConstraintsStr, " "))
 		for k, v := range aliases {
 			allAliases[k] = v
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -212,7 +212,7 @@ type bootstrapCommand struct {
 	clock jujuclock.Clock
 
 	Constraints              constraints.Value
-	ConstraintsStr           string
+	ConstraintsStr           common.ConstraintsFlag
 	BootstrapConstraints     constraints.Value
 	BootstrapConstraintsStr  string
 	BootstrapSeries          string
@@ -313,7 +313,7 @@ func (c *bootstrapCommand) setControllerName(controllerName string) {
 
 func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set model constraints")
+	f.Var(&c.ConstraintsStr, "constraints", "Set model constraints")
 	f.StringVar(&c.BootstrapConstraintsStr, "bootstrap-constraints", "", "Specify bootstrap machine constraints")
 	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine (deprecated use bootstrap-base)")
 	f.StringVar(&c.BootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
@@ -562,8 +562,8 @@ specify a credential using the --credential argument`[1:],
 func (c *bootstrapCommand) parseConstraints(ctx *cmd.Context) (err error) {
 	allAliases := map[string]string{}
 	defer common.WarnConstraintAliases(ctx, allAliases)
-	if c.ConstraintsStr != "" {
-		cons, aliases, err := constraints.ParseWithAliases(c.ConstraintsStr)
+	if c.ConstraintsStr.String() != "" {
+		cons, aliases, err := constraints.ParseWithAliases(strings.Join(c.ConstraintsStr, " "))
 		for k, v := range aliases {
 			allAliases[k] = v
 		}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -353,109 +353,119 @@ var bootstrapTests = []bootstrapTest{{
 	info:        "constraints",
 	args:        []string{"--constraints", "mem=4G cores=4"},
 	constraints: constraints.MustParse("mem=4G cores=4"),
-}, {
-	info:                 "bootstrap and environ constraints",
-	args:                 []string{"--constraints", "mem=4G cores=4", "--bootstrap-constraints", "mem=8G"},
-	constraints:          constraints.MustParse("mem=4G cores=4"),
-	bootstrapConstraints: constraints.MustParse("mem=8G cores=4"),
-}, {
-	info:        "unsupported constraint passed through but no error",
-	args:        []string{"--constraints", "mem=4G cores=4 cpu-power=10"},
-	constraints: constraints.MustParse("mem=4G cores=4 cpu-power=10"),
-}, {
-	info:        "--build-agent uses arch from constraint if it matches current version",
-	version:     "1.3.3-ubuntu-ppc64el",
-	hostArch:    "ppc64el",
-	args:        []string{"--build-agent", "--constraints", "arch=ppc64el"},
-	upload:      "1.3.3.1-ubuntu-ppc64el", // from jujuversion.Current
-	constraints: constraints.MustParse("arch=ppc64el"),
-}, {
-	info:      "--build-agent rejects mismatched arch",
-	version:   "1.3.3-ubuntu-amd64",
-	hostArch:  "amd64",
-	args:      []string{"--build-agent", "--constraints", "arch=ppc64el"},
-	silentErr: true,
-	logs: []jc.SimpleMessage{{
-		loggo.ERROR, `failed to bootstrap model: cannot use agent built for "ppc64el" using a machine running on "amd64"`,
-	}},
-}, {
-	info:      "--build-agent rejects non-supported arch",
-	version:   "1.3.3-ubuntu-mips64",
-	hostArch:  "mips64",
-	args:      []string{"--build-agent"},
-	silentErr: true,
-	logs: []jc.SimpleMessage{{
-		loggo.ERROR, fmt.Sprintf(`failed to bootstrap model: model %q of type dummy does not support instances running on "mips64"`, bootstrap.ControllerModelName),
-	}},
-}, {
-	info:     "--build-agent always bumps build number",
-	version:  "1.2.3.4-ubuntu-amd64",
-	hostArch: "amd64",
-	args:     []string{"--build-agent"},
-	upload:   "1.2.3.5-ubuntu-amd64",
-}, {
-	info:      "placement",
-	args:      []string{"--to", "something"},
-	placement: "something",
-}, {
-	info:       "keep broken",
-	args:       []string{"--keep-broken"},
-	keepBroken: true,
-}, {
-	info: "additional args",
-	args: []string{"anything", "else"},
-	err:  `unrecognized args: \["anything" "else"\]`,
-}, {
-	info: "--agent-version with --build-agent",
-	args: []string{"--agent-version", "1.1.0", "--build-agent"},
-	err:  `--agent-version and --build-agent can't be used together`,
-}, {
-	info: "invalid --agent-version value",
-	args: []string{"--agent-version", "foo"},
-	err:  `invalid version "foo"`,
-}, {
-	info:    "agent-version doesn't match client version major",
-	version: "1.3.3-ubuntu-ppc64el",
-	args:    []string{"--agent-version", "2.3.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
-}, {
-	info:    "agent-version doesn't match client version minor",
-	version: "1.3.3-ubuntu-ppc64el",
-	args:    []string{"--agent-version", "1.4.0"},
-	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
-}, {
-	info: "--clouds with --regions",
-	args: []string{"--clouds", "--regions", "aws"},
-	err:  `--clouds and --regions can't be used together`,
-}, {
-	info: "specifying bootstrap attribute as model-default",
-	args: []string{"--model-default", "bootstrap-timeout=10"},
-	err:  `"bootstrap-timeout" is a bootstrap only attribute, and cannot be set as a model-default`,
-}, {
-	info: "specifying controller attribute as model-default",
-	args: []string{"--model-default", "api-port=12345"},
-	err:  `"api-port" is a controller attribute, and cannot be set as a model-default`,
-}, {
-	info: "k8s config on iaas controller",
-	args: []string{"--config", "controller-service-type=loadbalancer"},
-	err:  `"controller-service-type", "controller-external-name" and "controller-external-ips"are only allowed for kubernetes controllers`,
-}, {
-	info: "controller name cannot be set via config",
-	args: []string{"--config", "controller-name=test"},
-	err:  `controller name cannot be set via config, please use cmd args`,
-}, {
-	info: "resource-group-name does not support add-model",
-	args: []string{"--config", "resource-group-name=foo", "--add-model", "foo"},
-	err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
-}, {
-	info: "missing storage pool name",
-	args: []string{"--storage-pool", "type=ebs"},
-	err:  `storage pool requires a name`,
-}, {
-	info: "missing storage pool type",
-	args: []string{"--storage-pool", "name=test"},
-	err:  `storage pool requires a type`,
-}}
+},
+	{
+		info:        "multiple constraints",
+		args:        []string{"--constraints", "mem=4G", "--constraints", "cores=4"},
+		constraints: constraints.MustParse("mem=4G cores=4"),
+	},
+	{
+		info:                 "multiple bootstrap constraints",
+		args:                 []string{"--bootstrap-constraints", "mem=4G", "--bootstrap-constraints", "cores=4"},
+		bootstrapConstraints: constraints.MustParse("mem=4G cores=4"),
+	}, {
+		info:                 "bootstrap and environ constraints",
+		args:                 []string{"--constraints", "mem=4G cores=4", "--bootstrap-constraints", "mem=8G"},
+		constraints:          constraints.MustParse("mem=4G cores=4"),
+		bootstrapConstraints: constraints.MustParse("mem=8G cores=4"),
+	}, {
+		info:        "unsupported constraint passed through but no error",
+		args:        []string{"--constraints", "mem=4G cores=4 cpu-power=10"},
+		constraints: constraints.MustParse("mem=4G cores=4 cpu-power=10"),
+	}, {
+		info:        "--build-agent uses arch from constraint if it matches current version",
+		version:     "1.3.3-ubuntu-ppc64el",
+		hostArch:    "ppc64el",
+		args:        []string{"--build-agent", "--constraints", "arch=ppc64el"},
+		upload:      "1.3.3.1-ubuntu-ppc64el", // from jujuversion.Current
+		constraints: constraints.MustParse("arch=ppc64el"),
+	}, {
+		info:      "--build-agent rejects mismatched arch",
+		version:   "1.3.3-ubuntu-amd64",
+		hostArch:  "amd64",
+		args:      []string{"--build-agent", "--constraints", "arch=ppc64el"},
+		silentErr: true,
+		logs: []jc.SimpleMessage{{
+			loggo.ERROR, `failed to bootstrap model: cannot use agent built for "ppc64el" using a machine running on "amd64"`,
+		}},
+	}, {
+		info:      "--build-agent rejects non-supported arch",
+		version:   "1.3.3-ubuntu-mips64",
+		hostArch:  "mips64",
+		args:      []string{"--build-agent"},
+		silentErr: true,
+		logs: []jc.SimpleMessage{{
+			loggo.ERROR, fmt.Sprintf(`failed to bootstrap model: model %q of type dummy does not support instances running on "mips64"`, bootstrap.ControllerModelName),
+		}},
+	}, {
+		info:     "--build-agent always bumps build number",
+		version:  "1.2.3.4-ubuntu-amd64",
+		hostArch: "amd64",
+		args:     []string{"--build-agent"},
+		upload:   "1.2.3.5-ubuntu-amd64",
+	}, {
+		info:      "placement",
+		args:      []string{"--to", "something"},
+		placement: "something",
+	}, {
+		info:       "keep broken",
+		args:       []string{"--keep-broken"},
+		keepBroken: true,
+	}, {
+		info: "additional args",
+		args: []string{"anything", "else"},
+		err:  `unrecognized args: \["anything" "else"\]`,
+	}, {
+		info: "--agent-version with --build-agent",
+		args: []string{"--agent-version", "1.1.0", "--build-agent"},
+		err:  `--agent-version and --build-agent can't be used together`,
+	}, {
+		info: "invalid --agent-version value",
+		args: []string{"--agent-version", "foo"},
+		err:  `invalid version "foo"`,
+	}, {
+		info:    "agent-version doesn't match client version major",
+		version: "1.3.3-ubuntu-ppc64el",
+		args:    []string{"--agent-version", "2.3.0"},
+		err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
+	}, {
+		info:    "agent-version doesn't match client version minor",
+		version: "1.3.3-ubuntu-ppc64el",
+		args:    []string{"--agent-version", "1.4.0"},
+		err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
+	}, {
+		info: "--clouds with --regions",
+		args: []string{"--clouds", "--regions", "aws"},
+		err:  `--clouds and --regions can't be used together`,
+	}, {
+		info: "specifying bootstrap attribute as model-default",
+		args: []string{"--model-default", "bootstrap-timeout=10"},
+		err:  `"bootstrap-timeout" is a bootstrap only attribute, and cannot be set as a model-default`,
+	}, {
+		info: "specifying controller attribute as model-default",
+		args: []string{"--model-default", "api-port=12345"},
+		err:  `"api-port" is a controller attribute, and cannot be set as a model-default`,
+	}, {
+		info: "k8s config on iaas controller",
+		args: []string{"--config", "controller-service-type=loadbalancer"},
+		err:  `"controller-service-type", "controller-external-name" and "controller-external-ips"are only allowed for kubernetes controllers`,
+	}, {
+		info: "controller name cannot be set via config",
+		args: []string{"--config", "controller-name=test"},
+		err:  `controller name cannot be set via config, please use cmd args`,
+	}, {
+		info: "resource-group-name does not support add-model",
+		args: []string{"--config", "resource-group-name=foo", "--add-model", "foo"},
+		err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
+	}, {
+		info: "missing storage pool name",
+		args: []string{"--storage-pool", "type=ebs"},
+		err:  `storage pool requires a name`,
+	}, {
+		info: "missing storage pool type",
+		args: []string{"--storage-pool", "name=test"},
+		err:  `storage pool requires a type`,
+	}}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")
@@ -684,8 +694,6 @@ func (s *BootstrapSuite) TestBootstrapAllSpacesAsConstraintsMerged(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestBootstrapAllConstraintsMerged(c *gc.C) {
-	s.patchVersionAndSeries(c, "jammy")
-
 	var bootstrapFuncs fakeBootstrapFuncs
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrapFuncs
@@ -693,7 +701,7 @@ func (s *BootstrapSuite) TestBootstrapAllConstraintsMerged(c *gc.C) {
 	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade",
 		"--config", "juju-ha-space=ha-space", "--config", "juju-mgmt-space=management-space",
-		"--constraints", "spaces=ha-space,random-space","--constraints","mem=4G",
+		"--constraints", "spaces=ha-space,random-space", "--constraints", "mem=4G",
 	)
 
 	bootstrapCons := constraints.MustParse("mem=4G spaces=ha-space,management-space,random-space")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -353,119 +353,117 @@ var bootstrapTests = []bootstrapTest{{
 	info:        "constraints",
 	args:        []string{"--constraints", "mem=4G cores=4"},
 	constraints: constraints.MustParse("mem=4G cores=4"),
-},
-	{
-		info:        "multiple constraints",
-		args:        []string{"--constraints", "mem=4G", "--constraints", "cores=4"},
-		constraints: constraints.MustParse("mem=4G cores=4"),
-	},
-	{
-		info:                 "multiple bootstrap constraints",
-		args:                 []string{"--bootstrap-constraints", "mem=4G", "--bootstrap-constraints", "cores=4"},
-		bootstrapConstraints: constraints.MustParse("mem=4G cores=4"),
-	}, {
-		info:                 "bootstrap and environ constraints",
-		args:                 []string{"--constraints", "mem=4G cores=4", "--bootstrap-constraints", "mem=8G"},
-		constraints:          constraints.MustParse("mem=4G cores=4"),
-		bootstrapConstraints: constraints.MustParse("mem=8G cores=4"),
-	}, {
-		info:        "unsupported constraint passed through but no error",
-		args:        []string{"--constraints", "mem=4G cores=4 cpu-power=10"},
-		constraints: constraints.MustParse("mem=4G cores=4 cpu-power=10"),
-	}, {
-		info:        "--build-agent uses arch from constraint if it matches current version",
-		version:     "1.3.3-ubuntu-ppc64el",
-		hostArch:    "ppc64el",
-		args:        []string{"--build-agent", "--constraints", "arch=ppc64el"},
-		upload:      "1.3.3.1-ubuntu-ppc64el", // from jujuversion.Current
-		constraints: constraints.MustParse("arch=ppc64el"),
-	}, {
-		info:      "--build-agent rejects mismatched arch",
-		version:   "1.3.3-ubuntu-amd64",
-		hostArch:  "amd64",
-		args:      []string{"--build-agent", "--constraints", "arch=ppc64el"},
-		silentErr: true,
-		logs: []jc.SimpleMessage{{
-			loggo.ERROR, `failed to bootstrap model: cannot use agent built for "ppc64el" using a machine running on "amd64"`,
-		}},
-	}, {
-		info:      "--build-agent rejects non-supported arch",
-		version:   "1.3.3-ubuntu-mips64",
-		hostArch:  "mips64",
-		args:      []string{"--build-agent"},
-		silentErr: true,
-		logs: []jc.SimpleMessage{{
-			loggo.ERROR, fmt.Sprintf(`failed to bootstrap model: model %q of type dummy does not support instances running on "mips64"`, bootstrap.ControllerModelName),
-		}},
-	}, {
-		info:     "--build-agent always bumps build number",
-		version:  "1.2.3.4-ubuntu-amd64",
-		hostArch: "amd64",
-		args:     []string{"--build-agent"},
-		upload:   "1.2.3.5-ubuntu-amd64",
-	}, {
-		info:      "placement",
-		args:      []string{"--to", "something"},
-		placement: "something",
-	}, {
-		info:       "keep broken",
-		args:       []string{"--keep-broken"},
-		keepBroken: true,
-	}, {
-		info: "additional args",
-		args: []string{"anything", "else"},
-		err:  `unrecognized args: \["anything" "else"\]`,
-	}, {
-		info: "--agent-version with --build-agent",
-		args: []string{"--agent-version", "1.1.0", "--build-agent"},
-		err:  `--agent-version and --build-agent can't be used together`,
-	}, {
-		info: "invalid --agent-version value",
-		args: []string{"--agent-version", "foo"},
-		err:  `invalid version "foo"`,
-	}, {
-		info:    "agent-version doesn't match client version major",
-		version: "1.3.3-ubuntu-ppc64el",
-		args:    []string{"--agent-version", "2.3.0"},
-		err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
-	}, {
-		info:    "agent-version doesn't match client version minor",
-		version: "1.3.3-ubuntu-ppc64el",
-		args:    []string{"--agent-version", "1.4.0"},
-		err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
-	}, {
-		info: "--clouds with --regions",
-		args: []string{"--clouds", "--regions", "aws"},
-		err:  `--clouds and --regions can't be used together`,
-	}, {
-		info: "specifying bootstrap attribute as model-default",
-		args: []string{"--model-default", "bootstrap-timeout=10"},
-		err:  `"bootstrap-timeout" is a bootstrap only attribute, and cannot be set as a model-default`,
-	}, {
-		info: "specifying controller attribute as model-default",
-		args: []string{"--model-default", "api-port=12345"},
-		err:  `"api-port" is a controller attribute, and cannot be set as a model-default`,
-	}, {
-		info: "k8s config on iaas controller",
-		args: []string{"--config", "controller-service-type=loadbalancer"},
-		err:  `"controller-service-type", "controller-external-name" and "controller-external-ips"are only allowed for kubernetes controllers`,
-	}, {
-		info: "controller name cannot be set via config",
-		args: []string{"--config", "controller-name=test"},
-		err:  `controller name cannot be set via config, please use cmd args`,
-	}, {
-		info: "resource-group-name does not support add-model",
-		args: []string{"--config", "resource-group-name=foo", "--add-model", "foo"},
-		err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
-	}, {
-		info: "missing storage pool name",
-		args: []string{"--storage-pool", "type=ebs"},
-		err:  `storage pool requires a name`,
-	}, {
-		info: "missing storage pool type",
-		args: []string{"--storage-pool", "name=test"},
-		err:  `storage pool requires a type`,
-	}}
+}, {
+	info:        "multiple constraints",
+	args:        []string{"--constraints", "mem=4G", "--constraints", "cores=4"},
+	constraints: constraints.MustParse("mem=4G cores=4"),
+}, {
+	info:                 "multiple bootstrap constraints",
+	args:                 []string{"--bootstrap-constraints", "mem=4G", "--bootstrap-constraints", "cores=4"},
+	bootstrapConstraints: constraints.MustParse("mem=4G cores=4"),
+}, {
+	info:                 "bootstrap and environ constraints",
+	args:                 []string{"--constraints", "mem=4G cores=4", "--bootstrap-constraints", "mem=8G"},
+	constraints:          constraints.MustParse("mem=4G cores=4"),
+	bootstrapConstraints: constraints.MustParse("mem=8G cores=4"),
+}, {
+	info:        "unsupported constraint passed through but no error",
+	args:        []string{"--constraints", "mem=4G cores=4 cpu-power=10"},
+	constraints: constraints.MustParse("mem=4G cores=4 cpu-power=10"),
+}, {
+	info:        "--build-agent uses arch from constraint if it matches current version",
+	version:     "1.3.3-ubuntu-ppc64el",
+	hostArch:    "ppc64el",
+	args:        []string{"--build-agent", "--constraints", "arch=ppc64el"},
+	upload:      "1.3.3.1-ubuntu-ppc64el", // from jujuversion.Current
+	constraints: constraints.MustParse("arch=ppc64el"),
+}, {
+	info:      "--build-agent rejects mismatched arch",
+	version:   "1.3.3-ubuntu-amd64",
+	hostArch:  "amd64",
+	args:      []string{"--build-agent", "--constraints", "arch=ppc64el"},
+	silentErr: true,
+	logs: []jc.SimpleMessage{{
+		loggo.ERROR, `failed to bootstrap model: cannot use agent built for "ppc64el" using a machine running on "amd64"`,
+	}},
+}, {
+	info:      "--build-agent rejects non-supported arch",
+	version:   "1.3.3-ubuntu-mips64",
+	hostArch:  "mips64",
+	args:      []string{"--build-agent"},
+	silentErr: true,
+	logs: []jc.SimpleMessage{{
+		loggo.ERROR, fmt.Sprintf(`failed to bootstrap model: model %q of type dummy does not support instances running on "mips64"`, bootstrap.ControllerModelName),
+	}},
+}, {
+	info:     "--build-agent always bumps build number",
+	version:  "1.2.3.4-ubuntu-amd64",
+	hostArch: "amd64",
+	args:     []string{"--build-agent"},
+	upload:   "1.2.3.5-ubuntu-amd64",
+}, {
+	info:      "placement",
+	args:      []string{"--to", "something"},
+	placement: "something",
+}, {
+	info:       "keep broken",
+	args:       []string{"--keep-broken"},
+	keepBroken: true,
+}, {
+	info: "additional args",
+	args: []string{"anything", "else"},
+	err:  `unrecognized args: \["anything" "else"\]`,
+}, {
+	info: "--agent-version with --build-agent",
+	args: []string{"--agent-version", "1.1.0", "--build-agent"},
+	err:  `--agent-version and --build-agent can't be used together`,
+}, {
+	info: "invalid --agent-version value",
+	args: []string{"--agent-version", "foo"},
+	err:  `invalid version "foo"`,
+}, {
+	info:    "agent-version doesn't match client version major",
+	version: "1.3.3-ubuntu-ppc64el",
+	args:    []string{"--agent-version", "2.3.0"},
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
+}, {
+	info:    "agent-version doesn't match client version minor",
+	version: "1.3.3-ubuntu-ppc64el",
+	args:    []string{"--agent-version", "1.4.0"},
+	err:     regexp.QuoteMeta(`this client can only bootstrap 1.3 agents`),
+}, {
+	info: "--clouds with --regions",
+	args: []string{"--clouds", "--regions", "aws"},
+	err:  `--clouds and --regions can't be used together`,
+}, {
+	info: "specifying bootstrap attribute as model-default",
+	args: []string{"--model-default", "bootstrap-timeout=10"},
+	err:  `"bootstrap-timeout" is a bootstrap only attribute, and cannot be set as a model-default`,
+}, {
+	info: "specifying controller attribute as model-default",
+	args: []string{"--model-default", "api-port=12345"},
+	err:  `"api-port" is a controller attribute, and cannot be set as a model-default`,
+}, {
+	info: "k8s config on iaas controller",
+	args: []string{"--config", "controller-service-type=loadbalancer"},
+	err:  `"controller-service-type", "controller-external-name" and "controller-external-ips"are only allowed for kubernetes controllers`,
+}, {
+	info: "controller name cannot be set via config",
+	args: []string{"--config", "controller-name=test"},
+	err:  `controller name cannot be set via config, please use cmd args`,
+}, {
+	info: "resource-group-name does not support add-model",
+	args: []string{"--config", "resource-group-name=foo", "--add-model", "foo"},
+	err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
+}, {
+	info: "missing storage pool name",
+	args: []string{"--storage-pool", "type=ebs"},
+	err:  `storage pool requires a name`,
+}, {
+	info: "missing storage pool type",
+	args: []string{"--storage-pool", "name=test"},
+	err:  `storage pool requires a type`,
+}}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -678,8 +678,26 @@ func (s *BootstrapSuite) TestBootstrapAllSpacesAsConstraintsMerged(c *gc.C) {
 		"--constraints", "spaces=ha-space,random-space",
 	)
 
+	c.Log(bootstrapFuncs.args.BootstrapConstraints.String())
 	got := *(bootstrapFuncs.args.BootstrapConstraints.Spaces)
 	c.Check(got, gc.DeepEquals, []string{"ha-space", "management-space", "random-space"})
+}
+
+func (s *BootstrapSuite) TestBootstrapAllConstraintsMerged(c *gc.C) {
+	s.patchVersionAndSeries(c, "jammy")
+
+	var bootstrapFuncs fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrapFuncs
+	})
+	cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade",
+		"--config", "juju-ha-space=ha-space", "--config", "juju-mgmt-space=management-space",
+		"--constraints", "spaces=ha-space,random-space","--constraints","mem=4G",
+	)
+
+	bootstrapCons := constraints.MustParse("mem=4G spaces=ha-space,management-space,random-space")
+	c.Assert(bootstrapFuncs.args.BootstrapConstraints, gc.DeepEquals, bootstrapCons)
 }
 
 func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsProcessedAttributes(c *gc.C) {

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -53,7 +53,7 @@ type enableHACommand struct {
 	Constraints constraints.Value
 
 	// ConstraintsStr contains the stringified version of the constraints.
-	ConstraintsStr string
+	ConstraintsStr common.ConstraintsFlag
 
 	// Placement specifies specific machine(s) which will be used to host
 	// new controllers. If there are more controllers required than
@@ -150,7 +150,7 @@ func (c *enableHACommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	f.IntVar(&c.NumControllers, "n", 0, "Number of controllers to make available")
 	f.StringVar(&c.PlacementSpec, "to", "", "The machine(s) to become controllers, bypasses constraints")
-	f.StringVar(&c.ConstraintsStr, "constraints", "", "Additional machine constraints")
+	f.Var(&c.ConstraintsStr, "constraints", "Additional machine constraints")
 	c.out.AddFlags(f, "simple", map[string]cmd.Formatter{
 		"yaml":   cmd.FormatYaml,
 		"json":   cmd.FormatJson,
@@ -216,7 +216,7 @@ func (c *enableHACommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
+	c.Constraints, err = common.ParseConstraints(ctx, strings.Join(c.ConstraintsStr, " "))
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -184,6 +184,19 @@ func (s *EnableHASuite) TestEnableHAWithConstraints(c *gc.C) {
 	c.Assert(len(s.fake.placement), gc.Equals, 0)
 }
 
+func (s *EnableHASuite) TestEnableHAWithMultipleConstraints(c *gc.C) {
+	ctx, err := s.runEnableHA(c, "--constraints", "cores=4", "--constraints", "mem=4G", "-n", "3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
+		"maintaining machines: 0\n"+
+			"adding machines: 1, 2\n")
+
+	c.Assert(s.fake.numControllers, gc.Equals, 3)
+	expectedCons := constraints.MustParse("cores=4 mem=4G")
+	c.Assert(s.fake.cons, gc.DeepEquals, expectedCons)
+	c.Assert(len(s.fake.placement), gc.Equals, 0)
+}
+
 func (s *EnableHASuite) TestEnableHAWithPlacement(c *gc.C) {
 	ctx, err := s.runEnableHA(c, "--to", "valid", "-n", "3")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -33,8 +33,8 @@ func (c *BootstrapConstraintsFlag) Set(value string) error {
 	return nil
 }
 
-// ConstraintsFlag records constraints set in add-machine, bootstrap and deploy commands
-// via constraints flag.
+// ConstraintsFlag records constraints set in add-machine, bootstrap, deploy
+// and enable-ha commands via constraints flag.
 type ConstraintsFlag []string
 
 // String implements gnuflag.Value.String.

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -33,7 +33,7 @@ func (c *BootstrapConstraintsFlag) Set(value string) error {
 	return nil
 }
 
-// ConstraintsFlag records constraints set in bootstrap and deploy commands
+// ConstraintsFlag records constraints set in add-machine, bootstrap and deploy commands
 // via constraints flag.
 type ConstraintsFlag []string
 

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -33,7 +33,7 @@ func (c *BootstrapConstraintsFlag) Set(value string) error {
 	return nil
 }
 
-// ConstraintsFlag records constraints set in bootstrap command
+// ConstraintsFlag records constraints set in bootstrap and deploy commands
 // via constraints flag.
 type ConstraintsFlag []string
 

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -18,6 +18,20 @@ import (
 	"github.com/juju/juju/core/constraints"
 )
 
+// ConstraintsFlag records constraints set in bootstrap command.
+type ConstraintsFlag []string
+
+// String implements gnuflag.Value.String.
+func (c *ConstraintsFlag) String() string {
+	return fmt.Sprintf("%v", *c)
+}
+
+// Set implements gnuflag.Value.Set.
+func (c *ConstraintsFlag) Set(value string) error {
+	*c = append(*c, value)
+	return nil
+}
+
 // ConfigFlag records k=v attributes from command arguments
 // and/or specified files containing key values.
 type ConfigFlag struct {

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -18,7 +18,23 @@ import (
 	"github.com/juju/juju/core/constraints"
 )
 
-// ConstraintsFlag records constraints set in bootstrap command.
+// BootstrapConstraintsFlag records constraints set in bootstrap command
+// via bootstrap-constraints flag.
+type BootstrapConstraintsFlag []string
+
+// String implements gnuflag.Value.String.
+func (c *BootstrapConstraintsFlag) String() string {
+	return fmt.Sprintf("%v", *c)
+}
+
+// Set implements gnuflag.Value.Set.
+func (c *BootstrapConstraintsFlag) Set(value string) error {
+	*c = append(*c, value)
+	return nil
+}
+
+// ConstraintsFlag records constraints set in bootstrap command
+// via constraints flag.
 type ConstraintsFlag []string
 
 // String implements gnuflag.Value.String.

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -165,7 +165,7 @@ type addCommand struct {
 	// If specified, these constraints are merged with those already in the model.
 	Constraints constraints.Value
 	// If specified, these constraints are merged with those already in the model.
-	ConstraintsStr string
+	ConstraintsStr common.ConstraintsFlag
 	// Placement is passed verbatim to the API, to be parsed and evaluated server-side.
 	Placement *instance.Placement
 	// NumMachines is the number of machines to add.
@@ -200,7 +200,7 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Series, "series", "", "The operating system series to install on the new machine(s). DEPRECATED use --base")
 	f.StringVar(&c.Base, "base", "", "The operating system base to install on the new machine(s)")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
-	f.StringVar(&c.ConstraintsStr, "constraints", "", "Machine constraints that overwrite those available from 'juju model-constraints' and provider's defaults")
+	f.Var(&c.ConstraintsStr, "constraints", "Machine constraints that overwrite those available from 'juju model-constraints' and provider's defaults")
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage constraints for disks to attach to the machine(s)")
 	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use during the connection")
 	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to add to the remote authorized keys")
@@ -305,7 +305,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
+	c.Constraints, err = common.ParseConstraints(ctx, strings.Join(c.ConstraintsStr, " "))
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -181,6 +181,18 @@ func (s *AddMachineSuite) TestParamsPassedOn(c *gc.C) {
 	c.Assert(param.Constraints.String(), gc.Equals, "mem=8192M")
 }
 
+func (s *AddMachineSuite) TestParamsPassedOnMultipleConstraints(c *gc.C) {
+	_, err := s.run(c, "--constraints", "mem=8G", "--constraints", "cores=4", "--base=ubuntu@22.04", "zone=nz")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeAddMachine.args, gc.HasLen, 1)
+
+	param := s.fakeAddMachine.args[0]
+
+	c.Assert(param.Placement.String(), gc.Equals, "fake-uuid:zone=nz")
+	c.Assert(param.Base, jc.DeepEquals, &params.Base{Name: "ubuntu", Channel: "22.04/stable"})
+	c.Assert(param.Constraints.String(), gc.Equals, "cores=4 mem=8192M")
+}
+
 func (s *AddMachineSuite) TestParamsPassedOnNTimes(c *gc.C) {
 	_, err := s.run(c, "-n", "3", "--constraints", "mem=8G", "--base=ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
@@ -190,6 +202,19 @@ func (s *AddMachineSuite) TestParamsPassedOnNTimes(c *gc.C) {
 	c.Assert(param.Base, jc.DeepEquals, &params.Base{Name: "ubuntu", Channel: "22.04/stable"})
 
 	c.Assert(param.Constraints.String(), gc.Equals, "mem=8192M")
+	c.Assert(param, jc.DeepEquals, s.fakeAddMachine.args[1])
+	c.Assert(param, jc.DeepEquals, s.fakeAddMachine.args[2])
+}
+
+func (s *AddMachineSuite) TestParamsPassedOnNTimesMultipleConstraints(c *gc.C) {
+	_, err := s.run(c, "-n", "3", "--constraints", "mem=8G", "--constraints", "cores=4", "--base=ubuntu@22.04")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fakeAddMachine.args, gc.HasLen, 3)
+
+	param := s.fakeAddMachine.args[0]
+	c.Assert(param.Base, jc.DeepEquals, &params.Base{Name: "ubuntu", Channel: "22.04/stable"})
+
+	c.Assert(param.Constraints.String(), gc.Equals, "cores=4 mem=8192M")
 	c.Assert(param, jc.DeepEquals, s.fakeAddMachine.args[1])
 	c.Assert(param, jc.DeepEquals, s.fakeAddMachine.args[2])
 }


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->
```juju bootstrap --constraints "a=b" --constraints "b=c"```
```juju bootstrap --bootstrap-constraints "a=b" --bootstrap-constraints "b=c"```
```juju deploy indico --constraints "a=b" --constraints "b=c"```
```juju add-machine --constraints "a=b" --constraints "b=c"```
```juju enable-ha --constraints "a=b" --constraints "b=c"```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2049439
**Jira card:** JUJU-

## TODO

- [x] the "--bootstrap-constraints" flag on the bootstrap command.
- [x] the "--constraints" flag on the deploy command.
- [x] the "--constraints" flag on the add-machine command.
- [x] the "--constraints" flag on the enable-ha command.

