### PR TITLE
Remove database critical logging

### DIFF
--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -107,12 +107,12 @@ func BootstrapDqlite(
 		return errors.Annotatef(err, "waiting for Dqlite readiness")
 	}
 
-	controller, err := runMigration(ctx, dqlite, coredatabase.ControllerNS, schema.ControllerDDL(), controllerBootstrapInit)
+	controller, err := runMigration(ctx, dqlite, coredatabase.ControllerNS, schema.ControllerDDL(), controllerBootstrapInit, logger)
 	if err != nil {
 		return errors.Annotate(err, "running controller migration")
 	}
 
-	model, err := runMigration(ctx, dqlite, uuid.String(), schema.ModelDDL(), emptyInit)
+	model, err := runMigration(ctx, dqlite, uuid.String(), schema.ModelDDL(), emptyInit, logger)
 	if err != nil {
 		return errors.Annotate(err, "running model migration")
 	}
@@ -126,7 +126,7 @@ func BootstrapDqlite(
 	return nil
 }
 
-func runMigration(ctx context.Context, dqlite *app.App, namespace string, schema Schema, init bootstrapInit) (coredatabase.TxnRunner, error) {
+func runMigration(ctx context.Context, dqlite *app.App, namespace string, schema Schema, init bootstrapInit, logger Logger) (coredatabase.TxnRunner, error) {
 	db, err := dqlite.Open(ctx, namespace)
 	if err != nil {
 		return nil, errors.Annotatef(err, "opening database for namespace %q", namespace)

--- a/internal/database/errors_test.go
+++ b/internal/database/errors_test.go
@@ -37,6 +37,8 @@ func (s *errorSuite) TestIsErrConstraintUnique(c *gc.C) {
 
 func (s *errorSuite) TestIsErrCode(c *gc.C) {
 	c.Check(isErrCode(nil, sqlite3.ErrConstraintCheck), checkers.IsFalse)
+	c.Check(isErrCode(sqlite3.ErrBusy, sqlite3.ErrConstraintCheck), checkers.IsFalse)
+	c.Check(isErrCode(sqlite3.ErrLocked, sqlite3.ErrConstraintCheck), checkers.IsFalse)
 
 	dErr := dqlite.Error{}
 	c.Check(isErrCode(dErr, sqlite3.ErrConstraintCheck), checkers.IsFalse)

--- a/internal/database/txn/errors.go
+++ b/internal/database/txn/errors.go
@@ -17,7 +17,6 @@ import (
 // See: https://github.com/canonical/go-dqlite/issues/220
 func IsErrRetryable(err error) bool {
 	var dErr *driver.Error
-
 	if errors.As(err, &dErr) && dErr.Code == driver.ErrBusy {
 		return true
 	}


### PR DESCRIPTION
We believed there was a bug in how dqlite was returning the wrong error for constraints. The logging never showed this in a visible way. Only that the database was locked.

So we now check that much earlier to prevent excess error coercion.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This is at the fundamental level of our domain services, so all the tests should pass and a simple smoke test should be applied.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links


**Jira card:** JUJU-

