### PR TITLE
Decouple charm upload handlers

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -777,8 +777,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 
 	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		ctxt:              httpCtxt,
+		stateAuthFunc:     httpCtxt.stateForRequestAuthenticatedUser,
 		objectStoreGetter: srv.shared.objectStoreGetter,
-		LegacyPostHandler: modelCharmsHandler.ServePost,
 	}
 
 	modelToolsUploadHandler := &toolsUploadHandler{
@@ -856,8 +856,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	}
 	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		ctxt:              httpCtxt,
+		stateAuthFunc:     httpCtxt.stateForMigrationImporting,
 		objectStoreGetter: srv.shared.objectStoreGetter,
-		LegacyPostHandler: migrateCharmsHandler.ServePost,
 	}
 	migrateToolsUploadHandler := &toolsUploadHandler{
 		ctxt:          httpCtxt,

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -291,11 +291,18 @@ func (s *putCharmObjectSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 	// Pretend we upload a zip by setting the Content-Type, so we can
 	// check the error at extraction time later.
 	resp := s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/zip", "local:somecharm", empty)
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*cannot open charm archive: zip: not a valid zip file$")
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*zip: not a valid zip file$")
 
 	// Now try with the default Content-Type.
 	resp = s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/octet-stream", "local:somecharm", empty)
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*expected Content-Type: application/zip, got: application/octet-stream$")
+}
+
+func (s *putCharmObjectSuite) TestCannotUploadCharmhubCharm(c *gc.C) {
+	// We should run verifications like this before processing the charm.
+	empty := strings.NewReader("")
+	resp := s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/zip", "ch:somecharm", empty)
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, `.*non-local charms may only be uploaded during model migration import`)
 }
 
 func (s *putCharmObjectSuite) TestUploadBumpsRevision(c *gc.C) {
@@ -550,7 +557,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 
 	s.assertErrorResponse(
 		c, resp, http.StatusBadRequest,
-		`model migration mode is "" instead of "importing"`,
+		`cannot upload charm: model migration mode is "" instead of "importing"`,
 	)
 }
 


### PR DESCRIPTION
This means the new handler drops it's dependency on charm url series. This is also a step towards deprecating and then removing the old handler

NOTE: Model migrations have been broken on 4.0 since this PR a few weeks ago: https://github.com/juju/juju/pull/17026

As such, so I could run the QA steps, the PR has been rebased back to the commit before this PR was merged. Fortunately it was recent enough to not cause any conflicts

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Deploy local charms

download a charm from charmhub
```
$ juju download ubuntu
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

Deploy several local charms
```
$ juju add-model local
$ juju deploy ./ubuntu_r24.charm ubu-arch
Located local charm "ubuntu", revision 0
Deploying "ubu-arch" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ./ubuntu_r24.charm ubu-focal --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubu-focal" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable


$ juju deploy ./testcharms/charms/ubuntu-plus/ ubu-dir
Located local charm "ubuntu-plus", revision 0
Deploying "ubu-dir" from local charm "ubuntu-plus", revision 0 on ubuntu@22.04/stable

$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta3.1  14:12:50+01:00

App        Version  Status   Scale  Charm        Channel  Rev  Exposed  Message
ubu-arch   22.04    active       1  ubuntu                  0  no       
ubu-dir             waiting      1  ubuntu-plus             0  no       Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal  20.04    active       1  ubuntu                  0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-arch/0*   active    idle   0        10.219.211.73          
ubu-dir/0*    waiting   idle   2        10.219.211.65          Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal/0*  active    idle   1        10.219.211.227         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.73   juju-99dc44-0  ubuntu@22.04      Running
1        started  10.219.211.227  juju-99dc44-1  ubuntu@20.04      Running
2        started  10.219.211.65   juju-99dc44-2  ubuntu@22.04      Running
```

### Model migrations

Repeat the following steps bootstrapping controllers:
1) `lxd-src` from this PR; `lxd-dst` from this PR
2) `lxd-src` from 3.5; `lxd-dst` from this PR

```
$ juju add-model m
$ juju deploy ./ubuntu_r24.charm ubu-local
$ juju deploy ubuntu ubu-ch
$ juju status
 Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta3.1  15:08:57+01:00

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst
Migration started with ID "355633ec-fc28-47a0-8a86-ae3dcd975167:0"

$ juju status
ERROR Model "admin/m" has been migrated to controller "lxd-dst".
To access it run 'juju switch lxd-dst:admin/m'.

$ juju switch lxd-dst:m
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta3.1  15:10:10+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju add-unit ubu-local
$ juju add-unit ubu-ch
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta3.1  15:34:30+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch              active      2  ubuntu  latest/stable   24  no       
ubu-local           active      2  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-ch/1      active    idle   2        10.219.211.3           
ubu-local/0*  active    idle   1        10.219.211.111         
ubu-local/1   active    idle   3        10.219.211.40          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running
2        started  10.219.211.3    juju-975167-2  ubuntu@22.04      Running
3        started  10.219.211.40   juju-975167-3  ubuntu@22.04      Running
```