### PR TITLE
Implement UpsertPermission

### DIFF
--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -373,3 +373,20 @@ func cloudRevoke(a Access) Access {
 		return NoAccess
 	}
 }
+
+// EqualOrGreaterThan returns true if the current access is
+// equal or greater than the passed in access level.
+func (a AccessSpec) EqualOrGreaterThan(access Access) bool {
+	switch a.Target.ObjectType {
+	case Cloud:
+		return a.Access.EqualOrGreaterCloudAccessThan(access)
+	case Controller:
+		return a.Access.EqualOrGreaterControllerAccessThan(access)
+	case Model:
+		return a.Access.EqualOrGreaterModelAccessThan(access)
+	case Offer:
+		return a.Access.EqualOrGreaterOfferAccessThan(access)
+	default:
+		return false
+	}
+}

--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -315,3 +315,61 @@ func (a Access) GreaterOfferAccessThan(access Access) bool {
 	}
 	return v1 > v2
 }
+
+// modelRevoke provides the logic of revoking
+// model access. Revoking:
+// * AddModel gets you Write
+// * Write gets you Read
+// * Read gets you NoAccess
+func modelRevoke(a Access) Access {
+	switch a {
+	case AddModelAccess:
+		return WriteAccess
+	case WriteAccess:
+		return ReadAccess
+	default:
+		return NoAccess
+	}
+}
+
+// offerRevoke provides the logic of revoking
+// offer access. Revoking:
+// * Admin gets you Consume
+// * Consume gets you Read
+// * Read gets you NoAccess
+func offerRevoke(a Access) Access {
+	switch a {
+	case AdminAccess:
+		return ConsumeAccess
+	case ConsumeAccess:
+		return ReadAccess
+	default:
+		return NoAccess
+	}
+}
+
+// controllerRevoke provides the logic of revoking
+// controller access. Revoking:
+// * Superuser gets you Login
+// * Login gets you NoAccess
+func controllerRevoke(a Access) Access {
+	switch a {
+	case SuperuserAccess:
+		return LoginAccess
+	default:
+		return NoAccess
+	}
+}
+
+// cloudRevoke provides the logic of revoking
+// cloud access. Revoking:
+// * Admin gets you AddModel
+// * AddModel gets you NoAccess
+func cloudRevoke(a Access) Access {
+	switch a {
+	case AdminAccess:
+		return AddModelAccess
+	default:
+		return NoAccess
+	}
+}

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -28,6 +28,24 @@ func (u AccessSpec) Validate() error {
 	return nil
 }
 
+// RevokeAccess returns the new access level based on the revoking the current
+// value setting. E.g. revoking SuperuserAccess sets LoginAccess for
+// controllers.
+func (a AccessSpec) RevokeAccess() Access {
+	switch a.Target.ObjectType {
+	case Cloud:
+		return cloudRevoke(a.Access)
+	case Controller:
+		return controllerRevoke(a.Access)
+	case Model:
+		return modelRevoke(a.Access)
+	case Offer:
+		return offerRevoke(a.Access)
+	default:
+		return NoAccess
+	}
+}
+
 // UserAccessSpec defines the attributes that can be set when adding a new
 // user access.
 type UserAccessSpec struct {

--- a/domain/access/service/permission.go
+++ b/domain/access/service/permission.go
@@ -122,12 +122,13 @@ func (s *PermissionService) ReadAllAccessForUserAndObjectType(ctx context.Contex
 	return userAccess, errors.Trace(err)
 }
 
-// UpsertPermission updates the permission on the target for the given
-// subject (user). The api user must have Admin permission on the target. If a
-// subject does not exist, it is created using the subject and api user. Access
-// can be granted or revoked. Revoking the permission on a user which does not
-// exist, is a no-op, AddUser will be ignored.
-func (s *PermissionService) UpsertPermission(ctx context.Context, args access.UpsertPermissionArgs) error {
+// UpdatePermission updates the permission on the target for the given
+// subject (user). The api user must have Superuser access or Admin access
+// on the target. If a subject does not exist and the args specify, it is
+// created using the subject and api user. Adding the user would typically
+// only happen for updates to model access. Access can be granted or revoked.
+// Revoking Read access will delete the permission.
+func (s *PermissionService) UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error {
 	if err := args.Validate(); err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/access/service/permission_test.go
+++ b/domain/access/service/permission_test.go
@@ -93,15 +93,17 @@ func (s *serviceSuite) TestUpsertPermission(c *gc.C) {
 	err := NewPermissionService(s.state).UpsertPermission(
 		context.Background(),
 		access.UpsertPermissionArgs{
-			Access:  corepermission.AddModelAccess,
+			AccessSpec: corepermission.AccessSpec{
+				Access: corepermission.AddModelAccess,
+				Target: corepermission.ID{
+					ObjectType: corepermission.Cloud,
+					Key:        "aws",
+				},
+			},
 			AddUser: false,
 			ApiUser: "admin",
 			Change:  corepermission.Grant,
 			Subject: "testme",
-			Target: corepermission.ID{
-				ObjectType: corepermission.Cloud,
-				Key:        "aws",
-			},
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/access/service/permission_test.go
+++ b/domain/access/service/permission_test.go
@@ -88,11 +88,11 @@ func (s *serviceSuite) TestDeletePermissionError(c *gc.C) {
 
 func (s *serviceSuite) TestUpsertPermission(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.state.EXPECT().UpsertPermission(gomock.Any(), gomock.AssignableToTypeOf(access.UpsertPermissionArgs{})).Return(nil)
+	s.state.EXPECT().UpsertPermission(gomock.Any(), gomock.AssignableToTypeOf(access.UpdatePermissionArgs{})).Return(nil)
 
-	err := NewPermissionService(s.state).UpsertPermission(
+	err := NewPermissionService(s.state).UpdatePermission(
 		context.Background(),
-		access.UpsertPermissionArgs{
+		access.UpdatePermissionArgs{
 			AccessSpec: corepermission.AccessSpec{
 				Access: corepermission.AddModelAccess,
 				Target: corepermission.ID{

--- a/domain/access/service/service.go
+++ b/domain/access/service/service.go
@@ -140,7 +140,7 @@ type PermissionState interface {
 	// subject (user). The api user must have Admin permission on the target. If a
 	// subject does not exist, it is created using the subject and api user. Access
 	// can be granted or revoked.
-	UpsertPermission(ctx context.Context, args access.UpsertPermissionArgs) error
+	UpsertPermission(ctx context.Context, args access.UpdatePermissionArgs) error
 
 	// ReadUserAccessForTarget returns the subject's (user) access for the
 	// given user on the given target.

--- a/domain/access/service/state_mock_test.go
+++ b/domain/access/service/state_mock_test.go
@@ -350,7 +350,7 @@ func (mr *MockStateMockRecorder) UpdateLastLogin(arg0, arg1 any) *gomock.Call {
 }
 
 // UpsertPermission mocks base method.
-func (m *MockState) UpsertPermission(arg0 context.Context, arg1 access.UpsertPermissionArgs) error {
+func (m *MockState) UpsertPermission(arg0 context.Context, arg1 access.UpdatePermissionArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertPermission", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -715,7 +715,7 @@ func (mr *MockPermissionStateMockRecorder) ReadUserAccessLevelForTarget(arg0, ar
 }
 
 // UpsertPermission mocks base method.
-func (m *MockPermissionState) UpsertPermission(arg0 context.Context, arg1 access.UpsertPermissionArgs) error {
+func (m *MockPermissionState) UpsertPermission(arg0 context.Context, arg1 access.UpdatePermissionArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertPermission", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -15,6 +15,7 @@ import (
 
 	coredatabase "github.com/juju/juju/core/database"
 	corepermission "github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
@@ -139,40 +140,14 @@ VALUES ($dbAddUserPermission.*)
 // returned.
 // If the permission does not exist, no error is returned.
 func (st *PermissionState) DeletePermission(ctx context.Context, subject string, target corepermission.ID) error {
-	// TODO: is target.Key sufficient to Delete a permission?
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	m := make(sqlair.M, 1)
-	m["grant_on"] = target.Key
-
-	// The combination of grant_to and grant_on are guaranteed to be
-	// unique, thus it is all that is deleted to select the row to be
-	// deleted.
-	deletePermission := `
-DELETE 
-FROM permission 
-WHERE grant_to = $M.grant_to AND grant_on = $M.grant_on
-`
-	deletePermissionStmt, err := sqlair.Prepare(deletePermission, m)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		userUUID, err := st.userUUIDForName(ctx, tx, subject)
-		if err != nil {
-			return errors.Annotatef(accesserrors.UserNotFound, "looking up UUID for user %q", subject)
-		}
-		m["grant_to"] = userUUID
-
-		err = tx.Query(ctx, deletePermissionStmt, m).Run()
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "deleting permission of %q on %q", subject, target.Key)
-		}
-		return nil
+		err := st.deletePermission(ctx, tx, subject, target)
+		return errors.Annotatef(err, "delete permission")
 	})
 	return errors.Trace(domain.CoerceError(err))
 }
@@ -182,7 +157,53 @@ WHERE grant_to = $M.grant_to AND grant_on = $M.grant_on
 // subject does not exist, it is created using the subject and api user. Access
 // can be granted or revoked.
 func (st *PermissionState) UpsertPermission(ctx context.Context, args access.UpsertPermissionArgs) error {
-	return errors.NotImplementedf("UpsertPermission")
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		apiUserUUID, err := st.upsertPermissionAuthorized(ctx, tx, args.ApiUser, args.AccessSpec.Target.Key)
+		if err != nil {
+			return errors.Annotatef(err, "permission creator %q", args.ApiUser)
+		}
+
+		subjectExists, err := st.userExists(ctx, tx, args.Subject)
+		if (err != nil && !errors.Is(err, accesserrors.UserNotFound)) ||
+			(errors.Is(err, accesserrors.UserNotFound) && !args.AddUser) {
+			return errors.Trace(err)
+		}
+
+		switch args.Change {
+		case corepermission.Grant:
+			if subjectExists {
+				return errors.Trace(st.grantPermission(ctx, tx, args))
+			}
+			userUUID, err := user.NewUUID()
+			if err != nil {
+				return errors.Annotate(err, "generating user UUID")
+			}
+			err = AddUser(ctx, tx, userUUID, args.Subject, "", apiUserUUID, args.AccessSpec)
+			if err != nil {
+				return errors.Annotatef(err, "granting permission for %q on %q", args.Subject, args.AccessSpec.Target.Key)
+			}
+			// TODO (hml) 202403-04
+			// Question, is this the right thing to do?
+			// Alternative is to change Read queries to not include disabled.
+			return errors.Annotatef(ensureUserAuthentication(ctx, tx, args.Subject), "enabling new user %q", args.Subject)
+		case corepermission.Revoke:
+			if !subjectExists {
+				return errors.Trace(errors.NotValidf("change type %q with non existent user %q", args.Change, args.Subject))
+			}
+			return errors.Trace(st.revokePermission(ctx, tx, args))
+		default:
+			return errors.Trace(errors.NotValidf("change type %q", args.Change))
+		}
+	})
+	if err != nil {
+		return errors.Trace(domain.CoerceError(err))
+	}
+
+	return nil
 }
 
 // ReadUserAccessForTarget returns the subject's (user) access for the
@@ -496,29 +517,36 @@ WHERE  u.removed = false
 	return users, nil
 }
 
-// userUUIDForName returns the user UUID for the associated name
+// userExists returns the true for the associated name
 // if the user is active.
-// Method borrowed from the user domain state.
-func (st *PermissionState) userUUIDForName(
+func (st *PermissionState) userExists(
 	ctx context.Context, tx *sqlair.TX, name string,
-) (string, error) {
-	stmt, err := st.Prepare(
-		`SELECT &M.uuid FROM user WHERE name = $M.name`, sqlair.M{})
+) (bool, error) {
+	stmt, err := st.Prepare(`
+SELECT  u.uuid AS &M.found_it 
+FROM    v_user_auth u 
+WHERE   name = $M.name
+AND     u.disabled = false
+AND     u.removed = false
+`, sqlair.M{})
 
 	if err != nil {
-		return "", errors.Annotate(err, "preparing user UUID statement")
+		return false, errors.Annotate(err, "preparing user exist statement")
 	}
 
 	var inOut = sqlair.M{"name": name}
 	err = tx.Query(ctx, stmt, inOut).Get(&inOut)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", errors.Annotatef(accesserrors.UserNotFound, "active user %q", name)
+			return false, errors.Annotatef(accesserrors.UserNotFound, "active user %q", name)
 		}
-		return "", errors.Annotatef(err, "getting user %q", name)
+		return false, errors.Annotatef(err, "getting user %q", name)
 	}
-
-	return inOut["uuid"].(string), nil
+	var result bool
+	if _, ok := inOut["found_it"].(string); ok {
+		result = true
+	}
+	return result, nil
 }
 
 func objectAccessID(
@@ -621,40 +649,6 @@ func objectTag(id corepermission.ID) (result names.Tag) {
 	return
 }
 
-// findAccessType returns the accessType and uuid of the
-// permission for the given grantOn and grantTo combination.
-// There can be only one.
-func (st *PermissionState) findAccessType(
-	ctx context.Context,
-	tx *sqlair.TX,
-	grantOn, grantTo string,
-) (string, string, error) {
-	findAccessTypeQuery := `
-SELECT (uuid, access_type) AS (&dbReadUserPermission.*)
-FROM   v_permission
-WHERE  grant_on = $dbReadUserPermission.grant_on
-       AND grant_to = $dbReadUserPermission.grant_to
-`
-	findAccessTypeStmt, err := st.Prepare(findAccessTypeQuery, dbReadUserPermission{})
-	if err != nil {
-		return "", "", errors.Annotate(err, "preparing select findAccessType query")
-	}
-
-	input := dbReadUserPermission{
-		GrantTo: grantTo,
-		GrantOn: grantOn,
-	}
-	result := dbReadUserPermission{}
-	err = tx.Query(ctx, findAccessTypeStmt, input).Get(&result)
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
-		return "", "", errors.Annotatef(accesserrors.PermissionNotFound, "for %q on %q", grantTo, grantOn)
-	} else if err != nil {
-		return "", "", errors.Annotatef(err, "getting permission for %q on %q", grantTo, grantOn)
-	}
-
-	return result.AccessType, result.UUID, nil
-}
-
 // readUsersPermissions returns all permissions for the grantTo, a user UUID.
 func (st *PermissionState) readUsersPermissions(ctx context.Context,
 	tx *sqlair.TX,
@@ -740,10 +734,10 @@ func (st *PermissionState) userAccessLevel(ctx context.Context, tx *sqlair.TX, s
 SELECT  p.access_type AS &inputOutput.access_type
 FROM    v_permission p
         LEFT JOIN v_user_auth u ON u.uuid = p.grant_to
-WHERE   u.name = $input.name
+WHERE   u.name = $inputOutput.name
 AND     u.disabled = false
 AND     u.removed = false
-AND     p.grant_on = $input.grant_on
+AND     p.grant_on = $inputOutput.grant_on
 `
 
 	readStmt, err := st.Prepare(readQuery, inputOutput{})
@@ -760,4 +754,160 @@ AND     p.grant_on = $input.grant_on
 		return corepermission.NoAccess, errors.Annotatef(err, "reading user access level for target")
 	}
 	return corepermission.Access(inOut.Access), nil
+}
+
+// upsertPermissionAuthorized determines if the given user is able a user and
+// create/update the given permissions. If superuser, the user can do
+// everything. If the user has admin permissions on the grantOn, the
+// permission changes can be made. If the apiUser has permissions, return their
+// UUID.
+func (st *PermissionState) upsertPermissionAuthorized(
+	ctx context.Context, tx *sqlair.TX, apiUser string, grantOn string,
+) (user.UUID, error) {
+	var apiUserUUID user.UUID
+	// Does the apiUser have superuser access?
+	// Is permission the apiUser has on the target Admin?
+	type input struct {
+		Name    string `db:"name"`
+		GrantOn string `db:"grant_on"`
+	}
+
+	authQuery := `
+WITH    ctrl AS (SELECT 'controller' AS c)
+SELECT  (p.grant_to, p.access_type) AS (&dbReadUserPermission.*)
+FROM    v_permission p
+        JOIN v_user_auth u ON u.uuid = p.grant_to
+        LEFT JOIN ctrl ON p.grant_on = ctrl.c
+WHERE   u.name = $input.name
+AND     (p.grant_on = $input.grant_on OR p.grant_on = ctrl.c)
+AND     u.disabled = false
+AND     u.removed = false
+`
+	authStmt, err := st.Prepare(authQuery, dbReadUserPermission{}, input{})
+	if err != nil {
+		return apiUserUUID, errors.Trace(err)
+	}
+	var readPerm []dbReadUserPermission
+	in := input{
+		GrantOn: grantOn,
+		Name:    apiUser,
+	}
+	err = tx.Query(ctx, authStmt, in).GetAll(&readPerm)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return apiUserUUID, errors.Annotatef(accesserrors.PermissionNotValid, "on %q", grantOn)
+	} else if err != nil {
+		return apiUserUUID, errors.Annotatef(err, "verifying authorization of %q", grantOn)
+	}
+	apiUserUUID = user.UUID(readPerm[0].GrantTo)
+
+	for _, read := range readPerm {
+		if read.AccessType == string(corepermission.SuperuserAccess) ||
+			read.AccessType == string(corepermission.AdminAccess) {
+			return apiUserUUID, nil
+		}
+	}
+
+	return apiUserUUID, accesserrors.PermissionNotValid
+}
+
+func (st *PermissionState) grantPermission(ctx context.Context, tx *sqlair.TX, args access.UpsertPermissionArgs) error {
+	userAccessLevel, err := st.userAccessLevel(ctx, tx, args.Subject, args.AccessSpec.Target)
+	if err != nil {
+		return errors.Annotatef(err, "getting current access for grant")
+	}
+	aSpec := corepermission.AccessSpec{
+		Target: args.AccessSpec.Target,
+		Access: userAccessLevel,
+	}
+	grantAccess := args.AccessSpec.Access
+	if aSpec.EqualOrGreaterThan(grantAccess) {
+		return errors.Errorf("user %q already has %q access or greater", args.Subject, grantAccess)
+	}
+	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, string(grantAccess)); err != nil {
+		return errors.Annotatef(err, "updating current access during grant")
+	}
+	return nil
+}
+
+func (st *PermissionState) revokePermission(ctx context.Context, tx *sqlair.TX, args access.UpsertPermissionArgs) error {
+	newAccess := args.AccessSpec.RevokeAccess()
+	if newAccess == corepermission.NoAccess {
+		err := st.deletePermission(ctx, tx, args.Subject, args.AccessSpec.Target)
+		return errors.Annotatef(err, "revoking %q", args.AccessSpec.Access)
+	}
+	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, string(newAccess)); err != nil {
+		return errors.Annotatef(err, "updating current access during revoke")
+	}
+	return nil
+}
+
+func (st *PermissionState) deletePermission(ctx context.Context, tx *sqlair.TX, subject string, target corepermission.ID) error {
+	type input struct {
+		Name    string `db:"name"`
+		GrantOn string `db:"grant_on"`
+	}
+
+	// The combination of grant_to and grant_on are guaranteed to be
+	// unique, thus it is all that is deleted to select the row to be
+	// deleted.
+	deletePermission := `
+DELETE
+FROM   permission
+WHERE  uuid IN (
+       SELECT p.uuid
+       FROM   permission p
+              LEFT JOIN user AS u ON u.uuid = p.grant_to
+       WHERE  u.name = $input.name
+       AND    p.grant_on = $input.grant_on
+)
+`
+	deletePermissionStmt, err := sqlair.Prepare(deletePermission, input{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	in := input{
+		Name:    subject,
+		GrantOn: target.Key,
+	}
+	err = tx.Query(ctx, deletePermissionStmt, in).Run()
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Annotatef(err, "deleting permission of %q on %q", subject, target.Key)
+	}
+	return nil
+}
+
+func (st *PermissionState) updatePermission(ctx context.Context, tx *sqlair.TX, subjectName, grantOn, access string) error {
+	type input struct {
+		Name    string `db:"name"`
+		GrantOn string `db:"grant_on"`
+		Access  string `db:"access"`
+	}
+
+	updateQuery := `
+UPDATE permission
+SET    permission_type_id = (
+           SELECT id 
+           FROM   permission_access_type 
+           WHERE  type = $input.access
+       ) 
+FROM   permission p
+       LEFT JOIN user u ON u.uuid = p.grant_to
+WHERE  p.grant_on = $input.grant_on
+AND    u.name = $input.name
+`
+	updateQueryStmt, err := st.Prepare(updateQuery, input{})
+	if err != nil {
+		return errors.Annotate(err, "preparing update updateLastLogin query")
+	}
+
+	in := input{
+		Name:    subjectName,
+		GrantOn: grantOn,
+		Access:  access,
+	}
+	if err := tx.Query(ctx, updateQueryStmt, in).Run(); err != nil {
+		return errors.Annotatef(err, "updating access on %q for %q to %q", grantOn, subjectName, access)
+	}
+	return nil
 }

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -488,7 +488,7 @@ func (s *permissionStateSuite) TestUpsertPermissionGrantNewUser(c *gc.C) {
 		ObjectType: corepermission.Model,
 		Key:        "default-model",
 	}
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: target,
 			Access: corepermission.WriteAccess,
@@ -520,7 +520,7 @@ func (s *permissionStateSuite) TestUpsertPermissionGrantExistingUser(c *gc.C) {
 		ObjectType: corepermission.Model,
 		Key:        "default-model",
 	}
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: target,
 			Access: corepermission.AdminAccess,
@@ -548,7 +548,7 @@ func (s *permissionStateSuite) TestUpsertPermissionGrantLessAccess(c *gc.C) {
 		ObjectType: corepermission.Model,
 		Key:        "default-model",
 	}
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: target,
 			Access: corepermission.ReadAccess,
@@ -565,7 +565,7 @@ func (s *permissionStateSuite) TestUpsertPermissionGrantLessAccess(c *gc.C) {
 func (s *permissionStateSuite) TestUpsertPermissionNotAuthorized(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
 				ObjectType: corepermission.Model,
@@ -590,7 +590,7 @@ func (s *permissionStateSuite) TestUpsertPermissionRevokeRemovePerm(c *gc.C) {
 		ObjectType: corepermission.Model,
 		Key:        "default-model",
 	}
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: target,
 			Access: corepermission.ReadAccess,
@@ -617,7 +617,7 @@ func (s *permissionStateSuite) TestUpsertPermissionRevoke(c *gc.C) {
 		ObjectType: corepermission.Cloud,
 		Key:        "test-cloud",
 	}
-	arg := access.UpsertPermissionArgs{
+	arg := access.UpdatePermissionArgs{
 		AccessSpec: corepermission.AccessSpec{
 			Target: target,
 			Access: corepermission.AdminAccess,

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -813,7 +813,7 @@ func (s *permissionStateSuite) printRead(c *gc.C) {
 SELECT  p.uuid, p.grant_on, p.grant_to, p.access_type,
         u.uuid, u.name, creator.name
 FROM    v_user_auth u
-        LEFT JOIN user AS creator ON u.created_by_uuid = creator.uuid
+        JOIN user AS creator ON u.created_by_uuid = creator.uuid
         JOIN v_permission p ON u.uuid = p.grant_to
 `
 	rows, _ := s.DB().Query(q)

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -12,8 +12,10 @@ import (
 // UpsertPermissionArgs are necessary arguments to run
 // UpdatePermissionOnTarget.
 type UpsertPermissionArgs struct {
-	// Access is what the permission access should change to.
-	Access permission.Access
+	// AccessSpec is what the permission access should change to
+	// combined with the target the subject's permission to is being
+	// updated on.
+	AccessSpec permission.AccessSpec
 	// AddUser will add the subject if the user does not exist.
 	AddUser bool
 	// ApiUser is the user requesting the change, they must have
@@ -23,9 +25,6 @@ type UpsertPermissionArgs struct {
 	Change permission.AccessChange
 	// Subject is the subject of the permission, e.g. user.
 	Subject string
-	// Target is the thing the subject's permission to is being
-	// updated on.
-	Target permission.ID
 }
 
 func (args UpsertPermissionArgs) Validate() error {
@@ -35,7 +34,7 @@ func (args UpsertPermissionArgs) Validate() error {
 	if args.Subject == "" {
 		return errors.Trace(errors.NotValidf("empty subject"))
 	}
-	if err := args.Target.ValidateAccess(args.Access); err != nil {
+	if err := args.AccessSpec.Validate(); err != nil {
 		return errors.Trace(err)
 	}
 	if args.Change != permission.Grant && args.Change != permission.Revoke {

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -9,9 +9,9 @@ import (
 	"github.com/juju/juju/core/permission"
 )
 
-// UpsertPermissionArgs are necessary arguments to run
+// UpdatePermissionArgs are necessary arguments to run
 // UpdatePermissionOnTarget.
-type UpsertPermissionArgs struct {
+type UpdatePermissionArgs struct {
 	// AccessSpec is what the permission access should change to
 	// combined with the target the subject's permission to is being
 	// updated on.
@@ -27,7 +27,7 @@ type UpsertPermissionArgs struct {
 	Subject string
 }
 
-func (args UpsertPermissionArgs) Validate() error {
+func (args UpdatePermissionArgs) Validate() error {
 	if args.ApiUser == "" {
 		return errors.Trace(errors.NotValidf("empty api user"))
 	}

--- a/domain/access/types_test.go
+++ b/domain/access/types_test.go
@@ -23,22 +23,26 @@ func (s *typesSuite) TestUpsertPermissionArgsValidationFail(c *gc.C) {
 			ApiUser: "admin",
 			Subject: "testme",
 		}, { // Target and Access don't mesh
-			Access:  permission.AddModelAccess,
+			AccessSpec: permission.AccessSpec{
+				Access: permission.AddModelAccess,
+				Target: permission.ID{
+					ObjectType: permission.Cloud,
+					Key:        "aws",
+				},
+			},
 			ApiUser: "admin",
 			Subject: "testme",
-			Target: permission.ID{
-				ObjectType: permission.Cloud,
-				Key:        "aws",
-			},
 		}, { // Invalid Change
-			Access:  permission.AddModelAccess,
+			AccessSpec: permission.AccessSpec{
+				Access: permission.AddModelAccess,
+				Target: permission.ID{
+					ObjectType: permission.Model,
+					Key:        "aws",
+				},
+			},
 			ApiUser: "admin",
 			Change:  "testing",
 			Subject: "testme",
-			Target: permission.ID{
-				ObjectType: permission.Model,
-				Key:        "aws",
-			},
 		}}
 	for i, args := range argsToTest {
 		c.Logf("Test %d", i)

--- a/domain/access/types_test.go
+++ b/domain/access/types_test.go
@@ -16,7 +16,7 @@ type typesSuite struct{}
 var _ = gc.Suite(&typesSuite{})
 
 func (s *typesSuite) TestUpsertPermissionArgsValidationFail(c *gc.C) {
-	argsToTest := []UpsertPermissionArgs{
+	argsToTest := []UpdatePermissionArgs{
 		{}, { // Missing Subject
 			ApiUser: "admin",
 		}, { // Missing Target


### PR DESCRIPTION

Implementation of UpsertPermission to replace the grant/revoke permission work done in the facades for clouds, controllers, models and application offers. This also consolidates the logic in one place, rather than 4 implementations of the same. To handle the logic around different permission uniquely for each type, that logic is now in core permission RevokeAccess and EqualOrGreaterThan methods on the AccessSpec structures.

The SQL logic around delete permission has also been consolidated into one to remove the current potato logic.

The specific revoke of a permission logic is from current modelmanager.ModifyModelAccess cloud.ChangeCloudAccess, and versions for offers and controller.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests. This work is not wired up just yet.

## Links

**Jira card:** JUJU-5559
A bit of work on JUJU-5793

