### PR TITLE
Move from https://dev.midipix.org/compat/musl-compat to https://github.com/juju/musl-compat

### DIFF
--- a/scripts/dqlite/scripts/dqlite/dqlite-build.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-build.sh
@@ -50,7 +50,7 @@ build() {
     sudo ln -s /usr/include/linux /usr/local/musl/include/linux || true
 
     # Grab the queue.h file that does not ship with musl
-    sudo wget https://dev.midipix.org/compat/musl-compat/raw/main/f/include/sys/queue.h -O /usr/local/musl/include/sys/queue.h
+    sudo wget https://raw.githubusercontent.com/juju/musl-compat/main/include/sys/queue.h -O /usr/local/musl/include/sys/queue.h
 
     # Install compile dependencies for statically linking everything:
     # --------------------------------------------------------------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,7 +96,7 @@ parts:
       ln -s /usr/include/linux /usr/local/musl/include/linux
 
   musl-compat:
-    source: https://dev.midipix.org/compat/musl-compat.git
+    source: https://github.com/juju/musl-compat.git
     source-type: git
     source-depth: 1
     plugin: nil


### PR DESCRIPTION
Fixes snap build issue due to issues with upstream being unavailable.