### PR TITLE
Add minimal secret state methods for create and get

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -61,9 +61,9 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("storage_volume_attachment", "uuid", tableVolumeAttachment),
 		changeLogTriggersForTable("storage_volume_attachment_plan", "uuid", tableVolumeAttachmentPlan),
 		changeLogTriggersForTableOnColumn(
-			"secret", "uuid", "auto_prune", tableSecretAutoPrune),
+			"secret", "id", "auto_prune", tableSecretAutoPrune),
 		changeLogTriggersForTableOnColumn(
-			"secret_rotation", "secret_uuid", "next_rotation_time", tableSecretRotation),
+			"secret_rotation", "secret_id", "next_rotation_time", tableSecretRotation),
 		changeLogTriggersForTableOnColumn(
 			"secret_revision", "uuid", "obsolete", tableSecretRevisionObsolete),
 		changeLogTriggersForTableOnColumn(

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -120,7 +120,7 @@ INSERT INTO secret_rotate_policy VALUES
 
 CREATE TABLE
     secret (
-        uuid TEXT PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         version INT,
         description TEXT,
         rotate_policy TEXT,
@@ -134,11 +134,11 @@ CREATE TABLE
 
 CREATE TABLE
     secret_rotation (
-        secret_uuid TEXT PRIMARY KEY,
+        secret_id TEXT PRIMARY KEY,
         next_rotation_time DATETIME NOT NULL,
-        CONSTRAINT fk_secret_rotation_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid)
+        CONSTRAINT fk_secret_rotation_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id)
     );
 
 -- 1:1
@@ -175,7 +175,7 @@ CREATE INDEX idx_secret_content_revision_uuid ON secret_content (revision_uuid);
 CREATE TABLE
     secret_revision (
         uuid TEXT PRIMARY KEY,
-        secret_uuid TEXT NOT NULL,
+        secret_id TEXT NOT NULL,
         revision INT NOT NULL,
         obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
         -- pending_delete is true if the revision is to be deleted.
@@ -183,12 +183,12 @@ CREATE TABLE
         pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
         create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
         update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-        CONSTRAINT fk_secret_revision_secret_uuid 
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid)
+        CONSTRAINT fk_secret_revision_secret_id 
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id)
     );
 
-CREATE UNIQUE INDEX idx_secret_revision_secret_uuid_revision ON secret_revision (secret_uuid,revision);
+CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision ON secret_revision (secret_id,revision);
 
 CREATE TABLE
     secret_revision_expire (
@@ -201,12 +201,12 @@ CREATE TABLE
 
 CREATE TABLE
     secret_application_owner (
-        secret_uuid TEXT PRIMARY KEY,
+        secret_id TEXT PRIMARY KEY,
         application_uuid TEXT NOT NULL,
         label TEXT,
-        CONSTRAINT fk_secret_application_owner_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_application_owner_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_application_owner_application_uuid
             FOREIGN KEY (application_uuid)
             REFERENCES application (uuid)
@@ -217,12 +217,12 @@ CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_own
 
 CREATE TABLE
     secret_unit_owner (
-        secret_uuid TEXT PRIMARY KEY,
+        secret_id TEXT PRIMARY KEY,
         unit_uuid TEXT NOT NULL,
         label TEXT,
-        CONSTRAINT fk_secret_unit_owner_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_unit_owner_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_unit_owner_unit_uuid
             FOREIGN KEY (unit_uuid)
             REFERENCES unit (uuid)
@@ -233,11 +233,11 @@ CREATE UNIQUE INDEX idx_secret_unit_owner_label ON secret_unit_owner (label,unit
 
 CREATE TABLE
     secret_model_owner (
-        secret_uuid TEXT PRIMARY KEY,
+        secret_id TEXT PRIMARY KEY,
         label TEXT,
-        CONSTRAINT fk_secret_model_owner_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid)
+        CONSTRAINT fk_secret_model_owner_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id)
     );
 
 CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label);
@@ -245,69 +245,69 @@ CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label);
 CREATE TABLE
     secret_application_consumer (
         uuid TEXT PRIMARY KEY,
-        secret_uuid TEXT NOT NULL,
+        secret_id TEXT NOT NULL,
         application_uuid TEXT NOT NULL,
         label TEXT,
         current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_application_consumer_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_application_consumer_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_application_consumer_application_uuid
             FOREIGN KEY (application_uuid)
             REFERENCES application (uuid)
     );
-CREATE UNIQUE INDEX idx_secret_application_consumer_secret_uuid_application_uuid ON secret_application_consumer (secret_uuid,application_uuid);
+CREATE UNIQUE INDEX idx_secret_application_consumer_secret_id_application_uuid ON secret_application_consumer (secret_id,application_uuid);
 CREATE UNIQUE INDEX idx_secret_application_consumer_label ON secret_application_consumer (label,application_uuid);
 
 CREATE TABLE
     secret_unit_consumer (
         uuid TEXT PRIMARY KEY,
-        secret_uuid TEXT NOT NULL,
+        secret_id TEXT NOT NULL,
         unit_uuid TEXT NOT NULL,
         label TEXT,
         current_revision INT NOT NULL, 
-        CONSTRAINT fk_secret_unit_consumer_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_unit_consumer_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_unit_consumer_unit_uuid
             FOREIGN KEY (unit_uuid)
             REFERENCES unit (uuid)
     );
 
-CREATE UNIQUE INDEX idx_secret_unit_consumer_secret_uuid_unit_uuid ON secret_unit_consumer (secret_uuid,unit_uuid);
+CREATE UNIQUE INDEX idx_secret_unit_consumer_secret_id_unit_uuid ON secret_unit_consumer (secret_id,unit_uuid);
 CREATE UNIQUE INDEX idx_secret_unit_consumer_label ON secret_unit_consumer (label,unit_uuid);
 
 CREATE TABLE
     secret_remote_application_consumer (
         uuid TEXT PRIMARY KEY,
-        secret_uuid TEXT NOT NULL,
+        secret_id TEXT NOT NULL,
         application_uuid TEXT NOT NULL,
         current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_remote_application_consumer_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_remote_application_consumer_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_remote_application_consumer_application_uuid
             FOREIGN KEY (application_uuid)
             REFERENCES application (uuid)
     );
 
-CREATE UNIQUE INDEX idx_secret_remote_application_consumer_secret_uuid_application_uuid ON secret_remote_application_consumer (secret_uuid,application_uuid);
+CREATE UNIQUE INDEX idx_secret_remote_application_consumer_secret_id_application_uuid ON secret_remote_application_consumer (secret_id,application_uuid);
 
 CREATE TABLE
     secret_remote_unit_consumer (
         uuid TEXT PRIMARY KEY,
-        secret_uuid TEXT NOT NULL,
+        secret_id TEXT NOT NULL,
         unit_uuid TEXT NOT NULL,
         current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_remote_unit_consumer_secret_uuid
-            FOREIGN KEY (secret_uuid)
-            REFERENCES secret (uuid),
+        CONSTRAINT fk_secret_remote_unit_consumer_secret_id
+            FOREIGN KEY (secret_id)
+            REFERENCES secret (id),
         CONSTRAINT fk_secret_remote_unit_consumer_unit_uuid
             FOREIGN KEY (unit_uuid)
             REFERENCES unit (uuid)
     );
 
-CREATE UNIQUE INDEX idx_secret_remote_unit_consumer_secret_uuid_unit_uuid ON secret_remote_unit_consumer (secret_uuid,unit_uuid);
+CREATE UNIQUE INDEX idx_secret_remote_unit_consumer_secret_id_unit_uuid ON secret_remote_unit_consumer (secret_id,unit_uuid);
 
 CREATE TABLE
     secret_role (

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -213,7 +213,7 @@ CREATE TABLE
     );
 
 -- We need to ensure the label is unique per the application.
-CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_owner (label,application_uuid);
+CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_owner (label,application_uuid) WHERE label != '';
 
 CREATE TABLE
     secret_unit_owner (
@@ -229,7 +229,7 @@ CREATE TABLE
     );
 
 -- We need to ensure the label is unique per unit.
-CREATE UNIQUE INDEX idx_secret_unit_owner_label ON secret_unit_owner (label,unit_uuid);
+CREATE UNIQUE INDEX idx_secret_unit_owner_label ON secret_unit_owner (label,unit_uuid) WHERE label != '';
 
 CREATE TABLE
     secret_model_owner (
@@ -240,7 +240,7 @@ CREATE TABLE
             REFERENCES secret (id)
     );
 
-CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label);
+CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label) WHERE label != '';
 
 CREATE TABLE
     secret_application_consumer (

--- a/domain/secret/errors/errors.go
+++ b/domain/secret/errors/errors.go
@@ -12,9 +12,9 @@ const (
 	// does not exist.
 	SecretNotFound = errors.ConstError("secret not found")
 
-	// SecretAlreadyExists describes an error that occurs when the secret being operated on
-	// already exists.
-	SecretAlreadyExists = errors.ConstError("secret already exists")
+	// SecretLabelAlreadyExists describes an error that occurs when there's already a secret label for
+	// a specified secret owner.
+	SecretLabelAlreadyExists = errors.ConstError("secret label already exists")
 
 	// SecretRevisionNotFound describes an error that occurs when the secret revision being operated on
 	// does not exist.

--- a/domain/secret/errors/errors.go
+++ b/domain/secret/errors/errors.go
@@ -11,4 +11,12 @@ const (
 	// SecretNotFound describes an error that occurs when the secret being operated on
 	// does not exist.
 	SecretNotFound = errors.ConstError("secret not found")
+
+	// SecretAlreadyExists describes an error that occurs when the secret being operated on
+	// already exists.
+	SecretAlreadyExists = errors.ConstError("secret already exists")
+
+	// SecretRevisionNotFound describes an error that occurs when the secret revision being operated on
+	// does not exist.
+	SecretRevisionNotFound = errors.ConstError("secret revision not found")
 )

--- a/domain/secret/params.go
+++ b/domain/secret/params.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secret
+
+import (
+	"time"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+// UpsertSecretParams are used to upsert a secret.
+type UpsertSecretParams struct {
+	RotatePolicy secrets.RotatePolicy
+	ExpireTime   time.Time
+	Description  string
+	Label        string
+	Data         secrets.SecretData
+	ValueRef     *secrets.ValueRef
+	AutoPrune    bool
+}

--- a/domain/secret/state/package_test.go
+++ b/domain/secret/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -1,0 +1,448 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	coredatabase "github.com/juju/juju/core/database"
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain"
+	domainsecret "github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// State represents database interactions dealing with storage pools.
+type State struct {
+	*domain.StateBase
+}
+
+// NewState returns a new secretMetadata state
+// based on the input database factory method.
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// CreateUserSecret creates a user secret, returning an error satisfying [secreterrors.SecretAlreadyExists]
+// if a user secret with the same label already exists.
+func (st State) CreateUserSecret(ctx context.Context, version int, uri *coresecrets.URI, secret domainsecret.UpsertSecretParams) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	revisionUUID, err := uuid.NewUUID()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	checkExistsSQL := "SELECT &secretOwner.secret_id FROM secret_model_owner WHERE label = $secretOwner.label"
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := st.createSecret(ctx, tx, version, uri, secret, revisionUUID, checkExistsSQL); err != nil {
+			return errors.Annotatef(err, "inserting secret records for secret %q", uri)
+		}
+
+		dbSecretOwner := secretOwner{SecretID: uri.ID, Label: secret.Label}
+		if err := st.upsertSecretModelOwner(ctx, tx, dbSecretOwner); err != nil {
+			return errors.Annotatef(err, "inserting user secret record for secret %q", uri)
+		}
+		return nil
+	})
+	return errors.Trace(domain.CoerceError(err))
+}
+
+// checkSecretExists returns an error if the secret with the given label already exists.
+func (st State) checkSecretExists(ctx context.Context, tx *sqlair.TX, label, checkExistsSQL string) error {
+	checkExistsStmt, err := st.Prepare(checkExistsSQL, secretOwner{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	dbSecretOwner := secretOwner{Label: label}
+	err = tx.Query(ctx, checkExistsStmt, dbSecretOwner).Get(&dbSecretOwner)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Trace(domain.CoerceError(err))
+	}
+	if err == nil {
+		return fmt.Errorf("secret with label %q %w", label, secreterrors.SecretAlreadyExists)
+	}
+	return nil
+}
+
+// createSecret creates the records needed to store secret data, excluding secret owner records.
+func (st State) createSecret(ctx context.Context, tx *sqlair.TX, version int, uri *coresecrets.URI, secret domainsecret.UpsertSecretParams, revisionUUID uuid.UUID, checkExistsSQL string) error {
+	if err := st.checkSecretExists(ctx, tx, secret.Label, checkExistsSQL); err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(secret.Data) == 0 && secret.ValueRef == nil {
+		return errors.Errorf("cannot create a secret without any data")
+	}
+
+	now := time.Now()
+	dbSecret := secretMetadata{
+		ID:          uri.ID,
+		Version:     version,
+		Description: secret.Description,
+		AutoPrune:   secret.AutoPrune,
+		CreateTime:  now,
+		UpdateTime:  now,
+	}
+	if err := st.upsertSecret(ctx, tx, dbSecret); err != nil {
+		return errors.Annotatef(err, "creating user secret %q", uri)
+	}
+
+	dbRevision := secretRevision{
+		ID:         revisionUUID.String(),
+		SecretID:   uri.ID,
+		Revision:   1,
+		CreateTime: now,
+		UpdateTime: now,
+	}
+	if err := st.upsertSecretRevision(ctx, tx, dbRevision); err != nil {
+		return errors.Annotatef(err, "inserting revision for secret %q", uri)
+	}
+
+	if len(secret.Data) > 0 {
+		if err := st.updateSecretContent(ctx, tx, dbRevision.ID, secret.Data); err != nil {
+			return errors.Annotatef(err, "updating content for secret %q", uri)
+		}
+	}
+
+	if secret.ValueRef != nil {
+		if err := st.upsertSecretValueRef(ctx, tx, dbRevision.ID, secret.ValueRef); err != nil {
+			return errors.Annotatef(err, "updating backend value reference for secret %q", uri)
+		}
+	}
+	return nil
+}
+
+func (st State) upsertSecret(ctx context.Context, tx *sqlair.TX, dbSecret secretMetadata) error {
+	insertQuery := `
+INSERT INTO secret (*)
+VALUES ($secretMetadata.*)
+ON CONFLICT(id) DO UPDATE SET version=excluded.version,
+                              description=excluded.description,
+                              rotate_policy=excluded.rotate_policy,
+                              auto_prune=excluded.auto_prune,
+                              update_time=excluded.update_time
+`
+
+	insertStmt, err := st.Prepare(insertQuery, secretMetadata{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = tx.Query(ctx, insertStmt, dbSecret).Run()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (st State) upsertSecretModelOwner(ctx context.Context, tx *sqlair.TX, secret secretOwner) error {
+	insertQuery := `
+INSERT INTO secret_model_owner (secret_id, label)
+VALUES      ($secretOwner.*)
+ON CONFLICT(secret_id) DO UPDATE SET label=excluded.label
+`
+
+	insertStmt, err := st.Prepare(insertQuery, secretOwner{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = tx.Query(ctx, insertStmt, secret).Run()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (st State) upsertSecretRevision(ctx context.Context, tx *sqlair.TX, dbRevision secretRevision) error {
+	insertQuery := `
+INSERT INTO secret_revision (*)
+VALUES (    $secretRevision.*)
+ON CONFLICT(uuid) DO UPDATE SET obsolete=excluded.obsolete,
+                                pending_delete=excluded.pending_delete,
+                                update_time=excluded.update_time
+`
+
+	insertStmt, err := st.Prepare(insertQuery, secretRevision{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = tx.Query(ctx, insertStmt, dbRevision).Run()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (st State) upsertSecretValueRef(ctx context.Context, tx *sqlair.TX, revisionUUID string, valueRef *coresecrets.ValueRef) error {
+	insertQuery := `
+INSERT INTO secret_value_ref (*)
+VALUES      ($secretValueRef.*)
+ON CONFLICT(revision_uuid) DO UPDATE SET backend_uuid=excluded.backend_uuid,
+                                         revision_id=excluded.revision_id
+`
+
+	insertStmt, err := st.Prepare(insertQuery, secretValueRef{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = tx.Query(ctx, insertStmt, secretValueRef{
+		ID:          revisionUUID,
+		BackendUUID: valueRef.BackendID,
+		RevisionID:  valueRef.RevisionID,
+	}).Run()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+type keysToKeep []string
+
+func (st State) updateSecretContent(ctx context.Context, tx *sqlair.TX, revisionUUID string, content coresecrets.SecretData) error {
+	// Delete any keys no longer in the content map.
+	deleteQuery := fmt.Sprintf(`
+DELETE FROM  secret_content
+WHERE        revision_uuid = $M.id
+AND          name NOT IN ($keysToKeep[:])
+`)
+
+	deleteStmt, err := st.Prepare(deleteQuery, sqlair.M{}, keysToKeep{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	insertQuery := `
+INSERT INTO secret_content
+VALUES (
+    $secretContent.revision_uuid,
+    $secretContent.name,
+    $secretContent.content
+)
+ON CONFLICT(revision_uuid, name) DO UPDATE SET name=excluded.name,
+                                               content=excluded.content
+`
+	insertStmt, err := st.Prepare(insertQuery, secretContent{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var keys keysToKeep
+	for k := range content {
+		keys = append(keys, k)
+	}
+	if err := tx.Query(ctx, deleteStmt, sqlair.M{"id": revisionUUID}, keys).Run(); err != nil {
+		return errors.Trace(err)
+	}
+	for key, value := range content {
+		if err := tx.Query(ctx, insertStmt, secretContent{
+			ID:      revisionUUID,
+			Name:    key,
+			Content: value,
+		}).Run(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// GetSecret returns the secret with the given URI, returning an error satisfying [secreterrors.SecretNotFound]
+// if the secret does not exist.
+// TODO(secrets) - fill in Access etc
+func (st State) GetSecret(ctx context.Context, uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	query := fmt.Sprintf(`
+SELECT 
+   id AS &secretInfo.id,
+   version as &secretInfo.version,
+   description as &secretInfo.description,
+   auto_prune as &secretInfo.auto_prune,
+   create_time as &secretInfo.create_time,
+   update_time as &secretInfo.update_time,
+   -- TODO(secrets) - sqlair doesn't like this
+   -- (SELECT MAX(revision) FROM secret_revision rev WHERE rev.secret_id = secret.id) AS &secretInfo.latest_revision,
+   so.owner_kind AS &secretOwner.owner_kind,
+   so.owner_id AS &secretOwner.owner_id,
+   so.label AS &secretOwner.label
+FROM   secret
+       LEFT JOIN (
+          SELECT '%s' AS owner_kind, (SELECT uuid FROM model) AS owner_id, label FROM secret_model_owner so WHERE so.secret_id = $M.id
+       UNION
+          SELECT '%s' AS owner_kind, application.name AS owner_id, label FROM secret_application_owner so
+          JOIN   application
+          WHERE  application.uuid = so.application_uuid
+          AND    so.secret_id = $M.id
+       UNION
+          SELECT '%s' AS owner_kind, unit.unit_id AS owner_id, label FROM secret_unit_owner so
+          JOIN   unit
+          WHERE  unit.uuid = so.unit_uuid
+          AND    so.secret_id = $M.id
+       ) so
+WHERE secret.id = $M.id
+`, coresecrets.ModelOwner, coresecrets.ApplicationOwner, coresecrets.UnitOwner)
+
+	queryStmt, err := st.Prepare(query, sqlair.M{}, secretInfo{}, secretOwner{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var (
+		dbSecrets      secrets
+		dbsecretOwners []secretOwner
+	)
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, queryStmt, sqlair.M{"id": uri.ID}).GetAll(&dbSecrets, &dbsecretOwners)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+		}
+		return errors.Annotatef(err, "retrieving secret %q", uri)
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying secrets")
+	}
+
+	secretMetadata, err := dbSecrets.toSecretMetadata(dbsecretOwners)
+	if err != nil {
+		return nil, errors.Annotatef(err, "composing secret %q from database", uri)
+	}
+	return secretMetadata[0], nil
+}
+
+// GetSecretRevision returns the secret revision with the given URI and revision number,
+// returning an error satisfying [secreterrors.SecretRevisionNotFound] if the secret does not exist.
+func (st State) GetSecretRevision(ctx context.Context, uri *coresecrets.URI, revision int) (*coresecrets.SecretRevisionMetadata, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	query := `
+SELECT (*) AS (&secretRevision.*)
+FROM   secret_revision
+WHERE  secret_id = $secretRevision.secret_id AND revision = $secretRevision.revision
+`
+
+	queryStmt, err := st.Prepare(query, secretRevision{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var (
+		dbSecretRevisions secretRevisions
+	)
+	want := secretRevision{SecretID: uri.ID, Revision: revision}
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, queryStmt, want).GetAll(&dbSecretRevisions)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return fmt.Errorf("secret revision %d for %q not found%w", revision, uri, errors.Hide(secreterrors.SecretRevisionNotFound))
+		}
+		return errors.Annotatef(err, "retrieving secret revision %d for %q", revision, uri)
+	}); err != nil {
+		return nil, errors.Annotate(err, "querying secret revisions")
+	}
+
+	secretRevisions, err := dbSecretRevisions.toSecretRevisions()
+	if err != nil {
+		return nil, errors.Annotatef(err, "composing secret revision %d for secret %q from database", revision, uri)
+	}
+	return secretRevisions[0], nil
+}
+
+// GetSecretValue returns the contents - either data or value reference - of a given secret revision,
+// returning an error satisfying [secreterrors.SecretRevisionNotFound] if the secret revision does not exist.
+func (st State) GetSecretValue(ctx context.Context, uri *coresecrets.URI, revision int) (coresecrets.SecretData, *coresecrets.ValueRef, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// We look for either content or a value reference, which ever is present.
+	contentQuery := `
+SELECT (*) AS (&secretContent.*)
+FROM   secret_content sc
+JOIN   secret_revision rev ON sc.revision_uuid = rev.uuid  
+WHERE  rev.secret_id = $secretRevision.secret_id AND rev.revision = $secretRevision.revision
+`
+
+	contentQueryStmt, err := st.Prepare(contentQuery, secretContent{}, secretRevision{})
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	valueRefQuery := `
+SELECT (*) AS (&secretValueRef.*)
+FROM   secret_value_ref val
+JOIN   secret_revision rev ON val.revision_uuid = rev.uuid  
+WHERE  rev.secret_id = $secretRevision.secret_id AND rev.revision = $secretRevision.revision
+`
+
+	valueRefQueryStmt, err := st.Prepare(valueRefQuery, secretValueRef{}, secretRevision{})
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	want := secretRevision{SecretID: uri.ID, Revision: revision}
+
+	var (
+		dbSecretValues    secretValues
+		dbSecretValueRefs []secretValueRef
+	)
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, contentQueryStmt, want).GetAll(&dbSecretValues)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Annotatef(err, "retrieving secret value for %q revision %d", uri, revision)
+		}
+		// Do we have content from the db?
+		if len(dbSecretValues) > 0 {
+			return nil
+		}
+
+		// No content, try a value reference.
+		err = tx.Query(ctx, valueRefQueryStmt, want).GetAll(&dbSecretValueRefs)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		return errors.Annotatef(err, "rrrrretrieving secret value ref for %q revision %d", uri, revision)
+	}); err != nil {
+		return nil, nil, errors.Annotate(err, "querying secret value")
+	}
+
+	// Compose and return any secret content from the db.
+	if len(dbSecretValues) > 0 {
+		content, err := dbSecretValues.toSecretData()
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "composing secret contentfor secret %q revision %d from database", uri, revision)
+		}
+		return content, nil, nil
+	}
+
+	// Process any value reference.
+	if len(dbSecretValueRefs) == 0 {
+		return nil, nil, fmt.Errorf("secret value for %q revision %d not found%w", uri, revision, errors.Hide(secreterrors.SecretRevisionNotFound))
+	}
+	if len(dbSecretValueRefs) != 1 {
+		return nil, nil, fmt.Errorf("unexpected secret value refs for %q revision %d: got %d values", uri, revision, len(dbSecretValues))
+	}
+	return nil, &coresecrets.ValueRef{
+		BackendID:  dbSecretValueRefs[0].BackendUUID,
+		RevisionID: dbSecretValueRefs[0].RevisionID,
+	}, nil
+}

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coredatabase "github.com/juju/juju/core/database"
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/schema/testing"
+	domainsecret "github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
+	"github.com/juju/juju/internal/uuid"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type stateSuite struct {
+	testing.ModelSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func newSecretState(factory coredatabase.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+func (s *stateSuite) setupModel(c *gc.C) string {
+	modelUUID := uuid.MustNewUUID()
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO model (uuid, controller_uuid, name, type, cloud)
+			VALUES (?, ?, "test", "iaas", "fluffy")
+		`, modelUUID.String(), coretesting.ControllerTag.Id())
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return modelUUID.String()
+}
+
+func (s *stateSuite) TestGetSecretNotFound(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	_, err := st.GetSecret(context.Background(), coresecrets.NewURI())
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretNotFound)
+}
+
+func (s *stateSuite) TestGetSecretRevisionNotFound(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	_, err := st.GetSecretRevision(context.Background(), coresecrets.NewURI(), 666)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretRevisionNotFound)
+
+	_, _, err = st.GetSecretValue(context.Background(), coresecrets.NewURI(), 666)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretRevisionNotFound)
+}
+
+func (s *stateSuite) TestCreateUserSecretAlreadyExists(c *gc.C) {
+	s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri, sp)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateUserSecret(ctx, 1, uri, sp)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretAlreadyExists)
+}
+
+func (s *stateSuite) assertSecret(c *gc.C, st *State, uri *coresecrets.URI, sp domainsecret.UpsertSecretParams, revision int, owner coresecrets.Owner) {
+	ctx := context.Background()
+	md, err := st.GetSecret(ctx, uri)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp.Label)
+	c.Assert(md.Description, gc.Equals, sp.Description)
+	// TODO(secrets) - sqlair doesn't like subselects
+	//c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp.AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, owner)
+	now := time.Now()
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	rev, err := st.GetSecretRevision(ctx, uri, revision)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rev.Revision, gc.Equals, revision)
+	c.Assert(rev.CreateTime, jc.Almost, now)
+	c.Assert(rev.UpdateTime, jc.Almost, now)
+}
+
+func (s *stateSuite) TestCreateUserSecretWithContent(c *gc.C) {
+	modelUUID := s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri, sp)
+	c.Assert(err, jc.ErrorIsNil)
+	owner := coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: modelUUID}
+	s.assertSecret(c, st, uri, sp, 1, owner)
+	data, ref, err := st.GetSecretValue(ctx, uri, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ref, gc.IsNil)
+	c.Assert(data, jc.DeepEquals, coresecrets.SecretData{"foo": "bar"})
+}
+
+func (s *stateSuite) TestCreateUserSecretWithValueReference(c *gc.C) {
+	modelUUID := s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		ValueRef:    &coresecrets.ValueRef{BackendID: "some-backend", RevisionID: "some-revision"},
+		AutoPrune:   true,
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri, sp)
+	c.Assert(err, jc.ErrorIsNil)
+	owner := coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: modelUUID}
+	s.assertSecret(c, st, uri, sp, 1, owner)
+	data, ref, err := st.GetSecretValue(ctx, uri, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.HasLen, 0)
+	c.Assert(ref, jc.DeepEquals, &coresecrets.ValueRef{BackendID: "some-backend", RevisionID: "some-revision"})
+}

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+)
+
+// These structs represent the persistent secretMetadata entity schema in the database.
+
+type secretMetadata struct {
+	ID          string    `db:"id"`
+	Version     int       `db:"version"`
+	Description string    `db:"description"`
+	AutoPrune   bool      `db:"auto_prune"`
+	CreateTime  time.Time `db:"create_time"`
+	UpdateTime  time.Time `db:"update_time"`
+}
+
+// secretInfo is used because sqlair doesn't seem to like struct embedding.
+type secretInfo struct {
+	ID          string    `db:"id"`
+	Version     int       `db:"version"`
+	Description string    `db:"description"`
+	AutoPrune   bool      `db:"auto_prune"`
+	CreateTime  time.Time `db:"create_time"`
+	UpdateTime  time.Time `db:"update_time"`
+
+	LatestRevision int `db:"latest_revision"`
+}
+
+type secretOwner struct {
+	SecretID  string `db:"secret_id"`
+	OwnerID   string `db:"owner_id"`
+	OwnerKind string `db:"owner_kind"`
+	Label     string `db:"label"`
+}
+
+type secretRevision struct {
+	ID            string    `db:"uuid"`
+	SecretID      string    `db:"secret_id"`
+	Revision      int       `db:"revision"`
+	Obsolete      bool      `db:"obsolete"`
+	PendingDelete bool      `db:"pending_delete"`
+	CreateTime    time.Time `db:"create_time"`
+	UpdateTime    time.Time `db:"update_time"`
+}
+
+type secretContent struct {
+	// ID holds the cloud uuid.
+	ID string `db:"revision_uuid"`
+
+	// Key is the key value.
+	Name string `db:"name"`
+
+	// Value is the value associated with key.
+	Content string `db:"content"`
+}
+
+type secretValueRef struct {
+	// ID holds the cloud uuid.
+	ID string `db:"revision_uuid"`
+
+	// Key is the key value.
+	BackendUUID string `db:"backend_uuid"`
+
+	// Value is the value associated with key.
+	RevisionID string `db:"revision_id"`
+}
+
+type secrets []secretInfo
+
+func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
+	if n := len(rows); n != len(secretOwners) {
+		// Should never happen.
+		return nil, errors.New("row length mismatch composing secret results")
+	}
+
+	result := make([]*coresecrets.SecretMetadata, len(rows))
+	for i, row := range rows {
+		uri, err := coresecrets.ParseURI(row.ID)
+		if err != nil {
+			return nil, errors.NotValidf(row.ID)
+		}
+		result[i] = &coresecrets.SecretMetadata{
+			URI:         uri,
+			Version:     row.Version,
+			Description: row.Description,
+			Label:       secretOwners[i].Label,
+			Owner: coresecrets.Owner{
+				Kind: coresecrets.OwnerKind(secretOwners[i].OwnerKind),
+				ID:   secretOwners[i].OwnerID,
+			},
+			CreateTime:     row.CreateTime,
+			UpdateTime:     row.UpdateTime,
+			LatestRevision: row.LatestRevision,
+			AutoPrune:      row.AutoPrune,
+		}
+	}
+	return result, nil
+}
+
+type secretRevisions []secretRevision
+
+func (rows secretRevisions) toSecretRevisions() ([]*coresecrets.SecretRevisionMetadata, error) {
+	result := make([]*coresecrets.SecretRevisionMetadata, len(rows))
+	for i, row := range rows {
+		result[i] = &coresecrets.SecretRevisionMetadata{
+			Revision:    row.Revision,
+			ValueRef:    nil,
+			CreateTime:  row.CreateTime,
+			UpdateTime:  row.UpdateTime,
+			BackendName: nil,
+			ExpireTime:  nil,
+		}
+	}
+	return result, nil
+}
+
+type secretValues []secretContent
+
+func (rows secretValues) toSecretData() (coresecrets.SecretData, error) {
+	result := make(coresecrets.SecretData)
+	for _, row := range rows {
+		result[row.Name] = row.Content
+	}
+	return result, nil
+}

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -52,31 +52,21 @@ type secretRevision struct {
 }
 
 type secretContent struct {
-	// ID holds the cloud uuid.
-	ID string `db:"revision_uuid"`
-
-	// Key is the key value.
-	Name string `db:"name"`
-
-	// Value is the value associated with key.
-	Content string `db:"content"`
+	RevisionUUID string `db:"revision_uuid"`
+	Name         string `db:"name"`
+	Content      string `db:"content"`
 }
 
 type secretValueRef struct {
-	// ID holds the cloud uuid.
-	ID string `db:"revision_uuid"`
-
-	// Key is the key value.
-	BackendUUID string `db:"backend_uuid"`
-
-	// Value is the value associated with key.
-	RevisionID string `db:"revision_id"`
+	RevisionUUID string `db:"revision_uuid"`
+	BackendUUID  string `db:"backend_uuid"`
+	RevisionID   string `db:"revision_id"`
 }
 
 type secrets []secretInfo
 
 func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
-	if n := len(rows); n != len(secretOwners) {
+	if len(rows) != len(secretOwners) {
 		// Should never happen.
 		return nil, errors.New("row length mismatch composing secret results")
 	}


### PR DESCRIPTION
This PR adds secret state methods for creating a user secret and getting its content. The get methods will return the revision metadata and also the content or value reference, whichever is set.

Because this is just for user secrets, things like rotation policy etc are not implemented. And not all secret metadata is filled out yet on retrieval. This is just the minimum to get started.

Also, the secret uuid column names are renamed to "id" since were are storing the secret XID, not a UUID.

## QA steps

unit tests

## Links

**Jira card:** JUJU-5807

