### PR TITLE
Remove unused AllCharmURLs method

### DIFF
--- a/apiserver/facades/client/modelupgrader/mocks/state_mock.go
+++ b/apiserver/facades/client/modelupgrader/mocks/state_mock.go
@@ -113,21 +113,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllCharmURLs mocks base method.
-func (m *MockState) AllCharmURLs() ([]*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllCharmURLs")
-	ret0, _ := ret[0].([]*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllCharmURLs indicates an expected call of AllCharmURLs.
-func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
-}
-
 // AllModelUUIDs mocks base method.
 func (m *MockState) AllModelUUIDs() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelupgrader/shims.go
+++ b/apiserver/facades/client/modelupgrader/shims.go
@@ -32,7 +32,6 @@ type State interface {
 	MongoCurrentStatus() (*replicaset.Status, error)
 	SetModelAgentVersion(newVersion version.Number, stream *string, ignoreAgentVersions bool, upgrader state.Upgrader) error
 	ControllerConfig() (controller.Config, error)
-	AllCharmURLs() ([]*string, error)
 }
 
 type SystemState interface {
@@ -126,10 +125,6 @@ func (s stateShim) MongoCurrentStatus() (*replicaset.Status, error) {
 		s.mgosession = s.PooledState.MongoSession()
 	}
 	return replicaset.CurrentStatus(s.mgosession)
-}
-
-func (s stateShim) AllCharmURLs() ([]*string, error) {
-	return s.PooledState.AllCharmURLs()
 }
 
 type modelShim struct {

--- a/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
@@ -72,21 +72,6 @@ func (mr *MockPrecheckBackendMockRecorder) AllApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllApplications", reflect.TypeOf((*MockPrecheckBackend)(nil).AllApplications))
 }
 
-// AllCharmURLs mocks base method.
-func (m *MockPrecheckBackend) AllCharmURLs() ([]*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllCharmURLs")
-	ret0, _ := ret[0].([]*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllCharmURLs indicates an expected call of AllCharmURLs.
-func (mr *MockPrecheckBackendMockRecorder) AllCharmURLs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockPrecheckBackend)(nil).AllCharmURLs))
-}
-
 // AllMachines mocks base method.
 func (m *MockPrecheckBackend) AllMachines() ([]migration.PrecheckMachine, error) {
 	m.ctrl.T.Helper()

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -31,7 +31,6 @@ type PrecheckBackend interface {
 	AllMachines() ([]PrecheckMachine, error)
 	AllApplications() ([]PrecheckApplication, error)
 	AllRelations() ([]PrecheckRelation, error)
-	AllCharmURLs() ([]*string, error)
 	ControllerBackend() (PrecheckBackend, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -1056,10 +1056,6 @@ func (b *fakeBackend) MongoCurrentStatus() (*replicaset.Status, error) {
 	return b.mongoCurrentStatus, b.mongoCurrentStatusErr
 }
 
-func (b *fakeBackend) AllCharmURLs() ([]*string, error) {
-	return nil, errors.NotFoundf("charms")
-}
-
 type fakePool struct {
 	models []migration.PrecheckModel
 }

--- a/internal/upgrades/upgradevalidation/interfaces.go
+++ b/internal/upgrades/upgradevalidation/interfaces.go
@@ -19,7 +19,6 @@ type StatePool interface {
 
 // State represents a point of use interface for modelling a current model.
 type State interface {
-	AllCharmURLs() ([]*string, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)
 	MongoCurrentStatus() (*replicaset.Status, error)

--- a/internal/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/internal/upgrades/upgradevalidation/mocks/state_mock.go
@@ -80,21 +80,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllCharmURLs mocks base method.
-func (m *MockState) AllCharmURLs() ([]*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllCharmURLs")
-	ret0, _ := ret[0].([]*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllCharmURLs indicates an expected call of AllCharmURLs.
-func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
-}
-
 // HasUpgradeSeriesLocks mocks base method.
 func (m *MockState) HasUpgradeSeriesLocks() (bool, error) {
 	m.ctrl.T.Helper()

--- a/state/charm.go
+++ b/state/charm.go
@@ -1140,28 +1140,3 @@ func (st *State) AddCharmMetadata(info CharmInfo) (*Charm, error) {
 	}
 	return ch, nil
 }
-
-// AllCharmURLs returns a slice of strings representing charm.URLs for every
-// charm deployed in this model.
-func (st *State) AllCharmURLs() ([]*string, error) {
-	applications, closer := st.db().GetCollection(charmsC)
-	defer closer()
-
-	var docs []struct {
-		CharmURL *string `bson:"url"`
-	}
-	err := applications.Find(bson.D{}).All(&docs)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("charms")
-	}
-	if err != nil {
-		return nil, errors.Errorf("cannot get all charm URLs")
-	}
-
-	curls := make([]*string, len(docs))
-	for i, v := range docs {
-		curls[i] = v.CharmURL
-	}
-
-	return curls, nil
-}

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -767,16 +767,6 @@ func (s *CharmSuite) TestAddCharmMetadataUpdatesPlaceholder(c *gc.C) {
 	c.Check(ch2.IsPlaceholder(), jc.IsFalse)
 }
 
-func (s *CharmSuite) TestAllCharmURLs(c *gc.C) {
-	ch2 := state.AddTestingCharmhubCharmForSeries(c, s.State, "jammy", "dummy")
-	state.AddTestingApplication(c, s.State, s.objectStore, "testme-jammy", ch2)
-
-	curls, err := s.State.AllCharmURLs()
-	c.Assert(err, jc.ErrorIsNil)
-	// One application from SetUpTest
-	c.Assert(len(curls), gc.Equals, 2, gc.Commentf("%v", curls))
-}
-
 type CharmTestHelperSuite struct {
 	ConnSuite
 }


### PR DESCRIPTION
This is a simple removal of some dead code found while breaking down the charm concerns Dqlite migration.

`AllCharmURLs` was used in tests/shims/mocks, but never called in-theatre.