### PR TITLE
Initial ListSecrets implementation.

### DIFF
--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -169,10 +169,10 @@ func isLeaderUnit(authTag names.Tag, leadershipChecker leadership.Checker) (bool
 }
 
 func (s *SecretsDrainAPI) getCharmSecrets(ctx context.Context) ([]*coresecrets.SecretMetadata, [][]*coresecrets.SecretRevisionMetadata, error) {
-	ownerName := s.authTag.Id()
-	owner := secretservice.CharmSecretOwners{
-		UnitName: &ownerName,
-	}
+	owners := []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   s.authTag.Id(),
+	}}
 	// Unit leaders can also get metadata for secrets owned by the app.
 	isLeader, err := isLeaderUnit(s.authTag, s.leadershipChecker)
 	if err != nil {
@@ -180,9 +180,12 @@ func (s *SecretsDrainAPI) getCharmSecrets(ctx context.Context) ([]*coresecrets.S
 	}
 	if isLeader {
 		appName := AuthTagApp(s.authTag)
-		owner.ApplicationName = &appName
+		owners = append(owners, secretservice.CharmSecretOwner{
+			Kind: secretservice.ApplicationOwner,
+			ID:   appName,
+		})
 	}
-	return s.secretService.ListCharmSecrets(ctx, owner)
+	return s.secretService.ListCharmSecrets(ctx, owners...)
 }
 
 // ChangeSecretBackend updates the backend for the specified secret after migration done.

--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -129,10 +129,13 @@ func (s *secretsDrainSuite) assertGetSecretsToDrain(
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().ListCharmSecrets(
 		gomock.Any(),
-		secretservice.CharmSecretOwners{
-			UnitName:        ptr("mariadb/0"),
-			ApplicationName: ptr("mariadb"),
-		}).Return([]*coresecrets.SecretMetadata{{
+		[]secretservice.CharmSecretOwner{{
+			Kind: secretservice.UnitOwner,
+			ID:   "mariadb/0",
+		}, {
+			Kind: secretservice.ApplicationOwner,
+			ID:   "mariadb",
+		}}).Return([]*coresecrets.SecretMetadata{{
 		URI:              uri,
 		Owner:            coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mariadb"},
 		Label:            "label",

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -240,9 +240,13 @@ func (mr *MockSecretServiceMockRecorder) GetSecretAccess(arg0, arg1, arg2 any) *
 }
 
 // ListCharmSecrets mocks base method.
-func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 service.CharmSecretOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharmSecrets", arg0, arg1)
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListCharmSecrets", varargs...)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)
 	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
 	ret2, _ := ret[2].(error)
@@ -250,9 +254,10 @@ func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 service.
 }
 
 // ListCharmSecrets indicates an expected call of ListCharmSecrets.
-func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0, arg1 any) *gomock.Call {
+func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), arg0, arg1)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), varargs...)
 }
 
 // ListConsumedSecrets mocks base method.

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -272,10 +272,13 @@ func (s *secretsSuite) assertBackendConfigInfoLeaderUnit(c *gc.C, wanted []strin
 	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
 	token.EXPECT().Check().Return(nil)
 
-	secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		UnitName:        ptr(unitTag.Id()),
-		ApplicationName: ptr("gitlab"),
-	}).Return(owned, [][]*coresecrets.SecretRevisionMetadata{{
+	secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   unitTag.Id(),
+	}, {
+		Kind: secretservice.ApplicationOwner,
+		ID:   "gitlab",
+	}}).Return(owned, [][]*coresecrets.SecretRevisionMetadata{{
 		{
 			Revision: 1,
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-1"},
@@ -370,9 +373,10 @@ func (s *secretsSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
 	token.EXPECT().Check().Return(leadership.NewNotLeaderError("", ""))
 
-	secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		UnitName: ptr(unitTag.Id()),
-	}).Return(unitOwned, [][]*coresecrets.SecretRevisionMetadata{{
+	secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   unitTag.Id(),
+	}}).Return(unitOwned, [][]*coresecrets.SecretRevisionMetadata{{
 		{
 			Revision: 1,
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-1"},
@@ -381,9 +385,10 @@ func (s *secretsSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-2"},
 		},
 	}}, nil)
-	secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		ApplicationName: ptr("gitlab"),
-	}).Return(appOwned, [][]*coresecrets.SecretRevisionMetadata{{
+	secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.ApplicationOwner,
+		ID:   "gitlab",
+	}}).Return(appOwned, [][]*coresecrets.SecretRevisionMetadata{{
 		{
 			Revision: 1,
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-1"},
@@ -482,9 +487,10 @@ func (s *secretsSuite) TestDrainBackendConfigInfo(c *gc.C) {
 	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
 	token.EXPECT().Check().Return(leadership.NewNotLeaderError("", ""))
 
-	secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		UnitName: ptr(unitTag.Id()),
-	}).Return(unitOwned, [][]*coresecrets.SecretRevisionMetadata{{
+	secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   unitTag.Id(),
+	}}).Return(unitOwned, [][]*coresecrets.SecretRevisionMetadata{{
 		{
 			Revision: 1,
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-1"},
@@ -493,9 +499,10 @@ func (s *secretsSuite) TestDrainBackendConfigInfo(c *gc.C) {
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-2"},
 		},
 	}}, nil)
-	secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		ApplicationName: ptr("gitlab"),
-	}).Return(appOwned, [][]*coresecrets.SecretRevisionMetadata{{
+	secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.ApplicationOwner,
+		ID:   "gitlab",
+	}}).Return(appOwned, [][]*coresecrets.SecretRevisionMetadata{{
 		{
 			Revision: 1,
 			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "app-owned-rev-1"},

--- a/apiserver/common/secrets/service.go
+++ b/apiserver/common/secrets/service.go
@@ -13,7 +13,7 @@ import (
 // SecretService instances provide secret service apis.
 type SecretService interface {
 	GetSecretAccess(ctx context.Context, uri *secrets.URI, consumer secretservice.SecretAccessor) (secrets.SecretRole, error)
-	ListCharmSecrets(context.Context, secretservice.CharmSecretOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ListConsumedSecrets(ctx context.Context, consumer secretservice.SecretConsumer) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ListUserSecrets(ctx context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error

--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -58,48 +58,63 @@ func (mr *MockSecretTriggersMockRecorder) SecretRotated(ctx, uri, originalRev, s
 }
 
 // WatchObsolete mocks base method.
-func (m *MockSecretTriggers) WatchObsolete(ctx context.Context, owner service.CharmSecretOwners) (watcher.StringsWatcher, error) {
+func (m *MockSecretTriggers) WatchObsolete(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchObsolete", ctx, owner)
+	varargs := []any{ctx}
+	for _, a := range owners {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchObsolete", varargs...)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchObsolete indicates an expected call of WatchObsolete.
-func (mr *MockSecretTriggersMockRecorder) WatchObsolete(ctx, owner any) *gomock.Call {
+func (mr *MockSecretTriggersMockRecorder) WatchObsolete(ctx any, owners ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretTriggers)(nil).WatchObsolete), ctx, owner)
+	varargs := append([]any{ctx}, owners...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretTriggers)(nil).WatchObsolete), varargs...)
 }
 
 // WatchSecretRevisionsExpiryChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(ctx context.Context, owner service.CharmSecretOwners) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSecretRevisionsExpiryChanges", ctx, owner)
+	varargs := []any{ctx}
+	for _, a := range owners {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchSecretRevisionsExpiryChanges", varargs...)
 	ret0, _ := ret[0].(watcher.SecretTriggerWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchSecretRevisionsExpiryChanges indicates an expected call of WatchSecretRevisionsExpiryChanges.
-func (mr *MockSecretTriggersMockRecorder) WatchSecretRevisionsExpiryChanges(ctx, owner any) *gomock.Call {
+func (mr *MockSecretTriggersMockRecorder) WatchSecretRevisionsExpiryChanges(ctx any, owners ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretTriggers)(nil).WatchSecretRevisionsExpiryChanges), ctx, owner)
+	varargs := append([]any{ctx}, owners...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretTriggers)(nil).WatchSecretRevisionsExpiryChanges), varargs...)
 }
 
 // WatchSecretsRotationChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretsRotationChanges(ctx context.Context, owner service.CharmSecretOwners) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretTriggers) WatchSecretsRotationChanges(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSecretsRotationChanges", ctx, owner)
+	varargs := []any{ctx}
+	for _, a := range owners {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchSecretsRotationChanges", varargs...)
 	ret0, _ := ret[0].(watcher.SecretTriggerWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchSecretsRotationChanges indicates an expected call of WatchSecretsRotationChanges.
-func (mr *MockSecretTriggersMockRecorder) WatchSecretsRotationChanges(ctx, owner any) *gomock.Call {
+func (mr *MockSecretTriggersMockRecorder) WatchSecretsRotationChanges(ctx any, owners ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretTriggers)(nil).WatchSecretsRotationChanges), ctx, owner)
+	varargs := append([]any{ctx}, owners...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretTriggers)(nil).WatchSecretsRotationChanges), varargs...)
 }
 
 // MockSecretsConsumer is a mock of SecretsConsumer interface.
@@ -369,9 +384,13 @@ func (mr *MockSecretServiceMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *g
 }
 
 // ListCharmSecrets mocks base method.
-func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 service.CharmSecretOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharmSecrets", arg0, arg1)
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListCharmSecrets", varargs...)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)
 	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
 	ret2, _ := ret[2].(error)
@@ -379,9 +398,10 @@ func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 service.
 }
 
 // ListCharmSecrets indicates an expected call of ListCharmSecrets.
-func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0, arg1 any) *gomock.Call {
+func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), arg0, arg1)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), varargs...)
 }
 
 // ProcessSecretConsumerLabel mocks base method.

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -251,8 +251,8 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	p := secretservice.CreateSecretParams{
-		Version: secrets.Version,
-		Owner:   coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mariadb"},
+		Version:    secrets.Version,
+		CharmOwner: &secretservice.CharmSecretOwner{Kind: secretservice.ApplicationOwner, ID: "mariadb"},
 		UpdateSecretParams: secretservice.UpdateSecretParams{
 			LeaderToken:  s.token,
 			RotatePolicy: ptr(coresecrets.RotateDaily),
@@ -311,8 +311,8 @@ func (s *SecretsManagerSuite) TestCreateSecretDuplicateLabel(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	p := secretservice.CreateSecretParams{
-		Version: secrets.Version,
-		Owner:   coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mariadb"},
+		Version:    secrets.Version,
+		CharmOwner: &secretservice.CharmSecretOwner{Kind: secretservice.ApplicationOwner, ID: "mariadb"},
 		UpdateSecretParams: secretservice.UpdateSecretParams{
 			LeaderToken: s.token,
 			Label:       ptr("foobar"),
@@ -583,10 +583,13 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 
 	now := time.Now()
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().ListCharmSecrets(gomock.Any(), secretservice.CharmSecretOwners{
-		UnitName:        ptr("mariadb/0"),
-		ApplicationName: ptr("mariadb"),
-	}).Return([]*coresecrets.SecretMetadata{{
+	s.secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   "mariadb/0",
+	}, {
+		Kind: secretservice.ApplicationOwner,
+		ID:   "mariadb",
+	}}).Return([]*coresecrets.SecretMetadata{{
 		URI:              uri,
 		Owner:            coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mariadb"},
 		Description:      "description",
@@ -1313,10 +1316,13 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.secretTriggers.EXPECT().WatchObsolete(gomock.Any(), secretservice.CharmSecretOwners{
-		ApplicationName: ptr("mariadb"),
-		UnitName:        ptr("mariadb/0"),
-	}).Return(
+	s.secretTriggers.EXPECT().WatchObsolete(gomock.Any(), []secretservice.CharmSecretOwner{{
+		Kind: secretservice.UnitOwner,
+		ID:   "mariadb/0",
+	}, {
+		Kind: secretservice.ApplicationOwner,
+		ID:   "mariadb",
+	}}).Return(
 		s.secretsWatcher, nil,
 	)
 	s.watcherRegistry.EXPECT().Register(s.secretsWatcher).Return("1", nil)
@@ -1346,10 +1352,13 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretsRotationChanges(gomock.Any(),
-		secretservice.CharmSecretOwners{
-			UnitName:        ptr("mariadb/0"),
-			ApplicationName: ptr("mariadb"),
-		}).Return(
+		[]secretservice.CharmSecretOwner{{
+			Kind: secretservice.UnitOwner,
+			ID:   "mariadb/0",
+		}, {
+			Kind: secretservice.ApplicationOwner,
+			ID:   "mariadb",
+		}}).Return(
 		s.secretsTriggerWatcher, nil,
 	)
 	s.watcherRegistry.EXPECT().Register(s.secretsTriggerWatcher).Return("1", nil)
@@ -1473,10 +1482,13 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretRevisionsExpiryChanges(gomock.Any(),
-		secretservice.CharmSecretOwners{
-			UnitName:        ptr("mariadb/0"),
-			ApplicationName: ptr("mariadb"),
-		}).Return(
+		[]secretservice.CharmSecretOwner{{
+			Kind: secretservice.UnitOwner,
+			ID:   "mariadb/0",
+		}, {
+			Kind: secretservice.ApplicationOwner,
+			ID:   "mariadb",
+		}}).Return(
 		s.secretsTriggerWatcher, nil,
 	)
 	s.watcherRegistry.EXPECT().Register(s.secretsTriggerWatcher).Return("1", nil)

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -14,9 +14,9 @@ import (
 
 // SecretTriggers instances provide secret rotation/expiry apis.
 type SecretTriggers interface {
-	WatchSecretRevisionsExpiryChanges(ctx context.Context, owner secretservice.CharmSecretOwners) (watcher.SecretTriggerWatcher, error)
-	WatchSecretsRotationChanges(ctx context.Context, owner secretservice.CharmSecretOwners) (watcher.SecretTriggerWatcher, error)
-	WatchObsolete(ctx context.Context, owner secretservice.CharmSecretOwners) (watcher.StringsWatcher, error)
+	WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
+	WatchSecretsRotationChanges(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
+	WatchObsolete(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.StringsWatcher, error)
 	SecretRotated(ctx context.Context, uri *secrets.URI, originalRev int, skip bool) error
 }
 
@@ -42,7 +42,7 @@ type SecretService interface {
 	DeleteCharmSecret(ctx context.Context, uri *secrets.URI, revisions []int, canDelete func(uri *secrets.URI) error) error
 	GetSecret(context.Context, *secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, *secrets.ValueRef, error)
-	ListCharmSecrets(context.Context, secretservice.CharmSecretOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ProcessSecretConsumerLabel(
 		ctx context.Context, unitName string, uri *secrets.URI, label string, checkCallerOwner func(secretOwner secrets.Owner) (bool, leadership.Token, error),
 	) (*secrets.URI, *string, error)

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -146,7 +146,7 @@ func (mr *MockSecretServiceMockRecorder) GrantSecretAccess(arg0, arg1, arg2 any)
 }
 
 // ListSecrets mocks base method.
-func (m *MockSecretService) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 secret.ModelOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+func (m *MockSecretService) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 bool) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -176,7 +176,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 		}},
 	}
 
-	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevisions, secret.NilLabels, secret.NilApplicationOwners, secret.NilUnitOwners, secret.NilModelOwners).Return(
+	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevisions, secret.NilLabels, secret.NilApplicationOwners, secret.NilUnitOwners, true).Return(
 		metadata, revisions, nil,
 	)
 	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
@@ -336,8 +336,8 @@ func (s *SecretsSuite) assertCreateSecrets(c *gc.C, isInternal bool, finalStepFa
 	s.secretService.EXPECT().CreateSecret(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, arg1 *coresecrets.URI, params secretservice.CreateSecretParams) error {
 		c.Assert(arg1, gc.DeepEquals, uri)
 		c.Assert(params.Version, gc.Equals, 1)
-		c.Assert(params.Owner.Kind, gc.Equals, coresecrets.ModelOwner)
-		c.Assert(params.Owner.ID, gc.Equals, coretesting.ModelTag.Id())
+		c.Assert(params.UserSecret, jc.IsTrue)
+		c.Assert(params.CharmOwner, gc.IsNil)
 		c.Assert(params.UpdateSecretParams.Description, gc.DeepEquals, ptr("this is a user secret."))
 		c.Assert(params.UpdateSecretParams.Label, gc.DeepEquals, ptr("label"))
 		if isInternal {

--- a/apiserver/facades/client/secrets/service.go
+++ b/apiserver/facades/client/secrets/service.go
@@ -26,7 +26,7 @@ type SecretService interface {
 	ListSecrets(ctx context.Context, uri *secrets.URI,
 		revisions domainsecret.Revisions,
 		labels domainsecret.Labels, appOwners domainsecret.ApplicationOwners,
-		unitOwners domainsecret.UnitOwners, modelOwners domainsecret.ModelOwners,
+		unitOwners domainsecret.UnitOwners, wantUser bool,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 
 	// Delete secrets.

--- a/domain/secret/service/access.go
+++ b/domain/secret/service/access.go
@@ -10,22 +10,26 @@ import (
 )
 
 func (s *SecretService) GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error) {
-	panic("implement me")
+	//TODO implement me
+	return nil, nil
 }
 
 func (s *SecretService) GetSecretAccess(ctx context.Context, uri *secrets.URI, consumer SecretAccessor) (secrets.SecretRole, error) {
 	//TODO implement me
-	panic("implement me")
+	return secrets.RoleManage, nil
 }
 
 func (s *SecretService) GetSecretAccessScope(ctx context.Context, uri *secrets.URI) (SecretConsumer, error) {
+	//TODO implement me
 	panic("implement me")
 }
 
 func (s *SecretService) GrantSecretAccess(ctx context.Context, uri *secrets.URI, params SecretAccessParams) error {
-	panic("implement me")
+	//TODO implement me
+	return nil
 }
 
 func (s *SecretService) RevokeSecretAccess(ctx context.Context, uri *secrets.URI, params SecretAccessParams) error {
-	panic("implement me")
+	//TODO implement me
+	return nil
 }

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -16,7 +16,9 @@ type CreateSecretParams struct {
 	UpdateSecretParams
 	Version int
 
-	Owner secrets.Owner
+	// Either a charm secret owner is needed, or a user secret is needed.
+	CharmOwner *CharmSecretOwner
+	UserSecret bool
 }
 
 // UpdateSecretParams are used to update a secret.
@@ -62,10 +64,18 @@ type SecretAccessor struct {
 	ModelUUID       *string
 }
 
-// CharmSecretOwners represents the owners of a secret created by a charm.
-// At least one owner is required to be non nil.
+// CharmSecretOwnerKind represents the kind of a charm secret owner entity.
+type CharmSecretOwnerKind string
+
+// These represent the kinds of charm secret owner.
+const (
+	ApplicationOwner CharmSecretOwnerKind = "application"
+	UnitOwner        CharmSecretOwnerKind = "unit"
+)
+
+// CharmSecretOwner is the owner of a secret.
 // This is used to query or watch secrets for specified owners.
-type CharmSecretOwners struct {
-	UnitName        *string
-	ApplicationName *string
+type CharmSecretOwner struct {
+	Kind CharmSecretOwnerKind
+	ID   string
 }

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -75,8 +75,8 @@ func (s *serviceSuite) TestCreateUserSecret(c *gc.C) {
 			Data:        map[string]string{"foo": "bar"},
 			AutoPrune:   ptr(true),
 		},
-		Version: 1,
-		Owner:   coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: coretesting.ModelTag.Id()},
+		Version:    1,
+		UserSecret: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -115,3 +115,19 @@ func (mr *MockStateMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockState)(nil).GetSecretValue), arg0, arg1, arg2)
 }
+
+// ListSecrets mocks base method.
+func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 bool) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListSecrets indicates an expected call of ListSecrets.
+func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -28,7 +28,7 @@ func (s *SecretService) WatchConsumedSecretsChanges(ctx context.Context, consume
 //
 // Obsolete revisions results are "uri/revno" and deleted
 // secret results are "uri".
-func (s *SecretService) WatchObsolete(ctx context.Context, owner CharmSecretOwners) (watcher.StringsWatcher, error) {
+func (s *SecretService) WatchObsolete(ctx context.Context, owners ...CharmSecretOwner) (watcher.StringsWatcher, error) {
 	ch := make(chan []string, 1)
 	ch <- []string{}
 	return watchertest.NewMockStringsWatcher(ch), nil
@@ -70,13 +70,13 @@ func (w *mockSecretTriggerWatcher) Wait() error {
 	return w.tomb.Wait()
 }
 
-func (s *SecretService) WatchSecretRevisionsExpiryChanges(ctx context.Context, owner CharmSecretOwners) (watcher.SecretTriggerWatcher, error) {
+func (s *SecretService) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	ch := make(chan []watcher.SecretTriggerChange, 1)
 	ch <- []watcher.SecretTriggerChange{}
 	return newMockTriggerWatcher(ch), nil
 }
 
-func (s *SecretService) WatchSecretsRotationChanges(ctx context.Context, owner CharmSecretOwners) (watcher.SecretTriggerWatcher, error) {
+func (s *SecretService) WatchSecretsRotationChanges(ctx context.Context, owners ...CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	ch := make(chan []watcher.SecretTriggerChange, 1)
 	ch <- []watcher.SecretTriggerChange{}
 	return newMockTriggerWatcher(ch), nil

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -99,8 +99,7 @@ func (s *stateSuite) assertSecret(c *gc.C, st *State, uri *coresecrets.URI, sp d
 	c.Assert(md.Version, gc.Equals, 1)
 	c.Assert(md.Label, gc.Equals, sp.Label)
 	c.Assert(md.Description, gc.Equals, sp.Description)
-	// TODO(secrets) - sqlair doesn't like subselects
-	//c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
 	c.Assert(md.AutoPrune, gc.Equals, sp.AutoPrune)
 	c.Assert(md.Owner, jc.DeepEquals, owner)
 	now := time.Now()
@@ -191,4 +190,120 @@ func (s *stateSuite) TestCreateUserSecretWithValueReference(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, 0)
 	c.Assert(ref, jc.DeepEquals, &coresecrets.ValueRef{BackendID: "some-backend", RevisionID: "some-revision"})
+}
+
+func (s *stateSuite) TestListSecretsNone(c *gc.C) {
+	s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	ctx := context.Background()
+	secrets, revisions, err := st.ListSecrets(
+		ctx, nil, domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 0)
+	c.Assert(len(revisions), gc.Equals, 0)
+}
+
+func (s *stateSuite) TestListSecrets(c *gc.C) {
+	modelUUID := s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+		AutoPrune:   true,
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateUserSecret(ctx, 1, uri[1], sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListSecrets(
+		ctx, nil, domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 2)
+	c.Assert(len(revisions), gc.Equals, 2)
+
+	for i, md := range secrets {
+		c.Assert(md.Version, gc.Equals, 1)
+		c.Assert(md.Label, gc.Equals, sp[i].Label)
+		c.Assert(md.Description, gc.Equals, sp[i].Description)
+		c.Assert(md.LatestRevision, gc.Equals, 1)
+		c.Assert(md.AutoPrune, gc.Equals, sp[i].AutoPrune)
+		c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: modelUUID})
+		now := time.Now()
+		c.Assert(md.CreateTime, jc.Almost, now)
+		c.Assert(md.UpdateTime, jc.Almost, now)
+
+		revs := revisions[i]
+		c.Assert(revs, gc.HasLen, 1)
+		c.Assert(revs[0].Revision, gc.Equals, 1)
+		c.Assert(revs[0].CreateTime, jc.Almost, now)
+		c.Assert(revs[0].UpdateTime, jc.Almost, now)
+	}
+}
+
+func (s *stateSuite) TestListSecretsByURI(c *gc.C) {
+	modelUUID := s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+		AutoPrune:   true,
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateUserSecret(ctx, 1, uri[1], sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListSecrets(
+		ctx, uri[0], domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 1)
+	c.Assert(len(revisions), gc.Equals, 1)
+
+	md := secrets[0]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[0].Label)
+	c.Assert(md.Description, gc.Equals, sp[0].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[0].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: modelUUID})
+	now := time.Now()
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs := revisions[0]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
 }

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -8,7 +8,6 @@ type (
 	Labels            []string
 	ApplicationOwners []string
 	UnitOwners        []string
-	ModelOwners       []string
 	Revisions         []int
 )
 
@@ -17,6 +16,5 @@ var (
 	NilLabels            = Labels(nil)
 	NilApplicationOwners = ApplicationOwners(nil)
 	NilUnitOwners        = UnitOwners(nil)
-	NilModelOwners       = ModelOwners(nil)
 	NilRevisions         = Revisions(nil)
 )


### PR DESCRIPTION
This PR adds support for listing secrets. For now, the only filter term used is URI. So you can either list all secrets or find one matching the specified URI.

It also tweaks the CharmOwner param used when creating a secret. Now, we don't reuse an Owner struct from a different layer. And the new CharmOwner is wired though the other apis which need it. The owner is now singular and we pass one or more of them instead of a single struct.

The list secrets also correctly reads the latest secret revision attribute - this was previously a TODO.
The state code is restructured a bit so that the secret metadata and any associated revisions are loaded in the one txn.

## QA steps

```
$ juju add-secret mysecret --info "a secret" foo=bar
secret:co9k77ucdhcib6crghc0
$ juju secrets
ID                    Name      Owner    Rotation  Revision  Last updated
co9k77ucdhcib6crghc0  mysecret  <model>  never            1  9 seconds ago  
$ juju secrets --format yaml
co9k77ucdhcib6crghc0:
  revision: 1
  owner: <model>
  description: a secret
  name: mysecret
  created: 2024-04-08T01:08:47.481861578Z
  updated: 2024-04-08T01:08:47.481861578Z
$ juju show-secret co9k77ucdhcib6crghc0
co9k77ucdhcib6crghc0:
  revision: 1
  owner: <model>
  description: a secret
  name: mysecret
  created: 2024-04-08T01:08:47.481861578Z
  updated: 2024-04-08T01:08:47.481861578Z
$ juju show-secret co9k77ucdhcib6crghc0 --reveal
co9k77ucdhcib6crghc0:
  revision: 1
  owner: <model>
  description: a secret
  name: mysecret
  created: 2024-04-08T01:08:47.481861578Z
  updated: 2024-04-08T01:08:47.481861578Z
  content:
    foo: bar
$ juju show-secret co9k77ucdhcib6crghc0 --reveal --revision 1
co9k77ucdhcib6crghc0:
  revision: 1
  owner: <model>
  description: a secret
  name: mysecret
  created: 2024-04-08T01:08:47.481861578Z
  updated: 2024-04-08T01:08:47.481861578Z
  content:
    foo: bar
$ juju add-secret mysecret2 --info "another secret" foo=bar2
secret:co9k7pucdhcib6crghcg
$ juju secrets
ID                    Name       Owner    Rotation  Revision  Last updated
co9k77ucdhcib6crghc0  mysecret   <model>  never            1  1 minute ago    
co9k7pucdhcib6crghcg  mysecret2  <model>  never            1  14 seconds ago  
$ juju show-secret co9k7pucdhcib6crghcg --reveal
co9k7pucdhcib6crghcg:
  revision: 1
  owner: <model>
  description: another secret
  name: mysecret2
  created: 2024-04-08T01:09:59.109706888Z
  updated: 2024-04-08T01:09:59.109706888Z
  content:
    foo: bar2
```

## Links

**Jira card:** JUJU-5733

