### PR TITLE
Dqlite repl dump to sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tests/tmp.*
 *.bundle
 *.log
 dqlite-deps.tar.bz2
+dump/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ tests/tmp.*
 *.bundle
 *.log
 dqlite-deps.tar.bz2
-dump/

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,13 @@ jujud-controller: musl-install-if-missing dqlite-install-if-missing
 	${run_cgo_install}
 	mv $(GO_INSTALL_PATH)/jujud-controller $(GO_INSTALL_PATH)/jujud
 
+.PHONY: dqlite-repl
+dqlite-repl: PACKAGE = github.com/juju/juju/scripts/dqlite/cmd
+dqlite-repl: musl-install-if-missing dqlite-install-if-missing
+## jujud: Install jujud without updating dependencies
+	${run_cgo_install}
+	mv $(GO_INSTALL_PATH)/cmd $(GO_INSTALL_PATH)/dqlite-repl
+
 .PHONY: containeragent
 containeragent: PACKAGE = github.com/juju/juju/cmd/containeragent
 containeragent:


### PR DESCRIPTION
There are a lot of sqlite cli commands[1] that are not available in the dqlite cli. Adding the ability to .dump to sqlite3 files then allows us to use sqlite3 cli directly on the output files from the repl command.

The main change piggybacks onto existing infrastructure that's available. The only problem is that we do need a real dqlite lib to be installed. If that's not available we can piggy back on to the static lib that's available.

 1. https://sqlite.org/cli.html


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```go
$ make dqlite-repl
$ dqlite-repl
$ dqlite > .dump
$ sqlite3 ./dump/tmp
$ sqlite> .expert
$ sqlite> SELECT  name FROM cloud;
(no new indexes)

SCAN cloud USING COVERING INDEX sqlite_autoindex_cloud_2
```

Another good example of this being useful:

```sh
$ sqlite> .timer on
$ sqlite> EXPLAIN QUERY PLAN SELECT cloud_uuid FROM cloud_defaults;
QUERY PLAN
`--SCAN cloud_defaults USING COVERING INDEX sqlite_autoindex_cloud_defaults_1
Run Time: real 0.000 user 0.000102 sys 0.000026
```

## Links


**Jira card:** JUJU-

