### PR TITLE
Remove series charm url reference in legacy handler

### DIFF
--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -213,7 +213,7 @@ func (h *objectsCharmHTTPHandler) processPut(r *http.Request, st *state.State) (
 		return nil, errors.Errorf("unsupported schema %q", schema)
 	}
 
-	return curl, errors.Trace(RepackageAndUploadCharm(r.Context(), objectStore, storageStateShim{State: st}, archive, curl))
+	return curl, errors.Trace(RepackageAndUploadCharm(r.Context(), objectStore, storageStateShim{State: st}, archive, curl.String(), curl.Revision))
 }
 
 func splitNameAndSHAFromQuery(query url.Values) (string, string, error) {

--- a/internal/bootstrap/deployer.go
+++ b/internal/bootstrap/deployer.go
@@ -442,7 +442,7 @@ func addLocalControllerCharm(ctx context.Context, objectStore services.Storage, 
 
 	// Now we need to repackage it with the reserved URL, upload it to
 	// provider storage and update the state.
-	err = apiserver.RepackageAndUploadCharm(ctx, objectStore, uploader, archive, curl)
+	err = apiserver.RepackageAndUploadCharm(ctx, objectStore, uploader, archive, curl.String(), archive.Revision())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This is required since old controllers do not allow charm urls to change during migration, and upload charms with a broken up charm url including a series

As such, this handler needs to be able to reason with charm urls with series. This is the only place in Juju this is required, so instead of continuing to support series, string-hack the charm url to include a series for compatibility.

This can be dropped when we no longer support migration from juju 3.3

This requires treating charm url as a string, and providing the revision separately in `RepackageAndUploadCharm`. This function is also used in `internal/bootstrap/deployer.go` & `apiserver/objects.go, hence the diffs there

This code is already well covered by unit tests. All existing unit tests passing without changes, in my opinion, is sufficient to unit test this change.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Ensure a local charm is available using:
```
$ juju download ubuntu
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

### Model migrations

Repeat the following steps, bootstrapping `lxd-src` from:
- This PR
- 3.5
- 3.3 (Note, you will need to hack 4.0 to support this. Simply apply https://pastebin.canonical.com/p/QF53nbrFcF/)

`lxd-dst` is always bootstraped from this PR

```
$ juju switch lxd-src
$ juju add-model m
$ juju deploy ubuntu ubu-ch
$ juju deploy ./ubuntu_r24.charm ubu-local
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd-src     localhost/localhost  3.5-beta1.1  unsupported  19:04:54+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.13          
ubu-local/0*  active    idle   1        10.219.211.28          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.13  juju-f7f82d-0  ubuntu@22.04      Running
1        started  10.219.211.28  juju-f7f82d-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst

$ juju status
ERROR Model "admin/m" has been migrated to controller "lxd-dst".
To access it run 'juju switch lxd-dst:admin/m`.

$ juju switch lxd-dst:m
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp     
m      lxd-dst     localhost/localhost  4.0-beta3.1  19:06:01+01:00 

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.147         
ubu-local/0*  active    idle   1        10.219.211.60          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.147  juju-80c1e5-0  ubuntu@22.04      Running
1        started  10.219.211.60   juju-80c1e5-1  ubuntu@22.04      Running
```