### PR TITLE
Remove series flag from a bunch of CLI commands

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -178,8 +178,6 @@ func (s *BundleDeploySuite) TestDeployBundleInvalidFlags(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "options provided but not supported when deploying a bundle: --config")
 	err = s.runDeploy(c, "ch:wordpress-simple", "-n", "2")
 	c.Assert(err, gc.ErrorMatches, "options provided but not supported when deploying a bundle: -n")
-	err = s.runDeploy(c, "ch:wordpress-simple", "--series", "xenial")
-	c.Assert(err, gc.ErrorMatches, "options provided but not supported when deploying a bundle: --series")
 	err = s.runDeploy(c, "ch:wordpress-simple", "--base", "ubuntu@18.04")
 	c.Assert(err, gc.ErrorMatches, "options provided but not supported when deploying a bundle: --base")
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -144,7 +144,7 @@ func (s *BundleDeploySuite) setupBundle(c *gc.C, url, name string, allBase ...ba
 	bundleResolveURL := charm.MustParseURL(url)
 	baseURL := *bundleResolveURL
 	baseURL.Revision = -1
-	withCharmRepoResolvable(s.fakeAPI, &baseURL, "")
+	withCharmRepoResolvable(s.fakeAPI, &baseURL, base.Base{})
 	bundleDir := testcharms.RepoWithSeries("bionic").BundleArchive(c.MkDir(), name)
 
 	// Resolve a bundle with no revision and return a url with a version.  Ensure
@@ -620,7 +620,7 @@ func (s *BundleDeploySuite) TestDeployBundleWithChannel(c *gc.C) {
 	// The second charm from the bundle does not require trust so no
 	// additional configuration should be injected
 	ubURL := charm.MustParseURL("ch:ubuntu")
-	withCharmRepoResolvable(s.fakeAPI, ubURL, "")
+	withCharmRepoResolvable(s.fakeAPI, ubURL, base.Base{})
 
 	withCharmDeployable(
 		s.fakeAPI, ubURL, defaultBase,
@@ -644,8 +644,8 @@ func (s *BundleDeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 	withAllWatcher(s.fakeAPI)
 
 	inURL := charm.MustParseURL("ch:aws-integrator")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "jammy")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "")
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.MustParseBaseFromString("ubuntu@22.04"))
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.Base{})
 
 	// The aws-integrator charm requires trust and since the operator passes
 	// --trust we expect to see a "trust: true" config value in the yaml
@@ -689,8 +689,8 @@ func (s *BundleDeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 	// The second charm from the bundle does not require trust so no
 	// additional configuration should be injected
 	ubURL := charm.MustParseURL("ch:ubuntu")
-	withCharmRepoResolvable(s.fakeAPI, ubURL, "jammy")
-	withCharmRepoResolvable(s.fakeAPI, ubURL, "")
+	withCharmRepoResolvable(s.fakeAPI, ubURL, base.MustParseBaseFromString("ubuntu@22.04"))
+	withCharmRepoResolvable(s.fakeAPI, ubURL, base.Base{})
 	withCharmDeployable(
 		s.fakeAPI, ubURL, defaultBase,
 		&charm.Meta{Name: "ubuntu", Series: []string{"jammy"}},
@@ -711,8 +711,8 @@ func (s *BundleDeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 	withAllWatcher(s.fakeAPI)
 
 	inURL := charm.MustParseURL("ch:apache2")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "jammy")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "")
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.MustParseBaseFromString("ubuntu@22.04"))
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.Base{})
 
 	withCharmDeployable(
 		s.fakeAPI, inURL, defaultBase,
@@ -778,8 +778,8 @@ func (s *BundleDeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 	withAllWatcher(s.fakeAPI)
 
 	inURL := charm.MustParseURL("ch:wordpress")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "jammy")
-	withCharmRepoResolvable(s.fakeAPI, inURL, "")
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.MustParseBaseFromString("ubuntu@22.04"))
+	withCharmRepoResolvable(s.fakeAPI, inURL, base.Base{})
 
 	withCharmDeployable(
 		s.fakeAPI, inURL, defaultBase,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -832,7 +832,7 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 func (s *DeploySuite) TestDeployCharmWithSomeEndpointBindingsSpecifiedSuccess(c *gc.C) {
 	curl := charm.MustParseURL("ch:wordpress-extra-bindings")
 	charmDir := testcharms.RepoWithSeries("bionic").CharmDir("wordpress-extra-bindings")
-	withCharmRepoResolvable(s.fakeAPI, curl, "")
+	withCharmRepoResolvable(s.fakeAPI, curl, corebase.Base{})
 	withCharmDeployable(s.fakeAPI, curl, defaultBase, charmDir.Meta(), false, 1, nil, nil)
 
 	origin := commoncharm.Origin{
@@ -1702,10 +1702,8 @@ func withCharmDeployableWithDevicesAndStorage(
 func withCharmRepoResolvable(
 	fakeAPI *fakeDeployAPI,
 	url *charm.URL,
-	aseries string,
+	base corebase.Base,
 ) {
-	base, _ := corebase.GetBaseFromSeries(aseries)
-
 	for _, risk := range []string{"", "stable"} {
 		origin := commoncharm.Origin{
 			Source:       commoncharm.OriginCharmHub,

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -734,7 +734,7 @@ func (d *factory) validateBundleFlags() error {
 func CharmOnlyFlags() []string {
 	charmOnlyFlags := []string{
 		"bind", "config", "constraints", "n", "num-units",
-		"series", "base", "to", "resource", "attach-storage",
+		"base", "to", "resource", "attach-storage",
 	}
 
 	return charmOnlyFlags

--- a/cmd/juju/application/setapplicationbase.go
+++ b/cmd/juju/application/setapplicationbase.go
@@ -124,7 +124,7 @@ func (c *setApplicationBase) Run(ctx *cmd.Context) error {
 			defer func() { _ = c.apiClient.Close() }()
 		}
 
-		base, err := c.parseBase(ctx, c.releaseArg)
+		base, err := corebase.ParseBaseFromString(c.releaseArg)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -150,18 +150,4 @@ func (c *setApplicationBase) updateApplicationBase(base corebase.Base) error {
 		block.BlockChange)
 
 	return err
-}
-
-func (c *setApplicationBase) parseBase(ctx *cmd.Context, arg string) (corebase.Base, error) {
-	// If this doesn't contain an @ then it's a series and not a base.
-	if strings.Contains(arg, "@") {
-		return corebase.ParseBaseFromString(arg)
-	}
-
-	ctx.Warningf("series argument is deprecated, use base instead")
-	_, err := corebase.GetOSFromSeries(arg)
-	if err != nil {
-		return corebase.Base{}, errors.Trace(err)
-	}
-	return corebase.GetBaseFromSeries(arg)
 }

--- a/cmd/juju/charmhub/charmhub.go
+++ b/cmd/juju/charmhub/charmhub.go
@@ -39,9 +39,6 @@ type charmHubCommand struct {
 	base        string
 	charmHubURL string
 
-	// DEPRECATED: Use --base instead.
-	series string
-
 	CharmHubClientFunc func(charmhub.Config) (CharmHubClient, error)
 }
 

--- a/cmd/juju/charmhub/data.go
+++ b/cmd/juju/charmhub/data.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	// SeriesAll defines a platform that targets all series.
-	SeriesAll = "all"
 	// ArchAll defines a platform that targets all architectures.
 	ArchAll = "all"
 )

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -269,16 +269,13 @@ func (s *downloadSuite) TestRunWithRevisionAndOtherArgs(c *gc.C) {
 	}
 
 	err := cmdtesting.InitCommand(command, []string{"test", "--arch=amd64", "--revision=99"})
-	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base, --channel or --series`)
+	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base or --channel`)
 
 	err = cmdtesting.InitCommand(command, []string{"test", "--base=ubuntu@22.04", "--revision=99"})
-	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base, --channel or --series`)
+	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base or --channel`)
 
 	err = cmdtesting.InitCommand(command, []string{"test", "--channel=edge", "--revision=99"})
-	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base, --channel or --series`)
-
-	err = cmdtesting.InitCommand(command, []string{"test", "--series=jammy", "--revision=99"})
-	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base, --channel or --series`)
+	c.Check(err, gc.ErrorMatches, `--revision cannot be specified together with --arch, --base or --channel`)
 }
 
 func (s *downloadSuite) newCharmHubCommand() *charmHubCommand {

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -79,7 +79,6 @@ func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.arch, "arch", ArchAll, fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
-	f.StringVar(&c.series, "series", SeriesAll, "specify a series. DEPRECATED use --base")
 	f.StringVar(&c.base, "base", "", "specify a base")
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
 	f.BoolVar(&c.config, "config", false, "display config for this charm")
@@ -94,10 +93,6 @@ func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init initializes the info command, including validating the provided
 // flags. It implements part of the cmd.Command interface.
 func (c *infoCommand) Init(args []string) error {
-	if c.base != "" && (c.series != "" && c.series != SeriesAll) {
-		return errors.New("--series and --base cannot be specified together")
-	}
-
 	if err := c.charmHubCommand.Init(args); err != nil {
 		return errors.Trace(err)
 	}
@@ -140,18 +135,6 @@ func (c *infoCommand) Run(cmdContext *cmd.Context) error {
 		base corebase.Base
 		err  error
 	)
-	// Note: we validated that both series and base cannot be specified in
-	// Init(), so it's safe to assume that only one of them is set here.
-	if c.series == SeriesAll {
-		c.series = ""
-	} else if c.series != "" {
-		cmdContext.Warningf("series flag is deprecated, use --base instead")
-		if base, err = corebase.GetBaseFromSeries(c.series); err != nil {
-			return errors.Annotatef(err, "attempting to convert %q to a base", c.series)
-		}
-		c.base = base.String()
-		c.series = ""
-	}
 	if c.base != "" {
 		if base, err = corebase.ParseBaseFromString(c.base); err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -212,7 +212,7 @@ func (s *infoSuite) TestRunJSONSpecifySeriesNotDefault(c *gc.C) {
 		charmHubCommand: s.newCharmHubCommand(),
 	}
 
-	err := cmdtesting.InitCommand(command, []string{"test", "--format", "json", "--series", "xenial"})
+	err := cmdtesting.InitCommand(command, []string{"test", "--format", "json", "--base", "ubuntu@16.04"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := commandContextForTest(c)
@@ -462,7 +462,7 @@ func (s *infoSuite) TestRunJSONWithSeriesFoundChannel(c *gc.C) {
 		charmHubCommand: s.newCharmHubCommand(),
 	}
 
-	err := cmdtesting.InitCommand(command, []string{"test", "--series", "focal", "--format", "json"})
+	err := cmdtesting.InitCommand(command, []string{"test", "--base", "ubuntu@20.04", "--format", "json"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := commandContextForTest(c)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1600,14 +1600,6 @@ func (s *BootstrapSuite) TestBootstrapProviderManyDetectedCredentials(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ambiguousDetectedCredentialError.Error())
 }
 
-func (s *BootstrapSuite) TestBootstrapWithBootstrapSeries(c *gc.C) {
-	s.patchVersionAndSeries(c, "jammy")
-	_, err := cmdtesting.RunCommand(
-		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--bootstrap-series", "spock",
-	)
-	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
-}
-
 func (s *BootstrapSuite) TestBootstrapWithDeprecatedBase(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "jammy")
 	_, err := cmdtesting.RunCommand(
@@ -1623,16 +1615,6 @@ func (s *BootstrapSuite) TestBootstrapWithNoBootstrapSeriesUsesFallbackButStillF
 		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--config", "default-base=spock",
 	)
 	c.Assert(err, gc.ErrorMatches, `invalid default base "spock".*`)
-}
-
-func (s *BootstrapSuite) TestBootstrapWithBootstrapSeriesDoesNotUseFallbackButStillFails(c *gc.C) {
-	s.patchVersionAndSeries(c, "jammy")
-	_, err := cmdtesting.RunCommand(
-		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl",
-		"--bootstrap-series", "spock",
-		"--config", "default-base=kirk",
-	)
-	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
 }
 
 func (s *BootstrapSuite) TestBootstrapBaseWithNoBootstrapSeriesUsesFallbackButStillFails(c *gc.C) {

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -126,11 +126,6 @@ func (s *AddMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, add, args...)
 }
 
-func (s *AddMachineSuite) TestSeriesAndBaseError(c *gc.C) {
-	_, err := s.run(c, "--series=jammy", "--base=ubuntu@22.04")
-	c.Assert(err, gc.ErrorMatches, "--series and --base cannot be specified together")
-}
-
 func (s *AddMachineSuite) TestAddMachine(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)

--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -8,7 +8,7 @@ run_charmhub_charmrevisionupdater() {
 	ensure "${model_name}" "${file}"
 
 	# Deploy an old revision of ubuntu
-	juju deploy ubuntu --channel=stable --revision=18 --series focal
+	juju deploy ubuntu --channel=stable --revision=18 --base ubuntu@20.04
 
 	# Wait for revision update worker to update the available revision.
 	# eg can-upgrade-to: ch:ubuntu-18

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -10,7 +10,7 @@ run_branch() {
 
 	juju branch | check 'Active branch is "master"'
 
-	juju deploy juju-qa-dummy-source --series jammy --config token=a
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04 --config token=a
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -22,7 +22,7 @@ run_offer_consume() {
 	ensure "model-offer" "${file}"
 
 	echo "Deploy consumed workload and create the offer"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink dummy-offer
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -33,7 +33,7 @@ run_offer_consume() {
 	echo "Deploy workload in consume model"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -91,7 +91,7 @@ run_offer_consume_cross_controller() {
 
 	echo "Deploy consumed workload and create the offer"
 	juju switch "${offer_controller}"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
@@ -100,7 +100,7 @@ run_offer_consume_cross_controller() {
 	juju switch "controller-consume"
 	juju add-model "model-consume"
 	juju switch "model-consume"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -41,7 +41,7 @@ run_deploy_charm_unsupported_series() {
 
 	# The charm in 3.0/stable only supports jammy and only
 	# one charm has been released to that channel.
-	juju deploy juju-qa-test --channel 3.0/stable --series focal | grep -q 'charm or bundle not found for channel' || true
+	juju deploy juju-qa-test --channel 3.0/stable --base ubuntu@20.04 | grep -q 'charm or bundle not found for channel' || true
 
 	destroy_model "${testname}"
 }
@@ -82,7 +82,7 @@ run_deploy_lxd_profile_charm() {
 	# This charm deploys to Xenial by default, which doesn't
 	# always result in a machine which becomes fully deployed
 	# with the lxd provider.
-	juju deploy juju-qa-lxd-profile-without-devices --series jammy
+	juju deploy juju-qa-lxd-profile-without-devices --base ubuntu@22.04
 	wait_for "lxd-profile-without-devices" "$(idle_condition "lxd-profile-without-devices")"
 
 	juju status --format=json | jq '.machines | .["0"] | .["lxd-profiles"] | keys[0]' | check "juju-test-deploy-lxd-profile-lxd-profile"
@@ -100,7 +100,7 @@ run_deploy_lxd_profile_charm_container() {
 	# This charm deploys to Xenial by default, which doesn't
 	# always result in a machine which becomes fully deployed
 	# with the lxd provider.
-	juju deploy juju-qa-lxd-profile-without-devices --to lxd --series jammy
+	juju deploy juju-qa-lxd-profile-without-devices --to lxd --base ubuntu@22.04
 	wait_for "lxd-profile-without-devices" "$(idle_condition "lxd-profile-without-devices")"
 
 	juju status --format=json | jq '.machines | .["0"] | .containers | .["0/lxd/0"] | .["lxd-profiles"] | keys[0]' |
@@ -170,7 +170,7 @@ run_deploy_lxd_to_machine() {
 
 	ensure "${model_name}" "${file}"
 
-	juju add-machine -n 2 --series=jammy
+	juju add-machine -n 2 --base ubuntu@22.04
 
 	charm=./tests/suites/deploy/charms/lxd-profile-alt
 	juju deploy "${charm}" --to 0 --base ubuntu@22.04

--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -7,8 +7,8 @@ run_deploy_aks_charms() {
 	juju add-model "test-deploy-aks-charms"
 
 	echo "Deploy some charms"
-	juju deploy juju-qa-dummy-sink --series jammy
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 
 	juju relate dummy-sink dummy-source
 

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,7 +6,7 @@ test_log_permissions() {
 	file="${TEST_DIR}/test_log_permissions.log"
 	ensure "correct-log" "${file}"
 
-	juju deploy juju-qa-test source --series focal
+	juju deploy juju-qa-test source --base ubuntu@20.04
 
 	wait_for "started" '.machines."0"."juju-status".current'
 

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -154,14 +154,14 @@ run_model_migration_saas_common() {
 	bootstrap_alt_controller "alt-model-migration-saas"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	add_model blog
 	juju switch blog
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -224,13 +224,13 @@ run_model_migration_saas_external() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -291,14 +291,14 @@ run_model_migration_saas_consumer() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy juju-qa-dummy-source --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
 	add_model "model-migration-consumer"
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 

--- a/tests/suites/model/multi.sh
+++ b/tests/suites/model/multi.sh
@@ -28,8 +28,8 @@ deploy_stack() {
 
 	juju switch "${name}"
 
-	juju deploy juju-qa-dummy-source --series jammy
-	juju deploy juju-qa-dummy-sink --series jammy
+	juju deploy juju-qa-dummy-source --base ubuntu@22.04
+	juju deploy juju-qa-dummy-sink --base ubuntu@22.04
 
 	juju integrate dummy-source dummy-sink
 	juju expose dummy-sink

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -45,7 +45,7 @@ run_refresh_local_resources() {
 	# a bug in charm, opening the resource file throws:
 	# TypeError: invalid file
 	# The charm is using python 3. No error in ubuntu 20.04.
-	juju deploy "${charm_name}" juju-qa-test --series focal --resource foo-file="./tests/suites/resources/foo-file.txt"
+	juju deploy "${charm_name}" juju-qa-test --base ubuntu@20.04 --resource foo-file="./tests/suites/resources/foo-file.txt"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	juju refresh juju-qa-test --path "${charm_name}"
@@ -120,7 +120,7 @@ run_refresh_revision() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy juju-qa-test --revision 22 --channel stable --series focal
+	juju deploy juju-qa-test --revision 22 --channel stable --base ubuntu@20.04
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	# refresh to a revision not at the tip of the stable channel


### PR DESCRIPTION
Remove deprecated --series flag from 4.0 from `deploy`, `set-application-base`, `info`, `download`, `bootstrap`, `add-machine` and `upgrade-machine`

Instead users should use a base (--base, --bootstrap-base, or base in the positional arguement)

This is a step towards removing the concept of a series from Juju

We also still use --series in a large number of our integration tests. Fix these while I'm here

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Uni tests pass

```
./main.sh -v machine
```

```
$ juju deploy -h | grep '\-\-series'
```

```
$ juju deploy ubuntu --series jammy
ERROR option provided but not defined: --series

$ juju deploy ubuntu --base ubuntu@20.04
```

```
$ juju set-application-base ubuntu jammy
ERROR expected base string to contain os and channel separated by '@'

$ juju set-application-base ubuntu ubuntu@22.04
WARNING To ensure the correct charm binaries are installed when add-unit is next called, please first run `juju refresh` for this application and any related subordinates.
```

```
$ juju info ubuntu --series focal
ERROR option provided but not defined: --series

$ juju info ubuntu --base ubuntu@20.04
name: ubuntu
publisher: charmers
summary: A pristine Ubuntu Server
description: |
  This simply deploys the Ubuntu Cloud/Server image
store-url: https://charmhub.io/ubuntu
charm-id: DksXQKAQTZfsUmBAGanZAhpoS4dpmXel
supports: ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
subordinate: false
channels: |
  latest/stable:     24  2023-05-26  (24)  2MB    amd64, arm, arm64, i386, ppc64
                     21  2022-09-15  (21)  2MB    amd64
                     19  2022-02-09  (19)  828kB  amd64, arm64, ppc64el, riscv64, s390x
                     18  2022-02-09  (18)  5MB    amd64, arm64, ppc64el, riscv64, s390x
                     17  2020-11-11  (17)  5MB    amd64, arm64, ppc64el, riscv64, s390x
  latest/candidate:  24  2023-05-19  (24)  2MB    amd64, arm, arm64, i386, ppc64
                     21  2022-09-15  (21)  2MB    amd64
                     19  2022-02-09  (19)  828kB  amd64, arm64, ppc64el, riscv64, s390x
                     18  2022-02-09  (18)  5MB    amd64, arm64, ppc64el, riscv64, s390x
                     17  2020-11-11  (17)  5MB    amd64, arm64, ppc64el, riscv64, s390x
  latest/beta:       24  2023-05-19  (24)  2MB    amd64, arm, arm64, i386, ppc64
                     21  2022-09-15  (21)  2MB    amd64
                     19  2022-02-09  (19)  828kB  amd64, arm64, ppc64el, riscv64, s390x
                     18  2022-02-09  (18)  5MB    amd64, arm64, ppc64el, riscv64, s390x
                     17  2020-11-11  (17)  5MB    amd64, arm64, ppc64el, riscv64, s390x
  latest/edge:       24  2023-05-19  (24)  2MB    amd64, arm, arm64, i386, ppc64
                     21  2022-09-15  (21)  2MB    amd64
                     19  2022-02-09  (19)  828kB  amd64, arm64, ppc64el, riscv64, s390x
                     18  2022-02-09  (18)  5MB    amd64, arm64, ppc64el, riscv64, s390x
                     17  2020-11-11  (17)  5MB    amd64, arm64, ppc64el, riscv64, s390x
```

```
$ juju download ubuntu --series focal
ERROR option provided but not defined: --series

$ juju download ubuntu --base ubuntu@20.04
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/20.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

```
$ juju bootstrap lxd lxd --bootstrap-series focal
ERROR option provided but not defined: --bootstrap-series

$ $ juju bootstrap lxd lxd --bootstrap-base ubuntu@20.04
Creating Juju controller "lxd" on lxd/localhost
Looking for packaged Juju agent version 4.0-beta3 for amd64
No packaged binary found, preparing local Juju agent binary
...
```

```
$ juju add-machine --series focal
ERROR option provided but not defined: --series

$ juju add-machine --base ubuntu@20.04
created machine 0

$ juju status
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m2     lxd-src     localhost/localhost  4.0-beta3.1  12:51:42+01:00

Machine  State    Address        Inst id        Base          AZ  Message
0        pending  10.219.211.85  juju-2cbd49-0  ubuntu@20.04      Running
```

```
$ juju upgrade-machine 0 prepare jammy
ERROR expected base string to contain os and channel separated by '@'

$$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubu/0 pre-series-upgrade hook running
ubu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete
```