### PR TITLE
Fix an error processing storage on k8s; handle storagepool notfound errors

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/storage"
@@ -160,6 +161,9 @@ func (m *mockStoragePoolGetter) GetStoragePoolByName(_ context.Context, name str
 	m.MethodCall(m, "GetStoragePoolByName", name)
 	if err := m.NextErr(); err != nil {
 		return nil, err
+	}
+	if name == "notpool" {
+		return nil, storageerrors.PoolNotFoundError
 	}
 	return storage.NewConfig(name, k8sconstants.StorageProviderType, map[string]interface{}{"foo": "bar"})
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -518,7 +518,7 @@ func CharmStorageParams(
 	}
 
 	providerType, attrs, err := poolStorageProvider(ctx, storagePoolGetter, registry, maybePoolName)
-	if err != nil && (!errors.Is(err, errors.NotFound) || poolName != "") {
+	if err != nil && (!errors.Is(err, storageerrors.PoolNotFoundError) || poolName != "") {
 		return nil, errors.Trace(err)
 	}
 	if err == nil {


### PR DESCRIPTION
We've started using bespoke, domain specific not found errors. There was a place in the k8s storage provisioning code where the older generic not found error was still being checked. This fixes that.

## QA steps

bootstrap k8s
deploy postgresql-k8s

check storage
```
Storage Unit      Storage ID  Type        Pool        Mountpoint                Size     Status    Message
postgresql-k8s/0  pgdata/0    filesystem  kubernetes  /var/lib/postgresql/data  1.0 GiB  attached  Successfully provisioned volume pvc-43da2f5a-7e38-424a-9691-2fb15cb7090d
```

## Links

**Jira card:** JUJU-5848

