### PR TITLE
Restore runcmd shell flag after setting juju's runcmd

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -241,6 +241,10 @@ func (w *unixConfigure) ConfigureJuju() error {
 	// To keep postruncmd at the end of any runcmd's that juju adds,
 	// this block must stay at the top.
 	if postruncmds, ok := w.icfg.CloudInitUserData["postruncmd"].([]interface{}); ok {
+
+		// revert the `set -xe` shell flag which was set after preruncmd
+		// LP: #1978454
+		w.conf.AddRunCmd("set +xe")
 		cmds := make([]string, len(postruncmds))
 		for i, v := range postruncmds {
 			cmd, err := runCmdToString(v)


### PR DESCRIPTION
Juju uses `set -xe` to force its cloud-config runcmds to fail
when an individual command fails. This shell option is not unset prior
to postruncmd commands, which leaks a side-effect to users. This causes
postruncmd scripts to behave differently than runcmd does and is not
documented.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~- [ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

unittests
```
ok  	github.com/juju/juju/internal/cloudconfig	0.266s
```

consider the script changes:

pre-change:
```bash
set -xe
true
false
echo success
```

output:
```bash
+ true
+ false
```

Note that the final command never runs, which is difference between `postruncmd` and `runcmd`'s behavior.

post-change:
```bash
set -xe
true
set +xe
false
echo success
```

output:
```bash
+ true
+ set +xe
success
```

Note that the final command runs, which is what one might expect since `postruncmd` is documented as a fix for a broken `runcmd`, and no change in behavior is documented from `runcmd` outside of being ordered after `runcmd`.

## Documentation changes

`postruncmd` is [documented as a workaround for a broken `runcmd`](https://juju.is/docs/juju/list-of-model-configuration-keys#heading--cloudinit-userdata) in Juju. This change brings Juju's behavior closer to its current documentation. Users that expect `postruncmd` to behave like `runcmd` will no longer be surprised.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1978454


