### PR TITLE
Add state and service logic for getting and saving secret consumer info.

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -142,8 +142,8 @@ func (c *Client) GetConsumerSecretsRevisionInfo(unitName string, uris []string) 
 			return nil, errors.Annotatef(err, "finding latest info for secret %q", uris[i])
 		}
 		info[uris[i]] = coresecrets.SecretRevisionInfo{
-			Revision: latest.Revision,
-			Label:    latest.Label,
+			LatestRevision: latest.Revision,
+			Label:          latest.Label,
 		}
 	}
 	return info, err

--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -185,6 +185,22 @@ func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumer(ctx, uri, unitName 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumer), ctx, uri, unitName)
 }
 
+// GetSecretConsumerAndLatest mocks base method.
+func (m *MockSecretsConsumer) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretConsumerAndLatest", ctx, uri, unitName)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSecretConsumerAndLatest indicates an expected call of GetSecretConsumerAndLatest.
+func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumerAndLatest(ctx, uri, unitName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumerAndLatest", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumerAndLatest), ctx, uri, unitName)
+}
+
 // GetURIByConsumerLabel mocks base method.
 func (m *MockSecretsConsumer) GetURIByConsumerLabel(ctx context.Context, label, unitName string) (*secrets.URI, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -479,11 +479,10 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingConsumerLa
 
 	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
 		&coresecrets.SecretConsumerMetadata{
-			LatestRevision: 666,
-			Label:          "label",
-		}, nil)
+			Label: "label",
+		}, 666, nil)
 
 	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "unit-mariadb/0",
@@ -503,10 +502,10 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingNoConsumer
 
 	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
 		&coresecrets.SecretConsumerMetadata{
-			LatestRevision: 666,
-		}, nil)
+			CurrentRevision: 665,
+		}, 666, nil)
 
 	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "unit-mariadb/0",
@@ -525,11 +524,11 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoForPeerUnitsAcce
 
 	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
 		&coresecrets.SecretConsumerMetadata{
-			LatestRevision: 666,
-			Label:          "owner-label",
-		}, nil)
+			CurrentRevision: 665,
+			Label:           "owner-label",
+		}, 666, nil)
 
 	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.Background(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "unit-mariadb/0",
@@ -1075,7 +1074,6 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 		}, 666, true, nil)
 
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
-		LatestRevision:  666,
 		CurrentRevision: 666,
 	})
 
@@ -1121,7 +1119,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(nil, errors.NotFoundf(""))
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(nil, secreterrors.SecretConsumerNotFound)
 	s.secretService.EXPECT().ProcessSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "", gomock.Any()).Return(uri, nil, nil)
 
 	s.remoteClient.EXPECT().GetSecretAccessScope(uri, "token", 0).Return("scope-token", nil)
@@ -1145,7 +1143,6 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *gc.C)
 		}, 666, true, nil)
 
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
-		LatestRevision:  666,
 		CurrentRevision: 666,
 	})
 

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -23,6 +23,7 @@ type SecretTriggers interface {
 // SecretsConsumer instances provide secret consumer apis.
 type SecretsConsumer interface {
 	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error)
+	GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
 	GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error)
 	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
 	GetConsumedRevision(

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -116,19 +116,19 @@ func (mr *MockSecretServiceMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretService)(nil).GetSecretValue), arg0, arg1, arg2)
 }
 
-// GetUserSecretByLabel mocks base method.
-func (m *MockSecretService) GetUserSecretByLabel(arg0 context.Context, arg1 string) (*secrets.SecretMetadata, error) {
+// GetUserSecretURIByLabel mocks base method.
+func (m *MockSecretService) GetUserSecretURIByLabel(arg0 context.Context, arg1 string) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserSecretByLabel", arg0, arg1)
-	ret0, _ := ret[0].(*secrets.SecretMetadata)
+	ret := m.ctrl.Call(m, "GetUserSecretURIByLabel", arg0, arg1)
+	ret0, _ := ret[0].(*secrets.URI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUserSecretByLabel indicates an expected call of GetUserSecretByLabel.
-func (mr *MockSecretServiceMockRecorder) GetUserSecretByLabel(arg0, arg1 any) *gomock.Call {
+// GetUserSecretURIByLabel indicates an expected call of GetUserSecretURIByLabel.
+func (mr *MockSecretServiceMockRecorder) GetUserSecretURIByLabel(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretByLabel", reflect.TypeOf((*MockSecretService)(nil).GetUserSecretByLabel), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretURIByLabel", reflect.TypeOf((*MockSecretService)(nil).GetUserSecretURIByLabel), arg0, arg1)
 }
 
 // GrantSecretAccess mocks base method.

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -436,11 +436,11 @@ func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*core
 	if uriStr != "" {
 		return coresecrets.ParseURI(uriStr)
 	}
-	md, err := s.secretService.GetUserSecretByLabel(ctx, label)
+	uri, err := s.secretService.GetUserSecretURIByLabel(ctx, label)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting user secret for label %q", label)
 	}
-	return md.URI, nil
+	return uri, nil
 }
 
 // RemoveSecrets isn't on the v1 API.

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -413,9 +413,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI, isInte
 	if uri == nil {
 		existingLabel = "my-secret"
 		uri = coresecrets.NewURI()
-		s.secretService.EXPECT().GetUserSecretByLabel(gomock.Any(), "my-secret").Return(&coresecrets.SecretMetadata{
-			URI: uri,
-		}, nil)
+		s.secretService.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my-secret").Return(uri, nil)
 	} else {
 		uriString = uri.String()
 	}
@@ -662,9 +660,7 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().GetUserSecretByLabel(gomock.Any(), "my-secret").Return(&coresecrets.SecretMetadata{
-		URI: uri,
-	}, nil)
+	s.secretService.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my-secret").Return(uri, nil)
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)

--- a/apiserver/facades/client/secrets/service.go
+++ b/apiserver/facades/client/secrets/service.go
@@ -21,7 +21,7 @@ type SecretService interface {
 	// View and fetch secrets.
 
 	GetSecret(ctx context.Context, uri *secrets.URI) (*secrets.SecretMetadata, error)
-	GetUserSecretByLabel(ctx context.Context, label string) (*secrets.SecretMetadata, error)
+	GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error)
 	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, *secrets.ValueRef, error)
 	ListSecrets(ctx context.Context, uri *secrets.URI,
 		revisions domainsecret.Revisions,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -246,9 +246,8 @@ func (s *CrossModelSecretsAPI) updateConsumedRevision(ctx stdcontext.Context, se
 		if consumerInfo == nil {
 			consumerInfo = &coresecrets.SecretConsumerMetadata{}
 		}
-		consumerInfo.LatestRevision = md.LatestRevision
 		consumerInfo.CurrentRevision = md.LatestRevision
-		if err := secretService.SaveSecretRemoteConsumer(ctx, uri, consumer.Id(), consumerInfo); err != nil {
+		if err := secretService.SaveSecretRemoteConsumer(ctx, uri, md.LatestRevision, consumer.Id(), consumerInfo); err != nil {
 			return 0, errors.Trace(err)
 		}
 	}

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -181,9 +181,8 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 	s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(&coresecrets.SecretMetadata{
 		LatestRevision: 667,
 	}, nil)
-	s.secretService.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, "remote-app/666", &coresecrets.SecretConsumerMetadata{
+	s.secretService.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, 667, "remote-app/666", &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 667,
-		LatestRevision:  667,
 	}).Return(nil)
 	s.secretService.EXPECT().GetSecretAccess(gomock.Any(), uri, consumer).Return(coresecrets.RoleView, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 667).Return(

--- a/apiserver/facades/controller/crossmodelsecrets/mocks/secretservice.go
+++ b/apiserver/facades/controller/crossmodelsecrets/mocks/secretservice.go
@@ -118,15 +118,15 @@ func (mr *MockSecretServiceMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *g
 }
 
 // SaveSecretRemoteConsumer mocks base method.
-func (m *MockSecretService) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+func (m *MockSecretService) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 string, arg4 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSecretRemoteConsumer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SaveSecretRemoteConsumer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveSecretRemoteConsumer indicates an expected call of SaveSecretRemoteConsumer.
-func (mr *MockSecretServiceMockRecorder) SaveSecretRemoteConsumer(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockSecretServiceMockRecorder) SaveSecretRemoteConsumer(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretRemoteConsumer", reflect.TypeOf((*MockSecretService)(nil).SaveSecretRemoteConsumer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretRemoteConsumer", reflect.TypeOf((*MockSecretService)(nil).SaveSecretRemoteConsumer), arg0, arg1, arg2, arg3, arg4)
 }

--- a/apiserver/facades/controller/crossmodelsecrets/service.go
+++ b/apiserver/facades/controller/crossmodelsecrets/service.go
@@ -16,7 +16,7 @@ type SecretService interface {
 	GetSecret(context.Context, *secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, *secrets.ValueRef, error)
 	GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error)
-	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, latestRevision int, unitName string, md *secrets.SecretConsumerMetadata) error
 	GetSecretAccess(ctx context.Context, uri *secrets.URI, consumer secretservice.SecretAccessor) (secrets.SecretRole, error)
 	GetSecretAccessScope(ctx context.Context, uri *secrets.URI, accessor secretservice.SecretAccessor) (secretservice.SecretAccessScope, error)
 }

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -236,14 +236,16 @@ type SecretConsumerMetadata struct {
 	// CurrentRevision is current revision the
 	// consumer wants to read.
 	CurrentRevision int
+
+	// TODO(secrets) - this will be removed
 	// LatestRevision is the latest secret revision.
 	LatestRevision int
 }
 
 // SecretRevisionInfo holds info used to read a secret vale.
 type SecretRevisionInfo struct {
-	Revision int
-	Label    string
+	LatestRevision int
+	Label          string
 }
 
 // Filter is used when querying secrets.

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -23,9 +23,6 @@ const (
 	tableSecretRotation
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
-	tableSecretApplicationConsumerCurrentRevision
-	tableSecretUnitConsumerCurrentRevision
-	tableSecretRemoteApplicationConsumerCurrentRevision
 	tableSecretRemoteUnitConsumerCurrentRevision
 )
 
@@ -68,12 +65,6 @@ func ModelDDL() *schema.Schema {
 			"secret_revision", "uuid", "obsolete", tableSecretRevisionObsolete),
 		changeLogTriggersForTableOnColumn(
 			"secret_revision_expire", "revision_uuid", "next_expire_time", tableSecretRevisionExpire),
-		changeLogTriggersForTableOnColumn(
-			"secret_application_consumer", "uuid", "current_revision", tableSecretApplicationConsumerCurrentRevision),
-		changeLogTriggersForTableOnColumn(
-			"secret_unit_consumer", "uuid", "current_revision", tableSecretUnitConsumerCurrentRevision),
-		changeLogTriggersForTableOnColumn(
-			"secret_remote_application_consumer", "uuid", "current_revision", tableSecretRemoteApplicationConsumerCurrentRevision),
 		changeLogTriggersForTableOnColumn(
 			"secret_remote_unit_consumer", "uuid", "current_revision", tableSecretRemoteUnitConsumerCurrentRevision),
 
@@ -140,10 +131,8 @@ INSERT INTO change_log_namespace VALUES
     (10, 'secret_rotation', 'Secret rotation changes based on UUID'),
     (11, 'secret_revision', 'Secret revision obsolete changes based on UUID'),
     (12, 'secret_revision_expire', 'Secret revision next expire time changes based on UUID'),
-    (13, 'secret_application_consumer', 'Secret application consumer current revision changes based on UUID'),
-    (14, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID'),
-    (15, 'secret_remote_application_consumer', 'Secret remote application consumer current revision changes based on UUID'),
-    (16, 'secret_remote_unit_consumer', 'Secret remote unit consumer current revision changes based on UUID');
+    (13, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID'),
+    (14, 'secret_remote_unit_consumer', 'Secret remote unit consumer current revision changes based on UUID');
 `)
 }
 

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -201,7 +201,7 @@ CREATE TABLE
 
 CREATE TABLE
     secret_application_owner (
-        secret_id TEXT PRIMARY KEY,
+        secret_id TEXT NOT NULL,
         application_uuid TEXT NOT NULL,
         label TEXT,
         CONSTRAINT fk_secret_application_owner_secret_id
@@ -210,6 +210,7 @@ CREATE TABLE
         CONSTRAINT fk_secret_application_owner_application_uuid
             FOREIGN KEY (application_uuid)
             REFERENCES application (uuid)
+        PRIMARY KEY (secret_id, application_uuid)
     );
 
 -- We need to ensure the label is unique per the application.
@@ -217,7 +218,7 @@ CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_own
 
 CREATE TABLE
     secret_unit_owner (
-        secret_id TEXT PRIMARY KEY,
+        secret_id TEXT NOT NULL,
         unit_uuid TEXT NOT NULL,
         label TEXT,
         CONSTRAINT fk_secret_unit_owner_secret_id
@@ -226,6 +227,7 @@ CREATE TABLE
         CONSTRAINT fk_secret_unit_owner_unit_uuid
             FOREIGN KEY (unit_uuid)
             REFERENCES unit (uuid)
+        PRIMARY KEY (secret_id, unit_uuid)
     );
 
 -- We need to ensure the label is unique per unit.

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -213,6 +213,7 @@ CREATE TABLE
         PRIMARY KEY (secret_id, application_uuid)
     );
 
+CREATE INDEX idx_secret_application_owner_secret_id ON secret_application_owner (secret_id);
 -- We need to ensure the label is unique per the application.
 CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_owner (label,application_uuid) WHERE label != '';
 
@@ -230,6 +231,7 @@ CREATE TABLE
         PRIMARY KEY (secret_id, unit_uuid)
     );
 
+CREATE INDEX idx_secret_unit_owner_secret_id ON secret_unit_owner (secret_id);
 -- We need to ensure the label is unique per unit.
 CREATE UNIQUE INDEX idx_secret_unit_owner_label ON secret_unit_owner (label,unit_uuid) WHERE label != '';
 

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -243,55 +243,20 @@ CREATE TABLE
 CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label) WHERE label != '';
 
 CREATE TABLE
-    secret_application_consumer (
-        uuid TEXT PRIMARY KEY,
-        secret_id TEXT NOT NULL,
-        application_uuid TEXT NOT NULL,
-        label TEXT,
-        current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_application_consumer_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id),
-        CONSTRAINT fk_secret_application_consumer_application_uuid
-            FOREIGN KEY (application_uuid)
-            REFERENCES application (uuid)
-    );
-CREATE UNIQUE INDEX idx_secret_application_consumer_secret_id_application_uuid ON secret_application_consumer (secret_id,application_uuid);
-CREATE UNIQUE INDEX idx_secret_application_consumer_label ON secret_application_consumer (label,application_uuid);
-
-CREATE TABLE
     secret_unit_consumer (
-        uuid TEXT PRIMARY KEY,
+        -- There's no FK to secret because cross model secrets
+        -- don't exist in this database.
         secret_id TEXT NOT NULL,
         unit_uuid TEXT NOT NULL,
         label TEXT,
         current_revision INT NOT NULL, 
-        CONSTRAINT fk_secret_unit_consumer_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id),
         CONSTRAINT fk_secret_unit_consumer_unit_uuid
             FOREIGN KEY (unit_uuid)
             REFERENCES unit (uuid)
     );
 
 CREATE UNIQUE INDEX idx_secret_unit_consumer_secret_id_unit_uuid ON secret_unit_consumer (secret_id,unit_uuid);
-CREATE UNIQUE INDEX idx_secret_unit_consumer_label ON secret_unit_consumer (label,unit_uuid);
-
-CREATE TABLE
-    secret_remote_application_consumer (
-        uuid TEXT PRIMARY KEY,
-        secret_id TEXT NOT NULL,
-        application_uuid TEXT NOT NULL,
-        current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_remote_application_consumer_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id),
-        CONSTRAINT fk_secret_remote_application_consumer_application_uuid
-            FOREIGN KEY (application_uuid)
-            REFERENCES application (uuid)
-    );
-
-CREATE UNIQUE INDEX idx_secret_remote_application_consumer_secret_id_application_uuid ON secret_remote_application_consumer (secret_id,application_uuid);
+CREATE UNIQUE INDEX idx_secret_unit_consumer_label ON secret_unit_consumer (label,unit_uuid) WHERE label != '';
 
 CREATE TABLE
     secret_remote_unit_consumer (

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -12,37 +12,57 @@ import (
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
-func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
-	return nil, secreterrors.SecretConsumerNotFound
-	/*
-		consumerMetadata, err := getConsumerMetadata(...)
-		//if consumerMetadata.Label != "" {
-		//	return consumerMetadata, nil
-		//}
-		// We allow units to access the application owned secrets using the application owner label,
-		// so we copy the owner label to consumer metadata.
-		//md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, "")
-		//if errors.Is(err, errors.NotFound) {
-		//	// The secret is owned by a different application.
-		//	return consumerMetadata, nil
-		//}
-		//if err != nil {
-		//	return nil, errors.Annotatef(err, "cannot get secret metadata for %q", uri)
-		//}
-		//consumerMetadata.Label = md.Label
+// GetSecretConsumerAndLatest returns the secret consumer info for the specified unit and secret, along with
+// the latest revision for the secret.
+// If the unit does not exist, an error satisfying [uniterrors.NotFound] is returned.
+// If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
+// If there's not currently a consumer record for the secret, the latest revision is still returned,
+// along with an error satisfying [secreterrors.SecretConsumerNotFound].
+func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error) {
+	consumerMetadata, latestRevision, err := s.st.GetSecretConsumer(ctx, uri, unitName)
 
-	*/
+	if err != nil {
+		return nil, latestRevision, errors.Trace(err)
+	}
+	if consumerMetadata.Label != "" {
+		return consumerMetadata, latestRevision, nil
+	}
+	// We allow units to access the application owned secrets using the application owner label,
+	// so we copy the owner label to consumer metadata.
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(ctx, uri, unitName, "")
+	if errors.Is(err, secreterrors.SecretNotFound) {
+		// The secret is owned by a different application.
+		return consumerMetadata, latestRevision, nil
+	}
+	if err != nil {
+		return nil, 0, errors.Annotatef(err, "cannot get secret metadata for %q", uri)
+	}
+	consumerMetadata.Label = md.Label
+	return consumerMetadata, latestRevision, nil
 }
 
+// GetSecretConsumer returns the secret consumer info for the specified unit and secret.
+// If the unit does not exist, an error satisfying [uniterrors.NotFound] is returned.
+// If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
+// If there's not currently a consumer record for the secret, an error satisfying [secreterrors.SecretConsumerNotFound]
+// is returned.
+func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
+	result, _, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
+	return result, err
+}
+
+// SaveSecretConsumer saves the consumer metadata for the given secret and unit.
+// If the unit does not exist, an error satisfying [uniterrors.NotFound] is returned.
+// If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
 func (s *SecretService) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error {
-	return nil
+	return s.st.SaveSecretConsumer(ctx, uri, unitName, md)
 }
 
 func (s *SecretService) GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
 	return nil, secreterrors.SecretConsumerNotFound
 }
 
-func (s *SecretService) SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error {
+func (s *SecretService) SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, latestRevision int, unitName string, md *secrets.SecretConsumerMetadata) error {
 	return nil
 }
 
@@ -52,10 +72,9 @@ func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string,
 
 // GetConsumedRevision returns the secret revision number for the specified consumer, possibly updating
 // the label associated with the secret for the consumer.
-// Only one of consumer app or unit name must be specified.
 // TODO(secrets) - test
 func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
-	consumerInfo, err := s.GetSecretConsumer(ctx, uri, unitName)
+	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
 	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
 		return 0, errors.Trace(err)
 	}
@@ -69,18 +88,13 @@ func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.UR
 
 	// Use the latest revision as the current one if --refresh or --peek.
 	if refresh || peek {
-		md, err := s.GetSecret(ctx, uri)
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
 		if consumerInfo == nil {
 			consumerInfo = &secrets.SecretConsumerMetadata{}
 		}
-		consumerInfo.LatestRevision = md.LatestRevision
 		if refresh {
-			consumerInfo.CurrentRevision = md.LatestRevision
+			consumerInfo.CurrentRevision = latestRevision
 		}
-		wantRevision = md.LatestRevision
+		wantRevision = latestRevision
 	}
 	// Save the latest consumer info if required.
 	if refresh || labelToUpdate != nil {

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -31,7 +31,7 @@ func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *sec
 	// so we copy the owner label to consumer metadata.
 	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(ctx, uri, unitName, "")
 	if errors.Is(err, secreterrors.SecretNotFound) {
-		// The secret is owned by a different application.
+		// The secret is owned by a different application; the named unit is the consumer.
 		return consumerMetadata, latestRevision, nil
 	}
 	if err != nil {

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -31,6 +31,9 @@ type State interface {
 		labels domainsecret.Labels, appOwners domainsecret.ApplicationOwners,
 		unitOwners domainsecret.UnitOwners, wantUser bool,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
+	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error)
 }
 
 // Logger facilitates emitting log messages.
@@ -205,10 +208,10 @@ func (s *SecretService) GetSecret(ctx context.Context, uri *secrets.URI) (*secre
 	return s.st.GetSecret(ctx, uri)
 }
 
-// GetUserSecretByLabel returns the user secret with the specified label.
+// GetUserSecretURIByLabel returns the user secret URI with the specified label.
 // If returns [secreterrors.SecretNotFound] is there's no such secret.
-func (s *SecretService) GetUserSecretByLabel(ctx context.Context, label string) (*secrets.SecretMetadata, error) {
-	return nil, errors.NotFound
+func (s *SecretService) GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error) {
+	return s.st.GetUserSecretURIByLabel(ctx, label)
 }
 
 // ListUserSecrets returns the secret metadata and revision metadata for any user secrets in the current model.

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -114,6 +114,74 @@ func (s *serviceSuite) TestGetSecretValue(c *gc.C) {
 	c.Assert(data, jc.DeepEquals, coresecrets.NewSecretValue(map[string]string{"foo": "bar"}))
 }
 
+func (s *serviceSuite) TestGetSecretConsumer(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	consumer := &coresecrets.SecretConsumerMetadata{
+		Label:           "my secret",
+		CurrentRevision: 666,
+	}
+
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mysql/0").Return(consumer, 666, nil)
+
+	got, err := s.service().GetSecretConsumer(context.Background(), uri, "mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, consumer)
+}
+
+func (s *serviceSuite) TestGetSecretConsumerAndLatest(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	consumer := &coresecrets.SecretConsumerMetadata{
+		Label:           "my secret",
+		CurrentRevision: 666,
+	}
+
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mysql/0").Return(consumer, 666, nil)
+
+	got, latest, err := s.service().GetSecretConsumerAndLatest(context.Background(), uri, "mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, consumer)
+	c.Assert(latest, gc.Equals, 666)
+}
+
+func (s *serviceSuite) TestSaveSecretConsumer(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	consumer := &coresecrets.SecretConsumerMetadata{
+		Label:           "my secret",
+		CurrentRevision: 666,
+	}
+
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mysql/0", consumer).Return(nil)
+
+	err := s.service().SaveSecretConsumer(context.Background(), uri, "mysql/0", consumer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestGetUserSecretURIByLabel(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my label").Return(uri, nil)
+
+	got, err := s.service().GetUserSecretURIByLabel(context.Background(), "my label")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, uri)
+}
+
 /*
 // TODO(secrets) - tests copied from facade which need to be re-implemented here
 func (s *serviceSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -85,6 +85,22 @@ func (mr *MockStateMockRecorder) GetSecret(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockState)(nil).GetSecret), arg0, arg1)
 }
 
+// GetSecretConsumer mocks base method.
+func (m *MockState) GetSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSecretConsumer indicates an expected call of GetSecretConsumer.
+func (mr *MockStateMockRecorder) GetSecretConsumer(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockState)(nil).GetSecretConsumer), arg0, arg1, arg2)
+}
+
 // GetSecretRevision mocks base method.
 func (m *MockState) GetSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int) (*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
@@ -116,6 +132,21 @@ func (mr *MockStateMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockState)(nil).GetSecretValue), arg0, arg1, arg2)
 }
 
+// GetUserSecretURIByLabel mocks base method.
+func (m *MockState) GetUserSecretURIByLabel(arg0 context.Context, arg1 string) (*secrets.URI, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserSecretURIByLabel", arg0, arg1)
+	ret0, _ := ret[0].(*secrets.URI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserSecretURIByLabel indicates an expected call of GetUserSecretURIByLabel.
+func (mr *MockStateMockRecorder) GetUserSecretURIByLabel(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretURIByLabel", reflect.TypeOf((*MockState)(nil).GetUserSecretURIByLabel), arg0, arg1)
+}
+
 // ListSecrets mocks base method.
 func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 bool) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
@@ -130,4 +161,18 @@ func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 se
 func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}
+
+// SaveSecretConsumer mocks base method.
+func (m *MockState) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
+func (mr *MockStateMockRecorder) SaveSecretConsumer(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockState)(nil).SaveSecretConsumer), arg0, arg1, arg2, arg3)
 }

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -63,6 +63,13 @@ type secretValueRef struct {
 	RevisionID   string `db:"revision_id"`
 }
 
+type secretUnitConsumer struct {
+	UnitUUID        string `db:"unit_uuid"`
+	SecretID        string `db:"secret_id"`
+	Label           string `db:"label"`
+	CurrentRevision int    `db:"current_revision"`
+}
+
 type secrets []secretInfo
 
 func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
@@ -118,6 +125,19 @@ func (rows secretValues) toSecretData() (coresecrets.SecretData, error) {
 	result := make(coresecrets.SecretData)
 	for _, row := range rows {
 		result[row.Name] = row.Content
+	}
+	return result, nil
+}
+
+type secretUnitConsumers []secretUnitConsumer
+
+func (rows secretUnitConsumers) toSecretConsumers() ([]*coresecrets.SecretConsumerMetadata, error) {
+	result := make([]*coresecrets.SecretConsumerMetadata, len(rows))
+	for i, row := range rows {
+		result[i] = &coresecrets.SecretConsumerMetadata{
+			Label:           row.Label,
+			CurrentRevision: row.CurrentRevision,
+		}
 	}
 	return result, nil
 }

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -444,8 +444,8 @@ func (m *mockSecretsClient) GetConsumerSecretsRevisionInfo(unitName string, uris
 			continue
 		}
 		result[uri] = secrets.SecretRevisionInfo{
-			Revision: 665 + i,
-			Label:    "label-" + uri,
+			LatestRevision: 665 + i,
+			Label:          "label-" + uri,
 		}
 	}
 	return result, nil

--- a/internal/worker/uniter/remotestate/watcher_test.go
+++ b/internal/worker/uniter/remotestate/watcher_test.go
@@ -519,12 +519,12 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ConsumedSecretInfo, jc.DeepEquals, map[string]secrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {
-			Revision: 666,
-			Label:    "label-secret:9m4e2mr0ui3e8a215n4g",
+			LatestRevision: 666,
+			Label:          "label-secret:9m4e2mr0ui3e8a215n4g",
 		},
 		"secret:8b4e2mr1wi3e8a215n5h": {
-			Revision: 667,
-			Label:    "label-secret:8b4e2mr1wi3e8a215n5h",
+			LatestRevision: 667,
+			Label:          "label-secret:8b4e2mr1wi3e8a215n5h",
 		},
 	})
 	c.Assert(s.watcher.Snapshot().DeletedSecrets, jc.DeepEquals, []string{"secret:999e2mr0ui3e8a215n4g"})
@@ -1106,12 +1106,12 @@ func (s *WatcherSuiteSidecarCharmModVer) TestRemoteStateChanged(c *gc.C) {
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ConsumedSecretInfo, jc.DeepEquals, map[string]secrets.SecretRevisionInfo{
 		"secret:9m4e2mr0ui3e8a215n4g": {
-			Revision: 666,
-			Label:    "label-secret:9m4e2mr0ui3e8a215n4g",
+			LatestRevision: 666,
+			Label:          "label-secret:9m4e2mr0ui3e8a215n4g",
 		},
 		"secret:8b4e2mr1wi3e8a215n5h": {
-			Revision: 667,
-			Label:    "label-secret:8b4e2mr1wi3e8a215n5h",
+			LatestRevision: 667,
+			Label:          "label-secret:8b4e2mr1wi3e8a215n5h",
 		},
 	})
 	c.Assert(s.watcher.Snapshot().DeletedSecrets, jc.DeepEquals, []string{"secret:999e2mr0ui3e8a215n4g"})

--- a/internal/worker/uniter/secrets/resolver.go
+++ b/internal/worker/uniter/secrets/resolver.go
@@ -70,12 +70,12 @@ func (s *secretsResolver) NextOp(
 	}
 	for uri, info := range remoteState.ConsumedSecretInfo {
 		existing := s.secretsTracker.ConsumedSecretRevision(uri)
-		s.logger.Debugf("%s: current=%d, new=%d", uri, existing, info.Revision)
-		if existing != info.Revision {
+		s.logger.Debugf("%s: current=%d, new=%d", uri, existing, info.LatestRevision)
+		if existing != info.LatestRevision {
 			op, err := opFactory.NewRunHook(hook.Info{
 				Kind:           hooks.SecretChanged,
 				SecretURI:      uri,
-				SecretRevision: info.Revision,
+				SecretRevision: info.LatestRevision,
 				SecretLabel:    info.Label,
 			})
 			return op, err

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -261,7 +261,7 @@ func (s *changeSecretsSuite) TestNextOpNotInstalled(c *gc.C) {
 		},
 	}
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
-		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
+		"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 666},
 	}
 	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
@@ -280,7 +280,7 @@ func (s *changeSecretsSuite) TestNextOpNoneExisting(c *gc.C) {
 		},
 	}
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
-		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
+		"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 666},
 	}
 	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
@@ -300,7 +300,7 @@ func (s *changeSecretsSuite) TestNextOpUpdatedRevision(c *gc.C) {
 		},
 	}
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
-		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
+		"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 666},
 	}
 	op, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
@@ -320,7 +320,7 @@ func (s *changeSecretsSuite) TestNextOpNone(c *gc.C) {
 		},
 	}
 	s.remoteState.ConsumedSecretInfo = map[string]coresecrets.SecretRevisionInfo{
-		"secret:9m4e2mr0ui3e8a215n4g": {Revision: 666},
+		"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 666},
 	}
 	_, err := s.resolver.NextOp(context.Background(), localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)

--- a/internal/worker/uniter/secrets/secrets.go
+++ b/internal/worker/uniter/secrets/secrets.go
@@ -77,7 +77,7 @@ func (s *Secrets) init() error {
 		}
 		updated := make(map[string]int)
 		for u, v := range info {
-			updated[u] = v.Revision
+			updated[u] = v.LatestRevision
 		}
 		changed = !reflect.DeepEqual(updated, s.secretsState.ConsumedSecretInfo)
 		if changed {

--- a/internal/worker/uniter/secrets/secrets_test.go
+++ b/internal/worker/uniter/secrets/secrets_test.go
@@ -59,7 +59,7 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 	)}, nil)
 	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo("foo/0",
 		[]string{"secret:666e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g"}).Return(
-		map[string]coresecrets.SecretRevisionInfo{"secret:9m4e2mr0ui3e8a215n4g": {Revision: 667}}, nil,
+		map[string]coresecrets.SecretRevisionInfo{"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 667}}, nil,
 	)
 	s.secretsClient.EXPECT().SecretMetadata().Return(nil, nil)
 
@@ -150,8 +150,8 @@ func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo("foo/0",
 		[]string{"secret:666e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g"}).Return(
 		map[string]coresecrets.SecretRevisionInfo{
-			"secret:666e2mr0ui3e8a215n4g": {Revision: 666},
-			"secret:9m4e2mr0ui3e8a215n4g": {Revision: 667},
+			"secret:666e2mr0ui3e8a215n4g": {LatestRevision: 666},
+			"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 667},
 		}, nil,
 	)
 	s.secretsClient.EXPECT().SecretMetadata().Return(

--- a/internal/worker/uniter/util_test.go
+++ b/internal/worker/uniter/util_test.go
@@ -2125,7 +2125,7 @@ func (s changeSecret) step(c *gc.C, ctx *testContext) {
 	ctx.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo(
 		ctx.unit.Name(), []string{ctx.createdSecretURI.String()},
 	).Return(map[string]secrets.SecretRevisionInfo{
-		ctx.createdSecretURI.String(): {Revision: 666},
+		ctx.createdSecretURI.String(): {LatestRevision: 666},
 	}, nil)
 	ctx.sendStrings(c, ctx.consumedSecretsCh, "secret change", ctx.createdSecretURI.String())
 	done := make(chan bool)


### PR DESCRIPTION
This PR add state and service logic for getting and saving secret consumer info. This is needed so that units can consumer secrets with the revision tracked.

The DDL needed to be changed as well. There were some unnecessary tables for application consumer which are not needed. It's also not necessary to use a uuid for the secret consumer tables as this is a join table and we just need the secret and unit uuids. And the associated triggers are removed since we'll be using a different approach to fire the relevant watchers.

The secret consumer table had a FK for the secret id. But for cross model secrets, the id does not exist in the model so the FK needs to be removed. But we have checks in the txn that the secret exists where needed (for local secrets).

In mongo, we needed to denormalise the latest revision and stick it in the consumer record. We don't do that now so there's a bit of fallout. The LatestRevision attr on SecretConsumerMetadata is not used any more except for old state code. For local secrets, we can look up the latest revision when needed. From model secrets, we'll need to add a table to store them. For now, just local secrets will work.

A small driveby improvement - rename the Revision attribute of the SecretRevisionInfo struct to LatestRevision.

## QA steps

bootstrap

```
$ juju add-secret mysecret --info "some secret" foo=bar
secret:cob1il8r4jm2b5mh01ng
$ juju exec -u controller/0 -- secret-get cob1il8r4jm2b5mh01ng
foo: bar
```

## Links

**Jira card:** JUJU-5855

