### PR TITLE
Remove series flag from juju metadata plugin

### DIFF
--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -36,7 +36,6 @@ type addImageMetadataCommand struct {
 
 	ImageId         string
 	Region          string
-	Series          string
 	Base            string
 	Version         string
 	Arch            string
@@ -48,9 +47,6 @@ type addImageMetadataCommand struct {
 
 // Init implements Command.Init.
 func (c *addImageMetadataCommand) Init(args []string) (err error) {
-	if c.Base != "" && c.Series != "" {
-		return errors.New("--series and --base cannot be specified together")
-	}
 	if len(args) == 0 {
 		return errors.New("image id must be supplied when adding image metadata")
 	}
@@ -75,7 +71,6 @@ func (c *addImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.cloudImageMetadataCommandBase.SetFlags(f)
 
 	f.StringVar(&c.Region, "region", "", "image cloud region")
-	f.StringVar(&c.Series, "series", "", "image series. DEPRECATED, use --base")
 	f.StringVar(&c.Base, "base", "", "image base")
 	f.StringVar(&c.Arch, "arch", "amd64", "image architecture")
 	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")
@@ -90,16 +85,6 @@ func (c *addImageMetadataCommand) Run(ctx *cmd.Context) error {
 		base corebase.Base
 		err  error
 	)
-	// Note: we validated that both series and base cannot be specified in
-	// Init(), so it's safe to assume that only one of them is set here.
-	if c.Series != "" {
-		ctx.Warningf("series flag is deprecated, use --base instead")
-		if base, err = corebase.GetBaseFromSeries(c.Series); err != nil {
-			return errors.Annotatef(err, "attempting to convert %q to a base", c.Series)
-		}
-		c.Base = base.String()
-		c.Series = ""
-	}
 	if c.Base != "" {
 		if base, err = corebase.ParseBaseFromString(c.Base); err != nil {
 			return errors.Trace(err)

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -69,7 +69,6 @@ type imageMetadataCommand struct {
 	modelcmd.ControllerCommandBase
 
 	Dir            string
-	Series         string
 	Base           string
 	Arch           string
 	ImageId        string
@@ -105,7 +104,6 @@ func (c *imageMetadataCommand) Info() *cmd.Info {
 }
 
 func (c *imageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.Series, "s", "", "the charm series. DEPRECATED use --base")
 	f.StringVar(&c.Base, "base", "", "the charm base")
 	f.StringVar(&c.Arch, "a", arch.AMD64, "the image architecture")
 	f.StringVar(&c.Dir, "d", "", "the destination directory in which to place the metadata files")
@@ -118,9 +116,6 @@ func (c *imageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *imageMetadataCommand) Init(args []string) error {
-	if c.Series != "" && c.Base != "" {
-		return errors.Errorf("cannot specify both base and series (series is deprecated)")
-	}
 	return nil
 }
 
@@ -218,16 +213,6 @@ func (c *imageMetadataCommand) Run(ctx *cmd.Context) error {
 		base corebase.Base
 		err  error
 	)
-	// Note: we validated that both series and base cannot be specified in
-	// Init(), so it's safe to assume that only one of them is set here.
-	if c.Series != "" {
-		ctx.Warningf("series flag is deprecated, use --base instead")
-		if base, err = corebase.GetBaseFromSeries(c.Series); err != nil {
-			return errors.Annotatef(err, "attempting to convert %q to a base", c.Series)
-		}
-		c.Base = base.String()
-		c.Series = ""
-	}
 	if c.Base != "" {
 		if base, err = corebase.ParseBaseFromString(c.Base); err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
Remove deprecated '--series' flag from juju-metadata plugin commands `juju metadata add-image`, `juju metadata generate-image`, `juju metadata list-images`, `juju metadata validate-images`

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
$ juju metadata add-image --series jammy
ERROR flag provided but not defined: --series

$ juju metadata generate-image --series jammy
ERROR flag provided but not defined: --series

$ juju metadata list-images --series jammy
ERROR flag provided but not defined: --series

$ juju metadata validate-images --series jammy
ERROR flag provided but not defined: --series
```