### PR TITLE
Implement secret state create charm secret and list secret methods.

### DIFF
--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -145,10 +145,31 @@ func (mr *MockSecretServiceMockRecorder) GrantSecretAccess(arg0, arg1, arg2 any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecretAccess", reflect.TypeOf((*MockSecretService)(nil).GrantSecretAccess), arg0, arg1, arg2)
 }
 
-// ListSecrets mocks base method.
-func (m *MockSecretService) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 bool) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListCharmSecrets mocks base method.
+func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListCharmSecrets", varargs...)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListCharmSecrets indicates an expected call of ListCharmSecrets.
+func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), varargs...)
+}
+
+// ListSecrets mocks base method.
+func (m *MockSecretService) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 *int, arg3 secret.Labels) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)
 	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
 	ret2, _ := ret[2].(error)
@@ -156,9 +177,9 @@ func (m *MockSecretService) ListSecrets(arg0 context.Context, arg1 *secrets.URI,
 }
 
 // ListSecrets indicates an expected call of ListSecrets.
-func (mr *MockSecretServiceMockRecorder) ListSecrets(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockSecretServiceMockRecorder) ListSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretService)(nil).ListSecrets), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretService)(nil).ListSecrets), arg0, arg1, arg2, arg3)
 }
 
 // RevokeSecretAccess mocks base method.

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -176,7 +176,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 		}},
 	}
 
-	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevisions, secret.NilLabels, secret.NilApplicationOwners, secret.NilUnitOwners, true).Return(
+	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevision, secret.NilLabels).Return(
 		metadata, revisions, nil,
 	)
 	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{

--- a/apiserver/facades/client/secrets/service.go
+++ b/apiserver/facades/client/secrets/service.go
@@ -24,10 +24,10 @@ type SecretService interface {
 	GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error)
 	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, *secrets.ValueRef, error)
 	ListSecrets(ctx context.Context, uri *secrets.URI,
-		revisions domainsecret.Revisions,
-		labels domainsecret.Labels, appOwners domainsecret.ApplicationOwners,
-		unitOwners domainsecret.UnitOwners, wantUser bool,
+		revision *int,
+		labels domainsecret.Labels,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	ListCharmSecrets(ctx context.Context, owners ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 
 	// Delete secrets.
 

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -147,10 +147,26 @@ func (mr *MockStateMockRecorder) GetUserSecretURIByLabel(arg0, arg1 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretURIByLabel", reflect.TypeOf((*MockState)(nil).GetUserSecretURIByLabel), arg0, arg1)
 }
 
-// ListSecrets mocks base method.
-func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 secret.Revisions, arg3 secret.Labels, arg4 secret.ApplicationOwners, arg5 secret.UnitOwners, arg6 bool) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListCharmSecrets mocks base method.
+func (m *MockState) ListCharmSecrets(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ListCharmSecrets", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListCharmSecrets indicates an expected call of ListCharmSecrets.
+func (mr *MockStateMockRecorder) ListCharmSecrets(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockState)(nil).ListCharmSecrets), arg0, arg1, arg2)
+}
+
+// ListSecrets mocks base method.
+func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 *int, arg3 secret.Labels) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)
 	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
 	ret2, _ := ret[2].(error)
@@ -158,9 +174,25 @@ func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 se
 }
 
 // ListSecrets indicates an expected call of ListSecrets.
-func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3)
+}
+
+// ListUserSecrets mocks base method.
+func (m *MockState) ListUserSecrets(arg0 context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUserSecrets", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListUserSecrets indicates an expected call of ListUserSecrets.
+func (mr *MockStateMockRecorder) ListUserSecrets(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecrets", reflect.TypeOf((*MockState)(nil).ListUserSecrets), arg0)
 }
 
 // SaveSecretConsumer mocks base method.

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -14,6 +14,7 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/schema/testing"
 	domainsecret "github.com/juju/juju/domain/secret"
@@ -201,7 +202,7 @@ func (s *stateSuite) TestListSecretsNone(c *gc.C) {
 
 	ctx := context.Background()
 	secrets, revisions, err := st.ListSecrets(
-		ctx, nil, domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+		ctx, domainsecret.NilSecretURI, domainsecret.NilRevision, domainsecret.NilLabels)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(secrets), gc.Equals, 0)
 	c.Assert(len(revisions), gc.Equals, 0)
@@ -235,7 +236,7 @@ func (s *stateSuite) TestListSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	secrets, revisions, err := st.ListSecrets(
-		ctx, nil, domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+		ctx, domainsecret.NilSecretURI, domainsecret.NilRevision, domainsecret.NilLabels)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(secrets), gc.Equals, 2)
 	c.Assert(len(revisions), gc.Equals, 2)
@@ -287,7 +288,7 @@ func (s *stateSuite) TestListSecretsByURI(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	secrets, revisions, err := st.ListSecrets(
-		ctx, uri[0], domainsecret.NilRevisions, domainsecret.NilLabels, domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners, true)
+		ctx, uri[0], domainsecret.NilRevision, domainsecret.NilLabels)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(secrets), gc.Equals, 1)
 	c.Assert(len(revisions), gc.Equals, 1)
@@ -332,6 +333,451 @@ VALUES (?, ?, ?, ?, (SELECT uuid from application WHERE name = ?))
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestListUserSecretsNone(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}
+	uri := coresecrets.NewURI()
+
+	ctx := context.Background()
+	err := st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListUserSecrets(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(secrets, gc.HasLen, 0)
+	c.Assert(revisions, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestListUserSecrets(c *gc.C) {
+	modelUUID := s.setupModel(c)
+
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmUnitSecret(ctx, 1, uri[1], "mysql/0", sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListUserSecrets(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 1)
+	c.Assert(len(revisions), gc.Equals, 1)
+
+	now := time.Now()
+
+	md := secrets[0]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[0].Label)
+	c.Assert(md.Description, gc.Equals, sp[0].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[0].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: modelUUID})
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs := revisions[0]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
+}
+
+func (s *stateSuite) TestCreateCharmApplicationSecretWithContent(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmApplicationSecret(ctx, 1, uri, "mysql", sp)
+	c.Assert(err, jc.ErrorIsNil)
+	owner := coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mysql"}
+	s.assertSecret(c, st, uri, sp, 1, owner)
+	data, ref, err := st.GetSecretValue(ctx, uri, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ref, gc.IsNil)
+	c.Assert(data, jc.DeepEquals, coresecrets.SecretData{"foo": "bar"})
+}
+
+func (s *stateSuite) TestCreateCharmApplicationSecretNotFound(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmApplicationSecret(ctx, 1, uri, "mysql", sp)
+	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *stateSuite) TestCreateCharmUserSecretWithContent(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+	c.Assert(err, jc.ErrorIsNil)
+	owner := coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "mysql/0"}
+	s.assertSecret(c, st, uri, sp, 1, owner)
+	data, ref, err := st.GetSecretValue(ctx, uri, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ref, gc.IsNil)
+	c.Assert(data, jc.DeepEquals, coresecrets.SecretData{"foo": "bar"})
+}
+
+func (s *stateSuite) TestCreateCharmUnitSecretNotFound(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+	c.Assert(err, jc.ErrorIs, uniterrors.NotFound)
+}
+
+func (s *stateSuite) TestCreateCharmApplicationSecretLabelAlreadyExists(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmApplicationSecret(ctx, 1, uri, "mysql", sp)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmApplicationSecret(ctx, 1, uri, "mysql", sp)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretLabelAlreadyExists)
+}
+
+func (s *stateSuite) TestCreateCharmUnitSecretLabelAlreadyExists(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := domainsecret.UpsertSecretParams{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+	}
+	uri := coresecrets.NewURI()
+	ctx := context.Background()
+	err := st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretLabelAlreadyExists)
+}
+
+func (s *stateSuite) TestCreateManyApplicationSecretsNoLabelClash(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	createAndCheck := func(label string) {
+		content := label
+		if content == "" {
+			content = "empty"
+		}
+		sp := domainsecret.UpsertSecretParams{
+			Description: "my secretMetadata",
+			Label:       label,
+			Data:        coresecrets.SecretData{"foo": content},
+		}
+		uri := coresecrets.NewURI()
+		ctx := context.Background()
+		err := st.CreateCharmApplicationSecret(ctx, 1, uri, "mysql", sp)
+		c.Assert(err, jc.ErrorIsNil)
+		owner := coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mysql"}
+		s.assertSecret(c, st, uri, sp, 1, owner)
+		data, ref, err := st.GetSecretValue(ctx, uri, 1)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ref, gc.IsNil)
+		c.Assert(data, jc.DeepEquals, coresecrets.SecretData{"foo": content})
+	}
+	createAndCheck("my label")
+	createAndCheck("")
+	createAndCheck("")
+	createAndCheck("another label")
+}
+
+func (s *stateSuite) TestCreateManyUnitSecretsNoLabelClash(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	createAndCheck := func(label string) {
+		content := label
+		if content == "" {
+			content = "empty"
+		}
+		sp := domainsecret.UpsertSecretParams{
+			Description: "my secretMetadata",
+			Label:       label,
+			Data:        coresecrets.SecretData{"foo": content},
+		}
+		uri := coresecrets.NewURI()
+		ctx := context.Background()
+		err := st.CreateCharmUnitSecret(ctx, 1, uri, "mysql/0", sp)
+		c.Assert(err, jc.ErrorIsNil)
+		owner := coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "mysql/0"}
+		s.assertSecret(c, st, uri, sp, 1, owner)
+		data, ref, err := st.GetSecretValue(ctx, uri, 1)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ref, gc.IsNil)
+		c.Assert(data, jc.DeepEquals, coresecrets.SecretData{"foo": content})
+	}
+	createAndCheck("my label")
+	createAndCheck("")
+	createAndCheck("")
+	createAndCheck("another label")
+}
+
+func (s *stateSuite) TestListCharmSecretsMissingOwners(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+	_, _, err := st.ListCharmSecrets(context.Background(),
+		domainsecret.NilApplicationOwners, domainsecret.NilUnitOwners)
+	c.Assert(err, gc.ErrorMatches, "querying charm secrets: must supply at least one app owner or unit owner")
+}
+
+func (s *stateSuite) TestListCharmSecretsByUnit(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmUnitSecret(ctx, 1, uri[1], "mysql/0", sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListCharmSecrets(ctx,
+		domainsecret.NilApplicationOwners, domainsecret.UnitOwners{"mysql/0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 1)
+	c.Assert(len(revisions), gc.Equals, 1)
+
+	now := time.Now()
+
+	md := secrets[0]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[1].Label)
+	c.Assert(md.Description, gc.Equals, sp[1].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[1].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "mysql/0"})
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs := revisions[0]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
+}
+
+func (s *stateSuite) TestListCharmSecretsByApplication(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmApplicationSecret(ctx, 1, uri[1], "mysql", sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListCharmSecrets(ctx,
+		domainsecret.ApplicationOwners{"mysql"}, domainsecret.NilUnitOwners)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 1)
+	c.Assert(len(revisions), gc.Equals, 1)
+
+	now := time.Now()
+
+	md := secrets[0]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[1].Label)
+	c.Assert(md.Description, gc.Equals, sp[1].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[1].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mysql"})
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs := revisions[0]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
+}
+
+func (s *stateSuite) TestListCharmSecretsApplicationOrUnit(c *gc.C) {
+	st := newSecretState(s.TxnRunnerFactory())
+
+	s.setupUnit(c, "mysql")
+	s.setupUnit(c, "postgresql")
+
+	sp := []domainsecret.UpsertSecretParams{{
+		Description: "my secretMetadata",
+		Label:       "my label",
+		Data:        coresecrets.SecretData{"foo": "bar"},
+		AutoPrune:   true,
+	}, {
+		Description: "my secretMetadata2",
+		Label:       "my label2",
+		Data:        coresecrets.SecretData{"foo": "bar2"},
+	}, {
+		Description: "my secretMetadata3",
+		Label:       "my label3",
+		Data:        coresecrets.SecretData{"foo": "bar3"},
+	}, {
+		Description: "my secretMetadata4",
+		Label:       "my label4",
+		Data:        coresecrets.SecretData{"foo": "bar4"},
+	}}
+	uri := []*coresecrets.URI{
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+		coresecrets.NewURI(),
+	}
+
+	ctx := context.Background()
+	err := st.CreateUserSecret(ctx, 1, uri[0], sp[0])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmApplicationSecret(ctx, 1, uri[1], "mysql", sp[1])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmUnitSecret(ctx, 1, uri[2], "mysql/0", sp[2])
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.CreateCharmUnitSecret(ctx, 1, uri[3], "postgresql/0", sp[3])
+	c.Assert(err, jc.ErrorIsNil)
+
+	secrets, revisions, err := st.ListCharmSecrets(ctx,
+		domainsecret.ApplicationOwners{"mysql"}, domainsecret.UnitOwners{"mysql/0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(secrets), gc.Equals, 2)
+	c.Assert(len(revisions), gc.Equals, 2)
+
+	now := time.Now()
+
+	first := 0
+	second := 1
+	if secrets[first].Label != sp[1].Label {
+		first = 1
+		second = 0
+	}
+
+	md := secrets[first]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[1].Label)
+	c.Assert(md.Description, gc.Equals, sp[1].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[1].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mysql"})
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs := revisions[first]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
+
+	md = secrets[second]
+	c.Assert(md.Version, gc.Equals, 1)
+	c.Assert(md.Label, gc.Equals, sp[2].Label)
+	c.Assert(md.Description, gc.Equals, sp[2].Description)
+	c.Assert(md.LatestRevision, gc.Equals, 1)
+	c.Assert(md.AutoPrune, gc.Equals, sp[2].AutoPrune)
+	c.Assert(md.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "mysql/0"})
+	c.Assert(md.CreateTime, jc.Almost, now)
+	c.Assert(md.UpdateTime, jc.Almost, now)
+
+	revs = revisions[second]
+	c.Assert(revs, gc.HasLen, 1)
+	c.Assert(revs[0].Revision, gc.Equals, 1)
+	c.Assert(revs[0].CreateTime, jc.Almost, now)
+	c.Assert(revs[0].UpdateTime, jc.Almost, now)
 }
 
 func (s *stateSuite) TestSaveSecretConsumer(c *gc.C) {

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -34,6 +34,23 @@ type secretInfo struct {
 	LatestRevision int `db:"latest_revision"`
 }
 
+type secretModelOwner struct {
+	SecretID string `db:"secret_id"`
+	Label    string `db:"label"`
+}
+
+type secretApplicationOwner struct {
+	SecretID        string `db:"secret_id"`
+	ApplicationUUID string `db:"application_uuid"`
+	Label           string `db:"label"`
+}
+
+type secretUnitOwner struct {
+	SecretID string `db:"secret_id"`
+	UnitUUID string `db:"unit_uuid"`
+	Label    string `db:"label"`
+}
+
 type secretOwner struct {
 	SecretID  string `db:"secret_id"`
 	OwnerID   string `db:"owner_id"`

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -3,12 +3,13 @@
 
 package secret
 
+import coresecrets "github.com/juju/juju/core/secrets"
+
 // These type aliases are used to specify filter terms.
 type (
 	Labels            []string
 	ApplicationOwners []string
 	UnitOwners        []string
-	Revisions         []int
 )
 
 // These consts are used to specify nil filter terms.
@@ -16,5 +17,6 @@ var (
 	NilLabels            = Labels(nil)
 	NilApplicationOwners = ApplicationOwners(nil)
 	NilUnitOwners        = UnitOwners(nil)
-	NilRevisions         = Revisions(nil)
+	NilRevision          = (*int)(nil)
+	NilSecretURI         = (*coresecrets.URI)(nil)
 )


### PR DESCRIPTION
The secret state gets support for creating charm owned secrets, ie secrets owned by an app or unit.

The list secrets methods are also implemented for user secrets and charm secrets. The interfaces for the list methods are better aligned with the user cases of their callers.

The secret service to adapt to the new state list methods. The next PR will wire up the service to the callers from the facades. The client secrets facade is adjusted in this PR since it used the existing list method which was tweaked.

## QA steps

This PR is primarily new backend state methods.
Just unit tests for now.

## Links

**Jira card:** JUJU-5865

