### PR TITLE
Streamline SQLair usage via StateBase

### DIFF
--- a/domain/query/package_test.go
+++ b/domain/query/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Canonical Ltd.
+// Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package query

--- a/domain/query/package_test.go
+++ b/domain/query/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package query
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/query/query.go
+++ b/domain/query/query.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package query provides generic functions designed to wrap variables,
+// designating them as inputs or single/multi row outputs for SQLair.
+// This package is small and dependency free, and exists so that these
+// functions can be imported via the "." alias, making their usage as
+// terse as possible.
+package query
+
+type processFunc = func(in, out, samples []any) ([]any, []any, []any)
+
+// In returns a processing function suitable for handling
+// the argument as an input to SQLair queries.
+func In[T any](v T) processFunc {
+	return func(in, out, samples []any) ([]any, []any, []any) {
+		return append(in, v), out, append(samples, v)
+	}
+}
+
+// Out returns a processing function suitable for handling the argument
+// as an output column of SQLair queries returning a single row.
+func Out[T any](v *T) processFunc {
+	return func(in, out, samples []any) ([]any, []any, []any) {
+		return in, append(out, v), append(samples, *v)
+	}
+}
+
+// OutM returns a processing function suitable for handling the argument
+// as the output column of SQLair queries returning multiple rows.
+func OutM[T any](v *[]T) processFunc {
+	return func(in, out, samples []any) ([]any, []any, []any) {
+		var val T
+		return in, append(out, v), append(samples, val)
+	}
+}

--- a/domain/query/query_test.go
+++ b/domain/query/query_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package query
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type dummy struct {
+	val string
+}
+
+type querySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&querySuite{})
+
+func (s *querySuite) TestIn(c *gc.C) {
+	v := dummy{val: "whatever"}
+
+	in, out, samples := runProcess(In(v))
+
+	c.Check(in, gc.DeepEquals, []any{v})
+	c.Check(out, gc.IsNil)
+	c.Check(samples, gc.DeepEquals, []any{v})
+}
+
+func (s *querySuite) TestOut(c *gc.C) {
+	var v dummy
+
+	in, out, samples := runProcess(Out(&v))
+
+	c.Check(in, gc.IsNil)
+	c.Check(out, gc.DeepEquals, []any{&v})
+	c.Check(samples, gc.DeepEquals, []any{v})
+}
+
+func (s *querySuite) TestOutM(c *gc.C) {
+	var v []dummy
+
+	in, out, samples := runProcess(OutM(&v))
+
+	c.Check(in, gc.IsNil)
+	c.Check(out, gc.DeepEquals, []any{&v})
+	c.Check(samples, gc.DeepEquals, []any{dummy{}})
+}
+
+func runProcess(f processFunc) ([]any, []any, []any) {
+	var in, out, samples []any
+	return f(in, out, samples)
+}

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -1,16 +1,22 @@
-// Copyright 2033 Canonical Ltd.
+// Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package domain
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/canonical/sqlair"
 	gc "gopkg.in/check.v1"
 
+	. "github.com/juju/juju/domain/query"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
+
+type TestType struct {
+	Name string `db:"name"`
+}
 
 type stateSuite struct {
 	schematesting.ControllerSuite
@@ -78,9 +84,6 @@ func (s *stateSuite) TestStateBasePrepareKeyClash(c *gc.C) {
 
 	// Prepare statement with a different type of the same name, this will
 	// retrieve the previously prepared statement which used the shadowed type.
-	type TestType struct {
-		Name string `db:"name"`
-	}
 	stmt, err := base.Prepare("SELECT &TestType.* FROM sqlite_schema", TestType{})
 
 	// Try and run a query.
@@ -95,4 +98,126 @@ func (s *stateSuite) TestStateBasePrepareKeyClash(c *gc.C) {
 		return nil
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot get result: parameter with type "domain.TestType" missing, have type with same name: "domain.TestType"`)
+}
+
+func (s *stateSuite) TestStateQueryRowSuccess(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	var result TestType
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := base.QueryRow(ctx, tx, "SELECT &TestType.* FROM sqlite_schema", Out(&result))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, gc.IsNil)
+	c.Check(result.Name, gc.Equals, "schema")
+}
+
+func (s *stateSuite) TestStateQueryRowWrongTypeError(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	var result []TestType
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := base.QueryRow(ctx, tx, "SELECT &TestType.* FROM sqlite_schema", Out(&result))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Check(err, gc.ErrorMatches, ".*cannot use anonymous slice")
+	c.Check(result, gc.IsNil)
+}
+
+func (s *stateSuite) TestStateQuerySuccess(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	var results []TestType
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := base.Query(ctx, tx, "SELECT &TestType.* FROM sqlite_schema WHERE name in ('schema')", OutM(&results))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Check(results[0].Name, gc.Equals, "schema")
+}
+
+func (s *stateSuite) TestStateQueryWrongTypeError(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	var result TestType
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := base.Query(ctx, tx, "SELECT &TestType.* FROM sqlite_schema WHERE name in ('schema')", Out(&result))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Check(err, gc.ErrorMatches, ".*need pointer to slice, got pointer to struct")
+	c.Check(result.Name, gc.Equals, "")
+}
+
+func (s *stateSuite) TestStateExecSuccess(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	arg := TestType{Name: "name"}
+	var res sql.Result
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		_, err := base.Exec(ctx, tx, "CREATE TABLE dummy (name string)")
+		if err != nil {
+			return err
+		}
+
+		res, err = base.Exec(ctx, tx, "INSERT INTO dummy VALUES ($TestType.name)", In(arg))
+		return err
+	})
+	c.Assert(err, gc.IsNil)
+
+	count, err := res.RowsAffected()
+	c.Assert(err, gc.IsNil)
+	c.Check(count, gc.Equals, int64(1))
+}
+
+func (s *stateSuite) TestStateExecWrongProcessorError(c *gc.C) {
+	f := s.TxnRunnerFactory()
+	base := NewStateBase(f)
+	db, err := base.DB()
+	c.Assert(err, gc.IsNil)
+	c.Assert(db, gc.NotNil)
+
+	arg := TestType{Name: "name"}
+	err = db.Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		_, err := base.Exec(ctx, tx, "CREATE TABLE dummy (name string)")
+		if err != nil {
+			return err
+		}
+
+		_, err = base.Exec(ctx, tx, "INSERT INTO dummy VALUES ($TestType.name)", Out(&arg))
+		return err
+	})
+	c.Assert(err, gc.ErrorMatches, "invalid input parameter.*")
 }


### PR DESCRIPTION
Previously, we added a SQLair statement cache to our state base, so that statement preparation is not repeated for a given statement text over the lifetime of a service.

Here we extend this idea, by wrapping both SQLair and the cache, so that explicit calls to `sqlair.Prepare` are obviated. 

To do this, we introduce the idea of generic argument processors for:
- `In` (input parameters).
- `Out` (single row outputs).
- `OutM` (multi-row outputs).

Passing these as arguments to query execution allows us to use them for the type samples to `sqlair.Prepare`, which avoids needless allocation to create zero types for this purpose.

Accompanying the new functionality are a few examples migrated from the old to the new query technique, to illustrate the ergonomic benefits.

## QA steps

No functional changes. Passing unit tests are preserved.

## Documentation changes

None

## Links

**Jira card:** [JUJU-5912](https://warthogs.atlassian.net/browse/JUJU-5912)

[JUJU-5912]: https://warthogs.atlassian.net/browse/JUJU-5912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ