### PR TITLE
Avoid panics from using a nil pointer

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -505,7 +505,9 @@ type caasDeployFromRepositoryValidator struct {
 //   - Check the charm's min version against the caasVersion
 func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	dt, errs := v.validator.validate(arg)
-
+	if len(errs) > 0 {
+		return dt, errs
+	}
 	if corecharm.IsKubernetes(dt.charm) && charm.MetaFormat(dt.charm) == charm.FormatV1 {
 		deployRepoLogger.Debugf("DEPRECATED: %q is a podspec charm, which will be removed in a future release", arg.CharmName)
 	}
@@ -523,11 +525,14 @@ type iaasDeployFromRepositoryValidator struct {
 	validator *deployFromRepositoryValidator
 }
 
-// ValidateArg validates DeployFromRepositoryArg from a iaas perspective.
+// ValidateArg validates DeployFromRepositoryArg from an iaas perspective.
 // First checking the common validation, then any validation specific to
 // iaas charms.
 func (v iaasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	dt, errs := v.validator.validate(arg)
+	if len(errs) > 0 {
+		return dt, errs
+	}
 	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
 	if len(attachStorageErrs) > 0 {
 		errs = append(errs, attachStorageErrs...)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/juju/charm/v11"
@@ -1016,6 +1017,34 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
+}
+
+func (s *validatorSuite) TestIaaSDeployFromRepositoryFailResolveCharm(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSimpleValidate()
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any()).Return(corecharm.ResolvedDataForDeploy{}, fmt.Errorf("fail resolve"))
+	s.model.EXPECT().UUID().Return("")
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testcharm",
+	}
+
+	_, errs := s.iaasDeployFromRepositoryValidator().ValidateArg(arg)
+	c.Assert(errs, gc.HasLen, 1)
+}
+
+func (s *validatorSuite) TestCaaSDeployFromRepositoryFailResolveCharm(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSimpleValidate()
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any()).Return(corecharm.ResolvedDataForDeploy{}, fmt.Errorf("fail resolve"))
+	s.model.EXPECT().UUID().Return("")
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testcharm",
+	}
+
+	_, errs := s.caasDeployFromRepositoryValidator(c).ValidateArg(arg)
+	c.Assert(errs, gc.HasLen, 1)
 }
 
 func getResolvedData(resultURL *charm.URL, resolvedOrigin corecharm.Origin) corecharm.ResolvedDataForDeploy {


### PR DESCRIPTION
If you return errors, it's essential to check them before continuing.

Not seen with the juju cli client as it was resolving the charm to determine if it was a charm or bundle, failing and not calling DeployFromRepository.  Added a test, which does panic without the actual code change.

This bug should have been caught in development and code review. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Technically this same problem exists on CAAS and IAAS configs, however only in the CAAS code path do we try to use the nil pointer before the errors are caught later. 

```
$ make microk8s-operator-update
$ juju bootstrap microk8s
```
Create a file with the following terraform plan:
```terraform
terraform {
  required_providers {
    juju = {
      version = ">= 0.11.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "duplicate-me"
}

resource "juju_application" "five" {
  model = juju_model.testmodel.name
  charm {
    name = "sdcore-nms-k8s"
    channel = "1.4/beta"
  }
}
```
Run terraform plan and see the error of the channel not found instead of a panic.
```
$ terraform init && terraform plan && terraform apply -auto-approve
....
juju_application.five: Creating...
╷
│ Error: Client Error
│
│   with juju_application.five,
│   on heather.tf line 17, in resource "juju_application" "five":
│   17: resource "juju_application" "five" {
│
│ Unable to create application, got error: selecting releases: charm or bundle not found for channel "1.4/beta", base "amd64"
│ available releases are:
│   channel "latest/beta": available bases are: ubuntu@22.04
│   channel "latest/edge": available bases are: ubuntu@22.04
│   channel "1.3/beta": available bases are: ubuntu@22.04
│   channel "1.3/edge": available bases are: ubuntu@22.04
╵
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2060561

**Jira card:** JUJU-5859

