### PR TITLE
Fix aws_ami_creation tests to cleanup snapshots.

### DIFF
--- a/tests/includes/aws_ami_creation.sh
+++ b/tests/includes/aws_ami_creation.sh
@@ -95,7 +95,9 @@ run_cleanup_ami() {
 	if [[ -f "${TEST_DIR}/ec2-amis" ]]; then
 		echo "====> Cleaning up EC2 AMIs"
 		while read -r ec2_ami; do
+			snapshot_ids=$(aws ec2 describe-images --image-ids="${ec2_ami}" | jq -r ".Images[0].BlockDeviceMappings | .[] .Ebs.SnapshotId | select(. != null)")
 			aws ec2 deregister-image --image-id="${ec2_ami}" >>"${TEST_DIR}/aws_cleanup"
+			echo ${snapshot_ids} | xargs -L 1 aws ec2 delete-snapshot --snapshot-id >>"${TEST_DIR}/aws_cleanup"
 		done <"${TEST_DIR}/ec2-amis"
 	fi
 


### PR DESCRIPTION
Work in #15609 only deregistered the AMIs which does not delete the snapshots created for that AMI. This corrects that by deleting the snapshots after deregistering the AMI.

## QA steps

- Run the tests.

## Documentation changes

N/A

## Links

#15609