### PR TITLE
Add rotate, expire attrs to create secret and secret get

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -64,7 +64,7 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTableOnColumn(
 			"secret_revision", "uuid", "obsolete", tableSecretRevisionObsolete),
 		changeLogTriggersForTableOnColumn(
-			"secret_revision_expire", "revision_uuid", "next_expire_time", tableSecretRevisionExpire),
+			"secret_revision_expire", "revision_uuid", "expire_time", tableSecretRevisionExpire),
 		changeLogTriggersForTableOnColumn(
 			"secret_remote_unit_consumer", "uuid", "current_revision", tableSecretRemoteUnitConsumerCurrentRevision),
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -384,9 +384,9 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_secret_remote_unit_consumer_current_revision_update",
 		"trg_log_secret_remote_unit_consumer_current_revision_delete",
 
-		"trg_log_secret_revision_expire_next_expire_time_insert",
-		"trg_log_secret_revision_expire_next_expire_time_update",
-		"trg_log_secret_revision_expire_next_expire_time_delete",
+		"trg_log_secret_revision_expire_expire_time_insert",
+		"trg_log_secret_revision_expire_expire_time_update",
+		"trg_log_secret_revision_expire_expire_time_delete",
 
 		"trg_log_secret_revision_obsolete_insert",
 		"trg_log_secret_revision_obsolete_update",
@@ -493,7 +493,7 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 4, tableSecretAutoPrune, 0)
 
 	secretURI := coresecrets.NewURI()
-	s.assertExecSQL(c, `INSERT INTO secret (id, description) VALUES (?, 'mySecret');`, "", secretURI.ID)
+	s.assertExecSQL(c, `INSERT INTO secret (id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
 	s.assertExecSQL(c, `UPDATE secret SET auto_prune = true WHERE id = ?;`, "", secretURI.ID)
 	s.assertExecSQL(c, `DELETE FROM secret WHERE id = ?;`, "", secretURI.ID)
 
@@ -506,7 +506,7 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 2, tableSecretRotation, 0)
 	s.assertChangeLogCount(c, 4, tableSecretRotation, 0)
 
-	s.assertExecSQL(c, `INSERT INTO secret (id, description) VALUES (?, 'mySecret');`, "", secretURI.ID)
+	s.assertExecSQL(c, `INSERT INTO secret (id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
 	s.assertExecSQL(c, `INSERT INTO secret_rotation (secret_id, next_rotation_time) VALUES (?, datetime('now', '+1 day'));`, "", secretURI.ID)
 	s.assertExecSQL(c, `UPDATE secret_rotation SET next_rotation_time = datetime('now', '+2 day') WHERE secret_id = ?;`, "", secretURI.ID)
 	s.assertExecSQL(c, `DELETE FROM secret_rotation WHERE secret_id = ?;`, "", secretURI.ID)
@@ -535,8 +535,8 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 4, tableSecretRevisionExpire, 0)
 
 	s.assertExecSQL(c, `INSERT INTO secret_revision (uuid, secret_id, revision) VALUES (?, ?, 1);`, "", revisionUUID, secretURI.ID)
-	s.assertExecSQL(c, `INSERT INTO secret_revision_expire (revision_uuid, next_expire_time) VALUES (?, datetime('now', '+1 day'));`, "", revisionUUID)
-	s.assertExecSQL(c, `UPDATE secret_revision_expire SET next_expire_time = datetime('now', '+2 day') WHERE revision_uuid = ?;`, "", revisionUUID)
+	s.assertExecSQL(c, `INSERT INTO secret_revision_expire (revision_uuid, expire_time) VALUES (?, datetime('now', '+1 day'));`, "", revisionUUID)
+	s.assertExecSQL(c, `UPDATE secret_revision_expire SET expire_time = datetime('now', '+2 day') WHERE revision_uuid = ?;`, "", revisionUUID)
 	s.assertExecSQL(c, `DELETE FROM secret_revision_expire WHERE revision_uuid = ?;`, "", revisionUUID)
 
 	s.assertChangeLogCount(c, 1, tableSecretRevisionExpire, 1)

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -123,13 +123,13 @@ CREATE TABLE
         id TEXT PRIMARY KEY,
         version INT,
         description TEXT,
-        rotate_policy TEXT,
+        rotate_policy_id INT NOT NULL,
         auto_prune BOOLEAN NOT NULL DEFAULT (FALSE),
         create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
         update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
         CONSTRAINT fk_secret_rotate_policy
-            FOREIGN KEY (rotate_policy)
-            REFERENCES secret_rotate_policy (policy)
+            FOREIGN KEY (rotate_policy_id)
+            REFERENCES secret_rotate_policy (id)
     );
 
 CREATE TABLE
@@ -193,7 +193,7 @@ CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision ON secret_revision (s
 CREATE TABLE
     secret_revision_expire (
         revision_uuid TEXT PRIMARY KEY,
-        next_expire_time DATETIME NOT NULL,
+        expire_time DATETIME NOT NULL,
         CONSTRAINT fk_secret_revision_expire_revision_uuid
             FOREIGN KEY (revision_uuid)
             REFERENCES secret_revision (uuid)

--- a/domain/secret/package_test.go
+++ b/domain/secret/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secret
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/secret/params.go
+++ b/domain/secret/params.go
@@ -11,11 +11,14 @@ import (
 
 // UpsertSecretParams are used to upsert a secret.
 type UpsertSecretParams struct {
-	RotatePolicy secrets.RotatePolicy
-	ExpireTime   time.Time
-	Description  string
-	Label        string
-	Data         secrets.SecretData
-	ValueRef     *secrets.ValueRef
-	AutoPrune    bool
+	RotatePolicy   *RotatePolicy
+	ExpireTime     *time.Time
+	NextRotateTime *time.Time
+	// TODO(secrets) - these should be pointers
+	Description string
+	Label       string
+	AutoPrune   bool
+
+	Data     secrets.SecretData
+	ValueRef *secrets.ValueRef
 }

--- a/domain/secret/rotatepolicy.go
+++ b/domain/secret/rotatepolicy.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secret
+
+import coresecrets "github.com/juju/juju/core/secrets"
+
+// RotatePolicy represents the rotate policy of a secret.
+// as recorded in the secret_rotate_policy lookup table.
+type RotatePolicy int
+
+const (
+	RotateNever RotatePolicy = iota
+	RotateHourly
+	RotateDaily
+	RotateWeekly
+	RotateMonthly
+	RotateQuarterly
+	RotateYearly
+)
+
+// MarshallRotatePolicy converts a secret rotate policy to a db rotate policy id.
+func MarshallRotatePolicy(policy *coresecrets.RotatePolicy) RotatePolicy {
+	if policy == nil {
+		return RotateNever
+	}
+	switch *policy {
+	case coresecrets.RotateHourly:
+		return RotateHourly
+	case coresecrets.RotateDaily:
+		return RotateDaily
+	case coresecrets.RotateWeekly:
+		return RotateWeekly
+	case coresecrets.RotateMonthly:
+		return RotateMonthly
+	case coresecrets.RotateQuarterly:
+		return RotateQuarterly
+	case coresecrets.RotateYearly:
+		return RotateYearly
+	}
+	return RotateNever
+}

--- a/domain/secret/rotatepolicy_test.go
+++ b/domain/secret/rotatepolicy_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secret
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type rotatePolicySuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&rotatePolicySuite{})
+
+// TestRotatePolicyDBValues ensures there's no skew between what's in the
+// database table for rotatepolicy and the typed consts used in the state packages.
+func (s *rotatePolicySuite) TestRotatePolicyDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, policy FROM secret_rotate_policy")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[RotatePolicy]string)
+	for rows.Next() {
+		var (
+			id    int
+			value string
+		)
+		err := rows.Scan(&id, &value)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[RotatePolicy(id)] = value
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[RotatePolicy]string{
+		RotateNever:     "never",
+		RotateHourly:    "hourly",
+		RotateDaily:     "daily",
+		RotateWeekly:    "weekly",
+		RotateMonthly:   "monthly",
+		RotateQuarterly: "quarterly",
+		RotateYearly:    "yearly",
+	})
+	// Also check the core secret enums match.
+	for _, p := range dbValues {
+		c.Assert(coresecrets.RotatePolicy(p).IsValid(), jc.IsTrue)
+	}
+}

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -58,16 +58,11 @@ func (s *SecretService) SaveSecretConsumer(ctx context.Context, uri *secrets.URI
 	return s.st.SaveSecretConsumer(ctx, uri, unitName, md)
 }
 
-func (s *SecretService) GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
-	return nil, secreterrors.SecretConsumerNotFound
-}
-
-func (s *SecretService) SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, latestRevision int, unitName string, md *secrets.SecretConsumerMetadata) error {
-	return nil
-}
-
+// GetURIByConsumerLabel looks up the secret URI using the label previously registered by the specified unit,
+// returning an error satisfying [secreterrors.SecretNotFound] if there's no corresponding URI.
+// If the unit does not exist, an error satisfying [uniterrors.NotFound] is returned.
 func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error) {
-	return nil, secreterrors.SecretNotFound
+	return s.st.GetURIByConsumerLabel(ctx, label, unitName)
 }
 
 // GetConsumedRevision returns the secret revision number for the specified consumer, possibly updating
@@ -113,4 +108,12 @@ func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.UR
 // The count of secret and revisions in the result must match.
 func (s *SecretService) ListGrantedSecrets(ctx context.Context, consumers ...SecretAccessor) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	return nil, nil, nil
+}
+
+func (s *SecretService) GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
+	return nil, secreterrors.SecretConsumerNotFound
+}
+
+func (s *SecretService) SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, latestRevision int, unitName string, md *secrets.SecretConsumerMetadata) error {
+	return nil
 }

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -264,6 +264,19 @@ func (s *serviceSuite) TestListCharmJustUnit(c *gc.C) {
 	c.Assert(gotRevisions, jc.DeepEquals, rev)
 }
 
+func (s *serviceSuite) TestGetURIByConsumerLabel(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().GetURIByConsumerLabel(gomock.Any(), "my label", "mysql/0").Return(uri, nil)
+
+	got, err := s.service().GetURIByConsumerLabel(context.Background(), "my label", "mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, uri)
+}
+
 /*
 // TODO(secrets) - tests copied from facade which need to be re-implemented here
 func (s *serviceSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -41,6 +41,34 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// CreateCharmApplicationSecret mocks base method.
+func (m *MockState) CreateCharmApplicationSecret(arg0 context.Context, arg1 int, arg2 *secrets.URI, arg3 string, arg4 secret.UpsertSecretParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCharmApplicationSecret", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateCharmApplicationSecret indicates an expected call of CreateCharmApplicationSecret.
+func (mr *MockStateMockRecorder) CreateCharmApplicationSecret(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCharmApplicationSecret", reflect.TypeOf((*MockState)(nil).CreateCharmApplicationSecret), arg0, arg1, arg2, arg3, arg4)
+}
+
+// CreateCharmUnitSecret mocks base method.
+func (m *MockState) CreateCharmUnitSecret(arg0 context.Context, arg1 int, arg2 *secrets.URI, arg3 string, arg4 secret.UpsertSecretParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCharmUnitSecret", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateCharmUnitSecret indicates an expected call of CreateCharmUnitSecret.
+func (mr *MockStateMockRecorder) CreateCharmUnitSecret(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCharmUnitSecret", reflect.TypeOf((*MockState)(nil).CreateCharmUnitSecret), arg0, arg1, arg2, arg3, arg4)
+}
+
 // CreateUserSecret mocks base method.
 func (m *MockState) CreateUserSecret(arg0 context.Context, arg1 int, arg2 *secrets.URI, arg3 secret.UpsertSecretParams) error {
 	m.ctrl.T.Helper()
@@ -130,6 +158,21 @@ func (m *MockState) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2
 func (mr *MockStateMockRecorder) GetSecretValue(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockState)(nil).GetSecretValue), arg0, arg1, arg2)
+}
+
+// GetURIByConsumerLabel mocks base method.
+func (m *MockState) GetURIByConsumerLabel(arg0 context.Context, arg1, arg2 string) (*secrets.URI, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetURIByConsumerLabel", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*secrets.URI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetURIByConsumerLabel indicates an expected call of GetURIByConsumerLabel.
+func (mr *MockStateMockRecorder) GetURIByConsumerLabel(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetURIByConsumerLabel", reflect.TypeOf((*MockState)(nil).GetURIByConsumerLabel), arg0, arg1, arg2)
 }
 
 // GetUserSecretURIByLabel mocks base method.


### PR DESCRIPTION
This PR adds support for the remaining secret attributes - rotate policy, expire time etc - when adding a charm secret. 
The attributes are also wired up when retrieving secrets.

Additionally, implement the GetURIByConsumerLabel method.

A few DDL tweaks also to adjust some column names.

With this change, a charm can add and get unit and app owned secret values and metadata.

## QA steps

Two units, ubuntu/0 and ubuntu/1 (leader),

```
$ juju exec -u ubuntu/0 -- secret-add --label foo --rotate hourly --expire 4h foo=bar
ERROR this unit is not the leader
ERROR the following task failed:
 - id "2" with return code 1

use 'juju show-task' to inspect the failure

$ juju exec -u ubuntu/1 -- secret-add --label foo --rotate hourly --expire 4h foo=bar
secret://545fa390-00ee-491f-8f5c-8a1a9804523f/cocag4k79f9jt1h8fgp0
$ juju exec -u ubuntu/1 -- secret-get cocag4k79f9jt1h8fgp0
foo: bar
$ juju exec -u ubuntu/1 -- secret-get --label foo
foo: bar
$ juju exec -u ubuntu/1 -- secret-add --label foo2 --rotate daily --expire 8h foo=bar2 --owner=unit
secret://545fa390-00ee-491f-8f5c-8a1a9804523f/cocah1c79f9jt1h8fgpg
$ juju exec -u ubuntu/0 -- secret-add --label foo2 --rotate daily --expire 8h foo=bar2 --owner=unit
secret://545fa390-00ee-491f-8f5c-8a1a9804523f/cocah3c79f9jt1h8fgq0
creating secrets: secret with label "foo2" is already being used
$ juju exec -u ubuntu/0 -- secret-add --label foo3 --rotate daily --expire 8h foo=bar2 --owner=unit
secret://545fa390-00ee-491f-8f5c-8a1a9804523f/cocah4k79f9jt1h8fgqg
$ juju exec -u ubuntu/0 -- secret-get --label foo
foo: bar
$ juju exec -u ubuntu/0 -- secret-get cocah4k79f9jt1h8fgqg
foo: bar2
$ juju exec -u ubuntu/0 -- secret-get --label foo3
foo: bar2
$ juju secrets
ID                    Name  Owner     Rotation  Revision  Last updated
cocag4k79f9jt1h8fgp0  -     ubuntu    hourly           1  2 minutes ago   
cocah4k79f9jt1h8fgqg  -     ubuntu/0  daily            1  49 seconds ago  
cocah1c79f9jt1h8fgpg  -     ubuntu/1  daily            1  1 minute ago    
$ juju show-secret cocag4k79f9jt1h8fgp0
cocag4k79f9jt1h8fgp0:
  revision: 1
  expires: 2024-04-12T07:18:42.708512685Z
  rotation: hourly
  rotates: 2024-04-12T04:18:42.715079034Z
  owner: ubuntu
  label: foo
  created: 2024-04-12T03:18:42.715626992Z
  updated: 2024-04-12T03:18:42.715626992Z
$ juju exec -u ubuntu/1 -- secret-info-get cocah1c79f9jt1h8fgpg
cocah1c79f9jt1h8fgpg:
  revision: 1
  label: foo2
  owner: unit
  rotation: daily
  expiry: 2024-04-12T11:20:37.022258471Z
  rotates: 2024-04-13T03:20:37.028238936Z
$ juju exec -u ubuntu/1 -- secret-info-get cocag4k79f9jt1h8fgp0
cocag4k79f9jt1h8fgp0:
  revision: 1
  label: foo
  owner: application
  rotation: hourly
  expiry: 2024-04-12T07:18:42.708512685Z
  rotates: 2024-04-12T04:18:42.715079034Z
$ juju exec -u ubuntu/0 -- secret-info-get cocag4k79f9jt1h8fgp0
ERROR secret "cocag4k79f9jt1h8fgp0" not found
ERROR the following task failed:
 - id "38" with return code 1

use 'juju show-task' to inspect the failure

$ juju exec -u ubuntu/0 -- secret-info-get cocah4k79f9jt1h8fgqg
cocah4k79f9jt1h8fgqg:
  revision: 1
  label: foo3
  owner: unit
  rotation: daily
  expiry: 2024-04-12T11:20:50.882829882Z
  rotates: 2024-04-13T03:20:50.887793785Z

```

## Links


**Jira card:** JUJU-5865

