### PR TITLE
Use uuid v7 when adding a space, change method signature

### DIFF
--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -114,7 +114,8 @@ func (s *spaceSuite) TestAddSpace(c *gc.C) {
 			ProviderId: "provider-id",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(returnedUUID.String(), gc.Equals, expectedUUID)
+	c.Check(returnedUUID.String(), gc.Not(gc.Equals), "")
+	c.Check(returnedUUID.String(), gc.Equals, expectedUUID)
 }
 
 func (s *spaceSuite) TestUpdateSpaceName(c *gc.C) {

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -48,7 +48,9 @@ func (s *spaceSuite) TestAddSpaceInvalidNameEmpty(c *gc.C) {
 	// Make sure no calls to state are done
 	s.st.EXPECT().AddSpace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
-	_, err := NewService(s.st, s.logger).AddSpace(context.Background(), "", "", []string{})
+	_, err := NewService(s.st, s.logger).AddSpace(
+		context.Background(),
+		network.SpaceInfo{})
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("space name \"\" not valid"))
 }
 
@@ -58,7 +60,12 @@ func (s *spaceSuite) TestAddSpaceInvalidName(c *gc.C) {
 	// Make sure no calls to state are done
 	s.st.EXPECT().AddSpace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
-	_, err := NewService(s.st, s.logger).AddSpace(context.Background(), "-bad name-", "provider-id", []string{})
+	_, err := NewService(s.st, s.logger).AddSpace(
+		context.Background(),
+		network.SpaceInfo{
+			Name:       "-bad name-",
+			ProviderId: "provider-id",
+		})
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("space name \"-bad name-\" not valid"))
 }
 
@@ -68,7 +75,17 @@ func (s *spaceSuite) TestAddSpaceErrorAdding(c *gc.C) {
 	s.st.EXPECT().AddSpace(gomock.Any(), gomock.Any(), "0", network.Id("provider-id"), []string{"0"}).
 		Return(errors.Errorf("updating subnet %q using space uuid \"space0\"", "0"))
 
-	_, err := NewService(s.st, s.logger).AddSpace(context.Background(), "0", network.Id("provider-id"), []string{"0"})
+	_, err := NewService(s.st, s.logger).AddSpace(
+		context.Background(),
+		network.SpaceInfo{
+			Name:       "0",
+			ProviderId: "provider-id",
+			Subnets: network.SubnetInfos{
+				{
+					ID: network.Id("0"),
+				},
+			},
+		})
 	c.Assert(err, gc.ErrorMatches, "updating subnet \"0\" using space uuid \"space0\"")
 }
 
@@ -90,7 +107,12 @@ func (s *spaceSuite) TestAddSpace(c *gc.C) {
 				return nil
 			})
 
-	returnedUUID, err := NewService(s.st, s.logger).AddSpace(context.Background(), "space0", network.Id("provider-id"), []string{})
+	returnedUUID, err := NewService(s.st, s.logger).AddSpace(
+		context.Background(),
+		network.SpaceInfo{
+			Name:       "space0",
+			ProviderId: "provider-id",
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(returnedUUID.String(), gc.Equals, expectedUUID)
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-querystring v1.1.0
-	github.com/google/uuid v1.5.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/gosuri/uitable v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,8 @@ github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWU
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=


### PR DESCRIPTION
_Note: This PR is a prelude to the the migration work being done. And this is also needed for the add of the ReloadSpaces functionality._

This patch updates the google/uuid library so we can make use of the new UUID V7 support. More specificaly, when adding a space we check if the provided space contains an ID, if it doesn't we generate a new V7 UUID for it.

We also changed the signature on the AddSpace method (by replacing the individual parameters by a `network.SpaceInfo` struct) of the service layer to do this.



## Checklist



- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This method is still not wired, so simply running the unit test should suffice:
```
TEST_PACKAGES="./domain/network/... -count=1 -race -check.vv" make run-go-tests
```


## Links


**Jira card:** JUJU-4835

