### PR TITLE
Merge 3.3 into 3.4

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -505,7 +505,9 @@ type caasDeployFromRepositoryValidator struct {
 //   - Check the charm's min version against the caasVersion
 func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	dt, errs := v.validator.validate(arg)
-
+	if len(errs) > 0 {
+		return dt, errs
+	}
 	if corecharm.IsKubernetes(dt.charm) && charm.MetaFormat(dt.charm) == charm.FormatV1 {
 		deployRepoLogger.Debugf("DEPRECATED: %q is a podspec charm, which will be removed in a future release", arg.CharmName)
 	}
@@ -523,11 +525,14 @@ type iaasDeployFromRepositoryValidator struct {
 	validator *deployFromRepositoryValidator
 }
 
-// ValidateArg validates DeployFromRepositoryArg from a iaas perspective.
+// ValidateArg validates DeployFromRepositoryArg from an iaas perspective.
 // First checking the common validation, then any validation specific to
 // iaas charms.
 func (v iaasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	dt, errs := v.validator.validate(arg)
+	if len(errs) > 0 {
+		return dt, errs
+	}
 	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
 	if len(attachStorageErrs) > 0 {
 		errs = append(errs, attachStorageErrs...)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/juju/charm/v12"
@@ -1016,6 +1017,34 @@ func (s *validatorSuite) TestCaasDeployFromRepositoryValidator(c *gc.C) {
 		numUnits:        1,
 		origin:          resolvedOrigin,
 	})
+}
+
+func (s *validatorSuite) TestIaaSDeployFromRepositoryFailResolveCharm(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSimpleValidate()
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any()).Return(corecharm.ResolvedDataForDeploy{}, fmt.Errorf("fail resolve"))
+	s.model.EXPECT().UUID().Return("")
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testcharm",
+	}
+
+	_, errs := s.iaasDeployFromRepositoryValidator().ValidateArg(arg)
+	c.Assert(errs, gc.HasLen, 1)
+}
+
+func (s *validatorSuite) TestCaaSDeployFromRepositoryFailResolveCharm(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSimpleValidate()
+	s.repo.EXPECT().ResolveForDeploy(gomock.Any()).Return(corecharm.ResolvedDataForDeploy{}, fmt.Errorf("fail resolve"))
+	s.model.EXPECT().UUID().Return("")
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testcharm",
+	}
+
+	_, errs := s.caasDeployFromRepositoryValidator(c).ValidateArg(arg)
+	c.Assert(errs, gc.HasLen, 1)
 }
 
 func getResolvedData(resultURL *charm.URL, resolvedOrigin corecharm.Origin) corecharm.ResolvedDataForDeploy {

--- a/tests/includes/aws_ami_creation.sh
+++ b/tests/includes/aws_ami_creation.sh
@@ -95,7 +95,9 @@ run_cleanup_ami() {
 	if [[ -f "${TEST_DIR}/ec2-amis" ]]; then
 		echo "====> Cleaning up EC2 AMIs"
 		while read -r ec2_ami; do
+			snapshot_ids=$(aws ec2 describe-images --image-ids="${ec2_ami}" | jq -r ".Images[0].BlockDeviceMappings | .[] .Ebs.SnapshotId | select(. != null)")
 			aws ec2 deregister-image --image-id="${ec2_ami}" >>"${TEST_DIR}/aws_cleanup"
+			echo ${snapshot_ids} | xargs -L 1 aws ec2 delete-snapshot --snapshot-id >>"${TEST_DIR}/aws_cleanup"
 		done <"${TEST_DIR}/ec2-amis"
 	fi
 


### PR DESCRIPTION

Contains the following changes:
- (upstream/3.3) Merge pull request #17188 from hmlanigan/k8s-charm-panic
- Merge pull request #17189 from hpidcock/fix-aws-ami-test
- Merge pull request #17173 from juju/increment-to-3.3.5
- (tag: v3.3.4) Merge pull request #17155 from hpidcock/fix-musl-compat-2
- Merge pull request #17154 from juju/revert-17141-juju-5800
- Merge pull request #17141 from nvinuesa/juju-5800
- Merge pull request #17138 from benhoyt/pebble-v1.4.2-juju-3.3

There were conflicts in, due to new pebble version and release of 3.3.5:
- go.mod
- go.sum
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go