### PR TITLE
Expose the namespace for changestream pruner

### DIFF
--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -250,7 +250,7 @@ func (w *Pruner) locateLowestWatermark(ctx context.Context, tx *sqlair.TX, names
 	// Gather all the watermarks that are within the windowed time period.
 	// If there are no watermarks within the window, then we can assume
 	// that the stream is keeping up and we don't need to prune anything.
-	lowest, ok := w.lowestWatermark(watermarks, w.cfg.Clock.Now())
+	lowest, ok := w.lowestWatermark(namespace, watermarks, w.cfg.Clock.Now())
 	if !ok {
 		// Check to see if the latest change log has a valid log in the last
 		// window duration, if not, then we can assume that the stream is not
@@ -286,7 +286,7 @@ func (w *Pruner) deleteChangeLog(ctx context.Context, tx *sqlair.TX, lowest Wate
 	return pruned, errors.Trace(err)
 }
 
-func (w *Pruner) lowestWatermark(watermarks []Watermark, now time.Time) (Watermark, bool) {
+func (w *Pruner) lowestWatermark(namespace string, watermarks []Watermark, now time.Time) (Watermark, bool) {
 	// Select the lower bound of the watermark, only if the updated_at time
 	// is within a windowed time period.
 	var (
@@ -311,7 +311,7 @@ func (w *Pruner) lowestWatermark(watermarks []Watermark, now time.Time) (Waterma
 		// good valid window time is. For now we'll just log a warning for
 		// visibility, before we solidify the approach.
 		if !view.contains(watermark.UpdatedAt) {
-			w.cfg.Logger.Warningf("Watermark %q is outside of window, check logs to see if the change stream is keeping up", watermark.ControllerID)
+			w.cfg.Logger.Warningf("namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up", namespace, watermark.ControllerID)
 		}
 
 		// Select the lower bound of the watermark.

--- a/internal/worker/changestreampruner/worker_test.go
+++ b/internal/worker/changestreampruner/worker_test.go
@@ -216,7 +216,7 @@ func (s *workerSuite) TestPruneModelLogsWarning(c *gc.C) {
 	s.expectDBGet("foo", s.TxnRunner())
 	s.expectClock()
 
-	s.logger.EXPECT().Warningf("Watermark %q is outside of window, check logs to see if the change stream is keeping up", gomock.Any()).Do(c.Logf).Times(2)
+	s.logger.EXPECT().Warningf("namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up", gomock.Any(), gomock.Any()).Do(c.Logf).Times(2)
 
 	pruner := s.newPruner(c)
 
@@ -424,7 +424,7 @@ func (s *workerSuite) TestLowestWatermark(c *gc.C) {
 	for i, test := range testCases {
 		c.Logf("test %d", i)
 
-		got, ok := s.newPruner(c).lowestWatermark(test.watermarks, test.now)
+		got, ok := s.newPruner(c).lowestWatermark("foo", test.watermarks, test.now)
 		c.Check(got, jc.DeepEquals, test.expected)
 		c.Check(ok, gc.Equals, test.expectedOK)
 	}


### PR DESCRIPTION
When the changestream pruner warns about an event multiplexer not keeping up we should at least know which model it's complaining about.

If there are no watchers reading the event multiplexer then we can at least see what to do next.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
$ juju debug-log -m controller
```

## Links

**Jira card:** JUJU-

