### PR TITLE
 Introduces end to end model config setting.

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -246,7 +246,6 @@ func (m *ModelManagerAPI) createModelNew(
 	ctx context.Context,
 	uuid string,
 	args params.ModelCreateArgs,
-	config *config.Config,
 ) error {
 	// TODO (stickupkid): We need to create a saga (pattern) coordinator here,
 	// to ensure that anything written to both databases are at least rollback
@@ -358,7 +357,7 @@ func (m *ModelManagerAPI) createModelNew(
 	modelDefaults := m.modelDefaultsService.ModelDefaultsProvider(modelUUID)
 	modelConfigService := modelServiceFactory.Config(modelDefaults)
 
-	if err := modelConfigService.SetModelConfig(ctx, config.SafeModelAttrs()); err != nil {
+	if err := modelConfigService.SetModelConfig(ctx, args.Config); err != nil {
 		return errors.Annotatef(err, "failed to set model config for model %q", modelUUID)
 	}
 
@@ -535,7 +534,7 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 	// mode and don't make the calls so test can keep passing.
 	// THIS IS VERY TEMPORARY.
 	if m.modelService != nil {
-		return modelInfo, m.createModelNew(ctx, modelInfo.UUID, args, newConfig)
+		return modelInfo, m.createModelNew(ctx, modelInfo.UUID, args)
 	}
 	return modelInfo, nil
 }

--- a/domain/modelconfig/modelmigration/import.go
+++ b/domain/modelconfig/modelmigration/import.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/modelconfig/service"
 	"github.com/juju/juju/domain/modelconfig/state"
-	"github.com/juju/juju/environs/config"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -67,12 +66,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		return errors.NotValidf("model config")
 	}
 
-	config, err := config.New(config.NoDefaults, attrs)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := i.service.SetModelConfig(ctx, config.SafeModelAttrs()); err != nil {
+	if err := i.service.SetModelConfig(ctx, attrs); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/domain/modeldefaults/service/service_test.go
+++ b/domain/modeldefaults/service/service_test.go
@@ -51,6 +51,9 @@ func (_ *serviceSuite) TestModelDefaultsProviderNotFound(c *gc.C) {
 				"foo": "bar",
 			},
 		},
+		MetadataDefaults: map[coremodel.UUID]map[string]string{
+			uuid: {},
+		},
 	})
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
@@ -84,6 +87,11 @@ func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
 				"bar": "foo",
 			},
 		},
+		MetadataDefaults: map[coremodel.UUID]map[string]string{
+			uuid: {
+				"model_type": "caas",
+			},
+		},
 	})
 
 	defaults, err := svc.ModelDefaults(context.Background(), uuid)
@@ -94,6 +102,8 @@ func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 	c.Check(defaults["bar"].Value, gc.Equals, "foo")
 	c.Check(defaults["bar"].Source, gc.Equals, "region")
+	c.Check(defaults["model_type"].Value, gc.Equals, "caas")
+	c.Check(defaults["model_type"].Source, gc.Equals, "controller")
 
 	defaults, err = svc.ModelDefaultsProvider(uuid)(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -103,4 +113,6 @@ func (_ *serviceSuite) TestModelDefaults(c *gc.C) {
 	c.Check(defaults["foo"].Source, gc.Equals, "controller")
 	c.Check(defaults["bar"].Value, gc.Equals, "foo")
 	c.Check(defaults["bar"].Source, gc.Equals, "region")
+	c.Check(defaults["model_type"].Value, gc.Equals, "caas")
+	c.Check(defaults["model_type"].Source, gc.Equals, "controller")
 }

--- a/domain/modeldefaults/service/testing/state.go
+++ b/domain/modeldefaults/service/testing/state.go
@@ -32,6 +32,10 @@ type State struct {
 	// Defaults is the values returned for ConfigDefaults. If this value is nil
 	// then the defaults recorded in environs config is returned.
 	Defaults map[string]any
+
+	// MetadataDefaults  maintains a list of metadata defaults for each model
+	// uuid.
+	MetadataDefaults map[coremodel.UUID]map[string]string
 }
 
 // ConfigDefaults returns the default configuration values set in Juju.
@@ -67,4 +71,14 @@ func (s *State) ModelProviderConfigSchema(_ context.Context, uuid coremodel.UUID
 		return schemaSource, nil
 	}
 	return nil, errors.NotFound
+}
+
+// ModelMetadataDefaults returns the default values for the model specified by
+// uuid.
+func (s *State) ModelMetadataDefaults(_ context.Context, uuid coremodel.UUID) (map[string]string, error) {
+	defaults, exists := s.MetadataDefaults[uuid]
+	if !exists {
+		return map[string]string{}, fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+	}
+	return defaults, nil
 }

--- a/domain/modeldefaults/state/state_test.go
+++ b/domain/modeldefaults/state/state_test.go
@@ -4,9 +4,45 @@
 package state
 
 import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	modeltesting "github.com/juju/juju/core/model/testing"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	modelstatetesting "github.com/juju/juju/domain/model/state/testing"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/environs/config"
 )
 
-type stateSuite struct{}
+type stateSuite struct {
+	schematesting.ControllerSuite
+}
 
 var _ = gc.Suite(&stateSuite{})
+
+// TestModelMetadataDefaults is asserting the happy path of model metadata
+// defaults.
+func (m *stateSuite) TestModelMetadataDefaults(c *gc.C) {
+	uuid := modelstatetesting.CreateTestModel(c, m.TxnRunnerFactory(), "test")
+	st := NewState(m.TxnRunnerFactory())
+	defaults, err := st.ModelMetadataDefaults(context.Background(), uuid)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(defaults, jc.DeepEquals, map[string]string{
+		config.NameKey: "test",
+		config.UUIDKey: uuid.String(),
+		config.TypeKey: "iaas",
+	})
+}
+
+// TestModelMetadataDefaultsNoModel is asserting that if we ask for the model
+// metadata defaults for a model that doesn't exist we get back a
+// [modelerrors.NotFound] error.
+func (m *stateSuite) TestModelMetadataDefaultsNoModel(c *gc.C) {
+	uuid := modeltesting.GenModelUUID(c)
+	st := NewState(m.TxnRunnerFactory())
+	defaults, err := st.ModelMetadataDefaults(context.Background(), uuid)
+	c.Check(err, jc.ErrorIs, modelerrors.NotFound)
+	c.Check(len(defaults), gc.Equals, 0)
+}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1737,17 +1737,6 @@ func (c *Config) AllAttrs() map[string]any {
 	return allAttrs
 }
 
-// SafeModelAttrs returns a copy of the raw configuration attributes that
-// remove any disallowed model config attributes.
-// See: disallowedModelConfigAttrs
-func (c *Config) SafeModelAttrs() map[string]any {
-	defined := c.AllAttrs()
-	for _, k := range disallowedModelConfigAttrs {
-		delete(defined, k)
-	}
-	return defined
-}
-
 // Remove returns a new configuration that has the attributes of c minus attrs.
 func (c *Config) Remove(attrs []string) (*Config, error) {
 	defined := c.AllAttrs()

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -856,58 +856,6 @@ func (s *ConfigSuite) TestAllAttrs(c *gc.C) {
 	c.Assert(newcfg.AllAttrs(), jc.DeepEquals, attrs)
 }
 
-func (s *ConfigSuite) TestSafeModelAttrs(c *gc.C) {
-	// Normally this is handled by jujutesting.FakeHome
-	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "")
-	attrs := map[string]interface{}{
-		"type":                       "my-type",
-		"name":                       "my-name",
-		"uuid":                       "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9",
-		"authorized-keys":            testing.FakeAuthKeys,
-		"firewall-mode":              config.FwInstance,
-		"unknown":                    "my-unknown",
-		"ssl-hostname-verification":  true,
-		"default-base":               jujuversion.DefaultSupportedLTSBase().String(),
-		"disable-network-management": false,
-		"ignore-machine-addresses":   false,
-		"automatically-retry-hooks":  true,
-		"proxy-ssh":                  false,
-		"development":                false,
-		"test-mode":                  false,
-		"secret-backend":             "auto",
-	}
-	cfg, err := config.New(config.NoDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Set from default
-	attrs["logging-config"] = "<root>=INFO"
-
-	// Default firewall mode is instance
-	attrs["firewall-mode"] = string(config.FwInstance)
-	c.Assert(cfg.SafeModelAttrs(), jc.DeepEquals, attrs)
-	c.Assert(cfg.UnknownAttrs(), jc.DeepEquals, map[string]interface{}{"unknown": "my-unknown"})
-
-	// Verify that default provisioner-harvest-mode is good.
-	c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, config.HarvestDestroyed)
-
-	newcfg, err := cfg.Apply(map[string]interface{}{
-		"name":        "new-name",
-		"uuid":        "6216dfc3-6e82-408f-9f74-8565e63e6158",
-		"new-unknown": "my-new-unknown",
-
-		// Ensure that we remove the following keys.
-		"agent-version":  "1.9.13",
-		"admin-secret":   "deadbeef",
-		"ca-private-key": "shh....",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	attrs["name"] = "new-name"
-	attrs["uuid"] = "6216dfc3-6e82-408f-9f74-8565e63e6158"
-	attrs["new-unknown"] = "my-new-unknown"
-	c.Assert(newcfg.SafeModelAttrs(), jc.DeepEquals, attrs)
-}
-
 type validationTest struct {
 	about string
 	new   testing.Attrs


### PR DESCRIPTION
 This commit makes the changes needed to have model config set properly
 via the model manager facade. The logic for figuring out model config
 items has been moved down in the services layer.

 This commit also introduces model metadata defaults. This allows the
 model defaults service to continuously push the default values for model
 config.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is unit tests to cover off on the specifics. At the moment we don't need manual testing as the values are not being used in this PR.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5851

