### PR TITLE
Add a parent secret table so that cross model secret references can have a FK

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -58,7 +58,7 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("storage_volume_attachment", "uuid", tableVolumeAttachment),
 		changeLogTriggersForTable("storage_volume_attachment_plan", "uuid", tableVolumeAttachmentPlan),
 		changeLogTriggersForTableOnColumn(
-			"secret", "id", "auto_prune", tableSecretAutoPrune),
+			"secret_metadata", "secret_id", "auto_prune", tableSecretAutoPrune),
 		changeLogTriggersForTableOnColumn(
 			"secret_rotation", "secret_id", "next_rotation_time", tableSecretRotation),
 		changeLogTriggersForTableOnColumn(

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -284,6 +284,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		// Secret
 		"secret_rotate_policy",
 		"secret",
+		"secret_metadata",
 		"secret_rotation",
 		"secret_value_ref",
 		"secret_content",
@@ -376,9 +377,9 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_object_store_metadata_path_update",
 		"trg_log_object_store_metadata_path_delete",
 
-		"trg_log_secret_auto_prune_insert",
-		"trg_log_secret_auto_prune_update",
-		"trg_log_secret_auto_prune_delete",
+		"trg_log_secret_metadata_auto_prune_insert",
+		"trg_log_secret_metadata_auto_prune_update",
+		"trg_log_secret_metadata_auto_prune_delete",
 
 		"trg_log_secret_remote_unit_consumer_current_revision_insert",
 		"trg_log_secret_remote_unit_consumer_current_revision_update",
@@ -493,9 +494,10 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 4, tableSecretAutoPrune, 0)
 
 	secretURI := coresecrets.NewURI()
-	s.assertExecSQL(c, `INSERT INTO secret (id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
-	s.assertExecSQL(c, `UPDATE secret SET auto_prune = true WHERE id = ?;`, "", secretURI.ID)
-	s.assertExecSQL(c, `DELETE FROM secret WHERE id = ?;`, "", secretURI.ID)
+	s.assertExecSQL(c, `INSERT INTO secret (id) VALUES (?);`, "", secretURI.ID)
+	s.assertExecSQL(c, `INSERT INTO secret_metadata (secret_id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
+	s.assertExecSQL(c, `UPDATE secret_metadata SET auto_prune = true WHERE secret_id = ?;`, "", secretURI.ID)
+	s.assertExecSQL(c, `DELETE FROM secret_metadata WHERE secret_id = ?;`, "", secretURI.ID)
 
 	s.assertChangeLogCount(c, 1, tableSecretAutoPrune, 1)
 	s.assertChangeLogCount(c, 2, tableSecretAutoPrune, 1)
@@ -506,7 +508,7 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 2, tableSecretRotation, 0)
 	s.assertChangeLogCount(c, 4, tableSecretRotation, 0)
 
-	s.assertExecSQL(c, `INSERT INTO secret (id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
+	s.assertExecSQL(c, `INSERT INTO secret_metadata (secret_id, description, rotate_policy_id) VALUES (?, 'mySecret', 0);`, "", secretURI.ID)
 	s.assertExecSQL(c, `INSERT INTO secret_rotation (secret_id, next_rotation_time) VALUES (?, datetime('now', '+1 day'));`, "", secretURI.ID)
 	s.assertExecSQL(c, `UPDATE secret_rotation SET next_rotation_time = datetime('now', '+2 day') WHERE secret_id = ?;`, "", secretURI.ID)
 	s.assertExecSQL(c, `DELETE FROM secret_rotation WHERE secret_id = ?;`, "", secretURI.ID)

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -14,7 +14,7 @@ import (
 // These structs represent the persistent secretMetadata entity schema in the database.
 
 type secretMetadata struct {
-	ID             string    `db:"id"`
+	ID             string    `db:"secret_id"`
 	Version        int       `db:"version"`
 	Description    string    `db:"description"`
 	AutoPrune      bool      `db:"auto_prune"`
@@ -25,7 +25,7 @@ type secretMetadata struct {
 
 // secretInfo is used because sqlair doesn't seem to like struct embedding.
 type secretInfo struct {
-	ID           string    `db:"id"`
+	ID           string    `db:"secret_id"`
 	Version      int       `db:"version"`
 	Description  string    `db:"description"`
 	RotatePolicy string    `db:"policy"`


### PR DESCRIPTION
For cross model secrets, we need to store consumer info, but the secret metadata exists in the other model.
This PR introduces a parent secret table with just the secret IDs of any secret referred to by entities in the model. The current secret table is renamed to secret_mtadata. This allows secret consumer records for cross model secrets to still have a FK to a table with the secret id.

## QA steps

unit tests

## Links

**Jira card:** JUJU-5869

