### PR TITLE
Remove JUJU_TARGET_SERIES envvar from hook context

### DIFF
--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/application"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/quota"
@@ -1350,20 +1349,8 @@ func (c *HookContext) HookVars(
 	}
 
 	if c.baseUpgradeTarget != "" {
-		// We need to set both the base and the series for the hook. This until
-		// we migrate everything to use base.
-		b, err := corebase.ParseBaseFromString(c.baseUpgradeTarget)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		s, err := corebase.GetSeriesFromBase(b)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
 		vars = append(vars,
 			"JUJU_TARGET_BASE="+c.baseUpgradeTarget,
-			"JUJU_TARGET_SERIES="+s,
 		)
 	}
 

--- a/internal/worker/uniter/runner/context/env_test.go
+++ b/internal/worker/uniter/runner/context/env_test.go
@@ -180,6 +180,13 @@ func (s *EnvSuite) setStorage(ctx *context.HookContext) (expectVars []string) {
 	}
 }
 
+func (s *EnvSuite) setBaseUpgrade(ctx *context.HookContext) (expectedVars []string) {
+	context.SetEnvironmentHookContextTargetBase(ctx, "ubuntu@24.04")
+	return []string{
+		"JUJU_TARGET_BASE=ubuntu@24.04",
+	}
+}
+
 func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
 	paths := context.OSDependentEnvVars(MockEnvPaths{}, context.NewHostEnvironmenter())
 	c.Assert(paths, gc.Not(gc.HasLen), 0)
@@ -240,9 +247,10 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	secretVars := s.setSecret(hookContext)
 	storageVars := s.setStorage(hookContext)
 	noticeVars := s.setNotice(hookContext)
+	upgradeVars := s.setBaseUpgrade(hookContext)
 	actualVars, err = hookContext.HookVars(stdcontext.Background(), paths, false, environmenter)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars, relationVars, secretVars, storageVars, noticeVars)
+	s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars, relationVars, secretVars, storageVars, noticeVars, upgradeVars)
 }
 
 func (s *EnvSuite) TestEnvCentos(c *gc.C) {

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -196,6 +196,10 @@ func SetEnvironmentHookContextNotice(context *HookContext, workloadName, noticeI
 	context.noticeKey = noticeKey
 }
 
+func SetEnvironmentHookContextTargetBase(context *HookContext, baseStr string) {
+	context.baseUpgradeTarget = baseStr
+}
+
 func PatchCachedStatus(ctx jujuc.Context, status, info string, data map[string]interface{}) func() {
 	hctx := ctx.(*HookContext)
 	oldStatus := hctx.status


### PR DESCRIPTION
Remove JUJU_TARGET_SERIES envvar from hook context

This envvar is being deprecated since it makes use of the series construct. It is to be removed in 4.0

This is part of the work to use bases instead of series

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing
