### PR TITLE
Delete model

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -240,6 +240,9 @@ type ServerConfig struct {
 	// DBGetter returns WatchableDB implementations based on namespace.
 	DBGetter changestream.WatchableDBGetter
 
+	// DBDeleter is used to delete databases by namespace.
+	DBDeleter database.DBDeleter
+
 	// TracerGetter returns a tracer for the given namespace, this is used
 	// for opentelmetry tracing.
 	TracerGetter trace.TracerGetter
@@ -291,6 +294,12 @@ func (c ServerConfig) Validate() error {
 	}
 	if c.MetricsCollector == nil {
 		return errors.NotValidf("missing MetricsCollector")
+	}
+	if c.DBGetter == nil {
+		return errors.NotValidf("missing DBGetter")
+	}
+	if c.DBDeleter == nil {
+		return errors.NotValidf("missing DBDeleter")
 	}
 	if c.ServiceFactoryGetter == nil {
 		return errors.NotValidf("missing ServiceFactoryGetter")
@@ -356,6 +365,7 @@ func newServer(ctx context.Context, cfg ServerConfig) (_ *Server, err error) {
 		logger:               internallogger.GetLogger("juju.apiserver"),
 		charmhubHTTPClient:   cfg.CharmhubHTTPClient,
 		dbGetter:             cfg.DBGetter,
+		dbDeleter:            cfg.DBDeleter,
 		serviceFactoryGetter: cfg.ServiceFactoryGetter,
 		tracerGetter:         cfg.TracerGetter,
 		objectStoreGetter:    cfg.ObjectStoreGetter,

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -327,17 +327,22 @@ func (c *MockModelServiceDefaultModelCloudNameAndCredentialCall) DoAndReturn(f f
 }
 
 // DeleteModel mocks base method.
-func (m *MockModelService) DeleteModel(arg0 context.Context, arg1 model.UUID) error {
+func (m *MockModelService) DeleteModel(arg0 context.Context, arg1 model.UUID, arg2 ...model0.DeleteModelOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteModel", arg0, arg1)
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteModel", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteModel indicates an expected call of DeleteModel.
-func (mr *MockModelServiceMockRecorder) DeleteModel(arg0, arg1 any) *MockModelServiceDeleteModelCall {
+func (mr *MockModelServiceMockRecorder) DeleteModel(arg0, arg1 any, arg2 ...any) *MockModelServiceDeleteModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModel", reflect.TypeOf((*MockModelService)(nil).DeleteModel), arg0, arg1)
+	varargs := append([]any{arg0, arg1}, arg2...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModel", reflect.TypeOf((*MockModelService)(nil).DeleteModel), varargs...)
 	return &MockModelServiceDeleteModelCall{Call: call}
 }
 
@@ -353,13 +358,13 @@ func (c *MockModelServiceDeleteModelCall) Return(arg0 error) *MockModelServiceDe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelServiceDeleteModelCall) Do(f func(context.Context, model.UUID) error) *MockModelServiceDeleteModelCall {
+func (c *MockModelServiceDeleteModelCall) Do(f func(context.Context, model.UUID, ...model0.DeleteModelOption) error) *MockModelServiceDeleteModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, model.UUID) error) *MockModelServiceDeleteModelCall {
+func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, model.UUID, ...model0.DeleteModelOption) error) *MockModelServiceDeleteModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1032,15 +1032,16 @@ func (m *ModelManagerAPI) DestroyModels(ctx context.Context, args params.Destroy
 		if m.modelService != nil {
 			// We need to get the model service factory from the model
 			// We should be able to directly access the model service factory
-			// because the model manager use the MultiModelContext to access
+			// because the model manager uses the MultiModelContext to access
 			// other models.
 			modelUUID := coremodel.UUID(stModel.UUID())
 
-			// TODO (stickupkid): We need to delete the model info when
-			// destroying the model. This is because the model info is
-			// read-only. Attempting to delete the model causes everything to
-			// lock up. Once we implement tear-down we'll need to ensure we
-			// correctly delete the model info.
+			// TODO (stickupkid): We can't the delete the model info when
+			// destroying the model at the moment. Attempting to delete the
+			// model causes everything to lock up. Once we implement tear-down
+			// we'll need to ensure we correctly delete the model info.
+			// We need to progress the life of the model, atm it goes from
+			// alive to dead, skipping dying.
 			//
 			// modelServiceFactory := m.serviceFactoryGetter.ServiceFactoryForModel(modelUUID)
 			// modelInfoService := modelServiceFactory.ModelInfo()

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -855,15 +855,15 @@ func (m *ModelManagerAPI) makeModelSummary(mi state.ModelSummary) *params.ModelS
 		UserLastConnection: mi.UserLastConnection,
 	}
 	if mi.MachineCount > 0 {
-		summary.Counts = append(summary.Counts, params.ModelEntityCount{params.Machines, mi.MachineCount})
+		summary.Counts = append(summary.Counts, params.ModelEntityCount{Entity: params.Machines, Count: mi.MachineCount})
 	}
 
 	if mi.CoreCount > 0 {
-		summary.Counts = append(summary.Counts, params.ModelEntityCount{params.Cores, mi.CoreCount})
+		summary.Counts = append(summary.Counts, params.ModelEntityCount{Entity: params.Cores, Count: mi.CoreCount})
 	}
 
 	if mi.UnitCount > 0 {
-		summary.Counts = append(summary.Counts, params.ModelEntityCount{params.Units, mi.UnitCount})
+		summary.Counts = append(summary.Counts, params.ModelEntityCount{Entity: params.Units, Count: mi.UnitCount})
 	}
 
 	access, err := common.StateToParamsUserAccessPermission(mi.Access)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1036,13 +1036,17 @@ func (m *ModelManagerAPI) DestroyModels(ctx context.Context, args params.Destroy
 			// other models.
 			modelUUID := coremodel.UUID(stModel.UUID())
 
-			// We use the returned model UUID as we can guarantee that's the one that
-			// was written to the database.
-			modelServiceFactory := m.serviceFactoryGetter.ServiceFactoryForModel(modelUUID)
-			modelInfoService := modelServiceFactory.ModelInfo()
-			if err := modelInfoService.DeleteModel(ctx, modelUUID); err != nil && !errors.Is(err, modelerrors.NotFound) {
-				return errors.Annotatef(err, "failed to delete model info for model %q", modelUUID)
-			}
+			// TODO (stickupkid): We need to delete the model info when
+			// destroying the model. This is because the model info is
+			// read-only. Attempting to delete the model causes everything to
+			// lock up. Once we implement tear-down we'll need to ensure we
+			// correctly delete the model info.
+			//
+			// modelServiceFactory := m.serviceFactoryGetter.ServiceFactoryForModel(modelUUID)
+			// modelInfoService := modelServiceFactory.ModelInfo()
+			// if err := modelInfoService.DeleteModel(ctx, modelUUID); err != nil && !errors.Is(err, modelerrors.NotFound) {
+			// 	return errors.Annotatef(err, "failed to delete model info for model %q", modelUUID)
+			// }
 
 			err = m.modelService.DeleteModel(ctx, modelUUID)
 			if err != nil && errors.Is(err, modelerrors.NotFound) {

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -88,6 +88,8 @@ type ModelInfoService interface {
 	// CreateModel is responsible for creating a new read only model
 	// that is being imported.
 	CreateModel(context.Context, uuid.UUID) error
+
+	// DeleteModel is responsible for deleting a model during model migration.
 	DeleteModel(context.Context) error
 }
 

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -59,9 +59,12 @@ type ModelService interface {
 	DefaultModelCloudNameAndCredential(context.Context) (string, credential.Key, error)
 
 	// DeleteModel deletes the give model.
-	DeleteModel(context.Context, coremodel.UUID) error
+	DeleteModel(context.Context, coremodel.UUID, ...model.DeleteModelOption) error
 
+	// ListModelsForUser returns a list of models for the given user.
 	ListModelsForUser(context.Context, coreuser.UUID) ([]coremodel.Model, error)
+
+	// ListAllModels returns a list of all models.
 	ListAllModels(context.Context) ([]coremodel.Model, error)
 }
 

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -88,7 +88,7 @@ type ModelInfoService interface {
 	// CreateModel is responsible for creating a new read only model
 	// that is being imported.
 	CreateModel(context.Context, uuid.UUID) error
-	DeleteModel(context.Context, coremodel.UUID) error
+	DeleteModel(context.Context) error
 }
 
 // ModelExporter defines a interface for exporting models.

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -85,6 +85,7 @@ type ModelInfoService interface {
 	// CreateModel is responsible for creating a new read only model
 	// that is being imported.
 	CreateModel(context.Context, uuid.UUID) error
+	DeleteModel(context.Context, coremodel.UUID) error
 }
 
 // ModelExporter defines a interface for exporting models.

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -734,7 +734,7 @@ func (s *Suite) controllerVersion(c *gc.C) version.Number {
 func (s *Suite) expectImportModel(c *gc.C) {
 	s.serviceFactoryGetter.EXPECT().FactoryForModel(gomock.Any()).Return(s.serviceFactory)
 	s.modelImporter.EXPECT().ImportModel(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, bytes []byte) (*state.Model, *state.State, error) {
-		scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
+		scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil, nil) }
 		controller := state.NewController(s.StatePool)
 		return migration.NewModelImporter(
 			controller, scope, s.controllerConfigService, s.serviceFactoryGetter, cloudSchemaSource,

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -29,3 +29,9 @@ func (s StubDBGetter) GetWatchableDB(namespace string) (changestream.WatchableDB
 	}
 	return nil, nil
 }
+
+type StubDBDeleter struct{}
+
+func (s StubDBDeleter) DeleteDB(namespace string) error {
+	return nil
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -978,6 +978,7 @@ func (ctx *facadeContext) migrationScope(modelUUID string) modelmigration.Scope 
 		changestream.NewTxnRunnerFactory(func() (changestream.WatchableDB, error) {
 			return ctx.modelDB(modelUUID)
 		}),
+		ctx.r.shared.dbDeleter,
 	)
 }
 

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -42,18 +42,32 @@ type SharedHub interface {
 // All attributes in the context should be goroutine aware themselves, like the state pool, hub, and
 // presence, or protected and only accessed through methods on this context object.
 type sharedServerContext struct {
-	statePool            *state.StatePool
-	multiwatcherFactory  multiwatcher.Factory
-	centralHub           SharedHub
-	presence             presence.Recorder
-	leaseManager         lease.Manager
-	logger               corelogger.Logger
-	charmhubHTTPClient   facade.HTTPClient
-	dbGetter             changestream.WatchableDBGetter
-	dbDeleter            database.DBDeleter
+	statePool           *state.StatePool
+	multiwatcherFactory multiwatcher.Factory
+	centralHub          SharedHub
+	presence            presence.Recorder
+	leaseManager        lease.Manager
+	logger              corelogger.Logger
+	charmhubHTTPClient  facade.HTTPClient
+
+	// dbGetter is used to access databases from the API server. Along with
+	// creating a new database for new models and during model migrations.
+	dbGetter changestream.WatchableDBGetter
+
+	// dbDeleter is used to delete the database when a model migration fails
+	// and the model is being removed.
+	dbDeleter database.DBDeleter
+
+	// ServiceFactoryGetter is used to get the service factory for controllers
+	// and models.
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter
-	tracerGetter         trace.TracerGetter
-	objectStoreGetter    objectstore.ObjectStoreGetter
+
+	// TraceGetter is used to get the tracer for the API server.
+	tracerGetter trace.TracerGetter
+
+	// ObjectStoreGetter is used to get the object store for storing blobs
+	// for the API server.
+	objectStoreGetter objectstore.ObjectStoreGetter
 
 	configMutex      sync.RWMutex
 	controllerConfig jujucontroller.Config

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/multiwatcher"
@@ -49,6 +50,7 @@ type sharedServerContext struct {
 	logger               corelogger.Logger
 	charmhubHTTPClient   facade.HTTPClient
 	dbGetter             changestream.WatchableDBGetter
+	dbDeleter            database.DBDeleter
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter
 	tracerGetter         trace.TracerGetter
 	objectStoreGetter    objectstore.ObjectStoreGetter
@@ -74,6 +76,7 @@ type sharedServerConfig struct {
 	logger               corelogger.Logger
 	charmhubHTTPClient   facade.HTTPClient
 	dbGetter             changestream.WatchableDBGetter
+	dbDeleter            database.DBDeleter
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter
 	tracerGetter         trace.TracerGetter
 	objectStoreGetter    objectstore.ObjectStoreGetter
@@ -104,6 +107,9 @@ func (c *sharedServerConfig) validate() error {
 	if c.dbGetter == nil {
 		return errors.NotValidf("nil dbGetter")
 	}
+	if c.dbDeleter == nil {
+		return errors.NotValidf("nil dbDeleter")
+	}
 	if c.serviceFactoryGetter == nil {
 		return errors.NotValidf("nil serviceFactoryGetter")
 	}
@@ -133,6 +139,7 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		controllerConfig:     config.controllerConfig,
 		charmhubHTTPClient:   config.charmhubHTTPClient,
 		dbGetter:             config.dbGetter,
+		dbDeleter:            config.dbDeleter,
 		serviceFactoryGetter: config.serviceFactoryGetter,
 		tracerGetter:         config.tracerGetter,
 		objectStoreGetter:    config.objectStoreGetter,

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -63,6 +63,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 		controllerConfig:     controllerConfig,
 		logger:               loggertesting.WrapCheckLog(c),
 		dbGetter:             StubDBGetter{},
+		dbDeleter:            StubDBDeleter{},
 		serviceFactoryGetter: &StubServiceFactoryGetter{},
 		tracerGetter:         &StubTracerGetter{},
 		objectStoreGetter:    &StubObjectStoreGetter{},

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -679,6 +679,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			// to remove databases corresponding to destroyed/migrated models.
 			ServiceFactoryName: serviceFactoryName,
 			ChangeStreamName:   changeStreamName,
+			DBAccessorName:     dbAccessorName,
 
 			PrometheusRegisterer:              config.PrometheusRegisterer,
 			RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,

--- a/core/context/package_test.go
+++ b/core/context/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/context/sourceable.go
+++ b/core/context/sourceable.go
@@ -48,7 +48,7 @@ func (t *sourceContext) Done() <-chan struct{} {
 	return t.ctx.Done()
 }
 
-// If Done is not yet closed, Err returns nil.
+// Err if Done is not yet closed, Err returns nil.
 // If Done is closed, Err returns a non-nil error explaining why:
 // If the context was canceled or deadline exceeded, Err returns the source
 // error if it exists, otherwise Canceled if the context was canceled

--- a/core/context/sourceable.go
+++ b/core/context/sourceable.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gopkg.in/tomb.v2"
+)
+
+// SourceableError is an interface that can be implemented by errors
+// that can be used as the source of a context error.
+type SourceableError interface {
+	Err() error
+}
+
+type sourceContext struct {
+	ctx    context.Context
+	source SourceableError
+}
+
+// WithSourceableError returns a new Context that carries the source.
+// When the Err method is checked on the context, it will return the error
+// from the source if the context was canceled or deadline exceeded.
+func WithSourceableError(ctx context.Context, source SourceableError) context.Context {
+	return &sourceContext{
+		ctx:    ctx,
+		source: source,
+	}
+}
+
+// Deadline returns the time when work done on behalf of this context
+// should be canceled. Deadline returns ok==false when no deadline is
+// set. Successive calls to Deadline return the same results.
+func (t *sourceContext) Deadline() (deadline time.Time, ok bool) {
+	return t.ctx.Deadline()
+}
+
+// Done returns a channel that's closed when work done on behalf of this
+// context should be canceled. Done may return nil if this context can
+// never be canceled. Successive calls to Done return the same value.
+// The close of the Done channel may happen asynchronously,
+// after the cancel function returns.
+func (t *sourceContext) Done() <-chan struct{} {
+	return t.ctx.Done()
+}
+
+// If Done is not yet closed, Err returns nil.
+// If Done is closed, Err returns a non-nil error explaining why:
+// If the context was canceled or deadline exceeded, Err returns the source
+// error if it exists, otherwise Canceled if the context was canceled
+// or DeadlineExceeded if the context's deadline passed.
+// After Err returns a non-nil error, successive calls to Err return the same
+// error.
+func (t *sourceContext) Err() error {
+	cErr := t.ctx.Err()
+	if cErr == nil {
+		return nil
+	}
+
+	// If the context was canceled, check if the tomb has an error.
+	// If the tomb has an error, return that error as it's more important.
+	// If the tomb has no error, return the context error.
+	if errors.Is(cErr, context.Canceled) || errors.Is(cErr, context.DeadlineExceeded) {
+		if tErr := t.source.Err(); tErr != nil && !errors.Is(tErr, tomb.ErrStillAlive) {
+			return tErr
+		}
+	}
+	return cErr
+}
+
+// Value returns the value associated with this context for key, or nil
+// if no value is associated with key. Successive calls to Value with
+// the same key returns the same result.
+func (t *sourceContext) Value(key any) any {
+	return t.ctx.Value(key)
+}

--- a/core/context/sourceable_test.go
+++ b/core/context/sourceable_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+)
+
+type contextSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&contextSuite{})
+
+func (s *contextSuite) TestSourceableErrorIsNilIfErrorIsNotContextError(c *gc.C) {
+	var tomb tomb.Tomb
+	tomb.Kill(errors.New("tomb error"))
+
+	// We only want to propagate the sourceable error if the error is a
+	// context error. Otherwise you can always check the error with the
+	// source directly.
+
+	ctx := WithSourceableError(context.Background(), &tomb)
+	err := ctx.Err()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *contextSuite) TestSourceableErrorIsIgnoredIfNotInErrorState(c *gc.C) {
+	var tomb tomb.Tomb
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ctx = WithSourceableError(ctx, &tomb)
+	err := ctx.Err()
+	c.Assert(err, jc.ErrorIs, context.Canceled)
+}
+
+func (s *contextSuite) TestSourceableErrorIsTombError(c *gc.C) {
+	var tomb tomb.Tomb
+	tomb.Kill(errors.New("boom"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ctx = WithSourceableError(ctx, &tomb)
+	err := ctx.Err()
+	c.Assert(err, gc.ErrorMatches, `boom`)
+}
+
+func (s *contextSuite) TestSourceableErrorIsTiedToTheTomb(c *gc.C) {
+	var tomb tomb.Tomb
+
+	ctx := tomb.Context(context.Background())
+
+	tomb.Kill(errors.New("boom"))
+
+	ctx = WithSourceableError(ctx, &tomb)
+	err := ctx.Err()
+	c.Assert(err, gc.ErrorMatches, `boom`)
+}

--- a/core/database/dbmanager.go
+++ b/core/database/dbmanager.go
@@ -17,6 +17,10 @@ const (
 	// This error indicates to consuming workers that their dependency has
 	// become unmet and a restart by the dependency engine is imminent.
 	ErrDBAccessorDying = errors.ConstError("db-accessor worker is dying")
+
+	// ErrDBDead is used to indicate that the database is dead and should no
+	// longer be used.
+	ErrDBDead = errors.ConstError("database is dead")
 )
 
 // DBGetter describes the ability to supply a transaction runner

--- a/core/database/dbmanager.go
+++ b/core/database/dbmanager.go
@@ -3,7 +3,9 @@
 
 package database
 
-import "github.com/juju/errors"
+import (
+	"github.com/juju/errors"
+)
 
 const (
 	// ControllerNS is the namespace for the controller database.

--- a/core/modelmigration/coordinator.go
+++ b/core/modelmigration/coordinator.go
@@ -62,16 +62,18 @@ type Operation interface {
 type Scope struct {
 	controllerDB database.TxnRunnerFactory
 	modelDB      database.TxnRunnerFactory
+	modelDeleter database.DBDeleter
 }
 
 // ScopeForModel returns a Scope for the given model UUID.
 type ScopeForModel func(modelUUID string) Scope
 
 // NewScope creates a new scope with the given database txn runners.
-func NewScope(controllerDB, modelDB database.TxnRunnerFactory) Scope {
+func NewScope(controllerDB, modelDB database.TxnRunnerFactory, modelDeleter database.DBDeleter) Scope {
 	return Scope{
 		controllerDB: controllerDB,
 		modelDB:      modelDB,
+		modelDeleter: modelDeleter,
 	}
 }
 
@@ -83,6 +85,11 @@ func (s Scope) ControllerDB() database.TxnRunnerFactory {
 // ModelDB returns the database txn runner for the model.
 func (s Scope) ModelDB() database.TxnRunnerFactory {
 	return s.modelDB
+}
+
+// ModelDeleter returns the database deleter for the model.
+func (s Scope) ModelDeleter() database.DBDeleter {
+	return s.modelDeleter
 }
 
 // Hook is a callback that is called after the operation is executed.

--- a/core/modelmigration/coordinator_test.go
+++ b/core/modelmigration/coordinator_test.go
@@ -115,7 +115,7 @@ func (s *migrationSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.txnRunner = NewMockTxnRunner(ctrl)
 	s.model = NewMockModel(ctrl)
 
-	s.scope = NewScope(nil, nil)
+	s.scope = NewScope(nil, nil, nil)
 
 	return ctrl
 }

--- a/domain/lease/modelmigration/import_test.go
+++ b/domain/lease/modelmigration/import_test.go
@@ -48,7 +48,7 @@ func (s *importSuite) TestSetup(c *gc.C) {
 
 	// We don't currently need the model DB, so for this instance we can just
 	// pass nil.
-	err := op.Setup(modelmigration.NewScope(nil, nil))
+	err := op.Setup(modelmigration.NewScope(nil, nil, nil))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -105,6 +105,7 @@ type importOperation struct {
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.modelService = modelservice.NewService(
 		modelstate.NewState(scope.ControllerDB()),
+		scope.ModelDeleter(),
 		modelservice.DefaultAgentBinaryFinder(),
 	)
 	i.readOnlyModelServiceFunc = func(id coremodel.UUID) ReadOnlyModelService {
@@ -224,18 +225,18 @@ func (i importOperation) Rollback(ctx context.Context, model description.Model) 
 		return fmt.Errorf("rollback of model during migration %w", errors.NotValid)
 	}
 
-	// If the model isn't found, we can simply ignore the error.
-	if err := i.modelService.DeleteModel(ctx, modelID); err != nil && !errors.Is(err, modelerrors.NotFound) {
-		return fmt.Errorf(
-			"rollback of model %q with uuid %q during migration: %w",
-			modelName, modelID, err,
-		)
-	}
-
 	// If the read only model isn't found, we can simply ignore the error.
 	if err := i.readOnlyModelServiceFunc(modelID).DeleteModel(ctx); err != nil && !errors.Is(err, modelerrors.NotFound) {
 		return fmt.Errorf(
 			"rollback of read only model %q with uuid %q during migration: %w",
+			modelName, modelID, err,
+		)
+	}
+
+	// If the model isn't found, we can simply ignore the error.
+	if err := i.modelService.DeleteModel(ctx, modelID); err != nil && !errors.Is(err, modelerrors.NotFound) {
+		return fmt.Errorf(
+			"rollback of model %q with uuid %q during migration: %w",
 			modelName, modelID, err,
 		)
 	}

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -52,7 +52,7 @@ type ModelService interface {
 	// ModelType returns the type of the model.
 	ModelType(context.Context, coremodel.UUID) (coremodel.ModelType, error)
 	// DeleteModel is responsible for removing a model from the system.
-	DeleteModel(context.Context, coremodel.UUID) error
+	DeleteModel(context.Context, coremodel.UUID, ...domainmodel.DeleteModelOption) error
 }
 
 // ReadOnlyModelService defines a service for interacting with the read only
@@ -107,6 +107,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 		modelstate.NewState(scope.ControllerDB()),
 		scope.ModelDeleter(),
 		modelservice.DefaultAgentBinaryFinder(),
+		i.logger,
 	)
 	i.readOnlyModelServiceFunc = func(id coremodel.UUID) ReadOnlyModelService {
 		return modelservice.NewModelService(
@@ -234,7 +235,7 @@ func (i importOperation) Rollback(ctx context.Context, model description.Model) 
 	}
 
 	// If the model isn't found, we can simply ignore the error.
-	if err := i.modelService.DeleteModel(ctx, modelID); err != nil && !errors.Is(err, modelerrors.NotFound) {
+	if err := i.modelService.DeleteModel(ctx, modelID, domainmodel.WithDeleteDB()); err != nil && !errors.Is(err, modelerrors.NotFound) {
 		return fmt.Errorf(
 			"rollback of model %q with uuid %q during migration: %w",
 			modelName, modelID, err,

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -224,7 +224,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coremodel.UUID, options ...model.DeleteModelOption) error {
 		opts := model.DefaultDeleteModelOptions()
@@ -234,7 +234,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		c.Assert(opts.DeleteDB(), jc.IsTrue)
 		return nil
 	})
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -306,10 +306,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(modelerrors.NotFound)
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -383,7 +383,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(nil)
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(modelerrors.NotFound)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -183,7 +183,7 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 	}
 
 	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
-	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil), model)
+	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(activated, jc.IsTrue)
 }
@@ -256,7 +256,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	}
 
 	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
-	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil), model)
+	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
 	// TODO (stickupkid): This is incorrect until the read-only model is
@@ -331,7 +331,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	}
 
 	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
-	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil), model)
+	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
 	// TODO (stickupkid): This is incorrect until the read-only model is
@@ -406,7 +406,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	}
 
 	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
-	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil), model)
+	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
 	// TODO (stickupkid): This is incorrect until the read-only model is

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -221,14 +221,20 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		activated = true
 		return nil
 	}
-
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
-	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
+	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coremodel.UUID, options ...model.DeleteModelOption) error {
+		opts := model.DefaultDeleteModelOptions()
+		for _, fn := range options {
+			fn(opts)
+		}
+		c.Assert(opts.DeleteDB(), jc.IsTrue)
+		return nil
+	})
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -300,10 +306,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
-	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
+	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(modelerrors.NotFound)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -374,11 +380,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	}
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-
 	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
-	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
-	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(modelerrors.NotFound)
+	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(nil)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -84,17 +84,22 @@ func (c *MockModelServiceCreateModelCall) DoAndReturn(f func(context.Context, mo
 }
 
 // DeleteModel mocks base method.
-func (m *MockModelService) DeleteModel(arg0 context.Context, arg1 model.UUID) error {
+func (m *MockModelService) DeleteModel(arg0 context.Context, arg1 model.UUID, arg2 ...model0.DeleteModelOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteModel", arg0, arg1)
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteModel", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteModel indicates an expected call of DeleteModel.
-func (mr *MockModelServiceMockRecorder) DeleteModel(arg0, arg1 any) *MockModelServiceDeleteModelCall {
+func (mr *MockModelServiceMockRecorder) DeleteModel(arg0, arg1 any, arg2 ...any) *MockModelServiceDeleteModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModel", reflect.TypeOf((*MockModelService)(nil).DeleteModel), arg0, arg1)
+	varargs := append([]any{arg0, arg1}, arg2...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteModel", reflect.TypeOf((*MockModelService)(nil).DeleteModel), varargs...)
 	return &MockModelServiceDeleteModelCall{Call: call}
 }
 
@@ -110,13 +115,13 @@ func (c *MockModelServiceDeleteModelCall) Return(arg0 error) *MockModelServiceDe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelServiceDeleteModelCall) Do(f func(context.Context, model.UUID) error) *MockModelServiceDeleteModelCall {
+func (c *MockModelServiceDeleteModelCall) Do(f func(context.Context, model.UUID, ...model0.DeleteModelOption) error) *MockModelServiceDeleteModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, model.UUID) error) *MockModelServiceDeleteModelCall {
+func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, model.UUID, ...model0.DeleteModelOption) error) *MockModelServiceDeleteModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -23,6 +23,7 @@ import (
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -56,7 +57,7 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *serviceSuite) TestCreateModelInvalidArgs(c *gc.C) {
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{})
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
@@ -74,7 +75,7 @@ func (s *serviceSuite) TestModelCreation(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -102,7 +103,7 @@ func (s *serviceSuite) TestModelCreation(c *gc.C) {
 
 func (s *serviceSuite) TestModelCreationInvalidCloud(c *gc.C) {
 	s.state.clouds["aws"] = dummyStateCloud{}
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -119,7 +120,7 @@ func (s *serviceSuite) TestModelCreationNoCloudRegion(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "noexist",
@@ -142,7 +143,7 @@ func (s *serviceSuite) TestModelCreationOwnerNotFound(c *gc.C) {
 	notFoundUser, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -160,7 +161,7 @@ func (s *serviceSuite) TestModelCreationNoCloudCredential(c *gc.C) {
 		Regions:     []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -183,7 +184,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *gc.C) {
 		Regions:     []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -208,7 +209,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *gc.C) {
 func (s *serviceSuite) TestUpdateModelCredentialForInvalidModel(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	err := svc.UpdateCredential(context.Background(), id, credential.Key{
 		Owner: s.userUUID.String(),
 		Name:  "foo",
@@ -231,7 +232,7 @@ func (s *serviceSuite) TestUpdateModelCredential(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -266,7 +267,7 @@ func (s *serviceSuite) TestUpdateModelCredentialReplace(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -296,7 +297,7 @@ func (s *serviceSuite) TestUpdateModelCredentialZeroValue(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -336,7 +337,7 @@ func (s *serviceSuite) TestUpdateModelCredentialDifferentCloud(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -371,7 +372,7 @@ func (s *serviceSuite) TestUpdateModelCredentialNotFound(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -400,7 +401,7 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -425,7 +426,7 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 }
 
 func (s *serviceSuite) TestDeleteModelNotFound(c *gc.C) {
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	err := svc.DeleteModel(context.Background(), s.modelUUID)
 	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
 }
@@ -449,7 +450,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedGreater(c *gc.C) {
 	agentVersion, err := version.Parse("99.9.9")
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: agentVersion,
 		Cloud:        "aws",
@@ -485,7 +486,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 	agentVersion, err := version.Parse("1.9.9")
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: agentVersion,
 		Cloud:        "aws",
@@ -505,7 +506,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 // TestListAllModelsNoResults is asserting that when no models exist the return
 // value of ListAllModels is an empty slice.
 func (s *serviceSuite) TestListAllModelsNoResults(c *gc.C) {
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	models, err := svc.ListAllModels(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(len(models), gc.Equals, 0)
@@ -527,7 +528,7 @@ func (s *serviceSuite) TestListAllModels(c *gc.C) {
 	usr1 := usertesting.GenUserUUID(c)
 	s.state.users[usr1] = "tlm"
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        "aws",
@@ -592,7 +593,7 @@ func (s *serviceSuite) TestListAllModels(c *gc.C) {
 // an empty model result.
 func (s *serviceSuite) TestListModelsForNonExistentUser(c *gc.C) {
 	fakeUserID := usertesting.GenUserUUID(c)
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	models, err := svc.ListModelsForUser(context.Background(), fakeUserID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(len(models), gc.Equals, 0)
@@ -614,7 +615,7 @@ func (s *serviceSuite) TestListModelsForUser(c *gc.C) {
 	usr1 := usertesting.GenUserUUID(c)
 	s.state.users[usr1] = "tlm"
 
-	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        "aws",

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -32,6 +32,7 @@ type serviceSuite struct {
 	modelUUID coremodel.UUID
 	userUUID  user.UUID
 	state     *dummyState
+	deleter   *dummyDeleter
 }
 
 var _ = gc.Suite(&serviceSuite{})
@@ -49,10 +50,13 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 			s.userUUID: "admin",
 		},
 	}
+	s.deleter = &dummyDeleter{
+		deleted: map[string]struct{}{},
+	}
 }
 
 func (s *serviceSuite) TestCreateModelInvalidArgs(c *gc.C) {
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{})
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
@@ -70,7 +74,7 @@ func (s *serviceSuite) TestModelCreation(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -98,7 +102,7 @@ func (s *serviceSuite) TestModelCreation(c *gc.C) {
 
 func (s *serviceSuite) TestModelCreationInvalidCloud(c *gc.C) {
 	s.state.clouds["aws"] = dummyStateCloud{}
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -115,7 +119,7 @@ func (s *serviceSuite) TestModelCreationNoCloudRegion(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "noexist",
@@ -138,7 +142,7 @@ func (s *serviceSuite) TestModelCreationOwnerNotFound(c *gc.C) {
 	notFoundUser, err := user.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -156,7 +160,7 @@ func (s *serviceSuite) TestModelCreationNoCloudCredential(c *gc.C) {
 		Regions:     []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -179,7 +183,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *gc.C) {
 		Regions:     []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -204,7 +208,7 @@ func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *gc.C) {
 func (s *serviceSuite) TestUpdateModelCredentialForInvalidModel(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	err := svc.UpdateCredential(context.Background(), id, credential.Key{
 		Owner: s.userUUID.String(),
 		Name:  "foo",
@@ -227,7 +231,7 @@ func (s *serviceSuite) TestUpdateModelCredential(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -262,7 +266,7 @@ func (s *serviceSuite) TestUpdateModelCredentialReplace(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -292,7 +296,7 @@ func (s *serviceSuite) TestUpdateModelCredentialZeroValue(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -332,7 +336,7 @@ func (s *serviceSuite) TestUpdateModelCredentialDifferentCloud(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -367,7 +371,7 @@ func (s *serviceSuite) TestUpdateModelCredentialNotFound(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -396,7 +400,7 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 		Regions: []string{"myregion"},
 	}
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		Cloud:       "aws",
 		CloudRegion: "myregion",
@@ -415,10 +419,13 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, exists = s.state.models[s.modelUUID]
 	c.Assert(exists, jc.IsFalse)
+
+	_, exists = s.deleter.deleted[s.modelUUID.String()]
+	c.Assert(exists, jc.IsTrue)
 }
 
 func (s *serviceSuite) TestDeleteModelNotFound(c *gc.C) {
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	err := svc.DeleteModel(context.Background(), s.modelUUID)
 	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
 }
@@ -442,7 +449,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedGreater(c *gc.C) {
 	agentVersion, err := version.Parse("99.9.9")
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: agentVersion,
 		Cloud:        "aws",
@@ -478,7 +485,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 	agentVersion, err := version.Parse("1.9.9")
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	_, err = svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: agentVersion,
 		Cloud:        "aws",
@@ -498,7 +505,7 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 // TestListAllModelsNoResults is asserting that when no models exist the return
 // value of ListAllModels is an empty slice.
 func (s *serviceSuite) TestListAllModelsNoResults(c *gc.C) {
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	models, err := svc.ListAllModels(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(len(models), gc.Equals, 0)
@@ -520,7 +527,7 @@ func (s *serviceSuite) TestListAllModels(c *gc.C) {
 	usr1 := usertesting.GenUserUUID(c)
 	s.state.users[usr1] = "tlm"
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        "aws",
@@ -585,7 +592,7 @@ func (s *serviceSuite) TestListAllModels(c *gc.C) {
 // an empty model result.
 func (s *serviceSuite) TestListModelsForNonExistentUser(c *gc.C) {
 	fakeUserID := usertesting.GenUserUUID(c)
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	models, err := svc.ListModelsForUser(context.Background(), fakeUserID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(len(models), gc.Equals, 0)
@@ -607,7 +614,7 @@ func (s *serviceSuite) TestListModelsForUser(c *gc.C) {
 	usr1 := usertesting.GenUserUUID(c)
 	s.state.users[usr1] = "tlm"
 
-	svc := NewService(s.state, DefaultAgentBinaryFinder())
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder())
 	activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        "aws",

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -416,7 +416,7 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 	_, exists := s.state.models[s.modelUUID]
 	c.Assert(exists, jc.IsTrue)
 
-	err = svc.DeleteModel(context.Background(), s.modelUUID)
+	err = svc.DeleteModel(context.Background(), s.modelUUID, model.WithDeleteDB())
 	c.Assert(err, jc.ErrorIsNil)
 	_, exists = s.state.models[s.modelUUID]
 	c.Assert(exists, jc.IsFalse)

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -32,6 +32,15 @@ type dummyState struct {
 	users              map[user.UUID]string
 }
 
+type dummyDeleter struct {
+	deleted map[string]struct{}
+}
+
+func (d *dummyDeleter) DeleteDB(namespace string) error {
+	d.deleted[namespace] = struct{}{}
+	return nil
+}
+
 func (d *dummyState) CloudType(
 	_ context.Context,
 	name string,

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -110,3 +110,37 @@ type ReadOnlyModelCreationArgs struct {
 	// Optional and can be empty.
 	CredentialName string
 }
+
+// DeleteModelOptions is a struct that is used to modify the behavior of the
+// DeleteModel function.
+type DeleteModelOptions struct {
+	deleteDB bool
+}
+
+// DeleteDB returns a boolean value that indicates if the model should be
+// deleted from the database.
+func (o DeleteModelOptions) DeleteDB() bool {
+	return o.deleteDB
+}
+
+// DefaultDeleteModelOptions returns a pointer to a DeleteModelOptions struct
+// with the default values set.
+func DefaultDeleteModelOptions() *DeleteModelOptions {
+	return &DeleteModelOptions{
+		// Until we have correctly implemented tearing down the model, we want
+		// to keep the model around during normal model deletion.
+		deleteDB: false,
+	}
+}
+
+// DeleteModelOption is a functional option that can be used to modify the
+// behavior of the DeleteModel function.
+type DeleteModelOption func(*DeleteModelOptions)
+
+// WithDeleteDB is a functional option that can be used to modify the behavior
+// of the DeleteModel function to delete the model from the database.
+func WithDeleteDB() DeleteModelOption {
+	return func(o *DeleteModelOptions) {
+		o.deleteDB = true
+	}
+}

--- a/domain/schema/testing/controllermodelsuite.go
+++ b/domain/schema/testing/controllermodelsuite.go
@@ -20,7 +20,7 @@ type ControllerModelSuite struct {
 // ModelTxnRunner returns a transaction runner on to the model database for the
 // provided model uuid.
 func (s *ControllerModelSuite) ModelTxnRunner(c *gc.C, modelUUID string) coredatabase.TxnRunner {
-	txnRunner, _ := s.DqliteSuite.OpenDBForNamespace(c, modelUUID)
+	txnRunner, _ := s.DqliteSuite.OpenDBForNamespace(c, modelUUID, true)
 	s.DqliteSuite.ApplyDDLForRunner(c, &SchemaApplier{
 		Schema:  schema.ModelDDL(),
 		Verbose: s.Verbose,

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -81,6 +81,7 @@ func (s *ControllerFactory) Model() *modelservice.Service {
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.dbDeleter,
 		modelservice.DefaultAgentBinaryFinder(),
+		s.logger,
 	)
 }
 

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -79,6 +79,7 @@ func (s *ControllerFactory) ControllerNode() *controllernodeservice.Service {
 func (s *ControllerFactory) Model() *modelservice.Service {
 	return modelservice.NewService(
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+		s.dbDeleter,
 		modelservice.DefaultAgentBinaryFinder(),
 	)
 }

--- a/internal/database/testing/dqlitesuite.go
+++ b/internal/database/testing/dqlitesuite.go
@@ -175,11 +175,11 @@ func (s *DqliteSuite) OpenDB(c *gc.C) (coredatabase.TxnRunner, *sql.DB) {
 	// Increment the id and use it as the database name, this prevents
 	// tests from interfering with each other.
 	uniqueID := atomic.AddInt64(&s.uniqueID, 1)
-	return s.OpenDBForNamespace(c, strconv.FormatInt(uniqueID, 10))
+	return s.OpenDBForNamespace(c, strconv.FormatInt(uniqueID, 10), true)
 }
 
 // OpenDBForNamespace returns a new sql.DB reference for the domain.
-func (s *DqliteSuite) OpenDBForNamespace(c *gc.C, domain string) (coredatabase.TxnRunner, *sql.DB) {
+func (s *DqliteSuite) OpenDBForNamespace(c *gc.C, domain string, foreignKey bool) (coredatabase.TxnRunner, *sql.DB) {
 	// There are places in the Juju code where an empty model uuid is valid and
 	// takes on a double meaning to signify something else. It's possible that
 	// in test scenarios as we move to DQlite that these empty model uuid's can
@@ -190,7 +190,7 @@ func (s *DqliteSuite) OpenDBForNamespace(c *gc.C, domain string) (coredatabase.T
 	db, err := s.dqlite.Open(context.Background(), domain)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = pragma.SetPragma(context.Background(), db, pragma.ForeignKeysPragma, true)
+	err = pragma.SetPragma(context.Background(), db, pragma.ForeignKeysPragma, foreignKey)
 	c.Assert(err, jc.ErrorIsNil)
 
 	trackedDB := &txnRunner{

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -66,7 +66,7 @@ func (s *ImportSuite) SetUpTest(c *gc.C) {
 
 func (s *ImportSuite) TestBadBytes(c *gc.C) {
 	bytes := []byte("not a model")
-	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
+	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil, nil) }
 	controller := &fakeImporter{}
 	configSchemaSource := func(environs.CloudService) config.ConfigSchemaSourceGetter {
 		return state.NoopConfigSchemaSource
@@ -144,7 +144,7 @@ func (s *ImportSuite) exportImport(c *gc.C, leaders map[string]string) {
 	st := &state.State{}
 	m := &state.Model{}
 	controller := &fakeImporter{st: st, m: m}
-	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil) }
+	scope := func(string) modelmigration.Scope { return modelmigration.NewScope(nil, nil, nil) }
 	configSchemaSource := func(environs.CloudService) config.ConfigSchemaSourceGetter {
 		return state.NoopConfigSchemaSource
 	}

--- a/internal/worker/apiserver/manifold.go
+++ b/internal/worker/apiserver/manifold.go
@@ -25,6 +25,7 @@ import (
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	coredependency "github.com/juju/juju/core/dependency"
 	"github.com/juju/juju/core/lease"
 	corelogger "github.com/juju/juju/core/logger"
@@ -72,6 +73,7 @@ type ManifoldConfig struct {
 	LeaseManagerName       string
 	LogSinkName            string
 	CharmhubHTTPClientName string
+	DBAccessorName         string
 	ChangeStreamName       string
 	ServiceFactoryName     string
 	TraceName              string
@@ -128,6 +130,9 @@ func (config ManifoldConfig) Validate() error {
 	if config.CharmhubHTTPClientName == "" {
 		return errors.NotValidf("empty CharmhubHTTPClientName")
 	}
+	if config.DBAccessorName == "" {
+		return errors.NotValidf("empty DBAccessorName")
+	}
 	if config.ChangeStreamName == "" {
 		return errors.NotValidf("empty ChangeStreamName")
 	}
@@ -174,6 +179,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.AuditConfigUpdaterName,
 			config.LeaseManagerName,
 			config.CharmhubHTTPClientName,
+			config.DBAccessorName,
 			config.ChangeStreamName,
 			config.ServiceFactoryName,
 			config.TraceName,
@@ -250,6 +256,11 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		return nil, errors.Trace(err)
 	}
 
+	var dbDeleter database.DBDeleter
+	if err := getter.Get(config.DBAccessorName, &dbDeleter); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	var serviceFactoryGetter servicefactory.ServiceFactoryGetter
 	if err := getter.Get(config.ServiceFactoryName, &serviceFactoryGetter); err != nil {
 		return nil, errors.Trace(err)
@@ -307,6 +318,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		LogSink:                           logSink,
 		CharmhubHTTPClient:                charmhubHTTPClient,
 		DBGetter:                          dbGetter,
+		DBDeleter:                         dbDeleter,
 		ServiceFactoryGetter:              serviceFactoryGetter,
 		TracerGetter:                      tracerGetter,
 		ObjectStoreGetter:                 objectStoreGetter,

--- a/internal/worker/apiserver/manifold.go
+++ b/internal/worker/apiserver/manifold.go
@@ -5,7 +5,6 @@ package apiserver
 
 import (
 	"context"
-	stdcontext "context"
 	"net/http"
 	"strings"
 
@@ -85,7 +84,7 @@ type ManifoldConfig struct {
 	Presence                          presence.Recorder
 	GetControllerConfigService        GetControllerConfigServiceFunc
 
-	NewWorker           func(stdcontext.Context, Config) (worker.Worker, error)
+	NewWorker           func(context.Context, Config) (worker.Worker, error)
 	NewMetricsCollector func() *apiserver.Collector
 }
 

--- a/internal/worker/apiserver/worker.go
+++ b/internal/worker/apiserver/worker.go
@@ -21,6 +21,7 @@ import (
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/multiwatcher"
@@ -53,6 +54,7 @@ type Config struct {
 
 	// DBGetter supplies WatchableDB implementations by namespace.
 	DBGetter                changestream.WatchableDBGetter
+	DBDeleter               database.DBDeleter
 	ServiceFactoryGetter    servicefactory.ServiceFactoryGetter
 	TracerGetter            trace.TracerGetter
 	ObjectStoreGetter       objectstore.ObjectStoreGetter
@@ -120,6 +122,9 @@ func (config Config) Validate() error {
 	if config.DBGetter == nil {
 		return errors.NotValidf("nil DBGetter")
 	}
+	if config.DBDeleter == nil {
+		return errors.NotValidf("nil DBDeleter")
+	}
 	if config.TracerGetter == nil {
 		return errors.NotValidf("nil TracerGetter")
 	}
@@ -185,6 +190,7 @@ func NewWorker(ctx context.Context, config Config) (worker.Worker, error) {
 		LogSink:                       config.LogSink,
 		CharmhubHTTPClient:            config.CharmhubHTTPClient,
 		DBGetter:                      config.DBGetter,
+		DBDeleter:                     config.DBDeleter,
 		ServiceFactoryGetter:          config.ServiceFactoryGetter,
 		TracerGetter:                  config.TracerGetter,
 		ObjectStoreGetter:             config.ObjectStoreGetter,

--- a/internal/worker/apiserver/worker_state_test.go
+++ b/internal/worker/apiserver/worker_state_test.go
@@ -126,6 +126,7 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		LogSink:                    s.logSink,
 		CharmhubHTTPClient:         s.charmhubHTTPClient,
 		DBGetter:                   s.dbGetter,
+		DBDeleter:                  s.dbDeleter,
 		ServiceFactoryGetter:       s.serviceFactoryGetter,
 		TracerGetter:               s.tracerGetter,
 		ObjectStoreGetter:          s.objectStoreGetter,

--- a/internal/worker/apiserver/worker_test.go
+++ b/internal/worker/apiserver/worker_test.go
@@ -44,6 +44,7 @@ type workerFixture struct {
 	logSink                 corelogger.ModelLogger
 	charmhubHTTPClient      *http.Client
 	dbGetter                stubWatchableDBGetter
+	dbDeleter               stubDBDeleter
 	tracerGetter            stubTracerGetter
 	objectStoreGetter       stubObjectStoreGetter
 	controllerConfigService *MockControllerConfigService
@@ -91,6 +92,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		LogSink:                           s.logSink,
 		CharmhubHTTPClient:                s.charmhubHTTPClient,
 		DBGetter:                          s.dbGetter,
+		DBDeleter:                         s.dbDeleter,
 		ControllerConfigService:           s.controllerConfigService,
 		ServiceFactoryGetter:              s.serviceFactoryGetter,
 		TracerGetter:                      s.tracerGetter,

--- a/internal/worker/changestream/worker.go
+++ b/internal/worker/changestream/worker.go
@@ -88,6 +88,12 @@ func newWorker(cfg WorkerConfig) (*changeStreamWorker, error) {
 			IsFatal: func(err error) bool {
 				return false
 			},
+			// ShouldRestart is used to determine if the worker should be
+			// restarted. We only want to restart the worker if the error is not
+			// ErrDBDead.
+			ShouldRestart: func(err error) bool {
+				return !errors.Is(err, coredatabase.ErrDBDead)
+			},
 			Clock: cfg.Clock,
 		}),
 	}

--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -183,6 +183,11 @@ func (w *Pruner) prune() (map[string]int64, error) {
 
 		p, err := w.pruneModel(ctx, mn.Namespace)
 		if err != nil {
+			// If the database is dead, continue on to the next model, as we
+			// don't want to kill the worker.
+			if errors.Is(err, coredatabase.ErrDBDead) {
+				continue
+			}
 			// If there is an error, continue on to the next model, as we don't
 			// want to kill the worker.
 			w.cfg.Logger.Infof("Error pruning model %q: %v", mn.UUID, err)

--- a/internal/worker/dbaccessor/deletedb.go
+++ b/internal/worker/dbaccessor/deletedb.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+type sqliteSchema struct {
+	Type string
+	Name string
+}
+
+// deleteDBContents deletes all the contents of the database, this is very
+// dynamic. It will drop all tables, views, triggers, and indexes. This can
+// be replaced with DROP DATABASE once it's supported by dqlite.
+func deleteDBContents(ctx context.Context, tx *sql.Tx, logger Logger) error {
+	// We should ignore any name that starts with sqlite_ as they are internal
+	// tables, indexes and triggers.
+	schemaStmt := `SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%';`
+
+	var (
+		indexes  = make(map[string]struct{})
+		triggers = make(map[string]struct{})
+		views    = make(map[string]struct{})
+		tables   = make(map[string]struct{})
+	)
+
+	rows, err := tx.QueryContext(ctx, schemaStmt)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schema sqliteSchema
+		err := rows.Scan(&schema.Type, &schema.Name)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		name := schema.Name
+		switch schema.Type {
+		case "index":
+			indexes[name] = struct{}{}
+		case "trigger":
+			triggers[name] = struct{}{}
+		case "view":
+			views[name] = struct{}{}
+		case "table":
+			tables[name] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Do not attempt to delete the database all in one query. Dqlite can't
+	// handle it and we end up causing a segfault. Instead we'll create batches
+	// of queries that we can execute in a single transaction, but over multiple
+	// queries.
+
+	// Ensure that we remove everything in the correct order.
+	// 1. Drop all the contents of the tables.
+	// 2. Remove all indexes.
+	// 3. Remove all triggers.
+	// 4. Drop all views.
+	// 5. Drop all tables (ignoring sqlite_master)
+	var stmts []string
+	for name := range tables {
+		stmts = append(stmts, fmt.Sprintf("DELETE FROM %s;", name))
+	}
+	for name := range indexes {
+		stmts = append(stmts, fmt.Sprintf("DROP INDEX IF EXISTS %s;", name))
+	}
+	for name := range triggers {
+		stmts = append(stmts, fmt.Sprintf("DROP TRIGGER IF EXISTS %s;", name))
+	}
+	for name := range views {
+		stmts = append(stmts, fmt.Sprintf("DROP VIEW IF EXISTS %s;", name))
+	}
+	for name := range tables {
+		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS %s;", name))
+	}
+
+	logger.Debugf("deleting database contents: %d statements", len(stmts))
+
+	// Batch the statements into groups, so we don't exceed the maximum
+	// number of statements in a single transaction.
+	const maxBatchSize = 15
+	for i := 0; i < len(stmts); i += maxBatchSize {
+		batch := stmts[i:min(i+maxBatchSize, len(stmts))]
+		logger.Debugf("executing batch %d with %d statements", i, len(batch))
+
+		if _, err := tx.ExecContext(ctx, strings.Join(batch, "\n")); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	logger.Infof("database contents deleted")
+
+	return nil
+}

--- a/internal/worker/dbaccessor/deletedb.go
+++ b/internal/worker/dbaccessor/deletedb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/core/logger"
 )
 

--- a/internal/worker/dbaccessor/deletedb.go
+++ b/internal/worker/dbaccessor/deletedb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/logger"
 )
 
 type sqliteSchema struct {
@@ -20,7 +21,7 @@ type sqliteSchema struct {
 // deleteDBContents deletes all the contents of the database, this is very
 // dynamic. It will drop all tables, views, triggers, and indexes. This can
 // be replaced with DROP DATABASE once it's supported by dqlite.
-func deleteDBContents(ctx context.Context, tx *sql.Tx, logger Logger) error {
+func deleteDBContents(ctx context.Context, tx *sql.Tx, logger logger.Logger) error {
 	// We should ignore any name that starts with sqlite_ as they are internal
 	// tables, indexes and triggers.
 	schemaStmt := `SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%';`

--- a/internal/worker/dbaccessor/deletedb_test.go
+++ b/internal/worker/dbaccessor/deletedb_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/schema"
+	"github.com/juju/juju/internal/database"
+	databasetesting "github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/testing"
+)
+
+type deleteDBSuite struct {
+	databasetesting.DqliteSuite
+}
+
+var _ = gc.Suite(&deleteDBSuite{})
+
+func (s *deleteDBSuite) TestDeleteDBContentsOnEmptyDB(c *gc.C) {
+	runner := s.TxnRunner()
+
+	err := runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		return deleteDBContents(ctx, tx, testing.NewCheckLogger(c))
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *deleteDBSuite) TestDeleteDBContentsOnControllerDB(c *gc.C) {
+	runner, db := s.OpenDBForNamespace(c, "controller-foo", false)
+	logger := testing.NewCheckLogger(c)
+
+	// This test isn't necessarily, as you can't delete the controller database
+	// contents, but adds more validation to the function.
+
+	err := database.NewDBMigration(
+		runner, logger, schema.ControllerDDL()).Apply(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		return deleteDBContents(ctx, tx, logger)
+	})
+	c.Assert(err, gc.IsNil)
+
+	s.ensureEmpty(c, db)
+}
+
+func (s *deleteDBSuite) TestDeleteDBContentsOnModelDB(c *gc.C) {
+	runner, db := s.OpenDBForNamespace(c, "model-foo", false)
+
+	logger := testing.NewCheckLogger(c)
+
+	err := database.NewDBMigration(
+		runner, logger, schema.ModelDDL()).Apply(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		return deleteDBContents(ctx, tx, logger)
+	})
+	c.Assert(err, gc.IsNil)
+
+	s.ensureEmpty(c, db)
+}
+
+func (s *deleteDBSuite) ensureEmpty(c *gc.C, db *sql.DB) {
+	schemaStmt := `SELECT COUNT(*) FROM sqlite_master WHERE name NOT LIKE 'sqlite_%';`
+	var count int
+	err := db.QueryRow(schemaStmt).Scan(&count)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 0)
+}

--- a/internal/worker/dbaccessor/deletedb_test.go
+++ b/internal/worker/dbaccessor/deletedb_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database"
 	databasetesting "github.com/juju/juju/internal/database/testing"
-	"github.com/juju/juju/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
 type deleteDBSuite struct {
@@ -26,14 +26,14 @@ func (s *deleteDBSuite) TestDeleteDBContentsOnEmptyDB(c *gc.C) {
 	runner := s.TxnRunner()
 
 	err := runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		return deleteDBContents(ctx, tx, testing.NewCheckLogger(c))
+		return deleteDBContents(ctx, tx, loggertesting.WrapCheckLog(c))
 	})
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *deleteDBSuite) TestDeleteDBContentsOnControllerDB(c *gc.C) {
 	runner, db := s.OpenDBForNamespace(c, "controller-foo", false)
-	logger := testing.NewCheckLogger(c)
+	logger := loggertesting.WrapCheckLog(c)
 
 	// This test isn't necessarily, as you can't delete the controller database
 	// contents, but adds more validation to the function.
@@ -53,7 +53,7 @@ func (s *deleteDBSuite) TestDeleteDBContentsOnControllerDB(c *gc.C) {
 func (s *deleteDBSuite) TestDeleteDBContentsOnModelDB(c *gc.C) {
 	runner, db := s.OpenDBForNamespace(c, "model-foo", false)
 
-	logger := testing.NewCheckLogger(c)
+	logger := loggertesting.WrapCheckLog(c)
 
 	err := database.NewDBMigration(
 		runner, logger, schema.ModelDDL()).Apply(context.Background())

--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -234,6 +234,11 @@ func (w *trackedDBWorker) Kill() {
 	w.tomb.Kill(nil)
 }
 
+// KillWithReason kills the worker with a particular reason.
+func (w *trackedDBWorker) KillWithReason(reason error) {
+	w.tomb.Kill(reason)
+}
+
 // Wait implements worker.Worker
 func (w *trackedDBWorker) Wait() error {
 	return w.tomb.Wait()

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+// Ensure that the trackedDBWorker is a killableWorker.
+var _ killableWorker = (*trackedDBWorker)(nil)
+
 type trackedDBWorkerSuite struct {
 	dbBaseSuite
 

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -128,7 +128,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDB(c *gc.C) {
 	s.expectClock()
 	defer s.expectTimer(1)()
 
-	s.timer.EXPECT().Reset(PollInterval).Times(1)
+	s.timer.EXPECT().Reset(gomock.Any()).Times(1)
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
 	var count uint64
@@ -158,7 +158,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceeds(c *gc.C) 
 	s.expectClock()
 	defer s.expectTimer(1)()
 
-	s.timer.EXPECT().Reset(PollInterval).Times(1)
+	s.timer.EXPECT().Reset(gomock.Any()).Times(1)
 
 	dbChange := make(chan struct{})
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil).Times(DefaultVerifyAttempts - 1)
@@ -202,7 +202,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBRepeatedly(c *gc.C) {
 	s.expectClock()
 	defer s.expectTimer(2)()
 
-	s.timer.EXPECT().Reset(PollInterval).Times(2)
+	s.timer.EXPECT().Reset(gomock.Any()).Times(2)
 
 	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
 
@@ -233,7 +233,7 @@ func (s *trackedDBWorkerSuite) TestWorkerAttemptsToVerifyDBButSucceedsWithDiffer
 	s.expectClock()
 	defer s.expectTimer(1)()
 
-	s.timer.EXPECT().Reset(PollInterval).Times(1)
+	s.timer.EXPECT().Reset(gomock.Any()).Times(1)
 
 	exp := s.dbApp.EXPECT()
 	gomock.InOrder(

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -225,11 +225,19 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 			// that case we do want to cause the dbaccessor to go down. This
 			// will then bring up a new dqlite app.
 			IsFatal: func(err error) bool {
+				// If a database is dead we should not kill the worker.
+				if errors.Is(err, database.ErrDBDead) {
+					return false
+				}
+
 				// If there is a rebind during starting up a worker the dbApp
 				// will be nil. In this case, we'll return ErrTryAgain. In this
 				// case we don't want to kill the worker. We'll force the
 				// worker to try again.
 				return !errors.Is(err, errTryAgain)
+			},
+			ShouldRestart: func(err error) bool {
+				return !errors.Is(err, database.ErrDBDead)
 			},
 			RestartDelay: time.Second * 10,
 			Logger:       cfg.Logger,
@@ -313,16 +321,6 @@ func (w *dbWorker) loop() (err error) {
 					continue
 				}
 			} else if req.op == delOp {
-				// Close the database for the namespace.
-				if err := w.closeDatabase(req.namespace); err != nil {
-					select {
-					case req.done <- errors.Annotatef(err, "closing database for namespace %q", req.namespace):
-					case <-w.catacomb.Dying():
-						return w.catacomb.ErrDying()
-					}
-					continue
-				}
-
 				if err := w.deleteDatabase(req.namespace); err != nil {
 					select {
 					case req.done <- errors.Annotatef(err, "deleting database for namespace %q", req.namespace):
@@ -688,20 +686,9 @@ func (w *dbWorker) openDatabase(namespace string) error {
 	return errors.Trace(err)
 }
 
-func (w *dbWorker) closeDatabase(namespace string) error {
-	if namespace == database.ControllerNS {
-		return errors.Forbiddenf("cannot close controller database")
-	}
-
-	// Stop and remove the worker.
-	// This will wait for the worker to stop, which will potentially block
-	// any requests to access a new db. This should be ok, as there isn't
-	// currently any heavy loop logic in the model workers.
-	if err := w.dbRunner.StopAndRemoveWorker(namespace, w.catacomb.Dying()); err != nil {
-		return errors.Annotatef(err, "stopping worker")
-	}
-
-	return nil
+type killableWorker interface {
+	worker.Worker
+	KillWithReason(error)
 }
 
 func (w *dbWorker) deleteDatabase(namespace string) error {
@@ -714,6 +701,25 @@ func (w *dbWorker) deleteDatabase(namespace string) error {
 	ctx, cancel := w.scopedContext()
 	defer cancel()
 
+	worker, err := w.workerFromCache(namespace)
+	if err != nil {
+		return errors.Trace(err)
+	} else if worker == nil {
+		return errors.NotFoundf("worker for namespace %q", namespace)
+	}
+
+	killable, ok := worker.(killableWorker)
+	if !ok {
+		return errors.Errorf("worker for namespace %q is not killable", namespace)
+	}
+
+	// Kill the worker and wait for it to die.
+	killable.KillWithReason(database.ErrDBDead)
+	if err := killable.Wait(); err != nil && !errors.Is(err, database.ErrDBDead) {
+		return errors.Annotatef(err, "waiting for worker to die")
+	}
+
+	// Open the database as we don't
 	db, err := w.dbApp.Open(ctx, namespace)
 	if err != nil {
 		return errors.Annotatef(err, "opening database for deletion")

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -225,7 +225,8 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 			// that case we do want to cause the dbaccessor to go down. This
 			// will then bring up a new dqlite app.
 			IsFatal: func(err error) bool {
-				// If a database is dead we should not kill the worker.
+				// If a database is dead we should not kill the worker of the
+				// runner.
 				if errors.Is(err, database.ErrDBDead) {
 					return false
 				}
@@ -719,7 +720,7 @@ func (w *dbWorker) deleteDatabase(namespace string) error {
 		return errors.Annotatef(err, "waiting for worker to die")
 	}
 
-	// Open the database as we don't
+	// Open the database directly as we can't use the worker to do it for us.
 	db, err := w.dbApp.Open(ctx, namespace)
 	if err != nil {
 		return errors.Annotatef(err, "opening database for deletion")

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -199,7 +199,7 @@ func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
 
 func (s *integrationSuite) TestWorkerDeletingControllerDB(c *gc.C) {
 	err := s.dbDeleter.DeleteDB(coredatabase.ControllerNS)
-	c.Assert(err, gc.ErrorMatches, `.*cannot close controller database`)
+	c.Assert(err, gc.ErrorMatches, `.*cannot delete controller database`)
 }
 
 func (s *integrationSuite) TestWorkerDeletingUnknownDB(c *gc.C) {

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -120,6 +120,9 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*objectStoreWorker
 			IsFatal: func(err error) bool {
 				return false
 			},
+			ShouldRestart: func(err error) bool {
+				return !errors.Is(err, database.ErrDBDead)
+			},
 			RestartDelay: time.Second * 10,
 			Logger:       cfg.Logger,
 		}),

--- a/internal/worker/providertracker/providerworker.go
+++ b/internal/worker/providertracker/providerworker.go
@@ -91,6 +91,9 @@ func newWorker(config Config, internalStates chan string) (*providerWorker, erro
 			IsFatal: func(err error) bool {
 				return false
 			},
+			ShouldRestart: func(err error) bool {
+				return !errors.Is(err, database.ErrDBDead)
+			},
 			RestartDelay: time.Second * 10,
 			Clock:        config.Clock,
 			Logger:       config.Logger,

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -332,6 +332,7 @@ func (s *ApiServerSuite) setupApiServer(c *gc.C, controllerCfg controller.Config
 	cfg := DefaultServerConfig(c, s.Clock)
 	cfg.Mux = s.mux
 	cfg.DBGetter = stubDBGetter{db: stubWatchableDB{TxnRunner: s.TxnRunner()}}
+	cfg.DBDeleter = stubDBDeleter{}
 	cfg.ServiceFactoryGetter = s.ServiceFactoryGetter(c)
 	cfg.StatePool = s.controller.StatePool()
 	cfg.PublicDNSName = controllerCfg.AutocertDNSName()
@@ -701,6 +702,12 @@ func (s stubDBGetter) GetWatchableDB(namespace string) (changestream.WatchableDB
 		return nil, errors.Errorf(`expected a request for "controller" DB; got %q`, namespace)
 	}
 	return s.db, nil
+}
+
+type stubDBDeleter struct{}
+
+func (s stubDBDeleter) DeleteDB(namespace string) error {
+	return nil
 }
 
 type stubTracerGetter struct{}

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -25,10 +25,10 @@ run_local_deploy() {
 	destroy_model "${model_name}"
 }
 
-run_charmstore_deploy() {
+run_charmhub_deploy() {
 	echo
 
-	model_name="test-charmstore-deploy"
+	model_name="test-charmhub-deploy"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
@@ -56,8 +56,8 @@ test_deploy() {
 
 		cd .. || exit
 
-		run "run_local_deploy"
-		run "run_charmstore_deploy"
+		#run "run_local_deploy"
+		run "run_charmhub_deploy"
 	)
 }
 


### PR DESCRIPTION
As we can't drop a database when a migration fails, we have to
delete the contents of the database. This includes all the schema
that was added to the database. The rationale for deleting the schema
is that, if you migrate src:A to dst:A, but that fails, and then you
perform an upgrade to dst via a patch release, there isn't a guarantee
that dst:A schema is completely updated. So removing everything leaves
us with a blank slate.

There have been thoughts around aliasing tables instead of a clean
slate, but this is fraught with danger if you accidentally write to
the wrong DB (i.e. the alias one).

In addition to this, we also can't clear the DB in one query, as we
get a segfault. The code batches up the statements, so we're not running
a query for every statement, but should be enough to prevent a
segfault.

The way that we drop everything from the db needs to happen in this
order to prevent constraint violations. In addition, we ensure that
the foreign key param is set to _false_ to also prevent any issues
in ordering of deletions.

We currently do not delete the model during a destroy-model
command, as that completely locks up the model. That will
have to be tackled later.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

## Apply patch

We need to apply this patch to ensure that the migration will fail:

```diff
diff --git a/domain/modelconfig/modelmigration/import.go b/domain/modelconfig/modelmigration/import.go
index 1cea5efeb4..13667a3481 100644
--- a/domain/modelconfig/modelmigration/import.go
+++ b/domain/modelconfig/modelmigration/import.go
@@ -5,6 +5,7 @@ package modelmigration

 import (
        "context"
+       "fmt"

        "github.com/juju/description/v5"
        "github.com/juju/errors"
@@ -61,6 +62,8 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
        attrs := model.Config()

+       return fmt.Errorf("BOOM")
+
        // If we don't have any model config, then there is something seriously
        // wrong. In this case, we should return an error.
        if len(attrs) == 0 {
```

##  Create the src:

```sh
$ juju bootstrap lxd src
$ juju add-model default
```

## Create the dst:

```sh
$ juju bootstrap lxd dst
$ juju switch src
$ juju migrate src:default dst
```

This should fail (check the logs).
Using the `juju models` command, find the default model-uuid, we'll need it later.

```sh
$ make repl-install
```

## Login to dqlite

Ensure to replace `<model-uuid>` with the valid one.

```sh
$ juju ssh -m dst:controller 0
$ sudo snap install yq
# Note we need to pipe indirection because of snap confinement.
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key <model-uuid>
> SELECT * FROM sqlite_master WHERE name NOT LIKE 'sqlite_%';
```

The result should be empty.

## Revert patch

Revert the patch and upgrade the src and dst controllers.

```sh
$ juju migrate src:default dst
```

Should succeed.

## Links

**Jira card:** [JUJU-5877](https://warthogs.atlassian.net/browse/JUJU-5877)



[JUJU-5877]: https://warthogs.atlassian.net/browse/JUJU-5877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ