### PR TITLE
Add state implementation for remote secret consumers

### DIFF
--- a/domain/secret/errors/errors.go
+++ b/domain/secret/errors/errors.go
@@ -12,6 +12,9 @@ const (
 	// does not exist.
 	SecretNotFound = errors.ConstError("secret not found")
 
+	// SecretIsNotLocal describes an error that occurs when a secret is not from the current model.
+	SecretIsNotLocal = errors.ConstError("secret is from a different model")
+
 	// SecretLabelAlreadyExists describes an error that occurs when there's already a secret label for
 	// a specified secret owner.
 	SecretLabelAlreadyExists = errors.ConstError("secret label already exists")

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -113,11 +113,27 @@ func (s *SecretService) ListGrantedSecrets(ctx context.Context, consumers ...Sec
 // UpdateRemoteConsumedRevision returns the latest revision for the specified secret,
 // updating the tracked revision for the specified consumer if refresh is true.
 func (s *SecretService) UpdateRemoteConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh bool) (int, error) {
-	return 1, nil
+	consumerInfo, latestRevision, err := s.st.GetSecretRemoteConsumer(ctx, uri, unitName)
+	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
+		return 0, errors.Trace(err)
+	}
+	refresh = refresh ||
+		err != nil // Not found, so need to create one.
+
+	if refresh {
+		if consumerInfo == nil {
+			consumerInfo = &secrets.SecretConsumerMetadata{}
+		}
+		consumerInfo.CurrentRevision = latestRevision
+		if err := s.st.SaveSecretRemoteConsumer(ctx, uri, unitName, consumerInfo); err != nil {
+			return 0, errors.Trace(err)
+		}
+	}
+	return latestRevision, nil
 }
 
 // UpdateRemoteSecretRevision records the specified revision for the secret
 // which has been consumed from a different model.
 func (s *SecretService) UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error {
-	return nil
+	return s.st.UpdateRemoteSecretRevision(ctx, uri, latestRevision)
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -40,6 +40,9 @@ type State interface {
 	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
 	GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error)
 	GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error)
+	GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
+	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error
 }
 
 // Logger facilitates emitting log messages.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -129,6 +129,22 @@ func (mr *MockStateMockRecorder) GetSecretConsumer(arg0, arg1, arg2 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockState)(nil).GetSecretConsumer), arg0, arg1, arg2)
 }
 
+// GetSecretRemoteConsumer mocks base method.
+func (m *MockState) GetSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretRemoteConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSecretRemoteConsumer indicates an expected call of GetSecretRemoteConsumer.
+func (mr *MockStateMockRecorder) GetSecretRemoteConsumer(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRemoteConsumer", reflect.TypeOf((*MockState)(nil).GetSecretRemoteConsumer), arg0, arg1, arg2)
+}
+
 // GetSecretRevision mocks base method.
 func (m *MockState) GetSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int) (*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
@@ -250,6 +266,34 @@ func (m *MockState) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, 
 func (mr *MockStateMockRecorder) SaveSecretConsumer(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockState)(nil).SaveSecretConsumer), arg0, arg1, arg2, arg3)
+}
+
+// SaveSecretRemoteConsumer mocks base method.
+func (m *MockState) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSecretRemoteConsumer", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSecretRemoteConsumer indicates an expected call of SaveSecretRemoteConsumer.
+func (mr *MockStateMockRecorder) SaveSecretRemoteConsumer(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretRemoteConsumer", reflect.TypeOf((*MockState)(nil).SaveSecretRemoteConsumer), arg0, arg1, arg2, arg3)
+}
+
+// UpdateRemoteSecretRevision mocks base method.
+func (m *MockState) UpdateRemoteSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRemoteSecretRevision indicates an expected call of UpdateRemoteSecretRevision.
+func (mr *MockStateMockRecorder) UpdateRemoteSecretRevision(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockState)(nil).UpdateRemoteSecretRevision), arg0, arg1, arg2)
 }
 
 // UpdateSecret mocks base method.

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -120,6 +120,17 @@ type secretUnitConsumer struct {
 	CurrentRevision int    `db:"current_revision"`
 }
 
+type secretRemoteUnitConsumer struct {
+	UnitID          string `db:"unit_id"`
+	SecretID        string `db:"secret_id"`
+	CurrentRevision int    `db:"current_revision"`
+}
+
+type remoteSecret struct {
+	SecretID       string `db:"secret_id"`
+	LatestRevision int    `db:"latest_revision"`
+}
+
 type secrets []secretInfo
 
 func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
@@ -190,6 +201,18 @@ func (rows secretValues) toSecretData() (coresecrets.SecretData, error) {
 	result := make(coresecrets.SecretData)
 	for _, row := range rows {
 		result[row.Name] = row.Content
+	}
+	return result, nil
+}
+
+type secretRemoteUnitConsumers []secretRemoteUnitConsumer
+
+func (rows secretRemoteUnitConsumers) toSecretConsumers() ([]*coresecrets.SecretConsumerMetadata, error) {
+	result := make([]*coresecrets.SecretConsumerMetadata, len(rows))
+	for i, row := range rows {
+		result[i] = &coresecrets.SecretConsumerMetadata{
+			CurrentRevision: row.CurrentRevision,
+		}
 	}
 	return result, nil
 }


### PR DESCRIPTION
The state implementation is done for the secret service methods dealing with cross model secrets.

As well, the method to mark secret revisions as obsolete is called from all the places where it's needed - when a secret is updated and when a consumer record is updated.

The check for local secrets is improved to return the local status, since this is needed when updating a consumer record and looking up the latest secret revision - it may be a local revision or a remote one.

## QA steps

end to end not done yet, so just unit tests

## Links

**Jira card:** JUJU-5876

