### PR TITLE
Add DDL to support secret permission access and roles

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/secretsmanager"
 	"github.com/juju/juju/apiserver/facades/agent/secretsmanager/mocks"
 	"github.com/juju/juju/core/leadership"
-	"github.com/juju/juju/core/permission"
 	coresecrets "github.com/juju/juju/core/secrets"
 	corewatcher "github.com/juju/juju/core/watcher"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
@@ -1451,8 +1450,8 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 	}, nil).AnyTimes()
 	s.secretsConsumer.EXPECT().GrantSecretAccess(gomock.Any(), uri, secretservice.SecretAccessParams{
 		LeaderToken: s.token,
-		Scope:       permission.ID{ObjectType: permission.Relation, Key: "wordpress:db mysql:server"},
-		Subject:     permission.ID{ObjectType: permission.Unit, Key: "wordpress/0"},
+		Scope:       secretservice.SecretAccessScope{Kind: secretservice.RelationAccessScope, ID: "wordpress:db mysql:server"},
+		Subject:     secretservice.SecretAccessor{Kind: secretservice.UnitAccessor, ID: "wordpress/0"},
 		Role:        coresecrets.RoleView,
 	}).Return(errors.New("boom"))
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
@@ -1495,8 +1494,8 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 	}, nil).AnyTimes()
 	s.secretsConsumer.EXPECT().RevokeSecretAccess(gomock.Any(), uri, secretservice.SecretAccessParams{
 		LeaderToken: s.token,
-		Scope:       permission.ID{ObjectType: permission.Relation, Key: "wordpress:db mysql:server"},
-		Subject:     permission.ID{ObjectType: permission.Unit, Key: "wordpress/0"},
+		Scope:       secretservice.SecretAccessScope{Kind: secretservice.RelationAccessScope, ID: "wordpress:db mysql:server"},
+		Subject:     secretservice.SecretAccessor{Kind: secretservice.UnitAccessor, ID: "wordpress/0"},
 		Role:        coresecrets.RoleView,
 	}).Return(errors.New("boom"))
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -520,8 +520,8 @@ func (s *SecretsAPI) secretsGrantRevoke(ctx context.Context, arg params.GrantRev
 
 	one := func(appName string) error {
 		if err := op(ctx, uri, secretservice.SecretAccessParams{
-			Scope:   permission.ID{ObjectType: permission.Model, Key: s.modelUUID},
-			Subject: permission.ID{ObjectType: permission.Application, Key: appName},
+			Scope:   secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: s.modelUUID},
+			Subject: secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: appName},
 			Role:    coresecrets.RoleView,
 		}); err != nil {
 			return errors.Annotatef(err, "cannot change access to %q for %q", uri, appName)

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -71,6 +71,8 @@ func (s *SecretsAPI) checkCanAdmin() error {
 }
 
 // ListSecrets lists available secrets.
+// If args specifies secret owners, then only charm secrets are queried because user secret don't have owners as such.
+// If no owners are specified, we use the more generic list method when returns all types of secret.
 func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs) (params.ListSecretResults, error) {
 	result := params.ListSecretResults{}
 	if arg.ShowSecrets {

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -615,8 +615,10 @@ func (s *SecretsSuite) TestGrantSecret(c *gc.C) {
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "gitlab"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -624,8 +626,10 @@ func (s *SecretsSuite) TestGrantSecret(c *gc.C) {
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "mysql"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -660,8 +664,10 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "gitlab"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -669,8 +675,10 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "mysql"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -719,8 +727,10 @@ func (s *SecretsSuite) TestRevokeSecret(c *gc.C) {
 	s.secretService.EXPECT().RevokeSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "gitlab"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -728,8 +738,10 @@ func (s *SecretsSuite) TestRevokeSecret(c *gc.C) {
 	s.secretService.EXPECT().RevokeSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
 			c.Assert(arg, gc.DeepEquals, uri)
-			c.Assert(params.Scope, jc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: coretesting.ModelTag.Id()})
-			c.Assert(params.Subject, jc.DeepEquals, permission.ID{ObjectType: permission.Application, Key: "mysql"})
+			c.Assert(params.Scope, jc.DeepEquals,
+				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+			c.Assert(params.Subject, jc.DeepEquals,
+				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, gc.Equals, coresecrets.RoleView)
 			return nil
 		},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34219,7 +34219,7 @@
                             "$ref": "#/definitions/ListSecretResults"
                         }
                     },
-                    "description": "ListSecrets lists available secrets."
+                    "description": "ListSecrets lists available secrets.\nIf args specifies secret owners, then only charm secrets are queried because user secret don't have owners as such.\nIf no owners are specified, we use the more generic list method when returns all types of secret."
                 },
                 "RemoveSecrets": {
                     "type": "object",

--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -76,20 +76,17 @@ type ObjectType string
 
 // These values must match the values in the permission_object_type table.
 const (
-	Cloud       ObjectType = "cloud"
-	Controller  ObjectType = "controller"
-	Model       ObjectType = "model"
-	Offer       ObjectType = "offer"
-	Application ObjectType = "application"
-	Unit        ObjectType = "unit"
-	Relation    ObjectType = "relation"
+	Cloud      ObjectType = "cloud"
+	Controller ObjectType = "controller"
+	Model      ObjectType = "model"
+	Offer      ObjectType = "offer"
 )
 
 // Validate returns an error if the object type is not in the
 // list of valid object types above.
 func (o ObjectType) Validate() error {
 	switch o {
-	case Cloud, Controller, Model, Offer, Application, Unit, Relation:
+	case Cloud, Controller, Model, Offer:
 	default:
 		return errors.NotValidf("object type %q", o)
 	}

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -66,6 +66,11 @@ func ModelDDL() *schema.Schema {
 			"secret_revision_expire", "revision_uuid", "expire_time", tableSecretRevisionExpire),
 
 		triggersForImmutableTable("model", "", "model table is immutable"),
+
+		// Secret permissions do not allow subject or scope to be updated.
+		triggersForImmutableTableUpdates("secret_permission",
+			"OLD.subject_type_id <> NEW.subject_type_id OR OLD.scope_uuid <> NEW.scope_uuid OR OLD.scope_type_id <> NEW.scope_type_id",
+			"secret permission subjects and scopes are immutable"),
 	)
 
 	patches = append(patches,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -298,6 +298,8 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"secret_remote_unit_consumer",
 		"secret_permission",
 		"secret_role",
+		"secret_grant_subject_type",
+		"secret_grant_scope_type",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "table"), jc.SameContents, expected.Union(internalTableNames).SortedValues())
 }
@@ -421,6 +423,8 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_storage_volume_insert",
 		"trg_log_storage_volume_update",
 		"trg_log_storage_volume_delete",
+
+		"trg_secret_permission_immutable_update",
 	)
 
 	// These are additional triggers that are not change log triggers, but

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -12,85 +12,80 @@ func secretBackendSchema() schema.Patch {
 	return schema.MakePatch(`
 -- Controller database tables for secret backends.
 
-CREATE TABLE
-    secret_backend_type (
-        id INT PRIMARY KEY,
-        type TEXT NOT NULL,
-        description TEXT,
-        CONSTRAINT chk_empty_type
-            CHECK(type != ''),
-        CONSTRAINT uniq_secret_backend_type_type
-            UNIQUE(type)
-    );
+CREATE TABLE secret_backend_type (
+    id INT PRIMARY KEY,
+    type TEXT NOT NULL,
+    description TEXT,
+    CONSTRAINT chk_empty_type
+        CHECK(type != ''),
+    CONSTRAINT uniq_secret_backend_type_type
+        UNIQUE(type)
+);
 
 INSERT INTO secret_backend_type VALUES
     (0, 'internal', 'the juju internal secret backend'),
     (1, 'vault', 'the vault secret backend'),
     (2, 'kubernetes', 'the kubernetes secret backend');
 
-CREATE TABLE
-    secret_backend (
-        uuid TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        backend_type TEXT NOT NULL,
-        token_rotate_interval INT,
-        CONSTRAINT chk_empty_name
-            CHECK(name != ''),
-        CONSTRAINT fk_secret_backend_type
-            FOREIGN KEY (backend_type)
-            REFERENCES secret_backend_type (type)
-    );
+CREATE TABLE secret_backend (
+    uuid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    backend_type TEXT NOT NULL,
+    token_rotate_interval INT,
+    CONSTRAINT chk_empty_name
+        CHECK(name != ''),
+    CONSTRAINT fk_secret_backend_type
+        FOREIGN KEY (backend_type)
+        REFERENCES secret_backend_type (type)
+);
 
 CREATE UNIQUE INDEX idx_secret_backend_name ON secret_backend (name);
 
-CREATE TABLE
-    secret_backend_config (
-        backend_uuid TEXT NOT NULL,
-        name TEXT NOT NULL,
-        content TEXT NOT NULL,
-        CONSTRAINT chk_empty_name
-            CHECK(name != ''),
-        CONSTRAINT chk_empty_content
-            CHECK(content != ''),
-        CONSTRAINT pk_secret_backend_config
-            PRIMARY KEY (backend_uuid, name),
-        CONSTRAINT fk_secret_backend_config_backend_uuid
-            FOREIGN KEY (backend_uuid)
-            REFERENCES secret_backend (uuid)
-    );
+CREATE TABLE secret_backend_config (
+    backend_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    CONSTRAINT chk_empty_name
+        CHECK(name != ''),
+    CONSTRAINT chk_empty_content
+        CHECK(content != ''),
+    CONSTRAINT pk_secret_backend_config
+        PRIMARY KEY (backend_uuid, name),
+    CONSTRAINT fk_secret_backend_config_backend_uuid
+        FOREIGN KEY (backend_uuid)
+        REFERENCES secret_backend (uuid)
+);
 
-CREATE TABLE
-    secret_backend_rotation (
-        backend_uuid TEXT PRIMARY KEY,
-        next_rotation_time DATETIME NOT NULL,
-        CONSTRAINT fk_secret_backend_rotation_secret_backend_uuid
-            FOREIGN KEY (backend_uuid)
-            REFERENCES secret_backend (uuid)
-    );
+CREATE TABLE secret_backend_rotation (
+    backend_uuid TEXT PRIMARY KEY,
+    next_rotation_time DATETIME NOT NULL,
+    CONSTRAINT fk_secret_backend_rotation_secret_backend_uuid
+        FOREIGN KEY (backend_uuid)
+        REFERENCES secret_backend (uuid)
+);
 
-CREATE TABLE
-    model_secret_backend (
-        model_uuid TEXT PRIMARY KEY,
-        -- TODO: change the secret_backend_uuid to NOT NULL once we start to insert the
-        -- internal and kubernetes secret backends into the secret_backend table.
-        secret_backend_uuid TEXT,
-        CONSTRAINT fk_model_secret_backend_model_uuid
-            FOREIGN KEY (model_uuid)
-            REFERENCES model_list (uuid),
-        CONSTRAINT fk_model_secret_backend_secret_backend_uuid
-            FOREIGN KEY (secret_backend_uuid)
-            REFERENCES secret_backend (uuid)
-    );
+CREATE TABLE model_secret_backend (
+    model_uuid TEXT PRIMARY KEY,
+    -- TODO: change the secret_backend_uuid to NOT NULL once we start to insert the
+    -- internal and kubernetes secret backends into the secret_backend table.
+    secret_backend_uuid TEXT,
+    CONSTRAINT fk_model_secret_backend_model_uuid
+        FOREIGN KEY (model_uuid)
+        REFERENCES model_list (uuid),
+    CONSTRAINT fk_model_secret_backend_secret_backend_uuid
+        FOREIGN KEY (secret_backend_uuid)
+        REFERENCES secret_backend (uuid)
+);
 
 CREATE VIEW v_model_secret_backend AS
-    SELECT
-        msb.model_uuid AS uuid,
-        mm.name,
-        mt.type,
-        msb.secret_backend_uuid
-    FROM model_secret_backend msb
-    INNER JOIN model_metadata mm ON msb.model_uuid = mm.model_uuid
-    INNER JOIN model_type mt ON mm.model_type_id = mt.id;
+SELECT
+    msb.model_uuid AS uuid,
+    mm.name,
+    mt.type,
+    msb.secret_backend_uuid
+FROM model_secret_backend msb
+INNER JOIN model_metadata mm ON msb.model_uuid = mm.model_uuid
+INNER JOIN model_type mt ON mm.model_type_id = mt.id;
 `)
 }
 
@@ -99,13 +94,12 @@ func secretSchema() schema.Patch {
 	return schema.MakePatch(`
 -- Model database tables for secrets.
 
-CREATE TABLE
-    secret_rotate_policy (
-        id INT PRIMARY KEY,
-        policy TEXT NOT NULL,
-        CONSTRAINT chk_empty_policy
-            CHECK(policy != '')
-    );
+CREATE TABLE secret_rotate_policy (
+    id INT PRIMARY KEY,
+    policy TEXT NOT NULL,
+    CONSTRAINT chk_empty_policy
+        CHECK(policy != '')
+);
 
 CREATE UNIQUE INDEX idx_secret_rotate_policy_policy ON secret_rotate_policy (policy);
 
@@ -118,193 +112,179 @@ INSERT INTO secret_rotate_policy VALUES
     (5, 'quarterly'),
     (6, 'yearly');
 
-CREATE TABLE
-    secret (
-        id TEXT PRIMARY KEY
-    );
+CREATE TABLE secret (
+    id TEXT PRIMARY KEY
+);
 
-CREATE TABLE
-    -- secret_reference stores details about
-    -- secrets hosted by another model and
-    -- is used on the consumer side of cross
-    -- model secrets.
-    secret_reference (
-        secret_id TEXT PRIMARY KEY,
-        latest_revision INT NOT NULL,
-        CONSTRAINT fk_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id)
-    );
+-- secret_reference stores details about
+-- secrets hosted by another model and
+-- is used on the consumer side of cross
+-- model secrets.
+CREATE TABLE secret_reference (
+    secret_id TEXT PRIMARY KEY,
+    latest_revision INT NOT NULL,
+    CONSTRAINT fk_secret_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret (id)
+);
 
-CREATE TABLE
-    secret_metadata (
-        secret_id TEXT PRIMARY KEY,
-        version INT NOT NULL,
-        description TEXT,
-        rotate_policy_id INT NOT NULL,
-        auto_prune BOOLEAN NOT NULL DEFAULT (FALSE),
-        create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-        update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-        CONSTRAINT fk_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id),
-        CONSTRAINT fk_secret_rotate_policy
-            FOREIGN KEY (rotate_policy_id)
-            REFERENCES secret_rotate_policy (id)
-    );
+CREATE TABLE secret_metadata (
+    secret_id TEXT PRIMARY KEY,
+    version INT NOT NULL,
+    description TEXT,
+    rotate_policy_id INT NOT NULL,
+    auto_prune BOOLEAN NOT NULL DEFAULT (FALSE),
+    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    CONSTRAINT fk_secret_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret (id),
+    CONSTRAINT fk_secret_rotate_policy
+        FOREIGN KEY (rotate_policy_id)
+        REFERENCES secret_rotate_policy (id)
+);
 
-CREATE TABLE
-    secret_rotation (
-        secret_id TEXT PRIMARY KEY,
-        next_rotation_time DATETIME NOT NULL,
-        CONSTRAINT fk_secret_rotation_secret_metadata_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id)
-    );
+CREATE TABLE secret_rotation (
+    secret_id TEXT PRIMARY KEY,
+    next_rotation_time DATETIME NOT NULL,
+    CONSTRAINT fk_secret_rotation_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id)
+);
 
 -- 1:1
-CREATE TABLE
-    secret_value_ref (
-        revision_uuid TEXT PRIMARY KEY,
-        -- backend_uuid is the UUID of the backend in the controller database.
-        backend_uuid TEXT NOT NULL,
-        revision_id TEXT NOT NULL,
-        CONSTRAINT fk_secret_value_ref_secret_revision_uuid
-            FOREIGN KEY (revision_uuid)
-            REFERENCES secret_revision (uuid)
-    );
+CREATE TABLE secret_value_ref (
+    revision_uuid TEXT PRIMARY KEY,
+    -- backend_uuid is the UUID of the backend in the controller database.
+    backend_uuid TEXT NOT NULL,
+    revision_id TEXT NOT NULL,
+    CONSTRAINT fk_secret_value_ref_secret_revision_uuid
+        FOREIGN KEY (revision_uuid)
+        REFERENCES secret_revision (uuid)
+);
 
 -- 1:many
-CREATE TABLE
-    secret_content (
-        revision_uuid TEXT NOT NULL,
-        name TEXT NOT NULL,
-        content TEXT NOT NULL,
-        CONSTRAINT chk_empty_name
-            CHECK(name != ''),
-        CONSTRAINT chk_empty_content
-            CHECK(content != ''),
-        CONSTRAINT pk_secret_content_revision_uuid_name
-            PRIMARY KEY (revision_uuid,name),
-        CONSTRAINT fk_secret_content_secret_revision_uuid
-            FOREIGN KEY (revision_uuid)
-            REFERENCES secret_revision (uuid)
-    );
+CREATE TABLE secret_content (
+    revision_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    CONSTRAINT chk_empty_name
+        CHECK(name != ''),
+    CONSTRAINT chk_empty_content
+        CHECK(content != ''),
+    CONSTRAINT pk_secret_content_revision_uuid_name
+        PRIMARY KEY (revision_uuid,name),
+    CONSTRAINT fk_secret_content_secret_revision_uuid
+        FOREIGN KEY (revision_uuid)
+        REFERENCES secret_revision (uuid)
+);
 
 CREATE INDEX idx_secret_content_revision_uuid ON secret_content (revision_uuid);
 
-CREATE TABLE
-    secret_revision (
-        uuid TEXT PRIMARY KEY,
-        secret_id TEXT NOT NULL,
-        revision INT NOT NULL,
-        obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
-        -- pending_delete is true if the revision is to be deleted.
-        -- It will not be drained to a new active backend.
-        pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
-        create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-        update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-        CONSTRAINT fk_secret_revision_secret_metadata_id 
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id)
-    );
+CREATE TABLE secret_revision (
+    uuid TEXT PRIMARY KEY,
+    secret_id TEXT NOT NULL,
+    revision INT NOT NULL,
+    obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
+    -- pending_delete is true if the revision is to be deleted.
+    -- It will not be drained to a new active backend.
+    pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
+    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    CONSTRAINT fk_secret_revision_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id)
+);
 
 CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision ON secret_revision (secret_id,revision);
 
-CREATE TABLE
-    secret_revision_expire (
-        revision_uuid TEXT PRIMARY KEY,
-        expire_time DATETIME NOT NULL,
-        CONSTRAINT fk_secret_revision_expire_revision_uuid
-            FOREIGN KEY (revision_uuid)
-            REFERENCES secret_revision (uuid)
-    );
+CREATE TABLE secret_revision_expire (
+    revision_uuid TEXT PRIMARY KEY,
+    expire_time DATETIME NOT NULL,
+    CONSTRAINT fk_secret_revision_expire_revision_uuid
+        FOREIGN KEY (revision_uuid)
+        REFERENCES secret_revision (uuid)
+);
 
-CREATE TABLE
-    secret_application_owner (
-        secret_id TEXT NOT NULL,
-        application_uuid TEXT NOT NULL,
-        label TEXT,
-        CONSTRAINT fk_secret_application_owner_secret_metadata_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id),
-        CONSTRAINT fk_secret_application_owner_application_uuid
-            FOREIGN KEY (application_uuid)
-            REFERENCES application (uuid)
-        PRIMARY KEY (secret_id, application_uuid)
-    );
+CREATE TABLE secret_application_owner (
+    secret_id TEXT NOT NULL,
+    application_uuid TEXT NOT NULL,
+    label TEXT,
+    CONSTRAINT fk_secret_application_owner_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id),
+    CONSTRAINT fk_secret_application_owner_application_uuid
+        FOREIGN KEY (application_uuid)
+        REFERENCES application (uuid)
+    PRIMARY KEY (secret_id, application_uuid)
+);
 
 CREATE INDEX idx_secret_application_owner_secret_id ON secret_application_owner (secret_id);
 -- We need to ensure the label is unique per the application.
 CREATE UNIQUE INDEX idx_secret_application_owner_label ON secret_application_owner (label,application_uuid) WHERE label != '';
 
-CREATE TABLE
-    secret_unit_owner (
-        secret_id TEXT NOT NULL,
-        unit_uuid TEXT NOT NULL,
-        label TEXT,
-        CONSTRAINT fk_secret_unit_owner_secret_metadata_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id),
-        CONSTRAINT fk_secret_unit_owner_unit_uuid
-            FOREIGN KEY (unit_uuid)
-            REFERENCES unit (uuid)
-        PRIMARY KEY (secret_id, unit_uuid)
-    );
+CREATE TABLE secret_unit_owner (
+    secret_id TEXT NOT NULL,
+    unit_uuid TEXT NOT NULL,
+    label TEXT,
+    CONSTRAINT fk_secret_unit_owner_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id),
+    CONSTRAINT fk_secret_unit_owner_unit_uuid
+        FOREIGN KEY (unit_uuid)
+        REFERENCES unit (uuid)
+    PRIMARY KEY (secret_id, unit_uuid)
+);
 
 CREATE INDEX idx_secret_unit_owner_secret_id ON secret_unit_owner (secret_id);
 -- We need to ensure the label is unique per unit.
 CREATE UNIQUE INDEX idx_secret_unit_owner_label ON secret_unit_owner (label,unit_uuid) WHERE label != '';
 
-CREATE TABLE
-    secret_model_owner (
-        secret_id TEXT PRIMARY KEY,
-        label TEXT,
-        CONSTRAINT fk_secret_model_owner_secret_metadata_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id)
-    );
+CREATE TABLE secret_model_owner (
+    secret_id TEXT PRIMARY KEY,
+    label TEXT,
+    CONSTRAINT fk_secret_model_owner_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id)
+);
 
 CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label) WHERE label != '';
 
-CREATE TABLE
-    secret_unit_consumer (
-        secret_id TEXT NOT NULL,
-        unit_uuid TEXT NOT NULL,
-        label TEXT,
-        current_revision INT NOT NULL, 
-        CONSTRAINT fk_secret_unit_consumer_unit_uuid
-            FOREIGN KEY (unit_uuid)
-            REFERENCES unit (uuid),
-        CONSTRAINT fk_secret_model_owner_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret (id)
-    );
+CREATE TABLE secret_unit_consumer (
+    secret_id TEXT NOT NULL,
+    unit_uuid TEXT NOT NULL,
+    label TEXT,
+    current_revision INT NOT NULL,
+    CONSTRAINT fk_secret_unit_consumer_unit_uuid
+        FOREIGN KEY (unit_uuid)
+        REFERENCES unit (uuid),
+    CONSTRAINT fk_secret_model_owner_secret_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret (id)
+);
 
 CREATE UNIQUE INDEX idx_secret_unit_consumer_secret_id_unit_uuid ON secret_unit_consumer (secret_id,unit_uuid);
 CREATE UNIQUE INDEX idx_secret_unit_consumer_label ON secret_unit_consumer (label,unit_uuid) WHERE label != '';
 
-CREATE TABLE
-    -- This table records the tracked revisions from
-    -- units in the consuming model for cross model secrets.
-    secret_remote_unit_consumer (
-        secret_id TEXT NOT NULL,
-        -- unit_id is the anonymised name of the unit
-        -- from the consuming model.
-        unit_id TEXT NOT NULL,
-        current_revision INT NOT NULL,
-        CONSTRAINT fk_secret_remote_unit_consumer_secret_metadata_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id)
-    );
+-- This table records the tracked revisions from
+-- units in the consuming model for cross model secrets.
+CREATE TABLE secret_remote_unit_consumer (
+    secret_id TEXT NOT NULL,
+    -- unit_id is the anonymised name of the unit
+    -- from the consuming model.
+    unit_id TEXT NOT NULL,
+    current_revision INT NOT NULL,
+    CONSTRAINT fk_secret_remote_unit_consumer_secret_metadata_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id)
+);
 
 CREATE UNIQUE INDEX idx_secret_remote_unit_consumer_secret_id_unit_id ON secret_remote_unit_consumer (secret_id,unit_id);
 
-CREATE TABLE
-    secret_role (
-        id INT PRIMARY KEY,
-        role TEXT
-    );
+CREATE TABLE secret_role (
+    id INT PRIMARY KEY,
+    role TEXT
+);
 
 CREATE UNIQUE INDEX idx_secret_role_role ON secret_role (role);
 
@@ -313,22 +293,21 @@ INSERT INTO secret_role VALUES
     (1, 'view'),
     (2, 'manage');
 
-CREATE TABLE
-    secret_grant_subject_type (
-        id   INT PRIMARY KEY,
-        type TEXT
-    );
+CREATE TABLE secret_grant_subject_type (
+    id   INT PRIMARY KEY,
+    type TEXT
+);
 
 INSERT INTO secret_grant_subject_type VALUES
     (0, 'unit'),
     (1, 'application'),
-    (2, 'model');
+    (2, 'model'),
+    (3, 'remote-application');
 
-CREATE TABLE
-    secret_grant_scope_type (
-        id   INT PRIMARY KEY,
-        type TEXT
-    );
+CREATE TABLE secret_grant_scope_type (
+    id   INT PRIMARY KEY,
+    type TEXT
+);
 
 INSERT INTO secret_grant_scope_type VALUES
     (0, 'unit'),
@@ -336,59 +315,60 @@ INSERT INTO secret_grant_scope_type VALUES
     (2, 'model'),
     (3, 'relation');
 
-CREATE TABLE
-    secret_permission (
-        secret_id TEXT NOT NULL,
-        role_id INT NOT NULL,
-        -- subject_uuid is the entity which  
-        -- has been granted access to a secret.  
-        -- It will be an application, unit, or model uuid.  
-        subject_uuid TEXT NOT NULL,
-        subject_type_id INT NOT NULL,
-        -- scope_uuid is the entity which  
-        -- defines the scope of the grant.  
-        -- It will be an application, unit, relation, or model uuid.  
-        scope_uuid TEXT NOT NULL,
-        scope_type_id TEXT NOT NULL,
-        CONSTRAINT pk_secret_permission_secret_id_subject_uuid
-            PRIMARY KEY (secret_id,subject_uuid),
-        CONSTRAINT chk_empty_scope_uuid
-            CHECK(scope_uuid != ''),
-        CONSTRAINT chk_empty_subject_uuid
-            CHECK(subject_uuid != ''),
-        CONSTRAINT fk_secret_permission_secret_id
-            FOREIGN KEY (secret_id)
-            REFERENCES secret_metadata (secret_id),
-        CONSTRAINT fk_secret_permission_secret_role_id
-            FOREIGN KEY (role_id)
-            REFERENCES secret_role (id),
-        CONSTRAINT fk_secret_permission_secret_grant_subject_type_id
-            FOREIGN KEY (subject_type_id)
-            REFERENCES secret_grant_subject_type (id),
-        CONSTRAINT fk_secret_permission_secret_grant_scope_type_id
-            FOREIGN KEY (scope_type_id)
-            REFERENCES secret_grant_scope_type (id)
-    );
+CREATE TABLE secret_permission (
+    secret_id TEXT NOT NULL,
+    role_id INT NOT NULL,
+    -- subject_uuid is the entity which
+    -- has been granted access to a secret.
+    -- It will be an application, unit, or model uuid.
+    subject_uuid TEXT NOT NULL,
+    subject_type_id INT NOT NULL,
+    -- scope_uuid is the entity which
+    -- defines the scope of the grant.
+    -- It will be an application, unit, relation, or model uuid.
+    scope_uuid TEXT NOT NULL,
+    scope_type_id TEXT NOT NULL,
+    CONSTRAINT pk_secret_permission_secret_id_subject_uuid
+        PRIMARY KEY (secret_id,subject_uuid),
+    CONSTRAINT chk_empty_scope_uuid
+        CHECK(scope_uuid != ''),
+    CONSTRAINT chk_empty_subject_uuid
+        CHECK(subject_uuid != ''),
+    CONSTRAINT fk_secret_permission_secret_id
+        FOREIGN KEY (secret_id)
+        REFERENCES secret_metadata (secret_id),
+    CONSTRAINT fk_secret_permission_secret_role_id
+        FOREIGN KEY (role_id)
+        REFERENCES secret_role (id),
+    CONSTRAINT fk_secret_permission_secret_grant_subject_type_id
+        FOREIGN KEY (subject_type_id)
+        REFERENCES secret_grant_subject_type (id),
+    CONSTRAINT fk_secret_permission_secret_grant_scope_type_id
+        FOREIGN KEY (scope_type_id)
+        REFERENCES secret_grant_scope_type (id)
+);
 
 CREATE INDEX idx_secret_permission_secret_id ON secret_permission (secret_id);
 CREATE INDEX idx_secret_permission_subject_uuid_subject_type_id ON secret_permission (subject_uuid,subject_type_id);
 
 CREATE VIEW v_secret_permission AS
-  SELECT secret_id, role_id, subject_type_id, scope_type_id,
-  -- subject_id is the natural id of the subject entity (uuid for model)
-  (CASE
-    WHEN sp.subject_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.subject_uuid)
-    WHEN sp.subject_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.subject_uuid) 
-    WHEN sp.subject_type_id = 2 THEN (SELECT uuid FROM model) 
-  END) AS subject_id,
-  -- scope_id is the natural id of the scope entity (uuid for model)
-  (CASE
-    WHEN sp.scope_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.scope_uuid)
-    WHEN sp.scope_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.scope_uuid) 
-    WHEN sp.scope_type_id = 2 THEN (SELECT uuid FROM model)
-    -- TODO: we don't have a relation table yet
-    WHEN sp.scope_type_id = 3 THEN sp.scope_uuid 
-  END) AS scope_id
-  FROM   secret_permission sp;
+SELECT secret_id, role_id, subject_type_id, scope_type_id,
+-- subject_id is the natural id of the subject entity (uuid for model)
+(CASE
+WHEN sp.subject_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.subject_uuid)
+WHEN sp.subject_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.subject_uuid)
+WHEN sp.subject_type_id = 2 THEN (SELECT uuid FROM model)
+-- TODO: we don't have a remote-application table yet
+WHEN sp.subject_type_id = 3 THEN sp.subject_uuid
+END) AS subject_id,
+-- scope_id is the natural id of the scope entity (uuid for model)
+(CASE
+WHEN sp.scope_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.scope_uuid)
+WHEN sp.scope_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.scope_uuid)
+WHEN sp.scope_type_id = 2 THEN (SELECT uuid FROM model)
+-- TODO: we don't have a relation table yet
+WHEN sp.scope_type_id = 3 THEN sp.scope_uuid
+END) AS scope_id
+FROM   secret_permission sp;
 `)
 }

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -355,20 +355,25 @@ CREATE VIEW v_secret_permission AS
 SELECT secret_id, role_id, subject_type_id, scope_type_id,
 -- subject_id is the natural id of the subject entity (uuid for model)
 (CASE
-WHEN sp.subject_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.subject_uuid)
-WHEN sp.subject_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.subject_uuid)
-WHEN sp.subject_type_id = 2 THEN (SELECT uuid FROM model)
+WHEN sp.subject_type_id = 0 THEN suu.unit_id
+WHEN sp.subject_type_id = 1 THEN sua.name
+WHEN sp.subject_type_id = 2 THEN m.uuid
 -- TODO: we don't have a remote-application table yet
 WHEN sp.subject_type_id = 3 THEN sp.subject_uuid
 END) AS subject_id,
 -- scope_id is the natural id of the scope entity (uuid for model)
 (CASE
-WHEN sp.scope_type_id = 0 THEN (SELECT unit_id FROM unit WHERE unit.uuid = sp.scope_uuid)
-WHEN sp.scope_type_id = 1 THEN (SELECT name FROM application WHERE application.uuid = sp.scope_uuid)
-WHEN sp.scope_type_id = 2 THEN (SELECT uuid FROM model)
+WHEN sp.scope_type_id = 0 THEN scu.unit_id
+WHEN sp.scope_type_id = 1 THEN sca.name
+WHEN sp.scope_type_id = 2 THEN m.uuid
 -- TODO: we don't have a relation table yet
 WHEN sp.scope_type_id = 3 THEN sp.scope_uuid
 END) AS scope_id
-FROM   secret_permission sp;
+FROM secret_permission sp
+LEFT JOIN unit suu ON suu.uuid = sp.subject_uuid
+LEFT JOIN application sua ON sua.uuid = sp.subject_uuid
+LEFT JOIN unit scu ON scu.uuid = sp.scope_uuid
+LEFT JOIN application sca ON sca.uuid = sp.scope_uuid
+JOIN model m;
 `)
 }

--- a/domain/schema/triggers.go
+++ b/domain/schema/triggers.go
@@ -39,3 +39,26 @@ CREATE TRIGGER trg_%[1]s_immutable_delete
 		return schema.MakePatch(stmt)
 	}
 }
+
+// triggersForImmutableTableUpdates returns a function that creates triggers to prevent updates
+// on the given table when the specified condition is met.
+// The tableName is the name of the table to create the triggers for.
+// The condition is an optional SQL condition that must be met for the trigger to be executed.
+// The errMsg is the error message that will be returned if the trigger is fired.
+func triggersForImmutableTableUpdates(tableName, condition, errMsg string) func() schema.Patch {
+	if condition != "" {
+		condition = fmt.Sprintf(`
+    WHEN %s`[1:], condition)
+	}
+	return func() schema.Patch {
+		stmt := fmt.Sprintf(`
+CREATE TRIGGER trg_%[1]s_immutable_update
+    BEFORE UPDATE ON %[1]s
+    FOR EACH ROW
+%[2]s
+    BEGIN
+        SELECT RAISE(FAIL, '%[3]s');
+    END;`[1:], tableName, condition, errMsg)
+		return schema.MakePatch(stmt)
+	}
+}

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/juju/core/leadership"
-	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/secrets"
 )
 
@@ -37,8 +36,8 @@ type UpdateSecretParams struct {
 // SecretAccessParams are used to define access to a secret.
 type SecretAccessParams struct {
 	LeaderToken leadership.Token
-	Scope       permission.ID
-	Subject     permission.ID
+	Scope       SecretAccessScope
+	Subject     SecretAccessor
 	Role        secrets.SecretRole
 }
 
@@ -73,6 +72,7 @@ const (
 	ApplicationAccessScope SecretAccessScopeKind = "application"
 	UnitAccessScope        SecretAccessScopeKind = "unit"
 	RelationAccessScope    SecretAccessScopeKind = "relation"
+	ModelAccessScope       SecretAccessScopeKind = "model"
 )
 
 // SecretAccessScope represents the scope of a secret permission.


### PR DESCRIPTION
This PR updates the secret permission DDL to reflect reality.
Secret permissions embody the following key attributes:
- subject (entity that can access the secret)
- secret 
- scope (the entity whose lifecycle defines the permission)

The subject and scope are modelled as a tuple (entity type, uuid). These are columns in the secret permission table with look up tables used to define the allowed subject and scope entity types.

Once a permission is created, the subject type and scope details are immutable, so a trigger is added to prevent accidental updates.

Additionally, the service params for subject and scope were of type permission.ID but we had since defined bespoke secret types and needed to replace the obsolete attribute type. NB the bespoke Accessor and AccessScope types use the natural ID as this is what comes over the wire - it is translated to UUID by the service / state.

A view `v_secret_permission` is created to facilitate access to the permission granted to a subject based on natural id, which again is what comes in over the wire.

As a follow up to PR#17185 commit https://github.com/juju/juju/pull/17212/commits/f748a98f5ee7ffa52e1da293e4eca244e0eae78f changes the SQL for checking duplicate labels to use joins instead of sub selects.

## QA steps

unit tests

## Links

**Jira card:** [JUJU-5879](https://warthogs.atlassian.net/browse/JUJU-5879)



[JUJU-5879]: https://warthogs.atlassian.net/browse/JUJU-5879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ