### PR TITLE
[JUJU-5878] Replace DetectSeries.. with DetectBase..

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -352,7 +352,7 @@ func bootstrapIAAS(
 	// characteristics of the instance we are about to bootstrap, use this
 	// information to backfill in any missing series and/or arch contstraints.
 	if detector, supported := environ.(environs.HardwareCharacteristicsDetector); supported {
-		detectedSeries, err := detector.DetectSeries()
+		detectedBase, err := detector.DetectBase()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -361,12 +361,8 @@ func bootstrapIAAS(
 			return errors.Trace(err)
 		}
 
-		if args.BootstrapBase.Empty() && detectedSeries != "" {
-			base, err := corebase.GetBaseFromSeries(detectedSeries)
-			if err != nil {
-				base = jujuversion.DefaultSupportedLTSBase()
-			}
-			args.BootstrapBase = base
+		if args.BootstrapBase.Empty() && !detectedBase.Empty() {
+			args.BootstrapBase = detectedBase
 			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapBase.String())
 		}
 		if args.BootstrapConstraints.Arch == nil &&

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1350,7 +1350,7 @@ func (s *bootstrapSuite) TestAvailableToolsInvalidArch(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestTargetSeriesOverride(c *gc.C) {
-	env := newBootstrapEnvironWithHardwareDetection("foo", "artful", "amd64", useDefaultKeys, nil)
+	env := newBootstrapEnvironWithHardwareDetection("foo", corebase.MustParseBaseFromString("ubuntu@17.10"), "amd64", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
@@ -1363,7 +1363,7 @@ func (s *bootstrapSuite) TestTargetSeriesOverride(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestTargetArchOverride(c *gc.C) {
-	env := newBootstrapEnvironWithHardwareDetection("foo", "bionic", "riscv", useDefaultKeys, nil)
+	env := newBootstrapEnvironWithHardwareDetection("foo", corebase.MustParseBaseFromString("ubuntu@18.04"), "riscv", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
@@ -1394,7 +1394,7 @@ func (s *bootstrapSuite) TestTargetSeriesAndArchOverridePriority(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, "released", "released")
 
-	env := newBootstrapEnvironWithHardwareDetection("foo", "haiku", "riscv", useDefaultKeys, nil)
+	env := newBootstrapEnvironWithHardwareDetection("foo", corebase.MustParseBaseFromString("ubuntu@17.04"), "riscv", useDefaultKeys, nil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{
 			AdminSecret:             "fake-moon-landing",
@@ -1551,11 +1551,11 @@ func (e bootstrapEnvironNoExplicitArchitectures) ConstraintsValidator(envcontext
 type bootstrapEnvironWithHardwareDetection struct {
 	*bootstrapEnviron
 
-	detectedSeries string
-	detectedHW     *instance.HardwareCharacteristics
+	detectedBase corebase.Base
+	detectedHW   *instance.HardwareCharacteristics
 }
 
-func newBootstrapEnvironWithHardwareDetection(name, detectedSeries, detectedArch string, defaultKeys bool, extraAttrs map[string]interface{}) *bootstrapEnvironWithHardwareDetection {
+func newBootstrapEnvironWithHardwareDetection(name string, detectedBase corebase.Base, detectedArch string, defaultKeys bool, extraAttrs map[string]interface{}) *bootstrapEnvironWithHardwareDetection {
 	var hw = new(instance.HardwareCharacteristics)
 	if detectedArch != "" {
 		hw.Arch = &detectedArch
@@ -1563,13 +1563,13 @@ func newBootstrapEnvironWithHardwareDetection(name, detectedSeries, detectedArch
 
 	return &bootstrapEnvironWithHardwareDetection{
 		bootstrapEnviron: newEnviron(name, defaultKeys, extraAttrs),
-		detectedSeries:   detectedSeries,
+		detectedBase:     detectedBase,
 		detectedHW:       hw,
 	}
 }
 
-func (e bootstrapEnvironWithHardwareDetection) DetectSeries() (string, error) {
-	return e.detectedSeries, nil
+func (e bootstrapEnvironWithHardwareDetection) DetectBase() (corebase.Base, error) {
+	return e.detectedBase, nil
 }
 func (e bootstrapEnvironWithHardwareDetection) DetectHardware() (*instance.HardwareCharacteristics, error) {
 	return e.detectedHW, nil

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -634,13 +634,13 @@ type DefaultConstraintsChecker interface {
 // provide advance information about the series and hardware for controller
 // instances that have not been provisioned yet.
 type HardwareCharacteristicsDetector interface {
-	// DetectSeries returns the series for the controller instance.
-	DetectSeries() (string, error)
+	// DetectBase returns the base for the controller instance.
+	DetectBase() (corebase.Base, error)
 	// DetectHardware returns the hardware characteristics for the
 	// controller instance.
 	DetectHardware() (*instance.HardwareCharacteristics, error)
 	// UpdateModelConstraints returns true if the model constraints should
-	// be updated based on the returns of DetectSeries() and
+	// be updated based on the returns of DetectBase() and
 	// DetectHardware().
 	UpdateModelConstraints() bool
 }

--- a/environs/manual/sshprovisioner/fakessh_test.go
+++ b/environs/manual/sshprovisioner/fakessh_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/service"
 )
@@ -86,17 +87,15 @@ func installFakeSSH(c *gc.C, input, output interface{}, rc int) testing.Restorer
 }
 
 // installDetectionFakeSSH installs a fake SSH command, which will respond
-// to the series/hardware detection script with the specified
-// series/arch.
-func installDetectionFakeSSH(c *gc.C, series, arch string) testing.Restorer {
-	if series == "" {
-		series = "precise"
-	}
+// to the base/hardware detection script with the specified
+// base/arch.
+func installDetectionFakeSSH(c *gc.C, base corebase.Base, arch string) testing.Restorer {
 	if arch == "" {
 		arch = "amd64"
 	}
 	detectionoutput := strings.Join([]string{
-		series,
+		base.OS,
+		base.Channel.String(),
 		arch,
 		"MemTotal: 4096 kB",
 		"processor: 0",
@@ -106,8 +105,8 @@ func installDetectionFakeSSH(c *gc.C, series, arch string) testing.Restorer {
 
 // fakeSSH wraps the invocation of InstallFakeSSH based on the parameters.
 type fakeSSH struct {
-	Series string
-	Arch   string
+	Base corebase.Base
+	Arch string
 
 	// Provisioned should be set to true if the fakeSSH script
 	// should respond to checkProvisioned with a non-empty result.
@@ -146,7 +145,7 @@ func (r fakeSSH) install(c *gc.C) testing.Restorer {
 		add(nil, nil, r.ProvisionAgentExitCode)
 	}
 	if !r.SkipDetection {
-		restore.Add(installDetectionFakeSSH(c, r.Series, r.Arch))
+		restore.Add(installDetectionFakeSSH(c, r.Base, r.Arch))
 	}
 	var checkProvisionedOutput interface{}
 	if r.Provisioned {

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -47,7 +47,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
+	base := jujuversion.DefaultSupportedLTSBase()
 	const arch = "amd64"
 
 	args := s.getArgs(c)
@@ -59,7 +59,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	envtools.DefaultBaseURL = ""
 
 	defer fakeSSH{
-		Series:             series,
+		Base:               base,
 		Arch:               arch,
 		InitUbuntuUser:     true,
 		SkipProvisionAgent: true,
@@ -84,7 +84,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	for i, errorCode := range []int{255, 0} {
 		c.Logf("test %d: code %d", i, errorCode)
 		defer fakeSSH{
-			Series:                 series,
+			Base:                   base,
 			Arch:                   arch,
 			InitUbuntuUser:         true,
 			ProvisionAgentExitCode: errorCode,
@@ -129,10 +129,10 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestFinishInstanceConfig(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
+	base := jujuversion.DefaultSupportedLTSBase()
 	const arch = "amd64"
 	defer fakeSSH{
-		Series:         series,
+		Base:           base,
 		Arch:           arch,
 		InitUbuntuUser: true,
 	}.install(c).Restore()
@@ -153,10 +153,10 @@ func (s *provisionerSuite) TestFinishInstanceConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	var series = jujuversion.DefaultSupportedLTS()
+	base := jujuversion.DefaultSupportedLTSBase()
 	const arch = "amd64"
 	defer fakeSSH{
-		Series:         series,
+		Base:           base,
 		Arch:           arch,
 		InitUbuntuUser: true,
 	}.install(c).Restore()

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
@@ -460,9 +461,9 @@ func (env *environ) AssignLXDProfiles(instID string, profilesNames []string, pro
 	return report(nil)
 }
 
-// DetectSeries is a no-op for lxd, must return an empty string.
-func (env *environ) DetectSeries() (string, error) {
-	return "", nil
+// DetectBase is a no-op for lxd, must return an empty string.
+func (env *environ) DetectBase() (base.Base, error) {
+	return base.Base{}, nil
 }
 
 // DetectHardware returns the hardware characteristics for the controller for

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -55,10 +55,10 @@ type manualEnviron struct {
 	user string
 	mu   sync.Mutex
 	cfg  *environConfig
-	// hw and series are detected by running a script on the
+	// hw and base are detected by running a script on the
 	// target machine. We cache these, as they should not change.
-	hw     *instance.HardwareCharacteristics
-	series string
+	hw   *instance.HardwareCharacteristics
+	base corebase.Base
 }
 
 var errNoStartInstance = errors.New("manual provider cannot start instances")
@@ -116,7 +116,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context
 	if provisioned {
 		return nil, manual.ErrProvisioned
 	}
-	hw, series, err := e.seriesAndHardwareCharacteristics()
+	hw, base, err := e.baseAndHardwareCharacteristics()
 	if err != nil {
 		return nil, err
 	}
@@ -129,10 +129,6 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context
 		return common.ConfigureMachine(ctx, ssh.DefaultClient, e.host, icfg, nil)
 	}
 
-	base, err := corebase.GetBaseFromSeries(series)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	result := &environs.BootstrapResult{
 		Arch:                    *hw.Arch,
 		Base:                    base,
@@ -346,7 +342,7 @@ func (e *manualEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (c
 	} else {
 		// We're running outside of the Juju controller, so we must
 		// SSH to the machine and detect its architecture.
-		hw, _, err := e.seriesAndHardwareCharacteristics()
+		hw, _, err := e.baseAndHardwareCharacteristics()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -355,18 +351,18 @@ func (e *manualEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (c
 	return validator, nil
 }
 
-func (e *manualEnviron) seriesAndHardwareCharacteristics() (_ *instance.HardwareCharacteristics, series string, _ error) {
+func (e *manualEnviron) baseAndHardwareCharacteristics() (*instance.HardwareCharacteristics, corebase.Base, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.hw != nil {
-		return e.hw, e.series, nil
+		return e.hw, e.base, nil
 	}
-	hw, series, err := sshprovisioner.DetectSeriesAndHardwareCharacteristics(e.host)
+	hw, base, err := sshprovisioner.DetectBaseAndHardwareCharacteristics(e.host)
 	if err != nil {
-		return nil, "", errors.Trace(err)
+		return nil, corebase.Base{}, errors.Trace(err)
 	}
-	e.hw, e.series = &hw, series
-	return e.hw, e.series, nil
+	e.hw, e.base = &hw, base
+	return e.hw, e.base, nil
 }
 
 func (*manualEnviron) Provider() environs.EnvironProvider {
@@ -377,18 +373,18 @@ func isRunningController() bool {
 	return filepath.Base(os.Args[0]) == names.Jujud
 }
 
-// DetectSeries returns the series for the controller for this environment.
+// DetectBase returns the base for the controller for this environment.
 // This method is part of the environs.HardwareCharacteristicsDetector interface.
-func (e *manualEnviron) DetectSeries() (string, error) {
-	_, series, err := e.seriesAndHardwareCharacteristics()
-	return series, err
+func (e *manualEnviron) DetectBase() (corebase.Base, error) {
+	_, base, err := e.baseAndHardwareCharacteristics()
+	return base, err
 }
 
 // DetectHardware returns the hardware characteristics for the controller for
 // this environment. This method is part of the environs.HardwareCharacteristicsDetector
 // interface.
 func (e *manualEnviron) DetectHardware() (*instance.HardwareCharacteristics, error) {
-	hw, _, err := e.seriesAndHardwareCharacteristics()
+	hw, _, err := e.baseAndHardwareCharacteristics()
 	return hw, err
 }
 

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
@@ -149,12 +150,12 @@ exit 0
 }
 
 func (s *environSuite) TestConstraintsValidator(c *gc.C) {
-	s.PatchValue(&sshprovisioner.DetectSeriesAndHardwareCharacteristics,
-		func(string) (instance.HardwareCharacteristics, string, error) {
+	s.PatchValue(&sshprovisioner.DetectBaseAndHardwareCharacteristics,
+		func(string) (instance.HardwareCharacteristics, base.Base, error) {
 			amd64 := "amd64"
 			return instance.HardwareCharacteristics{
 				Arch: &amd64,
-			}, "", nil
+			}, base.Base{}, nil
 		},
 	)
 


### PR DESCRIPTION
This only really affects the manual provider, but does touch the lxd provider a little

In the manual provider, since we're working with pre-deployed machines, we detect the OS and hw automatically via a script. Adjust this script to return base information rather than series, and follow this up the stack

This is part of the work to replace series with bases in our codebase

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Bootstrap lxd

```
$ juju bootstrap lxd lxd-jammy
(wait)
$ juju status -m controller
Model       Controller  Cloud/Region         Version    SLA          Timestamp
controller  lxd-jammy   localhost/localhost  3.5-beta1  unsupported  11:23:44+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.5/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.194         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.194  juju-581ce5-0  ubuntu@22.04      Running
```
```
$ juju bootstrap lxd lxd-focal --bootstrap-base ubuntu@20.04
(wait)
$ juju status -m controller
Model       Controller  Cloud/Region         Version    SLA          Timestamp
controller  lxd-focal   localhost/localhost  3.5-beta1  unsupported  11:23:29+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.5/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.143         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.143  juju-953de0-0  ubuntu@20.04      Running
```

### Bootstrap multipass with manual

#### Create some multipass vms
```
$ multipass launch jammy -n jammy-1
$ multipass launch jammy -n jammy-2
$ multipass launch focal -n focal-1
$ multipass launch focal -n focal-2

$ multipass ls
Name                    State             IPv4             Image
focal-1                 Running           10.90.50.172     Ubuntu 20.04 LTS
focal-2                 Running           10.90.50.106     Ubuntu 20.04 LTS
jammy-1                 Running           10.90.50.115     Ubuntu 22.04 LTS
jammy-2                 Running           10.90.50.124     Ubuntu 22.04 LTS
```

Be sure these machines are accessible over ssh

#### Add 2 clouds
```
$ juju add-cloud --client
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: manual

Enter a name for your manual cloud: multipass-jammy

Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: ubuntu@10.90.50.115    

Cloud "multipass-jammy" successfully added to your local client.

$ juju add-cloud --client
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: manual

Enter a name for your manual cloud: multipass-focal

Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: ubuntu@10.90.50.172

Cloud "multipass-focal" successfully added to your local client.

$ juju clouds | grep manual
multipass-focal              1        default            manual     0            local     
multipass-jammy              1        default            manual     0            local     
```

#### Bootstrap controllers + add machines
```
$ juju bootstrap multipass-jammy
(wait)
$ juju status -m controller
Model       Controller               Cloud/Region             Version    SLA          Timestamp
controller  multipass-jammy-default  multipass-jammy/default  3.5-beta1  unsupported  11:45:47+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.5/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.90.50.115           

Machine  State    Address       Inst id  Base          AZ  Message
0        started  10.90.50.115  manual:  ubuntu@22.04      Manually provisioned machine

$ juju add-model m
$ juju add-machine ssh:ubuntu@10.90.50.106 # <-- Note: This is focal-2
Warning: Permanently added '10.90.50.106' (ED25519) to the list of known hosts.
created machine 0

$ juju status
Model  Controller               Cloud/Region             Version    SLA          Timestamp
m      multipass-jammy-default  multipass-jammy/default  3.5-beta1  unsupported  11:47:56+01:00

Machine  State    Address       Inst id              Base          AZ  Message
0        started  10.90.50.106  manual:10.90.50.106  ubuntu@20.04      Manually provisioned machine
```

```
$ juju bootstrap multipass-focal
(wait)
$ juju status -m controller
Model       Controller               Cloud/Region             Version    SLA          Timestamp
controller  multipass-focal-default  multipass-focal/default  3.5-beta1  unsupported  11:50:29+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.5/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.90.50.172           

Machine  State    Address       Inst id  Base          AZ  Message
0        started  10.90.50.172  manual:  ubuntu@20.04      Manually provisioned machine

$ juju add-model m
$ juju add-machine ssh:ubuntu@10.90.50.124 # <-- Note: this is jammy-2
Warning: Permanently added '10.90.50.124' (ED25519) to the list of known hosts.
created machine 0

$ juju status
Model  Controller               Cloud/Region             Version    SLA          Timestamp
m      multipass-focal-default  multipass-focal/default  3.5-beta1  unsupported  11:51:17+01:00

Machine  State    Address       Inst id              Base          AZ  Message
0        started  10.90.50.124  manual:10.90.50.124  ubuntu@22.04      Manually provisioned machine
11:51 jack@jack-MS-7B85:~/juju/juju$ juju status
Model  Controller               Cloud/Region             Version    SLA          Timestamp
m      multipass-focal-default  multipass-focal/default  3.5-beta1  unsupported  11:51:26+01:00

Machine  State    Address       Inst id              Base          AZ  Message
0        started  10.90.50.124  manual:10.90.50.124  ubuntu@22.04      Manually provisioned machine
```

## Links

Jira card: https://warthogs.atlassian.net/browse/JUJU-5878