### PR TITLE
Backport charm upload changes

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -759,7 +759,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	modelCharmsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
 
 	modelObjectsCharmsHandler := &objectsCharmHandler{
-		ctxt: httpCtxt,
+		ctxt:          httpCtxt,
+		stateAuthFunc: httpCtxt.stateForRequestAuthenticatedUser,
 	}
 	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		GetHandler:          modelObjectsCharmsHandler.ServeGet,
@@ -830,9 +831,13 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		PostHandler: migrateCharmsHandler.ServePost,
 		GetHandler:  migrateCharmsHandler.ServeUnsupported,
 	}
+	migrateObjectsCharmsHandler := &objectsCharmHandler{
+		ctxt:          httpCtxt,
+		stateAuthFunc: httpCtxt.stateForMigrationImporting,
+	}
 	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
-		PutHandler:          modelObjectsCharmsHandler.ServePut,
-		GetHandler:          modelObjectsCharmsHandler.ServeUnsupported,
+		PutHandler:          migrateObjectsCharmsHandler.ServePut,
+		GetHandler:          migrateObjectsCharmsHandler.ServeUnsupported,
 		LegacyCharmsHandler: migrateCharmsHTTPHandler,
 	}
 	migrateToolsUploadHandler := &toolsUploadHandler{

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -117,7 +118,7 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 	if err != nil {
 		return errors.NewBadRequest(err, "")
 	}
-	return errors.Trace(sendStatusAndHeadersAndJSON(w, http.StatusOK, map[string]string{"Juju-Curl": charmURL.String()}, &params.CharmsResponse{CharmURL: charmURL.String()}))
+	return errors.Trace(sendStatusAndHeadersAndJSON(w, http.StatusOK, map[string]string{"Juju-Curl": charmURL}, &params.CharmsResponse{CharmURL: charmURL}))
 }
 
 func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
@@ -217,7 +218,7 @@ func (h *charmsHandler) archiveSender(w http.ResponseWriter, r *http.Request, bu
 }
 
 // processPost handles a charm upload POST request after authentication.
-func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.URL, error) {
+func (h *charmsHandler) processPost(r *http.Request, st *state.State) (string, error) {
 	query := r.URL.Query()
 	schema := query.Get("schema")
 	if schema == "" {
@@ -229,32 +230,25 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		// There's currently no other time where it makes sense
 		// to accept repository charms through this endpoint.
 		if isImporting, err := modelIsImporting(st); err != nil {
-			return nil, errors.Trace(err)
+			return "", errors.Trace(err)
 		} else if !isImporting {
-			return nil, errors.New("charms may only be uploaded during model migration import")
-		}
-	}
-
-	series := query.Get("series")
-	if series != "" {
-		if err := charm.ValidateSeries(series); err != nil {
-			return nil, errors.NewBadRequest(err, "")
+			return "", errors.New("charms may only be uploaded during model migration import")
 		}
 	}
 
 	charmFileName, err := writeCharmToTempFile(r.Body)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 	defer os.Remove(charmFileName)
 
 	err = h.processUploadedArchive(charmFileName)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	archive, err := charm.ReadCharmArchive(charmFileName)
 	if err != nil {
-		return nil, errors.BadRequestf("invalid charm archive: %v", err)
+		return "", errors.BadRequestf("invalid charm archive: %v", err)
 	}
 
 	// Use the name from the query string. If we're dealing with an older client
@@ -264,50 +258,74 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		name = archive.Meta().Name
 	}
 	if err := charm.ValidateName(name); err != nil {
-		return nil, errors.NewBadRequest(err, "")
+		return "", errors.NewBadRequest(err, "")
+	}
+
+	var revision int
+	if revisionStr := query.Get("revision"); revisionStr != "" {
+		revision, err = strconv.Atoi(revisionStr)
+		if err != nil {
+			return "", errors.NewBadRequest(errors.NewNotValid(err, "revision"), "")
+		}
+	} else {
+		revision = archive.Revision()
 	}
 
 	// We got it, now let's reserve a charm URL for it in state.
-	curl := &charm.URL{
-		Schema:       schema,
-		Architecture: query.Get("arch"),
-		Name:         name,
-		Revision:     archive.Revision(),
-		Series:       series,
-	}
+	curlStr := curlString(schema, query.Get("arch"), name, query.Get("series"), revision)
 
 	switch charm.Schema(schema) {
 	case charm.Local:
-		curl, err = st.PrepareLocalCharmUpload(curl.String())
+		curl, err := st.PrepareLocalCharmUpload(curlStr)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return "", errors.Trace(err)
 		}
+		curlStr = curl.String()
 
 	case charm.CharmHub:
-		// If a revision argument is provided, it takes precedence
-		// over the revision in the charm archive. This is required to
-		// handle the revision differences between unpublished and
-		// published charms in the charm store.
-		revisionStr := query.Get("revision")
-		if revisionStr != "" {
-			curl.Revision, err = strconv.Atoi(revisionStr)
-			if err != nil {
-				return nil, errors.NewBadRequest(errors.NewNotValid(err, "revision"), "")
-			}
-		}
-		if _, err := st.PrepareCharmUpload(curl.String()); err != nil {
-			return nil, errors.Trace(err)
+		if _, err := st.PrepareCharmUpload(curlStr); err != nil {
+			return "", errors.Trace(err)
 		}
 
 	default:
-		return nil, errors.Errorf("unsupported schema %q", schema)
+		return "", errors.Errorf("unsupported schema %q", schema)
 	}
 
-	err = RepackageAndUploadCharm(st, archive, curl)
+	err = RepackageAndUploadCharm(st, archive, curlStr, revision)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	return curl, nil
+	return curlStr, nil
+}
+
+// curlString takes the constituent parts of a charm url and renders the url as a string.
+// This is required since, to support migrations from legacy controllers, we need to support
+// charm urls with series since controllers do not allow migrations to mutate charm urls during
+// migration.
+//
+// This is the only place in Juju 4 where series in a charm url needs to be processed. As such,
+// instead of dragging support for series with us into 4.0, in this one place we string-hack the
+// url
+func curlString(schema, arch, name, series string, revision int) string {
+	if series == "" {
+		curl := &charm.URL{
+			Schema:       schema,
+			Architecture: arch,
+			Name:         name,
+			Revision:     revision,
+		}
+		return curl.String()
+	}
+	var curl string
+	if arch == "" {
+		curl = fmt.Sprintf("%s:%s/%s", schema, series, name)
+	} else {
+		curl = fmt.Sprintf("%s:%s/%s/%s", schema, arch, series, name)
+	}
+	if revision != -1 {
+		curl = fmt.Sprintf("%s-%d", curl, revision)
+	}
+	return curl
 }
 
 // processUploadedArchive opens the given charm archive from path,
@@ -400,7 +418,7 @@ func (d byDepth) Less(i, j int) bool { return depth(d[i]) < depth(d[j]) }
 // RepackageAndUploadCharm expands the given charm archive to a
 // temporary directory, repackages it with the given curl's revision,
 // then uploads it to storage, and finally updates the state.
-func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl *charm.URL) error {
+func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl string, charmRevision int) error {
 	// Create a temp dir to contain the extracted charm dir.
 	tempDir, err := os.MkdirTemp("", "charm-download")
 	if err != nil {
@@ -409,8 +427,8 @@ func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl 
 	defer os.RemoveAll(tempDir)
 	extractPath := filepath.Join(tempDir, "extracted")
 
-	// Expand and repack it with the revision specified by curl.
-	archive.SetRevision(curl.Revision)
+	// Expand and repack it with the specified revision
+	archive.SetRevision(charmRevision)
 	if err := archive.ExpandTo(extractPath); err != nil {
 		return errors.Annotate(err, "cannot extract uploaded charm")
 	}
@@ -453,7 +471,7 @@ func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl 
 		},
 	})
 
-	return charmStorage.Store(curl.String(), downloader.DownloadedCharm{
+	return charmStorage.Store(curl, downloader.DownloadedCharm{
 		Charm:        archive,
 		CharmData:    &repackagedArchive,
 		CharmVersion: version,

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -4,18 +4,18 @@
 package apiserver
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
+	"github.com/juju/utils/v3"
+
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 )
 
 type objectsCharmHTTPHandler struct {
@@ -35,10 +35,6 @@ func (h *objectsCharmHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		}
 	case "PUT":
 		err = errors.Annotate(h.PutHandler(w, r), "cannot upload charm")
-		if err == nil {
-			// Chain call to legacy (REST API) charms handler
-			h.LegacyCharmsHandler.ServeHTTP(w, r)
-		}
 	default:
 		http.Error(w, fmt.Sprintf("http method %s not implemented", r.Method), http.StatusNotImplemented)
 		return
@@ -55,7 +51,8 @@ func (h *objectsCharmHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 // objectsCharmHandler handles charm upload through S3-compatible HTTPS in the
 // API server.
 type objectsCharmHandler struct {
-	ctxt httpContext
+	ctxt          httpContext
+	stateAuthFunc func(*http.Request) (*state.PooledState, error)
 }
 
 func (h *objectsCharmHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request) error {
@@ -106,51 +103,91 @@ func (h *objectsCharmHandler) ServePut(w http.ResponseWriter, r *http.Request) e
 		return errors.BadRequestf("expected Content-Type: application/zip, got: %v", contentType)
 	}
 
-	query := r.URL.Query()
-	name, shaFromQuery, err := splitNameAndSHAFromQuery(query)
-	if err != nil {
-		return err
-	}
-
-	charmFileName, err := writeCharmToTempFile(r.Body)
+	st, err := h.stateAuthFunc(r)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer os.Remove(charmFileName)
+	defer st.Release()
+
+	// Add a charm to the store provider.
+	charmURL, err := h.processPut(r, st.State)
+	if err != nil {
+		return errors.NewBadRequest(err, "")
+	}
+	return errors.Trace(sendStatusAndHeadersAndJSON(w, http.StatusOK, map[string]string{"Juju-Curl": charmURL.String()}, &params.CharmsResponse{CharmURL: charmURL.String()}))
+}
+
+func (h *objectsCharmHandler) processPut(r *http.Request, st *state.State) (*charm.URL, error) {
+	query := r.URL.Query()
+	name, shaFromQuery, err := splitNameAndSHAFromQuery(query)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	curlStr := r.Header.Get("Juju-Curl")
 	curl, err := charm.ParseURL(curlStr)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.BadRequestf("%q is not a valid charm url", curlStr)
 	}
 	curl.Name = name
 
-	charmSHA, err := hashCharmArchive(charmFileName)
-	if err != nil {
-		return errors.Trace(err)
+	schema := curl.Schema
+	if schema != "local" {
+		// charmhub charms may only be uploaded into models
+		// which are being imported during model migrations.
+		// There's currently no other time where it makes sense
+		// to accept repository charms through this endpoint.
+		if isImporting, err := modelIsImporting(st); err != nil {
+			return nil, errors.Trace(err)
+		} else if !isImporting {
+			return nil, errors.New("non-local charms may only be uploaded during model migration import")
+		}
 	}
+
+	charmFileName, err := writeCharmToTempFile(r.Body)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer os.Remove(charmFileName)
+
+	charmSHA, _, err := utils.ReadFileSHA256(charmFileName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// ReadFileSHA256 returns a full 64 char SHA256. However, charm refs
+	// only use the first 7 chars. So truncate the sha to match
+	charmSHA = charmSHA[0:7]
 	if charmSHA != shaFromQuery {
-		return errors.BadRequestf("Uploaded charm sha256 (%v) does not match sha in url (%v)", charmSHA, shaFromQuery)
+		return nil, errors.BadRequestf("Uploaded charm sha256 (%v) does not match sha in url (%v)", charmSHA, shaFromQuery)
 	}
 
-	query.Add("schema", curl.Schema)
-	query.Add("name", curl.Name)
-	query.Add("revision", strconv.Itoa(curl.Revision))
-	query.Add("series", curl.Series)
-	query.Add("arch", curl.Architecture)
-	r.URL.RawQuery = query.Encode()
-
-	// We have already read the request body, so we need to refresh it
-	// so it can be read again in future
-	r.Body, err = os.Open(charmFileName)
+	archive, err := charm.ReadCharmArchive(charmFileName)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.BadRequestf("invalid charm archive: %v", err)
 	}
 
-	// The legacy charm uplaod handler expects a POST request
-	r.Method = "POST"
+	if curl.Revision == -1 {
+		curl.Revision = archive.Revision()
+	}
 
-	return nil
+	switch charm.Schema(schema) {
+	case charm.Local:
+		curl, err = st.PrepareLocalCharmUpload(curl.String())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+	case charm.CharmHub:
+		if _, err := st.PrepareCharmUpload(curl.String()); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+	default:
+		return nil, errors.Errorf("unsupported schema %q", schema)
+	}
+
+	return curl, errors.Trace(RepackageAndUploadCharm(st, archive, curl))
 }
 
 func splitNameAndSHAFromQuery(query url.Values) (string, string, error) {
@@ -164,19 +201,4 @@ func splitNameAndSHAFromQuery(query url.Values) (string, string, error) {
 	}
 	name, sha := charmObjectID[:splitIndex], charmObjectID[splitIndex+1:]
 	return name, sha, nil
-}
-
-func hashCharmArchive(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	defer func() { _ = file.Close() }()
-
-	hash := sha256.New()
-	_, err = io.Copy(hash, file)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return hex.EncodeToString(hash.Sum(nil))[0:7], nil
 }

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -187,7 +187,7 @@ func (h *objectsCharmHandler) processPut(r *http.Request, st *state.State) (*cha
 		return nil, errors.Errorf("unsupported schema %q", schema)
 	}
 
-	return curl, errors.Trace(RepackageAndUploadCharm(st, archive, curl))
+	return curl, errors.Trace(RepackageAndUploadCharm(st, archive, curl.String(), curl.Revision))
 }
 
 func splitNameAndSHAFromQuery(query url.Values) (string, string, error) {

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -146,11 +146,18 @@ func (s *putObjectsSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 	// Pretend we upload a zip by setting the Content-Type, so we can
 	// check the error at extraction time later.
 	resp := s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/zip", "local:somecharm", empty)
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*cannot open charm archive: zip: not a valid zip file$")
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*zip: not a valid zip file$")
 
 	// Now try with the default Content-Type.
 	resp = s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/octet-stream", "local:somecharm", empty)
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*expected Content-Type: application/zip, got: application/octet-stream$")
+}
+
+func (s *putObjectsSuite) TestCannotUploadCharmhubCharm(c *gc.C) {
+	// We should run verifications like this before processing the charm.
+	empty := strings.NewReader("")
+	resp := s.uploadRequest(c, s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)), "application/zip", "ch:somecharm", empty)
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, `.*non-local charms may only be uploaded during model migration import`)
 }
 
 func (s *putObjectsSuite) TestUploadBumpsRevision(c *gc.C) {

--- a/cmd/jujud-controller/agent/controllercharm.go
+++ b/cmd/jujud-controller/agent/controllercharm.go
@@ -278,7 +278,7 @@ func addLocalControllerCharm(st *state.State, charmFileName string) (*charm.URL,
 
 	// Now we need to repackage it with the reserved URL, upload it to
 	// provider storage and update the state.
-	err = apiserver.RepackageAndUploadCharm(st, archive, curl)
+	err = apiserver.RepackageAndUploadCharm(st, archive, curl.String(), archive.Revision())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This PR backports:
- https://github.com/juju/juju/pull/17148
- https://github.com/juju/juju/pull/17166

This removes our dependency on charm url series from the upload handler

We first decouple the charm upload handlers from eachother, and then re-write the legacy charm uploader to not depend on series

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Deploy local charms

download a charm from charmhub
```
$ juju download ubuntu
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

Deploy several local charms
```
$ juju add-model local
$ juju deploy ./ubuntu_r24.charm ubu-arch
Located local charm "ubuntu", revision 0
Deploying "ubu-arch" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ./ubuntu_r24.charm ubu-focal --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubu-focal" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable


$ juju deploy ./testcharms/charms/ubuntu-plus/ ubu-dir
Located local charm "ubuntu-plus", revision 0
Deploying "ubu-dir" from local charm "ubuntu-plus", revision 0 on ubuntu@22.04/stable

$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta3.1  14:12:50+01:00

App        Version  Status   Scale  Charm        Channel  Rev  Exposed  Message
ubu-arch   22.04    active       1  ubuntu                  0  no       
ubu-dir             waiting      1  ubuntu-plus             0  no       Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal  20.04    active       1  ubuntu                  0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-arch/0*   active    idle   0        10.219.211.73          
ubu-dir/0*    waiting   idle   2        10.219.211.65          Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal/0*  active    idle   1        10.219.211.227         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.73   juju-99dc44-0  ubuntu@22.04      Running
1        started  10.219.211.227  juju-99dc44-1  ubuntu@20.04      Running
2        started  10.219.211.65   juju-99dc44-2  ubuntu@22.04      Running
```

### Model migrations

Repeat the following steps, bootstrapping `lxd-src` from:
- This PR
- 3.3 

`lxd-dst` is always bootstraped from this PR

```
$ juju switch lxd-src
$ juju add-model m
$ juju deploy ubuntu ubu-ch
$ juju deploy ./ubuntu_r24.charm ubu-local
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd-src     localhost/localhost  3.5-beta1.1  unsupported  19:04:54+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.13          
ubu-local/0*  active    idle   1        10.219.211.28          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.13  juju-f7f82d-0  ubuntu@22.04      Running
1        started  10.219.211.28  juju-f7f82d-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst

$ juju status
ERROR Model "admin/m" has been migrated to controller "lxd-dst".
To access it run 'juju switch lxd-dst:admin/m`.

$ juju switch lxd-dst:m
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp     
m      lxd-dst     localhost/localhost  3.5-beta1.1  19:06:01+01:00 

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.147         
ubu-local/0*  active    idle   1        10.219.211.60          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.147  juju-80c1e5-0  ubuntu@22.04      Running
1        started  10.219.211.60   juju-80c1e5-1  ubuntu@22.04      Running
```
