### PR TITLE
Move to CLA verification 'v1'

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@1.1.7
+        uses: canonical/has-signed-canonical-cla@v1
         with:
           accept-existing-contributors: true


### PR DESCRIPTION
This was still using 1.7.1 but according to Maksim we should be moving to the 'v1' tag: 
https://discourse.canonical.com/t/canonical-contributor-license-agreement-cla-incident-investigation/3518
(sorry for the internal discussion)

This just makes sure that our CLA check is applying the right checks to confirm if someone has signed the Canonical CLA.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Theoretically ask for a submission from someone who is not a Canonical employee, but who has signed the CLA, and ask someone else who has not signed the CLA and see that it successfully says yes and no to the right people.

## Documentation changes

No change.

## Links

None.