### PR TITLE
Permission schema changes

### DIFF
--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -71,6 +71,11 @@ func (a Access) Validate() error {
 	return errors.NotValidf("access level %s", a)
 }
 
+// String returns the access level as a string.
+func (a Access) String() string {
+	return string(a)
+}
+
 // ObjectType is the type of the permission object/
 type ObjectType string
 
@@ -91,6 +96,11 @@ func (o ObjectType) Validate() error {
 		return errors.NotValidf("object type %q", o)
 	}
 	return nil
+}
+
+// String returns the object type as a string.
+func (o ObjectType) String() string {
+	return string(o)
 }
 
 // ID identifies the object of a permission, its key and type. Keys

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -111,8 +111,8 @@ func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissio
 		UUID:       spec.PermissionUUID,
 		GrantOn:    spec.Target.Key,
 		GrantTo:    spec.UserUUID,
-		AccessType: string(spec.Access),
-		ObjectType: string(spec.Target.ObjectType),
+		AccessType: spec.Access.String(),
+		ObjectType: spec.Target.ObjectType.String(),
 	}
 	err := insertPermission(ctx, tx, perm)
 	if err != nil {
@@ -697,8 +697,8 @@ AND     u.removed = false
 	apiUserUUID = user.UUID(readPerm[0].GrantTo)
 
 	for _, read := range readPerm {
-		if read.AccessType == string(corepermission.SuperuserAccess) ||
-			read.AccessType == string(corepermission.AdminAccess) {
+		if read.AccessType == corepermission.SuperuserAccess.String() ||
+			read.AccessType == corepermission.AdminAccess.String() {
 			return apiUserUUID, nil
 		}
 	}
@@ -737,7 +737,7 @@ func (st *PermissionState) grantPermission(ctx context.Context, tx *sqlair.TX, s
 	if aSpec.EqualOrGreaterThan(grantAccess) {
 		return errors.Errorf("user %q already has %q access or greater", args.Subject, grantAccess)
 	}
-	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, string(grantAccess)); err != nil {
+	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, grantAccess.String()); err != nil {
 		return errors.Annotatef(err, "updating current access during grant")
 	}
 	return nil
@@ -749,7 +749,7 @@ func (st *PermissionState) revokePermission(ctx context.Context, tx *sqlair.TX, 
 		err := st.deletePermission(ctx, tx, args.Subject, args.AccessSpec.Target)
 		return errors.Annotatef(err, "revoking %q", args.AccessSpec.Access)
 	}
-	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, string(newAccess)); err != nil {
+	if err := st.updatePermission(ctx, tx, args.Subject, args.AccessSpec.Target.Key, newAccess.String()); err != nil {
 		return errors.Annotatef(err, "updating current access during revoke")
 	}
 	return nil

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -74,7 +74,6 @@ func (st *PermissionState) CreatePermission(ctx context.Context, newPermissionUU
 		}
 
 		userAccess = user.toCoreUserAccess()
-
 		return nil
 	})
 	if err != nil {
@@ -104,15 +103,16 @@ func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissio
 		return fmt.Errorf("%q for %q %w ", spec.Access, spec.Target.Key, accesserrors.PermissionAccessInvalid)
 	}
 	// Validate the target exists.
-	if err := targetExists(ctx, tx, spec.Target.Key); err != nil {
+	if err := targetExists(ctx, tx, spec.Target); err != nil {
 		return errors.Trace(err)
 	}
 
-	perm := dbAddUserPermission{
-		UUID:    spec.PermissionUUID,
-		GrantOn: spec.Target.Key,
-		GrantTo: spec.UserUUID,
-		Access:  string(spec.Access),
+	perm := dbPermission{
+		UUID:       spec.PermissionUUID,
+		GrantOn:    spec.Target.Key,
+		GrantTo:    spec.UserUUID,
+		AccessType: string(spec.Access),
+		ObjectType: string(spec.Target.ObjectType),
 	}
 	err := insertPermission(ctx, tx, perm)
 	if err != nil {
@@ -201,7 +201,7 @@ func (st *PermissionState) ReadUserAccessForTarget(ctx context.Context, subject 
 	}
 
 	readQuery := `
-SELECT  (p.uuid, p.grant_on, p.grant_to, p.access_type) AS (&dbReadUserPermission.*),
+SELECT  (p.uuid, p.grant_on, p.grant_to, p.access_type, p.object_type) AS (&dbPermission.*),
         (u.uuid, u.name, u.display_name, u.created_at, u.disabled) AS (&dbPermissionUser.*),
         creator.name AS &dbPermissionUser.created_by_name
 FROM    v_user_auth u
@@ -213,13 +213,13 @@ AND     u.removed = false
 AND     p.grant_on = $permInOut.grant_on
 `
 
-	readStmt, err := st.Prepare(readQuery, dbReadUserPermission{}, dbPermissionUser{}, permInOut{})
+	readStmt, err := st.Prepare(readQuery, dbPermission{}, dbPermissionUser{}, permInOut{})
 	if err != nil {
 		return corepermission.UserAccess{}, errors.Trace(err)
 	}
 
 	var (
-		readUser dbReadUserPermission
+		readUser dbPermission
 		permUser dbPermissionUser
 	)
 
@@ -241,7 +241,6 @@ AND     p.grant_on = $permInOut.grant_on
 		return userAccess, errors.Trace(domain.CoerceError(err))
 	}
 
-	readUser.ObjectType = string(target.ObjectType)
 	return readUser.toUserAccess(permUser), nil
 }
 
@@ -272,30 +271,21 @@ func (st *PermissionState) ReadAllUserAccessForUser(ctx context.Context, subject
 		return nil, errors.Trace(err)
 	}
 	var (
-		permissions []dbReadUserPermission
+		permissions []dbPermission
 		users       []dbPermissionUser
 	)
 	query := `
-WITH what AS (
-    select 'cloud' AS type, name AS grant_on FROM cloud
-    UNION
-    select 'model' AS type, uuid AS grant_on FROM v_model
-    UNION
-    select 'controller' AS type, 'controller' AS grant_on
-)
 SELECT (u.uuid, u.name, u.display_name, u.created_at, u.disabled) AS (&dbPermissionUser.*),
        creator.name AS &dbPermissionUser.created_by_name,
-       w.type AS &dbReadUserPermission.object_type,
-       (p.uuid, p.grant_on, p.grant_to, p.access_type) AS (&dbReadUserPermission.*)
+       (p.uuid, p.grant_on, p.grant_to, p.access_type, p.object_type) AS (&dbPermission.*)
 FROM   v_user_auth u
        JOIN user AS creator ON u.created_by_uuid = creator.uuid
        JOIN v_permission p ON u.uuid = p.grant_to
-       JOIN what AS w ON p.grant_on = w.grant_on
 WHERE  u.removed = false
        AND u.name = $permUserName.name
 `
 
-	queryStmt, err := st.Prepare(query, dbPermissionUser{}, dbReadUserPermission{}, permUserName{})
+	queryStmt, err := st.Prepare(query, dbPermissionUser{}, dbPermission{}, permUserName{})
 	if err != nil {
 		return nil, errors.Annotate(err, "preparing select all access for user query")
 	}
@@ -333,7 +323,7 @@ func (st *PermissionState) ReadAllUserAccessForTarget(ctx context.Context, targe
 		return nil, errors.Trace(err)
 	}
 	var (
-		permissions []dbReadUserPermission
+		permissions []dbPermission
 		users       map[string]dbPermissionUser
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -366,7 +356,6 @@ func (st *PermissionState) ReadAllUserAccessForTarget(ctx context.Context, targe
 		if !ok {
 			return userAccess, errors.Annotatef(accesserrors.UserNotFound, "%q", p.GrantTo)
 		}
-		p.ObjectType = string(target.ObjectType)
 		userAccess[i] = p.toUserAccess(user)
 	}
 
@@ -382,17 +371,17 @@ func (st *PermissionState) ReadAllAccessForUserAndObjectType(ctx context.Context
 		return nil, errors.Trace(err)
 	}
 	var (
-		permissions []dbReadUserPermission
+		permissions []dbPermission
 		actualUser  []dbPermissionUser
 	)
-	var andClause string
+	var view string
 	switch objectType {
 	case corepermission.Controller:
-		andClause = `AND     p.grant_on = ctrl.c`
+		view = "v_permission_controller"
 	case corepermission.Model:
-		andClause = `AND     m.uuid NOT NULL`
+		view = "v_permission_model"
 	case corepermission.Cloud:
-		andClause = `AND     c.name NOT NULL`
+		view = "v_permission_cloud"
 	case corepermission.Offer:
 		// TODO implement for offers
 		return nil, errors.NotImplementedf("ReadAllAccessForUserAndObjectType for offers")
@@ -401,22 +390,18 @@ func (st *PermissionState) ReadAllAccessForUserAndObjectType(ctx context.Context
 	}
 	readQuery := fmt.Sprintf(`
 WITH    ctrl AS (SELECT 'controller' AS c)
-SELECT  (p.uuid, p.grant_on, p.grant_to, p.access_type) AS (&dbReadUserPermission.*),
+SELECT  (p.uuid, p.grant_on, p.grant_to, p.access_type, p.object_type) AS (&dbPermission.*),
         (u.uuid, u.name, u.display_name, u.created_at, u.disabled) AS (&dbPermissionUser.*),
         creator.name AS &dbPermissionUser.created_by_name
 FROM    v_user_auth u
         JOIN user AS creator ON u.created_by_uuid = creator.uuid
-        JOIN v_permission p ON u.uuid = p.grant_to
-        LEFT JOIN cloud c ON p.grant_on = c.name
-        LEFT JOIN v_model m on p.grant_on = m.uuid
-        LEFT JOIN ctrl ON p.grant_on = ctrl.c
+        JOIN %s p ON u.uuid = p.grant_to
 WHERE   u.name = $permUserName.name
 AND     u.disabled = false
 AND     u.removed = false
-%s
-`, andClause)
+`, view)
 
-	readStmt, err := st.Prepare(readQuery, dbReadUserPermission{}, dbPermissionUser{}, permUserName{})
+	readStmt, err := st.Prepare(readQuery, dbPermission{}, dbPermissionUser{}, permUserName{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -437,7 +422,6 @@ AND     u.removed = false
 
 	userAccess := make([]corepermission.UserAccess, len(permissions))
 	for i, p := range permissions {
-		p.ObjectType = string(objectType)
 		userAccess[i] = p.toUserAccess(actualUser[i])
 	}
 
@@ -519,46 +503,46 @@ WHERE  u.removed = false
 }
 
 // targetExists returns an error if the target does not exist in neither the
-// cloud nor v_model tables and is not a controller.
-func targetExists(ctx context.Context, tx *sqlair.TX, target string) error {
-	if target == coredatabase.ControllerNS {
+// cloud nor model tables and is not a controller.
+func targetExists(ctx context.Context, tx *sqlair.TX, target corepermission.ID) error {
+	var targetExists string
+	switch target.ObjectType {
+	case coredatabase.ControllerNS:
+		if target.Key != coredatabase.ControllerNS {
+			return fmt.Errorf("%q %w", target, accesserrors.PermissionTargetInvalid)
+		}
 		return nil
-	}
-
-	targetExists := `
-SELECT &M.found_it FROM (
-    SELECT "cloud" AS found_it FROM cloud WHERE cloud.name = $M.grant_on
-    UNION
-    SELECT "model" AS found_it FROM v_model WHERE v_model.uuid = $M.grant_on
-)
+	case corepermission.Model:
+		targetExists = `
+SELECT  model.uuid AS &M.found
+FROM    model
+WHERE   model.uuid = $M.grant_on
 `
+	case corepermission.Cloud:
+		targetExists = `
+SELECT  cloud.name AS &M.found
+FROM    cloud
+WHERE   cloud.name = $M.grant_on
+`
+	case corepermission.Offer:
+		return errors.NotImplementedf("db permission support for offers")
+	default:
+		return errors.NotValidf("object type %q", target.ObjectType)
+	}
 
 	targetExistsStmt, err := sqlair.Prepare(targetExists, sqlair.M{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	// Check that 1 row exists if the grant_on value is not ControllerNS.
-	// The behavior for this check is changing in sqlair, trying to
-	// account for either behavior. Old behavior: return no error and
-	// a slice length of zero. New behavior: if the length is 0, return
-	// ErrNoRows.
-	var foundIt = []sqlair.M{}
-	err = tx.Query(ctx, targetExistsStmt, sqlair.M{"grant_on": target}).GetAll(&foundIt)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+	m := sqlair.M{}
+	err = tx.Query(ctx, targetExistsStmt, sqlair.M{"grant_on": target.Key}).Get(&m)
+	if err != nil && errors.Is(err, sqlair.ErrNoRows) {
+		return fmt.Errorf("%q %w", target, accesserrors.PermissionTargetInvalid)
+	} else if err != nil {
 		return errors.Annotatef(err, "verifying %q target exists", target)
 	}
-
-	if len(foundIt) == 1 {
-		return nil
-	}
-
-	// Any answer other than 1 is an error. The target should exist
-	// as a unique identifier across the controller namespace.
-	if len(foundIt) == 0 {
-		return fmt.Errorf("%q %w", target, accesserrors.PermissionTargetInvalid)
-	}
-	return fmt.Errorf("%q %w", target, accesserrors.UniqueIdentifierIsNotUnique)
+	return nil
 }
 
 // objectTag returns a names.Tag for the given ID.
@@ -610,28 +594,28 @@ AND     u.removed = false
 	return inOut.UUID, nil
 }
 
-// targetPermissions returns a slice of dbReadUserPermission for
+// targetPermissions returns a slice of dbPermission for
 // every permission available for the given target specified by
 // grantOn.
 func (st *PermissionState) targetPermissions(ctx context.Context,
 	tx *sqlair.TX,
 	grantOn string,
-) ([]dbReadUserPermission, error) {
+) ([]dbPermission, error) {
 	type input struct {
 		GrantOn string `db:"grant_on"`
 	}
 	query := `
-SELECT (uuid, grant_on, grant_to, access_type) AS (&dbReadUserPermission.*)
+SELECT (uuid, grant_on, grant_to, access_type, object_type) AS (&dbPermission.*)
 FROM   v_permission
 WHERE  grant_on = $input.grant_on
 `
 	// Validate the grant_on target exists.
-	stmt, err := st.Prepare(query, dbReadUserPermission{}, input{})
+	stmt, err := st.Prepare(query, dbPermission{}, input{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	var usersPermissions = []dbReadUserPermission{}
+	var usersPermissions = []dbPermission{}
 	in := input{GrantOn: grantOn}
 	err = tx.Query(ctx, stmt, in).GetAll(&usersPermissions)
 	if err != nil {
@@ -686,7 +670,7 @@ func (st *PermissionState) upsertPermissionAuthorized(
 	// Is permission the apiUser has on the target Admin?
 	authQuery := `
 WITH    ctrl AS (SELECT 'controller' AS c)
-SELECT  (p.grant_to, p.access_type) AS (&dbReadUserPermission.*)
+SELECT  (p.grant_to, p.access_type) AS (&dbPermission.*)
 FROM    v_permission p
         JOIN v_user_auth u ON u.uuid = p.grant_to
         LEFT JOIN ctrl ON p.grant_on = ctrl.c
@@ -695,11 +679,11 @@ AND     (p.grant_on = $permInOut.grant_on OR p.grant_on = ctrl.c)
 AND     u.disabled = false
 AND     u.removed = false
 `
-	authStmt, err := st.Prepare(authQuery, dbReadUserPermission{}, permInOut{})
+	authStmt, err := st.Prepare(authQuery, dbPermission{}, permInOut{})
 	if err != nil {
 		return apiUserUUID, errors.Trace(err)
 	}
-	var readPerm []dbReadUserPermission
+	var readPerm []dbPermission
 	in := permInOut{
 		GrantOn: grantOn,
 		Name:    apiUser,
@@ -731,11 +715,13 @@ func (st *PermissionState) grantPermission(ctx context.Context, tx *sqlair.TX, s
 		if err != nil {
 
 		}
-		perm := dbAddUserPermission{
-			UUID:    newUUID.String(),
-			Access:  string(args.AccessSpec.Access),
-			GrantOn: args.AccessSpec.Target.Key,
-			GrantTo: subjectUUID,
+		spec := args.AccessSpec
+		perm := dbPermission{
+			UUID:       newUUID.String(),
+			GrantOn:    spec.Target.Key,
+			GrantTo:    subjectUUID,
+			AccessType: string(spec.Access),
+			ObjectType: string(spec.Target.ObjectType),
 		}
 		err = insertPermission(ctx, tx, perm)
 		return errors.Trace(err)
@@ -801,19 +787,19 @@ AND    grant_to IN (
 func (st *PermissionState) updatePermission(ctx context.Context, tx *sqlair.TX, subjectName, grantOn, access string) error {
 	updateQuery := `
 UPDATE permission
-SET    permission_type_id = (
-           SELECT id 
-           FROM   permission_access_type 
+SET    access_type_id = (
+           SELECT id
+           FROM   permission_access_type
            WHERE  type = $permInOut.access
-       ) 
+       )
 WHERE  grant_on = $permInOut.grant_on
 AND    grant_to IN (
-       SELECT uuid
-       FROM   v_user_auth
-       WHERE  name = $permInOut.name
-       AND    removed = false
-       AND    disabled = false
-)
+           SELECT uuid
+           FROM   v_user_auth
+           WHERE  name = $permInOut.name
+           AND    removed = false
+           AND    disabled = false
+       )
 `
 	updateQueryStmt, err := st.Prepare(updateQuery, permInOut{})
 	if err != nil {
@@ -831,22 +817,30 @@ AND    grant_to IN (
 	return nil
 }
 
-func insertPermission(ctx context.Context, tx *sqlair.TX, perm dbAddUserPermission) error {
+func insertPermission(ctx context.Context, tx *sqlair.TX, perm dbPermission) error {
 	// Insert a permission doc with
-	// * permissionObjectAccess as permission_type_id
+	// * id of access type as access_type_id
+	// * id of object type as object_type_id
 	// * uuid of the user (spec.User) as grant_to
 	// * spec.Target.Key as grant_on
 	newPermission := `
-INSERT INTO permission (uuid, permission_type_id, grant_to, grant_on)
-SELECT $dbAddUserPermission.uuid, t.id AS permission_type_id, u.uuid, $dbAddUserPermission.grant_on
-FROM   v_user_auth u, permission_access_type t
-WHERE  u.uuid = $dbAddUserPermission.grant_to
+INSERT INTO permission (uuid, access_type_id, object_type_id, grant_to, grant_on)
+SELECT $dbPermission.uuid,
+       at.id,
+       ot.id,
+       u.uuid,
+       $dbPermission.grant_on
+FROM   v_user_auth u,
+       permission_access_type at,
+       permission_object_type ot
+WHERE  u.uuid = $dbPermission.grant_to
 AND    u.disabled = false
 AND    u.removed = false
-AND    t.type = $dbAddUserPermission.access
+AND    at.type = $dbPermission.access_type
+AND    ot.type = $dbPermission.object_type
 `
 
-	insertPermissionStmt, err := sqlair.Prepare(newPermission, dbAddUserPermission{})
+	insertPermissionStmt, err := sqlair.Prepare(newPermission, dbPermission{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -857,7 +851,7 @@ AND    t.type = $dbAddUserPermission.access
 	if internaldatabase.IsErrConstraintUnique(err) {
 		return errors.Annotatef(accesserrors.PermissionAlreadyExists, "%q on %q", perm.GrantTo, perm.GrantOn)
 	} else if err != nil {
-		return errors.Annotatef(err, "adding permission %q for %q on %q", perm.Access, perm.GrantTo, perm.GrantOn)
+		return errors.Annotatef(err, "adding permission %q for %q on %q", perm.AccessType, perm.GrantTo, perm.GrantOn)
 	}
 	return nil
 }

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -316,7 +316,7 @@ WHERE grant_to = 123
 	c.Assert(row2.Err(), jc.ErrorIsNil)
 	err = row2.Scan(&userUuid, &accessTypeID, &objectTypeID, &grantTo, &grantOn)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Logf("%q, %d, to %q, on %q", userUuid, accessTypeID, objectTypeID, grantTo, grantOn)
+	c.Logf("%q, %d, %d to %q, on %q", userUuid, accessTypeID, objectTypeID, grantTo, grantOn)
 
 	readUserAccess, err := st.ReadUserAccessForTarget(context.Background(), "bob", target)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -49,7 +49,7 @@ func (s *permissionStateSuite) SetUpTest(c *gc.C) {
 func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
@@ -58,7 +58,8 @@ func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
 			},
 			Access: corepermission.WriteAccess,
 		},
-	})
+	}
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(userAccess.UserID, gc.Equals, "123")
@@ -69,13 +70,13 @@ func (s *permissionStateSuite) TestCreatePermissionModel(c *gc.C) {
 	c.Check(userAccess.UserName, gc.Equals, "bob")
 	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
 
-	s.checkPermissionRow(c, corepermission.WriteAccess, "123", s.modelUUID.String())
+	s.checkPermissionRow(c, userAccess.UserID, spec)
 }
 
 func (s *permissionStateSuite) TestCreatePermissionCloud(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
@@ -84,7 +85,8 @@ func (s *permissionStateSuite) TestCreatePermissionCloud(c *gc.C) {
 			},
 			Access: corepermission.AddModelAccess,
 		},
-	})
+	}
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(userAccess.UserID, gc.Equals, "123")
@@ -95,13 +97,13 @@ func (s *permissionStateSuite) TestCreatePermissionCloud(c *gc.C) {
 	c.Check(userAccess.UserName, gc.Equals, "bob")
 	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
 
-	s.checkPermissionRow(c, corepermission.AddModelAccess, "123", "test-cloud")
+	s.checkPermissionRow(c, userAccess.UserID, spec)
 }
 
 func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
-	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+	spec := corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
@@ -110,7 +112,8 @@ func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 			},
 			Access: corepermission.SuperuserAccess,
 		},
-	})
+	}
+	userAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(userAccess.UserID, gc.Equals, "123")
@@ -121,12 +124,13 @@ func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 	c.Check(userAccess.UserName, gc.Equals, "bob")
 	c.Check(userAccess.CreatedBy, gc.Equals, names.NewUserTag("admin"))
 
-	s.checkPermissionRow(c, corepermission.SuperuserAccess, "123", "controller")
+	s.checkPermissionRow(c, userAccess.UserID, spec)
 }
 
 func (s *permissionStateSuite) TestCreatePermissionForModelWithBadInfo(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
+	// model "foo-bar" is not created in this test suite, thus invalid.
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
@@ -143,6 +147,8 @@ func (s *permissionStateSuite) TestCreatePermissionForModelWithBadInfo(c *gc.C) 
 func (s *permissionStateSuite) TestCreatePermissionForControllerWithBadInfo(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), jujutesting.NewCheckLogger(c))
 
+	// The only valid key for an object type of Controller is
+	// 'controller'
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
@@ -156,26 +162,27 @@ func (s *permissionStateSuite) TestCreatePermissionForControllerWithBadInfo(c *g
 	c.Assert(err, jc.ErrorIs, accesserrors.PermissionTargetInvalid)
 }
 
-func (s *permissionStateSuite) checkPermissionRow(c *gc.C, access corepermission.Access, expectedGrantTo, expectedGrantON string) {
+func (s *permissionStateSuite) checkPermissionRow(c *gc.C, userUUID string, spec corepermission.UserAccessSpec) {
 	db := s.DB()
 
 	// Find the permission
 	row := db.QueryRow(`
-SELECT uuid, access_type, grant_to, grant_on
+SELECT uuid, access_type, object_type, grant_to, grant_on
 FROM v_permission
 `)
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	var (
-		accessType, userUuid, grantTo, grantOn string
+		accessType, objectType, permUuid, grantTo, grantOn string
 	)
-	err := row.Scan(&userUuid, &accessType, &grantTo, &grantOn)
+	err := row.Scan(&permUuid, &accessType, &objectType, &grantTo, &grantOn)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify the permission as expected.
-	c.Check(userUuid, gc.Not(gc.Equals), "")
-	c.Check(accessType, gc.Equals, string(access))
-	c.Check(grantTo, gc.Equals, expectedGrantTo)
-	c.Check(grantOn, gc.Equals, expectedGrantON)
+	c.Check(permUuid, gc.Not(gc.Equals), "")
+	c.Check(accessType, gc.Equals, string(spec.Access))
+	c.Check(objectType, gc.Equals, string(spec.Target.ObjectType))
+	c.Check(grantTo, gc.Equals, userUUID)
+	c.Check(grantOn, gc.Equals, spec.Target.Key)
 }
 
 func (s *permissionStateSuite) TestCreatePermissionErrorNoUser(c *gc.C) {
@@ -211,17 +218,17 @@ func (s *permissionStateSuite) TestCreatePermissionErrorDuplicate(c *gc.C) {
 
 	// Find the permission
 	row := s.DB().QueryRow(`
-SELECT uuid, permission_type_id, grant_to, grant_on 
+SELECT uuid, access_type_id, object_type_id, grant_to, grant_on
 FROM permission
-WHERE permission_type_id = 0
+WHERE access_type_id = 0 AND object_type_id = 2
 `)
 	c.Assert(row.Err(), jc.ErrorIsNil)
 
 	var (
 		userUuid, grantTo, grantOn string
-		permissionTypeId           int
+		accessTypeID, objectTypeID int
 	)
-	err = row.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	err = row.Scan(&userUuid, &accessTypeID, &objectTypeID, &grantTo, &grantOn)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure each combination of grant_on and grant_two
@@ -230,12 +237,12 @@ WHERE permission_type_id = 0
 	_, err = st.CreatePermission(context.Background(), uuid.MustNewUUID(), spec)
 	c.Assert(err, jc.ErrorIs, accesserrors.PermissionAlreadyExists)
 	row2 := s.DB().QueryRow(`
-SELECT uuid, permission_type_id, grant_to, grant_on 
+SELECT uuid, access_type_id, object_type_id, grant_to, grant_on
 FROM permission
-WHERE permission_type_id = 1
+WHERE access_type_id = 1 AND object_type_id = 2
 `)
 	c.Assert(row2.Err(), jc.ErrorIsNil)
-	err = row2.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	err = row2.Scan(&userUuid, &accessTypeID, &objectTypeID, &grantTo, &grantOn)
 	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
 }
 
@@ -298,18 +305,18 @@ func (s *permissionStateSuite) TestReadUserAccessForTarget(c *gc.C) {
 
 	var (
 		userUuid, grantTo, grantOn string
-		permissionTypeId           int
+		accessTypeID, objectTypeID int
 	)
 
 	row2 := s.DB().QueryRow(`
-SELECT uuid, permission_type_id, grant_to, grant_on 
+SELECT uuid, access_type_id, object_type_id, grant_to, grant_on
 FROM permission
 WHERE grant_to = 123
 `)
 	c.Assert(row2.Err(), jc.ErrorIsNil)
-	err = row2.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+	err = row2.Scan(&userUuid, &accessTypeID, &objectTypeID, &grantTo, &grantOn)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Logf("%q, %d, to %q, on %q", userUuid, permissionTypeId, grantTo, grantOn)
+	c.Logf("%q, %d, to %q, on %q", userUuid, accessTypeID, objectTypeID, grantTo, grantOn)
 
 	readUserAccess, err := st.ReadUserAccessForTarget(context.Background(), "bob", target)
 	c.Assert(err, jc.ErrorIsNil)
@@ -737,22 +744,21 @@ func (s *permissionStateSuite) ensureCloud(c *gc.C, uuid, name string) {
 
 func (s *permissionStateSuite) printPermissions(c *gc.C) {
 	rows, _ := s.DB().Query(`
-SELECT uuid, permission_type_id, grant_to, grant_on 
+SELECT uuid, access_type_id, object_type_id, grant_to, grant_on
 FROM permission
 `)
 	defer func() { _ = rows.Close() }()
 	var (
 		userUuid, grantTo, grantOn string
-		permissionTypeId           int
+		accessTypeID, objectTypeID int
 	)
 
 	c.Logf("PERMISSIONS")
 	for rows.Next() {
-		err := rows.Scan(&userUuid, &permissionTypeId, &grantTo, &grantOn)
+		err := rows.Scan(&userUuid, &accessTypeID, &objectTypeID, &grantTo, &grantOn)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("%q, %d, %q, %q", userUuid, permissionTypeId, grantTo, grantOn)
+		c.Logf("%q, %d, %d, %q, %q", userUuid, accessTypeID, objectTypeID, grantTo, grantOn)
 	}
-
 }
 
 func (s *permissionStateSuite) printUsers(c *gc.C) {
@@ -794,7 +800,7 @@ FROM user_authentication
 
 func (s *permissionStateSuite) printRead(c *gc.C) {
 	q := `
-SELECT  p.uuid, p.grant_on, p.grant_to, p.access_type,
+SELECT  p.uuid, p.grant_on, p.grant_to, p.access_type, p.object_type,
         u.uuid, u.name, creator.name
 FROM    v_user_auth u
         JOIN user AS creator ON u.created_by_uuid = creator.uuid
@@ -803,14 +809,14 @@ FROM    v_user_auth u
 	rows, _ := s.DB().Query(q)
 	defer func() { _ = rows.Close() }()
 	var (
-		permUUID, grantOn, grantTo, accessType string
-		userUUID, userName, createName         string
+		permUUID, grantOn, grantTo, accessType, objectType string
+		userUUID, userName, createName                     string
 	)
 	c.Logf("READ")
 	for rows.Next() {
-		err := rows.Scan(&permUUID, &grantOn, &grantTo, &accessType, &userUUID, &userName, &createName)
+		err := rows.Scan(&permUUID, &grantOn, &grantTo, &accessType, &objectType, &userUUID, &userName, &createName)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("LINE: %q, %q, %q, %q, %q, %q, %q,", permUUID, grantOn, grantTo, accessType, userUUID, userName, createName)
+		c.Logf("LINE: %q, %q, %q, %q, %q, %q, %q, %q", permUUID, grantOn, grantTo, accessType, objectType, userUUID, userName, createName)
 	}
 }
 

--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -105,26 +105,8 @@ func (u dbPermissionUser) toCoreUserAccess() corepermission.UserAccess {
 	}
 }
 
-// dbAddUserPermission represents a permission in the system where the values
-// overlap with corepermission.Permission.
-type dbAddUserPermission struct {
-	// UUID is the unique identifier for the permission.
-	UUID string `db:"uuid"`
-
-	// PermissionType is the type of permission.
-	Access string `db:"access"`
-
-	// GrantOn is the unique identifier of the permission target.
-	// A name or UUID depending on the ObjectType.
-	GrantOn string `db:"grant_on"`
-
-	// GrantTo is the unique identifier of the user the permission
-	// is granted to.
-	GrantTo string `db:"grant_to"`
-}
-
-// dbReadUserPermission represents a permission in the system.
-type dbReadUserPermission struct {
+// dbPermission represents a permission in the system.
+type dbPermission struct {
 	// UUID is the unique identifier for the permission.
 	UUID string `db:"uuid"`
 
@@ -143,9 +125,9 @@ type dbReadUserPermission struct {
 	ObjectType string `db:"object_type"`
 }
 
-// toUserAccess combines a dbReadUserPermission with a user to create
+// toUserAccess combines a dbPermission with a user to create
 // a core permission UserAccess.
-func (r dbReadUserPermission) toUserAccess(u dbPermissionUser) corepermission.UserAccess {
+func (r dbPermission) toUserAccess(u dbPermissionUser) corepermission.UserAccess {
 	userAccess := u.toCoreUserAccess()
 	userAccess.PermissionID = r.UUID
 	userAccess.Object = objectTag(corepermission.ID{

--- a/domain/cloud/state/types.go
+++ b/domain/cloud/state/types.go
@@ -189,7 +189,11 @@ type dbAddUserPermission struct {
 	// Name is the name of the user that the permission is granted to.
 	Name string `db:"name"`
 
-	// Access is the type of access for this user for the
+	// AccessType is the type of access for this user for the
 	// GrantOn value.
-	Access string `db:"access"`
+	AccessType string `db:"access_type"`
+
+	// ObjectType is the type of the object for this user for the
+	// GrantOn value.
+	ObjectType string `db:"object_type"`
 }

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -865,13 +865,9 @@ CREATE TABLE permission (
     CONSTRAINT         fk_permission_user_uuid
         FOREIGN KEY    (grant_to)
         REFERENCES     user(uuid),
-    CONSTRAINT      fk_permission_access_type
-        FOREIGN KEY (access_type_id)
-        REFERENCES  permission_access_type(id),
-    CONSTRAINT      fk_permission_object_type
-        FOREIGN KEY (object_type_id)
-        REFERENCES  permission_object_type(id)
-);
+    CONSTRAINT         fk_permission_object_access
+        FOREIGN KEY    (access_type_id, object_type_id)
+        REFERENCES     permission_object_access(access_type_id, object_type_id));
 
 -- Allow only 1 combination of grant_on and grant_to
 -- Otherwise we will get conflicting permissions.

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -880,9 +880,9 @@ ON permission (grant_on, grant_to);
 
 -- All permissions
 CREATE VIEW v_permission AS
-SELECT p.uuid AS uuid,
-       p.grant_on AS grant_on,
-       p.grant_to AS grant_to,
+SELECT p.uuid,
+       p.grant_on,
+       p.grant_to,
        at.type AS access_type,
        ot.type AS object_type
 FROM   permission p
@@ -891,39 +891,35 @@ FROM   permission p
 
 -- All model permissions, verifying the model does exist.
 CREATE VIEW v_permission_model AS
-SELECT p.uuid AS uuid,
-       p.grant_on AS grant_on,
-       p.grant_to AS grant_to,
-       at.type AS access_type,
-       ot.type AS object_type
-FROM   permission p
-       JOIN permission_access_type at ON at.id = p.access_type_id
-       JOIN permission_object_type ot ON ot.id = p.object_type_id
-       INNER JOIN model ON model.uuid = p.grant_on;
+SELECT p.uuid,
+       p.grant_on,
+       p.grant_to,
+       p.access_type,
+       p.object_type
+FROM   v_permission p
+       INNER JOIN model ON model.uuid = p.grant_on
+WHERE  p.object_type = 'model';
 
 -- All controller cloud, verifying the cloud does exist.
 CREATE VIEW v_permission_cloud AS
-SELECT p.uuid AS uuid,
-       p.grant_on AS grant_on,
-       p.grant_to AS grant_to,
-       at.type AS access_type,
-       ot.type AS object_type
-FROM   permission p
-       JOIN permission_access_type at ON at.id = p.access_type_id
-       JOIN permission_object_type ot ON ot.id = p.object_type_id
-       INNER JOIN cloud ON cloud.name = p.grant_on;
+SELECT p.uuid,
+       p.grant_on,
+       p.grant_to,
+       p.access_type,
+       p.object_type
+FROM   v_permission p
+       INNER JOIN cloud ON cloud.name = p.grant_on
+WHERE  p.object_type = 'cloud';
 
 -- All controller permissions
 CREATE VIEW v_permission_controller AS
-SELECT p.uuid AS uuid,
-       p.grant_on AS grant_on,
-       p.grant_to AS grant_to,
-       at.type AS access_type,
-       ot.type AS object_type
-FROM   permission p
-       JOIN permission_access_type at ON at.id = p.access_type_id
-       JOIN permission_object_type ot ON ot.id = p.object_type_id
-WHERE  grant_on = 'controller';
+SELECT p.uuid,
+       p.grant_on,
+       p.grant_to,
+       p.access_type,
+       p.object_type
+FROM   v_permission p
+WHERE  grant_on = 'controller' AND p.object_type = 'controller';
 
 `)
 }

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -811,14 +811,6 @@ INSERT INTO permission_access_type VALUES
     (5, 'add-model'),
     (6, 'superuser');
 
-CREATE VIEW v_permission AS
-SELECT at.type AS access_type,
-       p.uuid AS uuid,
-       p.grant_on AS grant_on,
-       p.grant_to AS grant_to
-FROM   permission p
-       JOIN permission_access_type at ON at.id = p.permission_type_id;
-
 CREATE TABLE permission_object_type (
     id    INT PRIMARY KEY,
     type  TEXT NOT NULL
@@ -866,20 +858,72 @@ INSERT INTO permission_object_access VALUES
 -- We will need to remove/replace it in the event of change
 CREATE TABLE permission (
     uuid               TEXT PRIMARY KEY,
-    permission_type_id INT NOT NULL,
+    access_type_id     INT NOT NULL,
+    object_type_id     INT NOT NULL,
     grant_on  		   TEXT NOT NULL, -- name or uuid of the object
     grant_to           TEXT NOT NULL,
     CONSTRAINT         fk_permission_user_uuid
         FOREIGN KEY    (grant_to)
         REFERENCES     user(uuid),
-    CONSTRAINT         fk_permission_access_type
-        FOREIGN KEY    (permission_type_id)
-        REFERENCES     permission_access_type(id)
+    CONSTRAINT      fk_permission_access_type
+        FOREIGN KEY (access_type_id)
+        REFERENCES  permission_access_type(id),
+    CONSTRAINT      fk_permission_object_type
+        FOREIGN KEY (object_type_id)
+        REFERENCES  permission_object_type(id)
 );
 
 -- Allow only 1 combination of grant_on and grant_to
 -- Otherwise we will get conflicting permissions.
 CREATE UNIQUE INDEX idx_permission_type_to
 ON permission (grant_on, grant_to);
+
+-- All permissions
+CREATE VIEW v_permission AS
+SELECT p.uuid AS uuid,
+       p.grant_on AS grant_on,
+       p.grant_to AS grant_to,
+       at.type AS access_type,
+       ot.type AS object_type
+FROM   permission p
+       JOIN permission_access_type at ON at.id = p.access_type_id
+       JOIN permission_object_type ot ON ot.id = p.object_type_id;
+
+-- All model permissions, verifying the model does exist.
+CREATE VIEW v_permission_model AS
+SELECT p.uuid AS uuid,
+       p.grant_on AS grant_on,
+       p.grant_to AS grant_to,
+       at.type AS access_type,
+       ot.type AS object_type
+FROM   permission p
+       JOIN permission_access_type at ON at.id = p.access_type_id
+       JOIN permission_object_type ot ON ot.id = p.object_type_id
+       INNER JOIN model ON model.uuid = p.grant_on;
+
+-- All controller cloud, verifying the cloud does exist.
+CREATE VIEW v_permission_cloud AS
+SELECT p.uuid AS uuid,
+       p.grant_on AS grant_on,
+       p.grant_to AS grant_to,
+       at.type AS access_type,
+       ot.type AS object_type
+FROM   permission p
+       JOIN permission_access_type at ON at.id = p.access_type_id
+       JOIN permission_object_type ot ON ot.id = p.object_type_id
+       INNER JOIN cloud ON cloud.name = p.grant_on;
+
+-- All controller permissions
+CREATE VIEW v_permission_controller AS
+SELECT p.uuid AS uuid,
+       p.grant_on AS grant_on,
+       p.grant_to AS grant_to,
+       at.type AS access_type,
+       ot.type AS object_type
+FROM   permission p
+       JOIN permission_access_type at ON at.id = p.access_type_id
+       JOIN permission_object_type ot ON ot.id = p.object_type_id
+WHERE  grant_on = 'controller';
+
 `)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -207,6 +207,9 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 
 		// Permissions
 		"v_permission",
+		"v_permission_cloud",
+		"v_permission_controller",
+		"v_permission_model",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }


### PR DESCRIPTION
Follow on to a  comment in [#17202 ](https://github.com/juju/juju/pull/17202#pullrequestreview-2003156542) regarding updates to the permission db schema.

Replace permission_type_id with its parts: access_type_id and object_type_id. This ensures that we can explicitly validate each object exists in the table it should. Today we know this by happenstance, aws can be a cloud name or a model name, however the object is a model uuid or a cloud name, thus no challenges to uniqueness. However it's better to be explicit. A side effect is simplifying many of the SQL queries.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests - there should be no outward change to current behavior.

## Links

**Jira card:** JUJU-5882

