### PR TITLE
Update the version of sqlair in go.mod

### DIFF
--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -419,24 +419,27 @@ func (s *State) SetModelSecretBackend(ctx context.Context, modelUUID coremodel.U
 		return errors.Trace(err)
 	}
 
-	modelBackendUpsertStmt, err := s.Prepare(`
+	// TODO(aflynn): Convert this query back to SQLair once we support nested
+	// select statements in INSERT statements. See SQLair issue #146.
+	modelBackendUpsertStmt := `
 INSERT INTO model_secret_backend
 	(model_uuid, secret_backend_uuid)
 VALUES (
-	$M.model_uuid,
-	(SELECT uuid FROM secret_backend WHERE name = $M.backend_name)
+	?,
+	(SELECT uuid FROM secret_backend WHERE name = ?)
 )
 ON CONFLICT (model_uuid) DO UPDATE SET
-	secret_backend_uuid = EXCLUDED.secret_backend_uuid`, sqlair.M{})
+	secret_backend_uuid = EXCLUDED.secret_backend_uuid`
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = tx.Query(ctx,
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		_, err = tx.ExecContext(ctx,
 			modelBackendUpsertStmt,
-			sqlair.M{"model_uuid": modelUUID, "backend_name": backendName},
-		).Run()
+			modelUUID,
+			backendName,
+		)
 		if database.IsErrConstraintForeignKey(err) {
 			return fmt.Errorf("%w: either model %q or secret backend %q", errors.NotFound, modelUUID, backendName)
 		}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
 	github.com/canonical/pebble v1.10.2
-	github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa
+	github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSH
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
 github.com/canonical/pebble v1.10.2 h1:TG0RYLqH+WEjnxsTB1JbaW0wzeygG0/dPHEEFQKn2JE=
 github.com/canonical/pebble v1.10.2/go.mod h1:BXpt85cFqrBgACeVRrTQ7JxZIdnGILv32V7mAfDcGFc=
-github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa h1:eRRgzybbMhVtJXwIyrTCTuS66n46Mq0Li/tQF3ZtHtU=
-github.com/canonical/sqlair v0.0.0-20240319123511-a48b89bb30aa/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
+github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b h1:jgRDcoa03uMllXr5RjGD+qAlG9cMbmAGAZ9d9Adb7Pw=
+github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Update SQLair to the latest version.

SQLair now supports:
- INSERT statements
- Bulk inserts
- Embedded structs
- Unicode chars
- Column names in quotes
- Selecting things in brackets into output expressions

There are a small subset of SQLair queries that do not work that did work before due to this change. This is tracked in SQLair issue https://github.com/canonical/sqlair/issues/146. There was one of these queries in juju which has been switched back to a database/sql query.

## QA steps
None of these changes change any existing behavior so no specific QA is needed.



<!-- How it affects user workflow (CLI or API). -->

