### PR TITLE
Remove unused upgrade series code

### DIFF
--- a/api/agent/upgradeseries/upgradeseries.go
+++ b/api/agent/upgradeseries/upgradeseries.go
@@ -69,47 +69,6 @@ func (s *Client) MachineStatus() (model.UpgradeSeriesStatus, error) {
 	return "", errors.Trace(r.Error)
 }
 
-// CurrentSeries returns what Juju thinks the current series of the machine is.
-// Note that a machine could have been upgraded out-of-band by running
-// do-release-upgrade outside of the upgrade-machine workflow,
-// making this value incorrect.
-func (s *Client) CurrentSeries() (string, error) {
-	series, err := s.series("CurrentSeries")
-	return series, errors.Trace(err)
-}
-
-// TargetSeries returns the series that a machine has been locked
-// for upgrading to.
-func (s *Client) TargetSeries() (string, error) {
-	series, err := s.series("TargetSeries")
-	return series, errors.Trace(err)
-}
-
-func (s *Client) series(methodName string) (string, error) {
-	var results params.StringResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: s.authTag.String()}},
-	}
-
-	err := s.facade.FacadeCall(methodName, args, &results)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-
-	r := results.Results[0]
-	if r.Error == nil {
-		return r.Result, nil
-	}
-
-	if params.IsCodeNotFound(r.Error) {
-		return "", errors.NewNotFound(r.Error, "")
-	}
-	return "", errors.Trace(r.Error)
-}
-
 // UnitsPrepared returns the units running on this machine that have
 // completed their upgrade-machine preparation, and are ready to be stopped and
 // have their unit agent services converted for the target series.

--- a/api/agent/upgradeseries/upgradeseries_test.go
+++ b/api/agent/upgradeseries/upgradeseries_test.go
@@ -98,44 +98,6 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *upgradeSeriesSuite) TestCurrentSeries(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	fCaller := mocks.NewMockFacadeCaller(ctrl)
-
-	resultSource := params.StringResults{
-		Results: []params.StringResult{{
-			Result: "xenial",
-		}},
-	}
-	fCaller.EXPECT().FacadeCall("CurrentSeries", s.args, gomock.Any()).SetArg(2, resultSource)
-
-	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	target, err := api.CurrentSeries()
-	c.Assert(err, gc.IsNil)
-	c.Check(target, gc.Equals, "xenial")
-}
-
-func (s *upgradeSeriesSuite) TestTargetSeries(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	fCaller := mocks.NewMockFacadeCaller(ctrl)
-
-	resultSource := params.StringResults{
-		Results: []params.StringResult{{
-			Result: "bionic",
-		}},
-	}
-	fCaller.EXPECT().FacadeCall("TargetSeries", s.args, gomock.Any()).SetArg(2, resultSource)
-
-	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	target, err := api.TargetSeries()
-	c.Assert(err, gc.IsNil)
-	c.Check(target, gc.Equals, "bionic")
-}
-
 func (s *upgradeSeriesSuite) TestUnitsPrepared(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -134,7 +134,7 @@ var facadeVersions = facades.FacadeVersions{
 	"UnitAssigner":                 {1},
 	"Uniter":                       {18, 19},
 	"Upgrader":                     {1},
-	"UpgradeSeries":                {3},
+	"UpgradeSeries":                {3, 4},
 	"UpgradeSteps":                 {2},
 	"UserManager":                  {3},
 	"VolumeAttachmentsWatcher":     {2},

--- a/apiserver/facades/agent/upgradeseries/register.go
+++ b/apiserver/facades/agent/upgradeseries/register.go
@@ -15,8 +15,19 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("UpgradeSeries", 3, func(ctx facade.Context) (facade.Facade, error) {
-		return newAPI(ctx) // Adds SetStatus.
+		return newAPIv3(ctx) // Adds SetStatus.
+	}, reflect.TypeOf((*APIv3)(nil)))
+	registry.MustRegister("UpgradeSeries", 4, func(ctx facade.Context) (facade.Facade, error) {
+		return newAPI(ctx) // Removes CurrentSeries and TargetSeries
 	}, reflect.TypeOf((*API)(nil)))
+}
+
+func newAPIv3(ctx facade.Context) (*APIv3, error) {
+	api, err := newAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv3{api}, nil
 }
 
 // newAPI creates a new instance of the API with the given context

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -30,6 +30,10 @@ type API struct {
 	leadership *common.LeadershipPinning
 }
 
+type APIv3 struct {
+	*API
+}
+
 // NewUpgradeSeriesAPI creates a new instance of the API server using the
 // dedicated state indirection.
 func NewUpgradeSeriesAPI(
@@ -120,7 +124,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 // Note that a machine could have been upgraded out-of-band by running
 // do-release-upgrade outside of the upgrade-machine workflow,
 // making this value incorrect.
-func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) {
+func (a *APIv3) CurrentSeries(args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -149,7 +153,7 @@ func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) 
 
 // TargetSeries returns the series that a machine has been locked
 // for upgrading to.
-func (a *API) TargetSeries(args params.Entities) (params.StringResults, error) {
+func (a *APIv3) TargetSeries(args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{}
 
 	canAccess, err := a.AccessMachine()

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -91,7 +91,9 @@ func (s *upgradeSeriesSuite) TestCurrentSeries(c *gc.C) {
 
 	s.machine.EXPECT().Base().Return(state.UbuntuBase("16.04")).AnyTimes()
 
-	results, err := s.api.CurrentSeries(s.entityArgs)
+	api := &upgradeseries.APIv3{s.api}
+
+	results, err := api.CurrentSeries(s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{{Result: "xenial"}},
@@ -103,7 +105,9 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesTarget(c *gc.C) {
 
 	s.machine.EXPECT().UpgradeSeriesTarget().Return("bionic", nil)
 
-	results, err := s.api.TargetSeries(s.entityArgs)
+	api := &upgradeseries.APIv3{s.api}
+
+	results, err := api.TargetSeries(s.entityArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{{Result: "bionic"}},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -51098,7 +51098,7 @@
     {
         "Name": "UpgradeSeries",
         "Description": "API serves methods required by the machine agent upgrade-machine worker.",
-        "Version": 3,
+        "Version": 4,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -51108,18 +51108,6 @@
         "Schema": {
             "type": "object",
             "properties": {
-                "CurrentSeries": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/StringResults"
-                        }
-                    },
-                    "description": "CurrentSeries returns what Juju thinks the current series of the machine is.\nNote that a machine could have been upgraded out-of-band by running\ndo-release-upgrade outside of the upgrade-machine workflow,\nmaking this value incorrect."
-                },
                 "FinishUpgradeSeries": {
                     "type": "object",
                     "properties": {
@@ -51209,18 +51197,6 @@
                         }
                     },
                     "description": "StartUnitCompletion starts the upgrade series completion phase for all subordinate\nunits of a given machine."
-                },
-                "TargetSeries": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/StringResults"
-                        }
-                    },
-                    "description": "TargetSeries returns the series that a machine has been locked\nfor upgrading to."
                 },
                 "UnitsCompleted": {
                     "type": "object",
@@ -51513,36 +51489,6 @@
                     "additionalProperties": false,
                     "required": [
                         "entities"
-                    ]
-                },
-                "StringResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "result": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "result"
-                    ]
-                },
-                "StringResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/StringResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "UpdateChannelArg": {

--- a/worker/upgradeseries/manifold.go
+++ b/worker/upgradeseries/manifold.go
@@ -65,8 +65,8 @@ func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) 
 
 	// Partially apply the upgrader factory function so we only need to request
 	// using the getter for the to/from OS series.
-	newUpgrader := func(currentSeries, targetSeries string) (Upgrader, error) {
-		return NewUpgrader(currentSeries, targetSeries, service.NewServiceManagerWithDefaults(), config.Logger)
+	newUpgrader := func() (Upgrader, error) {
+		return NewUpgrader(service.NewServiceManagerWithDefaults(), config.Logger)
 	}
 
 	cfg := Config{

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -41,21 +41,6 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 	return m.recorder
 }
 
-// CurrentSeries mocks base method.
-func (m *MockFacade) CurrentSeries() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CurrentSeries")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CurrentSeries indicates an expected call of CurrentSeries.
-func (mr *MockFacadeMockRecorder) CurrentSeries() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentSeries", reflect.TypeOf((*MockFacade)(nil).CurrentSeries))
-}
-
 // FinishUpgradeSeries mocks base method.
 func (m *MockFacade) FinishUpgradeSeries(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -140,21 +125,6 @@ func (m *MockFacade) StartUnitCompletion(arg0 string) error {
 func (mr *MockFacadeMockRecorder) StartUnitCompletion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartUnitCompletion", reflect.TypeOf((*MockFacade)(nil).StartUnitCompletion), arg0)
-}
-
-// TargetSeries mocks base method.
-func (m *MockFacade) TargetSeries() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TargetSeries")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TargetSeries indicates an expected call of TargetSeries.
-func (mr *MockFacadeMockRecorder) TargetSeries() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TargetSeries", reflect.TypeOf((*MockFacade)(nil).TargetSeries))
 }
 
 // UnitsCompleted mocks base method.

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -19,8 +19,6 @@ type Facade interface {
 	MachineStatus() (model.UpgradeSeriesStatus, error)
 	UnitsPrepared() ([]names.UnitTag, error)
 	UnitsCompleted() ([]names.UnitTag, error)
-	CurrentSeries() (string, error)
-	TargetSeries() (string, error)
 
 	// Setters
 	StartUnitCompletion(reason string) error

--- a/worker/upgradeseries/upgrader.go
+++ b/worker/upgradeseries/upgrader.go
@@ -25,16 +25,6 @@ type Upgrader interface {
 type upgrader struct {
 	logger Logger
 
-	// jujuCurrentSeries is what Juju thinks the
-	// current series of the machine is.
-	jujuCurrentSeries string
-
-	// fromSeries is the actual current series,
-	// determined directly from the machine.
-	fromSeries string
-
-	toSeries string
-
 	machineAgent string
 	unitAgents   []string
 
@@ -44,18 +34,11 @@ type upgrader struct {
 // NewUpgrader uses the input function to determine the series that should be
 // supported, and returns a reference to a new Upgrader that supports it.
 func NewUpgrader(
-	currentSeries, toSeries string, manager service.SystemdServiceManager, logger Logger,
+	manager service.SystemdServiceManager, logger Logger,
 ) (Upgrader, error) {
-	fromSeries, err := hostSeries()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	return &upgrader{
-		logger:            logger,
-		jujuCurrentSeries: currentSeries,
-		fromSeries:        fromSeries,
-		toSeries:          toSeries,
-		manager:           manager,
+		logger:  logger,
+		manager: manager,
 	}, nil
 }
 

--- a/worker/upgradeseries/upgrader_test.go
+++ b/worker/upgradeseries/upgrader_test.go
@@ -37,7 +37,7 @@ func (s *upgraderSuite) TestPerformUpgrade(c *gc.C) {
 	defer ctrl.Finish()
 	s.setupMocks(ctrl)
 
-	upg := s.newUpgrader(c, "focal", "jammy")
+	upg := s.newUpgrader(c)
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
@@ -49,8 +49,8 @@ func (s *upgraderSuite) setupMocks(ctrl *gomock.Controller) {
 	s.manager.EXPECT().FindAgents(paths.NixDataDir).Return(s.machineService, []string{"jujud-unit-ubuntu-0", "jujud-unit-redis-0"}, nil, nil)
 }
 
-func (s *upgraderSuite) newUpgrader(c *gc.C, currentSeries, toSeries string) upgradeseries.Upgrader {
-	upg, err := upgradeseries.NewUpgrader(currentSeries, toSeries, s.manager, s.logger)
+func (s *upgraderSuite) newUpgrader(c *gc.C) upgradeseries.Upgrader {
+	upg, err := upgradeseries.NewUpgrader(s.manager, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 	return upg
 }

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -50,7 +50,7 @@ type Config struct {
 	// UpgraderFactory is a factory method that will return an upgrader capable
 	// of handling service and agent binary manipulation for a
 	// runtime-determined current and target OS series.
-	UpgraderFactory func(string, string) (Upgrader, error)
+	UpgraderFactory func() (Upgrader, error)
 }
 
 // Validate validates the upgrade-series worker configuration.
@@ -83,7 +83,7 @@ type upgradeSeriesWorker struct {
 	catacomb        catacomb.Catacomb
 	logger          Logger
 	unitDiscovery   UnitDiscovery
-	upgraderFactory func(string, string) (Upgrader, error)
+	upgraderFactory func() (Upgrader, error)
 
 	// Some local state retained for reporting purposes.
 	mu             sync.Mutex
@@ -248,17 +248,7 @@ func (w *upgradeSeriesWorker) transitionPrepareComplete() error {
 	}
 
 	w.logger.Infof("preparing service units for series upgrade")
-	currentSeries, err := w.CurrentSeries()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	toSeries, err := w.TargetSeries()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	upgrader, err := w.upgraderFactory(currentSeries, toSeries)
+	upgrader, err := w.upgraderFactory()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -178,8 +178,6 @@ func (s *workerSuite) expectMachinePrepareStartedUnitFilesWrittenProgressPrepare
 	exp.MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	s.expectSetInstanceStatus(model.UpgradeSeriesPrepareStarted, "preparing units")
 	s.expectUnitsPrepared("wordpress/0", "mysql/0")
-	exp.CurrentSeries().Return("focal", nil)
-	exp.TargetSeries().Return("jammy", nil)
 
 	s.upgrader.EXPECT().PerformUpgrade().Return(nil)
 	s.expectSetInstanceStatus(model.UpgradeSeriesPrepareStarted, "completing preparation")
@@ -318,7 +316,7 @@ func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 		Logger:          s.logger,
 		Facade:          s.facade,
 		UnitDiscovery:   s.unitDiscovery,
-		UpgraderFactory: func(_, _ string) (upgradeseries.Upgrader, error) { return s.upgrader, nil },
+		UpgraderFactory: func() (upgradeseries.Upgrader, error) { return s.upgrader, nil },
 	}
 
 	w, err := upgradeseries.NewWorker(cfg)


### PR DESCRIPTION
The upgrade series worker had some attributes, jujuCurrentSeries,
toSeries and fromSeries, which it turns out are not used anywhere

Remove these attributes. Drop the code that constructs them

Some of this data would be collected with an api call.

Bump the facade version of UpgradeSeries and drop these two methods
from the new facade. They are not used anywhere else

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Download the ubuntu charm and edit it's `src/charm.py` file
```
$ mkdir ubuntu
$ cd ubuntu
$ juju download ubuntu
$ unzip ./ubuntu_r24.charm
$ cd ..
```

edit `src/charm.py` to include:
```
    def __init__(self, *args):
        """Initialize charm.

        Setup hook event observers and any other basic initialization.
        """
...
        self.framework.observe(self.on.config_changed, self._update_hostname)
        self.framework.observe(self.on.pre_series_upgrade, self._pre)

    def _pre(self, event):
        log.warning("=========== pre ===========")
        log.warning(msg=os.environ)
```

Note: This is now a local charm at `./ubuntu`

### Upgrade the base

```
$ juju add-model m
$ juju deploy ./ubuntu --base ubuntu@20.04
(wait until active-idle)
$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete

$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m2     lxd         localhost/localhost  3.5-beta2.1  unsupported  15:51:27+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.192         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.192  juju-869763-0  ubuntu@20.04      series upgrade prepare completed: waiting for completion command
```

Now look in the model `debug-logs`
```
$ juju debug-log
...
unit-ubuntu-0: 15:51:12 WARNING unit.ubuntu/0.juju-log =========== pre ===========
unit-ubuntu-0: 15:51:12 WARNING unit.ubuntu/0.juju-log environ({'JUJU_UNIT_NAME': 'ubuntu/0', 'JUJU_VERSION': '3.5-beta2.1', 'JUJU_CHARM_HTTP_PROXY': '', 'APT_LISTCHANGES_FRONTEND': 'none', 'JUJU_CONTEXT_ID': 'ubuntu/0-pre-series-upgrade-6160771519434089056', 'JUJU_AGENT_SOCKET_NETWORK': 'unix', 'JUJU_API_ADDRESSES': '10.219.211.70:17070', 'JUJU_CHARM_HTTPS_PROXY': '', 'JUJU_AGENT_SOCKET_ADDRESS': '@/var/lib/juju/agents/unit-ubuntu-0/agent.socket', 'JUJU_MODEL_NAME': 'm2', 'JUJU_DISPATCH_PATH': 'hooks/pre-series-upgrade', 'JUJU_TARGET_BASE': 'ubuntu@22.04', 'JUJU_AVAILABILITY_ZONE': '', 'JUJU_CHARM_DIR': '/var/lib/juju/agents/unit-ubuntu-0/charm', 'TERM': 'tmux-256color', 'PATH': '/var/lib/juju/tools/unit-ubuntu-0:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin', 'JUJU_METER_STATUS': 'AMBER', 'JUJU_HOOK_NAME': 'pre-series-upgrade', 'LANG': 'C.UTF-8', 'CLOUD_API_VERSION': '', 'DEBIAN_FRONTEND': 'noninteractive', 'JUJU_SLA': 'unsupported', 'JUJU_MODEL_UUID': '1af1725d-7c3e-4b53-8dc5-61c71e869763', 'JUJU_TARGET_SERIES': 'jammy', 'JUJU_MACHINE_ID': '0', 'JUJU_CHARM_FTP_PROXY': '', 'JUJU_METER_INFO': 'not set', 'PWD': '/var/lib/juju/agents/unit-ubuntu-0/charm', 'JUJU_PRINCIPAL_UNIT': '', 'JUJU_CHARM_NO_PROXY': '127.0.0.1,localhost,::1', 'PYTHONPATH': 'lib:venv', 'CHARM_DIR': '/var/lib/juju/agents/unit-ubuntu-0/charm', 'OPERATOR_DISPATCH': '1'})
...
```
Note that `'JUJU_TARGET_BASE': 'ubuntu@22.04'` and `'JUJU_TARGET_SERIES': 'jammy'` are both present

Continue with the upgrade
```
$ juju upgrade-machine 0 complete
machine-0 complete phase started
machine-0 start units after series upgrade
ubuntu/0 post-series-upgrade hook running
ubuntu/0 post-series-upgrade completed
machine-0 series upgrade complete

Upgrade machine base "0" has successfully completed
```

## Links

Jira card: https://warthogs.atlassian.net/browse/JUJU-5890