### PR TITLE
Backport pull request #17224

### DIFF
--- a/api/controller/caasunitprovisioner/client.go
+++ b/api/controller/caasunitprovisioner/client.go
@@ -96,7 +96,10 @@ func (c *Client) ApplicationConfig(applicationName string) (config.ConfigAttribu
 	if len(results.Results) != len(args.Entities) {
 		return nil, errors.Errorf("expected %d result(s), got %d", len(args.Entities), len(results.Results))
 	}
-	return config.ConfigAttributes(results.Results[0].Config), nil
+	if err := results.Results[0].Error; err != nil {
+		return nil, params.TranslateWellKnownError(err)
+	}
+	return results.Results[0].Config, nil
 }
 
 // WatchApplicationScale returns a NotifyWatcher that notifies of

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -77,7 +77,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCharm(c, app, s.charm.URL())
 	s.assertSettings(c, app, charm.Settings{})
-	s.assertApplicationConfig(c, app, coreconfig.ConfigAttributes(nil))
+	s.assertApplicationConfig(c, app, coreconfig.ConfigAttributes{})
 	s.assertConstraints(c, app, constraints.MustParse("arch=amd64"))
 	s.assertMachines(c, app, constraints.Value{})
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -899,6 +899,9 @@ func (k *kubernetesClient) EnsureService(
 	}
 
 	if params.PodSpec != nil {
+		if config == nil {
+			return errors.Errorf("config for k8s app %q cannot be nil", appName)
+		}
 		return k.ensureService(appName, deploymentName, statusCallback, params, numUnits, config)
 	}
 	if len(params.RawK8sSpec) > 0 {

--- a/state/application.go
+++ b/state/application.go
@@ -3232,13 +3232,13 @@ func (a *Application) ApplicationConfig() (config.ConfigAttributes, error) {
 	cfg, err := readSettings(a.st.db(), settingsC, a.applicationConfigKey())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return config.ConfigAttributes(nil), nil
+			return config.ConfigAttributes{}, nil
 		}
 		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
 	}
 
 	if len(cfg.Keys()) == 0 {
-		return config.ConfigAttributes(nil), nil
+		return config.ConfigAttributes{}, nil
 	}
 	return cfg.Map(), nil
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4659,6 +4659,7 @@ var updateApplicationConfigTests = []struct {
 }, {
 	about:  "unset missing string",
 	update: config.ConfigAttributes{"outlook": nil},
+	expect: config.ConfigAttributes{},
 }, {
 	about:   `empty strings are valid`,
 	initial: config.ConfigAttributes{"outlook": "positive"},
@@ -4682,6 +4683,7 @@ var updateApplicationConfigTests = []struct {
 	about:   "unset non-string type",
 	initial: config.ConfigAttributes{"skill-level": 303},
 	update:  config.ConfigAttributes{"skill-level": nil},
+	expect:  config.ConfigAttributes{},
 }}
 
 func (s *ApplicationSuite) TestUpdateApplicationConfig(c *gc.C) {
@@ -4725,7 +4727,7 @@ func (s *ApplicationSuite) TestApplicationConfigNotFoundNoError(c *gc.C) {
 
 	cfg, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cfg, gc.IsNil)
+	c.Assert(cfg, gc.HasLen, 0)
 }
 
 func (s *ApplicationSuite) TestStatusInitial(c *gc.C) {

--- a/worker/uniter/actions/resolver.go
+++ b/worker/uniter/actions/resolver.go
@@ -58,7 +58,7 @@ func (r *actionsResolver) NextOp(
 	// deferred until the unit is running. If the remote charm needs
 	// updating, hold off on action running.
 	if remoteState.ActionsBlocked || localState.OutdatedRemoteCharm {
-		r.logger.Infof("actions are blocked=%v; outdated remote charm=%v - have pending actions: %v", remoteState.ActionsBlocked, localState.OutdatedRemoteCharm, remoteState.ActionsPending)
+		r.logger.Debugf("actions are blocked=%v; outdated remote charm=%v - have pending actions: %v", remoteState.ActionsBlocked, localState.OutdatedRemoteCharm, remoteState.ActionsPending)
 		if localState.ActionId == nil {
 			r.logger.Debugf("actions are blocked, no in flight actions")
 			return nil, resolver.ErrNoOperation


### PR DESCRIPTION
https://github.com/juju/juju/pull/17224

This is a tactical fix for a nil map issue.
The root cause appears to be slow async download of a charm (not fully confirmed, just a plausible theory as to why this started happening in 3.x).

The call to state `ApplicationConfig()` for reasons perhaps lost to history decided to return a nil map AND a nil error if things were not found. The caller saw nil error and for podspec charms, the map was used and it all went pear shaped with a panic. There's other call sites too with same same potential issue, but this one occurs first.

The fix is to return an empty map. We could return a not found error but the existing code explicitly does not do this so to avoid unintended consequences this is the safest fix.

Also a couple of small driveby tweaks.

## QA steps

bootstrap microk8s
`juju deploy kubeflow-volumes --channel 1.8/stable`
```
Unit Workload Agent Address Ports Message
controller/0* active idle 10.1.78.81 37017/TCP 
kubeflow-volumes/0* active idle 10.1.78.84 5000/TCP 
```
Previously logs would have a panic and unit would be waiting forever.

## Links

https://bugs.launchpad.net/juju/+bug/2060943

**Jira card:** [JUJU-5887](https://warthogs.atlassian.net/browse/JUJU-5887)



[JUJU-5887]: https://warthogs.atlassian.net/browse/JUJU-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ