### PR TITLE
Fix insertion of new debug log records into the buffered logger

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1381,6 +1381,7 @@ func (s *apiclientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 		Level:         loggo.ERROR,
 		Replay:        true,
 		NoTail:        true,
+		Firehose:      true,
 		StartTime:     time.Date(2016, 11, 30, 11, 48, 0, 100, time.UTC),
 	}
 
@@ -1397,6 +1398,7 @@ func (s *apiclientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 		"level":         {"ERROR"},
 		"replay":        {"true"},
 		"noTail":        {"true"},
+		"firehose":      {"true"},
 		"startTime":     {"2016-11-30T11:48:00.0000001Z"},
 	}
 

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -61,6 +61,8 @@ type DebugLogParams struct {
 	// StartTime should be a time in the past - only records with a
 	// log time on or after StartTime will be returned.
 	StartTime time.Time
+	// Firehose streams logs from all models from the logsink.log file.
+	Firehose bool
 }
 
 func (args DebugLogParams) URLQuery() url.Values {
@@ -100,6 +102,9 @@ func (args DebugLogParams) URLQuery() url.Values {
 	if args.NoTail {
 		attrs.Set("noTail", fmt.Sprint(args.NoTail))
 	}
+	if args.Firehose {
+		attrs.Set("firehose", fmt.Sprint(args.Firehose))
+	}
 	if args.Limit > 0 {
 		attrs.Set("maxLines", fmt.Sprint(args.Limit))
 	}
@@ -117,6 +122,7 @@ func (args DebugLogParams) URLQuery() url.Values {
 
 // LogMessage is a structured logging entry.
 type LogMessage struct {
+	ModelUUID string
 	Entity    string
 	Timestamp time.Time
 	Severity  string
@@ -154,6 +160,7 @@ func StreamDebugLog(ctx context.Context, source base.StreamConnector, args Debug
 				return
 			}
 			messages <- LogMessage{
+				ModelUUID: msg.ModelUUID,
 				Entity:    msg.Entity,
 				Timestamp: msg.Timestamp,
 				Severity:  msg.Severity,

--- a/apiserver/debuglog_tailer.go
+++ b/apiserver/debuglog_tailer.go
@@ -78,6 +78,7 @@ func makeLogTailerParams(reqParams debugLogParams) logtailer.LogTailerParams {
 	tailerParams := logtailer.LogTailerParams{
 		MinLevel:      reqParams.filterLevel,
 		NoTail:        reqParams.noTail,
+		Firehose:      reqParams.firehose,
 		StartTime:     reqParams.startTime,
 		InitialLines:  int(reqParams.backlog),
 		IncludeEntity: reqParams.includeEntity,
@@ -95,6 +96,7 @@ func makeLogTailerParams(reqParams debugLogParams) logtailer.LogTailerParams {
 
 func formatLogRecord(r *corelogger.LogRecord) *params.LogMessage {
 	return &params.LogMessage{
+		ModelUUID: r.ModelUUID,
 		Entity:    r.Entity,
 		Timestamp: r.Time,
 		Severity:  r.Level.String(),

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -110,6 +110,12 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 				Replay:  true,
 			},
 		}, {
+			args: []string{"--firehose"},
+			expected: common.DebugLogParams{
+				Backlog:  10,
+				Firehose: true,
+			},
+		}, {
 			args:     []string{"--no-tail", "--tail"},
 			errMatch: `setting --tail and --no-tail not valid`,
 		}, {
@@ -168,6 +174,7 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand, _ []string) (DebugLogAPI, error) {
 		return &fakeDebugLogAPI{log: []common.LogMessage{
 			{
+				ModelUUID: "model-uuid",
 				Entity:    "machine-0",
 				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
 				Severity:  "INFO",
@@ -204,7 +211,7 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 		"machine-0: 14:15:23 INFO test.module somefile.go:123 this is the log output\n")
 	checkOutput(
 		"--format", "json",
-		`{"timestamp":"2016-10-09T08:15:23.345Z","entity":"machine-0","level":"INFO","module":"test.module","location":"somefile.go:123","message":"this is the log output"}`+"\n")
+		`{"model-uuid":"model-uuid","timestamp":"2016-10-09T08:15:23.345Z","entity":"machine-0","level":"INFO","module":"test.module","location":"somefile.go:123","message":"this is the log output"}`+"\n")
 }
 
 func (s *DebugLogSuite) TestSpecifiedController(c *gc.C) {

--- a/core/logger/buf.go
+++ b/core/logger/buf.go
@@ -49,7 +49,7 @@ func insertSorted(recs []LogRecord, in []LogRecord) []LogRecord {
 			recs = append(recs, r)
 			continue
 		}
-		copy(recs[:i+1], recs[i:])
+		recs = append(recs[:i+1], recs[i:]...)
 		recs[i] = r
 	}
 	return recs

--- a/core/logger/record.go
+++ b/core/logger/record.go
@@ -30,24 +30,26 @@ type LogRecord struct {
 }
 
 type logRecordJSON struct {
-	Time     time.Time         `json:"timestamp"`
-	Entity   string            `json:"entity"`
-	Level    string            `json:"level"`
-	Module   string            `json:"module"`
-	Location string            `json:"location"`
-	Message  string            `json:"message"`
-	Labels   map[string]string `json:"labels,omitempty"`
+	ModelUUID string            `json:"model-uuid,omitempty"`
+	Time      time.Time         `json:"timestamp"`
+	Entity    string            `json:"entity"`
+	Level     string            `json:"level"`
+	Module    string            `json:"module"`
+	Location  string            `json:"location"`
+	Message   string            `json:"message"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 func (r *LogRecord) MarshalJSON() ([]byte, error) {
 	jrec := logRecordJSON{
-		Time:     r.Time,
-		Entity:   r.Entity,
-		Level:    r.Level.String(),
-		Module:   r.Module,
-		Location: r.Location,
-		Message:  r.Message,
-		Labels:   r.Labels,
+		ModelUUID: r.ModelUUID,
+		Time:      r.Time,
+		Entity:    r.Entity,
+		Level:     r.Level.String(),
+		Module:    r.Module,
+		Location:  r.Location,
+		Message:   r.Message,
+		Labels:    r.Labels,
 	}
 	return json.Marshal(jrec)
 }

--- a/core/logger/record_test.go
+++ b/core/logger/record_test.go
@@ -34,6 +34,11 @@ func (s *LogRecordSuite) TestMarshall(c *gc.C) {
 	}
 	data, err := json.Marshal(rec)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, `{"model-uuid":"deadbeef-0bad-400d-8000-4b1d0d06f00d","timestamp":"2024-01-01T09:08:07Z","entity":"some-entity","level":"DEBUG","module":"some-module","location":"some-location","message":"some-message","labels":{"foo":"bar"}}`)
+
+	rec.ModelUUID = ""
+	data, err = json.Marshal(rec)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `{"timestamp":"2024-01-01T09:08:07Z","entity":"some-entity","level":"DEBUG","module":"some-module","location":"some-location","message":"some-message","labels":{"foo":"bar"}}`)
 }
 

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -850,6 +850,7 @@ type SingularClaims struct {
 // from the api server /logs endpoint.
 // The client is used for model migration and debug-log.
 type LogMessage struct {
+	ModelUUID string            `json:"uuid,omitempty"`
 	Entity    string            `json:"tag"`
 	Timestamp time.Time         `json:"ts"`
 	Severity  string            `json:"sev"`
@@ -872,6 +873,7 @@ type LogMessageV1 struct {
 }
 
 type logMessageJSON struct {
+	ModelUUID string    `json:"uuid,omitempty"`
 	Entity    string    `json:"tag"`
 	Timestamp time.Time `json:"ts"`
 	Severity  string    `json:"sev"`
@@ -888,6 +890,7 @@ func (m *LogMessage) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &jm); err != nil {
 		return errors.Trace(err)
 	}
+	m.ModelUUID = jm.ModelUUID
 	m.Timestamp = jm.Timestamp
 	m.Entity = jm.Entity
 	m.Severity = jm.Severity


### PR DESCRIPTION
There was an error in the code to add newly received debug-log messages into the buffered logger.
This could cause some messages to be lost and the flush to stall.

Also add a --firehose option to debug-log. This streams logs from the logsink.log file which includes all models. Hence the model uuid is printed with the log lines.

## QA steps

juju debug-log
juju debug-log --firehose
juju debug-log --firehose --format json

## Documentation changes

We'll need to document the --firehose arg.

## Links

**Jira card:** JUJU-5528(https://warthogs.atlassian.net/browse/JUJU-5528)

