### PR TITLE
Do not render empty pod affinity info

### DIFF
--- a/caas/kubernetes/provider/application/constraints.go
+++ b/caas/kubernetes/provider/application/constraints.go
@@ -159,13 +159,15 @@ func processNodeAffinity(pod *core.PodSpec, affinityLabels map[string]string) er
 	}
 	var nodeSelectorTerm core.NodeSelectorTerm
 	updateSelectorTerms(&nodeSelectorTerm, affinityTags)
-	if pod.Affinity == nil {
-		pod.Affinity = &core.Affinity{}
-	}
-	pod.Affinity.NodeAffinity = &core.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
-			NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
-		},
+	if len(nodeSelectorTerm.MatchExpressions) > 0 {
+		if pod.Affinity == nil {
+			pod.Affinity = &core.Affinity{}
+		}
+		pod.Affinity.NodeAffinity = &core.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+				NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
+			},
+		}
 	}
 	return nil
 }
@@ -240,12 +242,12 @@ func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) err
 			affinityTerm.TopologyKey = topologyKey
 		}
 	}
-	if pod.Affinity == nil {
-		pod.Affinity = &core.Affinity{}
-	}
 	var affinityTerm core.PodAffinityTerm
 	updateAffinityTerm(&affinityTerm, affinityTags)
 	if len(affinityTerm.LabelSelector.MatchExpressions) > 0 || affinityTerm.TopologyKey != "" {
+		if pod.Affinity == nil {
+			pod.Affinity = &core.Affinity{}
+		}
 		pod.Affinity.PodAffinity = &core.PodAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{affinityTerm},
 		}
@@ -254,6 +256,9 @@ func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) err
 	var antiAffinityTerm core.PodAffinityTerm
 	updateAffinityTerm(&antiAffinityTerm, antiAffinityTags)
 	if len(antiAffinityTerm.LabelSelector.MatchExpressions) > 0 || antiAffinityTerm.TopologyKey != "" {
+		if pod.Affinity == nil {
+			pod.Affinity = &core.Affinity{}
+		}
 		pod.Affinity.PodAntiAffinity = &core.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{antiAffinityTerm},
 		}

--- a/caas/kubernetes/provider/application/constraints_test.go
+++ b/caas/kubernetes/provider/application/constraints_test.go
@@ -69,6 +69,8 @@ func (s *applyConstraintsSuite) TestPodAffinityJustTopologyKey(c *gc.C) {
 			TopologyKey:   "foo",
 		}},
 	})
+	c.Assert(pod.Affinity.PodAntiAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.NodeAffinity, gc.IsNil)
 }
 
 func (s *applyConstraintsSuite) TestAffinityPod(c *gc.C) {
@@ -94,6 +96,8 @@ func (s *applyConstraintsSuite) TestAffinityPod(c *gc.C) {
 			},
 		}},
 	})
+	c.Assert(pod.Affinity.PodAntiAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.NodeAffinity, gc.IsNil)
 }
 
 func (s *applyConstraintsSuite) TestPodAffinityAll(c *gc.C) {
@@ -135,6 +139,8 @@ func (s *applyConstraintsSuite) TestAntiPodAffinityJustTopologyKey(c *gc.C) {
 			TopologyKey:   "foo",
 		}},
 	})
+	c.Assert(pod.Affinity.PodAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.NodeAffinity, gc.IsNil)
 }
 
 func (s *applyConstraintsSuite) TestAntiPodAffinity(c *gc.C) {
@@ -160,6 +166,8 @@ func (s *applyConstraintsSuite) TestAntiPodAffinity(c *gc.C) {
 			},
 		}},
 	})
+	c.Assert(pod.Affinity.PodAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.NodeAffinity, gc.IsNil)
 }
 
 func (s *applyConstraintsSuite) TestAntiPodAffinityAll(c *gc.C) {
@@ -186,6 +194,8 @@ func (s *applyConstraintsSuite) TestAntiPodAffinityAll(c *gc.C) {
 			TopologyKey: "foo",
 		}},
 	})
+	c.Assert(pod.Affinity.PodAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.NodeAffinity, gc.IsNil)
 }
 
 func (s *applyConstraintsSuite) TestNodeAntiAffinity(c *gc.C) {
@@ -210,4 +220,6 @@ func (s *applyConstraintsSuite) TestNodeAntiAffinity(c *gc.C) {
 			}},
 		},
 	})
+	c.Assert(pod.Affinity.PodAffinity, gc.IsNil)
+	c.Assert(pod.Affinity.PodAntiAffinity, gc.IsNil)
 }


### PR DESCRIPTION
When creating the podspec for a k8s charm, if the node affinity value is empty, Juju was rendering an empty struct which was causing the pods not be be scheduled.

## QA steps

See bug.

bootstrap k8s
`juju deploy snappass-test --constraints="tags=anti-pod.app.kubernetes.io/name=prom,anti-pod.topology-key=kubernetes.io/hostname"`

Inspect the podspec:

```
spec:
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: app.kubernetes.io/name
            operator: In
            values:
            - prom
        topologyKey: kubernetes.io/hostname
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

https://bugs.launchpad.net/bugs/2062934

**Jira card:** [JUJU-5906](https://warthogs.atlassian.net/browse/JUJU-5906)



[JUJU-5906]: https://warthogs.atlassian.net/browse/JUJU-5906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ