### PR TITLE
Remove HostSeries

### DIFF
--- a/api/agent/upgradeseries/upgradeseries.go
+++ b/api/agent/upgradeseries/upgradeseries.go
@@ -170,18 +170,14 @@ func (s *Client) StartUnitCompletion(reason string) error {
 // completely finished, passing the current host OS series.
 // We use the name "Finish" to distinguish this method from the various
 // "Complete" phases.
-func (s *Client) FinishUpgradeSeries(hostSeries string) error {
+func (s *Client) FinishUpgradeSeries(hostBase corebase.Base) error {
 	var results params.ErrorResults
-	base, err := corebase.GetBaseFromSeries(hostSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	args := params.UpdateChannelArgs{Args: []params.UpdateChannelArg{{
 		Entity:  params.Entity{Tag: s.authTag.String()},
-		Channel: base.Channel.Track,
+		Channel: hostBase.Channel.Track,
 	}}}
 
-	err = s.facade.FacadeCall("FinishUpgradeSeries", args, &results)
+	err := s.facade.FacadeCall("FinishUpgradeSeries", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/agent/upgradeseries/upgradeseries_test.go
+++ b/api/agent/upgradeseries/upgradeseries_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/agent/upgradeseries"
 	"github.com/juju/juju/api/base/mocks"
+	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
@@ -179,7 +180,7 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeries(c *gc.C) {
 	fCaller.EXPECT().FacadeCall("FinishUpgradeSeries", args, gomock.Any()).SetArg(2, resultSource)
 
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	err := api.FinishUpgradeSeries("xenial")
+	err := api.FinishUpgradeSeries(corebase.MustParseBaseFromString("ubuntu@16.04"))
 	c.Assert(err, gc.IsNil)
 }
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -129,7 +129,7 @@ func (s *getToolsSuite) TestOSTools(c *gc.C) {
 
 	current := coretesting.CurrentVersion()
 	currentCopy := current
-	currentCopy.Release = coretesting.HostSeries(c)
+	currentCopy.Release = "foo"
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -8,10 +8,9 @@ import (
 	"runtime"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 
 	"github.com/juju/juju/container"
-	"github.com/juju/juju/core/base"
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/packaging"
 	"github.com/juju/juju/packaging/dependency"
@@ -45,11 +44,7 @@ func (ci *containerInitialiser) Initialise() error {
 }
 
 func ensureDependencies() error {
-	hostSeries, err := series.HostSeries()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	hostBase, err := base.GetBaseFromSeries(hostSeries)
+	hostBase, err := coreos.HostBase()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/clock"
 
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/network"
 )
 
@@ -45,8 +46,8 @@ func PatchLXDViaSnap(patcher patcher, isSnap bool) {
 	patcher.PatchValue(&lxdViaSnap, func() bool { return isSnap })
 }
 
-func PatchHostSeries(patcher patcher, series string) {
-	patcher.PatchValue(&hostSeries, func() (string, error) { return series, nil })
+func PatchHostBase(patcher patcher, b base.Base) {
+	patcher.PatchValue(&hostBase, func() (base.Base, error) { return b, nil })
 }
 
 func PatchGetSnapManager(patcher patcher, mgr SnapManager) {

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -11,18 +11,18 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/packaging/v3/manager"
 	"github.com/juju/proxy"
 
 	"github.com/juju/juju/container"
 	corebase "github.com/juju/juju/core/base"
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/packaging"
 	"github.com/juju/juju/packaging/dependency"
 	"github.com/juju/juju/service"
 )
 
-var hostSeries = series.HostSeries
+var hostBase = coreos.HostBase
 
 type containerInitialiser struct {
 	containerNetworkingMethod string
@@ -68,11 +68,7 @@ func NewContainerInitialiser(lxdSnapChannel, containerNetworkingMethod string) c
 
 // Initialise is specified on the container.Initialiser interface.
 func (ci *containerInitialiser) Initialise() (err error) {
-	localSeries, err := hostSeries()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	localBase, err := corebase.GetBaseFromSeries(localSeries)
+	localBase, err := hostBase()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/container/lxd/mocks"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
+	"github.com/juju/juju/core/base"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -86,7 +87,7 @@ func (s *initialiserTestSuite) containerInitialiser(svr lxd.InstanceServer, lxdI
 
 func (s *InitialiserSuite) TestSnapInstalled(c *gc.C) {
 	PatchLXDViaSnap(s, true)
-	PatchHostSeries(s, "jammy")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@22.04"))
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -103,7 +104,7 @@ func (s *InitialiserSuite) TestSnapInstalled(c *gc.C) {
 
 func (s *InitialiserSuite) TestSnapChannelMismatch(c *gc.C) {
 	PatchLXDViaSnap(s, true)
-	PatchHostSeries(s, "focal")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@20.04"))
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -121,7 +122,7 @@ func (s *InitialiserSuite) TestSnapChannelMismatch(c *gc.C) {
 
 func (s *InitialiserSuite) TestSnapChannelPrefixMatch(c *gc.C) {
 	PatchLXDViaSnap(s, true)
-	PatchHostSeries(s, "focal")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@20.04"))
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -143,7 +144,7 @@ func (s *InitialiserSuite) TestSnapChannelPrefixMatch(c *gc.C) {
 func (s *InitialiserSuite) TestInstallViaSnap(c *gc.C) {
 	PatchLXDViaSnap(s, false)
 
-	PatchHostSeries(s, "focal")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@20.04"))
 
 	paccmder := commands.NewSnapPackageCommander()
 
@@ -157,7 +158,7 @@ func (s *InitialiserSuite) TestInstallViaSnap(c *gc.C) {
 
 func (s *InitialiserSuite) TestLXDAlreadyInitialized(c *gc.C) {
 	s.patchDF100GB()
-	PatchHostSeries(s, "focal")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@20.04"))
 
 	ci := s.containerInitialiser(nil, true, "local")
 	ci.getExecCommand = s.PatchExecHelper.GetExecCommand(testing.PatchExecConfig{
@@ -171,7 +172,7 @@ func (s *InitialiserSuite) TestLXDAlreadyInitialized(c *gc.C) {
 }
 
 func (s *InitialiserSuite) TestInitializeSetsProxies(c *gc.C) {
-	PatchHostSeries(s, "jammy")
+	PatchHostBase(s, base.MustParseBaseFromString("ubuntu@20.04"))
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -281,8 +281,8 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := jujuversion.DefaultSupportedLTS()
-	if coretesting.HostSeries(c) != defaultSeries {
+	defaultBase := jujuversion.DefaultSupportedLTSBase()
+	if !defaultBase.IsCompatible(coretesting.HostBase(c)) {
 		toolsVersion.Release = "ubuntu"
 		name := envtools.StorageName(toolsVersion, toolsDir)
 		err := stor.Remove(name)

--- a/testing/base.go
+++ b/testing/base.go
@@ -22,6 +22,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/os/ostype"
@@ -300,8 +301,8 @@ func CurrentVersion() version.Binary {
 }
 
 // HostSeries returns series.HostSeries(), asserting on error.
-func HostSeries(c *gc.C) string {
-	hostSeries, err := series.HostSeries()
+func HostBase(c *gc.C) base.Base {
+	hostBase, err := coreos.HostBase()
 	c.Assert(err, jc.ErrorIsNil)
-	return hostSeries
+	return hostBase
 }

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/packaging/v3/commands"
 	"github.com/juju/packaging/v3/config"
 	"github.com/juju/proxy"
@@ -164,12 +163,8 @@ func (w *proxyWorker) handleProxyValues(legacyProxySettings, jujuProxySettings p
 
 // getPackageCommander is a helper function which returns the
 // package commands implementation for the current system.
-func getPackageCommander() (commands.PackageCommander, error) {
-	hostSeries, err := series.HostSeries()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return commands.NewPackageCommander(hostSeries)
+func getPackageCommander() commands.PackageCommander {
+	return commands.NewAptPackageCommander()
 }
 
 func (w *proxyWorker) handleSnapProxyValues(proxy proxy.Settings, storeID, storeAssertions, storeProxyURL string) {
@@ -261,11 +256,7 @@ func (w *proxyWorker) handleAptProxyValues(aptSettings proxy.Settings, aptMirror
 		err      error
 	)
 	if updateNeeded {
-		paccmder, err = getPackageCommander()
-		if err != nil {
-			w.config.Logger.Errorf("unable to process apt proxy changes: %v", err)
-			return
-		}
+		paccmder = getPackageCommander()
 	}
 
 	if aptSettings != w.aptProxy || w.first {

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -226,8 +226,7 @@ func (s *ProxyUpdaterSuite) TestInitialStateLegacyProxy(c *gc.C) {
 	s.waitForFile(c, s.proxyEnvFile, proxySettings.AsScriptEnvironment())
 	s.waitForFile(c, s.proxySystemdFile, proxySettings.AsSystemdDefaultEnv())
 
-	paccmder, err := commands.NewPackageCommander(coretesting.HostSeries(c))
-	c.Assert(err, jc.ErrorIsNil)
+	paccmder := commands.NewAptPackageCommander()
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }
 
@@ -249,8 +248,7 @@ func (s *ProxyUpdaterSuite) TestInitialStateJujuProxy(c *gc.C) {
 	s.waitForFile(c, s.proxyEnvFile, empty.AsScriptEnvironment())
 	s.waitForFile(c, s.proxySystemdFile, empty.AsSystemdDefaultEnv())
 
-	paccmder, err := commands.NewPackageCommander(coretesting.HostSeries(c))
-	c.Assert(err, jc.ErrorIsNil)
+	paccmder := commands.NewAptPackageCommander()
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }
 

--- a/worker/upgradeseries/export_test.go
+++ b/worker/upgradeseries/export_test.go
@@ -3,10 +3,12 @@
 
 package upgradeseries
 
+import "github.com/juju/juju/core/base"
+
 type patcher interface {
 	PatchValue(interface{}, interface{})
 }
 
-func PatchHostSeries(patcher patcher, series string) {
-	patcher.PatchValue(&hostSeries, func() (string, error) { return series, nil })
+func PatchHostBase(patcher patcher, b base.Base) {
+	patcher.PatchValue(&hostBase, func() (base.Base, error) { return b, nil })
 }

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	base "github.com/juju/juju/core/base"
 	model "github.com/juju/juju/core/model"
 	watcher "github.com/juju/juju/core/watcher"
 	names "github.com/juju/names/v5"
@@ -42,7 +43,7 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 }
 
 // FinishUpgradeSeries mocks base method.
-func (m *MockFacade) FinishUpgradeSeries(arg0 string) error {
+func (m *MockFacade) FinishUpgradeSeries(arg0 base.Base) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinishUpgradeSeries", arg0)
 	ret0, _ := ret[0].(error)

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/agent/upgradeseries"
 	"github.com/juju/juju/api/base"
+	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 )
@@ -23,7 +24,7 @@ type Facade interface {
 	// Setters
 	StartUnitCompletion(reason string) error
 	SetMachineStatus(status model.UpgradeSeriesStatus, reason string) error
-	FinishUpgradeSeries(string) error
+	FinishUpgradeSeries(corebase.Base) error
 	PinMachineApplications() (map[string]error, error)
 	UnpinMachineApplications() (map[string]error, error)
 	SetInstanceStatus(model.UpgradeSeriesStatus, string) error

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -9,17 +9,17 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/rpc/params"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package mocks -destination mocks/package_mock.go github.com/juju/juju/worker/upgradeseries Facade,UnitDiscovery,Upgrader
 
-var hostSeries = series.HostSeries
+var hostBase = os.HostBase
 
 // Logger represents the methods required to emit log messages.
 type Logger interface {
@@ -308,11 +308,11 @@ func (w *upgradeSeriesWorker) handleCompleted() error {
 		return errors.Trace(err)
 	}
 
-	s, err := hostSeries()
+	b, err := hostBase()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = w.FinishUpgradeSeries(s); err != nil {
+	if err = w.FinishUpgradeSeries(b); err != nil {
 		return errors.Trace(err)
 	}
 	if err = w.unpinLeaders(); err != nil {

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/testing"
@@ -283,12 +284,13 @@ func (s *workerSuite) TestMachineCompletedFinishUpgradeSeries(c *gc.C) {
 }
 
 func (s *workerSuite) expectMachineCompletedFinishUpgradeSeries() {
-	s.patchHost("xenial")
+	b := base.MustParseBaseFromString("ubuntu@16.04")
+	s.patchHost(b)
 
 	exp := s.facade.EXPECT()
 	exp.MachineStatus().Return(model.UpgradeSeriesCompleted, nil)
 	s.expectSetInstanceStatus(model.UpgradeSeriesCompleted, "finalising upgrade")
-	exp.FinishUpgradeSeries("xenial").Return(nil)
+	exp.FinishUpgradeSeries(b).Return(nil)
 
 	s.expectSetInstanceStatus(model.UpgradeSeriesCompleted, "success")
 	exp.UnpinMachineApplications().Return(map[string]error{
@@ -361,8 +363,8 @@ func (s *workerSuite) cleanKill(c *gc.C, w worker.Worker) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *workerSuite) patchHost(series string) {
-	upgradeseries.PatchHostSeries(s, series)
+func (s *workerSuite) patchHost(b base.Base) {
+	upgradeseries.PatchHostBase(s, b)
 }
 
 // notify returns a suite behaviour that will cause the upgrade-series watcher


### PR DESCRIPTION
Remove HostSeries everywhere it appears

In most places, it needs to be replaces with the new HostBase. However, in a few places, it turns out it could just be dropped entirely

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests pass

### Create lxd containers

```
$ juju bootstrap aws aws
$ juju add-model m
$ juju add-machine
$ juju add-machine lxd:0
$ juju add-machine lxd:0 --base ubuntu@20.04
(wait)
$ juju status
Model  Controller  Cloud/Region   Version      SLA          Timestamp
m      aws         aws/eu-west-2  3.5-beta1.1  unsupported  13:25:13+01:00

Machine  State    Address         Inst id              Base          AZ          Message
0        started  18.170.114.179  i-0a1c12a72964544fe  ubuntu@22.04  eu-west-2c  running
0/lxd/0  started  252.41.183.122  juju-d23f30-0-lxd-0  ubuntu@22.04  eu-west-2c  Container started
0/lxd/1  started  252.41.183.143  juju-d23f30-0-lxd-1  ubuntu@20.04  eu-west-2c  Container started
```

### Upgrade the base

```
$ juju add-model m
$ juju deploy ubuntu --base ubuntu@20.04
(wait until active-idle)
$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete

$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m2     lxd         localhost/localhost  3.5-beta2.1  unsupported  15:51:27+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.192         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.192  juju-869763-0  ubuntu@20.04      series upgrade prepare completed: waiting for completion command

$ juju upgrade-machine 0 complete
machine-0 complete phase started
machine-0 start units after series upgrade
ubuntu/0 post-series-upgrade hook running
ubuntu/0 post-series-upgrade completed
machine-0 series upgrade complete

Upgrade machine base "0" has successfully completed
```