### PR TITLE
Custom initial namespace query

### DIFF
--- a/core/watcher/eventsource/base.go
+++ b/core/watcher/eventsource/base.go
@@ -23,10 +23,10 @@ type BaseWatcher struct {
 }
 
 // NewBaseWatcher returns a BaseWatcher constructed from the arguments.
-func NewBaseWatcher(watchableDB changestream.WatchableDB, l Logger) *BaseWatcher {
+func NewBaseWatcher(watchableDB changestream.WatchableDB, logger Logger) *BaseWatcher {
 	return &BaseWatcher{
 		watchableDB: watchableDB,
-		logger:      l,
+		logger:      logger,
 	}
 }
 
@@ -51,3 +51,6 @@ type Predicate func(context.Context, database.TxnRunner, []changestream.ChangeEv
 func defaultPredicate(context.Context, database.TxnRunner, []changestream.ChangeEvent) (bool, error) {
 	return true, nil
 }
+
+// Query is a function that returns the initial state of a watcher.
+type Query[T any] func(context.Context, database.TxnRunner) (T, error)

--- a/core/watcher/eventsource/namespace_test.go
+++ b/core/watcher/eventsource/namespace_test.go
@@ -69,7 +69,7 @@ func (s *namespaceSuite) TestInitialStateSent(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	w := NewNamespaceWatcher(
-		s.newBaseWatcher(), "random_namespace", changestream.All, "SELECT key_name FROM random_namespace")
+		s.newBaseWatcher(), "random_namespace", changestream.All, InitialNamespaceChanges("SELECT key_name FROM random_namespace"))
 	defer workertest.CleanKill(c, w)
 
 	select {
@@ -122,7 +122,7 @@ func (s *namespaceSuite) TestInitialStateSentByPredicate(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	w := NewNamespacePredicateWatcher(
-		s.newBaseWatcher(), "random_namespace", changestream.All, "SELECT key_name FROM random_namespace",
+		s.newBaseWatcher(), "random_namespace", changestream.All, InitialNamespaceChanges("SELECT key_name FROM random_namespace"),
 		func(ctx context.Context, runner database.TxnRunner, e []changestream.ChangeEvent) (bool, error) {
 			return false, nil
 		},
@@ -169,7 +169,7 @@ func (s *namespaceSuite) TestDeltasSent(c *gc.C) {
 	).Return(s.sub, nil)
 
 	w := NewNamespaceWatcher(
-		s.newBaseWatcher(), "external_controller", changestream.All, "SELECT uuid FROM external_controller")
+		s.newBaseWatcher(), "external_controller", changestream.All, InitialNamespaceChanges("SELECT uuid FROM external_controller"))
 	defer workertest.CleanKill(c, w)
 
 	// No initial data.
@@ -231,7 +231,7 @@ func (s *namespaceSuite) TestDeltasSentByPredicate(c *gc.C) {
 	).Return(s.sub, nil)
 
 	w := NewNamespacePredicateWatcher(
-		s.newBaseWatcher(), "external_controller", changestream.All, "SELECT uuid FROM external_controller",
+		s.newBaseWatcher(), "external_controller", changestream.All, InitialNamespaceChanges("SELECT uuid FROM external_controller"),
 		func(ctx context.Context, runner database.TxnRunner, e []changestream.ChangeEvent) (bool, error) {
 			return e[0].Changed() == "some-ec-uuid", nil
 		},
@@ -307,7 +307,7 @@ func (s *namespaceSuite) TestDeltasSentByPredicateError(c *gc.C) {
 	).Return(s.sub, nil)
 
 	w := NewNamespacePredicateWatcher(
-		s.newBaseWatcher(), "external_controller", changestream.All, "SELECT uuid FROM external_controller",
+		s.newBaseWatcher(), "external_controller", changestream.All, InitialNamespaceChanges("SELECT uuid FROM external_controller"),
 		func(ctx context.Context, runner database.TxnRunner, e []changestream.ChangeEvent) (bool, error) {
 			return false, errors.New("boom")
 		},
@@ -365,7 +365,7 @@ func (s *namespaceSuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
 	).Return(s.sub, nil)
 
 	w := NewNamespaceWatcher(
-		s.newBaseWatcher(), "external_controller", changestream.All, "SELECT uuid FROM external_controller")
+		s.newBaseWatcher(), "external_controller", changestream.All, InitialNamespaceChanges("SELECT uuid FROM external_controller"))
 	defer workertest.DirtyKill(c, w)
 
 	err := workertest.CheckKilled(c, w)
@@ -373,7 +373,7 @@ func (s *namespaceSuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
 }
 
 func (s *namespaceSuite) TestInvalidChangeMask(c *gc.C) {
-	w := NewNamespaceWatcher(s.newBaseWatcher(), "external_controller", 0, "SELECT uuid FROM external_controller")
+	w := NewNamespaceWatcher(s.newBaseWatcher(), "external_controller", 0, InitialNamespaceChanges("SELECT uuid FROM external_controller"))
 	defer workertest.DirtyKill(c, w)
 
 	err := workertest.CheckKilled(c, w)

--- a/domain/watcher.go
+++ b/domain/watcher.go
@@ -49,7 +49,10 @@ func (f *WatcherFactory) NewNamespaceWatcher(
 		return nil, errors.Annotate(err, "creating base watcher")
 	}
 
-	return eventsource.NewNamespaceWatcher(base, namespace, changeMask, initialStateQuery), nil
+	return eventsource.NewNamespaceWatcher(
+		base, namespace, changeMask,
+		eventsource.InitialNamespaceChanges(initialStateQuery),
+	), nil
 }
 
 // NewNamespacePredicateWatcher returns a new namespace watcher
@@ -63,7 +66,11 @@ func (f *WatcherFactory) NewNamespacePredicateWatcher(
 		return nil, errors.Annotate(err, "creating base watcher")
 	}
 
-	return eventsource.NewNamespacePredicateWatcher(base, namespace, changeMask, initialStateQuery, predicate), nil
+	return eventsource.NewNamespacePredicateWatcher(
+		base, namespace, changeMask,
+		eventsource.InitialNamespaceChanges(initialStateQuery),
+		predicate,
+	), nil
 }
 
 // NewValueWatcher returns a watcher for a particular change value


### PR DESCRIPTION
The initial namespace query was originally a string, but that prevents creating custom sql that requires things like where et al.

To provide a better way to do that, we create a HOF (high order function) to pass in a default Query, with the ability to supply your own.

The concept is really simple.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The existing set of test should pass. We've just inserted a function alias to an existing funciton.

## Links


**Jira card:** JUJU-

