### PR TITLE
Use type for user name input throughout access state

### DIFF
--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -138,9 +138,8 @@ func (r dbPermission) toUserAccess(u dbPermissionUser) corepermission.UserAccess
 	return userAccess
 }
 
-// permUserName is a struct to replace sqlair.M with permission
-// SQL that provides a user name for input.
-type permUserName struct {
+// userName is used to pass a user's name as an argument to SQL.
+type userName struct {
 	Name string `db:"name"`
 }
 


### PR DESCRIPTION
In prior changes, a type `permUserName` was introduced for the purpose of supplying a name as SQL argument, instead of instantiating a single entry map.

Here, we rename it to `userName` to indicate greater universality, and apply it throughout the access state package.

## QA steps

Passing tests verify the mechanical-only change.

