### PR TITLE
Drop GetSeriesFromBase call from equinix provider

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -45,7 +45,10 @@ import (
 
 var logger = loggo.GetLogger("juju.provider.equinix")
 
-const sshPort = 22
+const (
+	sshPort = 22
+	ubuntu  = "ubuntu"
+)
 
 type environConfig struct {
 	config *config.Config
@@ -328,7 +331,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// NOTE(achilleasa): this is a hack and is only meant to be used
 	// temporarily; we must ensure that equinix mirrors the official
 	// ubuntu cloud images.
-	if _, err := corebase.GetSeriesFromBase(args.InstanceConfig.Base); err == nil {
+	if args.InstanceConfig.Base.OS == ubuntu {
 		cloudCfg.AddScripts(
 			"apt-get update",
 			"DEBIAN_FRONTEND=noninteractive apt-get --option=Dpkg::Options::=--force-confdef --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet install dmidecode snapd",
@@ -340,7 +343,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// references the juju-assigned hostname before localhost. Otherwise,
 	// running 'hostname -f' would return localhost whereas 'hostname'
 	// returns the juju-assigned host (see LP1956538).
-	if _, err := corebase.GetSeriesFromBase(args.InstanceConfig.Base); err == nil {
+	if args.InstanceConfig.Base.OS == ubuntu {
 		cloudCfg.AddScripts(
 			`sed -i -e "/127\.0\.0\.1/c\127\.0\.0\.1 $(hostname) localhost" /etc/hosts`,
 		)


### PR DESCRIPTION
It looks like this call was added as a mistake. Examining the history of these lines, before we called GetSeriesFromBase, we called UbuntuSeriesVersion with the series param on InstanceConfig

Reading the error from this function, as we used to, was a way determine if a series was an ubuntu series.

Now that we use bases, we should instead just check the OS attribute of the base

https://github.com/juju/juju/pull/14723/files#diff-8bb58109c31e5e10245b3fed89271e67ef0796d716d718a9268a9b42324653e9L325

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Bootstrap an equinix controller
```
juju bootstrap equinix/dc equinix
```
(for some reason the default `px` region has image metadata issues)