### PR TITLE
Remove latest lts

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1334,7 +1334,6 @@ func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
 func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	sourceDir := createToolsSource(c, vAll)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.0"))
-	corebase.SetLatestLtsForTesting("focal")
 	resetJujuXDGDataHome(c)
 
 	// Bootstrap the controller with the valid source.

--- a/core/base/supportedbases.go
+++ b/core/base/supportedbases.go
@@ -86,15 +86,3 @@ func UbuntuBaseVersion(base Base) (string, error) {
 	}
 	return UbuntuSeriesVersion(s)
 }
-
-// LatestLTSBase returns the latest LTS base.
-// TODO(stickupkid): The underlying series version should be a base, until that
-// logic has changes, just convert between base and series.
-func LatestLTSBase() Base {
-	lts := LatestLTS()
-	b, err := GetBaseFromSeries(lts)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}

--- a/core/base/supportedseries.go
+++ b/core/base/supportedseries.go
@@ -274,34 +274,6 @@ var (
 	seriesVersionsMutex sync.Mutex
 )
 
-// latestLtsSeries is used to ensure we only do
-// the work to determine the latest lts series once.
-var latestLtsSeries string
-
-// LatestLTS returns the Latest LTS Release found in distro-info
-func LatestLTS() string {
-	if latestLtsSeries != "" {
-		return latestLtsSeries
-	}
-
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
-	updateSeriesVersionsOnce()
-
-	var latest SeriesName
-	for k, seriesVersion := range ubuntuSeries {
-		if !seriesVersion.LTS || !seriesVersion.Supported {
-			continue
-		}
-		if seriesVersion.Version > ubuntuSeries[latest].Version {
-			latest = k
-		}
-	}
-
-	latestLtsSeries = string(latest)
-	return latestLtsSeries
-}
-
 // versionSeries provides a mapping between versions and series names.
 var (
 	versionSeries     map[string]string

--- a/core/base/supportedseries_linux_test.go
+++ b/core/base/supportedseries_linux_test.go
@@ -28,20 +28,6 @@ func (s *SupportedSeriesLinuxSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *SupportedSeriesLinuxSuite) TestLatestLts(c *gc.C) {
-	table := []struct {
-		latest, want string
-	}{
-		{"testseries", "testseries"},
-		{"", "jammy"},
-	}
-	for _, test := range table {
-		SetLatestLtsForTesting(test.latest)
-		got := LatestLTS()
-		c.Assert(got, gc.Equals, test.want)
-	}
-}
-
 func (s *SupportedSeriesLinuxSuite) TestUbuntuSeriesVersionEmpty(c *gc.C) {
 	_, err := UbuntuSeriesVersion("")
 	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)

--- a/core/base/testing.go
+++ b/core/base/testing.go
@@ -7,16 +7,6 @@ import "sort"
 
 // These methods are used only in various tests.
 
-// SetLatestLtsForTesting is provided to allow tests to override the lts series
-// used and decouple the tests from the host by avoiding calling out to
-// distro-info.  It returns the previous setting so that it may be set back to
-// the original value by the caller.
-func SetLatestLtsForTesting(series string) string {
-	old := latestLtsSeries
-	latestLtsSeries = series
-	return old
-}
-
 // SupportedLts are the current supported LTS series in ascending order.
 func SupportedLts() []string {
 	seriesVersionsMutex.Lock()

--- a/core/charm/baseselector.go
+++ b/core/charm/baseselector.go
@@ -156,15 +156,6 @@ func (s BaseSelector) CharmBase() (selectedBase base.Base, err error) {
 		return s.userRequested(s.defaultBase)
 	}
 
-	// Prefer latest Ubuntu LTS.
-	preferredBase, err := BaseForCharm(base.LatestLTSBase(), s.supportedBases)
-	if err == nil {
-		s.logger.Infof(msgLatestLTSBase, base.LatestLTSBase())
-		return preferredBase, nil
-	} else if errors.Is(err, MissingBaseError) {
-		return base.Base{}, err
-	}
-
 	// Try juju's current default supported Ubuntu LTS
 	jujuDefaultBase, err := BaseForCharm(version.DefaultSupportedLTSBase(), s.supportedBases)
 	if err == nil {

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -32,7 +32,6 @@ var (
 	precise     = base.MustParseBaseFromString("ubuntu@14.04")
 	utopic      = base.MustParseBaseFromString("ubuntu@16.10")
 	vivid       = base.MustParseBaseFromString("ubuntu@17.04")
-	latest      = base.LatestLTSBase()
 	jujuDefault = version.DefaultSupportedLTSBase()
 )
 
@@ -128,31 +127,13 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 			err: `base: ubuntu@18.04/stable`,
 		},
 		{
-			title: "juju deploy multiseries    # fallback to base.LatestLTSBase()",
-			selector: BaseSelector{
-				supportedBases: []base.Base{utopic, vivid, latest},
-			},
-			expectedBase: latest,
-		},
-		{
 			title: "juju deploy multiseries    # fallback to version.DefaultSupportedLTSBase()",
 			selector: BaseSelector{
 				supportedBases: []base.Base{utopic, vivid, jujuDefault},
 			},
 			expectedBase: jujuDefault,
 		},
-		{
-			title: "juju deploy multiseries    # prefer base.LatestLTSBase() to  version.DefaultSupportedLTSBase()",
-			selector: BaseSelector{
-				supportedBases: []base.Base{utopic, vivid, jujuDefault, latest},
-			},
-			expectedBase: latest,
-		},
 	}
-
-	// Use bionic for LTS for all calls.
-	previous := base.SetLatestLtsForTesting("focal")
-	defer base.SetLatestLtsForTesting(previous)
 
 	for i, test := range deployBasesTests {
 		c.Logf("test %d [%s]", i, test.title)

--- a/core/charm/computedbase_test.go
+++ b/core/charm/computedbase_test.go
@@ -127,10 +127,6 @@ func (s *computedBaseSuite) TestBaseToUse(c *gc.C) {
 		supportedBases: []base.Base{focal, trusty},
 		baseToUse:      trusty,
 	}, {
-		series:         base.LatestLTSBase(),
-		supportedBases: []base.Base{focal, base.LatestLTSBase(), trusty},
-		baseToUse:      base.LatestLTSBase(),
-	}, {
 		series:         trusty,
 		supportedBases: []base.Base{jammy, focal},
 		err:            `base "ubuntu@16.04" not supported by charm.*`,

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/arch"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
@@ -375,7 +374,7 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:        coretesting.FakeControllerConfig(),
-			BootstrapBase:           corebase.LatestLTSBase(),
+			BootstrapBase:           jujuversion.DefaultSupportedLTSBase(),
 			AdminSecret:             testing.AdminSecret,
 			CAPrivateKey:            coretesting.CAKey,
 			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,


### PR DESCRIPTION
Remove LatestLTS & LatestLTSBase

These function both rely on distro-info sniffing which is to be removed

They were both used oth these functions are used only in tests with one
exception.

LatestLTSBase was used in the BaseSelector as a default base to deploy
charms to, if none are provded via flag or default-base model-config

We wish to remove this behaviour because it can lead to unexpected
changes in behaviour when deploying a charm within the same version of
Juju.

The direction we are moving in with workloads is to hard code a list of
supported bases inside Juju, and allow users to override this with
force. As such, it does not make sense to have a changing default base
to deploy to, this should be hard coded as well.

Remove this fallback option from the BaseSelector, fallback straight to
the DefaultSupportedLTS


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

1) standard
```
$ juju deploy ubuntu
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 24 in channel latest/stable on ubuntu@22.04/stable
```

2) With a patched controller
Apply the following patch:
```
diff --git a/version/base.go b/version/base.go
index 3e86d0468d..bfa28c3bd1 100644
--- a/version/base.go
+++ b/version/base.go
@@ -8,5 +8,5 @@ import corebase "github.com/juju/juju/core/base"
 // DefaultSupportedLTSBase returns the latest LTS base that Juju supports
 // and is compatible with.
 func DefaultSupportedLTSBase() corebase.Base {
-       return corebase.MakeDefaultBase("ubuntu", "22.04")
+       return corebase.MakeDefaultBase("ubuntu", "20.04")
 }
```
Then run:
```
$ juju upgrade-controller --build-agent
no prepackaged agent binaries available, using local agent binary 4.0-beta3.2 (built from source)
best version:
    4.0-beta3.2
started upgrade to 4.0-beta3.2

$ juju deploy ubuntu focal
Deployed "focal" from charm-hub charm "ubuntu", revision 24 in channel latest/stable on ubuntu@20.04/stable

(wait)
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd         localhost/localhost  4.0-beta3.1  22:57:00+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
focal   20.04    active      1  ubuntu  latest/stable   24  no       
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
focal/0*   active    idle   1        10.219.211.217         
ubuntu/0*  active    idle   0        10.219.211.237         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.237  juju-61fec5-0  ubuntu@22.04      Running
1        started  10.219.211.217  juju-61fec5-1  ubuntu@20.04      Running
```