### PR TITLE
Add backend support for revoking secret access and getting access

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -369,10 +369,10 @@ func (mr *MockSecretServiceMockRecorder) GetSecret(arg0, arg1 any) *gomock.Call 
 }
 
 // GetSecretGrants mocks base method.
-func (m *MockSecretService) GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error) {
+func (m *MockSecretService) GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]service.SecretAccess, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretGrants", ctx, uri, role)
-	ret0, _ := ret[0].([]secrets.AccessInfo)
+	ret0, _ := ret[0].([]service.SecretAccess)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -560,11 +560,17 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 			Revision: 667,
 		},
 	}}, nil)
-	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
+	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]secretservice.SecretAccess{
 		{
-			Target: "application-gitlab",
-			Scope:  "relation-key",
-			Role:   coresecrets.RoleView,
+			Scope: secretservice.SecretAccessScope{
+				Kind: secretservice.RelationAccessScope,
+				ID:   "gitlab:server mysql:db",
+			},
+			Subject: secretservice.SecretAccessor{
+				Kind: secretservice.ApplicationAccessor,
+				ID:   "gitlab",
+			},
+			Role: coresecrets.RoleView,
 		},
 	}, nil)
 
@@ -590,7 +596,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 				Revision: 667,
 			}},
 			Access: []params.AccessInfo{
-				{TargetTag: "application-gitlab", ScopeTag: "relation-key", Role: "view"},
+				{TargetTag: "application-gitlab", ScopeTag: "relation-gitlab.server#mysql.db", Role: "view"},
 			},
 		}},
 	})

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -48,5 +48,5 @@ type SecretService interface {
 		ctx context.Context, unitName string, uri *secrets.URI, label string, checkCallerOwner func(secretOwner secrets.Owner) (bool, leadership.Token, error),
 	) (*secrets.URI, *string, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error
-	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
+	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secretservice.SecretAccess, error)
 }

--- a/apiserver/facades/client/secrets/mocks/secretsstate.go
+++ b/apiserver/facades/client/secrets/mocks/secretsstate.go
@@ -86,10 +86,10 @@ func (mr *MockSecretServiceMockRecorder) GetSecret(arg0, arg1 any) *gomock.Call 
 }
 
 // GetSecretGrants mocks base method.
-func (m *MockSecretService) GetSecretGrants(arg0 context.Context, arg1 *secrets.URI, arg2 secrets.SecretRole) ([]secrets.AccessInfo, error) {
+func (m *MockSecretService) GetSecretGrants(arg0 context.Context, arg1 *secrets.URI, arg2 secrets.SecretRole) ([]service.SecretAccess, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretGrants", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]secrets.AccessInfo)
+	ret0, _ := ret[0].([]service.SecretAccess)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -179,11 +179,17 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevision, secret.NilLabels).Return(
 		metadata, revisions, nil,
 	)
-	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]coresecrets.AccessInfo{
+	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]secretservice.SecretAccess{
 		{
-			Target: "application-gitlab",
-			Scope:  "relation-key",
-			Role:   coresecrets.RoleView,
+			Scope: secretservice.SecretAccessScope{
+				Kind: secretservice.RelationAccessScope,
+				ID:   "gitlab:server mysql:db",
+			},
+			Subject: secretservice.SecretAccessor{
+				Kind: secretservice.ApplicationAccessor,
+				ID:   "gitlab",
+			},
+			Role: coresecrets.RoleView,
 		},
 	}, nil)
 
@@ -239,7 +245,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withBackend bool) {
 				ExpireTime:  ptr(now.Add(2 * time.Hour)),
 			}},
 			Access: []params.AccessInfo{
-				{TargetTag: "application-gitlab", ScopeTag: "relation-key", Role: "view"},
+				{TargetTag: "application-gitlab", ScopeTag: "relation-gitlab.server#mysql.db", Role: "view"},
 			},
 		}},
 	})

--- a/apiserver/facades/client/secrets/service.go
+++ b/apiserver/facades/client/secrets/service.go
@@ -35,7 +35,7 @@ type SecretService interface {
 
 	// Grant/revoke secret access.
 
-	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error)
+	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secretservice.SecretAccess, error)
 	GrantSecretAccess(ctx context.Context, uri *secrets.URI, p secretservice.SecretAccessParams) error
 	RevokeSecretAccess(ctx context.Context, uri *secrets.URI, p secretservice.SecretAccessParams) error
 }

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -265,13 +265,13 @@ func (s *CrossModelSecretsAPI) canRead(ctx stdcontext.Context, secretService Sec
 	}
 
 	appName, _ := names.UnitApplication(unit.Id())
-	k := secretservice.ApplicationAccessor
+	kind := secretservice.ApplicationAccessor
 	// Remote apps need a different accessor kind.
 	if strings.HasPrefix(appName, "remote-") {
-		k = secretservice.RemoteApplicationAccessor
+		kind = secretservice.RemoteApplicationAccessor
 	}
 	hasRole, _ = secretService.GetSecretAccess(ctx, uri, secretservice.SecretAccessor{
-		Kind: k,
+		Kind: kind,
 		ID:   appName,
 	})
 	return hasRole.Allowed(coresecrets.RoleView)
@@ -299,13 +299,13 @@ func (s *CrossModelSecretsAPI) accessScope(ctx stdcontext.Context, secretService
 		return tagFromAccessScope(scope), errors.Trace(err)
 	}
 	appName, _ := names.UnitApplication(unit.Id())
-	k := secretservice.ApplicationAccessor
+	kind := secretservice.ApplicationAccessor
 	// Remote apps need a different accessor kind.
 	if strings.HasPrefix(appName, "remote-") {
-		k = secretservice.RemoteApplicationAccessor
+		kind = secretservice.RemoteApplicationAccessor
 	}
 	scope, err = secretService.GetSecretAccessScope(ctx, uri, secretservice.SecretAccessor{
-		Kind: k,
+		Kind: kind,
 		ID:   appName,
 	})
 	return tagFromAccessScope(scope), errors.Trace(err)

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -82,6 +82,13 @@ type SecretAccessScope struct {
 	ID   string
 }
 
+// SecretAccess is used to define access to a secret.
+type SecretAccess struct {
+	Scope   SecretAccessScope
+	Subject SecretAccessor
+	Role    secrets.SecretRole
+}
+
 // CharmSecretOwnerKind represents the kind of a charm secret owner entity.
 type CharmSecretOwnerKind string
 

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -46,9 +46,10 @@ type State interface {
 	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
 	UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error
 	GrantAccess(ctx context.Context, uri *secrets.URI, params domainsecret.GrantParams) error
+	RevokeAccess(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) error
 	GetSecretAccess(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) (string, error)
 	GetSecretAccessScope(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) (*domainsecret.AccessScope, error)
-
+	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]domainsecret.GrantParams, error)
 	InitialWatchStatementForObsoleteRevision(
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) (tableName string, statement string)

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -179,6 +179,21 @@ func (mr *MockStateMockRecorder) GetSecretConsumer(arg0, arg1, arg2 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockState)(nil).GetSecretConsumer), arg0, arg1, arg2)
 }
 
+// GetSecretGrants mocks base method.
+func (m *MockState) GetSecretGrants(arg0 context.Context, arg1 *secrets.URI, arg2 secrets.SecretRole) ([]secret.GrantParams, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretGrants", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]secret.GrantParams)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretGrants indicates an expected call of GetSecretGrants.
+func (mr *MockStateMockRecorder) GetSecretGrants(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretGrants", reflect.TypeOf((*MockState)(nil).GetSecretGrants), arg0, arg1, arg2)
+}
+
 // GetSecretRemoteConsumer mocks base method.
 func (m *MockState) GetSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, int, error) {
 	m.ctrl.T.Helper()
@@ -331,6 +346,20 @@ func (m *MockState) ListUserSecrets(arg0 context.Context) ([]*secrets.SecretMeta
 func (mr *MockStateMockRecorder) ListUserSecrets(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecrets", reflect.TypeOf((*MockState)(nil).ListUserSecrets), arg0)
+}
+
+// RevokeAccess mocks base method.
+func (m *MockState) RevokeAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.AccessParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeAccess", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeAccess indicates an expected call of RevokeAccess.
+func (mr *MockStateMockRecorder) RevokeAccess(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeAccess", reflect.TypeOf((*MockState)(nil).RevokeAccess), arg0, arg1, arg2)
 }
 
 // SaveSecretConsumer mocks base method.

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -237,34 +237,56 @@ func (rows secretRevisions) toSecretRevisions(revExpire secretRevisionsExpire) (
 
 type secretValues []secretContent
 
-func (rows secretValues) toSecretData() (coresecrets.SecretData, error) {
+func (rows secretValues) toSecretData() coresecrets.SecretData {
 	result := make(coresecrets.SecretData)
 	for _, row := range rows {
 		result[row.Name] = row.Content
 	}
-	return result, nil
+	return result
 }
 
 type secretRemoteUnitConsumers []secretRemoteUnitConsumer
 
-func (rows secretRemoteUnitConsumers) toSecretConsumers() ([]*coresecrets.SecretConsumerMetadata, error) {
+func (rows secretRemoteUnitConsumers) toSecretConsumers() []*coresecrets.SecretConsumerMetadata {
 	result := make([]*coresecrets.SecretConsumerMetadata, len(rows))
 	for i, row := range rows {
 		result[i] = &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: row.CurrentRevision,
 		}
 	}
-	return result, nil
+	return result
 }
 
 type secretUnitConsumers []secretUnitConsumer
 
-func (rows secretUnitConsumers) toSecretConsumers() ([]*coresecrets.SecretConsumerMetadata, error) {
+func (rows secretUnitConsumers) toSecretConsumers() []*coresecrets.SecretConsumerMetadata {
 	result := make([]*coresecrets.SecretConsumerMetadata, len(rows))
 	for i, row := range rows {
 		result[i] = &coresecrets.SecretConsumerMetadata{
 			Label:           row.Label,
 			CurrentRevision: row.CurrentRevision,
+		}
+	}
+	return result
+}
+
+type secretAccessors []secretAccessor
+
+type secretAccessScopes []secretAccessScope
+
+func (rows secretAccessors) toSecretGrants(scopes secretAccessScopes) ([]domainsecret.GrantParams, error) {
+	if len(rows) != len(scopes) {
+		// Should never happen.
+		return nil, errors.New("row length mismatch composing grant results")
+	}
+	result := make([]domainsecret.GrantParams, len(rows))
+	for i, row := range rows {
+		result[i] = domainsecret.GrantParams{
+			SubjectTypeID: row.SubjectTypeID,
+			SubjectID:     row.SubjectID,
+			RoleID:        row.RoleID,
+			ScopeTypeID:   scopes[i].ScopeTypeID,
+			ScopeID:       scopes[i].ScopeID,
 		}
 	}
 	return result, nil


### PR DESCRIPTION
This PR adds state support for revoking secret access and getting secret access and ensure it's all wired up the the facades.

Also a small driveby to rename a couple of variables.


## QA steps

```
$ juju add-secret mysecret foo=bar
secret:coirr5bdaekhf5q4ujh0
$ juju grant-secret mysecret controller
$ juju exec -u controller/0 -- secret-get coirr5bdaekhf5q4ujh0
foo: bar
$ juju revoke-secret mysecret controller
$ juju exec -u controller/0 -- secret-get coirr5bdaekhf5q4ujh0
ERROR permission denied
ERROR the following task failed:
 - id "4" with return code 1

use 'juju show-task' to inspect the failure

$ juju grant-secret mysecret controller
$ juju show-secret coirr5bdaekhf5q4ujh0
coirr5bdaekhf5q4ujh0:
  revision: 1
  rotation: never
  owner: <model>
  name: mysecret
  created: 2024-04-22T01:29:57.189033961Z
  updated: 2024-04-22T01:29:57.189033961Z
  access:
  - target: application-controller
    scope: model-e303eb13-2d12-4f26-8730-58966c614efc
    role: view
```

## Links

**Jira card:** [JUJU-5892](https://warthogs.atlassian.net/browse/JUJU-5892)



[JUJU-5892]: https://warthogs.atlassian.net/browse/JUJU-5892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ