### PR TITLE
Adopt the customizable event source initial query

### DIFF
--- a/domain/controllerconfig/service/package_mock_test.go
+++ b/domain/controllerconfig/service/package_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	changestream "github.com/juju/juju/core/changestream"
 	watcher "github.com/juju/juju/core/watcher"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -108,7 +109,7 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 }
 
 // NewNamespaceWatcher mocks base method.
-func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 string) (watcher.Watcher[[]string], error) {
+func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 eventsource.NamespaceQuery) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNamespaceWatcher", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])

--- a/domain/controllerconfig/service/service.go
+++ b/domain/controllerconfig/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 )
 
 // ModificationValidatorFunc is a function that validates a modification
@@ -32,7 +33,7 @@ type State interface {
 type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
-	NewNamespaceWatcher(string, changestream.ChangeType, string) (watcher.StringsWatcher, error)
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
 }
 
 // Service defines a service for interacting with the underlying state.
@@ -245,8 +246,11 @@ func NewWatchableService(st State, wf WatcherFactory) *WatchableService {
 	}
 }
 
+// It's for testing.
+var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
+
 // Watch returns a watcher that returns keys for any changes to controller
 // config.
 func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
-	return s.watcherFactory.NewNamespaceWatcher("controller_config", changestream.All, s.st.AllKeysQuery())
+	return s.watcherFactory.NewNamespaceWatcher("controller_config", changestream.All, InitialNamespaceChanges(s.st.AllKeysQuery()))
 }

--- a/domain/controllerconfig/service/service_test.go
+++ b/domain/controllerconfig/service/service_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/changestream"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 )
 
 type serviceSuite struct {
@@ -162,7 +163,12 @@ func (s *serviceSuite) TestWatch(c *gc.C) {
 
 	q := "the query does not matter"
 	s.state.EXPECT().AllKeysQuery().Return(q)
-	s.watcherFactory.EXPECT().NewNamespaceWatcher("controller_config", changestream.All, q).Return(s.stringsWatcher, nil)
+
+	s.PatchValue(&InitialNamespaceChanges, func(selectAll string) eventsource.NamespaceQuery {
+		c.Assert(selectAll, gc.Equals, q)
+		return nil
+	})
+	s.watcherFactory.EXPECT().NewNamespaceWatcher("controller_config", changestream.All, gomock.Any()).Return(s.stringsWatcher, nil)
 
 	w, err := NewWatchableService(s.state, s.watcherFactory).Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/modelconfig/service/providerservice.go
+++ b/domain/modelconfig/service/providerservice.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -73,8 +74,13 @@ func NewWatchableProviderService(
 	}
 }
 
+// It's for testing.
+var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
+
 // Watch returns a watcher that returns keys for any changes to model
 // config.
 func (s *WatchableProviderService) Watch() (watcher.StringsWatcher, error) {
-	return s.watcherFactory.NewNamespaceWatcher("model_config", changestream.All, s.st.AllKeysQuery())
+	return s.watcherFactory.NewNamespaceWatcher(
+		"model_config", changestream.All, InitialNamespaceChanges(s.st.AllKeysQuery()),
+	)
 }

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -328,6 +328,6 @@ func NewWatchableService(
 func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
 	return s.watcherFactory.NewNamespaceWatcher(
 		"model_config", changestream.All,
-		eventsource.InitialNamespaceChanges(s.st.AllKeysQuery()),
+		InitialNamespaceChanges(s.st.AllKeysQuery()),
 	)
 }

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/modelconfig/validators"
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/environs/config"
@@ -48,7 +49,7 @@ type State interface {
 type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
-	NewNamespaceWatcher(string, changestream.ChangeType, string) (watcher.StringsWatcher, error)
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
 }
 
 // Service defines the service for interacting with ModelConfig.
@@ -325,5 +326,8 @@ func NewWatchableService(
 // Watch returns a watcher that returns keys for any changes to model
 // config.
 func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
-	return s.watcherFactory.NewNamespaceWatcher("model_config", changestream.All, s.st.AllKeysQuery())
+	return s.watcherFactory.NewNamespaceWatcher(
+		"model_config", changestream.All,
+		eventsource.InitialNamespaceChanges(s.st.AllKeysQuery()),
+	)
 }

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/modelconfig/service/testing"
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/environs/config"
@@ -53,6 +54,11 @@ func (s *serviceSuite) TestSetModelConfig(c *gc.C) {
 	defer st.Close()
 
 	svc := NewWatchableService(defaults, st, st)
+
+	s.PatchValue(&InitialNamespaceChanges, func(selectAll string) eventsource.NamespaceQuery {
+		c.Assert(selectAll, gc.Equals, st.AllKeysQuery())
+		return nil
+	})
 
 	watcher, err := svc.Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/modelconfig/service/testing/state.go
+++ b/domain/modelconfig/service/testing/state.go
@@ -67,7 +67,11 @@ func NewState() *MemoryState {
 	st := &MemoryState{
 		Config: make(map[string]string),
 	}
-	st.NamespaceWatcherFactory = testing.NewNamespaceWatcherFactory(st.KeysQuery)
+	st.NamespaceWatcherFactory = testing.NewNamespaceWatcherFactory(
+		func() ([]string, error) {
+			return st.KeysQuery(allKeysQuery)
+		},
+	)
 	return st
 }
 
@@ -98,9 +102,7 @@ func (s *MemoryState) UpdateModelConfig(
 	remove []string,
 ) error {
 	for _, k := range remove {
-		if _, exists := s.Config[k]; exists {
-			delete(s.Config, k)
-		}
+		delete(s.Config, k)
 	}
 	for k, v := range update {
 		s.Config[k] = v

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/objectstore"
 	"github.com/juju/juju/internal/uuid"
@@ -36,7 +37,7 @@ type State interface {
 type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
-	NewNamespaceWatcher(string, changestream.ChangeType, string) (watcher.StringsWatcher, error)
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
 }
 
 // Service provides the API for working with the coreobjectstore.
@@ -126,6 +127,9 @@ func NewWatchableService(st State, watcherFactory WatcherFactory) *WatchableServ
 	}
 }
 
+// It's for testing.
+var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
+
 // Watch returns a watcher that emits the path changes that either have been
 // added or removed.
 func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
@@ -133,6 +137,6 @@ func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
 	return s.watcherFactory.NewNamespaceWatcher(
 		table,
 		changestream.All,
-		stmt,
+		InitialNamespaceChanges(stmt),
 	)
 }

--- a/domain/objectstore/service/state_mock_test.go
+++ b/domain/objectstore/service/state_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	changestream "github.com/juju/juju/core/changestream"
 	watcher "github.com/juju/juju/core/watcher"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	objectstore "github.com/juju/juju/domain/objectstore"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -139,7 +140,7 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 }
 
 // NewNamespaceWatcher mocks base method.
-func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 string) (watcher.Watcher[[]string], error) {
+func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 eventsource.NamespaceQuery) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNamespaceWatcher", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -52,7 +53,7 @@ type State interface {
 	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]domainsecret.GrantParams, error)
 	InitialWatchStatementForObsoleteRevision(
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
-	) (tableName string, statement string)
+	) (tableName string, statement eventsource.NamespaceQuery)
 	GetRevisionIDsForObsolete(
 		ctx context.Context,
 		appOwners domainsecret.ApplicationOwners,
@@ -65,7 +66,7 @@ type State interface {
 type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
-	NewNamespaceWatcher(string, changestream.ChangeType, string) (watcher.StringsWatcher, error)
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
 }
 
 // Logger facilitates emitting log messages.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	secret "github.com/juju/juju/domain/secret"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -286,11 +287,11 @@ func (mr *MockStateMockRecorder) GrantAccess(arg0, arg1, arg2 any) *gomock.Call 
 }
 
 // InitialWatchStatementForObsoleteRevision mocks base method.
-func (m *MockState) InitialWatchStatementForObsoleteRevision(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) (string, string) {
+func (m *MockState) InitialWatchStatementForObsoleteRevision(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchStatementForObsoleteRevision", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
+	ret1, _ := ret[1].(eventsource.NamespaceQuery)
 	return ret0, ret1
 }
 

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -73,9 +73,9 @@ func (s *WatchableService) WatchObsolete(ctx context.Context, owners ...CharmSec
 	}
 
 	appOwners, unitOwners := splitCharmSecretOwners(owners...)
-	table, stmt := s.st.InitialWatchStatementForObsoleteRevision(ctx, appOwners, unitOwners)
+	table, query := s.st.InitialWatchStatementForObsoleteRevision(ctx, appOwners, unitOwners)
 	w, err := s.watcherFactory.NewNamespaceWatcher(
-		table, changestream.Update, stmt,
+		table, changestream.Update, query,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/secret/service/watcherfactory_mock_test.go
+++ b/domain/secret/service/watcherfactory_mock_test.go
@@ -14,6 +14,7 @@ import (
 
 	changestream "github.com/juju/juju/core/changestream"
 	watcher "github.com/juju/juju/core/watcher"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +42,7 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 }
 
 // NewNamespaceWatcher mocks base method.
-func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 string) (watcher.Watcher[[]string], error) {
+func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 eventsource.NamespaceQuery) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNamespaceWatcher", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])

--- a/domain/secretbackend/service/interface.go
+++ b/domain/secretbackend/service/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/secretbackend"
 )
 
@@ -42,5 +43,5 @@ type Logger interface {
 type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
-	NewNamespaceWatcher(string, changestream.ChangeType, string) (watcher.StringsWatcher, error)
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
 }

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -19,6 +19,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/secretbackend"
@@ -604,10 +605,13 @@ func newWatchableService(
 	}
 }
 
+// It's for testing.
+var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
+
 // WatchSecretBackendRotationChanges returns a watcher for secret backend rotation changes.
 func (s *WatchableService) WatchSecretBackendRotationChanges() (watcher.SecretBackendRotateWatcher, error) {
 	tableName, initialQ := s.st.InitialWatchStatement()
-	w, err := s.watcherFactory.NewNamespaceWatcher(tableName, changestream.All, initialQ)
+	w, err := s.watcherFactory.NewNamespaceWatcher(tableName, changestream.All, InitialNamespaceChanges(initialQ))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/domain/secretbackend/service/watcherfactory_mock_test.go
+++ b/domain/secretbackend/service/watcherfactory_mock_test.go
@@ -14,6 +14,7 @@ import (
 
 	changestream "github.com/juju/juju/core/changestream"
 	watcher "github.com/juju/juju/core/watcher"
+	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +42,7 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 }
 
 // NewNamespaceWatcher mocks base method.
-func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 string) (watcher.Watcher[[]string], error) {
+func (m *MockWatcherFactory) NewNamespaceWatcher(arg0 string, arg1 changestream.ChangeType, arg2 eventsource.NamespaceQuery) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNamespaceWatcher", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])

--- a/domain/watcher.go
+++ b/domain/watcher.go
@@ -35,30 +35,28 @@ func NewWatcherFactory(watchableDBFactory WatchableDBFactory, logger eventsource
 func (f *WatcherFactory) NewUUIDsWatcher(
 	tableName string, changeMask changestream.ChangeType,
 ) (watcher.StringsWatcher, error) {
-	w, err := f.NewNamespaceWatcher(tableName, changeMask, "SELECT uuid from "+tableName)
+	w, err := f.NewNamespaceWatcher(tableName, changeMask, eventsource.InitialNamespaceChanges("SELECT uuid from "+tableName))
 	return w, errors.Trace(err)
 }
 
 // NewNamespaceWatcher returns a new namespace watcher
 // for events based on the input change mask.
 func (f *WatcherFactory) NewNamespaceWatcher(
-	namespace string, changeMask changestream.ChangeType, initialStateQuery string,
+	namespace string, changeMask changestream.ChangeType, initialStateQuery eventsource.NamespaceQuery,
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
 		return nil, errors.Annotate(err, "creating base watcher")
 	}
 
-	return eventsource.NewNamespaceWatcher(
-		base, namespace, changeMask,
-		eventsource.InitialNamespaceChanges(initialStateQuery),
-	), nil
+	return eventsource.NewNamespaceWatcher(base, namespace, changeMask, initialStateQuery), nil
 }
 
 // NewNamespacePredicateWatcher returns a new namespace watcher
 // for events based on the input change mask and predicate.
 func (f *WatcherFactory) NewNamespacePredicateWatcher(
-	namespace string, changeMask changestream.ChangeType, initialStateQuery string,
+	namespace string, changeMask changestream.ChangeType,
+	initialStateQuery eventsource.NamespaceQuery,
 	predicate eventsource.Predicate,
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
@@ -67,9 +65,7 @@ func (f *WatcherFactory) NewNamespacePredicateWatcher(
 	}
 
 	return eventsource.NewNamespacePredicateWatcher(
-		base, namespace, changeMask,
-		eventsource.InitialNamespaceChanges(initialStateQuery),
-		predicate,
+		base, namespace, changeMask, initialStateQuery, predicate,
 	), nil
 }
 

--- a/domain/watcher_test.go
+++ b/domain/watcher_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/watcher/eventsource"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	jujutesting "github.com/juju/juju/testing"
 )
@@ -81,7 +82,10 @@ func (s *watcherSuite) TestNewNamespaceWatcherSuccess(c *gc.C) {
 		}, nil
 	}, nil)
 
-	w, err := factory.NewNamespaceWatcher("some-namespace", changestream.All, "SELECT uuid from some_namespace")
+	w, err := factory.NewNamespaceWatcher(
+		"some-namespace", changestream.All,
+		eventsource.InitialNamespaceChanges("SELECT uuid from some_namespace"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -113,9 +117,12 @@ func (s *watcherSuite) TestNewNamespacePredicateWatcherSuccess(c *gc.C) {
 		}, nil
 	}, nil)
 
-	w, err := factory.NewNamespacePredicateWatcher("some-namespace", changestream.All, "SELECT uuid from some_namespace", func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) (bool, error) {
-		return true, nil
-	})
+	w, err := factory.NewNamespacePredicateWatcher(
+		"some-namespace", changestream.All,
+		eventsource.InitialNamespaceChanges("SELECT uuid from some_namespace"),
+		func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) (bool, error) {
+			return true, nil
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {


### PR DESCRIPTION
This PR changed the argument of NewNamespaceWatcher method in `domain.WatcherFactory` to use the latest `eventsource.NamespaceQuery`.
Additionally, the secret revision obsolete watcher has been changed to use the customizable initial query for the event source watcher.