### PR TITLE
Domain errors

### DIFF
--- a/apiserver/common/charms.go
+++ b/apiserver/common/charms.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/errors"
 
 	corecharm "github.com/juju/juju/core/charm"
-	"github.com/juju/juju/domain"
+	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -31,7 +31,7 @@ func ReadCharmFromStorage(ctx context.Context, objectStore ReadObjectStore, data
 	// Use the storage to retrieve and save the charm archive.
 	reader, _, err := objectStore.Get(ctx, storagePath)
 	if err != nil {
-		if errors.Is(err, domain.ErrNoRecord) {
+		if errors.Is(err, objectstoreerrors.ErrNotFound) {
 			return "", errors.NewNotFound(err, "charm not found in model storage")
 		}
 		return "", errors.Annotate(err, "cannot get charm from model storage")

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	networkerrors "github.com/juju/juju/domain/network/errors"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -355,6 +356,9 @@ func (api *ProvisionerAPI) machineSpaceTopology(ctx context.Context, machineID s
 	for _, spaceName := range spaceNames {
 		subnetsAndZones, err := api.subnetsAndZonesForSpace(ctx, machineID, spaceName)
 		if err != nil {
+			if errors.Is(err, networkerrors.ErrSpaceNotFound) {
+				return topology, errors.NotFoundf("space with name %q", spaceName)
+			}
 			return topology, errors.Trace(err)
 		}
 

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -23,10 +23,7 @@ func CoerceError(err error) error {
 
 	// If the error is a sql error, a dqlite error or a database error, we mask
 	// the error to prevent it from being unwrapped.
-	if errors.Is(err, sql.ErrNoRows) ||
-		database.IsError(err) ||
-		errors.Is(err, sql.ErrTxDone) ||
-		errors.Is(err, sql.ErrConnDone) {
+	if isDatabaseError(err) {
 		return errors.Trace(maskError{error: err})
 	}
 
@@ -57,9 +54,17 @@ func (e maskError) As(target any) bool {
 // Is implements standard errors Is interface. Is will check if the target type
 // is a sql error that is trying to be retrieved and return false.
 func (e maskError) Is(target error) bool {
-	if database.IsError(target) {
+	if isDatabaseError(target) {
 		return false
 	}
 
 	return errors.Is(e.error, target)
+}
+
+// isDatabaseError checks if the error is a sql, sqlite or dqlite error.
+func isDatabaseError(err error) bool {
+	return errors.Is(err, sql.ErrNoRows) ||
+		database.IsError(err) ||
+		errors.Is(err, sql.ErrTxDone) ||
+		errors.Is(err, sql.ErrConnDone)
 }

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -50,6 +50,7 @@ func (e maskError) As(target any) bool {
 	if database.IsError(target) {
 		return false
 	}
+
 	return errors.As(e.error, target)
 }
 
@@ -59,5 +60,6 @@ func (e maskError) Is(target error) bool {
 	if database.IsError(target) {
 		return false
 	}
+
 	return errors.Is(e.error, target)
 }

--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -17,13 +17,13 @@ type asError struct {
 	Message string
 }
 
-type errorsSuite struct{}
-
-var _ = gc.Suite(&errorsSuite{})
-
 func (a asError) Error() string {
 	return a.Message
 }
+
+type errorsSuite struct{}
+
+var _ = gc.Suite(&errorsSuite{})
 
 // TestCoerceForNilError checks that if you pass a nil error to CoerceError you
 // get back a nil error.

--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -4,6 +4,7 @@
 package domain
 
 import (
+	"database/sql"
 	"fmt"
 
 	dqlite "github.com/canonical/go-dqlite/driver"
@@ -39,7 +40,6 @@ func (e *errorsSuite) TestMaskErrorIsHidesSqlErrors(c *gc.C) {
 	tests := []struct {
 		Name  string
 		Error error
-		Rval  bool
 	}{
 		{
 			Name: "Test sqlite3 errors are hidden from Is()",
@@ -47,7 +47,6 @@ func (e *errorsSuite) TestMaskErrorIsHidesSqlErrors(c *gc.C) {
 				Code:         sqlite3.ErrAbort,
 				ExtendedCode: sqlite3.ErrBusyRecovery,
 			},
-			Rval: false,
 		},
 		{
 			Name: "Test dqlite errors are hidden from Is()",
@@ -55,13 +54,48 @@ func (e *errorsSuite) TestMaskErrorIsHidesSqlErrors(c *gc.C) {
 				Code:    dqlite.ErrBusy,
 				Message: "something went wrong",
 			},
-			Rval: false,
+		},
+		{
+			Name:  "Test sql.ErrNoRows errors are hidden from Is()",
+			Error: sql.ErrNoRows,
+		},
+		{
+			Name:  "Test sql.ErrTxDone errors are hidden from Is()",
+			Error: sql.ErrTxDone,
+		},
+		{
+			Name:  "Test sql.ErrConnDone errors are hidden from Is()",
+			Error: sql.ErrConnDone,
 		},
 	}
 
 	for _, test := range tests {
 		err := maskError{fmt.Errorf("%q %w", test.Name, test.Error)}
-		c.Check(test.Rval, gc.Equals, errors.Is(err, test.Error), gc.Commentf(test.Name))
+		c.Check(errors.Is(err, test.Error), jc.IsFalse, gc.Commentf(test.Name))
+	}
+}
+
+func (e *errorsSuite) TestErrorMessagePreserved(c *gc.C) {
+	tests := []struct {
+		Error    error
+		Expected string
+	}{
+		{
+			Error:    fmt.Errorf("wrap orig error: %w", sql.ErrNoRows),
+			Expected: "wrap orig error: sql: no rows in result set",
+		},
+		{
+			Error:    fmt.Errorf("wrap orig error: %w%w", sql.ErrNoRows, dqlite.Error{Code: dqlite.ErrBusy}),
+			Expected: "wrap orig error: sql: no rows in result set",
+		},
+		{
+			Error:    fmt.Errorf("wrap orig error: %w - %w", sql.ErrNoRows, fmt.Errorf("nested error")),
+			Expected: "wrap orig error: sql: no rows in result set - nested error",
+		},
+	}
+	for _, test := range tests {
+		err := CoerceError(test.Error)
+		c.Check(err.Error(), gc.Equals, test.Expected)
 	}
 }
 

--- a/domain/network/errors/errors.go
+++ b/domain/network/errors/errors.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import "github.com/juju/errors"
+
+const (
+	// ErrAlreadyExists is returned when a space already exists.
+	ErrAlreadyExists = errors.ConstError("already exists")
+)

--- a/domain/network/errors/errors.go
+++ b/domain/network/errors/errors.go
@@ -6,6 +6,9 @@ package errors
 import "github.com/juju/errors"
 
 const (
-	// ErrAlreadyExists is returned when a space already exists.
-	ErrAlreadyExists = errors.ConstError("already exists")
+	// ErrSpaceAlreadyExists is returned when a space already exists.
+	ErrSpaceAlreadyExists = errors.ConstError("space already exists")
+
+	// ErrSpaceNotFound is returned when a space is not found.
+	ErrSpaceNotFound = errors.ConstError("space not found")
 )

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -53,14 +53,14 @@ func (st *State) AddSpace(
 INSERT INTO space (uuid, name) 
 VALUES ($Space.uuid, $Space.name)`, Space{})
 	if err != nil {
-		return errors.Trace(domain.CoerceError(err))
+		return errors.Trace(err)
 	}
 
 	insertProviderStmt, err := sqlair.Prepare(`
 INSERT INTO provider_space (provider_id, space_uuid)
 VALUES ($ProviderSpace.provider_id, $ProviderSpace.space_uuid)`, ProviderSpace{})
 	if err != nil {
-		return errors.Trace(domain.CoerceError(err))
+		return errors.Trace(err)
 	}
 
 	findFanSubnetsStmt, err := sqlair.Prepare(`
@@ -68,7 +68,7 @@ SELECT subject_subnet_uuid AS &Subnet.uuid
 FROM   subnet_association
 WHERE  association_type_id = 0 AND associated_subnet_uuid IN ($S[:])`, sqlair.S{}, Subnet{})
 	if err != nil {
-		return errors.Trace(domain.CoerceError(err))
+		return errors.Trace(err)
 	}
 
 	checkInputSubnetsStmt, err := sqlair.Prepare(`
@@ -78,7 +78,7 @@ JOIN   subnet_type
 ON     subnet.subnet_type_id = subnet_type.id
 WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair.S{}, Subnet{})
 	if err != nil {
-		return errors.Trace(domain.CoerceError(err))
+		return errors.Trace(err)
 	}
 
 	subnetIDsInS := sqlair.S{}
@@ -89,11 +89,9 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// We must first check on the provided subnet ids to validate
 		// that are of a type on which the space can be set.
-
 		var nonSettableSubnets []Subnet
 		if err := tx.Query(ctx, checkInputSubnetsStmt, subnetIDsInS).GetAll(&nonSettableSubnets); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			st.logger.Errorf("checking if there are fan subnets for space %q, %v", uuid, err)
-			return errors.Annotatef(domain.CoerceError(err), "checking if there are fan subnets for space %q", uuid)
+			return errors.Annotatef(err, "checking if there are fan subnets for space %q", uuid)
 		}
 
 		// If any row is returned we must fail with the returned fan
@@ -105,16 +103,14 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair
 		}
 
 		if err := tx.Query(ctx, insertSpaceStmt, Space{UUID: uuid, Name: name}).Run(); err != nil {
-			st.logger.Errorf("inserting space uuid %q into space table, %v", uuid, err)
 			if database.IsErrConstraintUnique(err) {
-				return fmt.Errorf("inserting space uuid %q into space table: %w", uuid, networkerrors.ErrAlreadyExists)
+				return fmt.Errorf("inserting space uuid %q into space table: %w with err: %w", uuid, networkerrors.ErrSpaceAlreadyExists, err)
 			}
-			return errors.Annotatef(domain.CoerceError(err), "inserting space uuid %q into space table", uuid)
+			return errors.Annotatef(err, "inserting space uuid %q into space table", uuid)
 		}
 		if providerID != "" {
 			if err := tx.Query(ctx, insertProviderStmt, ProviderSpace{ProviderID: providerID, SpaceUUID: uuid}).Run(); err != nil {
-				st.logger.Errorf("inserting provider id %q into provider_space table, %v", providerID, err)
-				return errors.Annotatef(domain.CoerceError(err), "inserting provider id %q into provider_space table", providerID)
+				return errors.Annotatef(err, "inserting provider id %q into provider_space table", providerID)
 			}
 		}
 
@@ -122,8 +118,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair
 		var fanSubnets []Subnet
 		err = tx.Query(ctx, findFanSubnetsStmt, subnetIDsInS).GetAll(&fanSubnets)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			st.logger.Errorf("retrieving the fan subnets for space %q, %v", uuid, err)
-			return errors.Annotatef(domain.CoerceError(err), "retrieving the fan subnets for space %q", uuid)
+			return errors.Annotatef(err, "retrieving the fan subnets for space %q", uuid)
 		}
 		// Append the fan subnet (unique) ids (if any) to the provided
 		// subnet ids.
@@ -134,8 +129,7 @@ WHERE  subnet_type.is_space_settable = FALSE AND subnet.uuid IN ($S[:])`, sqlair
 		// the space uuid.
 		for _, subnetID := range subnetIDs {
 			if err := st.updateSubnetSpaceID(ctx, tx, subnetID, uuid); err != nil {
-				st.logger.Errorf("updating subnet %q using space uuid %q, %v", subnetID, uuid, err)
-				return errors.Annotatef(domain.CoerceError(err), "updating subnet %q using space uuid %q", subnetID, uuid)
+				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid)
 			}
 		}
 		return nil
@@ -177,7 +171,7 @@ func (st *State) GetSpace(
 ) (*network.SpaceInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(domain.CoerceError(err))
+		return nil, errors.Trace(err)
 	}
 
 	// Append the space uuid condition to the query only if it's passed to the function.
@@ -185,23 +179,21 @@ func (st *State) GetSpace(
 
 	spacesStmt, err := sqlair.Prepare(q, SpaceSubnetRow{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Annotatef(domain.CoerceError(err), "preparing %q", q)
+		return nil, errors.Annotatef(err, "preparing %q", q)
 	}
 
 	var spaceRows SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, spacesStmt, sqlair.M{"id": uuid}).GetAll(&spaceRows)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			st.logger.Errorf("retrieving space %q, %v", uuid, err)
-			return errors.Annotatef(domain.CoerceError(err), "retrieving space %q", uuid)
+			return errors.Annotatef(err, "retrieving space %q", uuid)
 		}
 
 		return nil
 	}); errors.Is(err, sqlair.ErrNoRows) || len(spaceRows) == 0 {
-		return nil, errors.NotFoundf("space %q", uuid)
+		return nil, fmt.Errorf("space not found with %s: %w", uuid, networkerrors.ErrSpaceNotFound)
 	} else if err != nil {
-		st.logger.Errorf("querying spaces, %v", err)
-		return nil, errors.Annotate(domain.CoerceError(err), "querying spaces")
+		return nil, errors.Annotate(err, "querying spaces")
 	}
 
 	return &spaceRows.ToSpaceInfos()[0], nil
@@ -214,7 +206,7 @@ func (st *State) GetSpaceByName(
 ) (*network.SpaceInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(domain.CoerceError(err))
+		return nil, errors.Trace(err)
 	}
 
 	// Append the space.name condition to the query.
@@ -222,16 +214,15 @@ func (st *State) GetSpaceByName(
 
 	s, err := sqlair.Prepare(q, SpaceSubnetRow{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Annotatef(domain.CoerceError(err), "preparing %q", q)
+		return nil, errors.Annotatef(err, "preparing %q", q)
 	}
 
 	var rows SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return errors.Trace(tx.Query(ctx, s, sqlair.M{"name": name}).GetAll(&rows))
 	}); errors.Is(err, sqlair.ErrNoRows) || len(rows) == 0 {
-		return nil, errors.NotFoundf("space with name %q", name)
+		return nil, fmt.Errorf("space not found with %s: %w", name, networkerrors.ErrSpaceNotFound)
 	} else if err != nil {
-		st.logger.Errorf("querying spaces by name %q, %v", name, err)
 		return nil, errors.Annotate(domain.CoerceError(err), "querying spaces by name")
 	}
 
@@ -245,12 +236,12 @@ func (st *State) GetAllSpaces(
 
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(domain.CoerceError(err))
+		return nil, errors.Trace(err)
 	}
 
 	s, err := sqlair.Prepare(retrieveSpacesStmt, SpaceSubnetRow{})
 	if err != nil {
-		return nil, errors.Annotatef(domain.CoerceError(err), "preparing %q", retrieveSpacesStmt)
+		return nil, errors.Annotatef(err, "preparing %q", retrieveSpacesStmt)
 	}
 
 	var rows SpaceSubnetRows
@@ -281,22 +272,21 @@ func (st *State) UpdateSpace(
 UPDATE space
 SET    name = ?
 WHERE  uuid = ?;`
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, q, name, uuid)
 		if err != nil {
-			st.logger.Errorf("updating space %q with name %q, %v", uuid, name, err)
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Annotatef(err, "updating space %q with name %q", uuid, name)
 		}
 		affected, err := res.RowsAffected()
 		if err != nil {
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Trace(err)
 		}
 		if affected == 0 {
-			return errors.NotFoundf("space %q", uuid)
+			return fmt.Errorf("space not found with %s: %w", uuid, networkerrors.ErrSpaceNotFound)
 		}
-
 		return nil
 	})
+	return domain.CoerceError(err)
 }
 
 // DeleteSpace deletes the space identified by the passed uuid.
@@ -306,55 +296,52 @@ func (st *State) DeleteSpace(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(domain.CoerceError(err))
+		return errors.Trace(err)
 	}
 
 	deleteSpaceStmt := "DELETE FROM space WHERE uuid = ?;"
 	deleteProviderSpaceStmt := "DELETE FROM provider_space WHERE space_uuid = ?;"
 	updateSubnetSpaceUUIDStmt := "UPDATE subnet SET space_uuid = ? WHERE space_uuid = ?;"
 
-	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, deleteProviderSpaceStmt, uuid); err != nil {
-			st.logger.Errorf("removing space %q from the provider_space table, %v", uuid, err)
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Annotatef(err, "removing space %q from the provider_space table", uuid)
 		}
 
 		if _, err := tx.ExecContext(ctx, updateSubnetSpaceUUIDStmt, network.AlphaSpaceId, uuid); err != nil {
-			st.logger.Errorf("updating subnet table by removing the space %q, %v", uuid, err)
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Annotatef(err, "updating subnet table by removing the space %q", uuid)
 		}
 
 		delSpaceResult, err := tx.ExecContext(ctx, deleteSpaceStmt, uuid)
 		if err != nil {
-			st.logger.Errorf("removing space %q, %v", uuid, err)
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Annotatef(err, "removing space %q", uuid)
 		}
 		delSpaceAffected, err := delSpaceResult.RowsAffected()
 		if err != nil {
-			return errors.Trace(domain.CoerceError(err))
+			return errors.Trace(err)
 		}
 		if delSpaceAffected != 1 {
-			return fmt.Errorf("space %s not found", uuid)
+			return networkerrors.ErrSpaceNotFound
 		}
 
 		return nil
 	})
+	return domain.CoerceError(err)
 }
 
 // FanConfig returns the current model's fan config value.
 func (st *State) FanConfig(ctx context.Context) (string, error) {
-	var fanConfig string
-
 	db, err := st.DB()
 	if err != nil {
-		return fanConfig, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
 
+	var fanConfig string
 	return fanConfig, db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		stmt := `SELECT value FROM model_config WHERE key=?`
 		row := tx.QueryRowContext(ctx, stmt, config.FanConfig)
 		if err := row.Scan(&fanConfig); errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("model's fan config %w%w", errors.NotFound, errors.Hide(err))
+			return fmt.Errorf("model config fan config %w %w", networkerrors.ErrSpaceNotFound, err)
 		} else if err != nil {
 			return domain.CoerceError(err)
 		}

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -119,7 +119,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Check(name, gc.Equals, "space0")
 	// Fails when trying to add a new space with the same name.
 	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "bar", subnets)
-	c.Assert(err, jc.ErrorIs, networkerrors.ErrAlreadyExists)
+	c.Assert(err, jc.ErrorIs, networkerrors.ErrSpaceAlreadyExists)
 }
 
 func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
@@ -328,7 +328,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUIDNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	_, err := st.GetSpace(ctx.Background(), "unknown0")
-	c.Assert(err, gc.ErrorMatches, "space \"unknown0\" not found")
+	c.Assert(err, jc.ErrorIs, networkerrors.ErrSpaceNotFound)
 }
 
 func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
@@ -357,7 +357,7 @@ func (s *stateSuite) TestRetrieveSpaceByNameNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	_, err := st.GetSpaceByName(ctx.Background(), "unknown0")
-	c.Assert(err, gc.ErrorMatches, "space with name \"unknown0\" not found")
+	c.Assert(err, jc.ErrorIs, networkerrors.ErrSpaceNotFound)
 }
 
 func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
@@ -470,7 +470,7 @@ func (s *stateSuite) TestUpdateSpaceFailNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	err := st.UpdateSpace(ctx.Background(), "unknownSpace", "newSpaceName0")
-	c.Assert(err, gc.ErrorMatches, "space \"unknownSpace\" not found")
+	c.Assert(err, jc.ErrorIs, networkerrors.ErrSpaceNotFound)
 }
 
 func (s *stateSuite) TestDeleteSpace(c *gc.C) {

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
+	networkerrors "github.com/juju/juju/domain/network/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -118,8 +119,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Check(name, gc.Equals, "space0")
 	// Fails when trying to add a new space with the same name.
 	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "bar", subnets)
-	c.Assert(err, gc.ErrorMatches, "inserting space (.*) into space table: record already exists")
-
+	c.Assert(err, jc.ErrorIs, networkerrors.ErrAlreadyExists)
 }
 
 func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {

--- a/domain/objectstore/errors/errors.go
+++ b/domain/objectstore/errors/errors.go
@@ -6,6 +6,9 @@ package errors
 import "github.com/juju/errors"
 
 const (
+	// ErrNotFound is returned when a path is not found.
+	ErrNotFound = errors.ConstError("path not found")
+
 	// ErrHashAndSizeAlreadyExists is returned when a hash already exists, but
 	// the associated size is different. This should never happen, it means that
 	// there is a collision in the hash function.

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -165,6 +165,9 @@ func (s *State) RemoveMetadata(ctx context.Context, path string) error {
 		var metadataUUID string
 		row := tx.QueryRowContext(ctx, metadataUUIDQuery, path)
 		if err := row.Scan(&metadataUUID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return objectstoreerrors.ErrNotFound
+			}
 			return err
 		}
 

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -48,6 +48,9 @@ WHERE path = ?`
 		return row.Scan(&metadata.Path, &metadata.UUID, &metadata.Size, &metadata.Hash)
 	})
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return objectstore.Metadata{}, objectstoreerrors.ErrNotFound
+		}
 		return objectstore.Metadata{}, errors.Annotatef(domain.CoerceError(err), "retrieving metadata %s", path)
 	}
 	return metadata, nil

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -163,7 +162,7 @@ func (s *stateSuite) TestRemoveMetadataNotExists(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	err := st.RemoveMetadata(context.Background(), "foo")
-	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *gc.C) {

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -27,7 +27,7 @@ func (s *stateSuite) TestGetMetadataNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	_, err := st.GetMetadata(context.Background(), "foo")
-	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestGetMetadataFound(c *gc.C) {
@@ -226,9 +226,9 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 
 	// Ensure that both metadata have been removed.
 	_, err = st.GetMetadata(context.Background(), metadata1.Path)
-	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 	_, err = st.GetMetadata(context.Background(), metadata2.Path)
-	c.Assert(err, jc.ErrorIs, sql.ErrNoRows)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 
 	// Add a new metadata with the same hash and size.
 	metadata3 := objectstore.Metadata{

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/domain"
+	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/domain/objectstore/service"
 	"github.com/juju/juju/domain/objectstore/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
@@ -111,5 +112,5 @@ func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
 	}
 
 	_, err = svc.GetMetadata(context.Background(), metadata.Path)
-	c.Assert(err, jc.ErrorIs, domain.ErrNoRecord)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 }

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
-	"github.com/juju/juju/domain"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secretbackend"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
@@ -549,9 +548,6 @@ func (s *Service) CreateSecretBackend(ctx context.Context, backend coresecrets.S
 			NextRotateTime:      nextRotateTime,
 		},
 	)
-	if errors.Is(err, domain.ErrDuplicate) {
-		return fmt.Errorf("%w: secret backend with name %q", secretbackenderrors.AlreadyExists, backend.Name)
-	}
 	return errors.Trace(err)
 }
 

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -141,11 +141,15 @@ func IsError(target any) bool {
 	if _, is := target.(dqlite.Error); is {
 		return true
 	}
-	if _, is := target.(sqlite3.Error); is {
-		return true
-	}
+
+	// TODO (stickupkid): This is a compatibility layer for sqlite3, we should
+	// remove this once we are only using dqlite.
 	if _, is := target.(*sqlite3.Error); is {
 		return true
 	}
+	if _, is := target.(sqlite3.Error); is {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
This masks all sql, sqlite and dqlite errors so they're not available via errors.Is or errors.As. All errors should be trapped at the domain layer and not leaked outside. Thus the API client and server are never coupled to the underlying database errors.

Dropping the older domain errors for specific domain type errors gives more focused errors that can be trapped at the API server layer.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
TEST_PACKAGES="./domain/..."  make run-go-tests
```

## Links

**Jira card:** JUJU-

