### PR TITLE
Mapper watchers

### DIFF
--- a/core/watcher/eventsource/base.go
+++ b/core/watcher/eventsource/base.go
@@ -41,15 +41,29 @@ func (w *BaseWatcher) Wait() error {
 	return w.tomb.Wait()
 }
 
-// Predicate is a function that determines whether a change event
-// should be sent to the watcher.
-// Returning false will prevent the events from being sent.
-type Predicate func(context.Context, database.TxnRunner, []changestream.ChangeEvent) (bool, error)
+// Mapper is a function that maps a slice of change events to another slice
+// of change events. This allows modification or dropping of events if
+// necessary. When zero events returned, no change will be emitted.
+// The inverse is also possible, allowing fake events to be added to the stream.
+type Mapper func(context.Context, database.TxnRunner, []changestream.ChangeEvent) ([]changestream.ChangeEvent, error)
 
-// defaultPredicate is the default predicate used by the watchers.
-// It will always return true, allowing all events to be sent.
-func defaultPredicate(context.Context, database.TxnRunner, []changestream.ChangeEvent) (bool, error) {
-	return true, nil
+// defaultMapper is the default mapper used by the watchers.
+// It will always return the same change events, allowing all events to be sent.
+func defaultMapper(_ context.Context, _ database.TxnRunner, events []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+	return events, nil
+}
+
+// FilterEvents drops events that do not match the filter.
+func FilterEvents(filter func(changestream.ChangeEvent) bool) Mapper {
+	return func(_ context.Context, _ database.TxnRunner, events []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+		var filtered []changestream.ChangeEvent
+		for _, event := range events {
+			if filter(event) {
+				filtered = append(filtered, event)
+			}
+		}
+		return filtered, nil
+	}
 }
 
 // Query is a function that returns the initial state of a watcher.

--- a/domain/blockdevice/service/package_test.go
+++ b/domain/blockdevice/service/package_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package service -destination state_mock_test.go github.com/juju/juju/domain/blockdevice/service State,WatcherFactory
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/domain/blockdevice/service/service.go
+++ b/domain/blockdevice/service/service.go
@@ -18,7 +18,7 @@ import (
 type getWatcherFunc = func(
 	namespace, changeValue string,
 	changeMask changestream.ChangeType,
-	predicate eventsource.Predicate,
+	mapper eventsource.Mapper,
 ) (watcher.NotifyWatcher, error)
 
 // State defines an interface for interacting with the underlying state.
@@ -45,10 +45,10 @@ type Logger interface {
 
 // WatcherFactory describes methods for creating watchers.
 type WatcherFactory interface {
-	NewValuePredicateWatcher(
+	NewValueMapperWatcher(
 		namespace, changeValue string,
 		changeMask changestream.ChangeType,
-		predicate eventsource.Predicate,
+		mapper eventsource.Mapper,
 	) (watcher.NotifyWatcher, error)
 }
 
@@ -119,5 +119,5 @@ func (s *WatchableService) WatchBlockDevices(
 	ctx context.Context,
 	machineId string,
 ) (watcher.NotifyWatcher, error) {
-	return s.st.WatchBlockDevices(ctx, s.watcherFactory.NewValuePredicateWatcher, machineId)
+	return s.st.WatchBlockDevices(ctx, s.watcherFactory.NewValueMapperWatcher, machineId)
 }

--- a/domain/blockdevice/service/state_mock_test.go
+++ b/domain/blockdevice/service/state_mock_test.go
@@ -93,7 +93,7 @@ func (mr *MockStateMockRecorder) SetMachineBlockDevices(arg0, arg1 any, arg2 ...
 }
 
 // WatchBlockDevices mocks base method.
-func (m *MockState) WatchBlockDevices(arg0 context.Context, arg1 func(string, string, changestream.ChangeType, eventsource.Predicate) (watcher.Watcher[struct{}], error), arg2 string) (watcher.Watcher[struct{}], error) {
+func (m *MockState) WatchBlockDevices(arg0 context.Context, arg1 func(string, string, changestream.ChangeType, eventsource.Mapper) (watcher.Watcher[struct{}], error), arg2 string) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchBlockDevices", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -130,17 +130,17 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewValuePredicateWatcher mocks base method.
-func (m *MockWatcherFactory) NewValuePredicateWatcher(arg0, arg1 string, arg2 changestream.ChangeType, arg3 eventsource.Predicate) (watcher.Watcher[struct{}], error) {
+// NewValueMapperWatcher mocks base method.
+func (m *MockWatcherFactory) NewValueMapperWatcher(arg0, arg1 string, arg2 changestream.ChangeType, arg3 eventsource.Mapper) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewValuePredicateWatcher", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "NewValueMapperWatcher", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// NewValuePredicateWatcher indicates an expected call of NewValuePredicateWatcher.
-func (mr *MockWatcherFactoryMockRecorder) NewValuePredicateWatcher(arg0, arg1, arg2, arg3 any) *gomock.Call {
+// NewValueMapperWatcher indicates an expected call of NewValueMapperWatcher.
+func (mr *MockWatcherFactoryMockRecorder) NewValueMapperWatcher(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewValuePredicateWatcher", reflect.TypeOf((*MockWatcherFactory)(nil).NewValuePredicateWatcher), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewValueMapperWatcher", reflect.TypeOf((*MockWatcherFactory)(nil).NewValueMapperWatcher), arg0, arg1, arg2, arg3)
 }

--- a/domain/upgrade/service/package_mock_test.go
+++ b/domain/upgrade/service/package_mock_test.go
@@ -198,17 +198,17 @@ func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewValuePredicateWatcher mocks base method.
-func (m *MockWatcherFactory) NewValuePredicateWatcher(arg0, arg1 string, arg2 changestream.ChangeType, arg3 eventsource.Predicate) (watcher.Watcher[struct{}], error) {
+// NewValueMapperWatcher mocks base method.
+func (m *MockWatcherFactory) NewValueMapperWatcher(arg0, arg1 string, arg2 changestream.ChangeType, arg3 eventsource.Mapper) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewValuePredicateWatcher", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "NewValueMapperWatcher", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// NewValuePredicateWatcher indicates an expected call of NewValuePredicateWatcher.
-func (mr *MockWatcherFactoryMockRecorder) NewValuePredicateWatcher(arg0, arg1, arg2, arg3 any) *gomock.Call {
+// NewValueMapperWatcher indicates an expected call of NewValueMapperWatcher.
+func (mr *MockWatcherFactoryMockRecorder) NewValueMapperWatcher(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewValuePredicateWatcher", reflect.TypeOf((*MockWatcherFactory)(nil).NewValuePredicateWatcher), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewValueMapperWatcher", reflect.TypeOf((*MockWatcherFactory)(nil).NewValueMapperWatcher), arg0, arg1, arg2, arg3)
 }

--- a/domain/upgrade/service/service_test.go
+++ b/domain/upgrade/service/service_test.go
@@ -157,7 +157,7 @@ func (s *serviceSuite) TestWatchForUpgradeReady(c *gc.C) {
 
 	nw := watchertest.NewMockNotifyWatcher(nil)
 
-	s.watcherFactory.EXPECT().NewValuePredicateWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
+	s.watcherFactory.EXPECT().NewValueMapperWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
 
 	watcher, err := s.service.WatchForUpgradeReady(context.Background(), s.upgradeUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,7 +169,7 @@ func (s *serviceSuite) TestWatchForUpgradeState(c *gc.C) {
 
 	nw := watchertest.NewMockNotifyWatcher(nil)
 
-	s.watcherFactory.EXPECT().NewValuePredicateWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
+	s.watcherFactory.EXPECT().NewValueMapperWatcher(gomock.Any(), s.upgradeUUID.String(), gomock.Any(), gomock.Any()).Return(nw, nil)
 
 	watcher, err := s.service.WatchForUpgradeState(context.Background(), s.upgradeUUID, coreupgrade.Started)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/watcher.go
+++ b/domain/watcher.go
@@ -42,7 +42,8 @@ func (f *WatcherFactory) NewUUIDsWatcher(
 // NewNamespaceWatcher returns a new namespace watcher
 // for events based on the input change mask.
 func (f *WatcherFactory) NewNamespaceWatcher(
-	namespace string, changeMask changestream.ChangeType, initialStateQuery eventsource.NamespaceQuery,
+	namespace string, changeMask changestream.ChangeType,
+	initialStateQuery eventsource.NamespaceQuery,
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
@@ -52,20 +53,21 @@ func (f *WatcherFactory) NewNamespaceWatcher(
 	return eventsource.NewNamespaceWatcher(base, namespace, changeMask, initialStateQuery), nil
 }
 
-// NewNamespacePredicateWatcher returns a new namespace watcher
-// for events based on the input change mask and predicate.
-func (f *WatcherFactory) NewNamespacePredicateWatcher(
+// NewNamespaceMapperWatcher returns a new namespace watcher
+// for events based on the input change mask and mapper.
+func (f *WatcherFactory) NewNamespaceMapperWatcher(
 	namespace string, changeMask changestream.ChangeType,
 	initialStateQuery eventsource.NamespaceQuery,
-	predicate eventsource.Predicate,
+	mapper eventsource.Mapper,
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
 		return nil, errors.Annotate(err, "creating base watcher")
 	}
 
-	return eventsource.NewNamespacePredicateWatcher(
-		base, namespace, changeMask, initialStateQuery, predicate,
+	return eventsource.NewNamespaceMapperWatcher(
+		base, namespace, changeMask,
+		initialStateQuery, mapper,
 	), nil
 }
 
@@ -82,19 +84,19 @@ func (f *WatcherFactory) NewValueWatcher(
 	return eventsource.NewValueWatcher(base, namespace, changeValue, changeMask), nil
 }
 
-// NewValuePredicateWatcher returns a watcher for a particular change value
-// in a namespace, based on the input change mask and predicate.
-func (f *WatcherFactory) NewValuePredicateWatcher(
+// NewValueMapperWatcher returns a watcher for a particular change value
+// in a namespace, based on the input change mask and mapper.
+func (f *WatcherFactory) NewValueMapperWatcher(
 	namespace, changeValue string,
 	changeMask changestream.ChangeType,
-	predicate eventsource.Predicate,
+	mapper eventsource.Mapper,
 ) (watcher.NotifyWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
 		return nil, errors.Annotate(err, "creating base watcher")
 	}
 
-	return eventsource.NewValuePredicateWatcher(base, namespace, changeValue, changeMask, predicate), nil
+	return eventsource.NewValueMapperWatcher(base, namespace, changeValue, changeMask, mapper), nil
 }
 
 func (f *WatcherFactory) newBaseWatcher() (*eventsource.BaseWatcher, error) {

--- a/domain/watcher_test.go
+++ b/domain/watcher_test.go
@@ -97,7 +97,7 @@ func (s *watcherSuite) TestNewNamespaceWatcherSuccess(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *watcherSuite) TestNewNamespacePredicateWatcherSuccess(c *gc.C) {
+func (s *watcherSuite) TestNewNamespaceMapperWatcherSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectSourceWithSub()
 
@@ -117,11 +117,11 @@ func (s *watcherSuite) TestNewNamespacePredicateWatcherSuccess(c *gc.C) {
 		}, nil
 	}, nil)
 
-	w, err := factory.NewNamespacePredicateWatcher(
+	w, err := factory.NewNamespaceMapperWatcher(
 		"some-namespace", changestream.All,
 		eventsource.InitialNamespaceChanges("SELECT uuid from some_namespace"),
-		func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) (bool, error) {
-			return true, nil
+		func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+			return ce, nil
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -157,7 +157,7 @@ func (s *watcherSuite) TestNewValueWatcherSuccess(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *watcherSuite) TestNewValuePredicateWatcherSuccess(c *gc.C) {
+func (s *watcherSuite) TestNewValueMapperWatcherSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectSourceWithSub()
 
@@ -168,9 +168,12 @@ func (s *watcherSuite) TestNewValuePredicateWatcherSuccess(c *gc.C) {
 		}, nil
 	}, nil)
 
-	w, err := factory.NewValuePredicateWatcher("some-namespace", "some-id-from-namespace", changestream.All, func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) (bool, error) {
-		return true, nil
-	})
+	w, err := factory.NewValueMapperWatcher(
+		"some-namespace", "some-id-from-namespace", changestream.All,
+		func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+			return ce, nil
+		},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {


### PR DESCRIPTION
Instead of using a predicate to define if a change event should be filtered out, we can instead use a mapper. There was a flaw in with the predicate that meant that if one event was tainted then all events where tainted. This allows us to drop the tainted event whilst returning all the other events.

Generalising this further we can then map a change event to another event, or we can ask if a change event can be inserted, filtered or dropped (think flatMap).

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The tests should pass, but bootstrap should work correctly.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** JUJU-

